### PR TITLE
Added editor setData manual performance test

### DIFF
--- a/tests/manual/performance/_utils/large.txt
+++ b/tests/manual/performance/_utils/large.txt
@@ -1,0 +1,1 @@
+<h1>large data placeholder</h1>

--- a/tests/manual/performance/_utils/medium.txt
+++ b/tests/manual/performance/_utils/medium.txt
@@ -1,0 +1,1 @@
+<h1>Medium data placeholder</h1>

--- a/tests/manual/performance/_utils/small.txt
+++ b/tests/manual/performance/_utils/small.txt
@@ -1,0 +1,3 @@
+<h1>Hello world</h1>
+
+<p>This is rather short text with <em>very little</em> text <strong>formatting</strong>.</p>

--- a/tests/manual/performance/setdata.html
+++ b/tests/manual/performance/setdata.html
@@ -1,0 +1,9 @@
+<div id="test-controls">
+	Set data with:
+	<button id="small-content" data-file-name="small" disabled>small</button>
+	<button id="medium-content" data-file-name="medium" disabled>medium</button>
+	<button id="large-content" data-file-name="large" disabled>large</button>
+	HTML payload.
+</div>
+
+<div id="editor"></div>

--- a/tests/manual/performance/setdata.html
+++ b/tests/manual/performance/setdata.html
@@ -1,9 +1,11 @@
 <div id="test-controls">
-	Set data with:
+	Call <code>editor.setData()</code> with:
 	<button id="small-content" data-file-name="small" disabled>small</button>
 	<button id="medium-content" data-file-name="medium" disabled>medium</button>
 	<button id="large-content" data-file-name="large" disabled>large</button>
 	HTML payload.
 </div>
+
+<hr>
 
 <div id="editor"></div>

