### PR TITLE
#7263: Widget type around buttons should not show up when the ancestor is a selected nested editable

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
@@ -117,6 +117,24 @@
 }
 
 /*
+ * Hide type around buttons when the widget is selected as a child of a selected
+ * nested editable (e.g. mulit-cell table selection).
+ *
+ * See https://github.com/ckeditor/ckeditor5/issues/7263.
+ */
+.ck-editor__nested-editable.ck-editor__editable_selected {
+	& .ck-widget {
+		&.ck-widget_selected,
+		&:hover {
+			& > .ck-widget__type-around > .ck-widget__type-around__button {
+				pointer-events: none;
+				opacity: 0;
+			}
+		}
+	}
+}
+
+/*
  * Styles for the buttons when the widget is selected but the user clicked outside of the editor (blurred the editor).
  */
 .ck-editor__editable.ck-blurred .ck-widget.ck-widget_selected > .ck-widget__type-around > .ck-widget__type-around__button:not(:hover) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (theme-lark): Widget type around buttons should not show up when the ancestor is a selected nested editable. Closes #7263.