### PR TITLE
Improved the release scripts

### DIFF
--- a/scripts/release-ckeditor5.sh
+++ b/scripts/release-ckeditor5.sh
@@ -20,7 +20,7 @@ then
 	mgit exec 'git checkout -b stable 2> /dev/null && git push origin stable && git checkout master'
 
 	# Update all `stable` branches in all packages.
-	mgit exec 'git checkout stable && git merge master && git checkout master'
+	mgit exec 'git checkout stable && git pull origin stable && git merge master && git checkout master'
 
 	# Make sure that `mgit.json` for `stable` and `master` branches is correct.
 	# `stable` branch.

--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -9,10 +9,14 @@
 
 'use strict';
 
+// In order to use the same version for all packages (including builds and ckeditor5 itself), you can call:
+// npm run changelog [newVersion]
+
 const devEnv = require( '@ckeditor/ckeditor5-dev-env' );
 const commonOptions = {
 	cwd: process.cwd(),
-	packages: 'packages'
+	packages: 'packages',
+	newVersion: process.argv[ 2 ] || null
 };
 const editorBuildsGlob = '@ckeditor/ckeditor5-build-*';
 

--- a/scripts/release/release-dependencies.js
+++ b/scripts/release/release-dependencies.js
@@ -9,8 +9,13 @@
 
 'use strict';
 
+// In order to test the whole process, you can use:
+// npm run release:dependencies -- --dry-run
+// It will create some commits but nothing will be pushed or published.
+
 require( '@ckeditor/ckeditor5-dev-env' )
 	.releaseSubRepositories( {
 		cwd: process.cwd(),
-		packages: 'packages'
+		packages: 'packages',
+		dryRun: process.argv.includes( '--dry-run' )
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added support for generating the changelog for all packages with the same version. The script for releasing packages support `dry-run` mode now. See ckeditor/ckeditor5#1061.

---

Requires: https://github.com/ckeditor/ckeditor5-dev/pull/420