--- a/tests/manual/performance/setdata.js
+++ b/tests/manual/performance/setdata.js
@@ -52,9 +52,6 @@ const fileNames = Array.from( buttons ).map( button => button.getAttribute( 'dat
 
 preloadData( fileNames.map( name => `_utils/${ name }.txt` ) )
 	.then( fixtures => {
-		console.log( 'fixtures' );
-		console.log( fixtures );
-
 		for ( const button of buttons ) {
 			button.addEventListener( 'click', function() {
 				const content = fixtures[ this.getAttribute( 'data-file-name' ) ];

--- a/tests/manual/performance/setdata.js
+++ b/tests/manual/performance/setdata.js
@@ -28,17 +28,7 @@ ClassicEditor
 			'mediaEmbed',
 			'undo',
 			'redo'
-		],
-		image: {
-			toolbar: [ 'imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative' ]
-		},
-		table: {
-			contentToolbar: [
-				'tableColumn',
-				'tableRow',
-				'mergeTableCells'
-			]
-		}
+		]
 	} )
 	.then( editor => {
 		window.editor = editor;

--- a/tests/manual/performance/setdata.js
+++ b/tests/manual/performance/setdata.js
@@ -1,0 +1,76 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ ArticlePluginSet ],
+		toolbar: [
+			'heading',
+			'|',
+			'bold',
+			'italic',
+			'link',
+			'bulletedList',
+			'numberedList',
+			'|',
+			'outdent',
+			'indent',
+			'|',
+			'blockQuote',
+			'insertTable',
+			'mediaEmbed',
+			'undo',
+			'redo'
+		],
+		image: {
+			toolbar: [ 'imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative' ]
+		},
+		table: {
+			contentToolbar: [
+				'tableColumn',
+				'tableRow',
+				'mergeTableCells'
+			]
+		}
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );
+
+const buttons = document.querySelectorAll( '#test-controls button' );
+const fileNames = Array.from( buttons ).map( button => button.getAttribute( 'data-file-name' ) );
+
+preloadData( fileNames.map( name => `_utils/${ name }.txt` ) )
+	.then( fixtures => {
+		console.log( 'fixtures' );
+		console.log( fixtures );
+
+		for ( const button of buttons ) {
+			button.addEventListener( 'click', function() {
+				const content = fixtures[ this.getAttribute( 'data-file-name' ) ];
+
+				window.editor.setData( content );
+			} );
+			button.disabled = false;
+		}
+	} );
+
+function preloadData( urls ) {
+	// @todo: simplify it - inline literals instead of looping over arrays.
+	return Promise.all( urls.map( url => window.fetch( url ).then( resp => resp.text() ) ) )
+		.then( responses => {
+			return Object.fromEntries(
+				Array.from( responses.keys() ).map( index => [ fileNames[ index ], responses[ index ] ] )
+			);
+		} );
+}

--- a/tests/manual/performance/setdata.js
+++ b/tests/manual/performance/setdata.js
@@ -37,11 +37,10 @@ ClassicEditor
 		console.error( err.stack );
 	} );
 
-const buttons = document.querySelectorAll( '#test-controls button' );
-const fileNames = Array.from( buttons ).map( button => button.getAttribute( 'data-file-name' ) );
-
-preloadData( fileNames.map( name => `_utils/${ name }.txt` ) )
+preloadData()
 	.then( fixtures => {
+		const buttons = document.querySelectorAll( '#test-controls button' );
+
 		for ( const button of buttons ) {
 			button.addEventListener( 'click', function() {
 				const content = fixtures[ this.getAttribute( 'data-file-name' ) ];
@@ -52,12 +51,18 @@ preloadData( fileNames.map( name => `_utils/${ name }.txt` ) )
 		}
 	} );
 
-function preloadData( urls ) {
-	// @todo: simplify it - inline literals instead of looping over arrays.
-	return Promise.all( urls.map( url => window.fetch( url ).then( resp => resp.text() ) ) )
+function preloadData() {
+	return Promise.all( [ getFileContents( 'small' ), getFileContents( 'medium' ), getFileContents( 'large' ) ] )
 		.then( responses => {
-			return Object.fromEntries(
-				Array.from( responses.keys() ).map( index => [ fileNames[ index ], responses[ index ] ] )
-			);
+			return {
+				small: responses[ 0 ],
+				medium: responses[ 1 ],
+				large: responses[ 2 ]
+			};
 		} );
+
+	function getFileContents( fileName ) {
+		return window.fetch( `_utils/${ fileName }.txt` )
+			.then( resp => resp.text() );
+	}
 }

--- a/tests/manual/performance/setdata.md
+++ b/tests/manual/performance/setdata.md
@@ -1,0 +1,3 @@
+# Performance: `editor.setData()`
+
+1. Use any of "set data" buttons to perform a `editor.setData()` operation.

--- a/tests/manual/performance/setdata.md
+++ b/tests/manual/performance/setdata.md
@@ -2,4 +2,4 @@
 
 1. Begin performance recording in devtools.
 1. Use any button to call `editor.setData()` with chosen data size.
-1. (optionally) Stop performance recording.
+1. Stop performance recording.

--- a/tests/manual/performance/setdata.md
+++ b/tests/manual/performance/setdata.md
@@ -1,5 +1,5 @@
 # Performance: `editor.setData()`
 
-1. (optionally) Begin performance recording in devtools.
+1. Begin performance recording in devtools.
 1. Use any button to call `editor.setData()` with chosen data size.
 1. (optionally) Stop performance recording.

--- a/tests/manual/performance/setdata.md
+++ b/tests/manual/performance/setdata.md
@@ -1,3 +1,5 @@
 # Performance: `editor.setData()`
 
-1. Use any of "set data" buttons to perform a `editor.setData()` operation.
+1. (optionally) Begin performance recording in devtools.
+1. Use any button to call `editor.setData()` with chosen data size.
+1. (optionally) Stop performance recording.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added editor setData manual performance test. Part of #5880.

---

### Additional information

In this micro PR I added a manual test for calling setData on the editor.

Fixtures (so the data that we consider small/medium/large) are extracted as separate files to keep it DRY. Fun fact, it couldn't be `.html` file as it would not be served by our Karma/Webpack config so I went with `.txt`. Fixtures contain a dummy placeholder as setting it with proper content will be done in another PR.