### PR TITLE
We can remove 'use strict' since we use ES6 modules

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,63 +1,93 @@
 {
-	"esnext": true,
-
-	"requireCurlyBraces": [
-		"if", "else", "for", "while", "do", "switch", "try", "catch"
-	],
-	"requireSpaceBeforeKeywords": true,
-	"requireSpaceAfterKeywords": [
-		"do", "for", "if", "else", "switch", "case", "try", "catch", "void", "while", "with", "return", "typeof"
-	],
-	"requireSpaceBeforeBlockStatements": true,
-	"requireParenthesesAroundIIFE": true,
-	"requireSpacesInConditionalExpression": {
-		"afterTest": true,
-		"beforeConsequent": true,
-		"afterConsequent": true,
-		"beforeAlternate": true
-	},
-	"requireSpacesInFunction": {
-		"beforeOpeningCurlyBrace": true
-	},
-	"disallowSpacesInFunction": {
-		"beforeOpeningRoundBrace": true
-	},
-	"disallowSpacesInCallExpression": true,
-	"disallowMultipleVarDecl": "exceptUndefined",
-	"requireBlocksOnNewline": true,
-	"disallowPaddingNewlinesInBlocks": true,
-	"requirePaddingNewlinesBeforeKeywords": [
-		"do", "for", "if", "switch", "case", "try", "while", "with", "return"
-	],
-	"requireSpacesInsideObjectBrackets": "all",
-	"requireSpacesInsideArrayBrackets": "all",
-	"requireSpacesInsideParentheses": "all",
-	"disallowSpaceAfterObjectKeys": true,
-	"requireSpaceBeforeObjectValues": true,
-	"requireCommaBeforeLineBreak": true,
-	"requireOperatorBeforeLineBreak": true,
-	"disallowSpaceAfterPrefixUnaryOperators": true,
-	"disallowSpaceBeforePostfixUnaryOperators": true,
-	"requireSpaceBeforeBinaryOperators": true,
-	"disallowImplicitTypeConversion": [
-		"numeric", "binary", "string"
-	],
-	"requireCamelCaseOrUpperCaseIdentifiers": true,
-	"requireSpaceAfterBinaryOperators": true,
-	"disallowKeywords": [
-		"with"
-	],
-	"disallowMultipleLineStrings": true,
-	"disallowMultipleLineBreaks": true,
-	"disallowMixedSpacesAndTabs": true,
-	"disallowTrailingWhitespace": true,
-	"maximumLineLength": 140,
-	"requireCapitalizedConstructors": true,
-	"requireDotNotation": true,
-	"disallowYodaConditions": true,
-	"disallowNewlineBeforeBlockStatements": true,
-	"validateLineBreaks": "LF",
-	"validateQuoteMarks": "'",
-	"validateIndentation": "\t",
-	"safeContextKeyword": [ "that" ]
+  "esnext": true,
+  "requireCurlyBraces": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "switch",
+    "try",
+    "catch"
+  ],
+  "requireSpaceBeforeKeywords": true,
+  "requireSpaceAfterKeywords": [
+    "do",
+    "for",
+    "if",
+    "else",
+    "switch",
+    "case",
+    "try",
+    "catch",
+    "void",
+    "while",
+    "with",
+    "return",
+    "typeof"
+  ],
+  "requireSpaceBeforeBlockStatements": true,
+  "requireParenthesesAroundIIFE": true,
+  "requireSpacesInConditionalExpression": {
+    "afterTest": true,
+    "beforeConsequent": true,
+    "afterConsequent": true,
+    "beforeAlternate": true
+  },
+  "requireSpacesInFunction": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "disallowSpacesInFunction": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInCallExpression": true,
+  "disallowMultipleVarDecl": "exceptUndefined",
+  "requireBlocksOnNewline": true,
+  "disallowPaddingNewlinesInBlocks": true,
+  "requirePaddingNewlinesBeforeKeywords": [
+    "do",
+    "for",
+    "if",
+    "switch",
+    "case",
+    "try",
+    "while",
+    "with",
+    "return"
+  ],
+  "requireSpacesInsideObjectBrackets": "all",
+  "requireSpacesInsideArrayBrackets": "all",
+  "requireSpacesInsideParentheses": "all",
+  "disallowSpaceAfterObjectKeys": true,
+  "requireSpaceBeforeObjectValues": true,
+  "requireCommaBeforeLineBreak": true,
+  "requireOperatorBeforeLineBreak": true,
+  "disallowSpaceAfterPrefixUnaryOperators": true,
+  "disallowSpaceBeforePostfixUnaryOperators": true,
+  "requireSpaceBeforeBinaryOperators": true,
+  "disallowImplicitTypeConversion": [
+    "numeric",
+    "binary",
+    "string"
+  ],
+  "requireCamelCaseOrUpperCaseIdentifiers": true,
+  "requireSpaceAfterBinaryOperators": true,
+  "disallowKeywords": [
+    "with"
+  ],
+  "disallowMultipleLineStrings": true,
+  "disallowMultipleLineBreaks": true,
+  "disallowMixedSpacesAndTabs": true,
+  "disallowTrailingWhitespace": true,
+  "maximumLineLength": 140,
+  "requireCapitalizedConstructors": true,
+  "requireDotNotation": true,
+  "disallowYodaConditions": true,
+  "disallowNewlineBeforeBlockStatements": true,
+  "validateLineBreaks": "LF",
+  "validateQuoteMarks": "'",
+  "validateIndentation": "\t",
+  "safeContextKeyword": [
+    "that"
+  ]
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,13 +1,12 @@
 {
-	"browser": true,
-	"esnext": true,
-
-	"immed": true,
-	"loopfunc": true,
-	"noarg": true,
-	"nonbsp": true,
-	"undef": true,
-	"unused": true,
-	"strict": "global",
-	"varstmt": true
+  "browser": true,
+  "esnext": true,
+  "immed": true,
+  "loopfunc": true,
+  "noarg": true,
+  "nonbsp": true,
+  "undef": true,
+  "unused": true,
+  "strict": "implied",
+  "varstmt": true
 }

