### PR TITLE
[Docs] Remove an extra space caused by snippet's empty div on top of the feature overview

### DIFF
--- a/scripts/docs/snippetadapter.js
+++ b/scripts/docs/snippetadapter.js
@@ -163,14 +163,10 @@ module.exports = function snippetAdapter( snippets, options, umbertoHelpers ) {
 
 					let snippetHTML = fs.readFileSync( snippetData.snippetSources.html ).toString();
 
-					const elementClasses = [ 'live-snippet' ];
-
-					if ( !snippetHTML.trim() ) {
-						elementClasses.push( 'live-snippet--empty' );
+					if ( snippetHTML.trim() ) {
+						snippetHTML = snippetHTML.replace( /%BASE_PATH%/g, snippetData.basePath );
+						snippetHTML = `<div class="live-snippet">${ snippetHTML }</div>`;
 					}
-
-					snippetHTML = snippetHTML.replace( /%BASE_PATH%/g, snippetData.basePath );
-					snippetHTML = `<div class="${ elementClasses.join( ' ' ) }">${ snippetHTML }</div>`;
 
 					content = content.replace( getSnippetPlaceholder( snippetData.snippetName ), snippetHTML );
 

--- a/scripts/docs/snippetadapter.js
+++ b/scripts/docs/snippetadapter.js
@@ -163,8 +163,14 @@ module.exports = function snippetAdapter( snippets, options, umbertoHelpers ) {
 
 					let snippetHTML = fs.readFileSync( snippetData.snippetSources.html ).toString();
 
+					const elementClasses = [ 'live-snippet' ];
+
+					if ( !snippetHTML.trim() ) {
+						elementClasses.push( 'live-snippet--empty' );
+					}
+
 					snippetHTML = snippetHTML.replace( /%BASE_PATH%/g, snippetData.basePath );
-					snippetHTML = `<div class="live-snippet">${ snippetHTML }</div>`;
+					snippetHTML = `<div class="${ elementClasses.join( ' ' ) }">${ snippetHTML }</div>`;
 
 					content = content.replace( getSnippetPlaceholder( snippetData.snippetName ), snippetHTML );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Removed an extra space caused by snippet's empty div on top of the feature overview.

---

### Additional information

![Screenshot 2019-05-08 at 15 52 59](https://user-images.githubusercontent.com/1166967/57380532-6e923c80-71a9-11e9-9356-e0013cf54c43.png)
