### PR TITLE
doc: fix the framework guide

### DIFF
--- a/docs/framework/guides/quick-start.md
+++ b/docs/framework/guides/quick-start.md
@@ -56,14 +56,14 @@ module.exports = {
 	module: {
 		rules: [
 			{
-				// Or /ckeditor5-[^/]+\/theme\/icons\/[^/]+\.svg$/ if you want to limit this loader
+				// Or /ckeditor5-[^/]+\/theme\/icons\/.+\.svg$/ if you want to limit this loader
 				// to CKEditor 5 icons only.
 				test: /\.svg$/,
 
 				use: [ 'raw-loader' ]
 			},
 			{
-				// Or /ckeditor5-[^/]+\/theme\/[^/]+\.css$/ if you want to limit this loader
+				// Or /ckeditor5-[^/]+\/theme\/.+\.css$/ if you want to limit this loader
 				// to CKEditor 5 theme only.
 				test: /\.css$/,
 


### PR DESCRIPTION
fix the loader limit expression, some theme files are in **deep directories** like `.../theme/dirA/dirB/dirC/file.css`, e.g.: `ckeditor5-ui/theme/components/toolbar/toolbar.css`