### PR TITLE
Update development task changes.

### DIFF
--- a/dev/tasks/dev/tasks.js
+++ b/dev/tasks/dev/tasks.js
@@ -40,7 +40,7 @@ module.exports = ( config ) => {
 			}
 		} );
 
-		updateTask( ckeditor5Path, packageJSON, config.WORKSPACE_DIR, options[ 'npm-update' ] );
+		updateTask( installTask, ckeditor5Path, packageJSON, config.WORKSPACE_DIR, options[ 'npm-update' ] );
 	} );
 
 	gulp.task( 'status', () => {

--- a/dev/tasks/dev/tasks.js
+++ b/dev/tasks/dev/tasks.js
@@ -14,13 +14,17 @@ const pluginCreateTask = require( './tasks/create-package' );
 const updateTask = require( './tasks/update' );
 const relinkTask = require( './tasks/relink' );
 const log = require( './utils/log' );
+const gutil = require( 'gulp-util' );
 
 module.exports = ( config ) => {
 	const ckeditor5Path = process.cwd();
 	const packageJSON = require( '../../../package.json' );
 
 	// Configure logging.
-	log.configure( console.log, console.error );
+	log.configure(
+		( msg ) => gutil.log( msg ),
+		( msg ) => gutil.log( gutil.colors.red( msg ) )
+	);
 
 	gulp.task( 'init', () => {
 		initTask( installTask, ckeditor5Path, packageJSON, config.WORKSPACE_DIR );

--- a/dev/tasks/dev/tasks/install.js
+++ b/dev/tasks/dev/tasks/install.js
@@ -20,9 +20,8 @@ const log = require( '../utils/log' );
  * 2. If NPM module name is provided - gets GitHub URL from NPM and clones the repository.
  * 3. If path on disk is provided - it is used directly.
  * 4. Runs `npm install` in package repository.
- * 5. If package exists in `ckeditor5/node_modules/` - runs `npm uninstall package_name`.
- * 6. Links package directory into `ckeditor5/node_modules/`.
- * 7. Adds dependency to `ckeditor5/package.json`.
+ * 5. Links package directory into `ckeditor5/node_modules/`.
+ * 6. Adds dependency to `ckeditor5/package.json`.
  *
  * @param {String} ckeditor5Path Absolute path to `ckeditor5` repository.
  * @param {String} workspaceRoot Relative path to workspace root directory.
@@ -88,11 +87,6 @@ module.exports = ( ckeditor5Path, workspaceRoot, name ) => {
 		tools.npmInstall( repositoryPath );
 
 		const linkPath = path.join( ckeditor5Path, 'node_modules', urlInfo.name );
-
-		if ( tools.isDirectory( linkPath ) ) {
-			log.out( `Uninstalling ${ urlInfo.name } from CKEditor5 node_modules...` );
-			tools.npmUninstall( ckeditor5Path, urlInfo.name );
-		}
 
 		log.out( `Linking ${ linkPath } to ${ repositoryPath }...` );
 		tools.linkDirectories( repositoryPath, linkPath );

--- a/dev/tasks/dev/tasks/update.js
+++ b/dev/tasks/dev/tasks/update.js
@@ -9,20 +9,26 @@ const tools = require( '../utils/tools' );
 const git = require( '../utils/git' );
 const path = require( 'path' );
 const log = require( '../utils/log' );
-const installTask = require( './install' );
 
 /**
- * 1. Get CKEditor5 dependencies from package.json file.
- * 2. Scan workspace for repositories that match dependencies from package.json file.
- * 3. Run GIT pull command on each repository found.
+ * 1. Get CKEditor 5 dependencies from package.json in main CKEditor 5 repository.
+ * 2. If dependency's repository is already cloned in workspace:
+ * 		2.1. Fetch and checkout to specified branch.
+ * 		2.2. Pull changes to that branch.
+ * 		2.3. if --npm-update was specified run npm update --dev in that repository.
+ *		2.4. Recreate symbolic link between repo and main node_modules.
+ * 3. If dependency's repository is not cloned yet - run gulp install on this dependency.
+ * 4. Remove symbolic links to dependencies that are not used in current package.json configuration.
+ * 5. if --npm-update was specified run npm update --dev in main CKeditor 5 repository.
  *
+ * @param {Function} installTask Install task to use on each dependency that is missing from workspace.
  * @param {String} ckeditor5Path Path to main CKEditor5 repository.
  * @param {Object} packageJSON Parsed package.json file from CKEditor5 repository.
  * @param {String} workspaceRoot Relative path to workspace root.
  * @param {Boolean} runNpmUpdate When set to true `npm update` will be executed inside each plugin repository
  * and inside CKEditor 5 repository.
  */
-module.exports = ( ckeditor5Path, packageJSON, workspaceRoot, runNpmUpdate ) => {
+module.exports = ( installTask, ckeditor5Path, packageJSON, workspaceRoot, runNpmUpdate ) => {
 	const workspaceAbsolutePath = path.join( ckeditor5Path, workspaceRoot );
 
 	// Get all CKEditor dependencies from package.json.
@@ -31,45 +37,51 @@ module.exports = ( ckeditor5Path, packageJSON, workspaceRoot, runNpmUpdate ) => 
 	if ( dependencies ) {
 		const directories = tools.getCKE5Directories( workspaceAbsolutePath );
 
-		if ( directories.length ) {
-			for ( let dependency in dependencies ) {
-				const repositoryURL = dependencies[ dependency ];
-				const urlInfo = git.parseRepositoryUrl( repositoryURL );
-				const repositoryAbsolutePath = path.join( workspaceAbsolutePath, dependency );
+		for ( let dependency in dependencies ) {
+			const repositoryURL = dependencies[ dependency ];
+			const urlInfo = git.parseRepositoryUrl( repositoryURL );
+			const repositoryAbsolutePath = path.join( workspaceAbsolutePath, dependency );
 
-				// Check if repository's directory already exists.
-				if ( directories.indexOf( urlInfo.name ) > -1 ) {
-					log.out( `Checking out ${ urlInfo.name } to ${ urlInfo.branch }...` );
-					git.checkout( repositoryAbsolutePath, urlInfo.branch );
+			// Check if repository's directory already exists.
+			if ( directories.indexOf( urlInfo.name ) > -1 ) {
+				log.out( `Checking out ${ urlInfo.name } to ${ urlInfo.branch }...` );
+				git.checkout( repositoryAbsolutePath, urlInfo.branch );
 
-					log.out( `Pulling changes to ${ urlInfo.name }...` );
-					git.pull( repositoryAbsolutePath, urlInfo.branch );
+				log.out( `Pulling changes to ${ urlInfo.name }...` );
+				git.pull( repositoryAbsolutePath, urlInfo.branch );
 
-					if ( runNpmUpdate ) {
-						log.out( `Running "npm update" in ${ urlInfo.name }...` );
-						tools.npmUpdate( repositoryAbsolutePath );
-					}
-
-					try {
-						log.out( `Linking ${ repositoryURL }...` );
-						tools.linkDirectories( repositoryAbsolutePath, path.join( ckeditor5Path, 'node_modules', dependency ) );
-					} catch ( error ) {
-						log.err( error );
-					}
-				} else {
-					// Directory does not exits in workspace - install it.
-					installTask( ckeditor5Path, workspaceRoot, repositoryURL );
+				if ( runNpmUpdate ) {
+					log.out( `Running "npm update" in ${ urlInfo.name }...` );
+					tools.npmUpdate( repositoryAbsolutePath );
 				}
-			}
 
-			if ( runNpmUpdate ) {
-				log.out( `Running "npm update" in CKEditor5 repository...` );
-				tools.npmUpdate( ckeditor5Path );
+				try {
+					log.out( `Linking ${ repositoryURL }...` );
+					tools.linkDirectories( repositoryAbsolutePath, path.join( ckeditor5Path, 'node_modules', dependency ) );
+				} catch ( error ) {
+					log.err( error );
+				}
+			} else {
+				// Directory does not exits in workspace - install it.
+				installTask( ckeditor5Path, workspaceRoot, repositoryURL );
 			}
-		} else {
-			log.out( 'No CKEditor5 plugins in development mode.' );
+		}
+
+		if ( runNpmUpdate ) {
+			log.out( `Running "npm update" in CKEditor5 repository...` );
+			tools.npmUpdate( ckeditor5Path );
 		}
 	} else {
 		log.out( 'No CKEditor5 dependencies found in package.json file.' );
 	}
+
+	// Remove symlinks not used in this configuration.
+	const nodeModulesPath = path.join( ckeditor5Path, 'node_modules' );
+	const symlinks = tools.getCKE5Symlinks( nodeModulesPath );
+	symlinks
+		.filter( dir => typeof dependencies[ dir ] == 'undefined' )
+		.forEach( dir => {
+			log.out( `Removing symbolic link to ${ dir }.` );
+			tools.removeSymlink( path.join( nodeModulesPath, dir ) );
+		} );
 };

--- a/dev/tasks/dev/tasks/update.js
+++ b/dev/tasks/dev/tasks/update.js
@@ -13,9 +13,9 @@ const log = require( '../utils/log' );
 /**
  * 1. Get CKEditor 5 dependencies from package.json in main CKEditor 5 repository.
  * 2. If dependency's repository is already cloned in workspace:
- * 		2.1. Fetch and checkout to specified branch.
- * 		2.2. Pull changes to that branch.
- * 		2.3. if --npm-update was specified run npm update --dev in that repository.
+ *		2.1. Fetch and checkout to specified branch.
+ *		2.2. Pull changes to that branch.
+ *		2.3. if --npm-update was specified run npm update --dev in that repository.
  *		2.4. Recreate symbolic link between repo and main node_modules.
  * 3. If dependency's repository is not cloned yet - run gulp install on this dependency.
  * 4. Remove symbolic links to dependencies that are not used in current package.json configuration.

--- a/dev/tasks/dev/tasks/update.js
+++ b/dev/tasks/dev/tasks/update.js
@@ -9,6 +9,7 @@ const tools = require( '../utils/tools' );
 const git = require( '../utils/git' );
 const path = require( 'path' );
 const log = require( '../utils/log' );
+const installTask = require( './install' );
 
 /**
  * 1. Get CKEditor5 dependencies from package.json file.
@@ -48,6 +49,16 @@ module.exports = ( ckeditor5Path, packageJSON, workspaceRoot, runNpmUpdate ) => 
 						log.out( `Running "npm update" in ${ urlInfo.name }...` );
 						tools.npmUpdate( repositoryAbsolutePath );
 					}
+
+					try {
+						log.out( `Linking ${ repositoryURL }...` );
+						tools.linkDirectories( repositoryAbsolutePath, path.join( ckeditor5Path, 'node_modules', dependency ) );
+					} catch ( error ) {
+						log.err( error );
+					}
+				} else {
+					// Directory does not exits in workspace - install it.
+					installTask( ckeditor5Path, workspaceRoot, repositoryURL );
 				}
 			}
 

--- a/dev/tasks/dev/utils/git.js
+++ b/dev/tasks/dev/utils/git.js
@@ -66,7 +66,7 @@ module.exports = {
 	},
 
 	/**
-	 * Checks out branch on selected repository.
+	 * Fetches and checks out branch on selected repository.
 	 *
 	 * @param {String} repositoryLocation Absolute path to repository.
 	 * @param {String} branchName Name of the branch to checkout.
@@ -74,6 +74,7 @@ module.exports = {
 	checkout( repositoryLocation, branchName ) {
 		const checkoutCommands = [
 			`cd ${ repositoryLocation }`,
+			`git fetch origin ${ branchName }`,
 			`git checkout ${ branchName }`
 		];
 

--- a/dev/tasks/dev/utils/tools.js
+++ b/dev/tasks/dev/utils/tools.js
@@ -5,8 +5,9 @@
 
 'use strict';
 
+const gutil = require( 'gulp-util' );
+
 const dependencyRegExp = /^ckeditor5-/;
-const log = require( '../utils/log' );
 
 module.exports = {
 
@@ -20,25 +21,25 @@ module.exports = {
 	 */
 	shExec( command, logOutput ) {
 		const sh = require( 'shelljs' );
+
 		sh.config.silent = true;
 		logOutput = logOutput !== false;
 
 		const ret = sh.exec( command );
+		const logColor = ret.code ? gutil.colors.red : gutil.colors.grey;
 
 		if ( logOutput ) {
-			if ( ret.stdout !== '' ) {
-				log.out( ret.stdout );
+			if ( ret.stdout ) {
+				console.log( '\n' + logColor( ret.stdout.trim() ) + '\n' );
 			}
 
-			if ( ret.stderr !== '' ) {
-				log.err( ret.stderr );
+			if ( ret.stderr ) {
+				console.log( '\n' + gutil.colors.grey( ret.stderr.trim() ) + '\n' );
 			}
 		}
 
 		if ( ret.code ) {
-			throw new Error(
-				`Error while executing ${ command }: ${ ret.stderr }`
-			);
+			throw new Error( `Error while executing ${ command }: ${ ret.stderr }` );
 		}
 
 		return ret.stdout;

--- a/dev/tasks/dev/utils/tools.js
+++ b/dev/tasks/dev/utils/tools.js
@@ -215,12 +215,12 @@ module.exports = {
 	},
 
 	/**
-	 * Calls `npm update` command in specified path.
+	 * Calls `npm update --dev` command in specified path.
 	 *
 	 * @param {String} path
 	 */
 	npmUpdate( path ) {
-		this.shExec( `cd ${ path } && npm update` );
+		this.shExec( `cd ${ path } && npm update --dev` );
 	},
 
 	/**

--- a/dev/tests/dev/git.js
+++ b/dev/tests/dev/git.js
@@ -149,7 +149,11 @@ describe( 'utils', () => {
 				const shExecStub = sandbox.stub( tools, 'shExec' );
 				const repositoryLocation = 'path/to/repository';
 				const branchName = 'branch-to-checkout';
-				const checkoutCommands = `cd ${ repositoryLocation } && git checkout ${ branchName }`;
+				const checkoutCommands = [
+					`cd ${ repositoryLocation }`,
+					`git fetch origin ${ branchName }`,
+					`git checkout ${ branchName }`
+				].join( ' && ' );
 
 				git.checkout( repositoryLocation, branchName );
 

--- a/dev/tests/dev/install.js
+++ b/dev/tests/dev/install.js
@@ -33,7 +33,6 @@ describe( 'dev-install', () => {
 		spies.checkout = sinon.stub( git, 'checkout' );
 		spies.getGitUrlFromNpm = sinon.stub( tools, 'getGitUrlFromNpm' );
 		spies.readPackageName = sinon.stub( tools, 'readPackageName' );
-		spies.npmUninstall = sinon.stub( tools, 'npmUninstall' );
 	} );
 
 	afterEach( () => {
@@ -47,7 +46,7 @@ describe( 'dev-install', () => {
 
 		installTask( ckeditor5Path, workspacePath, repositoryUrl );
 
-		sinon.assert.calledThrice( spies.isDirectory );
+		sinon.assert.calledTwice( spies.isDirectory );
 		sinon.assert.calledOnce( spies.parseUrl );
 		sinon.assert.calledWithExactly( spies.parseUrl, repositoryUrl );
 
@@ -64,9 +63,6 @@ describe( 'dev-install', () => {
 		sinon.assert.calledWithExactly( spies.npmInstall, repositoryPath );
 
 		const linkPath = path.join( ckeditor5Path, 'node_modules', urlInfo.name );
-
-		sinon.assert.calledOnce( spies.npmUninstall );
-		sinon.assert.calledWithExactly( spies.npmUninstall, ckeditor5Path, urlInfo.name );
 
 		sinon.assert.calledOnce( spies.linkDirectories );
 		sinon.assert.calledWithExactly( spies.linkDirectories, repositoryPath, linkPath );
@@ -88,7 +84,7 @@ describe( 'dev-install', () => {
 
 		installTask( ckeditor5Path, workspacePath, moduleName );
 
-		sinon.assert.calledThrice( spies.isDirectory );
+		sinon.assert.calledTwice( spies.isDirectory );
 		sinon.assert.calledTwice( spies.parseUrl );
 		sinon.assert.calledWithExactly( spies.parseUrl.firstCall, moduleName );
 		expect( spies.parseUrl.firstCall.returnValue ).to.equal( null );
@@ -128,7 +124,7 @@ describe( 'dev-install', () => {
 
 		installTask( ckeditor5Path, workspacePath, '../ckeditor5-core' );
 
-		sinon.assert.calledThrice( spies.isDirectory );
+		sinon.assert.calledTwice( spies.isDirectory );
 		sinon.assert.calledOnce( spies.readPackageName );
 	} );
 
@@ -139,7 +135,7 @@ describe( 'dev-install', () => {
 
 		installTask( ckeditor5Path, workspacePath, '/ckeditor5-core' );
 
-		sinon.assert.calledThrice( spies.isDirectory );
+		sinon.assert.calledTwice( spies.isDirectory );
 		sinon.assert.calledOnce( spies.readPackageName );
 	} );
 

--- a/dev/tests/dev/tools.js
+++ b/dev/tests/dev/tools.js
@@ -50,16 +50,13 @@ describe( 'utils', () => {
 			it( 'should output using log functions', () => {
 				const sh = require( 'shelljs' );
 				const execStub = sandbox.stub( sh, 'exec' ).returns( { code: 0, stdout: 'out', stderr: 'err' } );
-				const log = require( '../../tasks/dev/utils/log' );
-				const outFn = sandbox.spy();
-				const errFn = sandbox.spy();
-				log.configure( outFn, errFn );
+
+				sandbox.stub( console, 'log' );
 
 				tools.shExec( 'command' );
 
 				sinon.assert.calledOnce( execStub );
-				sinon.assert.calledWithExactly( outFn, 'out' );
-				sinon.assert.calledWithExactly( errFn, 'err' );
+				sinon.assert.calledTwice( console.log );
 			} );
 
 			it( 'should not log when in silent mode', () => {

--- a/dev/tests/dev/tools.js
+++ b/dev/tests/dev/tools.js
@@ -76,12 +76,28 @@ describe( 'utils', () => {
 				sinon.assert.notCalled( outFn );
 				sinon.assert.notCalled( errFn );
 			} );
+
+			it( 'should not log if no output from executed command', () => {
+				const sh = require( 'shelljs' );
+				const execStub = sandbox.stub( sh, 'exec' ).returns( { code: 0, stdout: '', stderr: '' } );
+				const log = require( '../../tasks/dev/utils/log' );
+				const outFn = sandbox.spy();
+				const errFn = sandbox.spy();
+				log.configure( outFn, errFn );
+
+				tools.shExec( 'command' );
+
+				sinon.assert.calledOnce( execStub );
+				sinon.assert.notCalled( outFn );
+				sinon.assert.notCalled( errFn );
+			} );
 		} );
 
 		describe( 'linkDirectories', () => {
 			it( 'should be defined', () => expect( tools.linkDirectories ).to.be.a( 'function' ) );
 
 			it( 'should link directories', () => {
+				const isSymlinkStub = sandbox.stub( tools, 'isSymlink' ).returns( false );
 				const isDirectoryStub = sandbox.stub( tools, 'isDirectory' ).returns( false );
 				const symlinkStub = sandbox.stub( fs, 'symlinkSync' );
 				const source = '/source/dir';
@@ -90,6 +106,7 @@ describe( 'utils', () => {
 				tools.linkDirectories( source, destination );
 
 				expect( isDirectoryStub.calledOnce ).to.equal( true );
+				expect( isSymlinkStub.calledOnce ).to.equal( true );
 				expect( symlinkStub.calledOnce ).to.equal( true );
 				expect( symlinkStub.firstCall.args[ 0 ] ).to.equal( source );
 				expect( symlinkStub.firstCall.args[ 1 ] ).to.equal( destination );
@@ -97,6 +114,7 @@ describe( 'utils', () => {
 
 			it( 'should remove destination directory before linking', () => {
 				const shExecStub = sandbox.stub( tools, 'shExec' );
+				const isSymlinkStub = sandbox.stub( tools, 'isSymlink' ).returns( false );
 				const isDirectoryStub = sandbox.stub( tools, 'isDirectory' ).returns( true );
 				const symlinkStub = sandbox.stub( fs, 'symlinkSync' );
 				const source = '/source/dir';
@@ -105,7 +123,28 @@ describe( 'utils', () => {
 				tools.linkDirectories( source, destination );
 
 				expect( isDirectoryStub.calledOnce ).to.equal( true );
+				expect( isSymlinkStub.calledOnce ).to.equal( true );
 				expect( shExecStub.calledOnce ).to.equal( true );
+				expect( symlinkStub.firstCall.args[ 0 ] ).to.equal( source );
+				expect( symlinkStub.firstCall.args[ 1 ] ).to.equal( destination );
+			} );
+
+			it( 'should unlink destination directory if symlink', () => {
+				const shExecStub = sandbox.stub( tools, 'shExec' );
+				const isSymlinkStub = sandbox.stub( tools, 'isSymlink' ).returns( true );
+				const removeSymlinkStub = sandbox.stub( tools, 'removeSymlink' );
+				const isDirectoryStub = sandbox.stub( tools, 'isDirectory' ).returns( true );
+				const symlinkStub = sandbox.stub( fs, 'symlinkSync' );
+				const source = '/source/dir';
+				const destination = '/destination/dir';
+
+				tools.linkDirectories( source, destination );
+
+				expect( isDirectoryStub.notCalled ).to.equal( true );
+				expect( isSymlinkStub.calledOnce ).to.equal( true );
+				expect( shExecStub.notCalled ).to.equal( true );
+				expect( removeSymlinkStub.calledOnce ).to.equal( true );
+				expect( removeSymlinkStub.firstCall.args[ 0 ] ).to.equal( destination );
 				expect( symlinkStub.firstCall.args[ 0 ] ).to.equal( source );
 				expect( symlinkStub.firstCall.args[ 1 ] ).to.equal( destination );
 			} );
@@ -241,6 +280,26 @@ describe( 'utils', () => {
 			} );
 		} );
 
+		describe( 'isSymlink', () => {
+			it( 'should return true if path points to symbolic link', () => {
+				const path = 'path/to/file';
+				const fs = require( 'fs' );
+				sandbox.stub( fs, 'lstatSync' ).returns( {
+					isSymbolicLink: () => true
+				} );
+
+				expect( tools.isSymlink( path ) ).to.equal( true );
+			} );
+
+			it( 'should return false if lstatSync throws', () => {
+				const path = 'path/to/file';
+				const fs = require( 'fs' );
+				sandbox.stub( fs, 'lstatSync' ).throws();
+
+				expect( tools.isSymlink( path ) ).to.equal( false );
+			} );
+		} );
+
 		describe( 'getCKE5Directories', () => {
 			it( 'should be defined', () => expect( tools.getCKE5Directories ).to.be.a( 'function' ) );
 
@@ -348,7 +407,7 @@ describe( 'utils', () => {
 				tools.npmUpdate( path );
 
 				expect( shExecStub.calledOnce ).to.equal( true );
-				expect( shExecStub.firstCall.args[ 0 ] ).to.equal( `cd ${ path } && npm update` );
+				expect( shExecStub.firstCall.args[ 0 ] ).to.equal( `cd ${ path } && npm update --dev` );
 			} );
 		} );
 
@@ -439,6 +498,33 @@ describe( 'utils', () => {
 				} catch ( e ) {}
 
 				expect( getUrlSpy.threw( error ) ).to.equal( true );
+			} );
+		} );
+
+		describe( 'getCKE5Symlinks', () => {
+			it( 'should return CKE5 symlinks from provided path', () => {
+				const fs = require( 'fs' );
+				const path = 'path/to/dir';
+				sandbox.stub( fs, 'readdirSync' ).returns( [ 'ckeditor5-core', 'ckeditor5-image', 'other-dependency' ] );
+				sandbox.stub( tools, 'isSymlink' ).returns( true );
+
+				const symlinks = tools.getCKE5Symlinks( path );
+				expect( symlinks.length ).to.equal( 2 );
+				expect( symlinks[ 0 ] ).to.equal( 'ckeditor5-core' );
+				expect( symlinks[ 1 ] ).to.equal( 'ckeditor5-image' );
+			} );
+		} );
+
+		describe( 'removeSymlink', () => {
+			it( 'should unlink provided symlink', () => {
+				const fs = require( 'fs' );
+				const unlinkStub = sandbox.stub( fs, 'unlinkSync' );
+				const path = 'path/to/symlink';
+
+				tools.removeSymlink( path );
+
+				expect( unlinkStub.calledOnce ).to.equal( true );
+				expect( unlinkStub.firstCall.args[ 0 ] ).to.equal( path );
 			} );
 		} );
 	} );

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   ],
   "dependencies": {
     "ckeditor5-core": "ckeditor/ckeditor5-core",
-    "ckeditor5-utils": "ckeditor/ckeditor5-utils",
     "ckeditor5-ui": "ckeditor/ckeditor5-ui",
     "ckeditor5-ui-default": "ckeditor/ckeditor5-ui-default",
+    "ckeditor5-utils": "ckeditor/ckeditor5-utils",
     "requirejs": "Reinmar/requirejs"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR contains changes implemented in `gulp update` task according to #93. 
It also adds some changes to `gulp install` task as it is now used in updating when some of the dependencies are not cloned inside workspace directory. Install task is not uninstalling dependencies before cloning them - it is done by modified `tools.linkDirectories` method which now is able to unlink or remove destination directory. This should also resolve #108.