### PR TITLE
Added tests/_utils to files entry of package.json in core

### DIFF
--- a/packages/ckeditor5-core/package.json
+++ b/packages/ckeditor5-core/package.json
@@ -57,6 +57,7 @@
   "files": [
     "lang",
     "src",
-    "theme"
+    "theme",
+    "tests/_utils"
   ]
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (core): The test/\_utils are now exposed to applications depending on ckeditor5-core. Closes #6313, #6657.

---

### Additional information

Original PR: ckeditor/ckeditor5-core#219