### PR TITLE
Fixed a reference to the issue tracker in the docs

### DIFF
--- a/docs/builds/guides/support/reporting-issues.md
+++ b/docs/builds/guides/support/reporting-issues.md
@@ -22,9 +22,7 @@ Most of the issues are reproducible on the demo. If you have a different case th
 
 ## Reporting issues
 
-All issues should be reported in the [CKEditor 5 repositories](https://github.com/ckeditor?q=ckeditor5) on GitHub.
-
-Issues related to builds are usually caused by issues in the CKEditor 5 Framework components and plugins included in the build. You may report issues directly into the repositories that you think are related to them (like plugins) but, if you are unsure, the [`ckeditor5` issues page](https://github.com/ckeditor/ckeditor5/issues) should be used as the fallback place for any issue. The CKEditor 5 team will then move the issue to the right place or give you further instructions, if necessary.
+All issues should be reported in the [CKEditor 5 repository](https://github.com/ckeditor/ckeditor5/issues) on GitHub.
 
 Things to keep in mind:
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Fixed a reference to the issue tracker in the docs. Closes #5673.