### PR TITLE
Remove unnecessary tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -89,8 +89,8 @@ gulp.task( 'compile', () => {
 	} );
 } );
 
-// Tasks specific for preparing compiled output with unmodified source files. Used by `gulp docs` or `gulp build`.
-// Todo: These tasks should be moved direct to Docs and Bundler.
+// Tasks specific for preparing compiled output with unmodified source files. Used by `gulp docs`.
+// TODO: These tasks should be moved directly to ckeditor5-dev-docs.
 gulp.task( 'compile:clean:js:esnext', () => {
 	return compiler.tasks.clean.js( [ config.MODULE_DIR.esnext ] );
 } );
@@ -144,8 +144,8 @@ function getBuildOptions() {
 
 // Documentation. -------------------------------------------------------------
 
-gulp.task( 'docs', [ 'docs:clean', 'compile:js:esnext' ], ( done ) => {
-	runSequence( 'docs:editors', 'docs:build', done );
+gulp.task( 'docs', [ 'docs:clean', 'compile:js:esnext', 'compile:themes:esnext' ], ( done ) => {
+	runSequence( 'docs:build', done );
 } );
 
 // Documentation's helpers.
@@ -159,12 +159,6 @@ gulp.task( 'docs:build', () => {
 	const docsBuilder = require( '@ckeditor/ckeditor5-dev-docs' ).docs( config );
 
 	return docsBuilder.buildDocs();
-} );
-
-gulp.task( 'docs:editors', [ 'compile:js:esnext', 'compile:themes:esnext' ], () => {
-	const docsBuilder = require( '@ckeditor/ckeditor5-dev-docs' ).docs( config );
-
-	return docsBuilder.buildEditorsForSamples( getCKEditor5PackagesPaths(), config.DOCUMENTATION.SAMPLES );
 } );
 
 // Tests. ---------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-bundler-rollup": "^5.0.0",
     "@ckeditor/ckeditor5-dev-compiler": "^6.0.0",
-    "@ckeditor/ckeditor5-dev-docs": "^4.1.0",
+    "@ckeditor/ckeditor5-dev-docs": "^5.0.0",
     "@ckeditor/ckeditor5-dev-env": "^1.0.0",
     "@ckeditor/ckeditor5-dev-lint": "^1.0.1",
     "@ckeditor/ckeditor5-dev-tests": "^3.1.0",


### PR DESCRIPTION
Fixes #381. Requires: https://github.com/ckeditor/ckeditor5-dev-docs/pull/18.

I was only able to remove editor for samples building, because themes are necessary for documentation building.