--- a/bender.js
+++ b/bender.js
@@ -1,4 +1,4 @@
-/* jshint browser: false, node: true */
+/* jshint browser: false, node: true, strict: true */
 
 'use strict';
 

--- a/dev/.jshintrc
+++ b/dev/.jshintrc
@@ -1,13 +1,12 @@
 {
-	"node": true,
-	"esnext": true,
-
-	"immed": true,
-	"loopfunc": true,
-	"noarg": true,
-	"nonbsp": true,
-	"undef": true,
-	"unused": true,
-	"strict": true,
-	"varstmt": true
+  "node": true,
+  "esnext": true,
+  "immed": true,
+  "loopfunc": true,
+  "noarg": true,
+  "nonbsp": true,
+  "undef": true,
+  "unused": true,
+  "strict": true,
+  "varstmt": true
 }

--- a/dev/tasks/dev/templates/gulpfile.js
+++ b/dev/tasks/dev/templates/gulpfile.js
@@ -1,4 +1,4 @@
-/* jshint node: true */
+/* jshint browser: false, node: true, strict: true */
 
 'use strict';
 

--- a/dev/tasks/exec/functions/remove-use-strict.js
+++ b/dev/tasks/exec/functions/remove-use-strict.js
@@ -11,6 +11,12 @@ const replace = require( 'gulp-replace' );
 const mergeStream = require( 'merge-stream' );
 const filterGitignore = require( '../utils/filtergitignore' );
 
