### PR TITLE
Improvements for content styles script

### DIFF
--- a/docs/builds/guides/integration/content-styles.md
+++ b/docs/builds/guides/integration/content-styles.md
@@ -49,7 +49,7 @@ Below there is a full list of content styles used by the editor features. You ca
 ```css
 /*
  * CKEditor 5 (v12.4.0) content styles.
- * Generated on Thu, 17 Oct 2019 07:18:45 GMT.
+ * Generated on Mon, 21 Oct 2019 11:34:56 GMT.
  * For more information, check out https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/content-styles.html
  */
 
@@ -64,26 +64,12 @@ Below there is a full list of content styles used by the editor features. You ca
 	padding: .15em;
 	border-radius: 2px;
 }
-/* ckeditor5-image/theme/imageresize.css */
-.ck-content .image.image_resized {
-	max-width: 100%;
-	display: block;
-	box-sizing: border-box
-}
-/* ckeditor5-image/theme/imageresize.css */
-.ck-content .image.image_resized img {
-	width: 100%;
-}
-/* ckeditor5-image/theme/imageresize.css */
-.ck-content .image.image_resized > figcaption {
-	display: block;
-}
 /* ckeditor5-image/theme/image.css */
 .ck-content .image {
 	display: table;
 	clear: both;
 	text-align: center;
-	margin: 1em auto
+	margin: 1em auto;
 }
 /* ckeditor5-image/theme/image.css */
 .ck-content .image > img {
@@ -103,13 +89,34 @@ Below there is a full list of content styles used by the editor features. You ca
 	font-size: .75em;
 	outline-offset: -1px;
 }
+/* ckeditor5-image/theme/imageresize.css */
+.ck-content .image.image_resized {
+	max-width: 100%;
+	display: block;
+	box-sizing: border-box;
+}
+/* ckeditor5-image/theme/imageresize.css */
+.ck-content .image.image_resized img {
+	width: 100%;
+}
+/* ckeditor5-image/theme/imageresize.css */
+.ck-content .image.image_resized > figcaption {
+	display: block;
+}
+/* ckeditor5-media-embed/theme/mediaembed.css */
+.ck-content .media {
+	clear: both;
+	margin: 1em 0;
+	display: block;
+	min-width: 15em;
+}
 /* ckeditor5-list/theme/todolist.css */
 .ck-content .todo-list {
-	list-style: none
+	list-style: none;
 }
 /* ckeditor5-list/theme/todolist.css */
 .ck-content .todo-list li {
-	margin-bottom: 5px
+	margin-bottom: 5px;
 }
 /* ckeditor5-list/theme/todolist.css */
 .ck-content .todo-list li .todo-list {
@@ -127,7 +134,7 @@ Below there is a full list of content styles used by the editor features. You ca
 	left: -25px;
 	margin-right: -15px;
 	right: 0;
-	margin-left: 0
+	margin-left: 0;
 }
 /* ckeditor5-list/theme/todolist.css */
 .ck-content .todo-list .todo-list__label > input::before {
@@ -173,20 +180,13 @@ Below there is a full list of content styles used by the editor features. You ca
 /* ckeditor5-table/theme/table.css */
 .ck-content .table {
 	margin: 1em auto;
-	display: table
+	display: table;
 }
 /* ckeditor5-table/theme/table.css */
 .ck-content .table table {
 	border-collapse: collapse;
 	border-spacing: 0;
-	border: 1px double hsl(0, 0%, 70%)
-}
-/* ckeditor5-table/theme/table.css */
-.ck-content .table table td,
-.ck-content .table table th {
-	min-width: 2em;
-	padding: .4em;
-	border-color: hsl(0, 0%, 85%);
+	border: 1px double hsl(0, 0%, 70%);
 }
 /* ckeditor5-table/theme/table.css */
 .ck-content .table table td,
@@ -207,7 +207,7 @@ Below there is a full list of content styles used by the editor features. You ca
 	padding: 5px 0;
 	display: flex;
 	align-items: center;
-	justify-content: center
+	justify-content: center;
 }
 /* ckeditor5-page-break/theme/pagebreak.css */
 .ck-content .page-break::after {
@@ -235,14 +235,6 @@ Below there is a full list of content styles used by the editor features. You ca
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
-}
-/* ckeditor5-page-break/theme/pagebreak.css */
-.ck-content .page-break {
-	padding: 0
-}
-/* ckeditor5-page-break/theme/pagebreak.css */
-.ck-content .page-break::after {
-	display: none;
 }
 /* ckeditor5-image/theme/imagestyle.css */
 .ck-content .image-style-side,
@@ -286,18 +278,21 @@ Below there is a full list of content styles used by the editor features. You ca
 	border-left: 0;
 	border-right: solid 5px hsl(0, 0%, 80%);
 }
-/* ckeditor5-media-embed/theme/mediaembed.css */
-.ck-content .media {
-	clear: both;
-	margin: 1em 0;
-	display: block;
-	min-width: 15em;
-}
 /* ckeditor5-horizontal-line/theme/horizontalline.css */
 .ck-content hr {
 	border-width: 1px 0 0;
 	border-style: solid;
 	border-color: hsl(0, 0%, 37%);
 	margin: 0;
+}
+@media print {
+	/* ckeditor5-page-break/theme/pagebreak.css */
+	.ck-content .page-break {
+		padding: 0;
+	}
+	/* ckeditor5-page-break/theme/pagebreak.css */
+	.ck-content .page-break::after {
+		display: none;
+	}
 }
 ```

