### PR TITLE
#6667: Table heading rows should be properly updated after removing rows as a side effect of merging cells

### DIFF
--- a/packages/ckeditor5-table/package.json
+++ b/packages/ckeditor5-table/package.json
@@ -30,7 +30,8 @@
     "@ckeditor/ckeditor5-typing": "^19.0.0",
     "@ckeditor/ckeditor5-undo": "^19.0.0",
     "@ckeditor/ckeditor5-utils": "^19.0.0",
-    "json-diff": "^0.5.4"
+    "json-diff": "^0.5.4",
+    "lodash-es": "^4.17.10"
   },
   "engines": {
     "node": ">=8.0.0",

--- a/packages/ckeditor5-table/src/commands/mergecellcommand.js
+++ b/packages/ckeditor5-table/src/commands/mergecellcommand.js
@@ -109,7 +109,7 @@ export default class MergeCellCommand extends Command {
 			if ( !removedTableCellRow.childCount ) {
 				const tableUtils = this.editor.plugins.get( 'TableUtils' );
 
-				tableUtils.removeRows( table, { at: table.getChildIndex( removedTableCellRow ), batch: writer.batch } );
+				tableUtils.removeRows( table, { at: removedTableCellRow.index, batch: writer.batch } );
 			}
 		} );
 	}

