### PR TITLE
Fixed insert table row/column commands when a widget is selected inside the table cell

### DIFF
--- a/packages/ckeditor5-table/src/commands/insertcolumncommand.js
+++ b/packages/ckeditor5-table/src/commands/insertcolumncommand.js
@@ -9,6 +9,7 @@
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
 import { findAncestor } from './utils';
+import { getColumnIndexes, getSelectionAffectedTableCells } from '../utils';
 
 /**
  * The insert column command.
@@ -72,16 +73,11 @@ export default class InsertColumnCommand extends Command {
 		const tableUtils = editor.plugins.get( 'TableUtils' );
 		const insertBefore = this.order === 'left';
 
-		const referencePosition = insertBefore ? selection.getFirstPosition() : selection.getLastPosition();
-		const referenceRange = insertBefore ? selection.getFirstRange() : selection.getLastRange();
+		const affectedTableCells = getSelectionAffectedTableCells( selection );
+		const columnIndexes = getColumnIndexes( affectedTableCells );
 
-		const containedElement = referenceRange.getContainedElement();
-		const isTableCell = containedElement && containedElement.is( 'tableCell' );
-
-		const tableCell = isTableCell ? containedElement : findAncestor( 'tableCell', referencePosition );
-		const table = findAncestor( 'table', tableCell );
-
-		const { column } = tableUtils.getCellLocation( tableCell );
+		const column = insertBefore ? columnIndexes.first : columnIndexes.last;
+		const table = findAncestor( 'table', affectedTableCells[ 0 ] );
 
 		tableUtils.insertColumns( table, { columns: 1, at: insertBefore ? column : column + 1 } );
 	}

--- a/packages/ckeditor5-table/src/commands/insertcolumncommand.js
+++ b/packages/ckeditor5-table/src/commands/insertcolumncommand.js
@@ -75,8 +75,11 @@ export default class InsertColumnCommand extends Command {
 		const referencePosition = insertBefore ? selection.getFirstPosition() : selection.getLastPosition();
 		const referenceRange = insertBefore ? selection.getFirstRange() : selection.getLastRange();
 
-		const tableCell = referenceRange.getContainedElement() || findAncestor( 'tableCell', referencePosition );
-		const table = tableCell.parent.parent;
+		const containedElement = referenceRange.getContainedElement();
+		const isTableCell = containedElement && containedElement.is( 'tableCell' );
+
+		const tableCell = isTableCell ? containedElement : findAncestor( 'tableCell', referencePosition );
+		const table = findAncestor( 'table', tableCell );
 
 		const { column } = tableUtils.getCellLocation( tableCell );
 

--- a/packages/ckeditor5-table/src/commands/insertrowcommand.js
+++ b/packages/ckeditor5-table/src/commands/insertrowcommand.js
@@ -74,7 +74,10 @@ export default class InsertRowCommand extends Command {
 		const referencePosition = insertAbove ? selection.getFirstPosition() : selection.getLastPosition();
 		const referenceRange = insertAbove ? selection.getFirstRange() : selection.getLastRange();
 
-		const tableCell = referenceRange.getContainedElement() || findAncestor( 'tableCell', referencePosition );
+		const containedElement = referenceRange.getContainedElement();
+		const isTableCell = containedElement && containedElement.is( 'tableCell' );
+		const tableCell = isTableCell ? containedElement : findAncestor( 'tableCell', referencePosition );
+
 		const tableRow = tableCell.parent;
 		const table = tableRow.parent;
 

--- a/packages/ckeditor5-table/src/commands/insertrowcommand.js
+++ b/packages/ckeditor5-table/src/commands/insertrowcommand.js
@@ -9,6 +9,7 @@
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
 import { findAncestor } from './utils';
+import { getRowIndexes, getSelectionAffectedTableCells } from '../utils';
 
 /**
  * The insert row command.
@@ -71,18 +72,12 @@ export default class InsertRowCommand extends Command {
 		const tableUtils = editor.plugins.get( 'TableUtils' );
 		const insertAbove = this.order === 'above';
 
-		const referencePosition = insertAbove ? selection.getFirstPosition() : selection.getLastPosition();
-		const referenceRange = insertAbove ? selection.getFirstRange() : selection.getLastRange();
+		const affectedTableCells = getSelectionAffectedTableCells( selection );
+		const rowIndexes = getRowIndexes( affectedTableCells );
 
-		const containedElement = referenceRange.getContainedElement();
-		const isTableCell = containedElement && containedElement.is( 'tableCell' );
-		const tableCell = isTableCell ? containedElement : findAncestor( 'tableCell', referencePosition );
+		const row = insertAbove ? rowIndexes.first : rowIndexes.last;
+		const table = findAncestor( 'table', affectedTableCells[ 0 ] );
 
-		const tableRow = tableCell.parent;
-		const table = tableRow.parent;
-
-		const row = table.getChildIndex( tableRow );
-
-		tableUtils.insertRows( table, { rows: 1, at: this.order === 'below' ? row + 1 : row } );
+		tableUtils.insertRows( table, { rows: 1, at: insertAbove ? row : row + 1 } );
 	}
 }

--- a/packages/ckeditor5-table/tests/commands/insertcolumncommand.js
+++ b/packages/ckeditor5-table/tests/commands/insertcolumncommand.js
@@ -4,6 +4,7 @@
  */
 
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
+import HorizontalLineEditing from '@ckeditor/ckeditor5-horizontal-line/src/horizontallineediting';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 import InsertColumnCommand from '../../src/commands/insertcolumncommand';
@@ -18,7 +19,7 @@ describe( 'InsertColumnCommand', () => {
 	beforeEach( () => {
 		return ModelTestEditor
 			.create( {
-				plugins: [ TableUtils, TableSelection ]
+				plugins: [ TableUtils, TableSelection, HorizontalLineEditing ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;
@@ -180,6 +181,22 @@ describe( 'InsertColumnCommand', () => {
 					[ '21', '22', '', { colspan: 2, contents: '23' }, '25' ],
 					[ { colspan: 5, contents: '31' }, { colspan: 2, contents: '34' } ]
 				], { headingColumns: 5 } ) );
+			} );
+
+			it( 'should insert a column when a widget in the table cell is selected', () => {
+				setData( model, modelTable( [
+					[ '11', '12' ],
+					[ '21', '22' ],
+					[ '31', '[<horizontalLine></horizontalLine>]' ]
+				] ) );
+
+				command.execute();
+
+				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+					[ '11', '12', '' ],
+					[ '21', '22', '' ],
+					[ '31', '<horizontalLine></horizontalLine>', '' ]
+				] ) );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-table/tests/commands/insertrowcommand.js
+++ b/packages/ckeditor5-table/tests/commands/insertrowcommand.js
@@ -4,6 +4,7 @@
  */
 
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
+import HorizontalLineEditing from '@ckeditor/ckeditor5-horizontal-line/src/horizontallineediting';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 import InsertRowCommand from '../../src/commands/insertrowcommand';
@@ -18,7 +19,7 @@ describe( 'InsertRowCommand', () => {
 	beforeEach( () => {
 		return ModelTestEditor
 			.create( {
-				plugins: [ TableUtils, TableSelection ]
+				plugins: [ TableUtils, TableSelection, HorizontalLineEditing ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;
@@ -213,6 +214,23 @@ describe( 'InsertRowCommand', () => {
 					[ 0, 0 ],
 					[ 0, 0 ]
 				] );
+			} );
+
+			it( 'should insert a row when a widget in the table cell is selected', () => {
+				setData( model, modelTable( [
+					[ '11', '12' ],
+					[ '21', '22' ],
+					[ '31', '[<horizontalLine></horizontalLine>]' ]
+				] ) );
+
+				command.execute();
+
+				assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+					[ '11', '12' ],
+					[ '21', '22' ],
+					[ '31', '<horizontalLine></horizontalLine>' ],
+					[ '', '' ]
+				] ) );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): Fixed insert table row/column commands when a widget is selected inside the table cell. Closes #6607.

---

### Additional information