### PR TITLE
i/6334: The SVG icons compressed by the clean-up-svg-icons task (svgo) should be editable in graphical editors

### DIFF
--- a/scripts/svgo.config.json
+++ b/scripts/svgo.config.json
@@ -3,6 +3,7 @@
 		"collapseGroups",
 		"removeDimensions",
 		{ "removeAttrs": { "attrs": "(fill|stroke|fill-rule)" } },
+		{ "convertPathData": { "noSpaceAfterFlags": false } },
 		"removeTitle",
 		"removeComments",
 		"removeMetadata"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: The SVG icons compressed by the clean-up-svg-icons task (svgo) should be editable in graphical editors. Closes #6334.

---

### Additional information

After merging, execute `yarn clean-up-svg-icons packages/**/theme/icons`. 

Then

`mrgit commit -m "Internal: The SVG icons compressed by the clean-up-svg-icons task (svgo) should be editable in graphical editors (see ckeditor/ckeditor5#6334)"`

and push in all repos.
