### PR TITLE
Documented missing component properties in the react integration guide.

### DIFF
--- a/docs/builds/guides/frameworks/react.md
+++ b/docs/builds/guides/frameworks/react.md
@@ -45,10 +45,10 @@ class App extends Component {
 						const data = editor.getData();
 						console.log( { event, editor, data } );
 					} }
-					onBlur={ editor => {
+					onBlur={ ( event, editor ) => {
 						console.log( 'Blur.', editor );
 					} }
-					onFocus={ editor => {
+					onFocus={ ( event, editor ) => {
 						console.log( 'Focus.', editor );
 					} }
 				/>
@@ -67,16 +67,16 @@ The `<CKEditor>` component supports the following properties:
 * `editor` (required) &ndash; The {@link module:core/editor/editor~Editor `Editor`} constructor to use.
 * `data` &ndash; The initial data for the created editor. See the {@link builds/guides/integration/basic-api#interacting-with-the-editor Basic API} guide.
 * `config` &ndash; The editor configuration. See the {@link builds/guides/integration/configuration Configuration} guide.
-* `onChange` &ndash; A function called when the editor's data has changed. See the {@link module:engine/model/document~Document#event:change:data `editor.model.document#change:data`} event.
-
-	The callback receives two parameters:
-
-	1. An {@link module:utils/eventinfo~EventInfo `EventInfo`} object,
-	2. An {@link module:core/editor/editor~Editor `Editor`} instance.
 * `onInit` &ndash; A function called when the editor was initialized. It receives the initialized {@link module:core/editor/editor~Editor `editor`} as a parameter.
-* `onBlur` &ndash; A function called when the editor was blurred. It receives the blurred {@link module:core/editor/editor~Editor `editor`} as a parameter.
-* `onFocus` &ndash; A function called when the editor was focused. It receives the focused {@link module:core/editor/editor~Editor `editor`} as a parameter.
 * `disabled` &ndash; A boolean. The {@link module:core/editor/editor~Editor `editor`} is being switched to read-only mode if the property is set to `true`.
+* `onChange` &ndash; A function called when the editor's data has changed. See the {@link module:engine/model/document~Document#event:change:data `editor.model.document#change:data`} event.
+* `onBlur` &ndash; A function called when the editor was blurred. See the {@link module:engine/view/document~Document#event:blur `editor.editing.view.document#blur`} event. 
+* `onFocus` &ndash; A function called when the editor was focused. See the {@link module:engine/view/document~Document#event:focus `editor.editing.view.document#focus`} event.
+
+The editor events callbacks (`onChange`, `onBlur`, `onFocus`) receive two parameters:
+
+1. An {@link module:utils/eventinfo~EventInfo `EventInfo`} object,
+2. An {@link module:core/editor/editor~Editor `Editor`} instance.
 
 ### Customizing the builds
 
@@ -312,10 +312,10 @@ class App extends Component {
 						const data = editor.getData();
 						console.log( { event, editor, data } );
 					} }
-					onBlur={ editor => {
+					onBlur={ ( event, editor ) => {
 						console.log( 'Blur.', editor );
 					} }
-					onFocus={ editor => {
+					onFocus={ ( event, editor ) => {
 						console.log( 'Focus.', editor );
 					} }
 				/>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Fix React integration guide. Closes ckeditor/ckeditor5-react#102.

---

### Additional information

The event callbacks were missing event property and were wrongly documented.

I've re-ordered the properties entry so now it renders like this:

![Selection_068](https://user-images.githubusercontent.com/247363/61940858-9322d700-af96-11e9-90ef-766e61fa7216.png)
