### PR TITLE
#6819: Added Writer#cloneElement()

### DIFF
--- a/packages/ckeditor5-engine/src/model/element.js
+++ b/packages/ckeditor5-engine/src/model/element.js
@@ -232,7 +232,7 @@ export default class Element extends Node {
 
 	/**
 	 * Creates a copy of this element and returns it. Created element has the same name and attributes as the original element.
-	 * If clone is deep, the original element's children are also cloned. If not, then empty element is removed.
+	 * If clone is deep, the original element's children are also cloned. If not, then empty element is returned.
 	 *
 	 * @protected
 	 * @param {Boolean} [deep=false] If set to `true` clones element and all its children recursively. When set to `false`,

--- a/packages/ckeditor5-engine/src/model/utils/getselectedcontent.js
+++ b/packages/ckeditor5-engine/src/model/utils/getselectedcontent.js
@@ -73,7 +73,7 @@ export default function getSelectedContent( model, selection ) {
 			if ( item.is( 'textProxy' ) ) {
 				writer.appendText( item.data, item.getAttributes(), frag );
 			} else {
-				writer.append( item._clone( true ), frag );
+				writer.append( writer.cloneElement( item, true ), frag );
 			}
 		}
 

--- a/packages/ckeditor5-engine/src/model/writer.js
+++ b/packages/ckeditor5-engine/src/model/writer.js
@@ -117,6 +117,18 @@ export default class Writer {
 	}
 
 	/**
+	 * Creates a copy of the element and returns it. Created element has the same name and attributes as the original element.
+	 * If clone is deep, the original element's children are also cloned. If not, then empty element is returned.
+	 *
+	 * @param {module:engine/model/element~Element} element The element to clone.
+	 * @param {Boolean} [deep=true] If set to `true` clones element and all its children recursively. When set to `false`,
+	 * element will be cloned without any child.
+	 */
+	cloneElement( element, deep = true ) {
+		return element._clone( deep );
+	}
+
+	/**
 	 * Inserts item on given position.
 	 *
 	 *		const paragraph = writer.createElement( 'paragraph' );

--- a/packages/ckeditor5-engine/tests/model/writer.js
+++ b/packages/ckeditor5-engine/tests/model/writer.js
@@ -87,7 +87,7 @@ describe( 'Writer', () => {
 	} );
 
 	describe( 'cloneElement()', () => {
-		it( 'should make deep clone of element', () => {
+		it( 'should make deep copy of element', () => {
 			const element = createElement( 'foo', { 'abc': '123' } );
 
 			insertElement( createElement( 'bar', { 'xyz': '789' } ), element );
@@ -2931,7 +2931,7 @@ describe( 'Writer', () => {
 		} );
 	}
 
-	function cloneElement( element, deep = true ) {
+	function cloneElement( element, deep ) {
 		return model.change( writer => {
 			return writer.cloneElement( element, deep );
 		} );

--- a/packages/ckeditor5-engine/tests/model/writer.js
+++ b/packages/ckeditor5-engine/tests/model/writer.js
@@ -86,6 +86,35 @@ describe( 'Writer', () => {
 		} );
 	} );
 
+	describe( 'cloneElement()', () => {
+		it( 'should make deep clone of element', () => {
+			const element = createElement( 'foo', { 'abc': '123' } );
+
+			insertElement( createElement( 'bar', { 'xyz': '789' } ), element );
+
+			const clonedElement = cloneElement( element );
+
+			expect( clonedElement ).to.not.equal( element );
+			expect( clonedElement.getChild( 0 ) ).to.not.equal( element.getChild( 0 ) );
+			expect( clonedElement.toJSON() ).to.deep.equal( element.toJSON() );
+		} );
+
+		it( 'should make shallow copy of element', () => {
+			const element = createElement( 'foo', { 'abc': '123' } );
+
+			insertElement( createElement( 'bar', { 'xyz': '789' } ), element );
+
+			const elementJson = element.toJSON();
+			delete elementJson.children;
+
+			const clonedElement = cloneElement( element, false );
+
+			expect( clonedElement ).to.not.equal( element );
+			expect( clonedElement.childCount ).to.equal( 0 );
+			expect( clonedElement.toJSON() ).to.deep.equal( elementJson );
+		} );
+	} );
+
 	describe( 'insert()', () => {
 		it( 'should insert node at given position', () => {
 			const parent = createDocumentFragment();
@@ -2899,6 +2928,12 @@ describe( 'Writer', () => {
 	function createDocumentFragment() {
 		return model.change( writer => {
 			return writer.createDocumentFragment();
+		} );
+	}
+
+	function cloneElement( element, deep = true ) {
+		return model.change( writer => {
+			return writer.cloneElement( element, deep );
 		} );
 	}
 

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -295,7 +295,7 @@ function replaceSelectedCellsWithPasted( pastedTable, pastedDimensions, selected
 
 		// Clone cell to insert (to duplicate its attributes and children).
 		// Cloning is required to support repeating pasted table content when inserting to a bigger selection.
-		const cellToInsert = pastedCell._clone( true );
+		const cellToInsert = writer.cloneElement( pastedCell );
 
 		// Trim the cell if it's row/col-spans would exceed selection area.
 		trimTableCellIfNeeded( cellToInsert, row, column, lastRowOfSelection, lastColumnOfSelection, writer );

--- a/packages/ckeditor5-table/src/utils/structure.js
+++ b/packages/ckeditor5-table/src/utils/structure.js
@@ -75,7 +75,7 @@ export function cropTableToDimensions( sourceTable, cropDimensions, writer ) {
 		}
 		// Otherwise clone the cell with all children and trim if it exceeds cropped area.
 		else {
-			const tableCellCopy = tableCell._clone( true );
+			const tableCellCopy = writer.cloneElement( tableCell );
 
 			writer.append( tableCellCopy, row );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (engine): Added `Writer#cloneElement()`. Closes #6819.

Internal (table): Replaced `Element._clone()` usages with `Writer#cloneElement()`.

---

### Additional information