### PR TITLE
t/1517: Editor placeholder should be created from the "placeholder" attribute only when the source element is `<textarea>`.

### DIFF
--- a/docs/features/placeholder.md
+++ b/docs/features/placeholder.md
@@ -14,14 +14,14 @@ See the demo of the placeholder feature:
 
 There are two different ways of configuring the editor placeholder text:
 
-### Using the DOM attribute
+### Using the `placeholder` attribute of a textarea
 
-Set the `data-placeholder` attribute on an element passed to the `Editor.create()` method (for instance {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`}) to configure the placeholder:
+Set the `placeholder` attribute on a `<textarea>` element passed to the `Editor.create()` method (for instance {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`}) to configure the placeholder:
 
 ```html
-<div id="editor" data-placeholder="Type the content here!">
+<textarea id="editor" placeholder="Type the content here!">
 	<p>Editor content</p>
-</div>
+</textarea>
 ```
 
 ```js
@@ -40,7 +40,8 @@ ClassicEditor
 You can use the {@link module:core/editor/editorconfig~EditorConfig#placeholder `editor.config.placeholder`} configuration option:
 
 * when no element was passed into `Editor.create()` method,
-* to override the `data-placeholder` attribute value, for instance, if an element was passed into `Editor.create()` but the placeholder text should be different.
+* when the element passed into `Editor.create()` was not a `<textarea>` (for instance, a `<div>` element),
+* to override the `placeholder` text of a `<textarea>`, if one was passed into `Editor.create()` but the placeholder text should be different.
 
 ```js
 ClassicEditor

--- a/docs/features/placeholder.md
+++ b/docs/features/placeholder.md
@@ -16,10 +16,10 @@ There are two different ways of configuring the editor placeholder text:
 
 ### Using the DOM attribute
 
-Set the `placeholder` attribute on an element passed to the `Editor.create()` method (for instance {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`}) to configure the placeholder:
+Set the `data-placeholder` attribute on an element passed to the `Editor.create()` method (for instance {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`}) to configure the placeholder:
 
 ```html
-<div id="editor" placeholder="Type the content here!">
+<div id="editor" data-placeholder="Type the content here!">
 	<p>Editor content</p>
 </div>
 ```
@@ -40,7 +40,7 @@ ClassicEditor
 You can use the {@link module:core/editor/editorconfig~EditorConfig#placeholder `editor.config.placeholder`} configuration option:
 
 * when no element was passed into `Editor.create()` method,
-* to override the `placeholder` attribute value, for instance, if an element was passed into `Editor.create()` but the placeholder text should be different.
+* to override the `data-placeholder` attribute value, for instance, if an element was passed into `Editor.create()` but the placeholder text should be different.
 
 ```js
 ClassicEditor

--- a/docs/features/placeholder.md
+++ b/docs/features/placeholder.md
@@ -19,9 +19,7 @@ There are two different ways of configuring the editor placeholder text:
 Set the `placeholder` attribute on a `<textarea>` element passed to the `Editor.create()` method (for instance {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`}) to configure the placeholder:
 
 ```html
-<textarea id="editor" placeholder="Type the content here!">
-	<p>Editor content</p>
-</textarea>
+<textarea id="editor" placeholder="Type the content here!"></textarea>
 ```
 
 ```js


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Editor placeholder should be created from the "placeholder" attribute only when the source element is `<textarea>`. Closes #1517.

---

### Additional information

Requires changes in other PRs:
* https://github.com/ckeditor/ckeditor5-core/pull/163
* https://github.com/ckeditor/ckeditor5-editor-classic/pull/84
* https://github.com/ckeditor/ckeditor5-editor-decoupled/pull/29
* https://github.com/ckeditor/ckeditor5-editor-balloon/pull/30
* https://github.com/ckeditor/ckeditor5-editor-inline/pull/49