### PR TITLE
#6826: The mouse cursor should not change when mouse is over the insert paragraph buttons in widgets

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
@@ -18,7 +18,6 @@
 	 * Styles of the type around buttons
 	 */
 	& .ck-widget__type-around__button {
-		cursor: pointer;
 		width: var(--ck-widget-type-around-button-size);
 		height: var(--ck-widget-type-around-button-size);
 		background: var(--ck-color-widget-type-around-button);


### PR DESCRIPTION
Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (theme-lark): The mouse cursor should not change when mouse is over the insert paragraph buttons in widgets. Closes #6826.