### PR TITLE
[Docs] Do not center math equations and chemical formulas

### DIFF
--- a/docs/_snippets/features/mathtype.html
+++ b/docs/_snippets/features/mathtype.html
@@ -3,6 +3,7 @@
 	 * See: https://github.com/ckeditor/ckeditor5/issues/2080.
 	 */
 	.live-snippet .ck-editor p img {
+		display: inline;
 		margin: 0;
 	}
 </style>

--- a/docs/_snippets/features/mathtype.html
+++ b/docs/_snippets/features/mathtype.html
@@ -1,13 +1,3 @@
-<style>
-	/* Umberto stylesheet is centering `<img>` inside a `<p>`, let's overwrite it with higher CSS Specificity.
-	 * See: https://github.com/ckeditor/ckeditor5/issues/2080.
-	 */
-	.live-snippet .ck-editor p img {
-		display: inline;
-		margin: 0;
-	}
-</style>
-
 <div id="mathtype-editor">
 	<p>In elementary algebra, the <strong>quadratic formula</strong> is the solution of the quadratic equation.</p>
 

--- a/docs/_snippets/features/mathtype.html
+++ b/docs/_snippets/features/mathtype.html
@@ -1,3 +1,12 @@
+<style>
+	/* Umberto stylesheet is centering `<img>` inside a `<p>`, let's overwrite it with higher CSS Specificity.
+	 * See: https://github.com/ckeditor/ckeditor5-core/issues/198.
+	 */
+	.live-snippet .ck-editor p img {
+		margin: 0;
+	}
+</style>
+
 <div id="mathtype-editor">
 	<p>In elementary algebra, the <strong>quadratic formula</strong> is the solution of the quadratic equation.</p>
 

--- a/docs/_snippets/features/mathtype.html
+++ b/docs/_snippets/features/mathtype.html
@@ -1,6 +1,6 @@
 <style>
 	/* Umberto stylesheet is centering `<img>` inside a `<p>`, let's overwrite it with higher CSS Specificity.
-	 * See: https://github.com/ckeditor/ckeditor5-core/issues/198.
+	 * See: https://github.com/ckeditor/ckeditor5/issues/2080.
 	 */
 	.live-snippet .ck-editor p img {
 		margin: 0;

--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -200,6 +200,15 @@ It breaks CKEditor 5 (see how <p><code>[]</code></p> looks). */
 	margin: 0 auto;
 }
 
+/* Umberto stylesheet is centering `<img>` inside a `<p>`, let's overwrite it with higher CSS Specificity.
+ * See: https://github.com/ckeditor/ckeditor5/issues/2080.
+ */
+.live-snippet p img {
+	display: initial;
+	margin: initial;
+	box-sizing: initial;
+}
+
 .live-snippet blockquote p:first-of-type {
 	margin-bottom: 1.5rem;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Do not center math equations and chemical formulas. Closes #2080.

---

### Additional information

http://127.0.0.1:8080/build/docs/ckeditor5/12.4.0/features/math-equations.html

<img width="833" alt="Screenshot 2019-10-02 at 16 48 06" src="https://user-images.githubusercontent.com/10219857/66054555-75dd2c80-e534-11e9-9fe3-42b7363bf1d9.png">
