### PR TITLE
Docs: Fix nested editable styles in document editor sample.

### DIFF
--- a/docs/_snippets/examples/document-editor.html
+++ b/docs/_snippets/examples/document-editor.html
@@ -72,7 +72,7 @@
 		overflow-y: scroll;
 	}
 
-	.document-editor__editable-container .ck-editor__editable {
+	.document-editor__editable-container .document-editor__editable.ck-editor__editable {
 		/* Set the dimensions of the "page". */
 		width: 15.8cm;
 		min-height: 21cm;
@@ -92,7 +92,7 @@
 	}
 
 	/* Override the page's width in the "Examples" section which is wider. */
-	.main__content-wide .document-editor__editable-container .ck-editor__editable {
+	.main__content-wide .document-editor__editable-container .document-editor__editable.ck-editor__editable {
 		width: 18cm;
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Fix nested editable styles in document editor sample. Closes #940.

---

### Additional information

* All editables had styles that should go only for the main document editable.

Also similar bug in sample of decoupled document build: https://github.com/ckeditor/ckeditor5-build-decoupled-document/pull/9.

