### PR TITLE
i/5885: Remove "unsafe-eval" directive from wproofreader manual test template

### DIFF
--- a/tests/manual/wproofreader.html
+++ b/tests/manual/wproofreader.html
@@ -1,7 +1,6 @@
 <head>
 	<!--
 		Required to fetch runtime data from https://svc.webspellchecker.net.
-		Also both unsafe inline and eval are required for it to work (https://github.com/WebSpellChecker/wproofreader/issues/19).
 	-->
 	<meta http-equiv="Content-Security-Policy" content="script-src 'self' https://cksource.com https://svc.webspellchecker.net;">
 </head>

--- a/tests/manual/wproofreader.html
+++ b/tests/manual/wproofreader.html
@@ -3,7 +3,7 @@
 		Required to fetch runtime data from https://svc.webspellchecker.net.
 		Also both unsafe inline and eval are required for it to work (https://github.com/WebSpellChecker/wproofreader/issues/19).
 	-->
-	<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-eval' https://cksource.com https://svc.webspellchecker.net;">
+	<meta http-equiv="Content-Security-Policy" content="script-src 'self' https://cksource.com https://svc.webspellchecker.net;">
 </head>
 
 <script


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Test: Remove "unsafe-eval" directive from wproofreader manual test template. Closes #5885 .

