### PR TITLE
Typing over the link feature

### DIFF
--- a/packages/ckeditor5-link/package.json
+++ b/packages/ckeditor5-link/package.json
@@ -10,6 +10,7 @@
     "ckeditor5-plugin"
   ],
   "dependencies": {
+    "@ckeditor/ckeditor5-clipboard": "^20.0.0",
     "@ckeditor/ckeditor5-core": "^20.0.0",
     "@ckeditor/ckeditor5-engine": "^20.0.0",
     "@ckeditor/ckeditor5-image": "^20.0.0",
@@ -21,7 +22,6 @@
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^20.0.0",
     "@ckeditor/ckeditor5-block-quote": "^20.0.0",
-    "@ckeditor/ckeditor5-clipboard": "^20.0.0",
     "@ckeditor/ckeditor5-code-block": "^20.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^20.0.0",
     "@ckeditor/ckeditor5-enter": "^20.0.0",

--- a/packages/ckeditor5-link/src/linkediting.js
+++ b/packages/ckeditor5-link/src/linkediting.js
@@ -527,7 +527,7 @@ function shouldCopyAttributes( model ) {
 	// `nodeBefore` = the position is at the end of the link element.
 	const nodeAtLastPosition = lastPosition.textNode || lastPosition.nodeBefore;
 
-	// Both nodes must indicate the same node in the model tree.
+	// If both references the same node selection contains a single text node.
 	if ( nodeAtFirstPosition === nodeAtLastPosition ) {
 		return true;
 	}

--- a/packages/ckeditor5-link/tests/linkediting.js
+++ b/packages/ckeditor5-link/tests/linkediting.js
@@ -10,6 +10,7 @@ import UnlinkCommand from '../src/unlinkcommand';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
+import ItalicEditing from '@ckeditor/ckeditor5-basic-styles/src/italic/italicediting';
 import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
 import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
@@ -1066,7 +1067,7 @@ describe( 'LinkEditing', () => {
 
 		beforeEach( async () => {
 			editor = await ClassicTestEditor.create( element, {
-				plugins: [ Paragraph, LinkEditing, Enter, BoldEditing, ImageEditing ],
+				plugins: [ Paragraph, LinkEditing, Enter, BoldEditing, ItalicEditing, ImageEditing ],
 				link: {
 					decorators: {
 						isFoo: {
@@ -1108,7 +1109,7 @@ describe( 'LinkEditing', () => {
 			expect( LinkEditing.requires.includes( Input ) ).to.equal( true );
 		} );
 
-		it( 'should preserve the `linkHref` attribute when the entire link is selected', () => {
+		it( 'should preserve selection attributes when the entire link is selected', () => {
 			setModelData( model,
 				'<paragraph>This is [<$text linkHref="foo">Foo</$text>] from <$text linkHref="bar">Bar</$text>.</paragraph>'
 			);
@@ -1122,7 +1123,39 @@ describe( 'LinkEditing', () => {
 			);
 		} );
 
-		it( 'should preserve the `linkHref` attribute when the selection starts at the beginning of the link', () => {
+		it( 'should preserve selection attributes when the entire link is selected (mixed attributes in the link)', () => {
+			setModelData( model,
+				'<paragraph>' +
+					'This is [' +
+					'<$text linkHref="foo" italic="true">F</$text>' +
+					'<$text linkHref="foo" bold="true">o</$text>' +
+					'<$text linkHref="foo" bold="true" italic="true">o</$text>' +
+					'<$text linkHref="foo" bold="true">B</$text>' +
+					'<$text linkHref="foo" bold="true" italic="true">a</$text>' +
+					'<$text linkHref="foo">r</$text>]' +
+					' from ' +
+					'<$text linkHref="bar">Bar</$text>' +
+					'.' +
+				'</paragraph>'
+			);
+
+			editor.execute( 'input', {
+				text: 'Abcde'
+			} );
+
+			expect( getModelData( model ) ).to.equal(
+				'<paragraph>' +
+					'This is ' +
+					'<$text italic="true" linkHref="foo">Abcde</$text>' +
+					'<$text italic="true">[]</$text>' +
+					' from ' +
+					'<$text linkHref="bar">Bar</$text>' +
+					'.' +
+				'</paragraph>'
+			);
+		} );
+
+		it( 'should preserve selection attributes when the selection starts at the beginning of the link', () => {
 			setModelData( model,
 				'<paragraph>This is [<$text linkHref="foo">Fo]o</$text> from <$text linkHref="bar">Bar</$text>.</paragraph>'
 			);
@@ -1133,6 +1166,38 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>This is <$text linkHref="foo">Abcde[]o</$text> from <$text linkHref="bar">Bar</$text>.</paragraph>'
+			);
+		} );
+
+		it( 'should preserve selection attributes when it starts at the beginning of the link (mixed attributes in the link)', () => {
+			setModelData( model,
+				'<paragraph>' +
+					'This is [' +
+					'<$text linkHref="foo" italic="true">F</$text>' +
+					'<$text linkHref="foo" bold="true">o</$text>' +
+					'<$text linkHref="foo" bold="true" italic="true">o</$text>' +
+					'<$text linkHref="foo" bold="true">B</$text>' +
+					'<$text linkHref="foo" bold="true" italic="true">a]</$text>' +
+					'<$text linkHref="foo">r</$text>' +
+					' from ' +
+					'<$text linkHref="bar">Bar</$text>' +
+					'.' +
+				'</paragraph>'
+			);
+
+			editor.execute( 'input', {
+				text: 'Abcde'
+			} );
+
+			expect( getModelData( model ) ).to.equal(
+				'<paragraph>' +
+					'This is ' +
+					'<$text italic="true" linkHref="foo">Abcde[]</$text>' +
+					'<$text linkHref="foo">r</$text>' +
+					' from ' +
+					'<$text linkHref="bar">Bar</$text>' +
+					'.' +
+				'</paragraph>'
 			);
 		} );
 
@@ -1162,7 +1227,7 @@ describe( 'LinkEditing', () => {
 			);
 		} );
 
-		it( 'should not preserve the `linkHref` attribute when the changes are not caused by typing', () => {
+		it( 'should not preserve selection attributes when the changes are not caused by typing', () => {
 			setModelData( model,
 				'<paragraph>This is [<$text linkHref="foo">Foo</$text>] from <$text linkHref="bar">Bar</$text>.</paragraph>'
 			);
@@ -1177,7 +1242,7 @@ describe( 'LinkEditing', () => {
 			);
 		} );
 
-		it( 'should not preserve the `linkHref` attribute when the changes are not caused by typing (pasting check)', () => {
+		it( 'should not preserve selection attributes when the changes are not caused by typing (pasting check)', () => {
 			setModelData( model,
 				'<paragraph>This is [<$text linkHref="foo">Foo</$text>] from <$text linkHref="bar">Bar</$text>.</paragraph>'
 			);
@@ -1196,7 +1261,7 @@ describe( 'LinkEditing', () => {
 			);
 		} );
 
-		it( 'should not preserve the `linkHref` attribute when typed after cutting the content', () => {
+		it( 'should not preserve selection attributes when typed after cutting the content', () => {
 			setModelData( model,
 				'<paragraph>This is [<$text linkHref="foo">Foo</$text>] from <$text linkHref="bar">Bar</$text>.</paragraph>'
 			);
@@ -1230,7 +1295,7 @@ describe( 'LinkEditing', () => {
 			);
 		} );
 
-		it( 'should not preserve anything if selected text does not have the `linkHref` attribute', () => {
+		it( 'should not preserve anything if selected text does not have the `linkHref` attribute`', () => {
 			setModelData( model,
 				'<paragraph>This is [<$text bold="foo">Foo</$text>] from <$text linkHref="bar">Bar</$text>.</paragraph>'
 			);
@@ -1244,7 +1309,7 @@ describe( 'LinkEditing', () => {
 			);
 		} );
 
-		it( 'should not preserve the `linkHref` attribute when the entire link is selected and pressed "Backspace"', () => {
+		it( 'should not preserve selection attributes when the entire link is selected and pressed "Backspace"', () => {
 			setModelData( model,
 				'<paragraph>This is [<$text linkHref="foo">Foo</$text>] from <$text linkHref="bar">Bar</$text>.</paragraph>'
 			);
@@ -1263,7 +1328,7 @@ describe( 'LinkEditing', () => {
 			);
 		} );
 
-		it( 'should not preserve the `linkHref` attribute when the entire link is selected and pressed "Delete"', () => {
+		it( 'should not preserve selection attributes when the entire link is selected and pressed "Delete"', () => {
 			setModelData( model,
 				'<paragraph>This is [<$text linkHref="foo">Foo</$text>] from <$text linkHref="bar">Bar</$text>.</paragraph>'
 			);
@@ -1282,7 +1347,7 @@ describe( 'LinkEditing', () => {
 			);
 		} );
 
-		it( 'should not preserve the `linkHref` attribute when selected different links', () => {
+		it( 'should not preserve selection attributes when selected different links', () => {
 			setModelData( model,
 				'<paragraph>This is <$text linkHref="foo">[Foo</$text> from <$text linkHref="bar">Bar]</$text>.</paragraph>'
 			);
@@ -1294,7 +1359,7 @@ describe( 'LinkEditing', () => {
 			expect( getModelData( model ) ).to.equal( '<paragraph>This is Abcde[].</paragraph>' );
 		} );
 
-		it( 'should not preserve the `linkHref` attribute when selected more than single link (start of the selection)', () => {
+		it( 'should not preserve selection attributes when selected more than single link (start of the selection)', () => {
 			setModelData( model,
 				'<paragraph>This is[ <$text linkHref="foo">Foo]</$text> from <$text linkHref="bar">Bar</$text>.</paragraph>'
 			);
@@ -1308,7 +1373,7 @@ describe( 'LinkEditing', () => {
 			);
 		} );
 
-		it( 'should not preserve the `linkHref` attribute when selected more than single link (end of the selection)', () => {
+		it( 'should not preserve selection attributes when selected more than single link (end of the selection)', () => {
 			setModelData( model,
 				'<paragraph>This is <$text linkHref="foo">[Foo</$text> ]from <$text linkHref="bar">Bar</$text>.</paragraph>'
 			);

--- a/packages/ckeditor5-typing/src/inputcommand.js
+++ b/packages/ckeditor5-typing/src/inputcommand.js
@@ -89,6 +89,9 @@ export default class InputCommand extends Command {
 		model.enqueueChange( this._buffer.batch, writer => {
 			this._buffer.lock();
 
+			// Store the batch as an 'input' batch for the Input.isInput( batch ) check.
+			this._batches.add( this._buffer.batch );
+
 			model.deleteContent( selection );
 
 			if ( text ) {
@@ -104,9 +107,6 @@ export default class InputCommand extends Command {
 			this._buffer.unlock();
 
 			this._buffer.input( textInsertions );
-
-			// Store the batch as an 'input' batch for the Input.isInput( batch ) check.
-			this._batches.add( this._buffer.batch );
 		} );
 	}
 }

--- a/packages/ckeditor5-typing/src/utils/injectunsafekeystrokeshandling.js
+++ b/packages/ckeditor5-typing/src/utils/injectunsafekeystrokeshandling.js
@@ -110,7 +110,10 @@ export default function injectUnsafeKeystrokesHandling( editor ) {
 
 		buffer.lock();
 
-		model.enqueueChange( buffer.batch, () => {
+		const batch = buffer.batch;
+		inputCommand._batches.add( batch );
+
+		model.enqueueChange( batch, () => {
 			model.deleteContent( model.document.selection );
 		} );
 

--- a/packages/ckeditor5-typing/tests/inputcommand.js
+++ b/packages/ckeditor5-typing/tests/inputcommand.js
@@ -12,7 +12,7 @@ import ChangeBuffer from '../src/utils/changebuffer';
 import Input from '../src/input';
 
 describe( 'InputCommand', () => {
-	let editor, model, doc, buffer;
+	let editor, model, doc, buffer, inputCommand;
 
 	testUtils.createSinonSandbox();
 
@@ -23,7 +23,7 @@ describe( 'InputCommand', () => {
 				model = editor.model;
 				doc = model.document;
 
-				const inputCommand = new InputCommand( editor, 20 );
+				inputCommand = new InputCommand( editor, 20 );
 				editor.commands.add( 'input', inputCommand );
 
 				buffer = inputCommand.buffer;
@@ -280,6 +280,28 @@ describe( 'InputCommand', () => {
 				'<paragraph>foo[]</paragraph>' +
 				'<paragraph>z</paragraph>'
 			);
+		} );
+
+		it( 'uses typing batch while removing and inserting the content', () => {
+			expect( inputCommand._batches.has( getCurrentBatch() ), 'batch before typing' ).to.equal( false );
+
+			model.on( 'deleteContent', () => {
+				expect( inputCommand._batches.has( getCurrentBatch() ), 'batch when deleting content' ).to.equal( true );
+			}, { priority: 'highest' } );
+
+			model.on( 'insertContent', () => {
+				expect( inputCommand._batches.has( getCurrentBatch() ), 'batch when inserting content' ).to.equal( true );
+			}, { priority: 'lowest' } );
+
+			setData( model, '<paragraph>[foo]</paragraph>' );
+
+			editor.execute( 'input', { text: 'bar' } );
+
+			expect( getData( model ) ).to.equal( '<paragraph>bar[]</paragraph>' );
+
+			function getCurrentBatch() {
+				return editor.model.change( writer => writer.batch );
+			}
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (link): Typing over the selected link will not remove the link itself. Instead, the typed text will replace the link text. Closes #4762.
