### PR TITLE
Typing around the link element

### DIFF
--- a/packages/ckeditor5-link/src/linkcommand.js
+++ b/packages/ckeditor5-link/src/linkcommand.js
@@ -172,8 +172,8 @@ export default class LinkCommand extends Command {
 						writer.removeAttribute( item, linkRange );
 					} );
 
-					// Create new range wrapping changed link.
-					writer.setSelection( linkRange );
+					// Put the selection at the end of the updated link.
+					writer.setSelection( writer.createPositionAfter( linkRange.end.nodeBefore ) );
 				}
 				// If not then insert text node with `linkHref` attribute in place of caret.
 				// However, since selection in collapsed, attribute value will be used as data for text node.
@@ -191,9 +191,15 @@ export default class LinkCommand extends Command {
 
 					model.insertContent( node, position );
 
-					// Create new range wrapping created node.
-					writer.setSelection( writer.createRangeOn( node ) );
+					// Put the selection at the end of the inserted link.
+					writer.setSelection( writer.createPositionAfter( node ) );
 				}
+
+				// Remove the `linkHref` attribute and all link decorators from the selection.
+				// It stops adding a new content into the link element.
+				[ 'linkHref', ...truthyManualDecorators, ...falsyManualDecorators ].forEach( item => {
+					writer.removeSelectionAttribute( item );
+				} );
 			} else {
 				// If selection has non-collapsed ranges, we change attribute on nodes inside those ranges
 				// omitting nodes where the `linkHref` attribute is disallowed.

--- a/packages/ckeditor5-link/src/linkui.js
+++ b/packages/ckeditor5-link/src/linkui.js
@@ -160,7 +160,7 @@ export default class LinkUI extends Plugin {
 			const { value } = formView.urlInputView.fieldView.element;
 
 			// The regex checks for the protocol syntax ('xxxx://' or 'xxxx:')
-			// or non-word charecters at the begining of the link ('/', '#' etc.).
+			// or non-word characters at the beginning of the link ('/', '#' etc.).
 			const isProtocolNeeded = !!defaultProtocol && !protocolRegExp.test( value );
 			const isEmail = emailRegExp.test( value );
 

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -351,12 +351,12 @@ describe( 'LinkCommand', () => {
 		} );
 
 		describe( 'collapsed selection', () => {
-			it( 'should insert text with `linkHref` attribute, text data equal to href and select new link', () => {
+			it( 'should insert text with `linkHref` attribute, text data equal to href and put the selection after the new link', () => {
 				setData( model, 'foo[]bar' );
 
 				command.execute( 'url' );
 
-				expect( getData( model ) ).to.equal( 'foo[<$text linkHref="url">url</$text>]bar' );
+				expect( getData( model ) ).to.equal( 'foo<$text linkHref="url">url</$text>[]bar' );
 			} );
 
 			it( 'should insert text with `linkHref` attribute, and selection attributes', () => {
@@ -367,16 +367,16 @@ describe( 'LinkCommand', () => {
 				command.execute( 'url' );
 
 				expect( getData( model ) ).to.equal(
-					'<$text bold="true">foo</$text>[<$text bold="true" linkHref="url">url</$text>]<$text bold="true">bar</$text>'
+					'<$text bold="true">foo</$text><$text bold="true" linkHref="url">url</$text><$text bold="true">[]bar</$text>'
 				);
 			} );
 
-			it( 'should update `linkHref` attribute and select whole link when selection is inside text with `linkHref` attribute', () => {
+			it( 'should update `linkHref` attribute (text with `linkHref` attribute) and put the selection after the node', () => {
 				setData( model, '<$text linkHref="other url">foo[]bar</$text>' );
 
 				command.execute( 'url' );
 
-				expect( getData( model ) ).to.equal( '[<$text linkHref="url">foobar</$text>]' );
+				expect( getData( model ) ).to.equal( '<$text linkHref="url">foobar</$text>[]' );
 			} );
 
 			it( 'should not insert text with `linkHref` attribute when is not allowed in parent', () => {
@@ -455,7 +455,7 @@ describe( 'LinkCommand', () => {
 				command.execute( 'url', { linkIsFoo: true, linkIsBar: true, linkIsSth: true } );
 
 				expect( getData( model ) ).to
-					.equal( 'foo[<$text linkHref="url" linkIsBar="true" linkIsFoo="true" linkIsSth="true">url</$text>]bar' );
+					.equal( 'foo<$text linkHref="url" linkIsBar="true" linkIsFoo="true" linkIsSth="true">url</$text>[]bar' );
 			} );
 
 			it( 'should add additional attributes to link when link is modified', () => {
@@ -464,7 +464,7 @@ describe( 'LinkCommand', () => {
 				command.execute( 'url', { linkIsFoo: true, linkIsBar: true, linkIsSth: true } );
 
 				expect( getData( model ) ).to
-					.equal( 'f[<$text linkHref="url" linkIsBar="true" linkIsFoo="true" linkIsSth="true">ooba</$text>]r' );
+					.equal( 'f<$text linkHref="url" linkIsBar="true" linkIsFoo="true" linkIsSth="true">ooba</$text>[]r' );
 			} );
 
 			it( 'should remove additional attributes to link if those are falsy', () => {
@@ -472,7 +472,7 @@ describe( 'LinkCommand', () => {
 
 				command.execute( 'url', { linkIsFoo: false, linkIsBar: false } );
 
-				expect( getData( model ) ).to.equal( 'foo[<$text linkHref="url">url</$text>]bar' );
+				expect( getData( model ) ).to.equal( 'foo<$text linkHref="url">url</$text>[]bar' );
 			} );
 		} );
 

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -8,7 +8,7 @@
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
-import { setData as setModelData, getData as getModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
@@ -939,7 +939,7 @@ describe( 'LinkUI', () => {
 
 						expect( defaultProtocol ).to.equal( 'https://' );
 
-						editor.destroy();
+						return editor.destroy();
 					} );
 			} );
 
@@ -952,56 +952,64 @@ describe( 'LinkUI', () => {
 
 			it( 'should not add a protocol to the local links even when `config.link.defaultProtocol` configured', () => {
 				return createEditorWithDefaultProtocol( 'http://' ).then( ( { editor, formView } ) => {
+					const linkCommandSpy = sinon.spy( editor.commands.get( 'link' ), 'execute' );
 					formView.urlInputView.fieldView.value = '#test';
 					formView.fire( 'submit' );
 
-					expect( formView.urlInputView.fieldView.value ).to.equal( '#test' );
+					sinon.assert.calledWith( linkCommandSpy, '#test', sinon.match.any );
 
-					editor.destroy();
+					return editor.destroy();
 				} );
 			} );
 
 			it( 'should not add a protocol to the relative links even when `config.link.defaultProtocol` configured', () => {
 				return createEditorWithDefaultProtocol( 'http://' ).then( ( { editor, formView } ) => {
+					const linkCommandSpy = sinon.spy( editor.commands.get( 'link' ), 'execute' );
 					formView.urlInputView.fieldView.value = '/test.html';
 					formView.fire( 'submit' );
 
-					expect( formView.urlInputView.fieldView.value ).to.equal( '/test.html' );
+					sinon.assert.calledWith( linkCommandSpy, '/test.html', sinon.match.any );
 
-					editor.destroy();
+					return editor.destroy();
 				} );
 			} );
 
 			it( 'should not add a protocol when given provided within the value even when `config.link.defaultProtocol` configured', () => {
 				return createEditorWithDefaultProtocol( 'http://' ).then( ( { editor, formView } ) => {
+					const linkCommandSpy = sinon.spy( editor.commands.get( 'link' ), 'execute' );
 					formView.urlInputView.fieldView.value = 'http://example.com';
 					formView.fire( 'submit' );
 
 					expect( formView.urlInputView.fieldView.value ).to.equal( 'http://example.com' );
+					sinon.assert.calledWith( linkCommandSpy, 'http://example.com', sinon.match.any );
 
-					editor.destroy();
+					return editor.destroy();
 				} );
 			} );
 
 			it( 'should use the "http://" protocol when it\'s configured', () => {
 				return createEditorWithDefaultProtocol( 'http://' ).then( ( { editor, formView } ) => {
+					const linkCommandSpy = sinon.spy( editor.commands.get( 'link' ), 'execute' );
+
 					formView.urlInputView.fieldView.value = 'ckeditor.com';
 					formView.fire( 'submit' );
 
-					expect( formView.urlInputView.fieldView.value ).to.equal( 'http://ckeditor.com' );
+					sinon.assert.calledWith( linkCommandSpy, 'http://ckeditor.com', sinon.match.any );
 
-					editor.destroy();
+					return editor.destroy();
 				} );
 			} );
 
 			it( 'should use the "http://" protocol when it\'s configured and form input value contains "www."', () => {
 				return createEditorWithDefaultProtocol( 'http://' ).then( ( { editor, formView } ) => {
+					const linkCommandSpy = sinon.spy( editor.commands.get( 'link' ), 'execute' );
+
 					formView.urlInputView.fieldView.value = 'www.ckeditor.com';
 					formView.fire( 'submit' );
 
-					expect( formView.urlInputView.fieldView.value ).to.equal( 'http://www.ckeditor.com' );
+					sinon.assert.calledWith( linkCommandSpy, 'http://www.ckeditor.com', sinon.match.any );
 
-					editor.destroy();
+					return editor.destroy();
 				} );
 			} );
 
@@ -1016,7 +1024,7 @@ describe( 'LinkUI', () => {
 						'[<$text linkHref="http://ckeditor.com">ckeditor.com</$text>]'
 					);
 
-					editor.destroy();
+					return editor.destroy();
 				} );
 			} );
 
@@ -1032,7 +1040,7 @@ describe( 'LinkUI', () => {
 						'[<$text linkHref="mailto:email@example.com">email@example.com</$text>]'
 					);
 
-					editor.destroy();
+					return editor.destroy();
 				} );
 			} );
 
@@ -1044,7 +1052,7 @@ describe( 'LinkUI', () => {
 
 					expect( formView.urlInputView.fieldView.value ).to.equal( 'mailto:test@example.com' );
 
-					editor.destroy();
+					return editor.destroy();
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-link/tests/manual/link.md
+++ b/packages/ckeditor5-link/tests/manual/link.md
@@ -7,7 +7,8 @@
 3. Check if balloon panel attached to the selection appeared.
 4. Fill in `Link URL` input in the panel.
 5. Click `Save` button.
-6. Check if selected text is converted into a link.
+6. Check if the selection is after the text that was converted into a link.
+7. Typing should not modify the link node.
 
 ### Insert new link
 
@@ -16,7 +17,8 @@
 3. Check if balloon panel attached to the selection appeared.
 4. Fill in `Link URL` input in the panel.
 5. Click `Save` button.
-6. Check if new link with anchor text the same as url value has been inserted and selected.
+6. Check if new link with anchor text the same as url value has been inserted.
+7. Check if the selection is after the text node. Typing should not modify the node.
 
 ### Edit link
 
@@ -25,6 +27,7 @@
 3. Change `Link URL` input value.
 4. Click `Save` button.
 5. Check if link href value has changed.
+6. Check if the selection is after the updated text node. Typing should not modify the node.
 
 ### Keyboard support
 

--- a/packages/ckeditor5-mention/tests/mention-integration.js
+++ b/packages/ckeditor5-mention/tests/mention-integration.js
@@ -308,7 +308,7 @@ describe( 'Mention feature - integration', () => {
 					editor.execute( 'link', '@' );
 					editor.editing.view.document.fire( 'click' );
 
-					// The selection is after the link node.
+					// The selection is after the link node. See #1016.
 					expect( panelView.isVisible ).to.be.false;
 					expect( balloon.visibleView === mentionsView ).to.be.false; // LinkUI
 

--- a/packages/ckeditor5-mention/tests/mention-integration.js
+++ b/packages/ckeditor5-mention/tests/mention-integration.js
@@ -304,12 +304,18 @@ describe( 'Mention feature - integration', () => {
 
 			return new Promise( resolve => setTimeout( resolve, 200 ) )
 				.then( () => {
+					const model = editor.model;
+
 					// Show link UI
 					editor.execute( 'link', '@' );
+					// The link is not being selected after inserting it. We need to put the selection manually. See #1016.
+					model.change( writer => {
+						writer.setSelection( writer.createRangeOn( model.document.getRoot().getChild( 0 ).getChild( 0 ) ) );
+					} );
+
 					editor.editing.view.document.fire( 'click' );
 
-					// The selection is after the link node. See #1016.
-					expect( panelView.isVisible ).to.be.false;
+					expect( panelView.isVisible ).to.be.true;
 					expect( balloon.visibleView === mentionsView ).to.be.false; // LinkUI
 
 					model.change( writer => {

--- a/packages/ckeditor5-mention/tests/mention-integration.js
+++ b/packages/ckeditor5-mention/tests/mention-integration.js
@@ -308,7 +308,8 @@ describe( 'Mention feature - integration', () => {
 					editor.execute( 'link', '@' );
 					editor.editing.view.document.fire( 'click' );
 
-					expect( panelView.isVisible ).to.be.true;
+					// The selection is after the link node.
+					expect( panelView.isVisible ).to.be.false;
 					expect( balloon.visibleView === mentionsView ).to.be.false; // LinkUI
 
 					model.change( writer => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (link): The selection after inserting a link will land after the inserted element. Thanks to that a user will be able to type directly after the link without extending the link element. Closes #1016.

Other (link): After clicking at the beginning or end of the link element, the selection will land before/after the clicked element. Thanks to that a user will be able to typing before or after the link element as normal text without extending the link. See #1016.
