### PR TITLE
Disable resizing while in read-only mode

### DIFF
--- a/packages/ckeditor5-widget/src/widgetresize/resizer.js
+++ b/packages/ckeditor5-widget/src/widgetresize/resizer.js
@@ -116,12 +116,6 @@ export default class Resizer {
 
 				that._domResizerWrapper = domElement;
 
-				that.on( 'change:isEnabled', ( evt, propName, newValue ) => {
-					domElement.style.display = newValue ? '' : 'none';
-				} );
-
-				domElement.style.display = that.isEnabled ? '' : 'none';
-
 				return domElement;
 			} );
 
@@ -130,6 +124,14 @@ export default class Resizer {
 			writer.addClass( 'ck-widget_with-resizer', widgetElement );
 
 			this._viewResizerWrapper = viewResizerWrapper;
+
+			if ( !this.isEnabled ) {
+				writer.setStyle( 'display', 'none', this._viewResizerWrapper );
+			}
+
+			this.on( 'change:isEnabled', ( evt, propName, newValue ) => {
+				writer.setStyle( 'display', newValue ? '' : 'none', this._viewResizerWrapper );
+			} );
 		} );
 	}
 

--- a/packages/ckeditor5-widget/tests/widgetresize/resizer.js
+++ b/packages/ckeditor5-widget/tests/widgetresize/resizer.js
@@ -95,21 +95,25 @@ describe( 'Resizer', () => {
 		it( 'hides the resizer if it gets disabled at a runtime', () => {
 			const resizerInstance = createResizer();
 			resizerInstance.isEnabled = true;
+
 			resizerInstance.attach();
-			const domResizeeWrapper = resizerInstance._viewResizerWrapper.render( document );
+			resizerInstance._viewResizerWrapper.render( document );
 
 			resizerInstance.isEnabled = false;
-			expect( domResizeeWrapper.style.display ).to.equal( 'none' );
+
+			expect( resizerInstance._viewResizerWrapper.getStyle( 'display' ) ).to.equal( 'none' );
 		} );
 
 		it( 'restores the resizer if it gets enabled at a runtime', () => {
 			const resizerInstance = createResizer();
 			resizerInstance.isEnabled = false;
+
 			resizerInstance.attach();
-			const domResizeeWrapper = resizerInstance._viewResizerWrapper.render( document );
+			resizerInstance._viewResizerWrapper.render( document );
 
 			resizerInstance.isEnabled = true;
-			expect( domResizeeWrapper.style.display ).to.equal( '' );
+
+			expect( resizerInstance._viewResizerWrapper.getStyle( 'display' ) ).to.equal( '' );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix: The resize container will not be displayed while an editor is in read-only mode. Closes #6457.
