### PR TITLE
Typo in attach multiple code example

### DIFF
--- a/docs/framework/guides/development-tools.md
+++ b/docs/framework/guides/development-tools.md
@@ -60,8 +60,8 @@ You can specify the name of the editor when attaching to make working with multi
 
 ```js
 // Inspecting two editor instances at the same time.
-CKEditorInspector.attach( 'header-editor' editor );
-CKEditorInspector.attach( 'body-editor' editor );
+CKEditorInspector.attach( 'header-editor', editor );
+CKEditorInspector.attach( 'body-editor', editor );
 ```
 
 The editor switcher is in the upper–right corner of the inspector panel.


### PR DESCRIPTION
Docs: Typo in attach multiple code example