### PR TITLE
#6443: BalloonToolbar should not be displayed for multi cell table selection.

### DIFF
--- a/packages/ckeditor5-ui/package.json
+++ b/packages/ckeditor5-ui/package.json
@@ -27,7 +27,7 @@
     "@ckeditor/ckeditor5-list": "^19.0.1",
     "@ckeditor/ckeditor5-mention": "^19.0.1",
     "@ckeditor/ckeditor5-paragraph": "^19.1.0",
-    "@ckeditor/ckeditor5-horizontal-line": "^19.1.0",
+    "@ckeditor/ckeditor5-horizontal-line": "^19.0.1",
     "@ckeditor/ckeditor5-typing": "^19.0.1"
   },
   "engines": {

--- a/packages/ckeditor5-ui/package.json
+++ b/packages/ckeditor5-ui/package.json
@@ -27,6 +27,7 @@
     "@ckeditor/ckeditor5-list": "^19.0.1",
     "@ckeditor/ckeditor5-mention": "^19.0.1",
     "@ckeditor/ckeditor5-paragraph": "^19.1.0",
+    "@ckeditor/ckeditor5-horizontal-line": "^19.1.0",
     "@ckeditor/ckeditor5-typing": "^19.0.1"
   },
   "engines": {

--- a/packages/ckeditor5-ui/src/toolbar/balloon/balloontoolbar.js
+++ b/packages/ckeditor5-ui/src/toolbar/balloon/balloontoolbar.js
@@ -364,21 +364,24 @@ function getBalloonPositions( isBackward ) {
 	];
 }
 
+// Returns "true" when the selection has multiple ranges and each range contains an object
+// and nothing else.
+//
+// @private
+// @param {module:engine/model/selection~Selection} selection
+// @param {module:engine/model/schema~Schema} schema
+// @returns {Boolean}
 function selectionContainsOnlyMultipleObjects( selection, schema ) {
 	// It doesn't contain multiple objects if there is only one range.
-	if ( selection.rangeCount <= 1 ) {
+	if ( selection.rangeCount === 1 ) {
 		return false;
 	}
 
-	for ( const range of selection.getRanges() ) {
+	return [ ...selection.getRanges() ].every( range => {
 		const element = range.getContainedElement();
 
-		if ( !element || !schema.isObject( element ) ) {
-			return false;
-		}
-	}
-
-	return true;
+		return element && schema.isObject( element );
+	} );
 }
 
 /**

--- a/packages/ckeditor5-ui/tests/toolbar/balloon/balloontoolbar.js
+++ b/packages/ckeditor5-ui/tests/toolbar/balloon/balloontoolbar.js
@@ -376,7 +376,7 @@ describe( 'BalloonToolbar', () => {
 		} );
 
 		// https://github.com/ckeditor/ckeditor5/issues/6443
-		it( 'should not add the #toolbarView to the #_balloon when the selection contains more than one fully contained objects', () => {
+		it( 'should not add the #toolbarView to the #_balloon when the selection contains more than one fully contained object', () => {
 			// This is for multi cell selection in tables.
 			setData( model, '[<horizontalLine></horizontalLine>]<paragraph>foo</paragraph>[<horizontalLine></horizontalLine>]' );
 

--- a/packages/ckeditor5-ui/tests/toolbar/balloon/balloontoolbar.js
+++ b/packages/ckeditor5-ui/tests/toolbar/balloon/balloontoolbar.js
@@ -14,6 +14,7 @@ import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
 import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import HorizontalLine from '@ckeditor/ckeditor5-horizontal-line/src/horizontalline';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 import ResizeObserver from '@ckeditor/ckeditor5-utils/src/dom/resizeobserver';
 
@@ -55,7 +56,7 @@ describe( 'BalloonToolbar', () => {
 
 		return ClassicTestEditor
 			.create( editorElement, {
-				plugins: [ Paragraph, Bold, Italic, BalloonToolbar ],
+				plugins: [ Paragraph, Bold, Italic, BalloonToolbar, HorizontalLine ],
 				balloonToolbar: [ 'bold', 'italic' ]
 			} )
 			.then( newEditor => {
@@ -369,6 +370,15 @@ describe( 'BalloonToolbar', () => {
 
 		it( 'should not add the #toolbarView to the #_balloon when the selection is collapsed', () => {
 			setData( model, '<paragraph>b[]ar</paragraph>' );
+
+			balloonToolbar.show();
+			sinon.assert.notCalled( balloonAddSpy );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/6443
+		it( 'should not add the #toolbarView to the #_balloon when the selection contains more than one fully contained objects', () => {
+			// This is for multi cell selection in tables.
+			setData( model, '[<horizontalLine></horizontalLine>]<paragraph>foo</paragraph>[<horizontalLine></horizontalLine>]' );
 
 			balloonToolbar.show();
 			sinon.assert.notCalled( balloonAddSpy );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (ui): Table properties balloon should be displayed on cell multi-select in Balloon and Balloon Block editors. Closes #6443.

---

### Additional information