### PR TITLE
Updated in-node tests with new `ckeditor5-dev-utils`

### DIFF
--- a/dev/tasks/test/tasks.js
+++ b/dev/tasks/test/tasks.js
@@ -11,7 +11,7 @@ const filterBy = require( 'gulp-filter-by' );
 const filter = require( 'gulp-filter' );
 const sinon = require( 'sinon' );
 const semver = require( 'semver' );
-const { tools, build } = require( 'ckeditor5-dev-utils' );
+const { tools, stream } = require( 'ckeditor5-dev-utils' );
 const benderConfig = require( '../../../bender' );
 
 /**
@@ -100,7 +100,7 @@ module.exports = () => {
 				.pipe( tasks.skipManual() )
 				.pipe( tasks.skipIgnored() )
 				.pipe( mocha( { reporter: 'progress' } ) )
-				.pipe( tasks.coverage ? istanbul.writeReports() : build.noop() );
+				.pipe( tasks.coverage ? istanbul.writeReports() : stream.noop() );
 		},
 
 		/**
@@ -132,7 +132,7 @@ module.exports = () => {
 		devTest() {
 			return gulp.src( 'dev/tests/**/*.js' )
 				.pipe( mocha() )
-				.pipe( tasks.coverage ? istanbul.writeReports() : build.noop() );
+				.pipe( tasks.coverage ? istanbul.writeReports() : stream.noop() );
 		},
 
 		/**

--- a/dev/tests/test/tasks.js
+++ b/dev/tests/test/tasks.js
@@ -9,12 +9,12 @@
 
 const Vinyl = require( 'vinyl' );
 const tasks = require( '../../tasks/test/tasks' )();
-const { stream, tools } = require( 'ckeditor5-dev-utils' );
+const { stream: streamUtils, tools } = require( 'ckeditor5-dev-utils' );
 
 describe( 'test-node', () => {
 	describe( 'skipManual', () => {
 		it( 'should skip manual tests', ( done ) => {
-			const streamTask = tasks.skipManual();
+			const stream = tasks.skipManual();
 			const spy = sinon.spy();
 			const stub = sinon.stub( tools, 'isFile', ( file ) => {
 				return file == 'file1.md';
@@ -30,25 +30,25 @@ describe( 'test-node', () => {
 				contents: null
 			} );
 
-			streamTask.pipe( stream.noop( spy ) );
+			stream.pipe( streamUtils.noop( spy ) );
 
-			streamTask.once( 'finish', () => {
+			stream.once( 'finish', () => {
 				sinon.assert.calledOnce( spy );
 				sinon.assert.calledWithExactly( spy, unitTestFile );
 				done();
 			} );
 
-			streamTask.write( manualTestFile );
-			streamTask.write( unitTestFile );
+			stream.write( manualTestFile );
+			stream.write( unitTestFile );
 
-			streamTask.end();
+			stream.end();
 			stub.restore();
 		} );
 	} );
 
 	describe( 'skipIgnored', () => {
 		it( 'should skip files marked to ignore', ( done ) => {
-			const streamTask = tasks.skipIgnored();
+			const stream = tasks.skipIgnored();
 			const spy = sinon.spy();
 			const unitTestFile = new Vinyl( {
 				cwd: './',
@@ -60,18 +60,18 @@ describe( 'test-node', () => {
 				path: 'file1.js',
 				contents: new Buffer( '/* bender-tags: tag, browser-only */' )
 			} );
-			const noop = stream.noop( spy );
+			const noop = streamUtils.noop( spy );
 			noop.once( 'finish', () => {
 				sinon.assert.calledOnce( spy );
 				sinon.assert.calledWithExactly( spy, unitTestFile );
 				done();
 			} );
 
-			streamTask.pipe( noop );
-			streamTask.write( manualTestFile );
-			streamTask.write( unitTestFile );
+			stream.pipe( noop );
+			stream.write( manualTestFile );
+			stream.write( unitTestFile );
 
-			streamTask.end();
+			stream.end();
 		} );
 	} );
 } );

--- a/dev/tests/test/tasks.js
+++ b/dev/tests/test/tasks.js
@@ -9,12 +9,12 @@
 
 const Vinyl = require( 'vinyl' );
 const tasks = require( '../../tasks/test/tasks' )();
-const { build, tools } = require( 'ckeditor5-dev-utils' );
+const { stream, tools } = require( 'ckeditor5-dev-utils' );
 
 describe( 'test-node', () => {
 	describe( 'skipManual', () => {
 		it( 'should skip manual tests', ( done ) => {
-			const stream = tasks.skipManual();
+			const streamTask = tasks.skipManual();
 			const spy = sinon.spy();
 			const stub = sinon.stub( tools, 'isFile', ( file ) => {
 				return file == 'file1.md';
@@ -30,25 +30,25 @@ describe( 'test-node', () => {
 				contents: null
 			} );
 
-			stream.pipe( build.noop( spy ) );
+			streamTask.pipe( stream.noop( spy ) );
 
-			stream.once( 'finish', () => {
+			streamTask.once( 'finish', () => {
 				sinon.assert.calledOnce( spy );
 				sinon.assert.calledWithExactly( spy, unitTestFile );
 				done();
 			} );
 
-			stream.write( manualTestFile );
-			stream.write( unitTestFile );
+			streamTask.write( manualTestFile );
+			streamTask.write( unitTestFile );
 
-			stream.end();
+			streamTask.end();
 			stub.restore();
 		} );
 	} );
 
 	describe( 'skipIgnored', () => {
 		it( 'should skip files marked to ignore', ( done ) => {
-			const stream = tasks.skipIgnored();
+			const streamTask = tasks.skipIgnored();
 			const spy = sinon.spy();
 			const unitTestFile = new Vinyl( {
 				cwd: './',
@@ -60,18 +60,18 @@ describe( 'test-node', () => {
 				path: 'file1.js',
 				contents: new Buffer( '/* bender-tags: tag, browser-only */' )
 			} );
-			const noop = build.noop( spy );
+			const noop = stream.noop( spy );
 			noop.once( 'finish', () => {
 				sinon.assert.calledOnce( spy );
 				sinon.assert.calledWithExactly( spy, unitTestFile );
 				done();
 			} );
 
-			stream.pipe( noop );
-			stream.write( manualTestFile );
-			stream.write( unitTestFile );
+			streamTask.pipe( noop );
+			streamTask.write( manualTestFile );
+			streamTask.write( unitTestFile );
 
-			stream.end();
+			streamTask.end();
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes https://github.com/ckeditor/ckeditor5/issues/284.

Changed `ckeditor5-dev-utils` submodule name from `build` to `stream`.

**Please close this PR only after following PRs:**
https://github.com/ckeditor/ckeditor5-dev-utils/pull/13
https://github.com/ckeditor/ckeditor5-dev-builder/pull/7