--- a/scripts/docs/build-content-styles.js
+++ b/scripts/docs/build-content-styles.js
@@ -87,7 +87,7 @@ runWebpack( webpackConfig )
 
 		const atRulesDefinitions = [];
 
-		// Additional at-rules
+		// Additional at-rules.
 		for ( const atRuleName of Object.keys( contentRules.atRules ) ) {
 			const rules = transformCssRules( contentRules.atRules[ atRuleName ] )
 				.split( '\n' )

--- a/scripts/docs/content-styles/list-content-styles.js
+++ b/scripts/docs/content-styles/list-content-styles.js
@@ -15,21 +15,77 @@ module.exports = postcss.plugin( 'list-content-styles', function( options ) {
 
 	return root => {
 		root.walkRules( rule => {
-			rule.selectors.forEach( selector => {
+			for ( const selector of rule.selectors ) {
+				const data = {
+					file: root.source.input.file,
+					css: rule.toString()
+				};
+
 				if ( selector.match( ':root' ) ) {
-					variables.push( {
-						file: root.source.input.file,
-						css: rule.toString()
-					} );
+					addDefinition( variables, data );
 				}
 
 				if ( selector.match( '.ck-content' ) ) {
-					selectorStyles.push( {
-						file: root.source.input.file,
-						css: rule.toString()
-					} );
+					if ( rule.parent.name && rule.parent.params ) {
+						const atRule = getAtRuleArray( options.contentRules.atRules, rule.parent.name, rule.parent.params );
+
+						addDefinition( atRule, data );
+					} else {
+						addDefinition( selectorStyles, data );
+					}
 				}
-			} );
+			}
 		} );
 	};
 } );
+
+/**
+ * @param {Object} collection
+ * @param {String} name Name of an `at-rule`.
+ * @param {String} params Parameters that describes the `at-rule`.
+ * @returns {Array}
+ */
+function getAtRuleArray( collection, name, params ) {
+	const definition = `${ name } ${ params }`;
+
+	if ( !collection[ definition ] ) {
+		collection[ definition ] = [];
+	}
+
+	return collection[ definition ];
+}
+
+/**
+ * Checks whether specified definition is duplicated in the colletion.
+ *
+ * @param {Array.<StyleStructure>} collection
+ * @param {StyleStructure} def
+ * @returns {Boolean}
+ */
+function isDuplicatedDefinition( collection, def ) {
+	for ( const item of collection ) {
+		if ( item.file === def.file && item.css === def.css ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Adds definition to the collection if it does not exist in the collection.
+ *
+ * @param {Array.<StyleStructure>} collection
+ * @param {StyleStructure} def
+ */
+function addDefinition( collection, def ) {
+	if ( !isDuplicatedDefinition( collection, def ) ) {
+		collection.push( def );
+	}
+}
+
+/**
+ * @typedef {Object} StyleStructure
+ * @property {String} file An absolute path to the file where a definition is defined.
+ * @property {String} css Definition.
+ */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Content styles script does not print duplicated styles and handles `at-rule` selectors. Closes #5605. Closes #5604.
