### PR TITLE
#7438: The findOptimalInsertionPosition() helper should respect the "fake widget caret"

### DIFF
--- a/packages/ckeditor5-widget/src/utils.js
+++ b/packages/ckeditor5-widget/src/utils.js
@@ -14,6 +14,7 @@ import BalloonPanelView from '@ckeditor/ckeditor5-ui/src/panel/balloon/balloonpa
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
 import dragHandleIcon from '../theme/icons/drag-handle.svg';
+import { getTypeAroundFakeCaretPosition } from './widgettypearound/utils';
 
 /**
  * CSS class added to each widget element.
@@ -256,8 +257,18 @@ export function toWidgetEditable( editable, writer ) {
 export function findOptimalInsertionPosition( selection, model ) {
 	const selectedElement = selection.getSelectedElement();
 
-	if ( selectedElement && model.schema.isBlock( selectedElement ) ) {
-		return model.createPositionAfter( selectedElement );
+	if ( selectedElement ) {
+		const typeAroundFakeCaretPosition = getTypeAroundFakeCaretPosition( selection );
+
+		// If the WidgetTypeAround "fake caret" is displayed, use its position for the insertion
+		// to provide the most predictable UX (https://github.com/ckeditor/ckeditor5/issues/7438).
+		if ( typeAroundFakeCaretPosition ) {
+			return model.createPositionAt( selectedElement, typeAroundFakeCaretPosition );
+		}
+
+		if ( model.schema.isBlock( selectedElement ) ) {
+			return model.createPositionAfter( selectedElement );
+		}
 	}
 
 	const firstBlock = selection.getSelectedBlocks().next().value;

--- a/packages/ckeditor5-widget/src/widgettypearound/utils.js
+++ b/packages/ckeditor5-widget/src/widgettypearound/utils.js
@@ -10,6 +10,12 @@
 import { isWidget } from '../utils';
 
 /**
+ * The name of the type around model selection attribute responsible for
+ * displaying a "fake caret" next to a selected widget.
+ */
+export const TYPE_AROUND_SELECTION_ATTRIBUTE = 'widget-type-around';
+
+/**
  * Checks if an element is a widget that qualifies to get the type around UI.
  *
  * @param {module:engine/view/element~Element} viewElement
@@ -37,7 +43,7 @@ export function getClosestTypeAroundDomButton( domElement ) {
  * clicked by the user.
  *
  * @param {HTMLElement} domElement
- * @returns {String} Either `'before'` or `'after'`.
+ * @returns {'before'|'after'} Position of the button.
  */
 export function getTypeAroundButtonPosition( domElement ) {
 	return domElement.classList.contains( 'ck-widget__type-around__button_before' ) ? 'before' : 'after';
@@ -54,4 +60,16 @@ export function getClosestWidgetViewElement( domElement, domConverter ) {
 	const widgetDomElement = domElement.closest( '.ck-widget' );
 
 	return domConverter.mapDomToView( widgetDomElement );
+}
+
+/**
+ * For the passed selection instance, it returns the position of the "fake caret" displayed next to a widget.
+ *
+ * **Note**: If the "fake caret" is not currently displayed, `null` is returned.
+ *
+ * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} selection
+ * @returns {'before'|'after'|null} Position of the fake caret or `null` when none is preset.
+ */
+export function getTypeAroundFakeCaretPosition( selection ) {
+	return selection.getAttribute( TYPE_AROUND_SELECTION_ATTRIBUTE );
 }

--- a/packages/ckeditor5-widget/tests/utils.js
+++ b/packages/ckeditor5-widget/tests/utils.js
@@ -327,6 +327,11 @@ describe( 'widget utils', () => {
 				isBlock: true
 			} );
 
+			model.schema.register( 'horizontalLine', {
+				isObject: true,
+				allowWhere: '$block'
+			} );
+
 			model.schema.extend( 'span', { allowIn: 'paragraph' } );
 			model.schema.extend( '$text', { allowIn: 'span' } );
 		} );
