### PR TITLE
Remove mentions of a <textarea> element from guides.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Creating an editor using a CKEditor 5 build is very simple and can be described 
 In your HTML page add an element that CKEditor should replace:
 
 ```html
-<div name="content" id="editor"></div>
+<div id="editor"></div>
 ```
 
 Load the classic editor build (you can choose between [CDN](https://cdn.ckeditor.com/#ckeditor5), [npm](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/installation.html#npm) and [zip downloads](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/installation.html#zip-download)):

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Creating an editor using a CKEditor 5 build is very simple and can be described 
 In your HTML page add an element that CKEditor should replace:
 
 ```html
-<textarea name="content" id="editor"></textarea>
+<div name="content" id="editor"></div>
 ```
 
 Load the classic editor build (you can choose between [CDN](https://cdn.ckeditor.com/#ckeditor5), [npm](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/installation.html#npm) and [zip downloads](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/installation.html#zip-download)):

--- a/docs/builds/guides/integration/basic-api.md
+++ b/docs/builds/guides/integration/basic-api.md
@@ -30,9 +30,9 @@ Regardless of the chosen build, creating an editor is done using the static `cre
 Add an element that CKEditor should replace to your HTML page:
 
 ```html
-<textarea name="content" id="editor">
+<div name="content" id="editor">
 	&lt;p&gt;Here goes the initial content of the editor.&lt;/p&gt;
-</textarea>
+</div>
 ```
 
 Then call {@link module:editor-classic/classiceditor~ClassicEditor#create `ClassicEditor.create()`} to **replace** the `<textarea>` element with a {@link builds/guides/overview#classic-editor Classic editor}:

--- a/docs/builds/guides/integration/basic-api.md
+++ b/docs/builds/guides/integration/basic-api.md
@@ -30,8 +30,8 @@ Regardless of the chosen build, creating an editor is done using the static `cre
 Add an element that CKEditor should replace to your HTML page:
 
 ```html
-<div name="content" id="editor">
-	&lt;p&gt;Here goes the initial content of the editor.&lt;/p&gt;
+<div id="editor">
+	<p>Here goes the initial content of the editor.</p>
 </div>
 ```
 
@@ -56,7 +56,7 @@ Similarly to the previous example, add an element where CKEditor should initiali
 
 ```html
 <div id="editor">
-	&lt;p&gt;Here goes the initial content of the editor.&lt;/p&gt;
+	<p>Here goes the initial content of the editor.</p>
 </div>
 ```
 
@@ -81,7 +81,7 @@ Add an element where CKEditor should initialize to your page:
 
 ```html
 <div id="editor">
-	&lt;p&gt;Here goes the initial content of the editor.&lt;/p&gt;
+	<p>Here goes the initial content of the editor.</p>
 </div>
 ```
 

--- a/docs/builds/guides/quick-start.md
+++ b/docs/builds/guides/quick-start.md
@@ -22,7 +22,7 @@ Creating an editor using a CKEditor 5 build is very simple and can be described 
 In your HTML page add an element that CKEditor should replace:
 
 ```html
-<textarea name="content" id="editor"></textarea>
+<div name="content" id="editor"></div>
 ```
 
 Load the classic editor build (here [CDN](https://cdn.ckeditor.com/) location is used):
@@ -55,9 +55,9 @@ Call the {@link module:editor-classic/classiceditor~ClassicEditor#create `Classi
 </head>
 <body>
 	<h1>Classic editor</h1>
-	<textarea name="content" id="editor">
+	<div name="content" id="editor">
 		&lt;p&gt;This is some sample content.&lt;/p&gt;
-	</textarea>
+	</div>
 	<script>
 		ClassicEditor
 			.create( document.querySelector( '#editor' ) )

--- a/docs/builds/guides/quick-start.md
+++ b/docs/builds/guides/quick-start.md
@@ -22,7 +22,7 @@ Creating an editor using a CKEditor 5 build is very simple and can be described 
 In your HTML page add an element that CKEditor should replace:
 
 ```html
-<div name="content" id="editor"></div>
+<div id="editor"></div>
 ```
 
 Load the classic editor build (here [CDN](https://cdn.ckeditor.com/) location is used):
@@ -55,8 +55,8 @@ Call the {@link module:editor-classic/classiceditor~ClassicEditor#create `Classi
 </head>
 <body>
 	<h1>Classic editor</h1>
-	<div name="content" id="editor">
-		&lt;p&gt;This is some sample content.&lt;/p&gt;
+	<div id="editor">
+		<p>This is some sample content.</p>
 	</div>
 	<script>
 		ClassicEditor


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Remove mentions of a `<textarea>` element from guides.. Closes #1806.

---

### Additional information

* I've scanned the whole code base for `<textarea` occurences and only those in this PR might lead to a confusing behavior (#1591)
* the other mentions in the `.md` files were for the usage of CKEditor on forms (which uses `<textarea>` , placeholder usage or were just samples printing out contents of the editor (React sample)