+const jshintrcDirs = [
+	'/',
+	'dev/',
+	'tests/'
+];
+
 /**
  * Removes lines with `'use strict';` directive.
  *
@@ -33,14 +39,18 @@ module.exports = function executeRemoveUseStrict( workdir ) {
 // @param {String} workdir Path of directory to be processed.
 // @returns {Stream}
 function updateJshintrc( workdir ) {
-	const jshintrcPath = path.join( workdir, '.jshintrc' );
-	const strictRegex = /("strict":.*?").*?(".*)/;
-	const replaceWith = 'implied';
+	const jshintrcGlob = jshintrcDirs.map(
+		dir => path.join( workdir, dir, '.jshintrc' )
+	);
 
-	return gulp.src( jshintrcPath )
+	// Match everything after `"strict":` apart from optional comma. This should be matched into separate group.
+	const strictRegex = /"strict":[^,\n\r]*(,?)$/m;
+	const replaceWith = '"strict": "implied"';
+
+	return gulp.src( jshintrcGlob, { base: workdir } )
 		.pipe( replace(
 			strictRegex,
-			`$1${ replaceWith }$2`
+			`${ replaceWith }$1`
 		) )
 		.pipe( gulp.dest( workdir ) );
 }

--- a/dev/tasks/exec/functions/remove-use-strict.js
+++ b/dev/tasks/exec/functions/remove-use-strict.js
@@ -1,0 +1,35 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const gulp = require( 'gulp' );
+const path = require( 'path' );
+const replace = require( 'gulp-replace' );
+const filterGitignore = require( '../utils/filtergitignore' );
+
+/**
+ * Removes lines with `'use strict';` directive.
+ *
+ * Example:
+ *
+ *		gulp exec --task remove-use-strict
+ *
+ * @param {String} workdir
+ * @returns {Stream}
+ */
+module.exports = function executeRemoveUseStrict( workdir ) {
+	const useStrictRegex = /^\s*'use strict';\s*$/gm;
+	const glob = path.join( workdir, '**/*' );
+
+	return gulp.src( glob )
+		.pipe( filterGitignore() )
+		.pipe( replace(
+			useStrictRegex,
+			'',
+			{ skipBinary: true }
+		) )
+		.pipe( gulp.dest( workdir ) );
+};

--- a/dev/tasks/exec/functions/remove-use-strict.js
+++ b/dev/tasks/exec/functions/remove-use-strict.js
@@ -11,12 +11,6 @@ const replace = require( 'gulp-replace' );
 const filterGitignore = require( '../utils/filtergitignore' );
 const tools = require( '../../../utils/tools' );
 
-const jshintrcDirs = [
-	'/',
-	'dev/',
-	'tests/'
-];
-
 /**
  * Removes lines with `'use strict';` directive.
  *
@@ -29,6 +23,7 @@ const jshintrcDirs = [
  */
 module.exports = function executeRemoveUseStrict( workdir ) {
 	updateJshintrc( workdir );
+	reformatDevsJshintrc( workdir );
 
 	return removeUseStrict( workdir );
 };
