### PR TITLE
Docs (patch): Add note about createEditableElement in the data view.

### DIFF
--- a/packages/ckeditor5-engine/src/view/downcastwriter.js
+++ b/packages/ckeditor5-engine/src/view/downcastwriter.js
@@ -214,6 +214,8 @@ export default class DowncastWriter {
 	 *		writer.createEditableElement( 'div' );
 	 *		writer.createEditableElement( 'div', { id: 'foo-1234' } );
 	 *
+	 * Note: There is no reason to use createEditableElement in the data view; the properties it adds are only used in the editing view.
+	 *
 	 * @param {String} name Name of the element.
 	 * @param {Object} [attributes] Elements attributes.
 	 * @returns {module:engine/view/editableelement~EditableElement} Created element.

--- a/packages/ckeditor5-engine/src/view/downcastwriter.js
+++ b/packages/ckeditor5-engine/src/view/downcastwriter.js
@@ -214,7 +214,8 @@ export default class DowncastWriter {
 	 *		writer.createEditableElement( 'div' );
 	 *		writer.createEditableElement( 'div', { id: 'foo-1234' } );
 	 *
-	 * Note: There is no reason to use createEditableElement in the data view; the properties it adds are only used in the editing view.
+	 * Note: The editable element is to be used in the editing pipeline. Usually, together with
+	 * {@link module:widget/utils~toWidgetEditable `toWidgetEditable()`}.
 	 *
 	 * @param {String} name Name of the element.
 	 * @param {Object} [attributes] Elements attributes.


### PR DESCRIPTION
Added a comment clarifying the use of createEditableElement in the data view / pipeline.

See https://github.com/ckeditor/ckeditor5/issues/7274#issuecomment-645171865 for more information.

Let me know if this should be rephrased or moved somewhere else.

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (patch): Add note about createEditableElement in the data view. Closes #7274.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._

Docs change only, no code changes.