### PR TITLE
Add indent block support to ClassicEditor

### DIFF
--- a/packages/ckeditor5-build-classic/src/ckeditor.js
+++ b/packages/ckeditor5-build-classic/src/ckeditor.js
@@ -21,6 +21,7 @@ import ImageStyle from '@ckeditor/ckeditor5-image/src/imagestyle';
 import ImageToolbar from '@ckeditor/ckeditor5-image/src/imagetoolbar';
 import ImageUpload from '@ckeditor/ckeditor5-image/src/imageupload';
 import Indent from '@ckeditor/ckeditor5-indent/src/indent';
+import IndentBlock from '@ckeditor/ckeditor5-indent/src/indentblock';
 import Link from '@ckeditor/ckeditor5-link/src/link';
 import List from '@ckeditor/ckeditor5-list/src/list';
 import MediaEmbed from '@ckeditor/ckeditor5-media-embed/src/mediaembed';
@@ -49,6 +50,7 @@ ClassicEditor.builtinPlugins = [
 	ImageToolbar,
 	ImageUpload,
 	Indent,
+	IndentBlock,
 	Link,
 	List,
 	MediaEmbed,


### PR DESCRIPTION
[Here is a codepen](https://codepen.io/deadlyicon/pen/MWKvoON?editors=1111) of block indent not working in the ClassicEditor 