### PR TITLE
I/6122: Handling spanned table cells in pasting scenarios

### DIFF
--- a/packages/ckeditor5-table/src/commands/setheadercolumncommand.js
+++ b/packages/ckeditor5-table/src/commands/setheadercolumncommand.js
@@ -10,7 +10,7 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
 import { findAncestor, isHeadingColumnCell, updateNumericAttribute } from './utils';
-import { getColumnIndexes, getSelectionAffectedTableCells, getVerticallyOverlappingCells, splitVertically } from '../utils';
+import { getColumnIndexes, getSelectionAffectedTableCells, getHorizontallyOverlappingCells, splitVertically } from '../utils';
 
 /**
  * The header column command.
@@ -76,9 +76,9 @@ export default class SetHeaderColumnCommand extends Command {
 
 		model.change( writer => {
 			if ( headingColumnsToSet ) {
-				// Changing heading columns requires to check if any of a heading cell is overlapping vertically the table head.
+				// Changing heading columns requires to check if any of a heading cell is overlapping horizontally the table head.
 				// Any table cell that has a colspan attribute > 1 will not exceed the table head so we need to fix it in columns before.
-				const overlappingCells = getVerticallyOverlappingCells( table, headingColumnsToSet );
+				const overlappingCells = getHorizontallyOverlappingCells( table, headingColumnsToSet );
 
 				for ( const { cell, column } of overlappingCells ) {
 					splitVertically( cell, column, headingColumnsToSet, writer );

--- a/packages/ckeditor5-table/src/commands/setheadercolumncommand.js
+++ b/packages/ckeditor5-table/src/commands/setheadercolumncommand.js
@@ -10,7 +10,7 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
 import { findAncestor, isHeadingColumnCell, updateNumericAttribute } from './utils';
-import { getColumnIndexes, getSelectionAffectedTableCells } from '../utils';
+import { getColumnIndexes, getSelectionAffectedTableCells, getVerticallyOverlappingCells, splitVertically } from '../utils';
 
 /**
  * The header column command.
@@ -69,12 +69,21 @@ export default class SetHeaderColumnCommand extends Command {
 
 		const model = this.editor.model;
 		const selectedCells = getSelectionAffectedTableCells( model.document.selection );
-		const { first, last } = getColumnIndexes( selectedCells );
+		const table = findAncestor( 'table', selectedCells[ 0 ] );
 
+		const { first, last } = getColumnIndexes( selectedCells );
 		const headingColumnsToSet = this.value ? first : last + 1;
 
 		model.change( writer => {
-			const table = findAncestor( 'table', selectedCells[ 0 ] );
+			if ( headingColumnsToSet ) {
+				// Changing heading columns requires to check if any of a heading cell is overlapping vertically the table head.
+				// Any table cell that has a colspan attribute > 1 will not exceed the table head so we need to fix it in columns before.
+				const overlappingCells = getVerticallyOverlappingCells( table, headingColumnsToSet );
+
+				for ( const { cell, column } of overlappingCells ) {
+					splitVertically( cell, column, headingColumnsToSet, writer );
+				}
+			}
 
 			updateNumericAttribute( 'headingColumns', headingColumnsToSet, table, writer, 0 );
 		} );

--- a/packages/ckeditor5-table/src/commands/setheaderrowcommand.js
+++ b/packages/ckeditor5-table/src/commands/setheaderrowcommand.js
@@ -74,7 +74,7 @@ export default class SetHeaderRowCommand extends Command {
 
 		model.change( writer => {
 			if ( headingRowsToSet ) {
-				// Changing heading rows requires to check if any of a heading cell is overlapping vertically the table head.
+				// Changing heading rows requires to check if any of a heading cell is overlapping horizontally the table head.
 				// Any table cell that has a rowspan attribute > 1 will not exceed the table head so we need to fix it in rows below.
 				const startRow = headingRowsToSet > currentHeadingRows ? currentHeadingRows : 0;
 				const overlappingCells = getHorizontallyOverlappingCells( table, headingRowsToSet, startRow );

--- a/packages/ckeditor5-table/src/commands/setheaderrowcommand.js
+++ b/packages/ckeditor5-table/src/commands/setheaderrowcommand.js
@@ -9,9 +9,8 @@
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
-import { createEmptyTableCell, findAncestor, updateNumericAttribute } from './utils';
-import { getRowIndexes, getSelectionAffectedTableCells } from '../utils';
-import TableWalker from '../tablewalker';
+import { findAncestor, updateNumericAttribute } from './utils';
+import { cutCellsHorizontallyAt, getRowIndexes, getSelectionAffectedTableCells } from '../utils';
 
 /**
  * The header row command.
@@ -97,86 +96,4 @@ export default class SetHeaderRowCommand extends Command {
 
 		return !!headingRows && tableCell.parent.index < headingRows;
 	}
-}
-
-export function cutCellsHorizontallyAt( table, headingRowsToSet, currentHeadingRows, writer ) {
-	const cellsToSplit = getOverlappingCells( table, headingRowsToSet, currentHeadingRows );
-
-	for ( const cell of cellsToSplit ) {
-		splitHorizontally( cell, headingRowsToSet, writer );
-	}
-}
-
-// Returns cells that span beyond the new heading section.
-//
-// @param {module:engine/model/element~Element} table The table to check.
-// @param {Number} headingRowsToSet New heading rows attribute.
-// @param {Number} currentHeadingRows Current heading rows attribute.
-// @returns {Array.<module:engine/model/element~Element>}
-function getOverlappingCells( table, headingRowsToSet, currentHeadingRows ) {
-	const cellsToSplit = [];
-
-	const startAnalysisRow = headingRowsToSet > currentHeadingRows ? currentHeadingRows : 0;
-	// We're analyzing only when headingRowsToSet > 0.
-	const endAnalysisRow = headingRowsToSet - 1;
-
-	const tableWalker = new TableWalker( table, { startRow: startAnalysisRow, endRow: endAnalysisRow } );
-
-	for ( const { row, rowspan, cell } of tableWalker ) {
-		if ( rowspan > 1 && row + rowspan > headingRowsToSet ) {
-			cellsToSplit.push( cell );
-		}
-	}
-
-	return cellsToSplit;
-}
-
-// Splits the table cell horizontally.
-//
-// @param {module:engine/model/element~Element} tableCell
-// @param {Number} headingRows
-// @param {module:engine/model/writer~Writer} writer
-function splitHorizontally( tableCell, headingRows, writer ) {
-	const tableRow = tableCell.parent;
-	const table = tableRow.parent;
-	const rowIndex = tableRow.index;
-
-	const rowspan = parseInt( tableCell.getAttribute( 'rowspan' ) );
-	const newRowspan = headingRows - rowIndex;
-
-	const attributes = {};
-
-	const spanToSet = rowspan - newRowspan;
-
-	if ( spanToSet > 1 ) {
-		attributes.rowspan = spanToSet;
-	}
-
-	const colspan = parseInt( tableCell.getAttribute( 'colspan' ) || 1 );
-
-	if ( colspan > 1 ) {
-		attributes.colspan = colspan;
-	}
-
-	const startRow = table.getChildIndex( tableRow );
-	const endRow = startRow + newRowspan;
-	const tableMap = [ ...new TableWalker( table, { startRow, endRow, includeSpanned: true } ) ];
-
-	let columnIndex;
-
-	for ( const { row, column, cell, cellIndex } of tableMap ) {
-		if ( cell === tableCell && columnIndex === undefined ) {
-			columnIndex = column;
-		}
-
-		if ( columnIndex !== undefined && columnIndex === column && row === endRow ) {
-			const tableRow = table.getChild( row );
-			const tableCellPosition = writer.createPositionAt( tableRow, cellIndex );
-
-			createEmptyTableCell( writer, tableCellPosition, attributes );
-		}
-	}
-
-	// Update the rowspan attribute after updating table.
-	updateNumericAttribute( 'rowspan', newRowspan, tableCell, writer );
 }

--- a/packages/ckeditor5-table/src/commands/setheaderrowcommand.js
+++ b/packages/ckeditor5-table/src/commands/setheaderrowcommand.js
@@ -10,7 +10,7 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
 import { findAncestor, updateNumericAttribute } from './utils';
-import { cutCellsHorizontallyAt, getRowIndexes, getSelectionAffectedTableCells } from '../utils';
+import { getHorizontallyOverlappingCells, getRowIndexes, getSelectionAffectedTableCells, splitHorizontally } from '../utils';
 
 /**
  * The header row command.
@@ -76,7 +76,12 @@ export default class SetHeaderRowCommand extends Command {
 			if ( headingRowsToSet ) {
 				// Changing heading rows requires to check if any of a heading cell is overlapping vertically the table head.
 				// Any table cell that has a rowspan attribute > 1 will not exceed the table head so we need to fix it in rows below.
-				cutCellsHorizontallyAt( table, headingRowsToSet, currentHeadingRows, writer );
+				const startRow = headingRowsToSet > currentHeadingRows ? currentHeadingRows : 0;
+				const overlappingCells = getHorizontallyOverlappingCells( table, headingRowsToSet, startRow );
+
+				for ( const { cell } of overlappingCells ) {
+					splitHorizontally( cell, headingRowsToSet, writer );
+				}
 			}
 
 			updateNumericAttribute( 'headingRows', headingRowsToSet, table, writer, 0 );

--- a/packages/ckeditor5-table/src/commands/setheaderrowcommand.js
+++ b/packages/ckeditor5-table/src/commands/setheaderrowcommand.js
@@ -77,11 +77,7 @@ export default class SetHeaderRowCommand extends Command {
 			if ( headingRowsToSet ) {
 				// Changing heading rows requires to check if any of a heading cell is overlapping vertically the table head.
 				// Any table cell that has a rowspan attribute > 1 will not exceed the table head so we need to fix it in rows below.
-				const cellsToSplit = getOverlappingCells( table, headingRowsToSet, currentHeadingRows );
-
-				for ( const cell of cellsToSplit ) {
-					splitHorizontally( cell, headingRowsToSet, writer );
-				}
+				cutCellsHorizontallyAt( table, headingRowsToSet, currentHeadingRows, writer );
 			}
 
 			updateNumericAttribute( 'headingRows', headingRowsToSet, table, writer, 0 );
@@ -103,13 +99,21 @@ export default class SetHeaderRowCommand extends Command {
 	}
 }
 
+export function cutCellsHorizontallyAt( table, headingRowsToSet, currentHeadingRows, writer ) {
+	const cellsToSplit = getOverlappingCells( table, headingRowsToSet, currentHeadingRows );
+
+	for ( const cell of cellsToSplit ) {
+		splitHorizontally( cell, headingRowsToSet, writer );
+	}
+}
+
 // Returns cells that span beyond the new heading section.
 //
 // @param {module:engine/model/element~Element} table The table to check.
 // @param {Number} headingRowsToSet New heading rows attribute.
 // @param {Number} currentHeadingRows Current heading rows attribute.
 // @returns {Array.<module:engine/model/element~Element>}
-export function getOverlappingCells( table, headingRowsToSet, currentHeadingRows ) {
+function getOverlappingCells( table, headingRowsToSet, currentHeadingRows ) {
 	const cellsToSplit = [];
 
 	const startAnalysisRow = headingRowsToSet > currentHeadingRows ? currentHeadingRows : 0;
@@ -132,7 +136,7 @@ export function getOverlappingCells( table, headingRowsToSet, currentHeadingRows
 // @param {module:engine/model/element~Element} tableCell
 // @param {Number} headingRows
 // @param {module:engine/model/writer~Writer} writer
-export function splitHorizontally( tableCell, headingRows, writer ) {
+function splitHorizontally( tableCell, headingRows, writer ) {
 	const tableRow = tableCell.parent;
 	const table = tableRow.parent;
 	const rowIndex = tableRow.index;

--- a/packages/ckeditor5-table/src/commands/setheaderrowcommand.js
+++ b/packages/ckeditor5-table/src/commands/setheaderrowcommand.js
@@ -10,7 +10,7 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 
 import { findAncestor, updateNumericAttribute } from './utils';
-import { getHorizontallyOverlappingCells, getRowIndexes, getSelectionAffectedTableCells, splitHorizontally } from '../utils';
+import { getVerticallyOverlappingCells, getRowIndexes, getSelectionAffectedTableCells, splitHorizontally } from '../utils';
 
 /**
  * The header row command.
@@ -74,10 +74,10 @@ export default class SetHeaderRowCommand extends Command {
 
 		model.change( writer => {
 			if ( headingRowsToSet ) {
-				// Changing heading rows requires to check if any of a heading cell is overlapping horizontally the table head.
+				// Changing heading rows requires to check if any of a heading cell is overlapping vertically the table head.
 				// Any table cell that has a rowspan attribute > 1 will not exceed the table head so we need to fix it in rows below.
 				const startRow = headingRowsToSet > currentHeadingRows ? currentHeadingRows : 0;
-				const overlappingCells = getHorizontallyOverlappingCells( table, headingRowsToSet, startRow );
+				const overlappingCells = getVerticallyOverlappingCells( table, headingRowsToSet, startRow );
 
 				for ( const { cell } of overlappingCells ) {
 					splitHorizontally( cell, headingRowsToSet, writer );

--- a/packages/ckeditor5-table/src/commands/setheaderrowcommand.js
+++ b/packages/ckeditor5-table/src/commands/setheaderrowcommand.js
@@ -109,7 +109,7 @@ export default class SetHeaderRowCommand extends Command {
 // @param {Number} headingRowsToSet New heading rows attribute.
 // @param {Number} currentHeadingRows Current heading rows attribute.
 // @returns {Array.<module:engine/model/element~Element>}
-function getOverlappingCells( table, headingRowsToSet, currentHeadingRows ) {
+export function getOverlappingCells( table, headingRowsToSet, currentHeadingRows ) {
 	const cellsToSplit = [];
 
 	const startAnalysisRow = headingRowsToSet > currentHeadingRows ? currentHeadingRows : 0;
@@ -132,7 +132,7 @@ function getOverlappingCells( table, headingRowsToSet, currentHeadingRows ) {
 // @param {module:engine/model/element~Element} tableCell
 // @param {Number} headingRows
 // @param {module:engine/model/writer~Writer} writer
-function splitHorizontally( tableCell, headingRows, writer ) {
+export function splitHorizontally( tableCell, headingRows, writer ) {
 	const tableRow = tableCell.parent;
 	const table = tableRow.parent;
 	const rowIndex = tableRow.index;

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -14,7 +14,7 @@ import TableWalker from './tablewalker';
 import { getColumnIndexes, getRowIndexes, isSelectionRectangular } from './utils';
 import { findAncestor } from './commands/utils';
 import { cropTableToDimensions } from './tableselection/croptable';
-import { getOverlappingCells, splitHorizontally } from './commands/setheaderrowcommand';
+import { cutCellsHorizontallyAt } from './commands/setheaderrowcommand';
 import TableUtils from './tableutils';
 
 /**
@@ -309,16 +309,8 @@ function prepareLandingPlace( selectedTableCells, writer ) {
 	const { first: firstRow, last: lastRow } = getRowIndexes( selectedTableCells );
 
 	if ( firstRow > 0 ) {
-		const cellsToSplitHorizontallyAtFirstRow = getOverlappingCells( table, firstRow, 0 );
-
-		for ( const cell of cellsToSplitHorizontallyAtFirstRow ) {
-			splitHorizontally( cell, firstRow, writer );
-		}
+		cutCellsHorizontallyAt( table, firstRow, 0, writer );
 	}
 
-	const cellsToSplitHorizontallyAtLastRow = getOverlappingCells( table, lastRow + 1, firstRow );
-
-	for ( const cell of cellsToSplitHorizontallyAtLastRow ) {
-		splitHorizontally( cell, lastRow + 1, writer );
-	}
+	cutCellsHorizontallyAt( table, lastRow + 1, firstRow, writer );
 }

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -324,25 +324,25 @@ function createLocationMap( table, width, height ) {
 //                                                      ^          ^
 //                                                     first & last columns
 //
+// Will update table to:
+//
+//                       +----+----+----+----+----+
+//                       | 00 | 01 | 02 | 03      |
+//                       +    +----+----+----+----+
+//                       |    | 11 |    | 13 | 14 |
+//                       +----+----+    +    +----+
+//                       | 20 | 21 |    |    | 24 |
+//                       +----+----+    +----+----+
+//                       | 30 |    |    | 33 | 34 |
+//                       +    +----+----+----+    +
+//                       |    |    |    | 43 |    |
+//                       +----+----+----+----+----+
+//
 // In th example above:
 // - Cell "02" which have `rowspan = 4` must be trimmed at first and at after last row.
 // - Cell "03" which have `rowspan = 2` and `colspan = 2` must be trimmed at first column and after last row.
 // - Cells "00", "03" & "30" which cannot be cut by this algorithm as they are outside the trimmed area.
 // - Cell "13" cannot be cut as it is inside the trimmed area.
-//
-// Will update table to:
-//
-// +----+----+----+----+----+
-// | 00 | 01 | 02 | 03      |
-// +    +----+----+----+----+
-// |    | 11 |    | 13 | 14 |
-// +----+----+    +    +----+
-// | 20 | 21 |    |    | 24 |
-// +----+----+    +----+----+
-// | 30 |    |    | 33 | 34 |
-// +    +----+----+----+    +
-// |    |    |    | 43 |    |
-// +----+----+----+----+----+
 function trimCellsToRectangularSelection( selectedTableCells, writer ) {
 	const table = findAncestor( 'table', selectedTableCells[ 0 ] );
 

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -167,10 +167,19 @@ export default class TableClipboard extends Plugin {
 				// Beyond this point we will operate on fixed content table.
 				splitCellsToRectangularSelection( selectedTable, splitDimensions, writer );
 			}
-			// However a rectangular selection might consist an invalid sub-table (if the selected cell would be moved outside the table).
-			// This happens in a table which has:
-			// - last row has empty slots (so are covered by cells from rows above) and/or
-			// - last column has empty slots (are covered by cells from previous columns)
+			// However a selected table fragment might be invalid if examined alone. Ie such table fragment:
+			//
+			//    +---+---+---+---+
+			//  0 | a | b | c | d |
+			//    +   +   +---+---+
+			//  1 |   | e | f | g |
+			//    +   +---+   +---+
+			//  2 |   | h |   | i | <- last row, each cell has rowspan = 2,
+			//    +   +   +   +   +    so we need to return 3, not 2
+			//  3 |   |   |   |   |
+			//    +---+---+---+---+
+			//
+			// is invalid as the cells "h" and "i" have rowspans.
 			// This case needs only adjusting the selection dimension as the rest of the algorithm operates on empty slots also.
 			else {
 				lastRowOfSelection = adjustLastRowIndex( selectedTable, rowIndexes, columnIndexes );

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -169,24 +169,17 @@ export default class TableClipboard extends Plugin {
 				return;
 			}
 
-			pastedTable = cropTableToDimensions( pastedTable, {
+			// Crop pasted table if:
+			// - Pasted table dimensions exceeds selection area.
+			// - Pasted table has broken layout (ie some cells sticks out by the table dimensions established by the first and last row).
+			const cropDimensions = {
 				startRow: 0,
-				endRow: pasteHeight - 1,
 				startColumn: 0,
-				endColumn: pasteWidth - 1
-			}, writer, tableUtils );
+				endRow: Math.min( selectionHeight - 1, pasteHeight - 1 ),
+				endColumn: Math.min( selectionWidth - 1, pasteWidth - 1 )
+			};
 
-			// Crop pasted table if it extends selection area.
-			if ( selectionHeight < pasteHeight || selectionWidth < pasteWidth ) {
-				const cropDimensions = {
-					startRow: 0,
-					startColumn: 0,
-					endRow: selectionHeight - 1,
-					endColumn: selectionWidth - 1
-				};
-
-				pastedTable = cropTableToDimensions( pastedTable, cropDimensions, writer, tableUtils );
-			}
+			pastedTable = cropTableToDimensions( pastedTable, cropDimensions, writer, tableUtils );
 
 			// Holds two-dimensional array that is addressed by [ row ][ column ] that stores cells anchored at given location.
 			const pastedTableLocationMap = createLocationMap( pastedTable, selectionWidth, selectionHeight );

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -11,10 +11,9 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
 import TableSelection from './tableselection';
 import TableWalker from './tablewalker';
-import { getColumnIndexes, getRowIndexes, isSelectionRectangular } from './utils';
+import { cutCellsHorizontallyAt, getColumnIndexes, getRowIndexes, isSelectionRectangular } from './utils';
 import { findAncestor } from './commands/utils';
 import { cropTableToDimensions } from './tableselection/croptable';
-import { cutCellsHorizontallyAt } from './commands/setheaderrowcommand';
 import TableUtils from './tableutils';
 
 /**

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -11,7 +11,7 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
 import TableSelection from './tableselection';
 import TableWalker from './tablewalker';
-import { cutCellsHorizontallyAt, getColumnIndexes, getRowIndexes, isSelectionRectangular } from './utils';
+import { cutCellsHorizontallyAt, cutCellsVerticallyAt, getColumnIndexes, getRowIndexes, isSelectionRectangular } from './utils';
 import { findAncestor } from './commands/utils';
 import { cropTableToDimensions } from './tableselection/croptable';
 import TableUtils from './tableutils';
@@ -306,10 +306,17 @@ function prepareLandingPlace( selectedTableCells, writer ) {
 	const table = findAncestor( 'table', selectedTableCells[ 0 ] );
 
 	const { first: firstRow, last: lastRow } = getRowIndexes( selectedTableCells );
+	const { first: firstColumn, last: lastColumn } = getColumnIndexes( selectedTableCells );
 
 	if ( firstRow > 0 ) {
 		cutCellsHorizontallyAt( table, firstRow, 0, writer );
 	}
 
 	cutCellsHorizontallyAt( table, lastRow + 1, firstRow, writer );
+
+	if ( firstColumn > 0 ) {
+		cutCellsVerticallyAt( table, firstColumn, 0, writer );
+	}
+
+	cutCellsVerticallyAt( table, lastColumn + 1, firstColumn, writer );
 }

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -169,6 +169,13 @@ export default class TableClipboard extends Plugin {
 				return;
 			}
 
+			pastedTable = cropTableToDimensions( pastedTable, {
+				startRow: 0,
+				endRow: pasteHeight - 1,
+				startColumn: 0,
+				endColumn: pasteWidth - 1
+			}, writer, tableUtils );
+
 			// Crop pasted table if it extends selection area.
 			if ( selectionHeight < pasteHeight || selectionWidth < pasteWidth ) {
 				const cropDimensions = {
@@ -179,13 +186,6 @@ export default class TableClipboard extends Plugin {
 				};
 
 				pastedTable = cropTableToDimensions( pastedTable, cropDimensions, writer, tableUtils );
-			} else {
-				pastedTable = cropTableToDimensions( pastedTable, {
-					startRow: 0,
-					endRow: pasteHeight - 1,
-					startColumn: 0,
-					endColumn: pasteWidth - 1
-				}, writer, tableUtils );
 			}
 
 			// Holds two-dimensional array that is addressed by [ row ][ column ] that stores cells anchored at given location.

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -361,11 +361,11 @@ function trimCellsToRectangularSelection( selectedTableCells, writer ) {
 	doVerticalSplit( table, lastColumn + 1, rowIndexes, writer );
 
 	// 2. Split cells horizontally in two steps as first step might create cells that needs to split again.
-	doHorizontalSplit( table, firstRow, columnIndexes, writer, 0 );
+	doHorizontalSplit( table, firstRow, columnIndexes, writer );
 	doHorizontalSplit( table, lastRow + 1, columnIndexes, writer, firstRow );
 }
 
-function doHorizontalSplit( table, splitRow, limitColumns, writer, startRow ) {
+function doHorizontalSplit( table, splitRow, limitColumns, writer, startRow = 0 ) {
 	// If selection starts at first row then no split is needed.
 	if ( splitRow < 1 ) {
 		return;

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -142,15 +142,19 @@ export default class TableClipboard extends Plugin {
 			// Content table to which we insert a pasted table.
 			const selectedTable = findAncestor( 'table', selectedTableCells[ 0 ] );
 
-			if ( selectedTableCells.length === 1 ) {
+			// Single cell selected - expand selection to pasted table dimensions.
+			const shouldExpandSelection = selectedTableCells.length === 1;
+
+			if ( shouldExpandSelection ) {
 				lastRowOfSelection += pasteHeight - 1;
 				lastColumnOfSelection += pasteWidth - 1;
 
 				expandTableSize( selectedTable, lastRowOfSelection + 1, lastColumnOfSelection + 1, writer, tableUtils );
 			}
 
-			// Beyond this point we will operate on a fixed content table.
-			if ( selectedTableCells.length === 1 || !isSelectionRectangular( selectedTableCells, tableUtils ) ) {
+			// In case of expanding selection we do not reset the selection so in this case we will always try to fix selection
+			// like in the case of a non-rectangular area. This might be fixed by re-setting selected cells array but this shortcut is safe.
+			if ( shouldExpandSelection || !isSelectionRectangular( selectedTableCells, tableUtils ) ) {
 				const splitDimensions = {
 					firstRow: firstRowOfSelection,
 					lastRow: lastRowOfSelection,
@@ -172,6 +176,8 @@ export default class TableClipboard extends Plugin {
 				lastRowOfSelection = adjustLastRowIndex( selectedTable, rowIndexes, columnIndexes );
 				lastColumnOfSelection = adjustLastColumnIndex( selectedTable, rowIndexes, columnIndexes );
 			}
+
+			// Beyond this point we operate on a fixed content table with rectangular selection and proper last row/column values.
 
 			const selectionHeight = lastRowOfSelection - firstRowOfSelection + 1;
 			const selectionWidth = lastColumnOfSelection - firstColumnOfSelection + 1;

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -179,6 +179,13 @@ export default class TableClipboard extends Plugin {
 				};
 
 				pastedTable = cropTableToDimensions( pastedTable, cropDimensions, writer, tableUtils );
+			} else {
+				pastedTable = cropTableToDimensions( pastedTable, {
+					startRow: 0,
+					endRow: pasteHeight - 1,
+					startColumn: 0,
+					endColumn: pasteWidth - 1
+				}, writer, tableUtils );
 			}
 
 			// Holds two-dimensional array that is addressed by [ row ][ column ] that stores cells anchored at given location.

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -149,7 +149,7 @@ export default class TableClipboard extends Plugin {
 				expandTableSize( selectedTable, lastRowOfSelection + 1, lastColumnOfSelection + 1, writer, tableUtils );
 			}
 
-			// Beyond this point we will operate on fixed content table.
+			// Beyond this point we will operate on a fixed content table.
 			if ( selectedTableCells.length === 1 || !isSelectionRectangular( selectedTableCells, tableUtils ) ) {
 				const splitDimensions = {
 					firstRow: firstRowOfSelection,
@@ -306,24 +306,24 @@ function replaceSelectedCellsWithPasted( pastedTable, selectedTable, selectionDi
 	writer.setSelection( cellsToSelect.map( cell => writer.createRangeOn( cell ) ) );
 }
 
-// Expand table (in place) to expected size (rows and columns).
-function expandTableSize( table, rows, columns, writer, tableUtils ) {
+// Expand table (in place) to expected size.
+function expandTableSize( table, expectedHeight, expectedWidth, writer, tableUtils ) {
 	const tableWidth = tableUtils.getColumns( table );
 	const tableHeight = tableUtils.getRows( table );
 
-	if ( columns > tableWidth ) {
+	if ( expectedWidth > tableWidth ) {
 		tableUtils.insertColumns( table, {
 			batch: writer.batch,
 			at: tableWidth,
-			columns: columns - tableWidth
+			columns: expectedWidth - tableWidth
 		} );
 	}
 
-	if ( rows > tableHeight ) {
+	if ( expectedHeight > tableHeight ) {
 		tableUtils.insertRows( table, {
 			batch: writer.batch,
 			at: tableHeight,
-			rows: rows - tableHeight
+			rows: expectedHeight - tableHeight
 		} );
 	}
 }

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -133,11 +133,7 @@ export default class TableClipboard extends Plugin {
 			// Currently not handled. The selected table content should be trimmed to a rectangular selection.
 			// See: https://github.com/ckeditor/ckeditor5/issues/6122.
 			if ( !isSelectionRectangular( selectedTableCells, tableUtils ) ) {
-				// @if CK_DEBUG // console.log( 'NOT IMPLEMENTED YET: Selection is not rectangular (non-mergeable).' );
-
 				prepareLandingPlace( selectedTableCells, writer );
-
-				// return;
 			}
 
 			const { last: lastColumnOfSelection, first: firstColumnOfSelection } = getColumnIndexes( selectedTableCells );
@@ -308,15 +304,15 @@ function prepareLandingPlace( selectedTableCells, writer ) {
 	const { first: firstRow, last: lastRow } = getRowIndexes( selectedTableCells );
 	const { first: firstColumn, last: lastColumn } = getColumnIndexes( selectedTableCells );
 
-	if ( firstRow > 0 ) {
-		cutCellsHorizontallyAt( table, firstRow, 0, writer, { firstRow: 0, firstColumn, lastRow: 1000, lastColumn } );
-	}
-
-	cutCellsHorizontallyAt( table, lastRow + 1, firstRow, writer, { firstRow: 0, firstColumn, lastRow: 1000, lastColumn } );
-
 	if ( firstColumn > 0 ) {
 		cutCellsVerticallyAt( table, firstColumn, 0, writer, { firstRow, firstColumn: 0, lastRow, lastColumn: 1000 } );
 	}
 
 	cutCellsVerticallyAt( table, lastColumn + 1, firstColumn, writer, { firstRow, firstColumn: 0, lastRow, lastColumn: 1000 } );
+
+	if ( firstRow > 0 ) {
+		cutCellsHorizontallyAt( table, firstRow, 0, writer, { firstRow: 0, firstColumn, lastRow: 1000, lastColumn } );
+	}
+
+	cutCellsHorizontallyAt( table, lastRow + 1, firstRow, writer, { firstRow: 0, firstColumn, lastRow: 1000, lastColumn } );
 }

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -309,14 +309,14 @@ function prepareLandingPlace( selectedTableCells, writer ) {
 	const { first: firstColumn, last: lastColumn } = getColumnIndexes( selectedTableCells );
 
 	if ( firstRow > 0 ) {
-		cutCellsHorizontallyAt( table, firstRow, 0, writer );
+		cutCellsHorizontallyAt( table, firstRow, 0, writer, { firstRow: 0, firstColumn, lastRow: 1000, lastColumn } );
 	}
 
-	cutCellsHorizontallyAt( table, lastRow + 1, firstRow, writer );
+	cutCellsHorizontallyAt( table, lastRow + 1, firstRow, writer, { firstRow: 0, firstColumn, lastRow: 1000, lastColumn } );
 
 	if ( firstColumn > 0 ) {
-		cutCellsVerticallyAt( table, firstColumn, 0, writer );
+		cutCellsVerticallyAt( table, firstColumn, 0, writer, { firstRow, firstColumn: 0, lastRow, lastColumn: 1000 } );
 	}
 
-	cutCellsVerticallyAt( table, lastColumn + 1, firstColumn, writer );
+	cutCellsVerticallyAt( table, lastColumn + 1, firstColumn, writer, { firstRow, firstColumn: 0, lastRow, lastColumn: 1000 } );
 }

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -529,7 +529,7 @@ function adjustLastRowIndex( table, rowIndexes, columnIndexes ) {
 	}
 
 	// Otherwise get any cell's rowspan and adjust the last row index.
-	const rowspanAdjustment = lastRowMap.pop().rowspan - 1;
+	const rowspanAdjustment = lastRowMap[ 0 ].rowspan - 1;
 	return rowIndexes.last + rowspanAdjustment;
 }
 
@@ -565,6 +565,6 @@ function adjustLastColumnIndex( table, rowIndexes, columnIndexes ) {
 	}
 
 	// Otherwise get any cell's colspan and adjust the last column index.
-	const colspanAdjustment = lastColumnMap.pop().colspan - 1;
+	const colspanAdjustment = lastColumnMap[ 0 ].colspan - 1;
 	return columnIndexes.last + colspanAdjustment;
 }

--- a/packages/ckeditor5-table/src/utils.js
+++ b/packages/ckeditor5-table/src/utils.js
@@ -285,8 +285,9 @@ export function cutCellsVerticallyAt( table, headingColumnsToSet, currentHeading
 function filterToBoundingBox( boundingBox ) {
 	const { firstRow, firstColumn, lastRow, lastColumn } = boundingBox;
 
-	return ( { row, column } ) => {
-		return ( ( firstRow <= row ) && ( row <= lastRow ) ) && ( firstColumn <= column && column <= lastColumn );
+	return ( { row, column, colspan, rowspan } ) => {
+		return ( ( firstRow <= row + rowspan - 1 ) && ( row + rowspan - 1 <= lastRow ) ) &&
+			( firstColumn <= column + colspan - 1 && column + colspan - 1 <= lastColumn );
 	};
 }
 

--- a/packages/ckeditor5-table/src/utils.js
+++ b/packages/ckeditor5-table/src/utils.js
@@ -248,7 +248,7 @@ export function isSelectionRectangular( selectedTableCells, tableUtils ) {
 }
 
 /**
- * Returns cells that starts above and overlaps a given row.
+ * Returns slot info of cells that starts above and overlaps a given row.
  *
  * In a table below, passing `overlapRow = 3`
  *
@@ -264,11 +264,11 @@ export function isSelectionRectangular( selectedTableCells, tableUtils ) {
  *    4  │ o │ p │   │   │ q │
  *       └───┴───┴───┴───┴───┘
  *
- * will return cells: "j", "f", "k".
+ * will return slot info for cells: "j", "f", "k".
  *
  * @param {module:engine/model/element~Element} table The table to check.
  * @param {Number} overlapRow The index of the row to check.
- * @param {Number} [startRow=0] A row to start analysis if it is known where.
+ * @param {Number} [startRow=0] A row to start analysis. Use it when it is known that cells below that row will not overlap.
  * @returns {Array.<module:table/tablewalker~TableWalkerValue>}
  */
 export function getVerticallyOverlappingCells( table, overlapRow, startRow = 0 ) {
@@ -278,8 +278,9 @@ export function getVerticallyOverlappingCells( table, overlapRow, startRow = 0 )
 
 	for ( const slotInfo of tableWalker ) {
 		const { row, rowspan } = slotInfo;
+		const slotEndRow = row + rowspan - 1;
 
-		if ( rowspan > 1 && row + rowspan > overlapRow ) {
+		if ( row < overlapRow && overlapRow <= slotEndRow ) {
 			cells.push( slotInfo );
 		}
 	}
@@ -339,7 +340,7 @@ export function splitHorizontally( tableCell, splitRow, writer ) {
 }
 
 /**
- * Returns cells that starts before and overlaps a given column.
+ * Returns slot info of cells that starts before and overlaps a given column.
  *
  * In a table below, passing `overlapColumn = 3`
  *
@@ -358,7 +359,7 @@ export function splitHorizontally( tableCell, splitRow, writer ) {
  *                  ^
  *                  Overlap column to check
  *
- * will return cells: "b", "e", "i".
+ * will return slot info for cells: "b", "e", "i".
  *
  * @param {module:engine/model/element~Element} table The table to check.
  * @param {Number} overlapColumn The index of the column to check.
@@ -371,9 +372,9 @@ export function getHorizontallyOverlappingCells( table, overlapColumn ) {
 
 	for ( const slotInfo of tableWalker ) {
 		const { column, colspan } = slotInfo;
-		const endColumn = column + colspan - 1;
+		const slotEndColumn = column + colspan - 1;
 
-		if ( column < overlapColumn && overlapColumn <= endColumn ) {
+		if ( column < overlapColumn && overlapColumn <= slotEndColumn ) {
 			cellsToSplit.push( slotInfo );
 		}
 	}

--- a/packages/ckeditor5-table/src/utils.js
+++ b/packages/ckeditor5-table/src/utils.js
@@ -278,9 +278,9 @@ export function getVerticallyOverlappingCells( table, overlapRow, startRow = 0 )
 
 	for ( const slotInfo of tableWalker ) {
 		const { row, rowspan } = slotInfo;
-		const slotEndRow = row + rowspan - 1;
+		const cellEndRow = row + rowspan - 1;
 
-		if ( row < overlapRow && overlapRow <= slotEndRow ) {
+		if ( row < overlapRow && overlapRow <= cellEndRow ) {
 			cells.push( slotInfo );
 		}
 	}
@@ -372,9 +372,9 @@ export function getHorizontallyOverlappingCells( table, overlapColumn ) {
 
 	for ( const slotInfo of tableWalker ) {
 		const { column, colspan } = slotInfo;
-		const slotEndColumn = column + colspan - 1;
+		const cellEndColumn = column + colspan - 1;
 
-		if ( column < overlapColumn && overlapColumn <= slotEndColumn ) {
+		if ( column < overlapColumn && overlapColumn <= cellEndColumn ) {
 			cellsToSplit.push( slotInfo );
 		}
 	}

--- a/packages/ckeditor5-table/src/utils.js
+++ b/packages/ckeditor5-table/src/utils.js
@@ -268,7 +268,7 @@ export function isSelectionRectangular( selectedTableCells, tableUtils ) {
  *
  * @param {module:engine/model/element~Element} table The table to check.
  * @param {Number} overlapRow The index of the row to check.
- * @param {Number} [startRow=0] A row to start analysis. Use it when it is known that cells below that row will not overlap.
+ * @param {Number} [startRow=0] A row to start analysis. Use it when it is known that the cells above that row will not overlap.
  * @returns {Array.<module:table/tablewalker~TableWalkerValue>}
  */
 export function getVerticallyOverlappingCells( table, overlapRow, startRow = 0 ) {

--- a/packages/ckeditor5-table/tests/commands/setheadercolumncommand.js
+++ b/packages/ckeditor5-table/tests/commands/setheadercolumncommand.js
@@ -198,6 +198,18 @@ describe( 'SetHeaderColumnCommand', () => {
 			], { headingColumns: 1 } ) );
 		} );
 