--- a/packages/ckeditor5-table/src/commands/mergecellcommand.js
+++ b/packages/ckeditor5-table/src/commands/mergecellcommand.js
@@ -85,10 +85,7 @@ export default class MergeCellCommand extends Command {
 		const cellToMerge = this.value;
 		const direction = this.direction;
 
-		// Use single batch to modify table in steps but in one undo step.
-		const batch = model.createBatch();
-
-		model.enqueueChange( batch, writer => {
+		model.change( writer => {
 			const isMergeNext = direction == 'right' || direction == 'down';
 
 			// The merge mechanism is always the same so sort cells to be merged.
@@ -111,7 +108,8 @@ export default class MergeCellCommand extends Command {
 			// Remove empty row after merging.
 			if ( !removedTableCellRow.childCount ) {
 				const tableUtils = this.editor.plugins.get( 'TableUtils' );
-				tableUtils.removeRows( table, { at: table.getChildIndex( removedTableCellRow ), batch } );
+
+				tableUtils.removeRows( table, { at: table.getChildIndex( removedTableCellRow ), batch: writer.batch } );
 			}
 		} );
 	}

--- a/packages/ckeditor5-table/src/commands/mergecellcommand.js
+++ b/packages/ckeditor5-table/src/commands/mergecellcommand.js
@@ -80,7 +80,6 @@ export default class MergeCellCommand extends Command {
 		const model = this.editor.model;
 		const doc = model.document;
 		const tableCell = getTableCellsContainingSelection( doc.selection )[ 0 ];
-		const table = findAncestor( 'table', tableCell );
 
 		const cellToMerge = this.value;
 		const direction = this.direction;
@@ -108,6 +107,7 @@ export default class MergeCellCommand extends Command {
 			// Remove empty row after merging.
 			if ( !removedTableCellRow.childCount ) {
 				const tableUtils = this.editor.plugins.get( 'TableUtils' );
+				const table = findAncestor( 'table', removedTableCellRow );
 
 				tableUtils.removeRows( table, { at: removedTableCellRow.index, batch: writer.batch } );
 			}

--- a/packages/ckeditor5-table/src/commands/mergecellscommand.js
+++ b/packages/ckeditor5-table/src/commands/mergecellscommand.js
@@ -40,7 +40,10 @@ export default class MergeCellsCommand extends Command {
 		const model = this.editor.model;
 		const tableUtils = this.editor.plugins.get( TableUtils );
 
-		model.change( writer => {
+		// Use single batch to modify table in steps but in one undo step.
+		const batch = model.createBatch();
+
+		model.enqueueChange( batch, writer => {
 			const selectedTableCells = getSelectedTableCells( model.document.selection );
 
 			// All cells will be merged into the first one.
@@ -69,7 +72,7 @@ export default class MergeCellsCommand extends Command {
 				}
 			}
 
-			emptyRows.reverse().forEach( row => tableUtils.removeRows( table, { at: row } ) );
+			emptyRows.reverse().forEach( row => tableUtils.removeRows( table, { at: row, batch } ) );
 
 			writer.setSelection( firstTableCell, 'in' );
 		} );

--- a/packages/ckeditor5-table/src/commands/mergecellscommand.js
+++ b/packages/ckeditor5-table/src/commands/mergecellscommand.js
@@ -40,10 +40,7 @@ export default class MergeCellsCommand extends Command {
 		const model = this.editor.model;
 		const tableUtils = this.editor.plugins.get( TableUtils );
 
-		// Use single batch to modify table in steps but in one undo step.
-		const batch = model.createBatch();
-
-		model.enqueueChange( batch, writer => {
+		model.change( writer => {
 			const selectedTableCells = getSelectedTableCells( model.document.selection );
 
 			// All cells will be merged into the first one.
@@ -72,7 +69,7 @@ export default class MergeCellsCommand extends Command {
 				}
 			}
 
-			emptyRows.reverse().forEach( row => tableUtils.removeRows( table, { at: row, batch } ) );
+			emptyRows.reverse().forEach( row => tableUtils.removeRows( table, { at: row, batch: writer.batch } ) );
 
 			writer.setSelection( firstTableCell, 'in' );
 		} );

--- a/packages/ckeditor5-table/src/commands/mergecellscommand.js
+++ b/packages/ckeditor5-table/src/commands/mergecellscommand.js
@@ -8,7 +8,6 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import TableWalker from '../tablewalker';
 import { findAncestor, updateNumericAttribute } from './utils';
 import TableUtils from '../tableutils';
 import { getColumnIndexes, getRowIndexes, getSelectedTableCells } from '../utils';
@@ -46,6 +45,7 @@ export default class MergeCellsCommand extends Command {
 
 			// All cells will be merged into the first one.
 			const firstTableCell = selectedTableCells.shift();
+			const table = findAncestor( 'table', firstTableCell );
 
 			// Set the selection in cell that other cells are being merged to prevent model-selection-range-intersects error in undo.
 			// See https://github.com/ckeditor/ckeditor5/issues/6634.
@@ -57,38 +57,23 @@ export default class MergeCellsCommand extends Command {
 			updateNumericAttribute( 'colspan', mergeWidth, firstTableCell, writer );
 			updateNumericAttribute( 'rowspan', mergeHeight, firstTableCell, writer );
 
+			const emptyRows = [];
+
 			for ( const tableCell of selectedTableCells ) {
 				const tableRow = tableCell.parent;
+
 				mergeTableCells( tableCell, firstTableCell, writer );
-				removeRowIfEmpty( tableRow, writer );
+
+				if ( !tableRow.childCount ) {
+					emptyRows.push( table.getChildIndex( tableRow ) );
+				}
 			}
+
+			emptyRows.reverse().forEach( row => tableUtils.removeRows( table, { at: row } ) );
 
 			writer.setSelection( firstTableCell, 'in' );
 		} );
 	}
-}
-
-// Properly removes an empty row from a table. Updates the `rowspan` attribute of cells that overlap the removed row.
-//
-// @param {module:engine/model/element~Element} row
-// @param {module:engine/model/writer~Writer} writer
-function removeRowIfEmpty( row, writer ) {
-	if ( row.childCount ) {
-		return;
-	}
-
-	const table = row.parent;
-	const removedRowIndex = table.getChildIndex( row );
-
-	for ( const { cell, row, rowspan } of new TableWalker( table, { endRow: removedRowIndex } ) ) {
-		const overlapsRemovedRow = row + rowspan - 1 >= removedRowIndex;
-
-		if ( overlapsRemovedRow ) {
-			updateNumericAttribute( 'rowspan', rowspan - 1, cell, writer );
-		}
-	}
-
-	writer.remove( row );
 }
 
 // Merges two table cells. It will ensure that after merging cells with empty paragraphs the resulting table cell will only have one

--- a/packages/ckeditor5-table/src/commands/mergecellscommand.js
+++ b/packages/ckeditor5-table/src/commands/mergecellscommand.js
@@ -45,7 +45,6 @@ export default class MergeCellsCommand extends Command {
 
 			// All cells will be merged into the first one.
 			const firstTableCell = selectedTableCells.shift();
-			const table = findAncestor( 'table', firstTableCell );
 
 			// Set the selection in cell that other cells are being merged to prevent model-selection-range-intersects error in undo.
 			// See https://github.com/ckeditor/ckeditor5/issues/6634.
@@ -57,7 +56,7 @@ export default class MergeCellsCommand extends Command {
 			updateNumericAttribute( 'colspan', mergeWidth, firstTableCell, writer );
 			updateNumericAttribute( 'rowspan', mergeHeight, firstTableCell, writer );
 
-			const emptyRows = [];
+			const emptyRowsIndexes = [];
 
 			for ( const tableCell of selectedTableCells ) {
 				const tableRow = tableCell.parent;
@@ -65,11 +64,15 @@ export default class MergeCellsCommand extends Command {
 				mergeTableCells( tableCell, firstTableCell, writer );
 
 				if ( !tableRow.childCount ) {
-					emptyRows.push( tableRow.index );
+					emptyRowsIndexes.push( tableRow.index );
 				}
 			}
 
-			emptyRows.reverse().forEach( row => tableUtils.removeRows( table, { at: row, batch: writer.batch } ) );
+			if ( emptyRowsIndexes.length ) {
+				const table = findAncestor( 'table', firstTableCell );
+
+				emptyRowsIndexes.reverse().forEach( row => tableUtils.removeRows( table, { at: row, batch: writer.batch } ) );
+			}
 
 			writer.setSelection( firstTableCell, 'in' );
 		} );

--- a/packages/ckeditor5-table/src/commands/mergecellscommand.js
+++ b/packages/ckeditor5-table/src/commands/mergecellscommand.js
@@ -65,7 +65,7 @@ export default class MergeCellsCommand extends Command {
 				mergeTableCells( tableCell, firstTableCell, writer );
 
 				if ( !tableRow.childCount ) {
-					emptyRows.push( table.getChildIndex( tableRow ) );
+					emptyRows.push( tableRow.index );
 				}
 			}
 

--- a/packages/ckeditor5-table/src/tableutils.js
+++ b/packages/ckeditor5-table/src/tableutils.js
@@ -290,8 +290,8 @@ export default class TableUtils extends Plugin {
 		const batch = options.batch || 'default';
 
 		model.enqueueChange( batch, writer => {
-			// Removing rows from table requires most calculations to be done prior to changing table structure.
-			// Preparations must be done in enqueueChange callback to use the current table structure.
+			// Removing rows from the table require that most calculations to be done prior to changing table structure.
+			// Preparations must be done in the same enqueueChange callback to use the current table structure.
 
 			// 1. Preparation - get row-spanned cells that have to be modified after removing rows.
 			const { cellsToMove, cellsToTrim } = getCellsToMoveAndTrimOnRemoveRow( table, first, last );
@@ -758,7 +758,8 @@ function adjustHeadingColumns( table, removedColumnIndexes, writer ) {
 // Calculates a new heading rows value for removing rows from heading section.
 function updateHeadingRows( table, first, last, model, batch ) {
 	// Must be done after the changes in table structure (removing rows).
-	// Otherwise the downcast converter for headingRows attribute will fail. ckeditor/ckeditor5#6391.
+	// Otherwise the downcast converter for headingRows attribute will fail.
+	// See https://github.com/ckeditor/ckeditor5/issues/6391.
 	//
 	// Must be completely wrapped in enqueueChange to get the current table state (after applying other enqueued changes).
 	model.enqueueChange( batch, writer => {

--- a/packages/ckeditor5-table/tests/_utils/utils.js
+++ b/packages/ckeditor5-table/tests/_utils/utils.js
@@ -503,6 +503,9 @@ export function createTableAsciiArt( model, table ) {
 	const { row: lastRow, column: lastColumn } = tableMap[ tableMap.length - 1 ];
 	const columns = lastColumn + 1;
 
+	const headingRows = parseInt( table.getAttribute( 'headingRows' ) ) || 0;
+	const headingColumns = parseInt( table.getAttribute( 'headingColumns' ) ) || 0;
+
 	let result = '';
 
 	for ( let row = 0; row <= lastRow; row++ ) {
@@ -535,6 +538,10 @@ export function createTableAsciiArt( model, table ) {
 			if ( column == lastColumn ) {
 				gridLine += '+';
 				contentLine += '|';
+
+				if ( headingRows && row == headingRows ) {
+					gridLine += ' <-- heading rows';
+				}
 			}
 		}
 		result += gridLine + '\n';
@@ -542,6 +549,14 @@ export function createTableAsciiArt( model, table ) {
 
 		if ( row == lastRow ) {
 			result += `+${ '----+'.repeat( columns ) }`;
+
+			if ( headingRows && row == headingRows - 1 ) {
+				result += ' <-- heading rows';
+			}
+
+			if ( headingColumns > 0 ) {
+				result += `\n${ '     '.repeat( headingColumns ) }^-- heading columns`;
+			}
 		}
 	}
 

--- a/packages/ckeditor5-table/tests/commands/mergecellcommand.js
+++ b/packages/ckeditor5-table/tests/commands/mergecellcommand.js
@@ -701,6 +701,53 @@ describe( 'MergeCellCommand', () => {
 					[ '40', '41' ]
 				] ) );
 			} );
+
+			it( 'should adjust heading rows if empty row was removed ', () => {
+				// +----+----+
+				// | 00 | 01 |
+				// +    +----+
+				// |    | 11 |
+				// +----+----+ <-- heading rows
+				// | 20 | 21 |
+				// +----+----+
+				setData( model, modelTable( [
+					[ { contents: '00', rowspan: 2 }, '[]01' ],
+					[ '11' ],
+					[ '20', '21' ]
+				], { headingRows: 2 } ) );
+
+				command.execute();
+
+				assertEqualMarkup( getData( model ), modelTable( [
+					[ '00', '<paragraph>[01</paragraph><paragraph>11]</paragraph>' ],
+					[ '20', '21' ]
+				], { headingRows: 1 } ) );
+			} );
+
+			it( 'should create one undo step (1 batch)', () => {
+				// +----+----+
+				// | 00 | 01 |
+				// +    +----+
+				// |    | 11 |
+				// +----+----+ <-- heading rows
+				// | 20 | 21 |
+				// +----+----+
+				setData( model, modelTable( [
+					[ { contents: '00', rowspan: 2 }, '[]01' ],
+					[ '11' ],
+					[ '20', '21' ]
+				], { headingRows: 2 } ) );
+
+				const createdBatches = new Set();
+
+				model.on( 'applyOperation', ( evt, [ operation ] ) => {
+					createdBatches.add( operation.batch );
+				} );
+
+				command.execute();
+
+				expect( createdBatches.size ).to.equal( 1 );
+			} );
 		} );
 	} );
 
@@ -958,6 +1005,53 @@ describe( 'MergeCellCommand', () => {
 					[ '20', '<paragraph>[21</paragraph><paragraph>31]</paragraph>', { rowspan: 2, contents: '22' } ],
 					[ '40', '41' ]
 				] ) );
+			} );
+
+			it( 'should adjust heading rows if empty row was removed ', () => {
+				// +----+----+
+				// | 00 | 01 |
+				// +    +----+
+				// |    | 11 |
+				// +----+----+ <-- heading rows
+				// | 20 | 21 |
+				// +----+----+
+				setData( model, modelTable( [
+					[ { contents: '00', rowspan: 2 }, '01' ],
+					[ '[]11' ],
+					[ '20', '21' ]
+				], { headingRows: 2 } ) );
+
+				command.execute();
+
+				assertEqualMarkup( getData( model ), modelTable( [
+					[ '00', '<paragraph>[01</paragraph><paragraph>11]</paragraph>' ],
+					[ '20', '21' ]
+				], { headingRows: 1 } ) );
+			} );
+
+			it( 'should create one undo step (1 batch)', () => {
+				// +----+----+
+				// | 00 | 01 |
+				// +    +----+
+				// |    | 11 |
+				// +----+----+ <-- heading rows
+				// | 20 | 21 |
+				// +----+----+
+				setData( model, modelTable( [
+					[ { contents: '00', rowspan: 2 }, '01' ],
+					[ '[]11' ],
+					[ '20', '21' ]
+				], { headingRows: 2 } ) );
+
+				const createdBatches = new Set();
+
+				model.on( 'applyOperation', ( evt, [ operation ] ) => {
+					createdBatches.add( operation.batch );
+				} );
+
+				command.execute();
+
+				expect( createdBatches.size ).to.equal( 1 );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-table/tests/commands/mergecellscommand.js
+++ b/packages/ckeditor5-table/tests/commands/mergecellscommand.js
@@ -514,6 +514,28 @@ describe( 'MergeCellsCommand', () => {
 				] ) );
 			} );
 
+			it( 'should decrease heading rows if some heading rows were removed', () => {
+				setData( model, modelTable( [
+					[ '00' ],
+					[ '10' ],
+					[ '20' ]
+				], { headingRows: 2 } ) );
+
+				selectNodes( [
+					[ 0, 0, 0 ],
+					[ 0, 1, 0 ]
+				] );
+
+				command.execute();
+
+				assertEqualMarkup( getData( model ), modelTable( [
+					[
+						'<paragraph>[00</paragraph><paragraph>10]</paragraph>'
+					],
+					[ '20' ]
+				], { headingRows: 1 } ) );
+			} );
+
 			it( 'should decrease rowspan if cell overlaps removed row', () => {
 				setData( model, modelTable( [
 					[ '00', { rowspan: 2, contents: '01' }, { rowspan: 3, contents: '02' } ],

--- a/packages/ckeditor5-table/tests/commands/mergecellscommand.js
+++ b/packages/ckeditor5-table/tests/commands/mergecellscommand.js
@@ -536,6 +536,58 @@ describe( 'MergeCellsCommand', () => {
 				], { headingRows: 1 } ) );
 			} );
 
+			it( 'should decrease heading rows if multiple heading rows were removed', () => {
+				// +----+----+
+				// | 00 | 01 |
+				// +    +----+
+				// |    | 11 |
+				// +----+----+
+				// | 20 | 21 |
+				// +----+----+
+				// | 30 | 31 |
+				// +    +----+
+				// |    | 41 |
+				// +----+----+ <-- heading rows
+				// | 50 | 51 |
+				// +----+----+
+				setData( model, modelTable( [
+					[ { contents: '00', rowspan: 2 }, '01' ],
+					[ '11' ],
+					[ '20', '21' ],
+					[ { contents: '30', rowspan: 2 }, '31' ],
+					[ '41' ],
+					[ '50', '51' ]
+				], { headingRows: 5 } ) );
+
+				selectNodes( [
+					[ 0, 0, 1 ],
+					[ 0, 1, 0 ],
+					[ 0, 2, 1 ],
+					[ 0, 3, 1 ],
+					[ 0, 4, 0 ]
+				] );
+
+				command.execute();
+
+				const contents = [ '[01', '11', '21', '31', '41]' ].map( content => `<paragraph>${ content }</paragraph>` ).join( '' );
+
+				// +----+----+
+				// | 00 | 01 |
+				// +----+    +
+				// | 20 |    |
+				// +----+    +
+				// | 30 |    |
+				// +----+----+ <-- heading rows
+				// | 50 | 51 |
+				// +----+----+
+				assertEqualMarkup( getData( model ), modelTable( [
+					[ '00', { contents, rowspan: 3 } ],
+					[ '20' ],
+					[ '30' ],
+					[ '50', '51' ]
+				], { headingRows: 3 } ) );
+			} );
+
 			it( 'should create one undo step (1 batch)', () => {
 				setData( model, modelTable( [
 					[ '00' ],

--- a/packages/ckeditor5-table/tests/commands/mergecellscommand.js
+++ b/packages/ckeditor5-table/tests/commands/mergecellscommand.js
@@ -536,6 +536,29 @@ describe( 'MergeCellsCommand', () => {
 				], { headingRows: 1 } ) );
 			} );
 
+			it( 'should create one undo step (1 batch)', () => {
+				setData( model, modelTable( [
+					[ '00' ],
+					[ '10' ],
+					[ '20' ]
+				], { headingRows: 2 } ) );
+
+				selectNodes( [
+					[ 0, 0, 0 ],
+					[ 0, 1, 0 ]
+				] );
+
+				const createdBatches = new Set();
+
+				model.on( 'applyOperation', ( evt, [ operation ] ) => {
+					createdBatches.add( operation.batch );
+				} );
+
+				command.execute();
+
+				expect( createdBatches.size ).to.equal( 1 );
+			} );
+
 			it( 'should decrease rowspan if cell overlaps removed row', () => {
 				setData( model, modelTable( [
 					[ '00', { rowspan: 2, contents: '01' }, { rowspan: 3, contents: '02' } ],

--- a/packages/ckeditor5-table/tests/manual/tablemocking.js
+++ b/packages/ckeditor5-table/tests/manual/tablemocking.js
@@ -11,6 +11,7 @@ import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor'
 import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 import { diffString } from 'json-diff';
+import { debounce } from 'lodash-es';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 import TableWalker from '../../src/tablewalker';
 
@@ -67,7 +68,7 @@ ClassicEditor
 			updateAsciiAndDiff();
 		} );
 
-		editor.model.document.on( 'change:data', updateAsciiAndDiff );
+		editor.model.document.on( 'change:data', debounce( () => updateAsciiAndDiff(), 100 ) );
 		updateAsciiAndDiff();
 
 		function updateAsciiAndDiff() {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): Table heading rows should be properly updated after removing rows as a side effect of merging cells. Closes #6667.

---

### Additional information