### PR TITLE
T/456: Use a more standard directory/ notation in .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,10 @@
 # These files will be ignored by Git and by our linting tools:
 #	gulp lint
 #	gulp lint-staged
-#
-# Be sure to append /** to folders to have everything inside them ignored.
 
-node_modules/**
-build/**
-coverage/**
-packages/**
+node_modules/
+build/
+coverage/
+packages/
 docs/api/output.json
 lerna-debug.log

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-docs": "^7.1.0",
-    "@ckeditor/ckeditor5-dev-lint": "^3.0.0",
+    "@ckeditor/ckeditor5-dev-lint": "^3.1.0",
     "@ckeditor/ckeditor5-dev-tests": "^7.3.0",
     "eslint-config-ckeditor5": "^1.0.0",
     "gulp": "^3.9.1",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Use a more standard `"directory/"` notation in `.gitignore`. Closes #456.

---

### Additional information

- Requires https://github.com/ckeditor/ckeditor5-dev/pull/225.
- On every repo I've just pushed a branch `t/ckeditor5/456` which contain a new `.gitignore` file.
