### PR TITLE
i/353: Focus the editor before executing a command

### DIFF
--- a/docs/_snippets/framework/tutorials/block-widget.js
+++ b/docs/_snippets/framework/tutorials/block-widget.js
@@ -52,7 +52,10 @@ class SimpleBoxUI extends Plugin {
 			buttonView.bind( 'isOn', 'isEnabled' ).to( command, 'value', 'isEnabled' );
 
 			// Execute the command when the button is clicked (executed).
-			this.listenTo( buttonView, 'execute', () => editor.execute( 'insertSimpleBox' ) );
+			this.listenTo( buttonView, 'execute', () => {
+				editor.execute( 'insertSimpleBox' );
+				editor.editing.view.focus();
+			} );
 
 			return buttonView;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Focus the editor before executing toolbar buttons' command. Closes ckeditor/ckeditor5#353.
