### PR TITLE
#7251: Widget type around buttons should show/hide in sync with the outline of the widget

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
@@ -5,7 +5,6 @@
 
 :root {
 	--ck-widget-type-around-button-size: 20px;
-	--ck-widget-type-around-button-fade-in-animation: ck-widget-type-around-button-fade-in var(--ck-widget-handler-animation-curve) var(--ck-widget-handler-animation-duration) 1 normal forwards;
 	--ck-color-widget-type-around-button-active: var(--ck-color-focus-border);
 	--ck-color-widget-type-around-button-hover: var(--ck-color-widget-hover-border);
 	--ck-color-widget-type-around-button-blurred-editable: var(--ck-color-widget-blurred-border);
@@ -23,7 +22,10 @@
 		height: var(--ck-widget-type-around-button-size);
 		background: var(--ck-color-widget-type-around-button);
 		border-radius: 100px;
-		animation: var(--ck-widget-type-around-button-fade-in-animation);
+
+		pointer-events: none;
+		opacity: 0;
+		transition: opacity var(--ck-widget-handler-animation-duration) var(--ck-widget-handler-animation-curve), background var(--ck-widget-handler-animation-duration) var(--ck-widget-handler-animation-curve);
 
 		& svg {
 			width: 10px;
@@ -52,7 +54,7 @@
 			/*
 			 * Display the "sonar" around the button when hovered.
 			 */
-			animation: var(--ck-widget-type-around-button-fade-in-animation), ck-widget-type-around-button-sonar 1s ease infinite;
+			animation: ck-widget-type-around-button-sonar 1s ease infinite;
 
 			/*
 			 * Animate active button's icon.
@@ -66,6 +68,17 @@
 					animation: ck-widget-type-around-arrow-tip-dash 2s linear;
 				}
 			}
+		}
+	}
+
+	/*
+	 * Show type around buttons when the widget gets selected or being hovered.
+	 */
+	&.ck-widget_selected,
+	&:hover {
+		& > .ck-widget__type-around > .ck-widget__type-around__button {
+			pointer-events: auto;
+			opacity: 1;
 		}
 	}
 
@@ -141,15 +154,5 @@
 	}
 	100% {
 		box-shadow: 0 0 0 5px hsla(var(--ck-color-focus-border-coordinates), var(--ck-color-widget-type-around-button-radar-start-alpha));
-	}
-}
-
-@keyframes ck-widget-type-around-button-fade-in {
-	from {
-		opacity: 0;
-	}
-
-	to {
-		opacity: 1;
 	}
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
@@ -5,6 +5,7 @@
 
 :root {
 	--ck-widget-type-around-button-size: 20px;
+	--ck-widget-type-around-button-fade-in-animation: ck-widget-type-around-button-fade-in var(--ck-widget-handler-animation-curve) var(--ck-widget-handler-animation-duration) 1 normal forwards;
 	--ck-color-widget-type-around-button-active: var(--ck-color-focus-border);
 	--ck-color-widget-type-around-button-hover: var(--ck-color-widget-hover-border);
 	--ck-color-widget-type-around-button-blurred-editable: var(--ck-color-widget-blurred-border);
@@ -22,8 +23,7 @@
 		height: var(--ck-widget-type-around-button-size);
 		background: var(--ck-color-widget-type-around-button);
 		border-radius: 100px;
-		animation: fadein linear 300ms 1 normal forwards;
-		transition: opacity 100ms linear;
+		animation: var(--ck-widget-type-around-button-fade-in-animation);
 
 		& svg {
 			width: 10px;
@@ -52,7 +52,7 @@
 			/*
 			 * Display the "sonar" around the button when hovered.
 			 */
-			animation: ck-widget-type-around-button-sonar 1s ease infinite;
+			animation: var(--ck-widget-type-around-button-fade-in-animation), ck-widget-type-around-button-sonar 1s ease infinite;
 
 			/*
 			 * Animate active button's icon.
@@ -141,5 +141,15 @@
 	}
 	100% {
 		box-shadow: 0 0 0 5px hsla(var(--ck-color-focus-border-coordinates), var(--ck-color-widget-type-around-button-radar-start-alpha));
+	}
+}
+
+@keyframes ck-widget-type-around-button-fade-in {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
 	}
 }

--- a/packages/ckeditor5-widget/theme/widgettypearound.css
+++ b/packages/ckeditor5-widget/theme/widgettypearound.css
@@ -8,7 +8,7 @@
 	 * Styles of the type around buttons
 	 */
 	& .ck-widget__type-around__button {
-		display: none;
+		display: block;
 		position: absolute;
 		overflow: hidden;
 		z-index: var(--ck-z-default);
@@ -34,16 +34,6 @@
 			right: min(10%, 30px);
 
 			transform: translateY(50%);
-		}
-	}
-
-	/*
-	 * Show type around buttons when the widget gets selected or being hovered.
-	 */
-	&.ck-widget_selected,
-	&:hover {
-		& > .ck-widget__type-around > .ck-widget__type-around__button {
-			display: block;
 		}
 	}
 


### PR DESCRIPTION
## Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (theme-lark): Widget type around buttons should show/hide in sync with the outline of the widget. Closes #7251.

---