### PR TITLE
Added task allowing for custom shell commands

### DIFF
--- a/dev/tasks/exec/functions/sh.js
+++ b/dev/tasks/exec/functions/sh.js
@@ -1,0 +1,30 @@
+/**
+ * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const tools = require( '../../../utils/tools' );
+
+/**
+ * Runs custom shell command over each package.
+ *
+ * Example:
+ *
+ *		gulp exec --task sh --cmd "sed 's/find/replace' file.js"
+ *
+ * @param {String} workdir
+ * @param {Object} params
+ */
+module.exports = function executeShellCommand( workdir, params ) {
+	// Needed to see results of commands printing to stdout/stderr.
+	const shouldLogOutput = true;
+	const cmd = params.cmd;
+
+	if ( !cmd ) {
+		throw new Error( 'You must provide command to execute with parameter: --cmd "command"' );
+	}
+
+	tools.shExec( cmd, shouldLogOutput );
+};


### PR DESCRIPTION
Resolves: https://github.com/ckeditor/ckeditor5/issues/235

Example of use:

    gulp exec --task sh --cmd "sed 's/find/replace' file.js"