### PR TITLE
Adjusted the changelog script to the new API

### DIFF
--- a/docs/framework/guides/contributing/git-commit-message-convention.md
+++ b/docs/framework/guides/contributing/git-commit-message-convention.md
@@ -24,8 +24,8 @@ Type (other-package-name): If the change affects more than one package, it's pos
 
 Optional description.
 
-BREAKING CHANGE: If any breaking changes were done, they need to be listed here.
-BREAKING CHANGE: Another breaking change if needed. Closes #ZZZ.
+BREAKING CHANGE (scope): If any breaking changes were done, they need to be listed here.
+BREAKING CHANGE (scope): Another breaking change if needed. Closes #ZZZ.
 ```
 
 ### Commit types
@@ -49,6 +49,8 @@ Each commit can contain additional notes which will be inserted into the changel
 If any change contains the `MAJOR BREAKING CHANGE` note, the next release will be marked as `major` automatically.
 
 For reference on how to identify minor or major breaking change see the {@link framework/guides/support/versioning-policy versioning policy guide}.
+
+Each `BREAKING CHANGE` note must be followed by the scope of changes.
 
 ### Package name
 
@@ -95,7 +97,7 @@ Other (utils): Extracted the `utils.foo()` to a separate package. Closes #9.
 
 Feature (engine): Introduced the `engine.foo()` method. Closes #9.
 
-MAJOR BREAKING CHANGE: The `utils.foo()` method was moved to the `engine` package. See #9.
+MAJOR BREAKING CHANGE (utils): The `utils.foo()` method was moved to the `engine` package. See #9.
 ```
 
 For the commits shown above the changelog will look like this:
@@ -108,7 +110,7 @@ Changelog
 
 ### MAJOR BREAKING CHANGES [ℹ️](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/versioning-policy.html#major-and-minor-breaking-changes)
 
-* The `utils.foo()` method was moved to the `engine` package. See #9. See [#9](https://github.com/ckeditor/ckeditor5/issue/9).
+* **[utils](http://npmjs.com/package/@ckeditor/ckeditor5-utils)**: The `utils.foo()` method was moved to the `engine` package. See [#9](https://github.com/ckeditor/ckeditor5/issue/9).
 
 ### Features
 

--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -9,28 +9,31 @@
 
 'use strict';
 
-// In order to use the same version for all packages (including builds and ckeditor5 itself), you can call:
-// yarn run changelog [newVersion]
-
 const devEnv = require( '@ckeditor/ckeditor5-dev-env' );
-const commonOptions = {
-	cwd: process.cwd(),
-	packages: 'packages'
-};
-const editorBuildsGlob = '@ckeditor/ckeditor5-build-*';
-
-const optionsForDependencies = Object.assign( {}, commonOptions, {
-	skipPackages: editorBuildsGlob,
-	skipMainRepository: true
-} );
-
-const optionsForBuilds = Object.assign( {}, commonOptions, {
-	scope: editorBuildsGlob
-} );
 
 Promise.resolve()
-	.then( () => devEnv.generateChangelogForSubRepositories( optionsForDependencies ) )
-	.then( response => devEnv.generateSummaryChangelog( Object.assign( optionsForBuilds, response ) ) )
+	.then( () => devEnv.generateChangelogForSubRepositories( {
+		cwd: process.cwd(),
+		packages: 'packages',
+		highlightsPlaceholder: true,
+		collaborationFeatures: true,
+		from: '87c56114028c00b1e45b6ecba3bead575c6c1afe', // TODO: Remove the line after the nearest release.
+		transformScope: name => {
+			if ( name === 'ckeditor5' ) {
+				return 'https://www.npmjs.com/package/ckeditor5';
+			}
+
+			if ( name === 'build-*' ) {
+				return 'https://www.npmjs.com/search?q=keywords%3Ackeditor5-build%20maintainer%3Ackeditor';
+			}
+
+			if ( name === 'cloud-services-core' ) {
+				return 'https://www.npmjs.com/package/@ckeditor/ckeditor-cloud-services-core';
+			}
+
+			return 'https://www.npmjs.com/package/@ckeditor/ckeditor5-' + name;
+		}
+	} ) )
 	.then( () => {
 		console.log( 'Done!' );
 	} )

--- a/scripts/release/changelog.js
+++ b/scripts/release/changelog.js
@@ -12,7 +12,7 @@
 const devEnv = require( '@ckeditor/ckeditor5-dev-env' );
 
 Promise.resolve()
-	.then( () => devEnv.generateChangelogForSubRepositories( {
+	.then( () => devEnv.generateChangelogForMonoRepository( {
 		cwd: process.cwd(),
 		packages: 'packages',
 		highlightsPlaceholder: true,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Adjusted the changelog generator script to the new API of `ckeditor5-dev-env`.

---

### Additional information

Requires: https://github.com/ckeditor/ckeditor5-dev/pull/640.
