### PR TITLE
Table multi-cell selection should not be possible with the keystrokes when the TableSelection plugin is disabled

### DIFF
--- a/packages/ckeditor5-table/src/tablekeyboard.js
+++ b/packages/ckeditor5-table/src/tablekeyboard.js
@@ -468,9 +468,9 @@ export default class TableKeyboard extends Plugin {
 
 		const cellToSelect = tableMap.find( cellInfo => cellInfo.row == row && cellInfo.column == column ).cell;
 		const isForward = [ 'right', 'down' ].includes( direction );
+		const tableSelection = this.editor.plugins.get( 'TableSelection' );
 
-		if ( expandSelection ) {
-			const tableSelection = this.editor.plugins.get( 'TableSelection' );
+		if ( expandSelection && tableSelection.isEnabled ) {
 			const anchorCell = tableSelection.getAnchorCell() || focusCell;
 
 			tableSelection.setCellSelection( anchorCell, cellToSelect );

--- a/packages/ckeditor5-table/tests/tablekeyboard.js
+++ b/packages/ckeditor5-table/tests/tablekeyboard.js
@@ -1277,7 +1277,7 @@ describe( 'TableKeyboard', () => {
 						downArrowDomEvtDataStub.shiftKey = true;
 					} );
 
-					it( 'should not expand the selection if TableSelection plugin is disabled', () => {
+					it( 'should move to the cell below if TableSelection plugin is disabled', () => {
 						editor.plugins.get( 'TableSelection' ).forceDisabled();
 
 						editor.editing.view.document.fire( 'keydown', leftArrowDomEvtDataStub );

--- a/packages/ckeditor5-table/tests/tablekeyboard.js
+++ b/packages/ckeditor5-table/tests/tablekeyboard.js
@@ -1277,6 +1277,30 @@ describe( 'TableKeyboard', () => {
 						downArrowDomEvtDataStub.shiftKey = true;
 					} );
 
+					it( 'should not expand the selection if TableSelection plugin is disabled', () => {
+						editor.plugins.get( 'TableSelection' ).forceDisabled();
+
+						editor.editing.view.document.fire( 'keydown', leftArrowDomEvtDataStub );
+
+						assertEqualMarkup( getModelData( model ), modelTable( [
+							[ '00', '01', '02' ],
+							[ '10[]', '11', '12' ],
+							[ '20', '21', '22' ]
+						] ) );
+
+						editor.editing.view.document.fire( 'keydown', downArrowDomEvtDataStub );
+
+						assertEqualMarkup( getModelData( model ), modelTable( [
+							[ '00', '01', '02' ],
+							[ '10', '11', '12' ],
+							[ '[]20', '21', '22' ]
+						] ) );
+
+						expect( tableSelection.getAnchorCell() ).to.be.null;
+						expect( tableSelection.getFocusCell() ).to.be.null;
+						expect( selection.rangeCount ).to.equal( 1 );
+					} );
+
 					it( 'should expand the selection to the cell on the left', () => {
 						editor.editing.view.document.fire( 'keydown', leftArrowDomEvtDataStub );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): Table multi-cell selection should not be possible with the keystrokes when the TableSelection plugin is disabled. Closes #7483.

---

### Additional information