### PR TITLE
Feature (upload): Added XMLHttpRequest.withCredentials configuration.

### DIFF
--- a/packages/ckeditor5-upload/docs/features/simple-upload-adapter.md
+++ b/packages/ckeditor5-upload/docs/features/simple-upload-adapter.md
@@ -62,6 +62,9 @@ ClassicEditor
 			// The URL that the images are uploaded to.
 			uploadUrl: 'http://example.com',
 
+			// Enable XMLHttpRequest.withCredentials property
+			withCredentials: true,
+
 			// Headers sent along with the XMLHttpRequest to the upload server.
 			headers: {
 				'X-CSRF-TOKEN': 'CSFR-Token',

--- a/packages/ckeditor5-upload/src/adapters/simpleuploadadapter.js
+++ b/packages/ckeditor5-upload/src/adapters/simpleuploadadapter.js
@@ -205,6 +205,12 @@ class Adapter {
 			this.xhr.setRequestHeader( headerName, headers[ headerName ] );
 		}
 
+		// Set withCredentials if specified
+		const withCredentials = this.options.withCredentials || false;
+		if ( withCredentials ) {
+			this.xhr.withCredentials = true;
+		}
+
 		// Prepare the form data.
 		const data = new FormData();
 


### PR DESCRIPTION
Allow to enable [XMLHttpRequest.withCredentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) property.

This is needed when working with cross-domain requests (ex: upload from ckeditor on example.com domain to api.example.com sub-domain).