### PR TITLE
Docs: Fixed the way config is accessed in the "Using a React component in a block widget" guide.

### DIFF
--- a/docs/framework/guides/tutorials/using-react-in-a-widget.md
+++ b/docs/framework/guides/tutorials/using-react-in-a-widget.md
@@ -311,7 +311,7 @@ export default class ProductPreviewEditing extends Plugin {
 	_defineConverters() {
 		const editor = this.editor;
 		const conversion = editor.conversion;
-		const renderProduct = editor.config.get( 'products.productRenderer' );
+		const renderProduct = editor.config.get( 'products' ).productRenderer;
 
 		// <productPreview> converters ((data) view → model)
 		conversion.for( 'upcast' ).elementToElement( {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Fixed the way config is accessed in the "Using a React component in a block widget" guide. Closes #5900.