### PR TITLE
A new version should be taken from CHANGELOG.md instead of package.json

### DIFF
--- a/scripts/release/update-utils-version.js
+++ b/scripts/release/update-utils-version.js
@@ -34,9 +34,9 @@ if ( exec( 'git status -s' ).trim().length ) {
 	exec( 'git add src/version.js' );
 	exec( 'git commit -m "Internal: Updated version of CKEditor 5."' );
 
-	console.log( 'The version has been updated and committed.' );
+	console.log( `The hardcoded version in ckeditor5-utils has been updated to ${ version }.` );
 } else {
-	console.log( 'Nothing to commit. Version is up-to-date.' );
+	console.log( `Nothing to commit. Version in ckeditor5-utils is up-to-date (${ version }).` );
 }
 
 process.chdir( CWD );

--- a/scripts/release/update-utils-version.js
+++ b/scripts/release/update-utils-version.js
@@ -9,18 +9,19 @@
 
 'use strict';
 
-// This scripts updates version of CKEditor 5 in the `@ckeditor/ckeditor5-utils/src/version` module.
+// This script updates the version of CKEditor 5 in the `@ckeditor/ckeditor5-utils/src/version` module.
 // It should be called as a post hook, after generating changelogs.
 
 const fs = require( 'fs' );
 const path = require( 'path' );
 const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
+const versionUtils = require( '@ckeditor/ckeditor5-dev-env/lib/release-tools/utils/versions' );
 
 const CWD = process.cwd();
 const UTILS_PACKAGE_PATH = path.join( CWD, 'packages', 'ckeditor5-utils' );
 const UTILS_MODULE_PATH = path.join( UTILS_PACKAGE_PATH, 'src', 'version.js' );
 
-const { version } = require( path.join( CWD, 'package.json' ) );
+const version = versionUtils.getLastFromChangelog();
 
 const fileContent = fs.readFileSync( UTILS_MODULE_PATH, 'utf-8' )
 	.replace( /const version = '\d+\.\d+\.\d+';/, `const version = '${ version }';` );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fixed a way how to get a new version in the `postchangelog` script. The previous script read the version from `package.json` which is wrong because it will be update later. The version must be taken from `CHANGELOG.md`.
