### PR TITLE
T/1420: Review SVG raw-loader usage

### DIFF
--- a/docs/builds/guides/frameworks/vuejs.md
+++ b/docs/builds/guides/frameworks/vuejs.md
@@ -245,7 +245,7 @@ module.exports = {
 		// svgRule.uses.clear();
 
 		//  b) or exclude ckeditor directory from node_modules:
-		svgRule.exclude.add(__dirname + "/node_modules/@ckeditor");
+		svgRule.exclude.add( __dirname + '/node_modules/@ckeditor' );
 
 		// 3. Add entry for CKEditor's only .svg files, by either:
 
@@ -254,7 +254,7 @@ module.exports = {
 
 		// b) or by adding a new rule.
 		config.module
-			.rule('cke-svg')
+			.rule( 'cke-svg' )
 			.test( /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/ )
 			.use( 'raw-loader' )
 			.loader( 'raw-loader' );

--- a/docs/builds/guides/frameworks/vuejs.md
+++ b/docs/builds/guides/frameworks/vuejs.md
@@ -237,22 +237,25 @@ module.exports = {
 		// Vue CLI would normally use its own loader to load .svg files. The icons used by
 		// CKEditor should be loaded using raw-loader instead.
 
-		// 1. First get default rule for .svg files.
+		// Get the default rule for *.svg files.
 		const svgRule = config.module.rule( 'svg' );
 
-		// 2. then you can either:
-		//  a ) clear all loaders for existing 'svg' rule:
-		// svgRule.uses.clear();
-
-		//  b) or exclude ckeditor directory from node_modules:
+		// Then you can either:
+		//
+		// * clear all loaders for existing 'svg' rule:
+		//
+		//		svgRule.uses.clear();
+		//
+		// * or exclude ckeditor directory from node_modules:
 		svgRule.exclude.add( __dirname + '/node_modules/@ckeditor' );
 
-		// 3. Add entry for CKEditor's only .svg files, by either:
-
-		// a) by modifying existing 'svg' rule:
-		// svgRule.use('raw-loader' ).loader( 'raw-loader' );
-
-		// b) or by adding a new rule.
+		// Add an entry for *.svg files belonging to CKEditor. You can either:
+		//
+		// * modify the existing 'svg' rule:
+		//
+		//		svgRule.use( 'raw-loader' ).loader( 'raw-loader' );
+		//
+		// * or add a new one:
 		config.module
 			.rule( 'cke-svg' )
 			.test( /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/ )

--- a/docs/builds/guides/frameworks/vuejs.md
+++ b/docs/builds/guides/frameworks/vuejs.md
@@ -236,10 +236,27 @@ module.exports = {
 	chainWebpack: config => {
 		// Vue CLI would normally use its own loader to load .svg files. The icons used by
 		// CKEditor should be loaded using raw-loader instead.
+
+		// 1. First get default rule for .svg files.
+		const svgRule = config.module.rule( 'svg' );
+
+		// 2. then you can either:
+		//  a ) clear all loaders for existing 'svg' rule:
+		// svgRule.uses.clear();
+
+		//  b) or exclude ckeditor directory from node_modules:
+		svgRule.exclude.add(__dirname + "/node_modules/@ckeditor");
+
+		// 3. Add entry for CKEditor's only .svg files, by either:
+
+		// a) by modifying existing 'svg' rule:
+		// svgRule.use('raw-loader' ).loader( 'raw-loader' );
+
+		// b) or by adding a new rule.
 		config.module
-			.rule( 'svg' )
+			.rule('cke-svg')
 			.test( /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/ )
-			.use( 'file-loader' )
+			.use( 'raw-loader' )
 			.loader( 'raw-loader' );
 	}
 };

--- a/docs/builds/guides/frameworks/vuejs.md
+++ b/docs/builds/guides/frameworks/vuejs.md
@@ -193,7 +193,7 @@ npm install --save \
     @ckeditor/ckeditor5-dev-webpack-plugin \
     @ckeditor/ckeditor5-dev-utils \
     postcss-loader \
-    raw-loader@0.5.1
+    raw-loader
 ```
 
 Edit the `vue.config.js` file and use the following configuration. If the file is not present, create it in the root of the application (i.e. next to `package.json`):

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "mini-css-extract-plugin": "^0.4.0",
     "minimatch": "^3.0.4",
     "postcss-loader": "^3.0.0",
-    "raw-loader": "^0.5.1",
+    "raw-loader": "^1.0.0",
     "style-loader": "^0.23.0",
     "svgo": "^1.1.0",
     "uglifyjs-webpack-plugin": "^1.2.7",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Update raw-loader dependency. Closes #1420.

---

### Additional information

* AFAICS the `raw-loader`@`1.0.0` is safe to use with CKEditor 5 setup (tested: karma tests, manual tests, builds)
* The Vue guide was either outdated or wrong abut adding rules for `.svg` files. I've udpated the guide which fixes errors like ckeditor/ckeditor5-vue#16
* PR with changes in `ckeditor5-dev`: https://github.com/ckeditor/ckeditor5-dev/pull/462. (dep update)
* Updated dependencies in builds:
    * https://github.com/ckeditor/ckeditor5-build-inline/pull/13
    * https://github.com/ckeditor/ckeditor5-build-classic/pull/59
    * https://github.com/ckeditor/ckeditor5-build-decoupled-document/pull/17
    * https://github.com/ckeditor/ckeditor5-build-balloon/pull/22