### PR TITLE
#7245: Added normalization of pasted table.

### DIFF
--- a/packages/ckeditor5-table/src/converters/upcasttable.js
+++ b/packages/ckeditor5-table/src/converters/upcasttable.js
@@ -91,16 +91,16 @@ export default function upcastTable() {
 }
 
 /**
- * Conversion helper that skips empty <tr> from upcasting.
+ * Conversion helper that skips empty <tr> from upcasting at the beginning of the table.
  *
- * Empty row is considered a table model error.
+ * Empty row is considered a table model error if there are no cells spanned over that row.
  *
  * @returns {Function} Conversion helper.
  */
 export function skipEmptyTableRow() {
 	return dispatcher => {
 		dispatcher.on( 'element:tr', ( evt, data ) => {
-			if ( data.viewItem.isEmpty ) {
+			if ( data.viewItem.isEmpty && data.modelCursor.index == 0 ) {
 				evt.stop();
 			}
 		}, { priority: 'high' } );

--- a/packages/ckeditor5-table/src/converters/upcasttable.js
+++ b/packages/ckeditor5-table/src/converters/upcasttable.js
@@ -93,7 +93,11 @@ export default function upcastTable() {
 /**
  * Conversion helper that skips empty <tr> from upcasting at the beginning of the table.
  *
- * Empty row is considered a table model error if there are no cells spanned over that row.
+ * Empty row is considered a table model error but when handling clipboard data there could be rows that contain only row-spanned cells
+ * and empty TR-s are used to maintain table structure (also {@link module:table/tablewalker~TableWalker} assumes that there are only rows
+ * that have related tableRow elements).
+ *
+ * *Note:* Only first empty rows are removed because those have no meaning and solves issue of improper table with all empty rows.
  *
  * @returns {Function} Conversion helper.
  */

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -19,10 +19,11 @@ import { getColumnIndexes, getRowIndexes, getSelectionAffectedTableCells, isSele
 import {
 	cropTableToDimensions,
 	getHorizontallyOverlappingCells,
-	getVerticallyOverlappingCells,
+	getVerticallyOverlappingCells, removeEmptyRowsColumns,
 	splitHorizontally,
 	splitVertically,
-	trimTableCellIfNeeded
+	trimTableCellIfNeeded,
+	adjustLastRowIndex, adjustLastColumnIndex
 } from './utils/structure';
 
 /**
@@ -113,16 +114,18 @@ export default class TableClipboard extends Plugin {
 		const model = this.editor.model;
 		const tableUtils = this.editor.plugins.get( TableUtils );
 
-		const selectedTableCells = getSelectionAffectedTableCells( model.document.selection );
-
-		if ( !selectedTableCells.length ) {
-			return;
-		}
-
 		// We might need to crop table before inserting so reference might change.
 		let pastedTable = getTableIfOnlyTableInContent( content, model );
 
 		if ( !pastedTable ) {
+			return;
+		}
+
+		const selectedTableCells = getSelectionAffectedTableCells( model.document.selection );
+
+		if ( !selectedTableCells.length ) {
+			removeEmptyRowsColumns( pastedTable, tableUtils );
+
 			return;
 		}
 
@@ -512,73 +515,4 @@ function isAffectedBySelection( index, span, limit ) {
 	const overlapsSelectionFromOutside = index < first && endIndex >= first;
 
 	return isInsideSelection || overlapsSelectionFromOutside;
-}
-
-// Returns adjusted last row index if selection covers part of a row with empty slots (spanned by other cells).
-// The rowIndexes.last is equal to last row index but selection might be bigger.
-//
-// This happens *only* on rectangular selection so we analyze a case like this:
-//
-//    +---+---+---+---+
-//  0 | a | b | c | d |
-//    +   +   +---+---+
-//  1 |   | e | f | g |
-//    +   +---+   +---+
-//  2 |   | h |   | i | <- last row, each cell has rowspan = 2,
-//    +   +   +   +   +    so we need to return 3, not 2
-//  3 |   |   |   |   |
-//    +---+---+---+---+
-function adjustLastRowIndex( table, dimensions ) {
-	const lastRowMap = Array.from( new TableWalker( table, {
-		startColumn: dimensions.firstColumn,
-		endColumn: dimensions.lastColumn,
-		row: dimensions.lastRow
-	} ) );
-
-	const everyCellHasSingleRowspan = lastRowMap.every( ( { cellHeight } ) => cellHeight === 1 );
-
-	// It is a "flat" row, so the last row index is OK.
-	if ( everyCellHasSingleRowspan ) {
-		return dimensions.lastRow;
-	}
-
-	// Otherwise get any cell's rowspan and adjust the last row index.
-	const rowspanAdjustment = lastRowMap[ 0 ].cellHeight - 1;
-	return dimensions.lastRow + rowspanAdjustment;
-}
-
-// Returns adjusted last column index if selection covers part of a column with empty slots (spanned by other cells).
-// The columnIndexes.last is equal to last column index but selection might be bigger.
-//
-// This happens *only* on rectangular selection so we analyze a case like this:
-//
-//   0   1   2   3
-// +---+---+---+---+
-// | a             |
-// +---+---+---+---+
-// | b | c | d     |
-// +---+---+---+---+
-// | e     | f     |
-// +---+---+---+---+
-// | g | h         |
-// +---+---+---+---+
-//           ^
-//          last column, each cell has colspan = 2, so we need to return 3, not 2
-function adjustLastColumnIndex( table, dimensions ) {
-	const lastColumnMap = Array.from( new TableWalker( table, {
-		startRow: dimensions.firstRow,
-		endRow: dimensions.lastRow,
-		column: dimensions.lastColumn
-	} ) );
-
-	const everyCellHasSingleColspan = lastColumnMap.every( ( { cellWidth } ) => cellWidth === 1 );
-
-	// It is a "flat" column, so the last column index is OK.
-	if ( everyCellHasSingleColspan ) {
-		return dimensions.lastColumn;
-	}
-
-	// Otherwise get any cell's colspan and adjust the last column index.
-	const colspanAdjustment = lastColumnMap[ 0 ].cellWidth - 1;
-	return dimensions.lastColumn + colspanAdjustment;
 }

--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -19,11 +19,13 @@ import { getColumnIndexes, getRowIndexes, getSelectionAffectedTableCells, isSele
 import {
 	cropTableToDimensions,
 	getHorizontallyOverlappingCells,
-	getVerticallyOverlappingCells, removeEmptyRowsColumns,
+	getVerticallyOverlappingCells,
+	removeEmptyRowsColumns,
 	splitHorizontally,
 	splitVertically,
 	trimTableCellIfNeeded,
-	adjustLastRowIndex, adjustLastColumnIndex
+	adjustLastRowIndex,
+	adjustLastColumnIndex
 } from './utils/structure';
 
 /**

--- a/packages/ckeditor5-table/src/utils/structure.js
+++ b/packages/ckeditor5-table/src/utils/structure.js
@@ -328,7 +328,7 @@ function addHeadingsToCroppedTable( croppedTable, sourceTable, startRow, startCo
  * @protected
  * @param {module:engine/model/element~Element} table
  * @param {module:table/tableutils~TableUtils} tableUtils
- * @return {Boolean} True if removed some columns.
+ * @returns {Boolean} True if removed some columns.
  */
 export function removeEmptyColumns( table, tableUtils ) {
 	const width = tableUtils.getColumns( table );
@@ -381,7 +381,7 @@ export function removeEmptyColumns( table, tableUtils ) {
  * @param {module:engine/model/element~Element} table
  * @param {module:table/tableutils~TableUtils} tableUtils
  * @param {module:engine/model/batch~Batch|null} [batch] Batch that should be used for removing empty rows.
- * @return {Boolean} True if removed some rows.
+ * @returns {Boolean} True if removed some rows.
  */
 export function removeEmptyRows( table, tableUtils, batch ) {
 	const emptyRows = [];
@@ -437,4 +437,93 @@ export function removeEmptyRowsColumns( table, tableUtils, batch ) {
 	if ( !removedColumns ) {
 		removeEmptyRows( table, tableUtils, batch );
 	}
+}
+
+/**
+ * Returns adjusted last row index if selection covers part of a row with empty slots (spanned by other cells).
+ * The `dimensions.lastRow` is equal to last row index but selection might be bigger.
+ *
+ * This happens *only* on rectangular selection so we analyze a case like this:
+ *
+ *        +---+---+---+---+
+ *      0 | a | b | c | d |
+ *        +   +   +---+---+
+ *      1 |   | e | f | g |
+ *        +   +---+   +---+
+ *      2 |   | h |   | i | <- last row, each cell has rowspan = 2,
+ *        +   +   +   +   +    so we need to return 3, not 2
+ *      3 |   |   |   |   |
+ *        +---+---+---+---+
+ *
+ * @param {module:engine/model/element~Element} table
+ * @param {Object} dimensions
+ * @param {Number} dimensions.firstRow
+ * @param {Number} dimensions.firstColumn
+ * @param {Number} dimensions.lastRow
+ * @param {Number} dimensions.lastColumn
+ * @returns {Number} Adjusted last row index.
+ */
+export function adjustLastRowIndex( table, dimensions ) {
+	const lastRowMap = Array.from( new TableWalker( table, {
+		startColumn: dimensions.firstColumn,
+		endColumn: dimensions.lastColumn,
+		row: dimensions.lastRow
+	} ) );
+
+	const everyCellHasSingleRowspan = lastRowMap.every( ( { cellHeight } ) => cellHeight === 1 );
+
+	// It is a "flat" row, so the last row index is OK.
+	if ( everyCellHasSingleRowspan ) {
+		return dimensions.lastRow;
+	}
+
+	// Otherwise get any cell's rowspan and adjust the last row index.
+	const rowspanAdjustment = lastRowMap[ 0 ].cellHeight - 1;
+	return dimensions.lastRow + rowspanAdjustment;
+}
+
+/**
+ * Returns adjusted last column index if selection covers part of a column with empty slots (spanned by other cells).
+ * The `dimensions.lastColumn` is equal to last column index but selection might be bigger.
+ *
+ * This happens *only* on rectangular selection so we analyze a case like this:
+ *
+ *       0   1   2   3
+ *     +---+---+---+---+
+ *     | a             |
+ *     +---+---+---+---+
+ *     | b | c | d     |
+ *     +---+---+---+---+
+ *     | e     | f     |
+ *     +---+---+---+---+
+ *     | g | h         |
+ *     +---+---+---+---+
+ *               ^
+ *              last column, each cell has colspan = 2, so we need to return 3, not 2
+ *
+ * @param {module:engine/model/element~Element} table
+ * @param {Object} dimensions
+ * @param {Number} dimensions.firstRow
+ * @param {Number} dimensions.firstColumn
+ * @param {Number} dimensions.lastRow
+ * @param {Number} dimensions.lastColumn
+ * @returns {Number} Adjusted last column index.
+ */
+export function adjustLastColumnIndex( table, dimensions ) {
+	const lastColumnMap = Array.from( new TableWalker( table, {
+		startRow: dimensions.firstRow,
+		endRow: dimensions.lastRow,
+		column: dimensions.lastColumn
+	} ) );
+
+	const everyCellHasSingleColspan = lastColumnMap.every( ( { cellWidth } ) => cellWidth === 1 );
+
+	// It is a "flat" column, so the last column index is OK.
+	if ( everyCellHasSingleColspan ) {
+		return dimensions.lastColumn;
+	}
+
+	// Otherwise get any cell's colspan and adjust the last column index.
+	const colspanAdjustment = lastColumnMap[ 0 ].cellWidth - 1;
+	return dimensions.lastColumn + colspanAdjustment;
 }

--- a/packages/ckeditor5-table/tests/tableclipboard-copy-cut.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-copy-cut.js
@@ -191,6 +191,32 @@ describe( 'table clipboard', () => {
 			] ) );
 		} );
 
+		it( 'should output empty tr elements if needed by row-spanned cells', () => {
+			// +----+----+----+
+			// | 00 | 01 | 02 |
+			// +----+----+----+
+			// | 10 | 11 | 12 |
+			// +    +    +----+
+			// |    |    | 22 |
+			// +----+----+----+
+			setModelData( model, modelTable( [
+				[ '00', '01', '02' ],
+				[ { contents: '10', rowspan: 2 }, { contents: '11', rowspan: 2 }, '12' ],
+				[ '22' ]
+			] ) );
+
+			tableSelection.setCellSelection(
+				modelRoot.getNodeByPath( [ 0, 0, 0 ] ),
+				modelRoot.getNodeByPath( [ 0, 1, 1 ] )
+			);
+
+			assertClipboardContentOnMethod( 'copy', viewTable( [
+				[ '00', '01' ],
+				[ { contents: '10', rowspan: 2 }, { contents: '11', rowspan: 2 } ],
+				[] // The empty tr
+			] ) );
+		} );
+
 		it( 'should fix selected table to a selection rectangle (hardcore case)', () => {
 			// This test check how previous simple rules run together (mixed prepending and trimming).
 			// In the example below a selection is set from cell "21" to "77"

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -124,6 +124,30 @@ describe( 'table clipboard', () => {
 			] ) );
 		} );
 
+		it( 'should not alter model.insertContent if selection is outside table', () => {
+			model.change( writer => {
+				writer.insertElement( 'paragraph', modelRoot.getChild( 0 ), 'before' );
+				writer.setSelection( modelRoot.getChild( 0 ), 'before' );
+			} );
+
+			const data = {
+				dataTransfer: createDataTransfer(),
+				preventDefault: sinon.spy(),
+				stopPropagation: sinon.spy()
+			};
+			data.dataTransfer.setData( 'text/html', '<p>foo</p>' );
+			viewDocument.fire( 'paste', data );
+
+			editor.isReadOnly = false;
+
+			assertEqualMarkup( getModelData( model ), '<paragraph>foo[]</paragraph>' + modelTable( [
+				[ '00', '01', '02', '03' ],
+				[ '10', '11', '12', '13' ],
+				[ '20', '21', '22', '23' ],
+				[ '30', '31', '32', '33' ]
+			] ) );
+		} );
+
 		it( 'should normalize pasted table if selection is outside table', () => {
 			model.change( writer => {
 				writer.insertElement( 'paragraph', modelRoot.getChild( 0 ), 'before' );

--- a/packages/ckeditor5-table/tests/tableselection.js
+++ b/packages/ckeditor5-table/tests/tableselection.js
@@ -236,6 +236,99 @@ describe( 'TableSelection', () => {
 				[ '21', '22' ]
 			] ) );
 		} );
+
+		it( 'should adjust the selection dimensions if it\'s rectangular but last row has only row-spanned cells', () => {
+			// +----+----+----+
+			// | 00 | 01 | 02 |
+			// +----+----+----+
+			// | 10 | 11 | 12 |
+			// +    +    +----+
+			// |    |    | 22 |
+			// +----+----+----+
+			setModelData( model, modelTable( [
+				[ '00', '01', '02' ],
+				[ { contents: '10', rowspan: 2 }, { contents: '11', rowspan: 2 }, '12' ],
+				[ '22' ]
+			] ) );
+
+			tableSelection.setCellSelection(
+				modelRoot.getNodeByPath( [ 0, 0, 0 ] ),
+				modelRoot.getNodeByPath( [ 0, 1, 1 ] )
+			);
+
+			// +----+----+
+			// | 00 | 01 |
+			// +----+----+
+			// | 10 | 11 |
+			// +    +    +
+			// |    |    |
+			// +----+----+
+			expect( stringifyModel( tableSelection.getSelectionAsFragment() ) ).to.equal( modelTable( [
+				[ '00', '01' ],
+				[ { contents: '10', rowspan: 2 }, { contents: '11', rowspan: 2 } ],
+				[] // This is an empty row that should be here to properly handle pasting of this table fragment.
+			] ) );
+		} );
+
+		it( 'should adjust the selection dimensions if it\'s rectangular but last column has only col-spanned cells', () => {
+			// +----+----+----+
+			// | 00 | 01      |
+			// +----+----+----+
+			// | 10 | 11      |
+			// +----+----+----+
+			// | 20 | 21 | 22 |
+			// +----+----+----+
+			setModelData( model, modelTable( [
+				[ '00', { contents: '01', colspan: 2 } ],
+				[ '10', { contents: '11', colspan: 2 } ],
+				[ '20', '21', '22' ]
+			] ) );
+
+			tableSelection.setCellSelection(
+				modelRoot.getNodeByPath( [ 0, 0, 0 ] ),
+				modelRoot.getNodeByPath( [ 0, 1, 1 ] )
+			);
+
+			// +----+----+----+
+			// | 00 | 01      |
+			// +----+----+----+
+			// | 10 | 11      |
+			// +----+----+----+
+			expect( stringifyModel( tableSelection.getSelectionAsFragment() ) ).to.equal( modelTable( [
+				[ '00', { contents: '01', colspan: 2 } ],
+				[ '10', { contents: '11', colspan: 2 } ]
+			] ) );
+		} );
+
+		it( 'should crop table fragment to rectangular selection', () => {
+			// +----+----+----+
+			// | 00 | 01      |
+			// +----+----+----+
+			// | 10 | 11 | 12 |
+			// +    +----+----+
+			// |    | 21 | 22 |
+			// +----+----+----+
+			setModelData( model, modelTable( [
+				[ '00', { contents: '01', colspan: 2 } ],
+				[ { contents: '10', rowspan: 2 }, '11', '12' ],
+				[ '21', '22' ]
+			] ) );
+
+			tableSelection.setCellSelection(
+				modelRoot.getNodeByPath( [ 0, 0, 0 ] ),
+				modelRoot.getNodeByPath( [ 0, 1, 1 ] )
+			);
+
+			// +----+----+
+			// | 00 | 01 |
+			// +----+----+
+			// | 10 | 11 |
+			// +----+----+
+			expect( stringifyModel( tableSelection.getSelectionAsFragment() ) ).to.equal( modelTable( [
+				[ '00', '01' ],
+				[ '10', '11' ]
+			] ) );
+		} );
 	} );
 
 	describe( 'delete content', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): Copied and pasted table fragment should maintain proper structure while selection could contain rows that don't have any cells anchored in it. Closes #7245.

---

### Additional information