### PR TITLE
#6791: Stop normalizing color values passed to the UI, relax matching criteria for ColorInputView's text input.

### DIFF
--- a/packages/ckeditor5-font/tests/ui/colorui.js
+++ b/packages/ckeditor5-font/tests/ui/colorui.js
@@ -304,7 +304,7 @@ describe( 'ColorUI', () => {
 						label: '#000'
 					},
 					{
-						color: 'rgb(255,255,255)',
+						color: 'rgb(255, 255, 255)',
 						label: 'Biały'
 					},
 					{

--- a/packages/ckeditor5-table/src/ui/colorinputview.js
+++ b/packages/ckeditor5-table/src/ui/colorinputview.js
@@ -294,8 +294,9 @@ export default class ColorInputView extends View {
 	 */
 	_setInputValue( inputValue ) {
 		if ( !this._stillTyping ) {
+			const normalizedInputValue = normalizeColor( inputValue );
 			// Check if the value matches one of our defined colors.
-			const mappedColor = this.options.colorDefinitions.find( def => inputValue === def.color );
+			const mappedColor = this.options.colorDefinitions.find( def => normalizedInputValue === normalizeColor( def.color ) );
 
 			if ( mappedColor ) {
 				this._inputView.value = mappedColor.label;
@@ -304,4 +305,17 @@ export default class ColorInputView extends View {
 			}
 		}
 	}
+}
+
+// Normalizes color value, by stripping extensive whitespace.
+// For example., transforms:
+// * `   rgb(  25 50    0 )` to `rgb(25 50 0)`,
+// * "\t  rgb(  25 ,  50,0 )		" to `rgb(25 50 0)`.
+//
+// @param {String} colorString The value to be normalized.
+// @returns {String}
+function normalizeColor( colorString ) {
+	// Remove any whitespace at the beginning, after `(`, or `,`, at the end, before `)`, `,`, or another whitespace.
+	// Then, replace `,` or whitespace with single space.
+	return colorString.replace( /(?<=^|\(|,)\s*|\s*(?=$|\)|\s|,)|/g, '' ).replace( /,|\s/g, ' ' );
 }

--- a/packages/ckeditor5-table/src/ui/colorinputview.js
+++ b/packages/ckeditor5-table/src/ui/colorinputview.js
@@ -315,7 +315,10 @@ export default class ColorInputView extends View {
 // @param {String} colorString The value to be normalized.
 // @returns {String}
 function normalizeColor( colorString ) {
-	// Remove any whitespace at the beginning, after `(`, or `,`, at the end, before `)`, `,`, or another whitespace.
+	// Remove any whitespace right after `(` or `,`.
+	// Remove any whitespace at the beginning or right before the end, `)`, `,`, or another whitespace.
 	// Then, replace `,` or whitespace with single space.
-	return colorString.replace( /(?<=^|\(|,)\s*|\s*(?=$|\)|\s|,)|/g, '' ).replace( /,|\s/g, ' ' );
+	return colorString.replace( /([(,])\s+/g, '$1' )
+		.replace( /^\s+|\s+(?=[),\s]|$)/g, '' )
+		.replace( /,|\s/g, ' ' );
 }

--- a/packages/ckeditor5-table/src/ui/colorinputview.js
+++ b/packages/ckeditor5-table/src/ui/colorinputview.js
@@ -315,10 +315,11 @@ export default class ColorInputView extends View {
 // @param {String} colorString The value to be normalized.
 // @returns {String}
 function normalizeColor( colorString ) {
-	// Remove any whitespace right after `(` or `,`.
-	// Remove any whitespace at the beginning or right before the end, `)`, `,`, or another whitespace.
-	// Then, replace `,` or whitespace with single space.
-	return colorString.replace( /([(,])\s+/g, '$1' )
+	return colorString
+		// Remove any whitespace right after `(` or `,`.
+		.replace( /([(,])\s+/g, '$1' )
+		// Remove any whitespace at the beginning or right before the end, `)`, `,`, or another whitespace.
 		.replace( /^\s+|\s+(?=[),\s]|$)/g, '' )
+		// Then, replace `,` or whitespace with a single space.
 		.replace( /,|\s/g, ' ' );
 }

--- a/packages/ckeditor5-table/tests/ui/colorinputview.js
+++ b/packages/ckeditor5-table/tests/ui/colorinputview.js
@@ -218,6 +218,23 @@ describe( 'ColorInputView', () => {
 				expect( inputView.value ).to.equal( 'bar' );
 			} );
 
+			it( `when the color input value is set to one of defined colors, but with few additional white spaces,
+			should use its label as the text input value`, () => {
+				view.value = 'rgb(0,    255, 0)';
+				expect( inputView.value ).to.equal( 'Green' );
+
+				view.value = '   rgb( 255 0  0)    ';
+				expect( inputView.value ).to.equal( 'Red' );
+
+				view.value = ' 		  rgb(0,  0,  255 )';
+				expect( inputView.value ).to.equal( 'Blue' );
+
+				// Blindly stripping spaces may not work.
+				// rgb(25 50 0) != rgb(255 0 0)
+				view.value = ' 		  rgb(25 50  0)';
+				expect( inputView.value ).to.equal( ' 		  rgb(25 50  0)' );
+			} );
+
 			it( `when the color input value is set to one of defined colors,
 			should use its label as the text input value`, () => {
 				view.value = 'rgb(0,255,0)';

--- a/packages/ckeditor5-table/tests/ui/colorinputview.js
+++ b/packages/ckeditor5-table/tests/ui/colorinputview.js
@@ -218,22 +218,25 @@ describe( 'ColorInputView', () => {
 				expect( inputView.value ).to.equal( 'bar' );
 			} );
 
-			it( `when the color input value is set to one of defined colors, but with few additional white spaces,
-			should use its label as the text input value`, () => {
-				view.value = 'rgb(0,    255, 0)';
-				expect( inputView.value ).to.equal( 'Green' );
+			it(
+				`when the color input value is set to one of defined colors, but with few additional white spaces,
+				should use its label as the text input value`,
+				() => {
+					view.value = 'rgb(0,    255, 0)';
+					expect( inputView.value ).to.equal( 'Green' );
 
-				view.value = '   rgb( 255 0  0)    ';
-				expect( inputView.value ).to.equal( 'Red' );
+					view.value = '   rgb( 255 0  0)    ';
+					expect( inputView.value ).to.equal( 'Red' );
 
-				view.value = ' 		  rgb(0,  0,  255 )';
-				expect( inputView.value ).to.equal( 'Blue' );
+					view.value = ' 		  rgb(0,  0,  255 )';
+					expect( inputView.value ).to.equal( 'Blue' );
 
-				// Blindly stripping spaces may not work.
-				// rgb(25 50 0) != rgb(255 0 0)
-				view.value = ' 		  rgb(25 50  0)';
-				expect( inputView.value ).to.equal( ' 		  rgb(25 50  0)' );
-			} );
+					// Blindly stripping spaces may not work.
+					// rgb(25 50 0) != rgb(255 0 0)
+					view.value = ' 		  rgb(25 50  0)';
+					expect( inputView.value ).to.equal( ' 		  rgb(25 50  0)' );
+				}
+			);
 
 			it( `when the color input value is set to one of defined colors,
 			should use its label as the text input value`, () => {

--- a/packages/ckeditor5-ui/src/colorgrid/utils.js
+++ b/packages/ckeditor5-ui/src/colorgrid/utils.js
@@ -64,13 +64,16 @@ export function normalizeColorOptions( options ) {
 }
 
 // Creates a normalized color definition from the user-defined configuration.
+// The "normalization" means it will create full
+// {@link module:ui/colorgrid/colorgrid~ColorDefinition `ColorDefinition-like`}
+// object for string values, and add a `view` property, for each definition.
 //
 // @param {String|module:ui/colorgrid/colorgrid~ColorDefinition}
 // @returns {module:ui/colorgrid/colorgrid~ColorDefinition}
 export function normalizeSingleColorDefinition( color ) {
 	if ( typeof color === 'string' ) {
 		return {
-			model: color.replace( / /g, '' ),
+			model: color,
 			label: color,
 			hasBorder: false,
 			view: {
@@ -82,7 +85,7 @@ export function normalizeSingleColorDefinition( color ) {
 		};
 	} else {
 		return {
-			model: color.color.replace( / /g, '' ),
+			model: color.color,
 			label: color.label || color.color,
 			hasBorder: color.hasBorder === undefined ? false : color.hasBorder,
 			view: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): When the state is restored or the user enters color value manually, color input is able to provide matching color label. Closes #6791.

---

### Additional information

I decided to use more complicated `RegExp` instead of just stripping spaces, I hope it will not affect performance. The main reason was to support, (valid) color definitions, like `rgb(25 50 0)` and not to match them with `rgb(255 0 0)`. (this case is covered in tests)


By the way, I discovered that normalization util uses yet another object type - reported at https://github.com/ckeditor/ckeditor5/issues/6790#issuecomment-627412557/. It's a different type, but function docs refer `ColorDefinition` even though it does not match. It hurts my OCD, but I left it as it was, to minimize the set of changes, and leave the decision up to #6790.