### PR TITLE
Document how to use a custom port for the manual test server.

### DIFF
--- a/docs/framework/guides/contributing/testing-environment.md
+++ b/docs/framework/guides/contributing/testing-environment.md
@@ -57,6 +57,7 @@ The task accepts the following options:
 * `--files` &ndash; Specifies test files to run. Accepts a package name or a glob. For example `--files=ckeditor5` will run tests from the main repository. Read more about the [rules for converting the `--files` option to a glob pattern](https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-tests#rules-for-converting---files-option-to-glob-pattern).
 * `--additionalLanguages="ar,pl,..."` &ndash; Specifies extra languages to the [CKEditor 5 webpack plugin](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-webpack-plugin). Check out the {@link features/ui-language UI language guide} to learn more.
 * `--debug` (alias `-d`) &ndash; Allows specifying custom debug flags. For example, the `--debug engine` option uncomments the `// @if CK_DEBUG_ENGINE //` lines in the code. Note that by default `--debug` is set to `true` even if you did not specify it. This enables the base set of debug logs (`// @if CK_DEBUG //`) which should always be enabled in the testing environment. You can completely turn off the debug mode by setting the `--debug false` option.
+* `--port` &ndash; Specifies the port for the server to use. Defaults to `8125`.
 
 It starts the server available at http://localhost:8125.
 


### PR DESCRIPTION
As suggested at https://github.com/ckeditor/ckeditor5-dev/pull/626#issuecomment-620736291

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Document how to use a custom port for the manual test server.

---

### Additional information

This PR requires https://github.com/ckeditor/ckeditor5-dev/pull/626
