### PR TITLE
7248: Destroy token instance if created by CloudServices plugin

### DIFF
--- a/packages/ckeditor5-cloud-services/src/cloudservices.js
+++ b/packages/ckeditor5-cloud-services/src/cloudservices.js
@@ -71,6 +71,17 @@ export default class CloudServices extends ContextPlugin {
 
 		return this.token.init();
 	}
+
+	/**
+	 * @inheritDoc
+	 */
+	destroy() {
+		super.destroy();
+
+		if ( this.token ) {
+			this.token.destroy();
+		}
+	}
 }
 
 CloudServices.Token = Token;

--- a/packages/ckeditor5-cloud-services/tests/cloudservices.js
+++ b/packages/ckeditor5-cloud-services/tests/cloudservices.js
@@ -136,4 +136,35 @@ describe( 'CloudServices', () => {
 			} );
 		} );
 	} );
+
+	describe( 'destroy()', () => {
+		it( 'should destroy created token when tokenUrl was provided', async () => {
+			CloudServices.Token.initialToken = 'initial-token';
+
+			const context = await Context.create( {
+				plugins: [ CloudServices ],
+				cloudServices: {
+					tokenUrl: 'http://token-endpoint'
+				}
+			} );
+
+			const cloudServicesPlugin = context.plugins.get( CloudServices );
+
+			const destroySpy = sinon.spy( cloudServicesPlugin.token, 'destroy' );
+
+			await context.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+
+		it( 'should not crash when tokenUrl was not provided', async () => {
+			const context = await Context.create( { plugins: [ CloudServices ] } );
+
+			try {
+				await context.destroy();
+			} catch ( error ) {
+				expect.fail( 'Error should not be thrown.' );
+			}
+		} );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (cloud-services): Token instance will be destroyed by the `CloudServices` context plugin. Closes #7248 .

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._