### PR TITLE
#3274: Updated table layout post-fixer and upcast converters to properly fix empty rows.

### DIFF
--- a/packages/ckeditor5-table/src/converters/table-cell-paragraph-post-fixer.js
+++ b/packages/ckeditor5-table/src/converters/table-cell-paragraph-post-fixer.js
@@ -100,6 +100,8 @@ function fixTableRow( tableRow, writer ) {
 function fixTableCellContent( tableCell, writer ) {
 	// Insert paragraph to an empty table cell.
 	if ( tableCell.childCount == 0 ) {
+		// @if CK_DEBUG_TABLE // console.log( 'Post-fixing table: insert paragraph in empty cell.' );
+
 		writer.insertElement( 'paragraph', tableCell );
 
 		return true;
@@ -108,6 +110,8 @@ function fixTableCellContent( tableCell, writer ) {
 	// Check table cell children for directly placed text nodes.
 	// Temporary solution. See https://github.com/ckeditor/ckeditor5/issues/1464.
 	const textNodes = Array.from( tableCell.getChildren() ).filter( child => child.is( 'text' ) );
+
+	// @if CK_DEBUG_TABLE // textNodes.length && console.log( 'Post-fixing table: wrap cell content with paragraph.' );
 
 	for ( const child of textNodes ) {
 		writer.wrap( writer.createRangeOn( child ), 'paragraph' );

--- a/packages/ckeditor5-table/src/converters/table-cell-refresh-post-fixer.js
+++ b/packages/ckeditor5-table/src/converters/table-cell-refresh-post-fixer.js
@@ -37,6 +37,8 @@ function tableCellRefreshPostFixer( model ) {
 	}
 
 	if ( cellsToRefresh.size ) {
+		// @if CK_DEBUG_TABLE // console.log( `Post-fixing table: refreshing cells (${ cellsToRefresh.size }).` );
+
 		for ( const tableCell of cellsToRefresh.values() ) {
 			differ.refreshItem( tableCell );
 		}

--- a/packages/ckeditor5-table/src/converters/table-layout-post-fixer.js
+++ b/packages/ckeditor5-table/src/converters/table-layout-post-fixer.js
@@ -290,14 +290,16 @@ function fixTableRowsSizes( table, writer ) {
 	let wasFixed = false;
 
 	const rowsLengths = getRowsLengths( table );
+
+	// Verify if all the rows have the same number of columns.
 	const tableSize = rowsLengths[ 0 ];
+	const isValid = rowsLengths.every( length => length === tableSize );
 
-	const isValid = Object.values( rowsLengths ).every( length => length === tableSize );
+	if ( !isValid || !tableSize ) {
+		// Find the maximum number of columns (but it can't be less than one).
+		const maxColumns = rowsLengths.reduce( ( prev, current ) => current > prev ? current : prev, 1 );
 
-	if ( !isValid ) {
-		const maxColumns = Object.values( rowsLengths ).reduce( ( prev, current ) => current > prev ? current : prev, 0 );
-
-		for ( const [ rowIndex, size ] of Object.entries( rowsLengths ) ) {
+		for ( const [ rowIndex, size ] of rowsLengths.entries() ) {
 			const columnsToInsert = maxColumns - size;
 
 			if ( columnsToInsert ) {
@@ -346,12 +348,13 @@ function findCellsToTrim( table ) {
 	return cellsToTrim;
 }
 
-// Returns an object with lengths of rows assigned to the corresponding row index.
+// Returns an array with lengths of rows assigned to the corresponding row index.
 //
 // @param {module:engine/model/element~Element} table
-// @returns {Object}
+// @returns {Array.<Number>}
 function getRowsLengths( table ) {
-	const lengths = {};
+	// TableWalker will not provide items for the empty rows, we need to pre-fill this array.
+	const lengths = new Array( table.childCount ).fill( 0 );
 
 	for ( const { row } of new TableWalker( table, { includeSpanned: true } ) ) {
 		if ( !lengths[ row ] ) {

--- a/packages/ckeditor5-table/src/converters/table-layout-post-fixer.js
+++ b/packages/ckeditor5-table/src/converters/table-layout-post-fixer.js
@@ -290,14 +290,28 @@ function fixTableRowsSizes( table, writer ) {
 	let wasFixed = false;
 
 	const rowsLengths = getRowsLengths( table );
+	const rowsToRemove = [];
+
+	// Find empty rows.
+	for ( const [ rowIndex, size ] of rowsLengths.entries() ) {
+		if ( !size ) {
+			rowsToRemove.push( rowIndex );
+		}
+	}
+
+	// Remove empty rows.
+	for ( const rowIndex of rowsToRemove.reverse() ) {
+		writer.remove( table.getChild( rowIndex ) );
+		rowsLengths.splice( rowIndex, 1 );
+	}
 
 	// Verify if all the rows have the same number of columns.
 	const tableSize = rowsLengths[ 0 ];
 	const isValid = rowsLengths.every( length => length === tableSize );
 
-	if ( !isValid || !tableSize ) {
-		// Find the maximum number of columns (but it can't be less than one).
-		const maxColumns = rowsLengths.reduce( ( prev, current ) => current > prev ? current : prev, 1 );
+	if ( !isValid ) {
+		// Find the maximum number of columns.
+		const maxColumns = rowsLengths.reduce( ( prev, current ) => current > prev ? current : prev, 0 );
 
 		for ( const [ rowIndex, size ] of rowsLengths.entries() ) {
 			const columnsToInsert = maxColumns - size;

--- a/packages/ckeditor5-table/src/converters/table-layout-post-fixer.js
+++ b/packages/ckeditor5-table/src/converters/table-layout-post-fixer.js
@@ -357,11 +357,7 @@ function getRowsLengths( table ) {
 	const lengths = new Array( table.childCount ).fill( 0 );
 
 	for ( const { row } of new TableWalker( table, { includeSpanned: true } ) ) {
-		if ( !lengths[ row ] ) {
-			lengths[ row ] = 0;
-		}
-
-		lengths[ row ] += 1;
+		lengths[ row ]++;
 	}
 
 	return lengths;

--- a/packages/ckeditor5-table/src/converters/table-layout-post-fixer.js
+++ b/packages/ckeditor5-table/src/converters/table-layout-post-fixer.js
@@ -271,6 +271,8 @@ function fixTableCellsRowspan( table, writer ) {
 	const cellsToTrim = findCellsToTrim( table );
 
 	if ( cellsToTrim.length ) {
+		// @if CK_DEBUG_TABLE // console.log( `Post-fixing table: trimming cells row-spans (${ cellsToTrim.length }).` );
+
 		wasFixed = true;
 
 		for ( const data of cellsToTrim ) {
@@ -300,9 +302,15 @@ function fixTableRowsSizes( table, writer ) {
 	}
 
 	// Remove empty rows.
-	for ( const rowIndex of rowsToRemove.reverse() ) {
-		writer.remove( table.getChild( rowIndex ) );
-		rowsLengths.splice( rowIndex, 1 );
+	if ( rowsToRemove.length ) {
+		// @if CK_DEBUG_TABLE // console.log( `Post-fixing table: remove empty rows (${ rowsToRemove.length }).` );
+
+		wasFixed = true;
+
+		for ( const rowIndex of rowsToRemove.reverse() ) {
+			writer.remove( table.getChild( rowIndex ) );
+			rowsLengths.splice( rowIndex, 1 );
+		}
 	}
 
 	// Verify if all the rows have the same number of columns.
@@ -310,6 +318,8 @@ function fixTableRowsSizes( table, writer ) {
 	const isValid = rowsLengths.every( length => length === tableSize );
 
 	if ( !isValid ) {
+		// @if CK_DEBUG_TABLE // console.log( 'Post-fixing table: adding missing cells.' );
+
 		// Find the maximum number of columns.
 		const maxColumns = rowsLengths.reduce( ( prev, current ) => current > prev ? current : prev, 0 );
 

--- a/packages/ckeditor5-table/src/converters/upcasttable.js
+++ b/packages/ckeditor5-table/src/converters/upcasttable.js
@@ -52,11 +52,11 @@ export default function upcastTable() {
 			conversionApi.writer.insert( table, splitResult.position );
 			conversionApi.consumable.consume( viewTable, { name: true } );
 
-			if ( rows.length ) {
-				// Upcast table rows in proper order (heading rows first).
-				rows.forEach( row => conversionApi.convertItem( row, conversionApi.writer.createPositionAt( table, 'end' ) ) );
-			} else {
-				// Create one row and one table cell for empty table.
+			// Upcast table rows in proper order (heading rows first).
+			rows.forEach( row => conversionApi.convertItem( row, conversionApi.writer.createPositionAt( table, 'end' ) ) );
+
+			// Create one row and one table cell for empty table.
+			if ( table.isEmpty ) {
 				const row = conversionApi.writer.createElement( 'tableRow' );
 				conversionApi.writer.insert( row, conversionApi.writer.createPositionAt( table, 'end' ) );
 
@@ -87,6 +87,16 @@ export default function upcastTable() {
 				data.modelCursor = data.modelRange.end;
 			}
 		} );
+	};
+}
+
+export function upcastTableRow() {
+	return dispatcher => {
+		dispatcher.on( 'element:tr', ( evt, data ) => {
+			if ( data.viewItem.isEmpty ) {
+				evt.stop();
+			}
+		}, { priority: 'high' } );
 	};
 }
 

--- a/packages/ckeditor5-table/src/converters/upcasttable.js
+++ b/packages/ckeditor5-table/src/converters/upcasttable.js
@@ -90,7 +90,14 @@ export default function upcastTable() {
 	};
 }
 
-export function upcastTableRow() {
+/**
+ * Conversion helper that skips empty <tr> from upcasting.
+ *
+ * Empty row is considered a table model error.
+ *
+ * @returns {Function} Conversion helper.
+ */
+export function skipEmptyTableRow() {
 	return dispatcher => {
 		dispatcher.on( 'element:tr', ( evt, data ) => {
 			if ( data.viewItem.isEmpty ) {

--- a/packages/ckeditor5-table/src/tableediting.js
+++ b/packages/ckeditor5-table/src/tableediting.js
@@ -9,7 +9,7 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
-import upcastTable, { upcastTableCell, upcastTableRow } from './converters/upcasttable';
+import upcastTable, { upcastTableCell, skipEmptyTableRow } from './converters/upcasttable';
 import {
 	downcastInsertCell,
 	downcastInsertRow,
@@ -98,7 +98,7 @@ export default class TableEditing extends Plugin {
 
 		// Table row conversion.
 		conversion.for( 'upcast' ).elementToElement( { model: 'tableRow', view: 'tr' } );
-		conversion.for( 'upcast' ).add( upcastTableRow() );
+		conversion.for( 'upcast' ).add( skipEmptyTableRow() );
 
 		conversion.for( 'editingDowncast' ).add( downcastInsertRow( { asWidget: true } ) );
 		conversion.for( 'dataDowncast' ).add( downcastInsertRow() );

--- a/packages/ckeditor5-table/src/tableediting.js
+++ b/packages/ckeditor5-table/src/tableediting.js
@@ -9,7 +9,7 @@
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
-import upcastTable, { upcastTableCell } from './converters/upcasttable';
+import upcastTable, { upcastTableCell, upcastTableRow } from './converters/upcasttable';
 import {
 	downcastInsertCell,
 	downcastInsertRow,
@@ -98,6 +98,7 @@ export default class TableEditing extends Plugin {
 
 		// Table row conversion.
 		conversion.for( 'upcast' ).elementToElement( { model: 'tableRow', view: 'tr' } );
+		conversion.for( 'upcast' ).add( upcastTableRow() );
 
 		conversion.for( 'editingDowncast' ).add( downcastInsertRow( { asWidget: true } ) );
 		conversion.for( 'dataDowncast' ).add( downcastInsertRow() );

--- a/packages/ckeditor5-table/tests/_utils/utils.js
+++ b/packages/ckeditor5-table/tests/_utils/utils.js
@@ -500,6 +500,10 @@ function getClassToSet( attributes ) {
 export function createTableAsciiArt( model, table ) {
 	const tableMap = [ ...new TableWalker( table, { includeSpanned: true } ) ];
 
+	if ( !tableMap.length ) {
+		return '';
+	}
+
 	const { row: lastRow, column: lastColumn } = tableMap[ tableMap.length - 1 ];
 	const columns = lastColumn + 1;
 

--- a/packages/ckeditor5-table/tests/converters/table-layout-post-fixer.js
+++ b/packages/ckeditor5-table/tests/converters/table-layout-post-fixer.js
@@ -36,7 +36,8 @@ describe( 'Table layout post-fixer', () => {
 			const parsed = parse( modelTable( [
 				[ '00' ],
 				[ '10', '11', '12' ],
-				[ '20', '21' ]
+				[ '20', '21' ],
+				[]
 			] ), model.schema );
 
 			model.change( writer => {
@@ -47,7 +48,8 @@ describe( 'Table layout post-fixer', () => {
 			assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
 				[ '00', '', '' ],
 				[ '10', '11', '12' ],
-				[ '20', '21', '' ]
+				[ '20', '21', '' ],
+				[ '', '', '' ]
 			] ) );
 		} );
 

--- a/packages/ckeditor5-table/tests/converters/table-layout-post-fixer.js
+++ b/packages/ckeditor5-table/tests/converters/table-layout-post-fixer.js
@@ -36,8 +36,7 @@ describe( 'Table layout post-fixer', () => {
 			const parsed = parse( modelTable( [
 				[ '00' ],
 				[ '10', '11', '12' ],
-				[ '20', '21' ],
-				[]
+				[ '20', '21' ]
 			] ), model.schema );
 
 			model.change( writer => {
@@ -48,8 +47,7 @@ describe( 'Table layout post-fixer', () => {
 			assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
 				[ '00', '', '' ],
 				[ '10', '11', '12' ],
-				[ '20', '21', '' ],
-				[ '', '', '' ]
+				[ '20', '21', '' ]
 			] ) );
 		} );
 
@@ -88,6 +86,25 @@ describe( 'Table layout post-fixer', () => {
 				[ { colspan: 6, contents: '00' } ],
 				[ { rowspan: 2, contents: '10' }, '11', { colspan: 3, contents: '12' }, '' ],
 				[ '21', '22', '', '', '' ]
+			] ) );
+		} );
+
+		it( 'should remove empty rows', () => {
+			const parsed = parse( modelTable( [
+				[ '00', '01' ],
+				[ ],
+				[ '20', '21', '22' ],
+				[ ]
+			] ), model.schema );
+
+			model.change( writer => {
+				writer.remove( writer.createRangeIn( root ) );
+				writer.insert( parsed, root );
+			} );
+
+			assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
+				[ '00', '01', '' ],
+				[ '20', '21', '22' ]
 			] ) );
 		} );
 

--- a/packages/ckeditor5-table/tests/converters/upcasttable.js
+++ b/packages/ckeditor5-table/tests/converters/upcasttable.js
@@ -180,6 +180,32 @@ describe( 'upcastTable()', () => {
 		);
 	} );
 
+	it( 'should create valid table model from all empty rows', () => {
+		editor.setData(
+			'<table>' +
+				'<tr></tr>' +
+				'<tr></tr>' +
+			'</table>'
+		);
+
+		expectModel(
+			'<table><tableRow><tableCell><paragraph></paragraph></tableCell></tableRow></table>'
+		);
+	} );
+
+	it( 'should skip empty table rows', () => {
+		editor.setData(
+			'<table>' +
+				'<tr></tr>' +
+				'<tr><td>bar</td></tr>' +
+			'</table>'
+		);
+
+		expectModel(
+			'<table><tableRow><tableCell><paragraph>bar</paragraph></tableCell></tableRow></table>'
+		);
+	} );
+
 	it( 'should skip unknown table children', () => {
 		editor.setData(
 			'<table>' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): Table layout post-fixer and upcast converters should properly handle empty rows . Closes #3274.

---

### Additional information