### PR TITLE
Snippet Adapter does not require a full path to match snippets that should be built

### DIFF
--- a/scripts/docs/snippetadapter.js
+++ b/scripts/docs/snippetadapter.js
@@ -212,10 +212,11 @@ function filterWhitelistedSnippets( snippets, whitelistedSnippets ) {
 
 	// Find all snippets that matched to specified criteria.
 	for ( const snippetData of snippets ) {
-		const matchToPatterns = whitelistedSnippets.some( pattern => minimatch( snippetData.snippetName, pattern ) );
+		const shouldBeBuilt = whitelistedSnippets.some( pattern => {
+			return minimatch( snippetData.snippetName, pattern ) || snippetData.snippetName.includes( pattern );
+		} );
 
-		// Snippet should be built.
-		if ( matchToPatterns ) {
+		if ( shouldBeBuilt ) {
 			snippetsToBuild.add( snippetData );
 		}
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Snippet Adapter does not require a full path to match snippets that should be built. Closes #1725.
