### PR TITLE
t/1349: The navigation hint in the Examples index should respond to the type of the layout (desktop vs. mobile)

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -5,7 +5,7 @@ category: api-reference
 # API documentation
 
 <info-box>
-	Use the **navigation tree on the left** to navigate through CKEditor API.
+	Use the <span class="navigation-hint_desktop">**navigation tree on the left**</span><span class="navigation-hint_mobile">**main menu button in the upper-left corner**</span> to navigate through CKEditor API.
 </info-box>
 
 ## Popular API pages

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -44,3 +44,19 @@ https://github.com/ckeditor/ckeditor5-build-decoupled-document/issues/12 */
 		padding-right: 300px;
 	}
 }
+
+/* https://github.com/ckeditor/ckeditor5/issues/1349 */
+.main .examples-navigation-hint_mobile {
+	display: none;
+}
+
+/* https://github.com/ckeditor/ckeditor5/issues/1349 */
+@media only screen and (max-width: 960px) {
+	.main .examples-navigation-hint_desktop {
+		display: none;
+	}
+
+	.main .examples-navigation-hint_mobile {
+		display: inline;
+	}
+}

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -46,17 +46,17 @@ https://github.com/ckeditor/ckeditor5-build-decoupled-document/issues/12 */
 }
 
 /* https://github.com/ckeditor/ckeditor5/issues/1349 */
-.main .examples-navigation-hint_mobile {
+.main .navigation-hint_mobile {
 	display: none;
 }
 
 /* https://github.com/ckeditor/ckeditor5/issues/1349 */
 @media only screen and (max-width: 960px) {
-	.main .examples-navigation-hint_desktop {
+	.main .navigation-hint_desktop {
 		display: none;
 	}
 
-	.main .examples-navigation-hint_mobile {
+	.main .navigation-hint_mobile {
 		display: inline;
 	}
 }

--- a/docs/builds/index.md
+++ b/docs/builds/index.md
@@ -11,7 +11,7 @@ meta-description: Learn how to install, integrate, configure and develop CKEdito
 CKEditor 5 Builds are the fastest and easiest way to use CKEditor 5 in your application.
 
 <info-box>
-	Use the **navigation tree on the left** to navigate through CKEditor 5 Builds documentation.
+	Use the <span class="navigation-hint_desktop">**navigation tree on the left**</span><span class="navigation-hint_mobile">**main menu button in the upper-left corner**</span> to navigate through CKEditor 5 Builds documentation.
 </info-box>
 
 ## Related links

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -9,7 +9,7 @@ meta-description: Navigate through CKEditor 5 examples to see what you are able 
 # Examples
 
 <info-box>
-	Use the **navigation tree on the left** to navigate through CKEditor 5 examples. Visit the {@link features/index Features} section to see even more examples!
+	Use the <span class="examples-navigation-hint_desktop">**navigation tree on the left**</span><span class="examples-navigation-hint_mobile">**main menu button in the upper-left corner**</span> to navigate through CKEditor 5 examples. Visit the {@link features/index Features} section to see even more examples!
 </info-box>
 
 ## Related links

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -9,7 +9,7 @@ meta-description: Navigate through CKEditor 5 examples to see what you are able 
 # Examples
 
 <info-box>
-	Use the <span class="examples-navigation-hint_desktop">**navigation tree on the left**</span><span class="examples-navigation-hint_mobile">**main menu button in the upper-left corner**</span> to navigate through CKEditor 5 examples. Visit the {@link features/index Features} section to see even more examples!
+	Use the <span class="navigation-hint_desktop">**navigation tree on the left**</span><span class="navigation-hint_mobile">**main menu button in the upper-left corner**</span> to navigate through CKEditor 5 examples. Visit the {@link features/index Features} section to see even more examples!
 </info-box>
 
 ## Related links

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,7 +7,7 @@ toc: false
 # Features
 
 <info-box>
-	Use the **navigation tree on the left** to navigate through selected CKEditor 5 features.
+	Use the <span class="navigation-hint_desktop">**navigation tree on the left**</span><span class="navigation-hint_mobile">**main menu button in the upper-left corner**</span> to navigate through selected CKEditor 5 features.
 </info-box>
 
 ## Features availability

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -11,7 +11,7 @@ meta-description: Learn how to install, integrate, configure and develop CKEdito
 CKEditor 5 Framework is a set of components allowing you to create any kind of rich text editing solution.
 
 <info-box>
-    Use the **navigation tree on the left** to navigate through CKEditor 5 Framework documentation.
+    Use the <span class="navigation-hint_desktop">**navigation tree on the left**</span><span class="navigation-hint_mobile">**main menu button in the upper-left corner**</span> to navigate through CKEditor 5 Framework documentation.
 </info-box>
 
 ## Related links


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: The navigation hint in the Examples index should respond to the type of the layout (desktop vs. mobile). Closes #1349.
