### PR TITLE
[Docs] Improved RWD of demos in Examples section

### DIFF
--- a/docs/_snippets/examples/document-editor.html
+++ b/docs/_snippets/examples/document-editor.html
@@ -200,4 +200,40 @@
 	.document-editor .ck-content table td {
 		vertical-align: middle;
 	}
+
+	@media only screen and (max-width: 960px) {
+		/* Because on mobile 2cm paddings are to big. */
+		.document-editor__editable-container .document-editor__editable.ck-editor__editable {
+			padding: 1.5em;
+		}
+	}
+
+	@media only screen and (max-width: 1200px) {
+		.main__content-wide .document-editor__editable-container .document-editor__editable.ck-editor__editable {
+			width: 100%;
+		}
+	}
+
+	/* Style document editor a'ka Google Docs.*/
+	@media only screen and (min-width: 1360px) {
+		.main .main__content.main__content-wide {
+			padding-right: 0;
+		}
+	}
+
+	@media only screen and (min-width: 1600px) {
+		.main .main__content.main__content-wide {
+			width: 24cm;
+		}
+
+		.main .main__content.main__content-wide .main__content-inner {
+			width: auto;
+			margin: 0 50px;
+		}
+
+		/* Keep "page" look based on viewport width. */
+		.main__content-wide .document-editor__editable-container .document-editor__editable.ck-editor__editable {
+			width: 60%;
+		}
+	}
 </style>

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -11,6 +11,17 @@
 	}
 }
 
+/* https://github.com/ckeditor/ckeditor5/issues/1350
+https://github.com/ckeditor/ckeditor5-build-decoupled-document/issues/12 */
+@media only screen and (min-width: 960px) and (max-width: 1360px) {
+	/* https://github.com/ckeditor/ckeditor5/issues/1077 */
+	.main .main__content .main__content-inner,
+	.main .main__content-wide .main__content-inner {
+		padding-left: 30px;
+		padding-right: 30px
+	}
+}
+
 /* https://github.com/ckeditor/ckeditor5/issues/5598. */
 @media only screen and (max-width: 1360px) {
 	.main .main__content-inner {

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -31,8 +31,8 @@ https://github.com/ckeditor/ckeditor5-build-decoupled-document/issues/12 */
 /* https://github.com/ckeditor/ckeditor5/issues/5598. */
 @media only screen and (min-width: 1360px) {
 	.main .main__content--no-toc .main__content-inner {
-		/* Because there is `width: auto`, we need to set something minimal. */
-		min-width: 860px;
+		/* Because there is `width: auto`, we need to set some minimal value. */
+		min-width: 910px;
 	}
 }
 

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -2,46 +2,26 @@
  * Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
  */
 
-/* https://github.com/ckeditor/ckeditor5/issues/913 */
-@media only screen and (min-width: 1600px) {
-	/* https://github.com/ckeditor/ckeditor5/issues/1077 */
-	.main .main__content .main__content-inner,
-	.main .main__content-wide .main__content-inner {
-		width: 840px;
+/* https://github.com/ckeditor/ckeditor5/issues/5598. */
+@media only screen and (min-width: 960px) and (max-width: 1024px ) {
+	.main .main__content {
+		/* Reduce content width including side navigation (340px). */
+		max-width: calc( 100% - 340px );
+		min-width: auto;
 	}
 }
 
-/* https://github.com/ckeditor/ckeditor5/issues/1350
-https://github.com/ckeditor/ckeditor5-build-decoupled-document/issues/12 */
-@media only screen and (min-width: 960px) and (max-width: 1360px) {
-	/* https://github.com/ckeditor/ckeditor5/issues/1077 */
-	.main .main__content .main__content-inner,
-	.main .main__content-wide .main__content-inner {
-		max-width: 900px;
-		padding-left: 30px;
-		padding-right: 30px
+/* https://github.com/ckeditor/ckeditor5/issues/5598. */
+@media only screen and (max-width: 1360px) {
+	.main .main__content-inner {
+		max-width: 960px;
 	}
 }
-
-/* https://github.com/ckeditor/ckeditor5/issues/913 */
+/* https://github.com/ckeditor/ckeditor5/issues/5598. */
 @media only screen and (min-width: 1360px) {
-	.main .main__content.main__content-wide {
-		padding-right: 0;
-	}
-
-	.main .main__content-wide .main__content-inner {
-		max-width: 840px;
-	}
-}
-
-/* https://github.com/ckeditor/ckeditor5/issues/1007 */
-@media only screen and (min-width: 1600px) {
-	.main .main__content.main__content-wide {
-		/*
-		 * `.main__content` by default has 760px width and 340px right padding.
-		 * `.main__content-wide` is 40px wider (800px), that's why we are reducing this right padding.
-		 */
-		padding-right: 300px;
+	.main .main__content--no-toc .main__content-inner {
+		/* Because there is `width: auto`, we need to set something minimal. */
+		min-width: 860px;
 	}
 }
 

--- a/docs/examples/builds/balloon-block-editor.md
+++ b/docs/examples/builds/balloon-block-editor.md
@@ -1,6 +1,7 @@
 ---
 category: examples-builds
 order: 30
+classes: main__content--no-toc
 ---
 
 # Balloon block editor

--- a/docs/examples/builds/balloon-editor.md
+++ b/docs/examples/builds/balloon-editor.md
@@ -1,6 +1,7 @@
 ---
 category: examples-builds
 order: 30
+classes: main__content--no-toc
 ---
 
 # Balloon editor

--- a/docs/examples/builds/classic-editor.md
+++ b/docs/examples/builds/classic-editor.md
@@ -1,6 +1,7 @@
 ---
 category: examples-builds
 order: 10
+classes: main__content--no-toc
 ---
 
 # Classic editor

--- a/docs/examples/builds/custom-build.md
+++ b/docs/examples/builds/custom-build.md
@@ -1,6 +1,7 @@
 ---
 category: examples-builds
 order: 40
+classes: main__content--no-toc
 ---
 
 # Custom build

--- a/docs/examples/builds/document-editor.md
+++ b/docs/examples/builds/document-editor.md
@@ -1,7 +1,7 @@
 ---
 category: examples-builds
 order: 30
-classes: main__content-wide
+classes: 'main__content-wide main__content--no-toc'
 ---
 
 # Document editor

--- a/docs/examples/builds/inline-editor.md
+++ b/docs/examples/builds/inline-editor.md
@@ -1,6 +1,7 @@
 ---
 category: examples-builds
 order: 20
+classes: main__content--no-toc
 ---
 
 # Inline editor


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Improved RWD of demos in the Examples section. Closes #5598.

---

### Additional information

1. Enlarged container width of document editor demo

![Screenshot 2019-10-17 at 10 48 03](https://user-images.githubusercontent.com/10219857/66993353-b52a8200-f0cb-11e9-9b5f-495b711a8cac.png)

2. Fixed document editor demo for mobiles because ATM it looks like this:

Before:
![Screenshot 2019-10-17 at 10 24 28](https://user-images.githubusercontent.com/10219857/66993056-37ff0d00-f0cb-11e9-9176-e7f140393cb2.png)