### PR TITLE
T/724: Review PostCSS webpack integration.

### DIFF
--- a/docs/builds/guides/integration/advanced-setup.md
+++ b/docs/builds/guides/integration/advanced-setup.md
@@ -108,7 +108,7 @@ The minimal configuration, assuming that you use the same methods of handling as
 
 ```js
 const CKEditorWebpackPlugin = require( '@ckeditor/ckeditor5-dev-webpack-plugin' );
-const { getPostCssConfig } = require( '@ckeditor/ckeditor5-dev-utils' ).styles;
+const { styles } = require( '@ckeditor/ckeditor5-dev-utils' );
 
 module.exports = {
 	plugins: [
@@ -142,7 +142,7 @@ module.exports = {
 					},
 					{
 						loader: 'postcss-loader',
-						options: getPostCssConfig( {
+						options: styles.getPostCssConfig( {
 							themeImporter: {
 								themePath: require.resolve( '@ckeditor/ckeditor5-theme-lark' )
 							},
@@ -341,7 +341,7 @@ module.exports = {
 					use: [
 						{
 							loader: 'postcss-loader',
-							options: getPostCssConfig( {
+							options: styles.getPostCssConfig( {
 								themeImporter: {
 									themePath: require.resolve( '@ckeditor/ckeditor5-theme-lark' )
 								},

--- a/docs/builds/guides/integration/advanced-setup.md
+++ b/docs/builds/guides/integration/advanced-setup.md
@@ -130,7 +130,7 @@ module.exports = {
 				use: [ 'raw-loader' ]
 			},
 			{
-				// Or /ckeditor5-[^/]+\/theme\/[^/]+\.css$/ if you want to limit this loader
+				// Or /ckeditor5-[^/]+\/theme\/[\w-/]+\.css$/ if you want to limit this loader
 				// to CKEditor 5's theme only.
 				test: /\.css$/,
 				use: [

--- a/docs/framework/guides/quick-start.md
+++ b/docs/framework/guides/quick-start.md
@@ -40,7 +40,7 @@ The minimal webpack configuration needed to enable building CKEditor 5 is:
 'use strict';
 
 const path = require( 'path' );
-const { getPostCssConfig } = require( '@ckeditor/ckeditor5-dev-utils' ).styles;
+const { styles } = require( '@ckeditor/ckeditor5-dev-utils' );
 
 module.exports = {
 	// https://webpack.js.org/configuration/entry-context/
@@ -74,7 +74,7 @@ module.exports = {
 					},
 					{
 						loader: 'postcss-loader',
-						options: getPostCssConfig( {
+						options: styles.getPostCssConfig( {
 							themeImporter: {
 								themePath: require.resolve( '@ckeditor/ckeditor5-theme-lark' )
 							},

--- a/scripts/docs/snippetadapter.js
+++ b/scripts/docs/snippetadapter.js
@@ -8,7 +8,7 @@
 const path = require( 'path' );
 const fs = require( 'fs' );
 const webpack = require( 'webpack' );
-const { bundler, styles: { getPostCssConfig } } = require( '@ckeditor/ckeditor5-dev-utils' );
+const { bundler, styles } = require( '@ckeditor/ckeditor5-dev-utils' );
 const CKEditorWebpackPlugin = require( '@ckeditor/ckeditor5-dev-webpack-plugin' );
 const ExtractTextPlugin = require( 'extract-text-webpack-plugin' );
 const BabelMinifyPlugin = require( 'babel-minify-webpack-plugin' );
@@ -133,7 +133,7 @@ function getWebpackConfig( config ) {
 						use: [
 							{
 								loader: 'postcss-loader',
-								options: getPostCssConfig( {
+								options: styles.getPostCssConfig( {
 									themeImporter: {
 										themePath: require.resolve( '@ckeditor/ckeditor5-theme-lark' )
 									},


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

It's hard to decide as both are OK:

Docs: Update advanced setup PostCSS files RegExp in webpack example.
Other: Unify `getPostCssConfig()` from @ckeditor/ckeditor5-dev-utils package. Closes #724.

---

### Additional information

* The builds needs and update:
- https://github.com/ckeditor/ckeditor5-build-balloon/tree/t/ckeditor5/724
- https://github.com/ckeditor/ckeditor5-build-classic/tree/t/ckeditor5/724
- https://github.com/ckeditor/ckeditor5-build-inline/tree/t/ckeditor5/724

Proposed merge message:
```
Other: Unify the `getPostCssConfig()` import from `@ckeditor/ckeditor5-dev-utils` package. See ckeditor/ckeditor5#724.
```