### PR TITLE
#6749: Updated table mocking tools to preserve cells' content.

### DIFF
--- a/packages/ckeditor5-table/tests/_utils-tests/table-ascii-art.js
+++ b/packages/ckeditor5-table/tests/_utils-tests/table-ascii-art.js
@@ -44,7 +44,7 @@ describe( 'table ascii-art and model helpers', () => {
 		} );
 
 		it( 'should create proper ascii-art', () => {
-			const asciiArt = createTableAsciiArt( table );
+			const asciiArt = createTableAsciiArt( model, table );
 
 			expect( asciiArt ).to.equal( [
 				'+----+',
@@ -54,7 +54,7 @@ describe( 'table ascii-art and model helpers', () => {
 		} );
 
 		it( 'should create proper tableData', () => {
-			const modelData = prepareModelTableInput( table );
+			const modelData = prepareModelTableInput( model, table );
 			const modelDataString = prettyFormatModelTableInput( modelData );
 
 			expect( modelData ).to.deep.equal( tableData );
@@ -81,7 +81,7 @@ describe( 'table ascii-art and model helpers', () => {
 		} );
 
 		it( 'should create proper ascii-art', () => {
-			const asciiArt = createTableAsciiArt( table );
+			const asciiArt = createTableAsciiArt( model, table );
 
 			expect( asciiArt ).to.equal( [
 				'+----+----+',
@@ -91,7 +91,7 @@ describe( 'table ascii-art and model helpers', () => {
 		} );
 
 		it( 'should create proper tableData', () => {
-			const modelData = prepareModelTableInput( table );
+			const modelData = prepareModelTableInput( model, table );
 			const modelDataString = prettyFormatModelTableInput( modelData );
 
 			expect( modelData ).to.deep.equal( tableData );
@@ -119,7 +119,7 @@ describe( 'table ascii-art and model helpers', () => {
 		} );
 
 		it( 'should create proper ascii-art', () => {
-			const asciiArt = createTableAsciiArt( table );
+			const asciiArt = createTableAsciiArt( model, table );
 
 			expect( asciiArt ).to.equal( [
 				'+----+',
@@ -131,7 +131,7 @@ describe( 'table ascii-art and model helpers', () => {
 		} );
 
 		it( 'should create proper tableData', () => {
-			const modelData = prepareModelTableInput( table );
+			const modelData = prepareModelTableInput( model, table );
 			const modelDataString = prettyFormatModelTableInput( modelData );
 
 			expect( modelData ).to.deep.equal( tableData );
@@ -160,7 +160,7 @@ describe( 'table ascii-art and model helpers', () => {
 		} );
 
 		it( 'should create proper ascii-art', () => {
-			const asciiArt = createTableAsciiArt( table );
+			const asciiArt = createTableAsciiArt( model, table );
 
 			expect( asciiArt ).to.equal( [
 				'+----+----+',
@@ -172,7 +172,7 @@ describe( 'table ascii-art and model helpers', () => {
 		} );
 
 		it( 'should create proper tableData', () => {
-			const modelData = prepareModelTableInput( table );
+			const modelData = prepareModelTableInput( model, table );
 			const modelDataString = prettyFormatModelTableInput( modelData );
 
 			expect( modelData ).to.deep.equal( tableData );
@@ -203,7 +203,7 @@ describe( 'table ascii-art and model helpers', () => {
 		} );
 
 		it( 'should create proper ascii-art', () => {
-			const asciiArt = createTableAsciiArt( table );
+			const asciiArt = createTableAsciiArt( model, table );
 
 			expect( asciiArt ).to.equal( [
 				'+----+----+----+----+',
@@ -219,7 +219,7 @@ describe( 'table ascii-art and model helpers', () => {
 		} );
 
 		it( 'should create proper tableData', () => {
-			const modelData = prepareModelTableInput( table );
+			const modelData = prepareModelTableInput( model, table );
 			const modelDataString = prettyFormatModelTableInput( modelData );
 
 			expect( modelData ).to.deep.equal( tableData );
@@ -253,7 +253,7 @@ describe( 'table ascii-art and model helpers', () => {
 		} );
 
 		it( 'should create proper ascii-art', () => {
-			const asciiArt = createTableAsciiArt( table );
+			const asciiArt = createTableAsciiArt( model, table );
 
 			expect( asciiArt ).to.equal( [
 				'+----+----+----+----+',
@@ -271,7 +271,7 @@ describe( 'table ascii-art and model helpers', () => {
 		} );
 
 		it( 'should create proper tableData', () => {
-			const modelData = prepareModelTableInput( table );
+			const modelData = prepareModelTableInput( model, table );
 			const modelDataString = prettyFormatModelTableInput( modelData );
 
 			expect( modelData ).to.deep.equal( tableData );
@@ -293,8 +293,8 @@ describe( 'table ascii-art and model helpers', () => {
 
 		beforeEach( () => {
 			tableData = [
-				[ 'x', 'x' ],
-				[ 'x', 'x' ]
+				[ '', 'x' ],
+				[ '10', 'foobar' ]
 			];
 
 			setModelData( model, modelTable( tableData ) );
@@ -303,32 +303,32 @@ describe( 'table ascii-art and model helpers', () => {
 		} );
 
 		it( 'should create proper ascii-art', () => {
-			const asciiArt = createTableAsciiArt( table );
+			const asciiArt = createTableAsciiArt( model, table );
 
 			expect( asciiArt ).to.equal( [
 				'+----+----+',
-				'| 00 | 01 |',
+				'|    | x  |',
 				'+----+----+',
-				'| 10 | 11 |',
+				'| 10 | fo |',
 				'+----+----+'
 			].join( '\n' ) );
 		} );
 
 		it( 'should create proper tableData', () => {
-			const modelData = prepareModelTableInput( table );
+			const modelData = prepareModelTableInput( model, table );
 			const modelDataString = prettyFormatModelTableInput( modelData );
 
 			tableData = [
-				[ '00', '01' ],
-				[ '10', '11' ]
+				[ '', 'x' ],
+				[ '10', 'foobar' ]
 			];
 
 			expect( modelData ).to.deep.equal( tableData );
 
 			assertSameCodeString( modelDataString,
 				`[
-					[ '00', '01' ],
-					[ '10', '11' ]
+					[ '', 'x' ],
+					[ '10', 'foobar' ]
 				]`
 			);
 		} );

--- a/packages/ckeditor5-table/tests/_utils/utils.js
+++ b/packages/ckeditor5-table/tests/_utils/utils.js
@@ -493,10 +493,11 @@ function getClassToSet( attributes ) {
 /**
  * Returns ascii-art visualization of the table.
  *
+ * @param {module:engine/model/model~Model} model The editor model.
  * @param {module:engine/model/element~Element} table The table model element.
  * @returns {String}
  */
-export function createTableAsciiArt( table ) {
+export function createTableAsciiArt( model, table ) {
 	const tableMap = [ ...new TableWalker( table, { includeSpanned: true } ) ];
 
 	const { row: lastRow, column: lastColumn } = tableMap[ tableMap.length - 1 ];
@@ -525,8 +526,11 @@ export function createTableAsciiArt( table ) {
 			gridLine += !cellInfo.isColSpan || !cellInfo.isRowSpan ? '+' : ' ';
 			gridLine += !cellInfo.isRowSpan ? '----' : '    ';
 
+			let contents = getElementPlainText( model, cellInfo.cell ).substring( 0, 2 );
+			contents += ' '.repeat( 2 - contents.length );
+
 			contentLine += !cellInfo.isColSpan ? '|' : ' ';
-			contentLine += !cellInfo.isColSpan && !cellInfo.isRowSpan ? ` ${ cellInfo.row }${ cellInfo.column } ` : '    ';
+			contentLine += !cellInfo.isColSpan && !cellInfo.isRowSpan ? ` ${ contents } ` : '    ';
 
 			if ( column == lastColumn ) {
 				gridLine += '+';
@@ -547,10 +551,11 @@ export function createTableAsciiArt( table ) {
 /**
  * Generates input data for `modelTable` helper method.
  *
+ * @param {module:engine/model/model~Model} model The editor model.
  * @param {module:engine/model/element~Element} table The table model element.
  * @returns {Array.<Array.<String|Object>>}
  */
-export function prepareModelTableInput( table ) {
+export function prepareModelTableInput( model, table ) {
 	const result = [];
 	let row = [];
 
@@ -564,7 +569,7 @@ export function prepareModelTableInput( table ) {
 			continue;
 		}
 
-		const contents = `${ cellInfo.row }${ cellInfo.column }`;
+		const contents = getElementPlainText( model, cellInfo.cell );
 
 		if ( cellInfo.colspan > 1 || cellInfo.rowspan > 1 ) {
 			row.push( {
@@ -606,4 +611,12 @@ export function prettyFormatModelTableInput( data ) {
 	} );
 
 	return `[\n${ rowsStringified.join( ',\n' ) }\n]`;
+}
+
+// Returns all the text content from element.
+function getElementPlainText( model, element ) {
+	return [ ...model.createRangeIn( element ).getWalker() ]
+		.filter( ( { type } ) => type == 'text' )
+		.map( ( { item: { data } } ) => data )
+		.join( '' );
 }

--- a/packages/ckeditor5-table/tests/manual/tablemocking.html
+++ b/packages/ckeditor5-table/tests/manual/tablemocking.html
@@ -31,17 +31,18 @@
 	<label for="model-data">Table data as expected by <a href="https://github.com/ckeditor/ckeditor5-table/blob/1004f9106110be9de125825afd491a1618b71271/tests/_utils/utils.js#L48">modelTable</a> helper function:</label>
 	<textarea id="model-data">
 [
-	[ '00', '01', '02', '03', '04' ],
-	[ '10', '11', '12', '13', '14' ],
-	[ '20', '21', '22', '23', '24' ],
-	[ '30', '31', '32', '33', '34' ],
-	[ '40', '41', '42', '43', '44' ]
+	[ '00', { contents: '01', colspan: 2, rowspan: 2 }, { contents: '03', rowspan: 2 }, '04', '05' ],
+	[ '10', { contents: '14', colspan: 2 } ],
+	[ { contents: '20', colspan: 2, rowspan: 2 }, { contents: '22', rowspan: 2 }, '23', '24', '25' ],
+	[ { contents: '33', colspan: 2 }, '35' ],
+	[ '40', '41', '42', '43', '44', '45' ]
 ]
 	</textarea>
 
 	<button type="button" id="clear-content">Clear editor</button>
 	<button type="button" id="set-model-data">↓ Set model data ↓</button>
 	<button type="button" id="get-model-data">↑ Get model data ↑</button>
+	<button type="button" id="renumber-cells">Renumber cells</button>
 
 	<span id="input-status"></span>
 </div>

--- a/packages/ckeditor5-table/tests/manual/tablemocking.html
+++ b/packages/ckeditor5-table/tests/manual/tablemocking.html
@@ -31,11 +31,11 @@
 	<label for="model-data">Table data as expected by <a href="https://github.com/ckeditor/ckeditor5-table/blob/1004f9106110be9de125825afd491a1618b71271/tests/_utils/utils.js#L48">modelTable</a> helper function:</label>
 	<textarea id="model-data">
 [
-	[ '00', { contents: '01', colspan: 2, rowspan: 2 }, { contents: '03', rowspan: 2 }, '04', '05' ],
-	[ '10', { contents: '14', colspan: 2 } ],
-	[ { contents: '20', colspan: 2, rowspan: 2 }, { contents: '22', rowspan: 2 }, '23', '24', '25' ],
-	[ { contents: '33', colspan: 2 }, '35' ],
-	[ '40', '41', '42', '43', '44', '45' ]
+	[ '00', '01', '02', '03', '04' ],
+	[ '10', '11', '12', '13', '14' ],
+	[ '20', '21', '22', '23', '24' ],
+	[ '30', '31', '32', '33', '34' ],
+	[ '40', '41', '42', '43', '44' ]
 ]
 	</textarea>
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Updated table mocking tools to preserve cells' content. Closes #6749.

---

### Additional information