### PR TITLE
(Un)Link command state when an image is selected

### DIFF
--- a/packages/ckeditor5-link/package.json
+++ b/packages/ckeditor5-link/package.json
@@ -13,6 +13,7 @@
     "@ckeditor/ckeditor5-core": "^19.0.1",
     "@ckeditor/ckeditor5-engine": "^19.0.1",
     "@ckeditor/ckeditor5-ui": "^19.0.1",
+    "@ckeditor/ckeditor5-utils": "^19.0.1",
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
@@ -25,8 +26,7 @@
     "@ckeditor/ckeditor5-paragraph": "^19.1.0",
     "@ckeditor/ckeditor5-theme-lark": "^19.1.0",
     "@ckeditor/ckeditor5-typing": "^19.0.1",
-    "@ckeditor/ckeditor5-undo": "^19.0.1",
-    "@ckeditor/ckeditor5-utils": "^19.0.1"
+    "@ckeditor/ckeditor5-undo": "^19.0.1"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-link/src/linkcommand.js
+++ b/packages/ckeditor5-link/src/linkcommand.js
@@ -62,7 +62,7 @@ export default class LinkCommand extends Command {
 
 		// A check for the `LinkImage` plugin. If the selection contains an element, get values from the element.
 		// Currently the selection reads attributes from text nodes only. See #7429.
-		if ( selectedElement && selectedElement.name === 'image' ) {
+		if ( selectedElement && selectedElement.is( 'image' ) ) {
 			this.value = selectedElement.getAttribute( 'linkHref' );
 			this.isEnabled = model.schema.checkAttribute( selectedElement, 'linkHref' );
 		} else {

--- a/packages/ckeditor5-link/src/unlinkcommand.js
+++ b/packages/ckeditor5-link/src/unlinkcommand.js
@@ -9,6 +9,7 @@
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
 import findLinkRange from './findlinkrange';
+import first from '@ckeditor/ckeditor5-utils/src/first';
 
 /**
  * The unlink command. It is used by the {@link module:link/link~Link link plugin}.
@@ -20,7 +21,18 @@ export default class UnlinkCommand extends Command {
 	 * @inheritDoc
 	 */
 	refresh() {
-		this.isEnabled = this.editor.model.document.selection.hasAttribute( 'linkHref' );
+		const model = this.editor.model;
+		const doc = model.document;
+
+		const selectedImage = first( doc.selection.getSelectedBlocks() );
+
+		// A check for the `LinkImage` plugin. If the selection contains an image element, get values from the element.
+		// Currently the selection reads attributes from text nodes only. See #7429.
+		if ( selectedImage && selectedImage.name === 'image' ) {
+			this.isEnabled = model.schema.checkAttribute( selectedImage, 'linkHref' );
+		} else {
+			this.isEnabled = model.schema.checkAttributeInSelection( doc.selection, 'linkHref' );
+		}
 	}
 
 	/**

--- a/packages/ckeditor5-link/tests/unlinkcommand.js
+++ b/packages/ckeditor5-link/tests/unlinkcommand.js
@@ -51,6 +51,56 @@ describe( 'UnlinkCommand', () => {
 
 			expect( command.isEnabled ).to.false;
 		} );
+
+		describe( 'for images', () => {
+			beforeEach( () => {
+				model.schema.register( 'image', { isBlock: true, allowWhere: '$text', allowAttributes: [ 'linkHref' ] } );
+			} );
+
+			it( 'should be true when an image is selected', () => {
+				setData( model, '[<image linkHref="foo"></image>]' );
+
+				expect( command.isEnabled ).to.be.true;
+			} );
+
+			it( 'should be true when an image and a text are selected', () => {
+				setData( model, '[<image linkHref="foo"></image>Foo]' );
+
+				expect( command.isEnabled ).to.be.true;
+			} );
+
+			it( 'should be true when a text and an image are selected', () => {
+				setData( model, '[Foo<image linkHref="foo"></image>]' );
+
+				expect( command.isEnabled ).to.be.true;
+			} );
+
+			it( 'should be true when two images are selected', () => {
+				setData( model, '[<image linkHref="foo"></image><image linkHref="foo"></image>]' );
+
+				expect( command.isEnabled ).to.be.true;
+			} );
+
+			it( 'should be false when a fake image is selected', () => {
+				model.schema.register( 'fake', { isBlock: true, allowWhere: '$text' } );
+
+				setData( model, '[<fake></fake>]' );
+
+				expect( command.isEnabled ).to.be.false;
+			} );
+
+			it( 'should be false if an image does not accept the `linkHref` attribute in given context', () => {
+				model.schema.addAttributeCheck( ( ctx, attributeName ) => {
+					if ( ctx.endsWith( '$root image' ) && attributeName == 'linkHref' ) {
+						return false;
+					}
+				} );
+
+				setData( model, '[<image></image>]' );
+
+				expect( command.isEnabled ).to.be.false;
+			} );
+		} );
 	} );
 
 	describe( 'execute()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: `#value` and `#isEnabled` properties for `LinkCommand` and `UnlinkCommand` work properly with images. Closes #7429.
