### PR TITLE
i/4858: Automatically add a link protocol when not provided in the link form.

### DIFF
--- a/packages/ckeditor5-link/src/ui/linkformview.js
+++ b/packages/ckeditor5-link/src/ui/linkformview.js
@@ -21,6 +21,8 @@ import FocusTracker from '@ckeditor/ckeditor5-utils/src/focustracker';
 import FocusCycler from '@ckeditor/ckeditor5-ui/src/focuscycler';
 import KeystrokeHandler from '@ckeditor/ckeditor5-utils/src/keystrokehandler';
 
+import { DEFAULT_PROTOCOL } from '../utils';
+
 import checkIcon from '@ckeditor/ckeditor5-core/theme/icons/check.svg';
 import cancelIcon from '@ckeditor/ckeditor5-core/theme/icons/cancel.svg';
 import '../../theme/linkform.css';
@@ -40,8 +42,9 @@ export default class LinkFormView extends View {
 	 *
 	 * @param {module:utils/locale~Locale} [locale] The localization services instance.
 	 * @param {module:link/linkcommand~LinkCommand} linkCommand Reference to {@link module:link/linkcommand~LinkCommand}.
+	 * @param {String} [protocol] A value of a protocol to be displayed in the input's placeholder.
 	 */
-	constructor( locale, linkCommand ) {
+	constructor( locale, linkCommand, protocol ) {
 		super( locale );
 
 		const t = locale.t;
@@ -67,7 +70,7 @@ export default class LinkFormView extends View {
 		 *
 		 * @member {module:ui/labeledfield/labeledfieldview~LabeledFieldView}
 		 */
-		this.urlInputView = this._createUrlInput();
+		this.urlInputView = this._createUrlInput( protocol );
 
 		/**
 		 * The Save button view.
@@ -207,15 +210,15 @@ export default class LinkFormView extends View {
 	 * Creates a labeled input view.
 	 *
 	 * @private
+	 * @param {module:link/utils~DefaultProtocol} [protocol=http://] A value of a protocol to be displayed in the input's placeholder.
 	 * @returns {module:ui/labeledfield/labeledfieldview~LabeledFieldView} Labeled field view instance.
 	 */
-	_createUrlInput() {
+	_createUrlInput( protocol = DEFAULT_PROTOCOL ) {
 		const t = this.locale.t;
-
 		const labeledInput = new LabeledFieldView( this.locale, createLabeledInputText );
 
 		labeledInput.label = t( 'Link URL' );
-		labeledInput.fieldView.placeholder = 'https://example.com';
+		labeledInput.fieldView.placeholder = protocol + 'example.com';
 
 		return labeledInput;
 	}

--- a/packages/ckeditor5-link/src/utils.js
+++ b/packages/ckeditor5-link/src/utils.js
@@ -13,6 +13,13 @@ const ATTRIBUTE_WHITESPACES = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u20
 const SAFE_URL = /^(?:(?:https?|ftps?|mailto):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i;
 
 /**
+ * A default link protocol value.
+ * @typedef {String} module:link/utils~DefaultProtocol
+ * @default 'http://'
+ */
+export const DEFAULT_PROTOCOL = 'http://';
+
+/**
  * Returns `true` if a given view node is the link element.
  *
  * @param {module:engine/view/node~Node} node

--- a/packages/ckeditor5-link/tests/manual/protocol.html
+++ b/packages/ckeditor5-link/tests/manual/protocol.html
@@ -1,0 +1,52 @@
+<style>
+	code {
+		background: hsl(0, 0%, 90%);
+	}
+
+	sup {
+		position: relative;
+	}
+
+	.ck-editor__editable sup:after {
+		content: '';
+		display: inline-block;
+		position: absolute;
+		width: 14px;
+		height: 14px;
+		left: 1px;
+    top: 1px;
+		background: hsla(207, 87%, 55%, 0.5);
+		border-radius: 50px;
+		animation: pulse 2s linear infinite;
+	}
+
+	@keyframes pulse {
+		0% {
+			transform: scale(1);
+		}
+
+		50% {
+			transform: scale(2);
+		}
+
+		100% {
+			transform: scale(1);
+		}
+	}
+</style>
+
+<h2>The default configuration for the link protocol has been set to <code id="default-protocol"></code>.</h2>
+
+<h3>...but you can change it:</h3>
+<form id="protocol-settings" style="margin: 20px 0;">
+	<label for="http"><input type="radio" name="option" id="http" value="http://" />HTTP</label>
+	<label for="https"><input type="radio" name="option" id="https" value="https://" />HTTPS</label>
+	<label for="mailto"><input type="radio" name="option" id="mailto" value="mailto:" />MAILTO</label>
+	<label for="file"><input type="radio" name="option" id="file" value="file://" />FILE</label>
+</form>
+
+<div id="editor">
+	<p>This is <a href="http://ckeditor.com">CKEditor5</a> from <a href="http://cksource.com">CKSource</a>. If you need more information please contact us at support@example.com <sup class="indicator">[1]</sup>.</p>
+</div>
+
+<p><sup>[1]</sup> Copy the email address and create a link with it (<code>mailto:</code> protocol will be added automatically).</p>

--- a/packages/ckeditor5-link/tests/manual/protocol.js
+++ b/packages/ckeditor5-link/tests/manual/protocol.js
@@ -1,0 +1,49 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console:false, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import Enter from '@ckeditor/ckeditor5-enter/src/enter';
+import Typing from '@ckeditor/ckeditor5-typing/src/typing';
+import Link from '../../src/link';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Undo from '@ckeditor/ckeditor5-undo/src/undo';
+import Superscript from '@ckeditor/ckeditor5-basic-styles/src/superscript';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ Link, Typing, Paragraph, Undo, Enter, Superscript ],
+		toolbar: [ 'link', 'undo', 'redo' ],
+		link: {
+			addTargetToExternalLinks: true,
+			defaultProtocol: 'http://'
+		}
+	} )
+	.then( editor => {
+		window.editor = editor;
+
+		const LinkUIPlugin = editor.plugins.get( 'LinkUI' );
+		const formView = LinkUIPlugin.formView;
+		const defaultProtocol = editor.config.get( 'link.defaultProtocol' );
+
+		document.getElementById( 'default-protocol' ).innerText = defaultProtocol;
+
+		document.querySelectorAll( '#protocol-settings input[type="radio"]' ).forEach( radio => {
+			radio.checked = radio.value === defaultProtocol;
+
+			radio.addEventListener( 'click', ( {
+				target: { value: protocol }
+			} ) => {
+				editor.config.set( 'link.defaultProtocol', protocol );
+
+				// Change input placeholder just for manual test's case to provide more dynamic behavior.
+				formView.urlInputView.fieldView.placeholder = protocol + 'example.com';
+			} );
+		} );
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-link/tests/manual/protocol.md
+++ b/packages/ckeditor5-link/tests/manual/protocol.md
@@ -1,0 +1,8 @@
+## Link protocol
+
+This test checks whether:
+- `config.link.defaultProtocol` applies.
+- user is able to dynamically change the link protocol (just as an extended example of usage).
+- the plugin dynamically change link protocol to `mailto:` when email address was detected.
+
+When you dynamically change the value of the link protocol, the form input placeholder should change as well.

--- a/packages/ckeditor5-link/tests/ui/linkformview.js
+++ b/packages/ckeditor5-link/tests/ui/linkformview.js
@@ -21,6 +21,8 @@ import Link from '../../src/link';
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 
+import { DEFAULT_PROTOCOL } from '../../src/utils';
+
 describe( 'LinkFormView', () => {
 	let view;
 
@@ -83,7 +85,7 @@ describe( 'LinkFormView', () => {
 
 		describe( 'url input view', () => {
 			it( 'has placeholder', () => {
-				expect( view.urlInputView.fieldView.placeholder ).to.equal( 'https://example.com' );
+				expect( view.urlInputView.fieldView.placeholder ).to.equal( DEFAULT_PROTOCOL + 'example.com' );
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (link): A link protocol will be automatically added to a link when not provided by the user in the link form. Closes #4858.

MINOR BREAKING CHANGES (link): This PR introduces `config.link.defaultProtocol` API.
  - The `Link` plugin uses `http://` protocol by default, when no configuration provided.