### PR TITLE
t/1545: Docs: Put a border around balloon* editor content in examples to separate it from the example text.

### DIFF
--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -128,7 +128,11 @@ It breaks CKEditor 5 (see how <p><code>[]</code></p> looks). */
 	padding: 2rem;
 }
 
-#snippet-inline-editor .ck-content:not(.ck-focused) {
+/* Visually separate inline editors from example description.
+https://github.com/ckeditor/ckeditor5/issues/1545 */
+#snippet-inline-editor .ck-content:not(.ck-focused),
+#snippet-balloon-editor.ck-content:not(.ck-focused),
+#snippet-balloon-block-editor.ck-content:not(.ck-focused) {
 	border: 1px solid rgba(0, 0, 0, 0.15);
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Put a border around balloon* editor content in examples to separate it from the example text. Closes #1545.