### PR TITLE
Configure bundling and building paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 .*/**
 
 node_modules/**
-build/**
-bundle/**
+build/dist/**
+build/modules/**
+build/docs/**
 coverage/**
-dist/**

--- a/bender.js
+++ b/bender.js
@@ -25,7 +25,7 @@ const config = {
 			files: [
 				'node_modules/requirejs/require.js'
 			],
-			basePath: '/apps/ckeditor/build/amd/'
+			basePath: '/apps/ckeditor/build/modules/amd/'
 		}
 	},
 
@@ -33,18 +33,18 @@ const config = {
 		all: {
 			applications: [ 'ckeditor' ],
 			paths: [
-				'build/amd/tests/**',
-				'!build/amd/tests/**/@(_utils|_assets)/**'
+				'build/modules/amd/tests/**',
+				'!build/modules/amd/tests/**/@(_utils|_assets)/**'
 			]
 		}
 	},
 
 	coverage: {
 		paths: [
-			'build/amd/ckeditor.js',
-			'build/amd/ckeditor5/**/*.js',
-			'build/amd/tests/**/_*/*.js',
-			'!build/amd/ckeditor5/*/lib/**'
+			'build/modules/amd/ckeditor.js',
+			'build/modules/amd/ckeditor5/**/*.js',
+			'build/modules/amd/tests/**/_*/*.js',
+			'!build/modules/amd/ckeditor5/*/lib/**'
 		]
 	},
 

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,8 @@
+CKEditor 5 – Build Directory
+============================
+
+This directory contains files created during build process of CKEditor 5:
+
+ - `dist` - bundled version of CKEditor 5, created by executing `gulp bundle` task. See more: [Bundling](https://github.com/ckeditor/ckeditor5/wiki/Development-Workflow#bundling).
+ - `modules` - versions of CKEditor transpiled to specified module format: AMD, CommonJS and ES6 modules. See more: [Building CKEditor](https://github.com/ckeditor/ckeditor5/wiki/Development-Environment#building-ckeditor).
+ - `docs` - JavaScript documentation created form source code by `gulp docs` task.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,8 +12,13 @@ const runSequence = require( 'run-sequence' );
 
 const config = {
 	ROOT_DIR: '.',
-	BUILD_DIR: 'build',
-	BUNDLE_DIR: 'bundle',
+	MODULE_DIR: {
+		amd: 'build/modules/amd',
+		cjs: 'build/modules/cjs',
+		esnext: 'build/modules/esnext'
+	},
+	DOCS_DIR: 'build/docs',
+	BUNDLE_DIR: 'build/dist',
 	WORKSPACE_DIR: '..',
 
 	// Files ignored by jshint and jscs tasks. Files from .gitignore will be added automatically during tasks execution.
@@ -70,12 +75,14 @@ gulp.task( 'bundle', ( callback ) => {
 // Build tasks.
 const ckeditor5DevBuilder = require( 'ckeditor5-dev-builder' )( config );
 const builder = ckeditor5DevBuilder.builder;
+
 gulp.task( 'build', callback => {
 	runSequence( 'build:clean:all', 'build:themes', 'build:js', callback );
 } );
 
-gulp.task( 'build:clean:all', builder.clean.all );
-gulp.task( 'build:clean:themes', builder.clean.themes );
+// Clean tasks.
+gulp.task( 'build:clean:all', () => builder.clean.all() );
+gulp.task( 'build:clean:themes', () => builder.clean.themes() );
 gulp.task( 'build:clean:js', () => builder.clean.js() );
 
 gulp.task( 'build:themes', ( callback ) => {


### PR DESCRIPTION
Creates `build/` directory structure described in #226.
This PR should be closed with:

- https://github.com/ckeditor/ckeditor5-dev-builder/pull/14 - changes in builder configuration
- https://github.com/ckeditor/ckeditor5-dev-bundler-rollup/pull/17 - changes in bundler configuration