### PR TITLE
#7464: Table pasting integration should not affect inserting text node.

### DIFF
--- a/packages/ckeditor5-table/src/tableclipboard.js
+++ b/packages/ckeditor5-table/src/tableclipboard.js
@@ -342,6 +342,10 @@ function expandTableSize( table, expectedHeight, expectedWidth, writer, tableUti
 }
 
 function getTableIfOnlyTableInContent( content, model ) {
+	if ( !content.is( 'documentFragment' ) && !content.is( 'element' ) ) {
+		return null;
+	}
+
 	// Table passed directly.
 	if ( content.is( 'table' ) ) {
 		return content;

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -13,6 +13,7 @@ import ImageCaptionEditing from '@ckeditor/ckeditor5-image/src/imagecaption/imag
 import ImageEditing from '@ckeditor/ckeditor5-image/src/image/imageediting';
 import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Input from '@ckeditor/ckeditor5-typing/src/input';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
@@ -203,6 +204,17 @@ describe( 'table clipboard', () => {
 				[ '20', '21', '22', '23' ],
 				[ '30', '31', '32', '33' ]
 			] ) );
+		} );
+
+		it( 'should not alter model.insertContent if a text node is inserted', async () => {
+			await editor.destroy();
+			await createEditor( [ Input ] );
+
+			setModelData( model, '<paragraph>foo[]</paragraph>' );
+
+			editor.execute( 'input', { text: 'bar' } );
+
+			assertEqualMarkup( getModelData( model ), '<paragraph>foobar[]</paragraph>' );
 		} );
 
 		it( 'should not alter model.insertContent if mixed content is pasted (table + paragraph)', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (table): Table pasting integration should not affect inserting text node. Closes #7464.

---

### Additional information