### PR TITLE
Remove section about `allowJs` option from the angular integration docs

### DIFF
--- a/docs/builds/guides/frameworks/angular.md
+++ b/docs/builds/guides/frameworks/angular.md
@@ -32,14 +32,6 @@ Assuming that you picked [`@ckeditor/ckeditor5-build-classic`](https://www.npmjs
 npm install --save-dev @ckeditor/ckeditor5-build-classic
 ```
 
-**Note:** You may need to allow external JavaScript in your project's `tsconfig.json` for the builds to work properly:
-
-```json
-"compilerOptions": {
-	"allowJs": true
-}
-```
-
 Now, add `CKEditorModule` to your application module imports:
 
 ```ts


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Removed section about `allowJs` option from the angular integration docs. Closes #000.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
