### PR TITLE
Add docs linking to the online builder

### DIFF
--- a/docs/builds/guides/development/custom-builds.md
+++ b/docs/builds/guides/development/custom-builds.md
@@ -21,7 +21,9 @@ Some of the reasons for creating custom builds are:
 * Changing the {@link features/ui-language localization language} of the editor.
 * Enabling bug fixes which are still not a part of any public release.
 
+<info-box hint>
 If you are looking for an easy way to create a custom build of CKEditor 5, check also the [online builder](https://ckeditor.com/ckeditor-5/online-builder/), which allows you to create easily a custom build through a simple and intuitive UI.
+</info-box>
 
 ## Requirements
 

--- a/docs/builds/guides/development/custom-builds.md
+++ b/docs/builds/guides/development/custom-builds.md
@@ -22,7 +22,7 @@ Some of the reasons for creating custom builds are:
 * Enabling bug fixes which are still not a part of any public release.
 
 <info-box hint>
-If you are looking for an easy way to create a custom build of CKEditor 5, check also the [online builder](https://ckeditor.com/ckeditor-5/online-builder/), which allows you to create easily a custom build through a simple and intuitive UI.
+	If you are looking for an easy way to create a custom build of CKEditor 5, check also the [online builder](https://ckeditor.com/ckeditor-5/online-builder/), which allows you to create easily a custom build through a simple and intuitive UI.
 </info-box>
 
 ## Requirements

--- a/docs/builds/guides/development/custom-builds.md
+++ b/docs/builds/guides/development/custom-builds.md
@@ -21,6 +21,8 @@ Some of the reasons for creating custom builds are:
 * Changing the {@link features/ui-language localization language} of the editor.
 * Enabling bug fixes which are still not a part of any public release.
 
+If you are looking for an easy way to create a custom build of CKEditor 5, check also the [online builder](https://ckeditor.com/ckeditor-5/online-builder/), which allows you to create easily a custom build through a simple and intuitive UI.
+
 ## Requirements
 
 In order to start developing CKEditor 5 you will require:

--- a/docs/builds/guides/integration/installation.md
+++ b/docs/builds/guides/integration/installation.md
@@ -47,7 +47,7 @@ CKEditor will then be available at `node_modules/@ckeditor/ckeditor5-build-[name
 
 ### Online builder
 
-Go to the [Online builder page](https://ckeditor.com/ckeditor-5/online-builder/), go through a few creator steps to pick plugins and toolbar items and visualize the editor. Then download the prepared build with a simple instruction how to run it.
+The [online builder](https://ckeditor.com/ckeditor-5/online-builder/) lets you download CKEditor 5 builds and also allows you to create your own, customized builds (with a different set of plugins) in a few easy steps, through a simple and intuitive UI.
 
 ### Zip download
 
@@ -77,5 +77,4 @@ Once the CKEditor script is loaded, you can {@link builds/guides/integration/bas
 
 	Also, for a more advanced setup, you may wish to bundle the CKEditor script with other scripts used by your application. See {@link builds/guides/integration/advanced-setup Advanced setup} for more information about it.
 </info-box>
-
 

--- a/docs/builds/guides/integration/installation.md
+++ b/docs/builds/guides/integration/installation.md
@@ -14,6 +14,7 @@ There are several options to download CKEditor 5 builds:
 
 * [CDN](#cdn)
 * [npm](#npm)
+* [Online builder](#online-builder)
 * [Zip download](#zip-download)
 
 For the list of available builds check the {@link builds/guides/overview#available-builds Overview} page.
@@ -43,6 +44,10 @@ npm install --save @ckeditor/ckeditor5-build-decoupled-document
 ```
 
 CKEditor will then be available at `node_modules/@ckeditor/ckeditor5-build-[name]/build/ckeditor.js`. It can also be imported directly to your code by `require( '@ckeditor/ckeditor5-build-[name]' )`.
+
+### Online builder
+
+Go to the [Online builder page](https://ckeditor.com/ckeditor-5/online-builder/), go through a few creator steps to pick plugins and toolbar items and visualize the editor. Then download the prepared build with a simple instruction how to run it.
 
 ### Zip download
 

--- a/docs/builds/guides/integration/installing-plugins.md
+++ b/docs/builds/guides/integration/installing-plugins.md
@@ -13,7 +13,9 @@ In this guide you can learn how to add plugins to your editor in the two most co
 * When you use an {@link builds/guides/overview editor build},
 * When you {@link framework/guides/quick-start build your editor from source}.
 
+<info-box hint>
 If you are looking for an easy way to create a custom build of CKEditor 5 without installing anything, check the [online builder](https://ckeditor.com/ckeditor-5/online-builder/), which allows you to create easily a build with a custom set of plugins through a simple and intuitive UI.
+</info-box>
 
 ## Requirements
 

--- a/docs/builds/guides/integration/installing-plugins.md
+++ b/docs/builds/guides/integration/installing-plugins.md
@@ -14,7 +14,7 @@ In this guide you can learn how to add plugins to your editor in the two most co
 * When you {@link framework/guides/quick-start build your editor from source}.
 
 <info-box hint>
-If you are looking for an easy way to create a custom build of CKEditor 5 without installing anything, check the [online builder](https://ckeditor.com/ckeditor-5/online-builder/), which allows you to create easily a build with a custom set of plugins through a simple and intuitive UI.
+	If you are looking for an easy way to create a custom build of CKEditor 5 without installing anything, check the [online builder](https://ckeditor.com/ckeditor-5/online-builder/), which allows you to create easily a build with a custom set of plugins through a simple and intuitive UI.
 </info-box>
 
 ## Requirements

--- a/docs/builds/guides/integration/installing-plugins.md
+++ b/docs/builds/guides/integration/installing-plugins.md
@@ -13,6 +13,8 @@ In this guide you can learn how to add plugins to your editor in the two most co
 * When you use an {@link builds/guides/overview editor build},
 * When you {@link framework/guides/quick-start build your editor from source}.
 
+If you are looking for an easy way to create a custom build of CKEditor 5 without installing anything, check the [online builder](https://ckeditor.com/ckeditor-5/online-builder/), which allows you to create easily a build with a custom set of plugins through a simple and intuitive UI.
+
 ## Requirements
 
 In order to start developing CKEditor 5 you will require:


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Added docs linking to the online builder. Part of #1174.

---

### Additional information

I added the link to the online builder in the `Installation` section. However, I'm not sure if it's the best place to add it. Or if there are better places.

@wwalc suggested the [Custom builds guide](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/development/custom-builds.html), but to me, the online builder doesn't fit the *development* section of this guide and the guide itself focusing mostly on forking GH's `ckeditor5-build-*` repos.

cc @Reinmar @wwalc 