### PR TITLE
Renamed `contextual/contextualtoolbar~ContextualToolbar` to `balloon/balloontoolbar~BalloonToolbar`.

### DIFF
--- a/docs/builds/guides/migrate.md
+++ b/docs/builds/guides/migrate.md
@@ -508,7 +508,7 @@ Note: The number of options was reduced on purpose. We understood that configuri
 </tr>
 <tr>
 <td><a href="/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-toolbar">toolbar</a></td>
-<td><p>{@link module:core/editor/editorconfig~EditorConfig#toolbar <code>toolbar</code>}</p><p>See also {@link module:core/editor/editorconfig~EditorConfig#contextualToolbar <code>contextualToolbar</code>} to define the toolbar of a Balloon editor.</p></td>
+<td><p>{@link module:core/editor/editorconfig~EditorConfig#toolbar <code>toolbar</code>}</p><p>See also {@link module:core/editor/editorconfig~EditorConfig#balloonToolbar <code>contextualToolbar</code>} to define the toolbar of a Balloon editor.</p></td>
 </tr>
 <tr>
 <td><a href="/ckeditor4/docs/#!/api/CKEDITOR.config-cfg-toolbarCanCollapse">toolbarCanCollapse</a></td>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Aligned docs after ranaming ContextualToolbar to BallonToolbar.

---
Other: Rename `ContextualToolbar` to `BalloonToolbar`. Closes #ckeditor/ckeditor5/550.
### Additional information

Updated repositories that uses above mentioned toolbar are:
* https://github.com/ckeditor/ckeditor5-core/tree/t/ckeditor5/550
* https://github.com/ckeditor/ckeditor5-editor-balloon/tree/t/ckeditor5/550
* https://github.com/ckeditor/ckeditor5-image/tree/t/ckeditor5/550
* https://github.com/ckeditor/ckeditor5-ui/tree/t/ckeditor5/550

Proposed merge message for those branches:
```
Aligned code after ranaming ContextualToolbar to BallonToolbar.
```
but for: https://github.com/ckeditor/ckeditor5-ui/tree/t/ckeditor5/550:
```
Other: Rename `ContextualToolbar` to `BalloonToolbar`.  Closes ckeditor/ckeditor5#550.

BREAKING CHANGE: Renamed `contextual/contextualtoolbar~ContextualToolbar` to `balloon/balloontoolbar~BalloonToolbar`.
BREAKING CHANGE: Renamed `contextualToolbar` configuration option to `balloonToolbar`.
```