### PR TITLE
Performance manual tests: inline css variant of fixtures

### DIFF
--- a/tests/_utils/utils.js
+++ b/tests/_utils/utils.js
@@ -3,7 +3,16 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals window */
+/* globals window, console */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import FontColor from '@ckeditor/ckeditor5-font/src/fontcolor';
+import FontBackgroundColor from '@ckeditor/ckeditor5-font/src/fontbackgroundcolor';
+import FontFamily from '@ckeditor/ckeditor5-font/src/fontfamily';
+import FontSize from '@ckeditor/ckeditor5-font/src/fontsize';
+import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
+import StrikeThrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
 
 /**
  * Loads a predefined set of performance markup files.
@@ -16,12 +25,20 @@
  * @returns {Promise.<Object.<String, String>>}
  */
 export function loadPerformanceData() {
-	return Promise.all( [ getFileContents( 'small' ), getFileContents( 'medium' ), getFileContents( 'large' ) ] )
+	const predefinedFiles = [
+		'small',
+		'medium',
+		'large',
+		'small-inline-css'
+	];
+
+	return Promise.all( predefinedFiles.map( fileName => getFileContents( fileName ) ) )
 		.then( responses => {
 			return {
 				small: responses[ 0 ],
 				medium: responses[ 1 ],
-				large: responses[ 2 ]
+				large: responses[ 2 ],
+				'small-inline-css': responses[ 3 ]
 			};
 		} );
 
@@ -29,4 +46,55 @@ export function loadPerformanceData() {
 		return window.fetch( `_utils/${ fileName }.txt` )
 			.then( resp => resp.text() );
 	}
+}
+
+/**
+ * Creates a manual performance test editor instance.
+ *
+ * @param {HTMLElement} domElement
+ * @returns {Promise.<module:core/editor/editor~Editor>}
+ */
+export function createPerformanceEditor( domElement ) {
+	const config = {
+		plugins: [ ArticlePluginSet, FontColor, FontBackgroundColor, FontFamily, FontSize, Underline, StrikeThrough ],
+		toolbar: [
+			'heading',
+			'|',
+			'bold',
+			'italic',
+			'link',
+			'fontColor',
+			'fontBackgroundColor',
+			'fontFamily',
+			'fontSize',
+			'underline',
+			'strikeThrough',
+			'bulletedList',
+			'numberedList',
+			'|',
+			'outdent',
+			'indent',
+			'|',
+			'blockQuote',
+			'insertTable',
+			'mediaEmbed',
+			'undo',
+			'redo'
+		],
+		fontSize: {
+			options: [
+				11,
+				19,
+				32
+			]
+		}
+	};
+
+	return ClassicEditor.create( domElement, config )
+		.then( editor => {
+			window.editor = editor;
+		} )
+		.catch( err => {
+			console.error( err.stack );
+		} );
 }

--- a/tests/_utils/utils.js
+++ b/tests/_utils/utils.js
@@ -34,12 +34,13 @@ export function loadPerformanceData() {
 
 	return Promise.all( predefinedFiles.map( fileName => getFileContents( fileName ) ) )
 		.then( responses => {
-			return {
-				small: responses[ 0 ],
-				medium: responses[ 1 ],
-				large: responses[ 2 ],
-				'small-inline-css': responses[ 3 ]
-			};
+			const returnValue = {};
+
+			for ( let i = 0; i < predefinedFiles.length; i++ ) {
+				returnValue[ predefinedFiles[ i ] ] = responses[ i ];
+			}
+
+			return returnValue;
 		} );
 
 	function getFileContents( fileName ) {

--- a/tests/manual/performance/_utils/small-inline-css.txt
+++ b/tests/manual/performance/_utils/small-inline-css.txt
@@ -1,0 +1,33 @@
+<h2>The three greatest things
+	<span style="text-decoration: line-through; font-family: 'Trebuchet MS', Helvetica, sans-serif; font-size: 32px; background-color: #c2e0f4; color: #e03e2d;">You Learn from Traveling</span>
+</h2>
+
+<p>Like all the great things on
+	<span style="background-color: #fee7c0;">earth traveling teaches us</span>
+	by example. Here are some of the most precious lessons I&rsquo;ve
+	<span style="color: #e03e2d; font-family: helvetica, arial, sans-serif; font-size: 19px;">learned over the years of traveling</span>
+.</p>
+
+<figure class="media">
+	<oembed url="https://www.youtube.com/watch?v=CB70skVw3nU"></oembed>
+</figure>
+
+<h3>Appreciation of diversity</h3>
+
+<p>Getting used to an entirely different culture can be
+	challengi<span style="font-size: 11px;">ng. While it&rsquo;s also nice t</span>o
+	learn about cu<span style="font-size: 11px; font-family: 'Courier New', Courier, monospace;">ltures online or from boo</span>ks,
+	nothing comes close to experiencing cultural diversity in person. You learn to
+	<span style="background-color: #f8cac6;">appreciate each and every single</span>
+	one of
+	th<span style="text-decoration: underline;"><span style="color: #e67e23; text-decoration: underline;">e differences while you become</span> </span>more
+	culturally fluid.</p>
+<blockquote>
+
+	<p>The real voyage of
+		<span style="background-color: #c2e0f4;">discovery consists not in seeking new landscapes</span>,
+		but having new eyes.
+	</p>
+
+	<p><strong>Marcel Proust</strong></p>
+</blockquote>

--- a/tests/manual/performance/setdata.html
+++ b/tests/manual/performance/setdata.html
@@ -1,6 +1,7 @@
 <div id="test-controls">
 	Call <code>editor.setData()</code> with:
 	<button id="small-content" data-file-name="small" disabled>small</button>
+	<button id="small-inline-css-content" data-file-name="small-inline-css" disabled>small-inline-css</button>
 	<button id="medium-content" data-file-name="medium" disabled>medium</button>
 	<button id="large-content" data-file-name="large" disabled>large</button>
 	HTML payload.

--- a/tests/manual/performance/setdata.js
+++ b/tests/manual/performance/setdata.js
@@ -3,42 +3,12 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals console, window, document */
+/* globals window, document */
 
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
-import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
-import { loadPerformanceData } from '../../_utils/utils';
+import { loadPerformanceData, createPerformanceEditor } from '../../_utils/utils';
 
-ClassicEditor
-	.create( document.querySelector( '#editor' ), {
-		plugins: [ ArticlePluginSet ],
-		toolbar: [
-			'heading',
-			'|',
-			'bold',
-			'italic',
-			'link',
-			'bulletedList',
-			'numberedList',
-			'|',
-			'outdent',
-			'indent',
-			'|',
-			'blockQuote',
-			'insertTable',
-			'mediaEmbed',
-			'undo',
-			'redo'
-		]
-	} )
-	.then( editor => {
-		window.editor = editor;
-	} )
-	.catch( err => {
-		console.error( err.stack );
-	} );
-
-loadPerformanceData()
+createPerformanceEditor( document.querySelector( '#editor' ) )
+	.then( loadPerformanceData )
 	.then( fixtures => {
 		const buttons = document.querySelectorAll( '#test-controls button' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Added inline css variant of fixtures for manual performance tests. See #5880.

---

### Additional information

**Note:** I have added example styling only for one fixture, to make sure this is the right direction before we go with bigger fixtures. This way we'll avoid losing a lot of time in case we're looking for something else.