### PR TITLE
Fixed a bug where the rendered attribute name is always lower case

### DIFF
--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -242,7 +242,7 @@ export default class DomConverter {
 
 				// Copy element's attributes.
 				for ( const key of viewNode.getAttributeKeys() ) {
-					domElement.setAttribute( key, viewNode.getAttribute( key ) );
+					domElement.setAttributeNS( null, key, viewNode.getAttribute( key ) );
 				}
 			}
 

--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -242,7 +242,21 @@ export default class DomConverter {
 
 				// Copy element's attributes.
 				for ( const key of viewNode.getAttributeKeys() ) {
-					domElement.setAttributeNS( null, key, viewNode.getAttribute( key ) );
+					let namespaceUri = null;
+
+					// There are certain cases where namespace URI needs to be carefully maintained, otherwise
+					// it will throw an exception. See the specification for more details:
+					// https://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-ElSetAttrNS
+					if ( key.startsWith( 'xml:' ) ) {
+						namespaceUri = 'http://www.w3.org/XML/1998/namespace';
+					} else if ( key == 'xmlns' ) {
+						namespaceUri = 'http://www.w3.org/2000/xmlns/';
+					} else if ( key.includes( ':' ) ) {
+						// Workaround for custom namespaces. Verified to work with Firefox, Chrome.
+						namespaceUri = ' ';
+					}
+
+					domElement.setAttributeNS( namespaceUri, key, viewNode.getAttribute( key ) );
 				}
 			}
 

--- a/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
@@ -97,10 +97,9 @@ describe( 'DomConverter', () => {
 
 		it( 'should preserve attribute letter casing', () => {
 			const viewP = new ViewElement( viewDocument, 'p', { fooBar: 'bAz' } );
-
-			const domP = converter.viewToDom( viewP, document, { bind: true } );
-
+			const domP = converter.viewToDom( viewP, document );
 			const attributeNames = Array.from( domP.attributes ).map( attr => attr.name );
+
 			expect( attributeNames ).to.include( 'fooBar' );
 		} );
 

--- a/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
@@ -95,6 +95,15 @@ describe( 'DomConverter', () => {
 			expect( converter.findCorrespondingViewText( domP.childNodes[ 0 ] ) ).to.equal( viewP.getChild( 0 ) );
 		} );
 
+		it( 'should preserve attribute letter casing', () => {
+			const viewP = new ViewElement( viewDocument, 'p', { fooBar: 'bAz' } );
+
+			const domP = converter.viewToDom( viewP, document, { bind: true } );
+
+			const attributeNames = Array.from( domP.attributes ).map( attr => attr.name );
+			expect( attributeNames ).to.include( 'fooBar' );
+		} );
+
 		it( 'should create tree of DOM elements from view element without children', () => {
 			const viewImg = new ViewElement( viewDocument, 'img' );
 			const viewText = new ViewText( viewDocument, 'foo' );

--- a/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
@@ -185,13 +185,31 @@ describe( 'DomConverter', () => {
 			expect( domTextNode.data ).to.equal( 'foo' );
 		} );
 
-		it( 'should create namespaced elements', () => {
+		it( 'should create namespaced attributes', () => {
 			const namespace = 'http://www.w3.org/2000/svg';
 			const viewSvg = new ViewElement( viewDocument, 'svg', { xmlns: namespace } );
 
 			const domSvg = converter.viewToDom( viewSvg, document );
 
 			expect( domSvg.createSVGRect ).to.be.a( 'function' );
+		} );
+
+		it( 'should handle attributes with xml: prefix', () => {
+			const viewSvg = new ViewElement( viewDocument, 'foo', { 'xml:fooBar': 'baz' } );
+
+			const domElement = converter.viewToDom( viewSvg, document );
+			const attributeNames = Array.from( domElement.attributes ).map( attr => attr.name );
+
+			expect( attributeNames ).to.include( 'xml:fooBar' );
+		} );
+
+		it( 'should handle attributes with custom namespace prefix', () => {
+			const viewSvg = new ViewElement( viewDocument, 'foo', { 'myPrefix:fooBar': 'baz' } );
+
+			const domElement = converter.viewToDom( viewSvg, document );
+			const attributeNames = Array.from( domElement.attributes ).map( attr => attr.name );
+
+			expect( attributeNames ).to.include( 'myPrefix:fooBar' );
 		} );
 
 		describe( 'it should convert spaces to &nbsp;', () => {

--- a/packages/ckeditor5-engine/tests/view/renderer.js
+++ b/packages/ckeditor5-engine/tests/view/renderer.js
@@ -478,6 +478,21 @@ describe( 'Renderer', () => {
 			expect( domP.childNodes[ 1 ].childNodes.length ).to.equal( 0 );
 		} );
 
+		it( 'should preserve attribute casing', () => {
+			const viewP = new ViewElement( viewDocument, 'p', {
+				fooBar: 'bazBom'
+			} );
+
+			viewRoot._appendChild( viewP );
+
+			renderer.markToSync( 'children', viewRoot );
+			renderer.render();
+
+			expect( domRoot.childNodes.length ).to.equal( 1 );
+			const attributeNames = Array.from( domRoot.childNodes[ 0 ].attributes ).map( attr => attr.name );
+			expect( attributeNames ).to.include( 'fooBar' );
+		} );
+
 		it( 'should add and remove inline filler in case <p>foo<b>[]</b>bar</p>', () => {
 			const domSelection = document.getSelection();
 

--- a/packages/ckeditor5-engine/tests/view/renderer.js
+++ b/packages/ckeditor5-engine/tests/view/renderer.js
@@ -478,21 +478,6 @@ describe( 'Renderer', () => {
 			expect( domP.childNodes[ 1 ].childNodes.length ).to.equal( 0 );
 		} );
 
-		it( 'should preserve attribute casing', () => {
-			const viewP = new ViewElement( viewDocument, 'p', {
-				fooBar: 'bazBom'
-			} );
-
-			viewRoot._appendChild( viewP );
-
-			renderer.markToSync( 'children', viewRoot );
-			renderer.render();
-
-			expect( domRoot.childNodes.length ).to.equal( 1 );
-			const attributeNames = Array.from( domRoot.childNodes[ 0 ].attributes ).map( attr => attr.name );
-			expect( attributeNames ).to.include( 'fooBar' );
-		} );
-
 		it( 'should add and remove inline filler in case <p>foo<b>[]</b>bar</p>', () => {
 			const domSelection = document.getSelection();
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): Fixed a bug where the rendered attribute name is always lower case. Closes #7228.

MAJOR BREAKING CHANGE: Output HTML attributes are no longer lowercased. This relates to both, markup in the data and the editor output.

---

### Additional information

As mentioned in https://github.com/ckeditor/ckeditor5/issues/7228#issuecomment-630728949:

> And the reason for the whole problem is:
>
> https://github.com/ckeditor/ckeditor5/blob/5709039272f541cb04939fc421705b427c7dc16a/packages/ckeditor5-engine/src/view/domconverter.js#L245
>
> `HTMLElement.setAttribttribute()` forces implicitly converts attribute name to lower-case, as everyone might expect /s
>
> `HTMLElement.setAttribttributeNS()` being more XML oriented doesn't have this wonderful feature 😄

I consider this change to be a major breaking change, as it might wreak havoc for some editor configurations.