+		it( 'should remove "headingColumns" attribute from table if no value was given', () => {
+			setData( model, modelTable( [
+				[ '[]00', '01', '02', '03' ]
+			], { headingColumns: 3 } ) );
+
+			command.execute();
+
+			assertEqualMarkup( getData( model ), modelTable( [
+				[ '[]00', '01', '02', '03' ]
+			] ) );
+		} );
+
 		describe( 'multi-cell selection', () => {
 			describe( 'setting header', () => {
 				it( 'should set it correctly in a middle of single-row, multiple cell selection', () => {

--- a/packages/ckeditor5-table/tests/commands/setheadercolumncommand.js
+++ b/packages/ckeditor5-table/tests/commands/setheadercolumncommand.js
@@ -404,7 +404,7 @@ describe( 'SetHeaderColumnCommand', () => {
 			], { headingColumns: 2 } ) );
 		} );
 
-		it( 'should respect forceValue parameter #1', () => {
+		it( 'should respect forceValue parameter (forceValue=true)', () => {
 			setData( model, modelTable( [
 				[ '00', '01[]', '02', '03' ]
 			], { headingColumns: 3 } ) );
@@ -416,7 +416,7 @@ describe( 'SetHeaderColumnCommand', () => {
 			], { headingColumns: 3 } ) );
 		} );
 
-		it( 'should respect forceValue parameter #2', () => {
+		it( 'should respect forceValue parameter (forceValue=false)', () => {
 			setData( model, modelTable( [
 				[ '00', '01[]', '02', '03' ]
 			], { headingColumns: 1 } ) );

--- a/packages/ckeditor5-table/tests/commands/setheadercolumncommand.js
+++ b/packages/ckeditor5-table/tests/commands/setheadercolumncommand.js
@@ -427,5 +427,95 @@ describe( 'SetHeaderColumnCommand', () => {
 				[ '00', '01[]', '02', '03' ]
 			], { headingColumns: 1 } ) );
 		} );
+
+		it( 'should fix col-spanned cells on the edge of an table heading columns section', () => {
+			// +----+----+----+
+			// | 00 | 01      |
+			// +----+         +
+			// | 10 |         |
+			// +----+----+----+
+			// | 20 | 21 | 22 |
+			// +----+----+----+
+			//      ^-- heading columns
+			setData( model, modelTable( [
+				[ '00', { contents: '[]01', colspan: 2, rowspan: 2 } ],
+				[ '10' ],
+				[ '20', '21', '22' ]
+			], { headingColumns: 1 } ) );
+
+			command.execute();
+
+			// +----+----+----+
+			// | 00 | 01 |    |
+			// +----+    +    +
+			// | 10 |    |    |
+			// +----+----+----+
+			// | 20 | 21 | 22 |
+			// +----+----+----+
+			//           ^-- heading columns
+			assertEqualMarkup( getData( model ), modelTable( [
+				[ '00', { contents: '[]01', rowspan: 2 }, { contents: '', rowspan: 2 } ],
+				[ '10' ],
+				[ '20', '21', '22' ]
+			], { headingColumns: 2 } ) );
+		} );
+
+		it( 'should split to at most 2 table cells when fixing col-spanned cells on the edge of an table heading columns section', () => {
+			// +----+----+----+----+----+----+
+			// | 00 | 01                     |
+			// +----+                        +
+			// | 10 |                        |
+			// +----+----+----+----+----+----+
+			// | 20 | 21 | 22 | 23 | 24 | 25 |
+			// +----+----+----+----+----+----+
+			//      ^-- heading columns
+			setData( model, modelTable( [
+				[ '00', { contents: '01', colspan: 5, rowspan: 2 } ],
+				[ '10' ],
+				[ '20', '21', '22[]', '23', '24', '25' ]
+			], { headingColumns: 1 } ) );
+
+			command.execute();
+
+			// +----+----+----+----+----+----+
+			// | 00 | 01      |              |
+			// +----+         +              +
+			// | 10 |         |              |
+			// +----+----+----+----+----+----+
+			// | 20 | 21 | 22 | 23 | 24 | 25 |
+			// +----+----+----+----+----+----+
+			//                ^-- heading columns
+			assertEqualMarkup( getData( model ), modelTable( [
+				[ '00', { contents: '01', colspan: 2, rowspan: 2 }, { contents: '', colspan: 3, rowspan: 2 } ],
+				[ '10' ],
+				[ '20', '21', '22[]', '23', '24', '25' ]
+			], { headingColumns: 3 } ) );
+		} );
+
+		it( 'should fix col-spanned cells on the edge of an table heading columns section when creating section', () => {
+			// +----+----+
+			// | 00      |
+			// +----+----+
+			// | 10 | 11 |
+			// +----+----+
+			//           ^-- heading columns
+			setData( model, modelTable( [
+				[ { contents: '00', colspan: 2 } ],
+				[ '10', '[]11' ]
+			], { headingColumns: 2 } ) );
+
+			command.execute();
+
+			// +----+----+
+			// | 00 |    |
+			// +----+----+
+			// | 10 | 11 |
+			// +----+----+
+			//      ^-- heading columns
+			assertEqualMarkup( getData( model ), modelTable( [
+				[ '00', '' ],
+				[ '10', '[]11' ]
+			], { headingColumns: 1 } ) );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-table/tests/commands/setheaderrowcommand.js
+++ b/packages/ckeditor5-table/tests/commands/setheaderrowcommand.js
@@ -551,7 +551,7 @@ describe( 'SetHeaderRowCommand', () => {
 			} );
 		} );
 
-		it( 'should respect forceValue parameter #1', () => {
+		it( 'should respect forceValue parameter (forceValue=true)', () => {
 			setData( model, modelTable( [
 				[ '00' ],
 				[ '[]10' ],
@@ -569,7 +569,7 @@ describe( 'SetHeaderRowCommand', () => {
 			], { headingRows: 3 } ) );
 		} );
 
-		it( 'should respect forceValue parameter #2', () => {
+		it( 'should respect forceValue parameter (forceValue=false)', () => {
 			setData( model, modelTable( [
 				[ '00' ],
 				[ '[]10' ],

--- a/packages/ckeditor5-table/tests/commands/setheaderrowcommand.js
+++ b/packages/ckeditor5-table/tests/commands/setheaderrowcommand.js
@@ -225,7 +225,7 @@ describe( 'SetHeaderRowCommand', () => {
 			], { headingRows: 1 } ) );
 		} );
 
-		it( 'should unsetset heading rows attribute', () => {
+		it( 'should remove "headingRows" attribute from table if no value was given', () => {
 			setData( model, modelTable( [
 				[ '[]00' ],
 				[ '10' ],

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -765,6 +765,39 @@ describe( 'table clipboard', () => {
 						[ '', '', '', 'ea', 'eb', 'ec', 'ed' ]
 					] ) );
 				} );
+
+				it( 'should fix non-rectangular are on matched table fragment', () => {
+					// +----+----+----+
+					// | 00 | 01 | 02 |
+					// +----+----+    +
+					// | 10 | 11 |    |
+					// +----+----+----+
+					// | 20      | 22 |
+					// +----+----+----+
+					setModelData( model, modelTable( [
+						[ '00', '01', { contents: '02', rowspan: 2 } ],
+						[ '10', '11[]' ],
+						[ { contents: '20', colspan: 2 }, '22' ]
+					] ) );
+
+					pasteTable( [
+						[ 'aa', 'ab' ],
+						[ 'ba', 'bb' ]
+					] );
+
+					// +----+----+----+
+					// | 00 | 01 | 02 |
+					// +----+----+----+
+					// | 10 | aa | ab |
+					// +----+----+----+
+					// | 20 | ba | bb |
+					// +----+----+----+
+					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
+						[ '00', '01', '02' ],
+						[ '10', 'aa', 'ab' ],
+						[ '20', 'ba', 'bb' ]
+					] ) );
+				} );
 			} );
 		} );
 

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -1271,8 +1271,8 @@ describe( 'table clipboard', () => {
 
 					// Select 02 -> 23
 					tableSelection.setCellSelection(
-						modelRoot.getNodeByPath( [ 0, 2, 0 ] ),
-						modelRoot.getNodeByPath( [ 0, 3, 1 ] )
+						modelRoot.getNodeByPath( [ 0, 0, 2 ] ),
+						modelRoot.getNodeByPath( [ 0, 2, 3 ] )
 					);
 
 					pasteTable( [
@@ -1311,8 +1311,8 @@ describe( 'table clipboard', () => {
 
 					// Select 01 -> 22
 					tableSelection.setCellSelection(
-						modelRoot.getNodeByPath( [ 0, 1, 0 ] ),
-						modelRoot.getNodeByPath( [ 0, 2, 1 ] )
+						modelRoot.getNodeByPath( [ 0, 0, 1 ] ),
+						modelRoot.getNodeByPath( [ 0, 2, 2 ] )
 					);
 
 					pasteTable( [
@@ -1329,9 +1329,9 @@ describe( 'table clipboard', () => {
 					// | 20 | ca | cb | 23 | 24 |
 					// +----+----+----+----+----+
 					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
-						[ '00', '01', 'aa', 'ab', '04' ],
-						[ { contents: '10', colspan: 2 }, 'ba', 'bb', '14' ],
-						[ '20', '21', 'ca', 'cb', '24' ]
+						[ '00', 'aa', 'ab', '03', '04' ],
+						[ '10', 'ba', 'bb', '', '14' ],
+						[ '20', 'ca', 'cb', '23', '24' ]
 					] ) );
 				} );
 
@@ -1352,7 +1352,7 @@ describe( 'table clipboard', () => {
 					// Select 00 -> 21
 					tableSelection.setCellSelection(
 						modelRoot.getNodeByPath( [ 0, 0, 0 ] ),
-						modelRoot.getNodeByPath( [ 0, 1, 1 ] )
+						modelRoot.getNodeByPath( [ 0, 2, 1 ] )
 					);
 
 					pasteTable( [
@@ -1364,20 +1364,20 @@ describe( 'table clipboard', () => {
 					// +----+----+----+----+----+
 					// | aa | ab | 02 | 03 | 04 |
 					// +----+----+----+----+----+
-					// | ba | bb |    |    | 14 |
+					// | ba | bb |         | 14 |
 					// +----+----+----+----+----+
 					// | ca | cb | 22 | 23 | 24 |
 					// +----+----+----+----+----+
 					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
-						[ '00', '01', 'aa', 'ab', '04' ],
-						[ { contents: '10', colspan: 2 }, 'ba', 'bb', '14' ],
-						[ '20', '21', 'ca', 'cb', '24' ]
+						[ 'aa', 'ab', '02', '03', '04' ],
+						[ 'ba', 'bb', { colspan: 2, contents: '' }, '14' ],
+						[ 'ca', 'cb', '22', '23', '24' ]
 					] ) );
 				} );
 
 				it( 'should properly handle complex case', () => {
 					// +----+----+----+----+----+----+----+
-					// | 00           | 03 | 04 | 05 | 06 |
+					// | 00           | 03 | 04           |
 					// +              +    +----+----+----+
 					// |              |    | 14 | 15 | 16 |
 					// +              +    +----+----+----+
@@ -1392,7 +1392,7 @@ describe( 'table clipboard', () => {
 					// | 60 | 61 | 62 |    | 64 |         |
 					// +----+----+----+----+----+----+----+
 					setModelData( model, modelTable( [
-						[ { contents: '00', colspan: 3, rowspan: 3 }, { contents: '03', rowspan: 3 }, '04', '05', '06' ],
+						[ { contents: '00', colspan: 3, rowspan: 3 }, { contents: '03', rowspan: 3 }, { colspan: 3, contents: '04' } ],
 						[ '14', '15', '16' ],
 						[ { contents: '24', colspan: 3 } ],
 						[
@@ -1419,7 +1419,7 @@ describe( 'table clipboard', () => {
 					] );
 
 					// +----+----+----+----+----+----+----+
-					// | 00      |    | 03 | 04 | 05 | 06 |
+					// | 00      |    | 03 | 04           |
 					// +         +    +    +----+----+----+
 					// |         |    |    | 14 | 15 | 16 |
 					// +----+----+----+----+----+----+----+

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -1392,7 +1392,7 @@ describe( 'table clipboard', () => {
 					// Select 21 -> 12
 					tableSelection.setCellSelection(
 						modelRoot.getNodeByPath( [ 0, 2, 1 ] ),
-						modelRoot.getNodeByPath( [ 0, 1, 1 ] )
+						modelRoot.getNodeByPath( [ 0, 1, 0 ] )
 					);
 
 					pasteTable( [

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -1128,10 +1128,10 @@ describe( 'table clipboard', () => {
 
 					/* eslint-disable no-multi-spaces */
 					assertSelectedCells( model, [
-						[ 1, 1, 1, 1, 0 ],
-						[ 1, 1, 0 ],
-						[ 1, 1, 0 ],
-						[ 1, 1, 1, 0 ],
+						[ 1,    1, 1, 1, 0 ],
+						[ 1, 1,          0 ],
+						[ 1,          1, 0 ],
+						[    1, 1, 1,    0 ],
 						[ 0, 0, 0, 0, 0, 0 ]
 					] );
 					/* eslint-enable no-multi-spaces */

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -1375,6 +1375,84 @@ describe( 'table clipboard', () => {
 					] ) );
 				} );
 
+				it( 'should split cells anchored outside selection rectangle that overlaps selection (above selection)', () => {
+					// +----+----+----+
+					// | 00      | 02 |
+					// +         +----+
+					// |         | 12 |
+					// +----+----+----+
+					// | 20 | 21 | 22 |
+					// +----+----+----+
+					setModelData( model, modelTable( [
+						[ { contents: '00', colspan: 2, rowspan: 2 }, '02' ],
+						[ '12' ],
+						[ '20', '21', '22' ]
+					] ) );
+
+					// Select 21 -> 12
+					tableSelection.setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 2, 1 ] ),
+						modelRoot.getNodeByPath( [ 0, 1, 1 ] )
+					);
+
+					pasteTable( [
+						[ 'aa', 'ab' ],
+						[ 'ba', 'bb' ]
+					] );
+
+					// +----+----+----+
+					// | 00 |    | 02 |
+					// +    +----+----+
+					// |    | aa | ab |
+					// +----+----+----+
+					// | 20 | ba | bb |
+					// +----+----+----+
+					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
+						[ { contents: '00', rowspan: 2 }, '', '02' ],
+						[ 'aa', 'ab' ],
+						[ '20', 'ba', 'bb' ]
+					] ) );
+				} );
+
+				it( 'should split cells anchored outside selection rectangle that overlaps selection (below selection)', () => {
+					// +----+----+----+
+					// | 00 | 01 | 02 |
+					// +----+----+----+
+					// | 10      | 12 |
+					// +         +----+
+					// |         | 22 |
+					// +----+----+----+
+					setModelData( model, modelTable( [
+						[ '00', '01', '02' ],
+						[ { contents: '10', colspan: 2, rowspan: 2 }, '12' ],
+						[ '22' ]
+					] ) );
+
+					// Select 01 -> 12
+					tableSelection.setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 0, 1 ] ),
+						modelRoot.getNodeByPath( [ 0, 1, 1 ] )
+					);
+
+					pasteTable( [
+						[ 'aa', 'ab' ],
+						[ 'ba', 'bb' ]
+					] );
+
+					// +----+----+----+
+					// | 00 | aa | ab |
+					// +----+----+----+
+					// | 10 | ba | bb |
+					// +    +----+----+
+					// |    |    | 22 |
+					// +----+----+----+
+					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
+						[ '00', 'aa', 'ab' ],
+						[ { contents: '10', rowspan: 2 }, 'ba', 'bb' ],
+						[ '', '22' ]
+					] ) );
+				} );
+
 				it( 'should properly handle complex case', () => {
 					// +----+----+----+----+----+----+----+
 					// | 00           | 03 | 04           |

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -1422,29 +1422,29 @@ describe( 'table clipboard', () => {
 					// | 00      |    | 03 | 04           |
 					// +         +    +    +----+----+----+
 					// |         |    |    | 14 | 15 | 16 |
-					// +----+----+----+----+----+----+----+
+					// +         +----+----+----+----+----+
 					// |         | aa | ab | ac |         |
 					// +----+----+----+----+----+----+----+
 					// | 30 | 31 | ba | bb | bc | 35 | 36 |
 					// +    +----+----+----+----+----+----+
 					// |    | 41 | ca | cb | cc | 45      |
 					// +    +----+----+----+----+         +
-					// |    | 51 | 52 | 53 | 54 |         |
+					// |    | 51 | 52 |    | 54 |         |
 					// +----+----+----+    +----+         +
 					// | 60 | 61 | 62 |    | 64 |         |
 					// +----+----+----+----+----+----+----+
 					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
 						[
-							{ contents: '00', colspan: 2, rowspan: 2 },
+							{ contents: '00', colspan: 2, rowspan: 3 },
 							{ contents: '', rowspan: 2 },
 							{ contents: '03', rowspan: 2 },
-							'04', '05', '06'
+							{ contents: '04', colspan: 3 }
 						],
 						[ '14', '15', '16' ],
-						[ { contents: '', colspan: 2 }, 'aa', 'ab', 'ac', { contents: '', colspan: 2 } ],
+						[ 'aa', 'ab', 'ac', { contents: '', colspan: 2 } ],
 						[ { contents: '30', rowspan: 3 }, '31', 'ba', 'bb', 'bc', '35', '36' ],
 						[ '41', 'ca', 'cb', 'cc', { contents: '45', colspan: 2, rowspan: 3 } ],
-						[ '51', '52', { contents: '53', rowspan: 2 }, '54' ],
+						[ '51', '52', { contents: '', rowspan: 2 }, '54' ],
 						[ '60', '61', '62', '64' ]
 					] ) );
 				} );

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -2142,6 +2142,154 @@ describe( 'table clipboard', () => {
 				] );
 				/* eslint-enable no-multi-spaces */
 			} );
+
+			it(
+				'should trim pasted cells\' width if they exceeds pasted table width (pasted height is bigger then selection height)',
+				() => {
+					// Select 00 -> 11 (selection 2x2 - smaller by height than the expected fixed table)
+					tableSelection.setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 0, 0 ] ),
+						modelRoot.getNodeByPath( [ 0, 1, 1 ] )
+					);
+
+					// +----+----+
+					// | aa | ab |             <- First row establish table width=2.
+					// +----+----+----+----+
+					// | ba | bb           |   <- Cell "bb" sticks out by 2 slots.
+					// +----+----+----+----+
+					// | ca           |        <- Cell "ca" sticks out by 1 slot.
+					// +----+----+----+
+					pasteTable( [
+						[ 'aa', 'ab' ],
+						[ 'ba', { colspan: 3, contents: 'bb' } ],
+						[ { colspan: 3, contents: 'ca' } ]
+					] );
+
+					// +----+----+----+----+
+					// | aa | ab | 02 | 03 |
+					// +----+----+----+----+
+					// | ba | bb | 12 | 13 |
+					// +----+----+----+----+
+					// | 20 | 21 | 22 | 23 |
+					// +----+----+----+----+
+					// | 30 | 31 | 32 | 33 |
+					// +----+----+----+----+
+					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
+						[ 'aa', 'ab', '02', '03' ],
+						[ 'ba', 'bb', '12', '13' ],
+						[ '20', '21', '22', '23' ],
+						[ '30', '31', '32', '33' ]
+					] ) );
+
+					assertSelectedCells( model, [
+						[ 1, 1, 0, 0 ],
+						[ 1, 1, 0, 0 ],
+						[ 0, 0, 0, 0 ],
+						[ 0, 0, 0, 0 ]
+					] );
+				}
+			);
+
+			it(
+				'should trim pasted cells\' height if they exceeds pasted table height (pasted width is bigger then selection width)',
+				() => {
+					// Select 00 -> 11 (selection 2x2 - smaller by width than the expected fixed table)
+					tableSelection.setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 0, 0 ] ),
+						modelRoot.getNodeByPath( [ 0, 1, 1 ] )
+					);
+
+					// +----+----+----+
+					// | aa | ab | ac |
+					// +----+----+    +
+					// | ba | bb |    |   <- Last row establish table height=2.
+					// +----+    +    +
+					//      |    |    |   <- Cell "ac" sticks out by 1 slot.
+					//      +    +----+
+					//      |    |        <- Cell "bb" sticks out by 2 slots.
+					//      +----+
+					pasteTable( [
+						[ 'aa', 'ab', { contents: 'ac', rowspan: 3 } ],
+						[ 'ba', { contents: 'bb', rowspan: 3 } ]
+					] );
+
+					// +----+----+----+----+
+					// | aa | ab | 02 | 03 |
+					// +----+----+----+----+
+					// | ba | bb | 12 | 13 |
+					// +----+----+----+----+
+					// | 20 | 21 | 22 | 23 |
+					// +----+----+----+----+
+					// | 30 | 31 | 32 | 33 |
+					// +----+----+----+----+
+					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
+						[ 'aa', 'ab', '02', '03' ],
+						[ 'ba', 'bb', '12', '13' ],
+						[ '20', '21', '22', '23' ],
+						[ '30', '31', '32', '33' ]
+					] ) );
+
+					/* eslint-disable no-multi-spaces */
+					assertSelectedCells( model, [
+						[ 1, 1, 0, 0 ],
+						[ 1, 1, 0, 0 ],
+						[ 0, 0, 0, 0 ],
+						[ 0, 0, 0, 0 ]
+					] );
+					/* eslint-enable no-multi-spaces */
+				}
+			);
+
+			it(
+				`should trim pasted pasted cells' height and width if they exceeds pasted table dimensions
+				(pasted table is bigger then selection width)`,
+				() => {
+					// Select 00 -> 11 (selection 2x2 - smaller than the expected fixed table)
+					tableSelection.setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 0, 0 ] ),
+						modelRoot.getNodeByPath( [ 0, 1, 1 ] )
+					);
+
+					// +----+----+----+
+					// | aa | ab | ac |
+					// +----+----+----+----+
+					// | ba | bb           | <- Cell "bb" sticks out by 1 slots in width and by 1 slot in height.
+					// +----+              +
+					// | ca |              |
+					// +----+              +
+					//      |              |
+					//      +----+----+----+
+					pasteTable( [
+						[ 'aa', 'ab' ],
+						[ 'ba', { contents: 'bb', colspan: 3, rowspan: 2 } ]
+					] );
+
+					// +----+----+----+----+
+					// | aa | ab | 02 | 03 |
+					// +----+----+----+----+
+					// | ba | bb | 12 | 13 |
+					// +----+----+----+----+
+					// | 20 | 21 | 22 | 23 |
+					// +----+----+----+----+
+					// | 30 | 31 | 32 | 33 |
+					// +----+----+----+----+
+					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
+						[ 'aa', 'ab', '02', '03' ],
+						[ 'ba', 'bb', '12', '13' ],
+						[ '20', '21', '22', '23' ],
+						[ '30', '31', '32', '33' ]
+					] ) );
+
+					/* eslint-disable no-multi-spaces */
+					assertSelectedCells( model, [
+						[ 1, 1, 0, 0 ],
+						[ 1, 1, 0, 0 ],
+						[ 0, 0, 0, 0 ],
+						[ 0, 0, 0, 0 ]
+					] );
+					/* eslint-enable no-multi-spaces */
+				}
+			);
 		} );
 	} );
 

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -248,33 +248,6 @@ describe( 'table clipboard', () => {
 			] ) );
 		} );
 
