### PR TITLE
Docs: Reduced content margin for mobile devices [skip ci].

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -11,8 +11,9 @@
 	}
 }
 
-/* https://github.com/ckeditor/ckeditor5-build-decoupled-document/issues/12 */
-@media only screen and (max-width: 1360px) {
+/* https://github.com/ckeditor/ckeditor5/issues/1350
+https://github.com/ckeditor/ckeditor5-build-decoupled-document/issues/12 */
+@media only screen and (min-width: 960px) and (max-width: 1360px) {
 	/* https://github.com/ckeditor/ckeditor5/issues/1077 */
 	.main .main__content .main__content-inner,
 	.main .main__content-wide .main__content-inner {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Content margin should not be overridden for mobile devices. Closes #1350.

---

### Additional information

Side margin should be inherited (umberto default 1em for RWD).

<img width="480" alt="screenshot 2018-11-20 at 08 27 13" src="https://user-images.githubusercontent.com/10219857/48757774-27b59680-ec9e-11e8-8081-8dc55cca6722.png">
