### PR TITLE
Fix missing comma in vuejs editorConfig documentation

### DIFF
--- a/docs/builds/guides/frameworks/vuejs.md
+++ b/docs/builds/guides/frameworks/vuejs.md
@@ -516,7 +516,7 @@ Specifies the {@link module:core/editor/editorconfig~EditorConfig configuration}
 			return {
 				editor: ClassicEditor,
 				editorConfig: {
-					toolbar: [ 'bold', 'italic', '|' 'link' ]
+					toolbar: [ 'bold', 'italic', '|', 'link' ]
 				}
 			};
 		}


### PR DESCRIPTION
There is a missing comma after the separator

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Type: Message. Closes #000.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
