### PR TITLE
[Docs] Removed obsolete Bootstrap CSS fix.

### DIFF
--- a/docs/builds/guides/frameworks/overview.md
+++ b/docs/builds/guides/frameworks/overview.md
@@ -60,18 +60,9 @@ body {
 	--ck-z-default: 100;
 	--ck-z-modal: calc( var(--ck-z-default) + 999 );
 }
-
-/*
-	Override Bootstrap's CSS.
-	Note: This will not be necessary once the following issue is fixed and released:
-	https://github.com/ckeditor/ckeditor5-theme-lark/issues/189
-*/
-.ck.ck-button {
-	-webkit-appearance: none;
-}
 ```
 
-And passing the `focus: false` option to Boostrap's `modal()` function:
+And passing the [`focus: false`](https://getbootstrap.com/docs/4.1/components/modal/#options) option to Boostrap's `modal()` function:
 
 ```js
 $( '#modal-container' ).modal( {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Removed obsolete Bootstrap override of `.ck-button`. Closes #1391 .

---

### Additional information

I've updated codepen demo too - https://codepen.io/ckeditor/pen/vzvgOe.