### PR TITLE
README.md: updated ckeditor5 screenshot. [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ CKEditor 5 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?styl
 
 A set of ready-to-use rich text editors created with a powerful framework. Made with real-time collaborative editing in mind.
 
-![CKEditor 5 Classic rich text editor build screenshot](https://c.cksource.com/a/1/img/npm/ckeditor%205%20classic%20screeshot.png)
+![CKEditor 5 Classic rich text editor build screenshot](https://c.cksource.com/a/1/img/npm/ckeditor5-build-classic.png)
 
 ## ⚠ This package does not contain any source code
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Updated ckeditor5 screenshot in README.md. Closes #1311.

---

### Additional information

Screenshots in the builds repo (classic, inline, decoupled, balloon) are updated. 

To keep proper naming (unnecessary spaces in the image name and typo), we will use the same image as `ckeditor5-build-classic` repository.

![ckeditor5-build-classic](https://user-images.githubusercontent.com/10219857/47704293-79c94600-dc23-11e8-8b6b-69985afb18fe.png)
