### PR TITLE
Cleaned up how and which params are passed to Umberto

### DIFF
--- a/docs/framework/guides/contributing/development-environment.md
+++ b/docs/framework/guides/contributing/development-environment.md
@@ -185,13 +185,20 @@ npm run docs
 
 The documentation will be available in `build/docs/`.
 
-This task accepts two arguments which can speed up the process:
+This task accepts the following arguments:
 
 * `--skip-api` &ndash; Skips building the API documentation (which takes the majority of the total time).
 * `--skip-snippets` &ndash; Skips building live snippets.
 * `--skip-validation` &ndash; Skips the final link validation.
+* `--watch` &ndash; Runs the documentation generator in a watch mode. It covers guides (it does not cover API docs).
+* `--production` &ndash; Minifies the assets and performs other actions which are unnecessary during CKEditor 5 development.
+* `--verbose` &ndash; Prints out more information.
 
-Note: These arguments must be passed after additional `--`: `npm run docs -- --skip-api`.
+Note: These arguments must be passed after additional `--`:
+
+```
+npm run docs -- --skip-api
+```
 
 ## Bisecting through a multi-repository
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Cleaned up how and which params are passed to Umberto.

Changes in `npm run docs`:

* Umberto introduced the `--watch` mode so you can now specify this param to `npm run docs` too.
* `--dev` was removed – docs are by default built in this mode. You can still pass `--production` which enables this mode in the snippets adapter and Umberto itself.
* The `skipApi` option of Umberto that appeared many months ago allowed us to remove the code which cleans the old `builds/docs/output.json` file.