@@ -37,7 +32,7 @@ module.exports = function executeRemoveUseStrict( workdir ) {
 //
 // @param {String} workdir Path of directory to be processed.
 function updateJshintrc( workdir ) {
-	jshintrcDirs.forEach(
+	[ '/', 'tests/' ].forEach(
 		dir => {
 			const jshintrcPath = path.join( workdir, dir, '.jshintrc' );
 
@@ -50,12 +45,21 @@ function updateJshintrc( workdir ) {
 	);
 }
 
+// Only reformats (to match other .jshintrc files and package.json code style) the .jshintrc from dev/.
+//
+// @param {String} workdir Path of directory to be processed.
+function reformatDevsJshintrc( workdir ) {
+	const jshintrcPath = path.join( workdir, 'dev', '.jshintrc' );
+
+	tools.updateJSONFile( jshintrcPath, json => json );
+}
+
 // Removes `'use strict';` directive from project's source files. Omits files listed in `.gitignore`.
 //
 // @param {String} workdir Path of directory to be processed.
 // @returns {Stream}
 function removeUseStrict( workdir ) {
-	const glob = path.join( workdir, '**/*.js' );
+	const glob = path.join( workdir, '@(src|tests)/**/*.js' );
 	const useStrictRegex = /^\s*'use strict';\s*$/gm;
 
 	return gulp.src( glob )

--- a/dev/tasks/exec/tasks.js
+++ b/dev/tasks/exec/tasks.js
@@ -23,6 +23,10 @@ const ckeditor5Dirs = require( '../../utils/ckeditor5-dirs' );
  *
  *		gulp exec --task task-name --repository ckeditor5-utils
  *
+ * Example of running task including root `ckeditor5` package
+ *
+ *		gulp exec --task task-name --include-root
+ *
  * @param {Object} config Task runner configuration.
  * @returns {Stream} Stream with processed files.
  */
@@ -75,8 +79,9 @@ function execute( execTask, ckeditor5Path, packageJSON, workspaceRoot, params ) 
 	const workspacePath = path.join( ckeditor5Path, workspaceRoot );
 	const mergedStream = merge();
 	const specificRepository = params.repository;
+	const includeRoot = !!params[ 'include-root' ];
 
-	let devDirectories = ckeditor5Dirs.getDevDirectories( workspacePath, packageJSON, ckeditor5Path );
+	let devDirectories = ckeditor5Dirs.getDevDirectories( workspacePath, packageJSON, ckeditor5Path, includeRoot );
 
 	if ( specificRepository ) {
 		devDirectories = devDirectories.filter( ( dir ) => {

--- a/dev/tests/utils/ckeditor5-dirs.js
+++ b/dev/tests/utils/ckeditor5-dirs.js
@@ -141,6 +141,29 @@ describe( 'utils', () => {
 						repositoryPath: '/workspace/path/ckeditor5/node_modules/ckeditor5-core'
 					} );
 			} );
+
+			it( 'should return only ckeditor5 directories in development mode, including root directory', () => {
+				sandbox.stub( ckeditor5Dirs, 'getDirectories', () => sourceDirectories );
+				sandbox.stub( ckeditor5Dirs, 'getDependencies', () => dependencies );
+				sandbox.stub( git, 'parseRepositoryUrl' ).returns( repositoryInfo );
+				const includeRoot = true;
+
+				const directories = ckeditor5Dirs.getDevDirectories( workspacePath, packageJSONDependencies, ckeditor5Path, includeRoot );
+
+				expect( directories.length ).equal( 3 );
+				expect( directories[ 0 ] ).eql( {
+						repositoryURL: 'ckeditor/ckeditor5-plugin-image',
+						repositoryPath: '/workspace/path/ckeditor5/node_modules/ckeditor5-plugin-image'
+					} );
+				expect( directories[ 1 ] ).eql( {
+						repositoryURL: 'ckeditor/ckeditor5-core',
+						repositoryPath: '/workspace/path/ckeditor5/node_modules/ckeditor5-core'
+					} );
+				expect( directories[ 2 ] ).eql( {
+						repositoryURL: 'ckeditor/ckeditor5',
+						repositoryPath: '/workspace/path/ckeditor5'
+					} );
+			} );
 		} );
 	} );
 } );

--- a/dev/tests/utils/ckeditor5-dirs.js
+++ b/dev/tests/utils/ckeditor5-dirs.js
@@ -65,9 +65,9 @@ describe( 'utils', () => {
 				sandbox.stub( tools, 'getDirectories', () => sourceDirectories );
 				const directories = ckeditor5Dirs.getDirectories( workspacePath );
 
-				expect( directories.length ).equal( 2 );
-				expect( directories[ 0 ] ).equal( 'ckeditor5-core' );
-				expect( directories[ 1 ] ).equal( 'ckeditor5-plugin-image' );
+				expect( directories.length ).to.equal( 2 );
+				expect( directories[ 0 ] ).to.equal( 'ckeditor5-core' );
+				expect( directories[ 1 ] ).to.equal( 'ckeditor5-plugin-image' );
 			} );
 		} );
 
