### PR TITLE
[Docs] Migration table should display `<code>` inside properly

### DIFF
--- a/docs/builds/guides/migrate.md
+++ b/docs/builds/guides/migrate.md
@@ -68,7 +68,19 @@ The following table presents configuration options available in CKEditor 4 and t
 
 Note: The number of options was reduced on purpose. We understood that configuring CKEditor 4 was a bit too troublesome due to the number of configuration options available (over 240). Sometimes they were definitely too low-level, also many times they were so infrequently used that it did not justify the increased level of the application complexity. This is why when designing CKEditor 5 from scratch, we decided to come with a simplified editor, with well-thought default behavior, based on the results of the [Editor Recommendations](http://ckeditor.github.io/editor-recommendations/) project.
 
-<table class="docsearch-txt">
+<style>
+/* See: https://github.com/ckeditor/ckeditor5/issues/1718. */
+.docsearch-txt {
+	table-layout: fixed;
+}
+
+.docsearch-txt tr th:nth-child( 1 ),
+.docsearch-txt tr td:nth-child( 1 ) {
+	width: 300px;
+}
+</style>
+
+<table class="docsearch-txt" style="table-layout: fixed">
 	<thead>
 		<tr>
 			<th>CKEditor 4</th>

--- a/docs/builds/guides/migrate.md
+++ b/docs/builds/guides/migrate.md
@@ -76,11 +76,11 @@ Note: The number of options was reduced on purpose. We understood that configuri
 
 .docsearch-txt tr th:nth-child( 1 ),
 .docsearch-txt tr td:nth-child( 1 ) {
-	width: 300px;
+	width: 250px;
 }
 </style>
 
-<table class="docsearch-txt" style="table-layout: fixed">
+<table class="docsearch-txt">
 	<thead>
 		<tr>
 			<th>CKEditor 4</th>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Migration table should display `<code>` inside properly. Closes #1718.

---

### Additional information

![Screenshot 2019-05-21 at 14 37 32](https://user-images.githubusercontent.com/10219857/58096707-ffb7d900-7bd5-11e9-84b0-433891fd3f96.png)
