### PR TITLE
t/1542: Fixed `CKEDITOR_VERSION` collision error in the editor placeholder guide

### DIFF
--- a/docs/_snippets/features/placeholder-custom.js
+++ b/docs/_snippets/features/placeholder-custom.js
@@ -3,9 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals console, window, document */
-
-import ClassicEditor from '@ckeditor/ckeditor5-build-classic/src/ckeditor';
+/* globals console, window, document, ClassicEditor */
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-placeholder-custom' ), {

--- a/docs/_snippets/features/placeholder.js
+++ b/docs/_snippets/features/placeholder.js
@@ -3,9 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals console, window, document */
-
-import ClassicEditor from '@ckeditor/ckeditor5-build-classic/src/ckeditor';
+/* globals console, window, document, ClassicEditor */
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-placeholder' ), {

--- a/docs/features/placeholder.md
+++ b/docs/features/placeholder.md
@@ -2,6 +2,8 @@
 category: features
 ---
 
+{@snippet build-classic-source}
+
 # Editor placeholder
 
 CKEditor 5 can display a configurable placeholder text when the content is empty. The placeholder helps users locate the editor in the application and prompts to input the content. It works similarly to the native DOM [`placeholder` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#The_placeholder_attribute) used by inputs.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Fixed `CKEDITOR_VERSION` collision error in the editor placeholder guide. Closes #1542.