-		it( 'should block non-rectangular selection', () => {
-			setModelData( model, modelTable( [
-				[ { contents: '00', colspan: 3 } ],
-				[ '10', '11', '12' ],
-				[ '20', '21', '22' ]
-			] ) );
-
-			tableSelection.setCellSelection(
-				modelRoot.getNodeByPath( [ 0, 0, 0 ] ),
-				modelRoot.getNodeByPath( [ 0, 1, 1 ] )
-			);
-
-			// Catches the temporary console log in the CK_DEBUG mode.
-			sinon.stub( console, 'log' );
-
-			pasteTable( [
-				[ 'aa', 'ab' ],
-				[ 'ba', 'bb' ]
-			] );
-
-			assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
-				[ { contents: '00', colspan: 3 } ],
-				[ '10', '11', '12' ],
-				[ '20', '21', '22' ]
-			] ) );
-		} );
-
 		describe( 'single cell selected', () => {
 			it( 'blocks this case', () => {
 				setModelData( model, modelTable( [
@@ -1120,11 +1093,40 @@ describe( 'table clipboard', () => {
 					/* eslint-disable no-multi-spaces */
 					assertSelectedCells( model, [
 						[ 0, 0, 0, 0 ],
-						[ 0, 1,    0 ],
+						[ 0, 1, 0 ],
 						[ 0, 1, 1, 0 ],
 						[ 0, 0, 0, 0 ]
 					] );
 					/* eslint-enable no-multi-spaces */
+				} );
+			} );
+
+			describe( 'non-rectangular content table', () => {
+				it( 'should block non-rectangular selection', () => {
+					setModelData( model, modelTable( [
+						[ { contents: '00', colspan: 3 } ],
+						[ '10', '11', '12' ],
+						[ '20', '21', '22' ]
+					] ) );
+
+					tableSelection.setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 0, 0 ] ),
+						modelRoot.getNodeByPath( [ 0, 1, 1 ] )
+					);
+
+					// Catches the temporary console log in the CK_DEBUG mode.
+					sinon.stub( console, 'log' );
+
+					pasteTable( [
+						[ 'aa', 'ab' ],
+						[ 'ba', 'bb' ]
+					] );
+
+					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
+						[ { contents: '00', colspan: 3 } ],
+						[ '10', '11', '12' ],
+						[ '20', '21', '22' ]
+					] ) );
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -604,10 +604,10 @@ describe( 'table clipboard', () => {
 
 					/* eslint-disable no-multi-spaces */
 					assertSelectedCells( model, [
-						[ 1,    1, 1, 1, 0 ],
-						[ 1, 1,          0 ],
-						[ 1,          1, 0 ],
-						[    1, 1, 1,    0 ],
+						[ 1, 1, 1, 1, 0 ],
+						[ 1, 1, 0 ],
+						[ 1, 1, 0 ],
+						[ 1, 1, 1, 0 ],
 						[ 0, 0, 0, 0, 0, 0 ]
 					] );
 					/* eslint-enable no-multi-spaces */
@@ -897,6 +897,50 @@ describe( 'table clipboard', () => {
 					] );
 				} );
 
+				it( 'handles pasting table that has cell with colspan (multiple ending rows in the selection are spanned)', () => {
+					// +----+----+----+
+					// | 00 | 01 | 02 |
+					// +----+    +    +
+					// | 10 |    |    |
+					// +----+    +    +
+					// | 20 |    |    |
+					// +----+----+----+
+					// | 30 | 31 | 32 |
+					// +----+----+----+
+					setModelData( model, modelTable( [
+						[ '00', { contents: '01', rowspan: 3 }, { contents: '02', rowspan: 3 } ],
+						[ '10' ],
+						[ '20' ],
+						[ '30', '31', '32' ]
+					] ) );
+
+					// Select 01 -> 02 (selection 2x2)
+					tableSelection.setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 0, 1 ] ),
+						modelRoot.getNodeByPath( [ 0, 0, 2 ] )
+					);
+
+					pasteTable( [
+						[ 'aa', 'ab' ],
+						[ 'ba', 'bb' ],
+						[ 'ca', 'cb' ]
+					] );
+
+					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
+						[ '00', 'aa', 'ab' ],
+						[ '10', 'ba', 'bb' ],
+						[ '20', 'ca', 'cb' ],
+						[ '30', '31', '32' ]
+					] ) );
+
+					assertSelectedCells( model, [
+						[ 0, 1, 1 ],
+						[ 0, 1, 1 ],
+						[ 0, 1, 1 ],
+						[ 0, 0, 0 ]
+					] );
+				} );
+
 				it( 'handles pasting table that has cell with colspan (last column in selection is spanned)', () => {
 					// +----+----+----+----+
 					// | 00 | 01      | 03 |
@@ -938,6 +982,44 @@ describe( 'table clipboard', () => {
 						[ 1, 1, 1, 0 ],
 						[ 1, 1, 1, 0 ],
 						[ 0, 0, 0, 0 ]
+					] );
+				} );
+
+				it( 'handles pasting table that has cell with colspan (multiple ending columns in the selection are spanned)', () => {
+					// +----+----+----+----+
+					// | 00 | 01 | 02 | 03 |
+					// +----+----+----+----+
+					// | 10           | 13 |
+					// +----+----+----+----+
+					// | 20           | 23 |
+					// +----+----+----+----+
+					setModelData( model, modelTable( [
+						[ '00', '01', '02', '03' ],
+						[ { contents: '10', colspan: 3 }, '13' ],
+						[ { contents: '20', colspan: 3 }, '23' ]
+					] ) );
+
+					// Select 10 -> 20 (selection 3x2)
+					tableSelection.setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 1, 0 ] ),
+						modelRoot.getNodeByPath( [ 0, 2, 0 ] )
+					);
+
+					pasteTable( [
+						[ 'aa', 'ab', 'ac' ],
+						[ 'ba', 'bb', 'bc' ]
+					] );
+
+					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
+						[ '00', '01', '02', '03' ],
+						[ 'aa', 'ab', 'ac', '13' ],
+						[ 'ba', 'bb', 'bc', '23' ]
+					] ) );
+
+					assertSelectedCells( model, [
+						[ 0, 0, 0, 0 ],
+						[ 1, 1, 1, 0 ],
+						[ 1, 1, 1, 0 ]
 					] );
 				} );
 			} );

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -853,8 +853,7 @@ describe( 'table clipboard', () => {
 					/* eslint-enable no-multi-spaces */
 				} );
 