@@ -409,6 +414,73 @@ describe( 'widget utils', () => {
 			const pos = findOptimalInsertionPosition( doc.selection, model );
 
 			expect( pos.path ).to.deep.equal( [ 3 ] );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/7438
+		describe( 'integration with the WidgetTypeAround feature ("widget-type-around" model selection attribute)', () => {
+			it( 'should respect the attribute value when a widget (block and an object) is selected ("fake caret" before a widget)', () => {
+				setData( model, '<paragraph>x</paragraph>[<image></image>]<paragraph>y</paragraph>' );
+
+				model.change( writer => {
+					writer.setSelectionAttribute( 'widget-type-around', 'before' );
+				} );
+
+				const pos = findOptimalInsertionPosition( doc.selection, model );
+
+				expect( pos.path ).to.deep.equal( [ 1 ] );
+			} );
+
+			it( 'should respect the attribute value when a widget (block and an object) is selected ("fake caret" after a widget)', () => {
+				setData( model, '<paragraph>x</paragraph>[<image></image>]<paragraph>y</paragraph>' );
+
+				model.change( writer => {
+					writer.setSelectionAttribute( 'widget-type-around', 'after' );
+				} );
+
+				const pos = findOptimalInsertionPosition( doc.selection, model );
+
+				expect( pos.path ).to.deep.equal( [ 2 ] );
+			} );
+
+			it( 'should return a position after a selected widget (block and an object) ("fake caret" not displayed)', () => {
+				setData( model, '<paragraph>x</paragraph>[<image></image>]<paragraph>y</paragraph>' );
+
+				const pos = findOptimalInsertionPosition( doc.selection, model );
+
+				expect( pos.path ).to.deep.equal( [ 2 ] );
+			} );
+
+			it( 'should respect the attribute value when a widget (an object) is selected ("fake caret" before a widget)', () => {
+				setData( model, '<paragraph>x</paragraph>[<horizontalLine></horizontalLine>]<paragraph>y</paragraph>' );
+
+				model.change( writer => {
+					writer.setSelectionAttribute( 'widget-type-around', 'before' );
+				} );
+
+				const pos = findOptimalInsertionPosition( doc.selection, model );
+
+				expect( pos.path ).to.deep.equal( [ 1 ] );
+			} );
+
+			it( 'should respect the attribute value when a widget (an object) is selected ("fake caret" after a widget)', () => {
+				setData( model, '<paragraph>x</paragraph>[<horizontalLine></horizontalLine>]<paragraph>y</paragraph>' );
+
+				model.change( writer => {
+					writer.setSelectionAttribute( 'widget-type-around', 'after' );
+				} );
+
+				const pos = findOptimalInsertionPosition( doc.selection, model );
+
+				expect( pos.path ).to.deep.equal( [ 2 ] );
+			} );
+
+			it( 'should return a position after a selected widget (an object) ("fake caret" not displayed)', () => {
+				setData( model, '<paragraph>x</paragraph>[<horizontalLine></horizontalLine>]<paragraph>y</paragraph>' );
+
+				const pos = findOptimalInsertionPosition( doc.selection, model );
+
+				expect( pos.path ).to.deep.equal( [ 2 ] );
+			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-widget/tests/widgettypearound/utils.js
+++ b/packages/ckeditor5-widget/tests/widgettypearound/utils.js
@@ -1,0 +1,36 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import Selection from '@ckeditor/ckeditor5-engine/src/model/selection';
+import {
+	TYPE_AROUND_SELECTION_ATTRIBUTE,
+	getTypeAroundFakeCaretPosition
+} from '../../src/widgettypearound/utils';
+
+describe( 'widget type around utils', () => {
+	let selection;
+
+	beforeEach( () => {
+		selection = new Selection();
+	} );
+
+	describe( 'getTypeAroundFakeCaretPosition()', () => {
+		it( 'should return "before" if the model selection attribute is "before"', () => {
+			selection.setAttribute( TYPE_AROUND_SELECTION_ATTRIBUTE, 'before' );
+
+			expect( getTypeAroundFakeCaretPosition( selection ) ).to.equal( 'before' );
+		} );
+
+		it( 'should return "after" if the model selection attribute is "after"', () => {
+			selection.setAttribute( TYPE_AROUND_SELECTION_ATTRIBUTE, 'after' );
+
+			expect( getTypeAroundFakeCaretPosition( selection ) ).to.equal( 'after' );
+		} );
+
+		it( 'should return undefined if the model selection attribute is not set', () => {
+			expect( getTypeAroundFakeCaretPosition( selection ) ).to.be.undefined;
+		} );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (widget): The `findOptimalInsertionPosition()` helper should respect the "fake widget caret" to provide the best UX. Closes #7438.