### PR TITLE
Removed ckeditor5-delete from dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   ],
   "dependencies": {
     "ckeditor5-basic-styles": "ckeditor/ckeditor5-basic-styles",
-    "ckeditor5-delete": "ckeditor/ckeditor5-delete",
     "ckeditor5-editor-classic": "ckeditor/ckeditor5-editor-classic",
     "ckeditor5-engine": "ckeditor/ckeditor5-engine",
     "ckeditor5-enter": "ckeditor/ckeditor5-enter",


### PR DESCRIPTION
Fixes: https://github.com/ckeditor/ckeditor5-typing/issues/17

This PR can be merged after https://github.com/ckeditor/ckeditor5-typing/pull/24