### PR TITLE
Adds remote into created package.

### DIFF
--- a/dev/tasks/dev/tasks/create-package.js
+++ b/dev/tasks/dev/tasks/create-package.js
@@ -14,7 +14,7 @@ const log = require( '../utils/log' );
 /**
  * 1. Ask for new package name.
  * 2. Ask for initial version.
- * 3. Ask for GitHub URL.
+ * 3. Ask for GitHub path.
  * 4. Initialize repository.
  * 5. Add remote.
  * 6. Copy files to new repository.
@@ -59,7 +59,7 @@ module.exports = ( ckeditor5Path, workspaceRoot ) => {
 	let packageFullName;
 	let repositoryPath;
 	let packageVersion;
-	let gitHubUrl;
+	let gitHubPath;
 	let packageDescription;
 
 	return inquiries.getPackageName()
@@ -77,10 +77,10 @@ module.exports = ( ckeditor5Path, workspaceRoot ) => {
 		.then( result => {
 			packageVersion = result;
 
-			return inquiries.getPackageGitHubUrl( packageName );
+			return inquiries.getPackageGitHubPath( packageName );
 		} )
 		.then( result => {
-			gitHubUrl = result;
+			gitHubPath = result;
 
 			return inquiries.getPackageDescription();
 		} )
@@ -91,14 +91,14 @@ module.exports = ( ckeditor5Path, workspaceRoot ) => {
 			git.initializeRepository( repositoryPath );
 
 			log.out( `Adding remote ${ repositoryPath }...` );
-			git.addRemote( repositoryPath, gitHubUrl );
+			git.addRemote( repositoryPath, gitHubPath );
 
 			log.out( `Copying files into ${ repositoryPath }...` );
 
 			for ( let destination in fileStructure ) {
 				tools.copyTemplateFiles( fileStructure[ destination ], path.join( repositoryPath, destination ), {
 					'{{AppName}}': packageFullName,
-					'{{GitHubRepositoryPath}}': gitHubUrl,
+					'{{GitHubRepositoryPath}}': gitHubPath,
 					'{{ProjectDescription}}': packageDescription
 				} );
 			}
@@ -116,7 +116,7 @@ module.exports = ( ckeditor5Path, workspaceRoot ) => {
 				if ( !json.dependencies ) {
 					json.dependencies = {};
 				}
-				json.dependencies[ packageName ] = gitHubUrl;
+				json.dependencies[ packageName ] = gitHubPath;
 				json.dependencies = tools.sortObject( json.dependencies );
 
 				return json;

--- a/dev/tasks/dev/tasks/create-package.js
+++ b/dev/tasks/dev/tasks/create-package.js
@@ -16,12 +16,13 @@ const log = require( '../utils/log' );
  * 2. Ask for initial version.
  * 3. Ask for GitHub URL.
  * 4. Initialize repository.
- * 5. Copy files to new repository.
- * 6. Update package.json file in new package's repository.
- * 7. Update package.json file in CKEditor5 repository.
- * 8. Create initial commit.
- * 9. Link new package.
- * 10. Call `npm install` in package repository.
+ * 5. Add remote.
+ * 6. Copy files to new repository.
+ * 7. Update package.json file in new package's repository.
+ * 8. Update package.json file in CKEditor5 repository.
+ * 9. Create initial commit.
+ * 10. Link new package.
+ * 11. Call `npm install` in package repository.
  *
  * @param {String} ckeditor5Path Path to main CKEditor5 repository.
  * @param {String} workspaceRoot Relative path to workspace root.
@@ -88,6 +89,9 @@ module.exports = ( ckeditor5Path, workspaceRoot ) => {
 
 			log.out( `Initializing repository ${ repositoryPath }...` );
 			git.initializeRepository( repositoryPath );
+
+			log.out( `Adding remote ${ repositoryPath }...` );
+			git.addRemote( repositoryPath, gitHubUrl );
 
 			log.out( `Copying files into ${ repositoryPath }...` );
 

--- a/dev/tasks/dev/utils/git.js
+++ b/dev/tasks/dev/utils/git.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const tools = require( './tools' );
+const defaultOrigin = 'origin';
 
 module.exports = {
 
@@ -89,7 +90,7 @@ module.exports = {
 	pull( repositoryLocation, branchName ) {
 		const pullCommands = [
 			`cd ${ repositoryLocation }`,
-			`git pull origin ${ branchName }`
+			`git pull ${ defaultOrigin } ${ branchName }`
 		];
 
 		tools.shExec( pullCommands.join( ' && ' ) );
@@ -142,5 +143,20 @@ module.exports = {
 		];
 
 		tools.shExec( commitCommands.join( ' && ' ) );
+	},
+
+	/**
+	 * Adds remote to repository under specified path.
+	 *
+	 * @param {String} repositoryPath
+	 * @param {String} gitHubPath
+	 */
+	addRemote( repositoryPath, gitHubPath ) {
+		const addRemoteCommands = [
+			`cd ${ repositoryPath }`,
+			`git remote add ${ defaultOrigin } git@github.com:${ gitHubPath }.git`
+		];
+
+		tools.shExec( addRemoteCommands.join( ' && ' ) );
 	}
 };

