### PR TITLE
Introduced task for building and testing manual tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 # Be sure to append /** to folders to have everything inside them ignored.
 
 # All "dot directories".
-.*/**
+**/.*/**
 
 node_modules/**
 build/dist/**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -176,7 +176,7 @@ gulp.task( 'docs:editors', [ 'compile:js:esnext', 'compile:themes:esnext' ], () 
 const tests = require( '@ckeditor/ckeditor5-dev-tests' );
 
 gulp.task( 'test', () => {
-	return tests.tasks.test( getTestOptions() );
+	return tests.tasks.automated.test( getTestOptions() );
 } );
 
 // Requires compiled sources. Task should be used in parallel with `gulp compile --formats=esnext --watch`.
@@ -184,13 +184,12 @@ gulp.task( 'test:server', () => {
 	const options = getTestOptions();
 	options.sourcePath = path.resolve( config.MODULE_DIR.esnext );
 
-	return tests.tasks.runTests( options );
+	return tests.tasks.automated.runTests( options );
 } );
 
 gulp.task( 'test:manual', ( done ) => {
-	tests.tasks.manualTests.run( {
-		packages: getCKEditor5PackagesPaths(),
-		destinationPath: path.resolve( config.ROOT_DIR, '.manual' ),
+	tests.tasks.manual.run( {
+		packages: getCKEditor5PackagesPaths()
 	}, done );
 } );
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -187,6 +187,13 @@ gulp.task( 'test:server', () => {
 	return tests.tasks.runTests( options );
 } );
 
+gulp.task( 'test:manual', ( done ) => {
+	tests.tasks.manualTests.run( {
+		packages: getCKEditor5PackagesPaths(),
+		destinationPath: path.resolve( config.ROOT_DIR, '.manual' ),
+	}, done );
+} );
+
 function getTestOptions() {
 	const options = tests.utils.parseArguments();
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@ckeditor/ckeditor5-dev-docs": "^4.1.0",
     "@ckeditor/ckeditor5-dev-env": "^1.0.0",
     "@ckeditor/ckeditor5-dev-lint": "^1.0.1",
-    "@ckeditor/ckeditor5-dev-tests": "^2.0.0",
+    "@ckeditor/ckeditor5-dev-tests": "^3.0.0",
     "babel-polyfill": "^6.13.0",
     "benderjs": "^0.4.1",
     "benderjs-chai": "^0.2.0",


### PR DESCRIPTION
Fixes: #363.

Requires: https://github.com/ckeditor/ckeditor5-dev-tests/pull/28

Also requires changes in **all manual tests**. I prepared shell scripts which will do it.

1. Paste the files in `path-to/ckeditor5/.helpers/`

* `change-css-paths.js` - fixes a path to a stylesheet in HTML files:
```js
#!/usr/bin/env node

/**
 * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
 * For licensing, see LICENSE.md.
 */

'use strict';

const fs = require( 'fs' );
const path = require( 'path' );
const glob = require( 'glob' );

const testsPath = path.join( process.cwd(), 'tests', '**', 'manual' );

for ( const filePath of glob.sync( path.join( testsPath, '**', '*.html' ) ) ) {
	const fileContent = fs.readFileSync( filePath, 'utf-8' )
		.replace(
			'<link rel="stylesheet" href="%APPS_DIR%ckeditor/build/modules/amd/theme/ckeditor.css">',
			'<link rel="stylesheet" href="/theme/ckeditor.css">'
		)

	fs.writeFileSync( filePath, fileContent );
}
```

* `change-paths.js` - removes the first slash `/` from imports in script files:

```js
#!/usr/bin/env node

/**
 * @license Copyright (c) 2003-2016, CKSource - Frederico Knabben. All rights reserved.
 * For licensing, see LICENSE.md.
 */

'use strict';

const fs = require( 'fs' );
const path = require( 'path' );
const glob = require( 'glob' );

const regex = new RegExp( `(.*from ')\/(.*)`, 'g' );

for ( const filePath of glob.sync( path.join( process.cwd(), 'tests', '**', 'manual', '**', '*.js' ) ) ) {
	const fileContent = fs.readFileSync( filePath, 'utf-8' )
		.replace( regex, ( content, firstPart, secondPart ) => {
			return firstPart + secondPart;
		} );

	fs.writeFileSync( filePath, fileContent );
}
```

2. Execute the scripts (from CKE5 directory):
  * ``` gulp exec --task sh --cmd "node `pwd`/.helpers/change-css-path.js" ```
  * ``` gulp exec --task sh --cmd "node `pwd`/.helpers/change-css-paths.js" ```

After merging this PR, the changes in manual tests should be committed.