### PR TITLE
Use "release" branch for releasing

### DIFF
--- a/scripts/release/bump-versions.js
+++ b/scripts/release/bump-versions.js
@@ -11,21 +11,21 @@
 
 // This scripts preparing all packages to release:
 //   - checking what should be released,
-//   - updates version of all dependencies for all packages,
 //   - validates the whole process (whether the changes could be published),
 //   - tagging new versions.
 //
 // You can test the whole process using `dry-run` mode. It won't change anything in the project
 // and any repository.
 //
-// This task must be called before: `yarn run release:publish`.
+// This task must be called before: `npm run release:publish`.
 //
 // Use:
-// yarn run release:bump-version --dry-run
+// npm run release:bump-version --dry-run
 
 require( '@ckeditor/ckeditor5-dev-env' )
 	.bumpVersions( {
 		cwd: process.cwd(),
 		packages: 'packages',
+		releaseBranch: 'release',
 		dryRun: process.argv.includes( '--dry-run' )
 	} );

--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -16,10 +16,10 @@
 //
 // Note: This task based on versions published on NPM and GitHub. If something went wrong, you can call this script one more time.
 //
-// This task should be executed after: `yarn run release:bump-version`.
+// This task should be executed after: `npm run release:bump-version`.
 //
 // Use:
-// yarn run release:publish --dry-run
+// npm run release:publish --dry-run
 
 /* eslint-disable max-len */
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (ckeditor5): Use the `release` branch for release. See #7271.

---

### Additional information

Requires https://github.com/ckeditor/ckeditor5-dev/pull/643.
