### PR TITLE
doc(advanced-setup): add section for Webpack Encore

### DIFF
--- a/docs/builds/guides/integration/advanced-setup.md
+++ b/docs/builds/guides/integration/advanced-setup.md
@@ -194,12 +194,14 @@ Encore.
   	})
 	
 	// Configure PostCSS loader
-	.enablePostCssLoader(options => {
-    	Object.assign(options, styles.getPostCssConfig({
+	.addLoader({
+    	test: /ckeditor5-[^/\\]+[/\\].+\.css$/,
+    	loader: 'postcss-loader',
+    	options: styles.getPostCssConfig({
       		themeImporter: {
         		themePath: require.resolve('@ckeditor/ckeditor5-theme-lark'),
       		},
-    	}));
+    	}),
   	})
 ```
 

--- a/docs/builds/guides/integration/advanced-setup.md
+++ b/docs/builds/guides/integration/advanced-setup.md
@@ -166,6 +166,43 @@ module.exports = {
 };
 ```
 
+#### Webpack Encore
+
+If you use [Webpack Encore](https://github.com/symfony/webpack-encore), you can use the following configuration:
+
+```js
+const CKEditorWebpackPlugin = require( '@ckeditor/ckeditor5-dev-webpack-plugin' );
+const { styles } = require( '@ckeditor/ckeditor5-dev-utils' );
+
+Encore.
+    // ... your configuration ...
+	
+    .addPlugin(new CKEditorWebpackPlugin({
+	    // See https://ckeditor.com/docs/ckeditor5/latest/features/ui-language.html
+        language: 'pl',
+    }))
+	
+	// Use raw-loader for CKEditor5 SVG files
+	.addRule({
+		test: /ckeditor5-[^/]+\/theme\/icons\/[^/]+\.svg$/,
+    	loader: 'raw-loader'
+  	})
+  
+  	// Configure other image loaders to exclude CKEditor5 SVG files
+  	.configureLoaderRule('images', loader => {
+    	loader.exclude = /ckeditor5-[^/]+\/theme\/icons\/[^/]+\.svg$/;
+  	})
+	
+	// Configure PostCSS loader
+	.enablePostCssLoader(options => {
+    	Object.assign(options, styles.getPostCssConfig({
+      		themeImporter: {
+        		themePath: require.resolve('@ckeditor/ckeditor5-theme-lark'),
+      		},
+    	}));
+  	})
+```
+
 ### Running the editor – method 1
 
 You can now import all the needed plugins and the creator directly into your code and use it there. The easiest way to do so is to copy it from the `src/ckeditor.js` file available in every build repository.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Added docs for building from source in Webpack Encore

---

Hi, today I've had some issues while trying to make [Webpack Encore](https://github.com/symfony/webpack-encore) able to build CKEditor5, but I've finally make it works and I think it will be helpful for other people.

Thanks