### PR TITLE
(Un)LinkCommand should read the state properly when LinkImage is disabled

### DIFF
--- a/packages/ckeditor5-link/package.json
+++ b/packages/ckeditor5-link/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^19.0.1",
     "@ckeditor/ckeditor5-engine": "^19.0.1",
+    "@ckeditor/ckeditor5-image": "^19.0.1",
     "@ckeditor/ckeditor5-ui": "^19.0.1",
     "@ckeditor/ckeditor5-utils": "^19.0.1",
     "lodash-es": "^4.17.15"
@@ -22,7 +23,6 @@
     "@ckeditor/ckeditor5-clipboard": "^19.0.1",
     "@ckeditor/ckeditor5-editor-classic": "^19.0.1",
     "@ckeditor/ckeditor5-enter": "^19.0.1",
-    "@ckeditor/ckeditor5-image": "^19.0.1",
     "@ckeditor/ckeditor5-paragraph": "^19.1.0",
     "@ckeditor/ckeditor5-theme-lark": "^19.1.0",
     "@ckeditor/ckeditor5-typing": "^19.0.1",

--- a/packages/ckeditor5-link/src/linkcommand.js
+++ b/packages/ckeditor5-link/src/linkcommand.js
@@ -61,8 +61,8 @@ export default class LinkCommand extends Command {
 		const selectedElement = first( doc.selection.getSelectedBlocks() );
 
 		// A check for the `LinkImage` plugin. If the selection contains an element, get values from the element.
-		// Currently the selection reads attributes from text nodes only. See #7429.
-		if ( selectedElement && selectedElement.is( 'image' ) ) {
+		// Currently the selection reads attributes from text nodes only. See #7429 and #7465.
+		if ( selectedElement && selectedElement.is( 'image' ) && model.schema.checkAttribute( 'image', 'linkHref' ) ) {
 			this.value = selectedElement.getAttribute( 'linkHref' );
 			this.isEnabled = model.schema.checkAttribute( selectedElement, 'linkHref' );
 		} else {

--- a/packages/ckeditor5-link/src/unlinkcommand.js
+++ b/packages/ckeditor5-link/src/unlinkcommand.js
@@ -24,12 +24,12 @@ export default class UnlinkCommand extends Command {
 		const model = this.editor.model;
 		const doc = model.document;
 
-		const selectedImage = first( doc.selection.getSelectedBlocks() );
+		const selectedElement = first( doc.selection.getSelectedBlocks() );
 
 		// A check for the `LinkImage` plugin. If the selection contains an image element, get values from the element.
-		// Currently the selection reads attributes from text nodes only. See #7429.
-		if ( selectedImage && selectedImage.name === 'image' ) {
-			this.isEnabled = model.schema.checkAttribute( selectedImage, 'linkHref' );
+		// Currently the selection reads attributes from text nodes only. See #7429 and #7465.
+		if ( selectedElement && selectedElement.is( 'image' ) && model.schema.checkAttribute( 'image', 'linkHref' ) ) {
+			this.isEnabled = model.schema.checkAttribute( selectedElement, 'linkHref' );
 		} else {
 			this.isEnabled = model.schema.checkAttributeInSelection( doc.selection, 'linkHref' );
 		}

--- a/packages/ckeditor5-link/tests/linkimage-integration.js
+++ b/packages/ckeditor5-link/tests/linkimage-integration.js
@@ -1,0 +1,71 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import Image from '@ckeditor/ckeditor5-image/src/image';
+import ImageCaption from '@ckeditor/ckeditor5-image/src/imagecaption';
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import Enter from '@ckeditor/ckeditor5-enter/src/enter';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Typing from '@ckeditor/ckeditor5-typing/src/typing';
+import Link from '../src/link';
+
+import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import global from '@ckeditor/ckeditor5-utils/src/dom/global';
+
+describe( 'LinkImage integration', () => {
+	let editorElement, editor, model;
+
+	beforeEach( () => {
+		editorElement = global.document.createElement( 'div' );
+		global.document.body.appendChild( editorElement );
+	} );
+
+	afterEach( () => {
+		editorElement.remove();
+	} );
+
+	describe( 'when LinkImage is not loaded', () => {
+		beforeEach( () => {
+			return ClassicEditor
+				.create( editorElement, {
+					plugins: [
+						Enter, Typing, Paragraph, Image, ImageCaption, Link
+					]
+				} )
+				.then( newEditor => {
+					editor = newEditor;
+					model = editor.model;
+				} );
+		} );
+
+		afterEach( () => {
+			return editor.destroy();
+		} );
+
+		it( 'link command should link a figcaption element if an image is selected', () => {
+			setModelData(
+				model,
+				'<paragraph>Foo.</paragraph>[<image src="/assets/sample.png"><caption>Foo.</caption></image>]'
+			);
+
+			editor.execute( 'link', 'https://cksource.com' );
+
+			expect( getModelData( model ) ).to.equal(
+				'<paragraph>Foo.</paragraph>' +
+				'[<image src="/assets/sample.png"><caption><$text linkHref="https://cksource.com">Foo.</$text></caption></image>]'
+			);
+		} );
+
+		it( 'unlink command should be enabled when an image with a linked figcaption is selected', () => {
+			setModelData(
+				model,
+				'<paragraph>Foo.</paragraph>' +
+				'[<image src="/assets/sample.png"><caption><$text linkHref="https://cksource.com">Foo.</$text></caption></image>]'
+			);
+
+			expect( editor.commands.get( 'unlink' ).isEnabled ).to.equal( true );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: `LinkCommand` and `UnlinkCommand` should read the state properly when the `LinkImage` plugin is disabled. Closes #7465.
