### PR TITLE
Removed a workaround for missing MathType icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "css-loader": "^1.0.0",
     "eslint": "^5.5.0",
     "eslint-config-ckeditor5": "^2.0.0",
-    "file-loader": "^4.1.0",
     "glob": "^7.1.2",
     "husky": "^1.3.1",
     "lint-staged": "^7.0.0",

--- a/scripts/docs/snippetadapter.js
+++ b/scripts/docs/snippetadapter.js
@@ -365,24 +365,6 @@ function getWebpackConfig( snippets, config ) {
 							} )
 						}
 					]
-				},
-				// `file-loader` is used to handle assets introduced by 3rd party plugins.
-				// All guides in the documentation that could use images should be named as follow: `guide-type/guide-name`
-				//
-				// NOTE: You cannot use more than single slash `/` in the guide name.
-				// All images will be saved in the `snippets/` directory as `assets/images/[file]`.
-				// Unfortunately, compiled JS/CSS file that requires images will be looking for those assets in:
-				// `snippets/[guide-type/guide-name]/assets/images/` so we need to manually go up twice.
-				// ATM there is no easy way to find the number how many directories we need to go up so the assumption about names of
-				// the guides seems to be a safer solution.
-				{
-					test: /\.(png|jpe?g|gif)$/,
-					loader: 'file-loader',
-					options: {
-						name: config.production ? '[sha512:hash:base64:7].[ext]' : '[name].[ext]',
-						outputPath: path.join( 'assets', 'images' ),
-						publicPath: [ '..', '..', 'assets', 'images' ].join( '/' )
-					},
 				}
 			]
 		}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4361,14 +4361,6 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
-file-loader@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-4.2.0.tgz#5fb124d2369d7075d70a9a5abecd12e60a95215e"
-  integrity sha512-+xZnaK5R8kBJrHK0/6HRlrKNamvVS5rjyuju+rnyxRGuwUJwpAMsVzUl5dz6rK8brkzjV6JpcFNjp6NqV0g1OQ==
-  dependencies:
-    loader-utils "^1.2.3"
-    schema-utils "^2.0.0"
-
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9717,7 +9717,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.0.0, schema-utils@^2.0.1:
+schema-utils@^2.0.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.5.0.tgz#8f254f618d402cc80257486213c8970edfd7c22f"
   integrity sha512-32ISrwW2scPXHUSusP8qMg5dLUawKkyV+/qIEV9JdXKx+rsM6mi8vZY8khg2M69Qom16rtroWXD3Ybtiws38gQ==


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Removed a workaround for missing MathType icons. Closes ckeditor/ckeditor5-dev#572.