### PR TITLE
#7418: Improved the look of horizontal lines in the editor content

### DIFF
--- a/packages/ckeditor5-horizontal-line/theme/horizontalline.css
+++ b/packages/ckeditor5-horizontal-line/theme/horizontalline.css
@@ -10,7 +10,7 @@
 }
 
 .ck-content hr {
-	margin: 20px 0;
+	margin: 15px 0;
 	height: 4px;
 	background: hsl(0, 0%, 87%);
 	border: 0;

--- a/packages/ckeditor5-horizontal-line/theme/horizontalline.css
+++ b/packages/ckeditor5-horizontal-line/theme/horizontalline.css
@@ -10,8 +10,8 @@
 }
 
 .ck-content hr {
-	border-width: 1px 0 0;
-	border-style: solid;
-	border-color: hsl(0, 0%, 37%);
-	margin: 0;
+	margin: 20px 0;
+	height: 4px;
+	background: hsl(0, 0%, 87%);
+	border: 0;
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-horizontal-line/horizontalline.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-horizontal-line/horizontalline.css
@@ -3,7 +3,8 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-.ck-editor__editable .ck-horizontal-line {
-	/* Helps selecting the horizontal rule widget by giving it some space. */
-	padding: 5px 0;
-}
+/*
+ * Note: This file should contain the wireframe styles only. But since there are no such styles,
+ * it acts as a message to the builder telling that it should look for the corresponding styles
+ * **in the theme** when compiling the editor.
+ */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other: Improved the look of horizontal lines in the editor content. Closes #7418.

---

### Before

![](https://user-images.githubusercontent.com/1099479/84780324-bb1f8c80-afe5-11ea-8cf2-4bd10e830751.png)

### After

![](https://user-images.githubusercontent.com/1099479/84780334-be1a7d00-afe5-11ea-804e-c6917cb32850.png)

### Problem

To pass WCAG AA for non-text object, the color would need to be much darker (around `#949494`) which does not look good IMO. I checked what GitHub makes of it and they don't comply with the standard. WDYT?

![](https://user-images.githubusercontent.com/1099479/84780353-c2df3100-afe5-11ea-9e67-c575eb3c222e.png)