@@ -131,12 +131,12 @@ describe( 'utils', () => {
 
 				const directories = ckeditor5Dirs.getDevDirectories( workspacePath, packageJSONDependencies, ckeditor5Path );
 
-				expect( directories.length ).equal( 2 );
-				expect( directories[ 0 ] ).eql( {
+				expect( directories.length ).to.equal( 2 );
+				expect( directories[ 0 ] ).to.deep.equal( {
 						repositoryURL: 'ckeditor/ckeditor5-plugin-image',
 						repositoryPath: '/workspace/path/ckeditor5/node_modules/ckeditor5-plugin-image'
 					} );
-				expect( directories[ 1 ] ).eql( {
+				expect( directories[ 1 ] ).to.deep.equal( {
 						repositoryURL: 'ckeditor/ckeditor5-core',
 						repositoryPath: '/workspace/path/ckeditor5/node_modules/ckeditor5-core'
 					} );
@@ -150,18 +150,18 @@ describe( 'utils', () => {
 
 				const directories = ckeditor5Dirs.getDevDirectories( workspacePath, packageJSONDependencies, ckeditor5Path, includeRoot );
 
-				expect( directories.length ).equal( 3 );
-				expect( directories[ 0 ] ).eql( {
+				expect( directories.length ).to.equal( 3 );
+				expect( directories[ 0 ] ).to.deep.equal( {
+						repositoryURL: 'ckeditor/ckeditor5',
+						repositoryPath: '/workspace/path/ckeditor5'
+					} );
+				expect( directories[ 1 ] ).to.deep.equal( {
 						repositoryURL: 'ckeditor/ckeditor5-plugin-image',
 						repositoryPath: '/workspace/path/ckeditor5/node_modules/ckeditor5-plugin-image'
 					} );
-				expect( directories[ 1 ] ).eql( {
+				expect( directories[ 2 ] ).to.deep.equal( {
 						repositoryURL: 'ckeditor/ckeditor5-core',
 						repositoryPath: '/workspace/path/ckeditor5/node_modules/ckeditor5-core'
-					} );
-				expect( directories[ 2 ] ).eql( {
-						repositoryURL: 'ckeditor/ckeditor5',
-						repositoryPath: '/workspace/path/ckeditor5'
 					} );
 			} );
 		} );

--- a/dev/utils/ckeditor5-dirs.js
+++ b/dev/utils/ckeditor5-dirs.js
@@ -72,18 +72,26 @@ module.exports = {
 	 * @param {String} workspacePath Absolute path to workspace.
 	 * @param {Object} packageJSON Contents of `ckeditor5` repo `package.json` file.
 	 * @param {String} ckeditor5Path Absolute path to ckeditor5 root directory.
+	 * @param {Boolean} includeRoot Include main `ckeditor5` package.
 	 * @returns {Array.<Object>}
 	 */
-	getDevDirectories( workspacePath, packageJSON, ckeditor5Path ) {
+	getDevDirectories( workspacePath, packageJSON, ckeditor5Path, includeRoot ) {
 		const directories = this.getDirectories( workspacePath );
 		const dependencies = this.getDependencies( packageJSON.dependencies );
+
+		if ( includeRoot ) {
+			// Add root dependency and directory.
+			dependencies.ckeditor5 = 'ckeditor/ckeditor5';
+			directories.push( 'ckeditor5' );
+		}
 
 		let devDirectories = [];
 
 		for ( let dependency in dependencies ) {
 			const repositoryURL = dependencies[ dependency ];
 			const urlInfo = git.parseRepositoryUrl( repositoryURL );
-			const repositoryPath = path.join( ckeditor5Path, 'node_modules', dependency );
+			const isRootDep = dependency == 'ckeditor5';
+			const repositoryPath = isRootDep ? ckeditor5Path : path.join( ckeditor5Path, 'node_modules', dependency );
 
 			// Check if repository's directory already exists.
 			if ( directories.indexOf( urlInfo.name ) > -1 ) {

--- a/dev/utils/ckeditor5-dirs.js
+++ b/dev/utils/ckeditor5-dirs.js
@@ -79,19 +79,12 @@ module.exports = {
 		const directories = this.getDirectories( workspacePath );
 		const dependencies = this.getDependencies( packageJSON.dependencies );
 
-		if ( includeRoot ) {
-			// Add root dependency and directory.
-			dependencies.ckeditor5 = 'ckeditor/ckeditor5';
-			directories.push( 'ckeditor5' );
-		}
-
 		let devDirectories = [];
 
 		for ( let dependency in dependencies ) {
 			const repositoryURL = dependencies[ dependency ];
 			const urlInfo = git.parseRepositoryUrl( repositoryURL );
-			const isRootDep = dependency == 'ckeditor5';
-			const repositoryPath = isRootDep ? ckeditor5Path : path.join( ckeditor5Path, 'node_modules', dependency );
+			const repositoryPath = path.join( ckeditor5Path, 'node_modules', dependency );
 
 			// Check if repository's directory already exists.
 			if ( directories.indexOf( urlInfo.name ) > -1 ) {
@@ -100,6 +93,14 @@ module.exports = {
 					repositoryURL
 				} );
 			}
+		}
+
+		if ( includeRoot ) {
+			// Add root dependency and directory.
+			devDirectories.unshift( {
+				repositoryPath: ckeditor5Path,
+				repositoryURL: 'ckeditor/ckeditor5'
+			} );
 		}
 
 		return devDirectories;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,4 @@
-/* jshint node: true */
+/* jshint browser: false, node: true, strict: true */
 
 'use strict';
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "parse-gitignore": "^0.2.0",
     "pretty-bytes": "^3.0.1",
     "regenerator-runtime": "^0.9.5",
-    "parse-gitignore": "^0.2.0",
     "replace": "^0.3.0",
     "rollup": "^0.33.0",
     "rollup-plugin-babel": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "parse-gitignore": "^0.2.0",
     "pretty-bytes": "^3.0.1",
     "regenerator-runtime": "^0.9.5",
+    "parse-gitignore": "^0.2.0",
     "replace": "^0.3.0",
     "rollup": "^0.33.0",
     "rollup-plugin-babel": "^2.4.0",

--- a/src/command/attributecommand.js
+++ b/src/command/attributecommand.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import Command from './command.js';
 import TreeWalker from '../engine/model/treewalker.js';
 import Range from '../engine/model/range.js';

--- a/src/command/command.js
+++ b/src/command/command.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import ObservableMixin from '../utils/observablemixin.js';
 import mix from '../utils/mix.js';
 

--- a/src/editor/editor.js
+++ b/src/editor/editor.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import EmitterMixin from '../utils/emittermixin.js';
 import Config from '../utils/config.js';
 import PluginCollection from '../plugincollection.js';

--- a/src/editor/standardeditor.js
+++ b/src/editor/standardeditor.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import Editor from './editor.js';
 import KeystrokeHandler from '../keystrokehandler.js';
 import EditingController from '../engine/editingcontroller.js';

--- a/src/feature.js
+++ b/src/feature.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import Plugin from './plugin.js';
 
 /**

--- a/src/keystrokehandler.js
+++ b/src/keystrokehandler.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import EmitterMixin from './utils/emittermixin.js';
 import { getCode, parseKeystroke } from './utils/keyboard.js';
 

--- a/src/load__amd.js
+++ b/src/load__amd.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 // We import the 'require' module, so Require.JS gives us a localized version of require().
 // Otherwise we would use the global one which resolves paths relatively to the base dir.
 import require from 'require';

--- a/src/load__cjs.js
+++ b/src/load__cjs.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 /* global require */
 
 export default function load( modulePath ) {

--- a/src/load__esnext.js
+++ b/src/load__esnext.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 /* global System */
 
 export default function load( modulePath ) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import ObservableMixin from './utils/observablemixin.js';
 import mix from './utils/mix.js';
 

--- a/src/plugincollection.js
+++ b/src/plugincollection.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import Plugin from './plugin.js';
 import CKEditorError from './utils/ckeditorerror.js';
 import log from './utils/log.js';

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -1,25 +1,23 @@
 {
-	"browser": true,
-	"esnext": true,
-
-	"expr": true,
-	"immed": true,
-	"loopfunc": true,
-	"noarg": true,
-	"nonbsp": true,
-	"strict": "global",
-	"undef": true,
-	"unused": true,
-	"varstmt": true,
-
-	"globals": {
-		"after": false,
-		"afterEach": false,
-		"before": false,
-		"beforeEach": false,
-		"describe": false,
-		"expect": false,
-		"it": false,
-		"sinon": false
-	}
+  "browser": true,
+  "esnext": true,
+  "expr": true,
+  "immed": true,
+  "loopfunc": true,
+  "noarg": true,
+  "nonbsp": true,
+  "strict": "implied",
+  "undef": true,
+  "unused": true,
+  "varstmt": true,
+  "globals": {
+    "after": false,
+    "afterEach": false,
+    "before": false,
+    "beforeEach": false,
+    "describe": false,
+    "expect": false,
+    "it": false,
+    "sinon": false
+  }
 }

--- a/tests/_utils-tests/classictesteditor.js
+++ b/tests/_utils-tests/classictesteditor.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import StandardEditor from '/ckeditor5/editor/standardeditor.js';
 import ClassicTestEditor from '/tests/ckeditor5/_utils/classictesteditor.js';
 import HtmlDataProcessor from '/ckeditor5/engine/dataprocessor/htmldataprocessor.js';

--- a/tests/_utils-tests/createsinonsandbox.js
+++ b/tests/_utils-tests/createsinonsandbox.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import testUtils from '/tests/ckeditor5/_utils/utils.js';
 
 const obj = {

--- a/tests/_utils-tests/modeltesteditor.js
+++ b/tests/_utils-tests/modeltesteditor.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import Editor from '/ckeditor5/editor/editor.js';
 import ModelTestEditor from '/tests/ckeditor5/_utils/modeltesteditor.js';
 import HtmlDataProcessor from '/ckeditor5/engine/dataprocessor/htmldataprocessor.js';

--- a/tests/_utils-tests/module__amd.js
+++ b/tests/_utils-tests/module__amd.js
@@ -5,8 +5,6 @@
 
 /* global require, bender */
 
-'use strict';
-
 import testUtils from '/tests/ckeditor5/_utils/utils.js';
 import moduleTestUtils from '/tests/ckeditor5/_utils/module.js';
 

--- a/tests/_utils-tests/module__cjs.js
+++ b/tests/_utils-tests/module__cjs.js
@@ -5,8 +5,6 @@
 
 /* global require, process */
 
-'use strict';
-
 import testUtils from '/tests/ckeditor5/_utils/utils.js';
 import moduleTestUtils from '/tests/ckeditor5/_utils/module.js';
 

--- a/tests/_utils-tests/virtualtesteditor.js
+++ b/tests/_utils-tests/virtualtesteditor.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import StandardEditor from '/ckeditor5/editor/standardeditor.js';
 import VirtualTestEditor from '/tests/ckeditor5/_utils/virtualtesteditor.js';
 import HtmlDataProcessor from '/ckeditor5/engine/dataprocessor/htmldataprocessor.js';

--- a/tests/_utils/classictesteditor.js
+++ b/tests/_utils/classictesteditor.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import StandardEditor from '/ckeditor5/editor/standardeditor.js';
 
 import HtmlDataProcessor from '/ckeditor5/engine/dataprocessor/htmldataprocessor.js';

--- a/tests/_utils/modeltesteditor.js
+++ b/tests/_utils/modeltesteditor.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import Editor from '/ckeditor5/editor/editor.js';
 import HtmlDataProcessor from '/ckeditor5/engine/dataprocessor/htmldataprocessor.js';
 

--- a/tests/_utils/module__amd.js
+++ b/tests/_utils/module__amd.js
@@ -5,8 +5,6 @@
 
 /* globals bender, define, require */
 
-'use strict';
-
 /**
  * AMD tools related to CKEditor.
  */

--- a/tests/_utils/module__cjs.js
+++ b/tests/_utils/module__cjs.js
@@ -5,8 +5,6 @@
 
 /* globals require, process */
 
-'use strict';
-
 const mockery = require( 'mockery' );
 mockery.enable( {
 	warnOnReplace: false,

--- a/tests/_utils/utils.js
+++ b/tests/_utils/utils.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 /**
  * General test utils for CKEditor.
  */

--- a/tests/_utils/virtualtesteditor.js
+++ b/tests/_utils/virtualtesteditor.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import StandardEditor from '/ckeditor5/editor/standardeditor.js';
 import HtmlDataProcessor from '/ckeditor5/engine/dataprocessor/htmldataprocessor.js';
 

--- a/tests/command/attributecommand.js
+++ b/tests/command/attributecommand.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import Editor from '/ckeditor5/editor/editor.js';
 import Document from '/ckeditor5/engine/model/document.js';
 import AttributeCommand from '/ckeditor5/command/attributecommand.js';

--- a/tests/command/command.js
+++ b/tests/command/command.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import Editor from '/ckeditor5/editor/editor.js';
 import Command from '/ckeditor5/command/command.js';
 

--- a/tests/editor/editor-base.js
+++ b/tests/editor/editor-base.js
@@ -5,8 +5,6 @@
 
 /* bender-tags: editor */
 
-'use strict';
-
 import Editor from '/ckeditor5/editor/editor.js';
 import Command from '/ckeditor5/command/command.js';
 import Locale from '/ckeditor5/utils/locale.js';

--- a/tests/editor/editor.js
+++ b/tests/editor/editor.js
@@ -5,8 +5,6 @@
 
 /* bender-tags: editor, browser-only */
 
-'use strict';
-
 import moduleUtils from '/tests/ckeditor5/_utils/module.js';
 import Editor from '/ckeditor5/editor/editor.js';
 import Plugin from '/ckeditor5/plugin.js';

--- a/tests/editor/standardeditor.js
+++ b/tests/editor/standardeditor.js
@@ -5,8 +5,6 @@
 
 /* bender-tags: editor, browser-only */
 
-'use strict';
-
 import StandardEditor from '/ckeditor5/editor/standardeditor.js';
 import HtmlDataProcessor from '/ckeditor5/engine/dataprocessor/htmldataprocessor.js';
 import { getData, setData } from '/tests/engine/_utils/model.js';

--- a/tests/keystrokehandler.js
+++ b/tests/keystrokehandler.js
@@ -5,8 +5,6 @@
 
 /* bender-tags: browser-only */
 
-'use strict';
-
 import VirtualTestEditor from '/tests/ckeditor5/_utils/virtualtesteditor.js';
 import KeystrokeHandler from '/ckeditor5/keystrokehandler.js';
 import { keyCodes } from '/ckeditor5/utils/keyboard.js';

--- a/tests/load.js
+++ b/tests/load.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import load from '/ckeditor5/load.js';
 
 describe( 'load()', () => {

--- a/tests/plugin.js
+++ b/tests/plugin.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md.
  */
 
-'use strict';
-
 import Plugin from '/ckeditor5/plugin.js';
 import Editor from '/ckeditor5/editor/editor.js';
 

--- a/tests/plugincollection.js
+++ b/tests/plugincollection.js
@@ -5,8 +5,6 @@
 
 /* bender-tags: browser-only */
 
-'use strict';
-
 import moduleUtils from '/tests/ckeditor5/_utils/module.js';
 import testUtils from '/tests/ckeditor5/_utils/utils.js';
 import Editor from '/ckeditor5/editor/editor.js';


### PR DESCRIPTION
Fixes: https://github.com/ckeditor/ckeditor5/issues/149

Allows for `'use strict';` directive removal from our source code. Respects `.gitignore`'s rules. What it also does is update `.jshintrc` option `"strict"` with `"implied"` value - instead of usual `"global"`.

Task will be considered done when all code in every `ckeditor5-*` package will be processed with this script.

Example of usage:
```
gulp exec --task remove-use-strict
```

I've also added support for processing root package `ckeditor5`. This can be achieved with:
```
gulp exec --task remove-use-strict --include-root
```