### PR TITLE
#6241 Display a defined color label in the text input field.

### DIFF
--- a/packages/ckeditor5-table/src/ui/colorinputview.js
+++ b/packages/ckeditor5-table/src/ui/colorinputview.js
@@ -109,7 +109,7 @@ export default class ColorInputView extends View {
 		 * The flag that indicates whether the user is still typing.
 		 * If set to true, it means that the text input field ({@link #_inputView}) still has the focus.
 		 * So, we should interrupt the user by replacing the input's value.
-		 * 
+		 *
 		 * @protected
 		 * @member {Boolean}
 		 */
@@ -133,7 +133,7 @@ export default class ColorInputView extends View {
 			]
 		} );
 
-		this.on( 
+		this.on(
 			'change:value',
 			( ev, n, inputValue ) => this._setInputValue( inputValue ),
 			{ priority: 'high' }
@@ -143,12 +143,12 @@ export default class ColorInputView extends View {
 	/**
 	 * Sets {@link #_inputView}'s value property to the color value or color label,
 	 * if there is one and the user is not typing.
-	 * 
+	 *
 	 * @private
 	 * @param {String} inputValue Color value to be set.
 	 */
-	_setInputValue( inputValue ){
-		if( !this._stillTyping ){
+	_setInputValue( inputValue ) {
+		if ( !this._stillTyping ) {
 			// Check if the value matches one of our defined colors.
 			const mappedColor = this.options.colorDefinitions.find( def => inputValue === def.color );
 			if ( mappedColor ) {
@@ -228,8 +228,11 @@ export default class ColorInputView extends View {
 	 */
 	_createInputTextView() {
 		const locale = this.locale;
-		const inputView = new InputTextView( locale, {
-			blur: this.bindTemplate.to('blur')
+		const inputView = new InputTextView( locale );
+		inputView.extendTemplate( {
+			on: {
+				blur: this.bindTemplate.to( 'blur' )
+			}
 		} );
 
 		inputView.value = this.value;

--- a/packages/ckeditor5-table/src/ui/colorinputview.js
+++ b/packages/ckeditor5-table/src/ui/colorinputview.js
@@ -206,9 +206,10 @@ export default class ColorInputView extends View {
 	_createInputTextView() {
 		const locale = this.locale;
 		const inputView = new InputTextView( locale );
+
 		inputView.extendTemplate( {
 			on: {
-				blur: this.bindTemplate.to( 'blur' )
+				blur: inputView.bindTemplate.to( 'blur' )
 			}
 		} );
 
@@ -224,7 +225,8 @@ export default class ColorInputView extends View {
 			this._stillTyping = true;
 			this.value = mappedColor && mappedColor.color || inputValue;
 		} );
-		this.on( 'blur', () => {
+
+		inputView.on( 'blur', () => {
 			this._stillTyping = false;
 			this._setInputValue( inputView.element.value );
 		} );

--- a/packages/ckeditor5-table/src/ui/colorinputview.js
+++ b/packages/ckeditor5-table/src/ui/colorinputview.js
@@ -186,25 +186,26 @@ export default class ColorInputView extends View {
 	}
 
 	/**
-	 * Creates and configures the {@link #_inputView}.
+	 * Creates and configures an instance of {@link module:ui/inputtext/inputtextview~InputTextView}.
 	 *
 	 * @private
+	 * @returns {module:ui/inputtext/inputtextview~InputTextView} A configured instance to be set as {@link #_inputView}.
 	 */
 	_createInputTextView() {
 		const locale = this.locale;
-		const input = new InputTextView( locale );
+		const inputView = new InputTextView( locale );
 
-		input.bind( 'value' ).to( this );
-		input.bind( 'isReadOnly' ).to( this );
-		input.bind( 'hasError' ).to( this );
+		inputView.bind( 'value' ).to( this );
+		inputView.bind( 'isReadOnly' ).to( this );
+		inputView.bind( 'hasError' ).to( this );
 
-		input.on( 'input', () => {
-			this.value = input.element.value;
+		inputView.on( 'input', () => {
+			this.value = inputView.element.value;
 		} );
 
-		input.delegate( 'input' ).to( this );
+		inputView.delegate( 'input' ).to( this );
 
-		return input;
+		return inputView;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/ui/colorinputview.js
+++ b/packages/ckeditor5-table/src/ui/colorinputview.js
@@ -101,7 +101,7 @@ export default class ColorInputView extends View {
 		 * An instance of the input allowing the user to type a color value.
 		 *
 		 * @protected
-		 * @member {module:ui/dropdown/dropdown~DropdownView}
+		 * @member {module:ui/inputtext/inputtextview~InputTextView}
 		 */
 		this._inputView = this._createInputTextView( locale );
 

--- a/packages/ckeditor5-table/src/ui/colorinputview.js
+++ b/packages/ckeditor5-table/src/ui/colorinputview.js
@@ -133,11 +133,7 @@ export default class ColorInputView extends View {
 			]
 		} );
 
-		this.on(
-			'change:value',
-			( evt, name, inputValue ) => this._setInputValue( inputValue ),
-			{ priority: 'high' }
-		);
+		this.on( 'change:value', ( evt, name, inputValue ) => this._setInputValue( inputValue ) );
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/ui/colorinputview.js
+++ b/packages/ckeditor5-table/src/ui/colorinputview.js
@@ -135,28 +135,9 @@ export default class ColorInputView extends View {
 
 		this.on(
 			'change:value',
-			( ev, n, inputValue ) => this._setInputValue( inputValue ),
+			( evt, name, inputValue ) => this._setInputValue( inputValue ),
 			{ priority: 'high' }
 		);
-	}
-
-	/**
-	 * Sets {@link #_inputView}'s value property to the color value or color label,
-	 * if there is one and the user is not typing.
-	 *
-	 * @private
-	 * @param {String} inputValue Color value to be set.
-	 */
-	_setInputValue( inputValue ) {
-		if ( !this._stillTyping ) {
-			// Check if the value matches one of our defined colors.
-			const mappedColor = this.options.colorDefinitions.find( def => inputValue === def.color );
-			if ( mappedColor ) {
-				this._inputView.value = mappedColor.label;
-			} else {
-				this._inputView.value = inputValue || '';
-			}
-		}
 	}
 
 	/**
@@ -299,5 +280,30 @@ export default class ColorInputView extends View {
 		colorGrid.bind( 'selectedColor' ).to( this, 'value' );
 
 		return colorGrid;
+	}
+
+	/**
+	 * Sets {@link #_inputView}'s value property to the color value or color label,
+	 * if there is one and the user is not typing.
+	 *
+	 * Handles cases like:
+	 *
+	 * * Someone picks the color in the grid.
+	 * * The color is set from the plugin level.
+	 *
+	 * @private
+	 * @param {String} inputValue Color value to be set.
+	 */
+	_setInputValue( inputValue ) {
+		if ( !this._stillTyping ) {
+			// Check if the value matches one of our defined colors.
+			const mappedColor = this.options.colorDefinitions.find( def => inputValue === def.color );
+
+			if ( mappedColor ) {
+				this._inputView.value = mappedColor.label;
+			} else {
+				this._inputView.value = inputValue || '';
+			}
+		}
 	}
 }

--- a/packages/ckeditor5-table/tests/ui/colorinputview.js
+++ b/packages/ckeditor5-table/tests/ui/colorinputview.js
@@ -146,6 +146,14 @@ describe( 'ColorInputView', () => {
 				expect( view.value ).to.equal( 'rgb(0,0,255)' );
 			} );
 
+			it( 'should set input text #value to the selected color\'s label upon #execute', () => {
+				expect( inputView.value ).to.equal( '' );
+
+				colorGridView.items.last.fire( 'execute' );
+
+				expect( inputView.value ).to.equal( 'Blue' );
+			} );
+
 			it( 'should close the dropdown upon #execute', () => {
 				view._dropdownView.isOpen = true;
 
@@ -208,6 +216,15 @@ describe( 'ColorInputView', () => {
 				expect( inputView.value ).to.equal( 'bar' );
 			} );
 
+			it( `when the color input value is set to one of defined colors, 
+			should use its label as the text input value`, () => {
+				view.value = 'rgb(0,255,0)';
+				expect( inputView.value ).to.equal( 'Green' );
+
+				view.value = 'rgb(255,0,0)';
+				expect( inputView.value ).to.equal( 'Red' );
+			} );
+
 			it( 'should have #isReadOnly bound to the color input', () => {
 				view.isReadOnly = true;
 				expect( inputView.isReadOnly ).to.equal( true );
@@ -234,6 +251,60 @@ describe( 'ColorInputView', () => {
 				inputView.fire( 'input' );
 
 				expect( view.value ).to.equal( 'bar' );
+			} );
+
+			it( `when any defined color label is given as the text input #value (case-sensitive),
+			should set the color as #value on #input event`, () => {
+				inputView.element.value = 'Red';
+				inputView.fire( 'input' );
+
+				expect( view.value ).to.equal( 'rgb(255,0,0)' );
+
+				inputView.element.value = 'Green';
+				inputView.fire( 'input' );
+
+				expect( view.value ).to.equal( 'rgb(0,255,0)' );
+
+				inputView.element.value = 'blue';
+				inputView.fire( 'input' );
+
+				expect( view.value ).to.equal( 'blue' );
+			} );
+
+			it( `when any defined color label is given as the text input #value (case-sensitive),
+			then a non-defined value is set to the color input, 
+			the latter value should be set to text input`, () => {
+				inputView.element.value = 'Red';
+				inputView.fire( 'input' );
+
+				expect( view.value ).to.equal( 'rgb(255,0,0)' );
+
+				
+				view.value = 'rgb(0,0,255)';
+
+				expect( view.value ).to.equal( 'rgb(0,0,255)' );
+			} );
+
+			it( `when any defined color value is given as the text input #value (case-sensitive),
+			its value should be set to color and text inputs after input event`, () => {
+				inputView.element.value = 'rgb(255,0,0)';
+				inputView.fire( 'input' );
+
+				expect( view.value ).to.equal( 'rgb(255,0,0)' );
+				expect( inputView.element.value ).to.equal( 'rgb(255,0,0)' );
+			} );
+
+			it( `when any defined color value is given as the text input #value (case-sensitive),
+			its label should be set to text inputs after blur event on input view input element`, () => {
+				inputView.element.value = 'rgb(255,0,0)';
+
+				inputView.fire( 'input' );
+
+				expect( inputView.element.value ).to.equal( 'rgb(255,0,0)' );
+
+				inputView.element.dispatchEvent( new Event( 'blur' ) );
+
+				expect( inputView.element.value ).to.equal( 'Red' );
 			} );
 
 			it( 'should have #input event delegated to the color input', () => {

--- a/packages/ckeditor5-table/tests/ui/colorinputview.js
+++ b/packages/ckeditor5-table/tests/ui/colorinputview.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+/* global Event */
+
 import ColorInputView from '../../src/ui/colorinputview';
 import InputTextView from '@ckeditor/ckeditor5-ui/src/inputtext/inputtextview';
 import ColorGridView from '@ckeditor/ckeditor5-ui/src/colorgrid/colorgridview';
@@ -138,7 +140,7 @@ describe( 'ColorInputView', () => {
 				expect( colorGridView ).to.be.instanceOf( ColorGridView );
 			} );
 
-			it( 'should set #value upon #execute', () => {
+			it( 'should set ColorInputView#value upon ColorTileView#execute', () => {
 				expect( view.value ).to.equal( '' );
 
 				colorGridView.items.last.fire( 'execute' );
@@ -146,7 +148,7 @@ describe( 'ColorInputView', () => {
 				expect( view.value ).to.equal( 'rgb(0,0,255)' );
 			} );
 
-			it( 'should set input text #value to the selected color\'s label upon #execute', () => {
+			it( 'should set InputTextView#value to the selected color\'s label upon ColorTileView#execute', () => {
 				expect( inputView.value ).to.equal( '' );
 
 				colorGridView.items.last.fire( 'execute' );
@@ -154,7 +156,7 @@ describe( 'ColorInputView', () => {
 				expect( inputView.value ).to.equal( 'Blue' );
 			} );
 
-			it( 'should close the dropdown upon #execute', () => {
+			it( 'should close the dropdown upon ColorTileView#execute', () => {
 				view._dropdownView.isOpen = true;
 
 				colorGridView.items.last.fire( 'execute' );
@@ -162,7 +164,7 @@ describe( 'ColorInputView', () => {
 				expect( view._dropdownView.isOpen ).to.be.false;
 			} );
 
-			it( 'should fire #input upon #execute', () => {
+			it( 'should fire the ColorInputView#input event upon ColorTileView#execute', () => {
 				const spy = sinon.spy( view, 'fire' );
 
 				colorGridView.items.last.fire( 'execute' );
@@ -216,7 +218,7 @@ describe( 'ColorInputView', () => {
 				expect( inputView.value ).to.equal( 'bar' );
 			} );
 
-			it( `when the color input value is set to one of defined colors, 
+			it( `when the color input value is set to one of defined colors,
 			should use its label as the text input value`, () => {
 				view.value = 'rgb(0,255,0)';
 				expect( inputView.value ).to.equal( 'Green' );
@@ -253,59 +255,70 @@ describe( 'ColorInputView', () => {
 				expect( view.value ).to.equal( 'bar' );
 			} );
 
-			it( `when any defined color label is given as the text input #value (case-sensitive),
-			should set the color as #value on #input event`, () => {
-				inputView.element.value = 'Red';
-				inputView.fire( 'input' );
+			it(
+				`when any defined color label is given as the text input #value (case-sensitive),
+				should set the color as #value on #input event`,
+				() => {
+					inputView.element.value = 'Red';
+					inputView.fire( 'input' );
 
-				expect( view.value ).to.equal( 'rgb(255,0,0)' );
+					expect( view.value ).to.equal( 'rgb(255,0,0)' );
 
-				inputView.element.value = 'Green';
-				inputView.fire( 'input' );
+					inputView.element.value = 'Green';
+					inputView.fire( 'input' );
 
-				expect( view.value ).to.equal( 'rgb(0,255,0)' );
+					expect( view.value ).to.equal( 'rgb(0,255,0)' );
 
-				inputView.element.value = 'blue';
-				inputView.fire( 'input' );
+					inputView.element.value = 'blue';
+					inputView.fire( 'input' );
 
-				expect( view.value ).to.equal( 'blue' );
-			} );
+					expect( view.value ).to.equal( 'blue' );
+				}
+			);
 
-			it( `when any defined color label is given as the text input #value (case-sensitive),
-			then a non-defined value is set to the color input, 
-			the latter value should be set to text input`, () => {
-				inputView.element.value = 'Red';
-				inputView.fire( 'input' );
+			it(
+				`when any defined color label is given as the text input #value (case-sensitive),
+				then a non-defined value is set to the color input,
+				the latter value should be set to text input`,
+				() => {
+					inputView.element.value = 'Red';
+					inputView.fire( 'input' );
 
-				expect( view.value ).to.equal( 'rgb(255,0,0)' );
+					expect( view.value ).to.equal( 'rgb(255,0,0)' );
 
-				
-				view.value = 'rgb(0,0,255)';
+					view.value = 'rgb(0,0,255)';
 
-				expect( view.value ).to.equal( 'rgb(0,0,255)' );
-			} );
+					expect( view.value ).to.equal( 'rgb(0,0,255)' );
+				}
+			);
 
-			it( `when any defined color value is given as the text input #value (case-sensitive),
-			its value should be set to color and text inputs after input event`, () => {
-				inputView.element.value = 'rgb(255,0,0)';
-				inputView.fire( 'input' );
+			it(
+				`when any defined color value is given as the text input #value (case-sensitive),
+				its value should be set to color and text inputs after input event`,
+				() => {
+					inputView.element.value = 'rgb(255,0,0)';
+					inputView.fire( 'input' );
 
-				expect( view.value ).to.equal( 'rgb(255,0,0)' );
-				expect( inputView.element.value ).to.equal( 'rgb(255,0,0)' );
-			} );
+					expect( view.value ).to.equal( 'rgb(255,0,0)' );
+					expect( inputView.element.value ).to.equal( 'rgb(255,0,0)' );
+				}
+			);
 
-			it( `when any defined color value is given as the text input #value (case-sensitive),
-			its label should be set to text inputs after blur event on input view input element`, () => {
-				inputView.element.value = 'rgb(255,0,0)';
+			it(
+				`when any defined color value is given as the text input #value (case-sensitive),
+				its label should be set to text inputs after blur event on input view input element`,
+				() => {
+					inputView.element.value = 'rgb(255,0,0)';
 
-				inputView.fire( 'input' );
+					inputView.fire( 'input' );
 
-				expect( inputView.element.value ).to.equal( 'rgb(255,0,0)' );
+					expect( inputView.element.value ).to.equal( 'rgb(255,0,0)' );
 
-				inputView.element.dispatchEvent( new Event( 'blur' ) );
+					inputView.element.dispatchEvent( new Event( 'blur' ) );
 
-				expect( inputView.element.value ).to.equal( 'Red' );
-			} );
+					expect( inputView.element.value ).to.equal( 'Red' );
+				}
+			);
 
 			it( 'should have #input event delegated to the color input', () => {
 				const spy = sinon.spy();

--- a/packages/ckeditor5-ui/src/colorgrid/colorgridview.js
+++ b/packages/ckeditor5-ui/src/colorgrid/colorgridview.js
@@ -95,21 +95,21 @@ export default class ColorGridView extends View {
 			colorTile.isOn = colorTile.color === this.selectedColor;
 		} );
 
-		colorDefinitions.forEach( item => {
+		colorDefinitions.forEach( color => {
 			const colorTile = new ColorTileView();
 
 			colorTile.set( {
-				color: item.color,
-				label: item.label,
+				color: color.color,
+				label: color.label,
 				tooltip: true,
-				hasBorder: item.options.hasBorder
+				hasBorder: color.options.hasBorder
 			} );
 
 			colorTile.on( 'execute', () => {
 				this.fire( 'execute', {
-					value: item.color,
-					hasBorder: item.options.hasBorder,
-					label: item.label
+					value: color.color,
+					hasBorder: color.options.hasBorder,
+					label: color.label
 				} );
 			} );
 
@@ -175,13 +175,26 @@ export default class ColorGridView extends View {
 		// Start listening for the keystrokes coming from #element.
 		this.keystrokes.listenTo( this.element );
 	}
+
+	/**
+	 * Fired when the `ColorTileView` for the picked item is executed.
+	 *
+	 * @event execute
+	 * @param {Object} data Additional information about the event.
+	 * @param {String} data.value The value of the selected color 
+	 * ({@link module:ui/colorgrid/colorgrid~ColorDefinition#member-color `color.color`}).
+	 * @param {Boolean} data.hasBorder The `hasBorder` property of the selected color 
+	 * ({@link module:ui/colorgrid/colorgrid~ColorDefinition#member-options.hasBorder `color.options.hasBorder`}).
+	 * @param {String} data.Label The label of the selected color 
+	 * ({@link module:ui/colorgrid/colorgrid~ColorDefinition#member-label `color.label`})
+	 */
 }
 
 /**
  * A color definition used to create a {@link module:ui/colorgrid/colortile~ColorTileView}.
  *
  *		{
- *			color: hsl(0, 0%, 75%),
+ *			color: 'hsl(0, 0%, 75%)',
  *			label: 'Light Grey',
  *			options: {
  *				hasBorder: true

--- a/packages/ckeditor5-ui/src/colorgrid/colorgridview.js
+++ b/packages/ckeditor5-ui/src/colorgrid/colorgridview.js
@@ -181,12 +181,12 @@ export default class ColorGridView extends View {
 	 *
 	 * @event execute
 	 * @param {Object} data Additional information about the event.
-	 * @param {String} data.value The value of the selected color 
-	 * ({@link module:ui/colorgrid/colorgrid~ColorDefinition#member-color `color.color`}).
-	 * @param {Boolean} data.hasBorder The `hasBorder` property of the selected color 
-	 * ({@link module:ui/colorgrid/colorgrid~ColorDefinition#member-options.hasBorder `color.options.hasBorder`}).
-	 * @param {String} data.Label The label of the selected color 
-	 * ({@link module:ui/colorgrid/colorgrid~ColorDefinition#member-label `color.label`})
+	 * @param {String} data.value The value of the selected color
+	 * ({@link module:ui/colorgrid/colorgrid~ColorDefinition#color `color.color`}).
+	 * @param {Boolean} data.hasBorder The `hasBorder` property of the selected color
+	 * ({@link module:ui/colorgrid/colorgrid~ColorDefinition#options.hasBorder `color.options.hasBorder`}).
+	 * @param {String} data.Label The label of the selected color
+	 * ({@link module:ui/colorgrid/colorgrid~ColorDefinition#label `color.label`})
 	 */
 }
 

--- a/packages/ckeditor5-ui/src/inputtext/inputtextview.js
+++ b/packages/ckeditor5-ui/src/inputtext/inputtextview.js
@@ -18,8 +18,9 @@ import '../../theme/components/inputtext/inputtext.css';
 export default class InputTextView extends View {
 	/**
 	 * @inheritDoc
+	 * @param {Object} listeners Map of additional listeners to be attached on template
 	 */
-	constructor( locale ) {
+	constructor( locale, listeners ) {
 		super( locale );
 
 		/**
@@ -91,7 +92,8 @@ export default class InputTextView extends View {
 				'aria-describedby': bind.to( 'ariaDescribedById' )
 			},
 			on: {
-				input: bind.to( 'input' )
+				input: bind.to( 'input' ),
+				...listeners
 			}
 		} );
 

--- a/packages/ckeditor5-ui/src/inputtext/inputtextview.js
+++ b/packages/ckeditor5-ui/src/inputtext/inputtextview.js
@@ -18,9 +18,8 @@ import '../../theme/components/inputtext/inputtext.css';
 export default class InputTextView extends View {
 	/**
 	 * @inheritDoc
-	 * @param {Object} listeners Map of additional listeners to be attached on template
 	 */
-	constructor( locale, listeners ) {
+	constructor( locale ) {
 		super( locale );
 
 		/**
@@ -92,8 +91,7 @@ export default class InputTextView extends View {
 				'aria-describedby': bind.to( 'ariaDescribedById' )
 			},
 			on: {
-				input: bind.to( 'input' ),
-				...listeners
+				input: bind.to( 'input' )
 			}
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (table): Display a human readable color label in the text input field. Closes #6241.

---

### Additional information

This also adds docs, for ColorGridView@execute