### PR TITLE
Internal (ckeditor5): Fixed CC upload so that it works when CI job is reset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ cache:
 - node_modules
 before_install:
 - export START_TIME=$( date +%s )
+- export COVERALLS_SERVICE_JOB_ID=$( TRAVIS_JOB_ID )
+- export COVERALLS_SERVICE_NAME="CKEditor5 code coverage"
 - npm i -g yarn
 install:
 - yarn install


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (ckeditor5): Fixed CC upload so that it works when CI job is reset. Closes #7244.

---

### Additional information

In a fascinating twist of reverse engineering and guessing I was able to get it working.

Unfortunately providing _Coveralls token_ (suggested in Coveralls error message) didn't fix the problem.

I noticed a very strange thing, that our env `TRAVIS_JOB_ID` is different than the job id in the Travis link… e.g. for https://travis-ci.org/github/ckeditor/ckeditor5/builds/689606488 `TRAVIS_JOB_ID` will be `689606489`.

I wanted to force an unique job id, by making it e.g. a timestamp - but Coveralls backend was complaining that it could not match corresponding Travis build - so it means it has a special handling for Travis. So I checked the source code of `coveralls` npm package, to see how it determines whether it's Travis or not - turned out it should be based on the service name. So I adjusted the service name, and... it works 🧙‍♂️