### PR TITLE
#7310: Added vertical-align: middle to table cells in all editors in the docs

### DIFF
--- a/docs/_snippets/examples/document-editor.html
+++ b/docs/_snippets/examples/document-editor.html
@@ -195,12 +195,6 @@
 		margin-right: calc( 2 * var(--ck-spacing-large) );
 	}
 
-	/* Some table cells have a lot content and some not. Align them vertically
-	to make reading easier. */
-	.document-editor .ck-content table td {
-		vertical-align: middle;
-	}
-
 	@media only screen and (max-width: 960px) {
 		/* Because on mobile 2cm paddings are to big. */
 		.document-editor__editable-container .document-editor__editable.ck-editor__editable {

--- a/docs/_snippets/framework/tutorials/using-react-in-widget.html
+++ b/docs/_snippets/framework/tutorials/using-react-in-widget.html
@@ -141,10 +141,6 @@
 	animation: slideUp 0.3s ease;
 }
 
-.app .ck-content .table td {
-	vertical-align: middle;
-}
-
 @keyframes slideUp {
 	0% {
 		opacity: 0;

--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -232,6 +232,12 @@ It breaks CKEditor 5 (see how <p><code>[]</code></p> looks). */
 	display: table;
 }
 
+/* https://github.com/ckeditor/ckeditor5/issues/7310 */
+.live-snippet .ck.ck-content .table td,
+.live-snippet .ck.ck-content .table th {
+	vertical-align: middle;
+}
+
 /* https://github.com/ckeditor/ckeditor5/issues/1282 */
 .live-snippet .ck.ck-content .table p:first-child {
 	padding-top: 0;

--- a/packages/ckeditor5-table/docs/_snippets/features/table.html
+++ b/packages/ckeditor5-table/docs/_snippets/features/table.html
@@ -46,9 +46,3 @@
 	</table>
 </div>
 
-<style>
-	.ck.ck-content table td,
-	.ck.ck-content table th {
-		vertical-align: middle;
-	}
-</style>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

 Docs (ckeditor5, table): Added `vertical-align: middle` to table cells in all editors in the docs. Closes #7310.