### PR TITLE
Fixed a runtime error in the "Using a React component in a block widget" guide

### DIFF
--- a/docs/_snippets/framework/tutorials/using-react-in-widget.js
+++ b/docs/_snippets/framework/tutorials/using-react-in-widget.js
@@ -63,7 +63,7 @@ class ProductPreviewEditing extends Plugin {
 	_defineConverters() {
 		const editor = this.editor;
 		const conversion = editor.conversion;
-		const renderProduct = editor.config.get( 'products.productRenderer' );
+		const renderProduct = editor.config.get( 'products' ).productRenderer;
 
 		// <productPreview> converters ((data) view → model)
 		conversion.for( 'upcast' ).elementToElement( {

--- a/docs/framework/guides/tutorials/using-react-in-a-widget.md
+++ b/docs/framework/guides/tutorials/using-react-in-a-widget.md
@@ -1130,7 +1130,7 @@ export default class ProductPreviewEditing extends Plugin {
 	_defineConverters() {
 		const editor = this.editor;
 		const conversion = editor.conversion;
-		const renderProduct = editor.config.get( 'products.productRenderer' );
+		const renderProduct = editor.config.get( 'products' ).productRenderer;
 
 		// <productPreview> converters ((data) view → model)
 		conversion.for( 'upcast' ).elementToElement( {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fixed a runtime error in the "Using a React component in a block widget" guide. Closes #5850.

---

### Additional information

Decided to put it as "Internal" as it doesn't make sense to put it into changelog, since broken docs were not published in any release.