--- a/dev/tasks/dev/utils/inquiries.js
+++ b/dev/tasks/dev/utils/inquiries.js
@@ -9,7 +9,7 @@ const inquirer = require( 'inquirer' );
 const sanitize = require( './sanitize' );
 const DEFAULT_PLUGIN_NAME_PREFIX = 'ckeditor5-';
 const DEFAULT_PLUGIN_VERSION = '0.0.1';
-const DEFAULT_GITHUB_URL_PREFIX = 'ckeditor/';
+const DEFAULT_GITHUB_PATH_PREFIX = 'ckeditor/';
 
 module.exports = {
 	getPackageName() {
@@ -51,16 +51,16 @@ module.exports = {
 		} );
 	},
 
-	getPackageGitHubUrl( packageName ) {
-		const defaultGitHubUrl = DEFAULT_GITHUB_URL_PREFIX + packageName;
+	getPackageGitHubPath( packageName ) {
+		const defaultGitHubPath = DEFAULT_GITHUB_PATH_PREFIX + packageName;
 
 		return new Promise( ( resolve ) => {
 			inquirer.prompt( [ {
-				name: 'gitHubUrl',
-				message: 'Enter package\'s GitHub URL:',
-				default: defaultGitHubUrl
+				name: 'gitHubPath',
+				message: 'Enter package\'s GitHub path:',
+				default: defaultGitHubPath
 			} ], ( answers ) => {
-				resolve( answers.gitHubUrl );
+				resolve( answers.gitHubPath );
 			} );
 		} );
 	},

--- a/dev/tests/dev/create-package.js
+++ b/dev/tests/dev/create-package.js
@@ -42,7 +42,8 @@ describe( 'dev-create-package', () => {
 			initializeRepository: sinon.stub( git, 'initializeRepository' ),
 			updateJSONFile: sinon.stub( tools, 'updateJSONFile' ),
 			copy: sinon.stub( tools, 'copyTemplateFiles' ),
-			initialCommit: sinon.stub( git, 'initialCommit' )
+			initialCommit: sinon.stub( git, 'initialCommit' ),
+			addRemote: sinon.stub( git, 'addRemote' )
 		};
 	}
 
@@ -66,6 +67,9 @@ describe( 'dev-create-package', () => {
 			expect( spies.getPackageDescription.calledOnce ).to.equal( true );
 			expect( spies.initializeRepository.calledOnce ).to.equal( true );
 			expect( spies.initializeRepository.firstCall.args[ 0 ] ).to.equal( repositoryPath );
+			expect( spies.addRemote.calledOnce ).to.equal( true );
+			expect( spies.addRemote.firstCall.args[ 0 ] ).to.equal( repositoryPath );
+			expect( spies.addRemote.firstCall.args[ 1 ] ).to.equal( gitHubUrl );
 			expect( spies.copy.called ).to.equal( true );
 			expect( spies.updateJSONFile.calledTwice ).to.equal( true );
 			expect( spies.updateJSONFile.firstCall.args[ 0 ] ).to.equal( path.join( repositoryPath, 'package.json' ) );

--- a/dev/tests/dev/create-package.js
+++ b/dev/tests/dev/create-package.js
@@ -24,7 +24,7 @@ describe( 'dev-create-package', () => {
 	const packageName = 'package-name';
 	const applicationName = 'Full application name';
 	const packageVersion = '0.0.1';
-	const gitHubUrl = 'ckeditor5/package-name';
+	const gitHubPath = 'ckeditor5/package-name';
 	const packageDescription = 'Package description.';
 
 	beforeEach( () => createSpies() );
@@ -37,7 +37,7 @@ describe( 'dev-create-package', () => {
 			getPackageName: sinon.stub( inquiries, 'getPackageName' ).returns( new Promise( ( r ) => r( packageName ) ) ),
 			getApplicationName: sinon.stub( inquiries, 'getApplicationName' ).returns( new Promise( ( r ) => r( applicationName ) ) ),
 			getPackageVersion: sinon.stub( inquiries, 'getPackageVersion' ).returns( new Promise( ( r ) => r( packageVersion ) ) ),
-			getPackageGitHubUrl: sinon.stub( inquiries, 'getPackageGitHubUrl' ).returns( new Promise( ( r ) => r( gitHubUrl ) ) ),
+			getPackageGitHubPath: sinon.stub( inquiries, 'getPackageGitHubPath' ).returns( new Promise( ( r ) => r( gitHubPath ) ) ),
 			getPackageDescription: sinon.stub( inquiries, 'getPackageDescription' ).returns( new Promise( ( r ) => r( packageDescription ) ) ),
 			initializeRepository: sinon.stub( git, 'initializeRepository' ),
 			updateJSONFile: sinon.stub( tools, 'updateJSONFile' ),
@@ -63,13 +63,13 @@ describe( 'dev-create-package', () => {
 			expect( spies.getPackageName.calledOnce ).to.equal( true );
 			expect( spies.getApplicationName.calledOnce ).to.equal( true );
 			expect( spies.getPackageVersion.calledOnce ).to.equal( true );
-			expect( spies.getPackageGitHubUrl.calledOnce ).to.equal( true );
+			expect( spies.getPackageGitHubPath.calledOnce ).to.equal( true );
 			expect( spies.getPackageDescription.calledOnce ).to.equal( true );
 			expect( spies.initializeRepository.calledOnce ).to.equal( true );
 			expect( spies.initializeRepository.firstCall.args[ 0 ] ).to.equal( repositoryPath );
 			expect( spies.addRemote.calledOnce ).to.equal( true );
 			expect( spies.addRemote.firstCall.args[ 0 ] ).to.equal( repositoryPath );
-			expect( spies.addRemote.firstCall.args[ 1 ] ).to.equal( gitHubUrl );
+			expect( spies.addRemote.firstCall.args[ 1 ] ).to.equal( gitHubPath );
 			expect( spies.copy.called ).to.equal( true );
 			expect( spies.updateJSONFile.calledTwice ).to.equal( true );
 			expect( spies.updateJSONFile.firstCall.args[ 0 ] ).to.equal( path.join( repositoryPath, 'package.json' ) );
@@ -81,7 +81,7 @@ describe( 'dev-create-package', () => {
 			updateFn = spies.updateJSONFile.secondCall.args[ 1 ];
 			json = updateFn( {} );
 			expect( json.dependencies ).to.be.an( 'object' );
-			expect( json.dependencies[ packageName ] ).to.equal( gitHubUrl );
+			expect( json.dependencies[ packageName ] ).to.equal( gitHubPath );
 			expect( spies.initialCommit.calledOnce ).to.equal( true );
 			expect( spies.initialCommit.firstCall.args[ 0 ] ).to.equal( packageName );
 			expect( spies.initialCommit.firstCall.args[ 1 ] ).to.equal( repositoryPath );

--- a/dev/tests/dev/git.js
+++ b/dev/tests/dev/git.js
@@ -243,5 +243,24 @@ describe( 'utils', () => {
 				expect( shExecStub.firstCall.args[ 0 ] ).to.equal( commitCommands.join( ' && ' ) );
 			} );
 		} );
+
+		describe( 'addRemote', () => {
+			it( 'should be defined', () => expect( git.addRemote ).to.be.a( 'function' ) );
+
+			it( 'should execute add remote commands', () => {
+				const shExecStub = sandbox.stub( tools, 'shExec' );
+				const gitHubPath = 'ckeditor5/ckeditor5-plugin-name';
+				const repositoryPath = '/path/to/repo';
+				const addRemoteCommands = [
+					`cd ${ repositoryPath }`,
+					`git remote add origin git@github.com:${ gitHubPath }.git`
+				];
+
+				git.addRemote( repositoryPath, gitHubPath );
+
+				expect( shExecStub.calledOnce ).to.equal( true );
+				expect( shExecStub.firstCall.args[ 0 ] ).to.equal( addRemoteCommands.join( ' && ' ) );
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes: #89 

During `gulp create-package`, remote was not created. Now, after init a repository, remote will be added and `git push` shouldn't throw any errors.