### PR TITLE
Fix the attribute assertion message.

### DIFF
--- a/packages/ckeditor5-core/tests/_utils-tests/assertions/attribute.js
+++ b/packages/ckeditor5-core/tests/_utils-tests/assertions/attribute.js
@@ -54,7 +54,7 @@ describe( 'attribute chai assertion', () => {
 				hasAttribute: () => true,
 				getAttribute: () => 'bar'
 			} ).to.have.attribute( 'foo', 'baz' );
-		} ).to.throw( 'expected { Object (hasAttribute, getAttribute) } to have attribute \'foo\' of \'bar\', but got \'baz\'' );
+		} ).to.throw( 'expected { Object (hasAttribute, getAttribute) } to have attribute \'foo\' of \'baz\', but got \'bar\'' );
 	} );
 
 	it( 'negated, should assert for the given type the \'target.getAttribute\' returns a value different than the given one', () => {

--- a/packages/ckeditor5-core/tests/_utils/assertions/attribute.js
+++ b/packages/ckeditor5-core/tests/_utils/assertions/attribute.js
@@ -54,8 +54,8 @@ chai.Assertion.addMethod( 'attribute', function attributeAssertion( key, value, 
 			attributeValue === value,
 			`expected #{this} to have attribute '${ key }' of #{exp}, but got #{act}`,
 			`expected #{this} to not have attribute '${ key }' of #{exp}`,
-			attributeValue,
-			value
+			value,
+			attributeValue
 		);
 	}
 } );


### PR DESCRIPTION
The actual and expected values were switched.

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Tests (core): Fix the placement of the actual and expected values in the `attribute` assertion message.

---

