### PR TITLE
Improved the changelog generator

### DIFF
--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -32,7 +32,7 @@ const optionsForBuilds = Object.assign( {}, commonOptions, {
 
 Promise.resolve()
 	.then( () => devEnv.generateChangelogForSubRepositories( optionsForDependencies ) )
-	.then( () => devEnv.generateSummaryChangelog( optionsForBuilds ) )
+	.then( response => devEnv.generateSummaryChangelog( Object.assign( optionsForBuilds, response ) ) )
 	.then( () => {
 		console.log( 'Done!' );
 	} )

--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -15,9 +15,7 @@
 const devEnv = require( '@ckeditor/ckeditor5-dev-env' );
 const commonOptions = {
 	cwd: process.cwd(),
-	packages: 'packages',
-	// `newVersion` is mostly used for testing purposes. It allows generating changelog that contains the same version for all packages.
-	newVersion: process.argv[ 2 ] || null
+	packages: 'packages'
 };
 const editorBuildsGlob = '@ckeditor/ckeditor5-build-*';
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Passed a response from `devEnv.generateChangelogForSubRepositories()` task to `devEnv.generateSummaryChangelog()`.

---

### Additional information

Requires https://github.com/ckeditor/ckeditor5-dev/pull/573.