### PR TITLE
t/ckeditor5-editor-decoupled/7: Made the config.toolbarContainer and config.editableContainer accept only HTMLElement

### DIFF
--- a/docs/_snippets/examples/document-editor.js
+++ b/docs/_snippets/examples/document-editor.js
@@ -10,8 +10,8 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloudservices/tests/_utils/clouds
 
 DecoupledDocumentEditor
 	.create( document.querySelector( '.document-editor__data' ).innerHTML, {
-		toolbarContainer: '.document-editor__toolbar',
-		editableContainer: '.document-editor__editable',
+		toolbarContainer: document.querySelector( '.document-editor__toolbar' ),
+		editableContainer: document.querySelector( '.document-editor__editable' ),
 
 		cloudServices: CS_CONFIG
 	} )

--- a/docs/builds/guides/quick-start.md
+++ b/docs/builds/guides/quick-start.md
@@ -194,9 +194,8 @@ The decoupled editor requires you to define the containers for the toolbar and e
 	DecoupledDocumentEditor
 		.create( '<p>The initial editor data</p>', {
 			// Define the containers for the toolbar and editable.
-			// Use the document.querySelector-friendly strings here or references to existing DOM elements.
-			toolbarContainer: '.toolbar-container',
-			editableContainer: '.editable-container'
+			toolbarContainer: document.querySelector( '.toolbar-container' ),
+			editableContainer: document.querySelector( '.editable-container' )
 		} )
 		.catch( error => {
 			console.error( error );
@@ -227,9 +226,8 @@ The decoupled editor requires you to define the containers for the toolbar and e
 		DecoupledDocumentEditor
 			.create( '<p>The initial editor data</p>', {
 				// Define the containers for the toolbar and editable.
-				// Use the document.querySelector-friendly strings here or references to existing DOM elements.
-				toolbarContainer: '.toolbar-container',
-				editableContainer: '.editable-container'
+				toolbarContainer: document.querySelector( '.toolbar-container' ),
+				editableContainer: document.querySelector( '.editable-container' )
 			} )
 			.catch( error => {
 				console.error( error );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Made the `config.toolbarContainer` and `config.editableContainer` accept only `HTMLElement` (previously also String) (see ckeditor/ckeditor5-editor-decoupled#7).

---

### Additional information

Requires https://github.com/ckeditor/ckeditor5-editor-decoupled/pull/8.