-				// TODO: Skipped case - should allow pasting but no tools to compare areas (like in MergeCellsCommand).
-				it.skip( 'handles pasting table that has cell with colspan (last row in selection is spanned)', () => {
+				it( 'handles pasting table that has cell with colspan (last row in selection is spanned)', () => {
 					// +----+----+----+----+
 					// | 00 | 01 | 02 | 03 |
 					// +----+----+----+----+
@@ -871,9 +870,54 @@ describe( 'table clipboard', () => {
 						[ '30', '31', '32', '33' ]
 					] ) );
 
+					// Select 02 -> 10 (selection 3x3)
 					tableSelection.setCellSelection(
 						modelRoot.getNodeByPath( [ 0, 0, 2 ] ),
 						modelRoot.getNodeByPath( [ 0, 1, 0 ] )
+					);
+
+					pasteTable( [
+						[ 'aa', 'ab', 'ac' ],
+						[ 'ba', 'bb', 'bc' ],
+						[ 'ca', 'cb', 'cc' ]
+					] );
+
+					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
+						[ 'aa', 'ab', 'ac', '03' ],
+						[ 'ba', 'bb', 'bc', '13' ],
+						[ 'ca', 'cb', 'cc', '23' ],
+						[ '30', '31', '32', '33' ]
+					] ) );
+
+					assertSelectedCells( model, [
+						[ 1, 1, 1, 0 ],
+						[ 1, 1, 1, 0 ],
+						[ 1, 1, 1, 0 ],
+						[ 0, 0, 0, 0 ]
+					] );
+				} );
+
+				it( 'handles pasting table that has cell with colspan (last column in selection is spanned)', () => {
+					// +----+----+----+----+
+					// | 00 | 01      | 03 |
+					// +----+----+----+----+
+					// | 10 | 11      | 13 |
+					// +----+         +----+
+					// | 20 |         | 23 |
+					// +----+----+----+----+
+					// | 30 | 31 | 32 | 33 |
+					// +----+----+----+----+
+					setModelData( model, modelTable( [
+						[ '00', { contents: '01', colspan: 2 }, '03' ],
+						[ '10', { contents: '11', colspan: 2, rowspan: 2 }, '13' ],
+						[ '20', '23' ],
+						[ '30', '31', '32', '33' ]
+					] ) );
+
+					// Select 20 -> 01 (selection 3x3)
+					tableSelection.setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 2, 0 ] ),
+						modelRoot.getNodeByPath( [ 0, 0, 1 ] )
 					);
 
 					pasteTable( [
@@ -1047,8 +1091,7 @@ describe( 'table clipboard', () => {
 					/* eslint-enable no-multi-spaces */
 				} );
 
-				// TODO: Skipped case - should allow pasting but no tools to compare areas (like in MergeCellsCommand).
-				it.skip( 'handles pasting table that has cell with colspan (last row in selection is spanned)', () => {
+				it( 'handles pasting table that has cell with colspan (last row in selection is spanned)', () => {
 					// +----+----+----+----+
 					// | 00 | 01 | 02 | 03 |
 					// +----+----+----+----+
@@ -1065,6 +1108,7 @@ describe( 'table clipboard', () => {
 						[ '30', '31', '32', '33' ]
 					] ) );
 
+					// Select 02 -> 10 (selection 3x3)
 					tableSelection.setCellSelection(
 						modelRoot.getNodeByPath( [ 0, 0, 2 ] ),
 						modelRoot.getNodeByPath( [ 0, 1, 0 ] )
@@ -1084,17 +1128,70 @@ describe( 'table clipboard', () => {
 					] );
 
 					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
-						[ '00', '01', '02', '03' ],
-						[ '10', { colspan: 2, contents: 'aa' }, '13' ],
-						[ '20', 'ba', 'bb', '23' ],
+						[ 'aa', 'ab', 'ac', '03' ],
+						[ { contents: 'ba', colspan: 2, rowspan: 2 }, 'bc', '13' ],
+						[ 'cc', '23' ],
 						[ '30', '31', '32', '33' ]
 					] ) );
 
 					/* eslint-disable no-multi-spaces */
 					assertSelectedCells( model, [
-						[ 0, 0, 0, 0 ],
-						[ 0, 1, 0 ],
-						[ 0, 1, 1, 0 ],
+						[ 1, 1, 1, 0 ],
+						[ 1,    1, 0 ],
+						[       1, 0 ],
+						[ 0, 0, 0, 0 ]
+					] );
+					/* eslint-enable no-multi-spaces */
+				} );
+
+				it( 'handles pasting table that has cell with colspan (last column in selection is spanned)', () => {
+					// +----+----+----+----+
+					// | 00 | 01      | 03 |
+					// +----+----+----+----+
+					// | 10 | 11      | 13 |
+					// +----+         +----+
+					// | 20 |         | 23 |
+					// +----+----+----+----+
+					// | 30 | 31 | 32 | 33 |
+					// +----+----+----+----+
+					setModelData( model, modelTable( [
+						[ '00', { contents: '01', colspan: 2 }, '03' ],
+						[ '10', { contents: '11', colspan: 2, rowspan: 2 }, '13' ],
+						[ '20', '23' ],
+						[ '30', '31', '32', '33' ]
+					] ) );
+
+					// Select 20 -> 01 (selection 3x3)
+					tableSelection.setCellSelection(
+						modelRoot.getNodeByPath( [ 0, 2, 0 ] ),
+						modelRoot.getNodeByPath( [ 0, 0, 1 ] )
+					);
+
+					// +----+----+----+
+					// | aa | ab | ac |
+					// +----+----+----+
+					// | ba      | bc |
+					// +         +----+
+					// |         | cc |
+					// +----+----+----+
+					pasteTable( [
+						[ 'aa', 'ab', 'ac' ],
+						[ { contents: 'ba', colspan: 2, rowspan: 2 }, 'bc' ],
+						[ 'cc' ]
+					] );
+
+					assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
+						[ 'aa', 'ab', 'ac', '03' ],
+						[ { contents: 'ba', colspan: 2, rowspan: 2 }, 'bc', '13' ],
+						[ 'cc', '23' ],
+						[ '30', '31', '32', '33' ]
+					] ) );
+
+					/* eslint-disable no-multi-spaces */
+					assertSelectedCells( model, [
+						[ 1, 1, 1, 0 ],
+						[ 1,    1, 0 ],
+						[       1, 0 ],
 						[ 0, 0, 0, 0 ]
 					] );
 					/* eslint-enable no-multi-spaces */

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -2068,10 +2068,8 @@ describe( 'table clipboard', () => {
 				//      |    |        <- Cell "bb" sticks out by 2 slots.
 				//      +----+
 				pasteTable( [
-					[
-						[ 'aa', 'ab', { contents: 'ac', rowspan: 3 } ],
-						[ 'ba', { contents: 'bb', rowspan: 3 } ]
-					]
+					[ 'aa', 'ab', { contents: 'ac', rowspan: 3 } ],
+					[ 'ba', { contents: 'bb', rowspan: 3 } ]
 				] );
 
 				// +----+----+----+----+
@@ -2084,9 +2082,9 @@ describe( 'table clipboard', () => {
 				// | 30 | 31 | 32 | 33 |
 				// +----+----+----+----+
 				assertEqualMarkup( getModelData( model, { withoutSelection: true } ), modelTable( [
-					[ 'aa', 'ab', '02', '03' ],
-					[ 'ba', 'bb', '12', '13' ],
-					[ { contents: 'ca', colspan: 2 }, '22', '23' ],
+					[ 'aa', 'ab', { rowspan: 2, contents: 'ac' }, '03' ],
+					[ 'ba', 'bb', '13' ],
+					[ '20', '21', '22', '23' ],
 					[ '30', '31', '32', '33' ]
 				] ) );
 

--- a/packages/ckeditor5-table/tests/utils.js
+++ b/packages/ckeditor5-table/tests/utils.js
@@ -13,7 +13,7 @@ import { modelTable } from './_utils/utils';
 import {
 	getSelectedTableCells,
 	getTableCellsContainingSelection,
-	getSelectionAffectedTableCells
+	getSelectionAffectedTableCells, getVerticallyOverlappingCells, getHorizontallyOverlappingCells
 } from '../src/utils';
 
 describe( 'table utils', () => {
@@ -357,6 +357,94 @@ describe( 'table utils', () => {
 			} );
 
 			expect( getSelectionAffectedTableCells( selection ) ).to.be.empty;
+		} );
+	} );
+
+	describe( 'getVerticallyOverlappingCells()', () => {
+		let table;
+
+		beforeEach( () => {
+			// +----+----+----+----+----+
+			// | 00 | 01 | 02 | 03 | 04 |
+			// +    +    +----+    +----+
+			// |    |    | 12 |    | 14 |
+			// +    +    +    +----+----+
+			// |    |    |    | 23 | 24 |
+			// +    +----+    +    +----+
+			// |    | 31 |    |    | 34 |
+			// +    +    +----+----+----+
+			// |    |    | 42 | 43 | 44 |
+			// +----+----+----+----+----+
+			setModelData( model, modelTable( [
+				[ { contents: '00', rowspan: 5 }, { contents: '01', rowspan: 3 }, '02', { contents: '03', rowspan: 2 }, '04' ],
+				[ { contents: '12', rowspan: 3 }, '14' ],
+				[ { contents: '23', rowspan: 2 }, '24' ],
+				[ { contents: '31', rowspan: 2 }, '34' ],
+				[ '42', '43', '44' ]
+			] ) );
+
+			table = modelRoot.getChild( 0 );
+		} );
+
+		it( 'should return empty array for no overlapping cells', () => {
+			const cellsInfo = getVerticallyOverlappingCells( table, 0 );
+
+			expect( cellsInfo ).to.be.empty;
+		} );
+
+		it( 'should return overlapping cells info for given overlapRow', () => {
+			const cellsInfo = getVerticallyOverlappingCells( table, 2 );
+
+			expect( cellsInfo[ 0 ].cell ).to.equal( modelRoot.getNodeByPath( [ 0, 0, 0 ] ) ); // Cell 00
+			expect( cellsInfo[ 1 ].cell ).to.equal( modelRoot.getNodeByPath( [ 0, 0, 1 ] ) ); // Cell 01
+			expect( cellsInfo[ 2 ].cell ).to.equal( modelRoot.getNodeByPath( [ 0, 1, 0 ] ) ); // Cell 12
+		} );
+
+		it( 'should ignore rows below startRow', () => {
+			const cellsInfo = getVerticallyOverlappingCells( table, 2, 1 );
+
+			expect( cellsInfo[ 0 ].cell ).to.equal( modelRoot.getNodeByPath( [ 0, 1, 0 ] ) ); // Cell 12
+		} );
+	} );
+
+	describe( 'getHorizontallyOverlappingCells()', () => {
+		let table;
+
+		beforeEach( () => {
+			// +----+----+----+----+----+
+			// | 00                     |
+			// +----+----+----+----+----+
+			// | 10           | 13      |
+			// +----+----+----+----+----+
+			// | 20 | 21           | 24 |
+			// +----+----+----+----+----+
+			// | 30      | 32      | 34 |
+			// +----+----+----+----+----+
+			// | 40 | 41 | 42 | 43 | 44 |
+			// +----+----+----+----+----+
+			setModelData( model, modelTable( [
+				[ { contents: '00', colspan: 5 } ],
+				[ { contents: '10', colspan: 3 }, { contents: '13', colspan: 2 } ],
+				[ '20', { contents: '21', colspan: 3 }, '24' ],
+				[ { contents: '30', colspan: 2 }, { contents: '32', colspan: 2 }, '34' ],
+				[ '40', '41', '42', '43', '44' ]
+			] ) );
+
+			table = modelRoot.getChild( 0 );
+		} );
+
+		it( 'should return empty array for no overlapping cells', () => {
+			const cellsInfo = getHorizontallyOverlappingCells( table, 0 );
+
+			expect( cellsInfo ).to.be.empty;
+		} );
+
+		it( 'should return overlapping cells info for given overlapColumn', () => {
+			const cellsInfo = getHorizontallyOverlappingCells( table, 2 );
+
+			expect( cellsInfo[ 0 ].cell ).to.equal( modelRoot.getNodeByPath( [ 0, 0, 0 ] ) ); // Cell 00
+			expect( cellsInfo[ 1 ].cell ).to.equal( modelRoot.getNodeByPath( [ 0, 1, 0 ] ) ); // Cell 10
+			expect( cellsInfo[ 2 ].cell ).to.equal( modelRoot.getNodeByPath( [ 0, 2, 1 ] ) ); // Cell 21
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (table): Handle spanned table cells in pasting scenarios. Closes #6122.

Fix (table): Setting column as header will now split it col-spaned cells. Closes #6658.

---

### Additional information

This PR:

*   Introduces handling cases of spanned cells (both in selected table and pasted table) that have spans that exceeds rectangular selection.
*   Introduces fix to #6658 as the utils used were also created (they mirrors the logic of setting table header rows).
*   Handles a rectangular selection with cells spanned at the last row or column (like here: https://github.com/ckeditor/ckeditor5/pull/6786#issuecomment-627214164)
*   We also assume that pasted table is either valid or near valid. One case of invalid table structure was moved to a followup.