### PR TITLE
Introduced the Collection.addMany method and Collection.change event

### DIFF
--- a/packages/ckeditor5-font/src/documentcolorcollection.js
+++ b/packages/ckeditor5-font/src/documentcolorcollection.js
@@ -29,6 +29,10 @@ export default class DocumentColorCollection extends Collection {
 		 * @member {Boolean} #isEmpty
 		 */
 		this.set( 'isEmpty', true );
+
+		this.on( 'change', () => {
+			this.set( 'isEmpty', this.length === 0 );
+		} );
 	}
 
 	/**
@@ -44,6 +48,7 @@ export default class DocumentColorCollection extends Collection {
 	 * @param {Number} [index] The position of the item in the collection. The item
 	 * is pushed to the collection when `index` is not specified.
 	 * @fires add
+	 * @fires change
 	 */
 	add( item, index ) {
 		if ( this.find( element => element.color === item.color ) ) {
@@ -52,21 +57,6 @@ export default class DocumentColorCollection extends Collection {
 		}
 
 		super.add( item, index );
-
-		this.set( 'isEmpty', false );
-	}
-
-	/**
-	 * @inheritdoc
-	 */
-	remove( subject ) {
-		const ret = super.remove( subject );
-
-		if ( this.length === 0 ) {
-			this.set( 'isEmpty', true );
-		}
-
-		return ret;
 	}
 
 	/**

--- a/packages/ckeditor5-utils/src/collection.js
+++ b/packages/ckeditor5-utils/src/collection.js
@@ -298,7 +298,15 @@ export default class Collection {
 	 * @fires change
 	 */
 	remove( subject ) {
-		return this._remove( subject );
+		const [ item, index ] = this._remove( subject );
+
+		this.fire( 'change', {
+			added: [],
+			removed: [ item ],
+			index
+		} );
+
+		return item;
 	}
 
 	/**
@@ -656,18 +664,16 @@ export default class Collection {
 	}
 
 	/**
-	 * Removes an item from the collection.
+	 * Core {@link #remove} method implementation shared in other functions.
 	 *
-	 * This is an internal implementation allowing to skip the {@link #event:change} event.
+	 * In contrast this method **does not** fire the {@link #event:change} event.
 	 *
 	 * @private
 	 * @param {Object} subject The item to remove, its id or index in the collection.
-	 * @param {Boolean} [skipChange] If `true` no {@link #event:change} event is fired.
-	 * @returns {Object} The removed item.
+	 * @returns {Array} Returns an array with the removed item and its index.
 	 * @fires remove
-	 * @fires change
 	 */
-	_remove( subject, skipChange ) {
+	_remove( subject ) {
 		let index, id, item;
 		let itemDoesNotExist = false;
 		const idProperty = this._idProperty;
@@ -713,15 +719,7 @@ export default class Collection {
 
 		this.fire( 'remove', item, index );
 
-		if ( !skipChange ) {
-			this.fire( 'change', {
-				added: [],
-				removed: [ item ],
-				index
-			} );
-		}
-
-		return item;
+		return [ item, index ];
 	}
 
 	/**

--- a/packages/ckeditor5-utils/src/collection.js
+++ b/packages/ckeditor5-utils/src/collection.js
@@ -199,9 +199,7 @@ export default class Collection {
 	addMany( items, index ) {
 		if ( index === undefined ) {
 			index = this._items.length;
-		}
-
-		if ( index > this._items.length || index < 0 ) {
+		} else if ( index > this._items.length || index < 0 ) {
 			/**
 			 * The index number has invalid value.
 			 *
@@ -213,8 +211,8 @@ export default class Collection {
 		for ( let offset = 0; offset < items.length; offset++ ) {
 			const item = items[ offset ];
 			const itemId = this._getItemIdBeforeAdding( item );
-
 			const currentItemIndex = index + offset;
+
 			this._items.splice( currentItemIndex, 0, item );
 			this._itemMap.set( itemId, item );
 
@@ -355,7 +353,7 @@ export default class Collection {
 			this._bindToCollection = null;
 		}
 
-		const removedItems = [ ...this._items ];
+		const removedItems = Array.from( this._items );
 
 		while ( this.length ) {
 			this._remove( 0, true );
@@ -664,7 +662,7 @@ export default class Collection {
 	 *
 	 * @private
 	 * @param {Object} subject The item to remove, its id or index in the collection.
-	 * @param {Boolean} [skipChange] If `true` no change event is fired.
+	 * @param {Boolean} [skipChange] If `true` no {@link #event:change} event is fired.
 	 * @returns {Object} The removed item.
 	 * @fires remove
 	 * @fires change

--- a/packages/ckeditor5-utils/src/collection.js
+++ b/packages/ckeditor5-utils/src/collection.js
@@ -179,7 +179,7 @@ export default class Collection {
 	 * @param {Number} [index] The position of the item in the collection. The item
 	 * is pushed to the collection when `index` not specified.
 	 * @fires add
-	 * @fires addBatch
+	 * @fires change
 	 */
 	add( item, index ) {
 		return this.addMany( [ item ], index );
@@ -194,7 +194,7 @@ export default class Collection {
 	 * @param {Iterable.<Object>} item
 	 * @param {Number} [index] The position of the insertion. Items will be appended if no `index` is specified.
 	 * @fires add
-	 * @fires addBatch
+	 * @fires change
 	 */
 	addMany( items, index ) {
 		if ( index === undefined ) {
@@ -221,7 +221,11 @@ export default class Collection {
 			this.fire( 'add', item, currentItemIndex );
 		}
 
-		this.fire( 'addBatch', items, index );
+		this.fire( 'change', {
+			added: items,
+			removed: [],
+			index
+		} );
 
 		return this;
 	}
@@ -700,6 +704,15 @@ export default class Collection {
 	 *
 	 * @event add
 	 * @param {Object} item The added item.
+	 */
+
+	/**
+	 * Fired when the collection was changed due to adding or removing items.
+	 *
+	 * @event change
+	 * @param {Iterable.<Object>} added List of added items.
+	 * @param {Iterable.<Object>} removed List of removed items.
+	 * @param {Number} index Index where the addition or removal occurred.
 	 */
 
 	/**

--- a/packages/ckeditor5-utils/src/collection.js
+++ b/packages/ckeditor5-utils/src/collection.js
@@ -364,7 +364,7 @@ export default class Collection {
 		const removedItems = Array.from( this._items );
 
 		while ( this.length ) {
-			this._remove( 0, true );
+			this._remove( 0 );
 		}
 
 		this.fire( 'change', {

--- a/packages/ckeditor5-utils/src/collection.js
+++ b/packages/ckeditor5-utils/src/collection.js
@@ -352,7 +352,7 @@ export default class Collection {
 			this._bindToCollection = null;
 		}
 
-		const removedItems = this._items.concat( [] );
+		const removedItems = [ ...this._items ];
 
 		while ( this.length ) {
 			this._remove( 0, true );

--- a/packages/ckeditor5-utils/src/collection.js
+++ b/packages/ckeditor5-utils/src/collection.js
@@ -294,7 +294,7 @@ export default class Collection {
 	/**
 	 * Removes an item from the collection.
 	 *
-	 * @param {Object} subject The item to remove, its id or index in the collection.
+	 * @param {Object|Number|String} subject The item to remove, its id or index in the collection.
 	 * @returns {Object} The removed item.
 	 * @fires remove
 	 * @fires change
@@ -345,6 +345,9 @@ export default class Collection {
 	/**
 	 * Removes all items from the collection and destroys the binding created using
 	 * {@link #bindTo}.
+	 *
+	 * @fires remove
+	 * @fires change
 	 */
 	clear() {
 		if ( this._bindToCollection ) {
@@ -743,9 +746,9 @@ export default class Collection {
 	 * Fired when the collection was changed due to adding or removing items.
 	 *
 	 * @event change
-	 * @param {Iterable.<Object>} added List of added items.
-	 * @param {Iterable.<Object>} removed List of removed items.
-	 * @param {Number} index Index where the addition or removal occurred.
+	 * @param {Iterable.<Object>} added A list of added items.
+	 * @param {Iterable.<Object>} removed A list of removed items.
+	 * @param {Number} index An index where the addition or removal occurred.
 	 */
 
 	/**

--- a/packages/ckeditor5-utils/src/collection.js
+++ b/packages/ckeditor5-utils/src/collection.js
@@ -179,14 +179,29 @@ export default class Collection {
 	 * @param {Number} [index] The position of the item in the collection. The item
 	 * is pushed to the collection when `index` not specified.
 	 * @fires add
+	 * @fires addBatch
 	 */
 	add( item, index ) {
-		const itemId = this._getItemIdBeforeAdding( item );
+		return this.addBatch( [ item ], index );
+	}
 
-		// TODO: Use ES6 default function argument.
+	/**
+	 * Adds multiple items into the collection.
+	 *
+	 * Any item not containing an id will get an automatically generated one.
+	 *
+	 * @chainable
+	 * @param {Iterable.<Object>} item
+	 * @param {Number} [index] The position of the insertion. Items will be appended if no `index` is specified.
+	 * @fires add
+	 * @fires addBatch
+	 */
+	addBatch( items, index ) {
 		if ( index === undefined ) {
 			index = this._items.length;
-		} else if ( index > this._items.length || index < 0 ) {
+		}
+
+		if ( index > this._items.length || index < 0 ) {
 			/**
 			 * The index number has invalid value.
 			 *
@@ -195,11 +210,18 @@ export default class Collection {
 			throw new CKEditorError( 'collection-add-item-invalid-index', this );
 		}
 
-		this._items.splice( index, 0, item );
+		for ( let offset = 0; offset < items.length; offset++ ) {
+			const item = items[ offset ];
+			const itemId = this._getItemIdBeforeAdding( item );
 
-		this._itemMap.set( itemId, item );
+			const currentItemIndex = index + offset;
+			this._items.splice( currentItemIndex, 0, item );
+			this._itemMap.set( itemId, item );
 
-		this.fire( 'add', item, index );
+			this.fire( 'add', item, currentItemIndex );
+		}
+
+		this.fire( 'addBatch', items, index );
 
 		return this;
 	}

--- a/packages/ckeditor5-utils/src/collection.js
+++ b/packages/ckeditor5-utils/src/collection.js
@@ -182,7 +182,7 @@ export default class Collection {
 	 * @fires addBatch
 	 */
 	add( item, index ) {
-		return this.addBatch( [ item ], index );
+		return this.addMany( [ item ], index );
 	}
 
 	/**
@@ -196,7 +196,7 @@ export default class Collection {
 	 * @fires add
 	 * @fires addBatch
 	 */
-	addBatch( items, index ) {
+	addMany( items, index ) {
 		if ( index === undefined ) {
 			index = this._items.length;
 		}

--- a/packages/ckeditor5-utils/tests/collection.js
+++ b/packages/ckeditor5-utils/tests/collection.js
@@ -391,7 +391,7 @@ describe( 'Collection', () => {
 
 			collection.addMany( items );
 
-			expect( spy.callCount, 'call count' ).to.equal( 1 );
+			sinon.assert.calledOnce( spy );
 			expect( spy.args[ 0 ][ 1 ] ).to.deep.eql( {
 				added: items,
 				removed: [],
@@ -638,6 +638,23 @@ describe( 'Collection', () => {
 			sinon.assert.calledWithExactly( spy, sinon.match.has( 'source', collection ), item3, 0 );
 		} );
 
+		it( 'should fire the "change" event', () => {
+			const item = getItem( 'foo' );
+			const spy = sinon.spy();
+
+			collection.add( item );
+			collection.on( 'change', spy );
+
+			collection.remove( item );
+
+			sinon.assert.calledOnce( spy );
+			expect( spy.args[ 0 ][ 1 ] ).to.deep.eql( {
+				added: [],
+				removed: [ item ],
+				index: 0
+			} );
+		} );
+
 		it( 'should throw an error on invalid index', () => {
 			collection.add( getItem( 'foo' ) );
 
@@ -747,6 +764,24 @@ describe( 'Collection', () => {
 			expect( collection ).to.have.length( 0 );
 
 			expect( collection._bindToCollection ).to.be.null;
+		} );
+
+		it( 'should fire the "change" event', () => {
+			const items = [ {}, {}, {} ];
+			const spy = sinon.spy();
+
+			collection.addMany( items );
+			collection.on( 'change', spy );
+
+			collection.clear();
+
+			sinon.assert.calledOnce( spy );
+
+			expect( spy.args[ 0 ][ 1 ] ).to.deep.eql( {
+				added: [],
+				removed: items,
+				index: 0
+			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-utils/tests/collection.js
+++ b/packages/ckeditor5-utils/tests/collection.js
@@ -383,29 +383,39 @@ describe( 'Collection', () => {
 			sinon.assert.calledWithExactly( spy, sinon.match.has( 'source', collection ), item, 1 );
 		} );
 
-		it( 'should fire the "addBatch" event', () => {
+		it( 'should fire the "change" event', () => {
 			const spy = sinon.spy();
 			const items = [ {}, {} ];
 
-			collection.on( 'addBatch', spy );
+			collection.on( 'change', spy );
 
 			collection.addMany( items );
 
-			sinon.assert.calledWithExactly( spy, sinon.match.has( 'source', collection ), items, 0 );
+			expect( spy.callCount, 'call count' ).to.equal( 1 );
+			expect( spy.args[ 0 ][ 1 ] ).to.deep.eql( {
+				added: items,
+				removed: [],
+				index: 0
+			} );
 		} );
 
-		it( 'should fire the "addBatch" event with the index argument', () => {
+		it( 'should fire the "change" event with the index argument', () => {
 			const spy = sinon.spy();
 			const firstBatch = [ {}, {} ];
 			const secondBatch = [ {}, {} ];
 
 			collection.addMany( firstBatch );
 
-			collection.on( 'addBatch', spy );
+			collection.on( 'change', spy );
 
 			collection.addMany( secondBatch, 1 );
 
-			sinon.assert.calledWithExactly( spy, sinon.match.has( 'source', collection ), secondBatch, 1 );
+			expect( spy.callCount, 'call count' ).to.equal( 1 );
+			expect( spy.args[ 0 ][ 1 ] ).to.deep.eql( {
+				added: secondBatch,
+				removed: [],
+				index: 1
+			} );
 		} );
 
 		it( 'should support an optional index argument', () => {

--- a/packages/ckeditor5-utils/tests/collection.js
+++ b/packages/ckeditor5-utils/tests/collection.js
@@ -148,8 +148,8 @@ describe( 'Collection', () => {
 	} );
 
 	describe( 'add()', () => {
-		it( 'should proxy its calls to addBatch', () => {
-			const spy = sinon.spy( collection, 'addBatch' );
+		it( 'should proxy its calls to addMany', () => {
+			const spy = sinon.spy( collection, 'addMany' );
 			const item = {};
 
 			collection.add( item );
@@ -159,7 +159,7 @@ describe( 'Collection', () => {
 		} );
 
 		it( 'should proxy custom index', () => {
-			const stub = sinon.stub( collection, 'addBatch' );
+			const stub = sinon.stub( collection, 'addMany' );
 			const item = {};
 
 			collection.add( item, 5 );
@@ -170,7 +170,7 @@ describe( 'Collection', () => {
 
 		it( 'should proxy returned value', () => {
 			const expectedReturn = {};
-			sinon.stub( collection, 'addBatch' ).returns( expectedReturn );
+			sinon.stub( collection, 'addMany' ).returns( expectedReturn );
 
 			expect( collection.add( 1 ) ).to.equal( expectedReturn );
 		} );
@@ -186,18 +186,18 @@ describe( 'Collection', () => {
 		} );
 	} );
 
-	describe( 'addBatch()', () => {
+	describe( 'addMany()', () => {
 		it( 'should be chainable', () => {
-			expect( collection.addBatch( [ {} ] ) ).to.equal( collection );
+			expect( collection.addMany( [ {} ] ) ).to.equal( collection );
 		} );
 
 		it( 'should change the length', () => {
 			expect( collection ).to.have.length( 0 );
 
-			collection.addBatch( [ {}, {} ] );
+			collection.addMany( [ {}, {} ] );
 			expect( collection ).to.have.length( 2 );
 
-			collection.addBatch( [ {} ] );
+			collection.addMany( [ {} ] );
 			expect( collection ).to.have.length( 3 );
 		} );
 
@@ -205,7 +205,7 @@ describe( 'Collection', () => {
 			const item1 = {};
 			const item2 = {};
 
-			collection.addBatch( [ item1, item2 ] );
+			collection.addMany( [ item1, item2 ] );
 			expect( collection.get( 0 ) ).to.equal( item1 );
 			expect( collection.get( 1 ) ).to.equal( item2 );
 		} );
@@ -214,7 +214,7 @@ describe( 'Collection', () => {
 			const item1 = getItem( 'foo' );
 			const item2 = getItem( 'bar' );
 
-			collection.addBatch( [ item1, item2 ] );
+			collection.addMany( [ item1, item2 ] );
 
 			expect( collection.get( 'foo' ) ).to.equal( item1 );
 			expect( collection.get( 'bar' ) ).to.equal( item2 );
@@ -235,7 +235,7 @@ describe( 'Collection', () => {
 		it( 'should generate an id when not defined', () => {
 			const item = {};
 
-			collection.addBatch( [ item ] );
+			collection.addMany( [ item ] );
 
 			expect( item.id ).to.be.a( 'string' );
 			expect( collection.get( item.id ) ).to.equal( item );
@@ -245,7 +245,7 @@ describe( 'Collection', () => {
 			const collection = new Collection( { idProperty: 'name' } );
 			const item = {};
 
-			collection.addBatch( [ item ] );
+			collection.addMany( [ item ] );
 
 			expect( item.name ).to.be.a( 'string' );
 			expect( collection.get( item.name ) ).to.equal( item );
@@ -254,7 +254,7 @@ describe( 'Collection', () => {
 		it( 'should not change an existing id of an item', () => {
 			const item = getItem( 'foo' );
 
-			collection.addBatch( [ item ] );
+			collection.addMany( [ item ] );
 
 			expect( item.id ).to.equal( 'foo' );
 		} );
@@ -263,7 +263,7 @@ describe( 'Collection', () => {
 			const item1 = getItem( 'foo' );
 
 			expectToThrowCKEditorError( () => {
-				collection.addBatch( [ item1, item1 ] );
+				collection.addMany( [ item1, item1 ] );
 			}, /^collection-add-item-already-exists/ );
 		} );
 
@@ -271,10 +271,10 @@ describe( 'Collection', () => {
 			const item1 = getItem( 'foo' );
 			const item2 = getItem( 'foo' );
 
-			collection.addBatch( [ item1 ] );
+			collection.addMany( [ item1 ] );
 
 			expectToThrowCKEditorError( () => {
-				collection.addBatch( [ item2 ] );
+				collection.addMany( [ item2 ] );
 			}, /^collection-add-item-already-exists/ );
 		} );
 
@@ -282,7 +282,7 @@ describe( 'Collection', () => {
 			const item = { id: 1 };
 
 			expectToThrowCKEditorError( () => {
-				collection.addBatch( [ item ] );
+				collection.addMany( [ item ] );
 			}, /^collection-add-invalid-id/ );
 		} );
 
@@ -295,9 +295,9 @@ describe( 'Collection', () => {
 				const itemA = {};
 				const itemB = {};
 
-				collectionA.addBatch( [ itemA ] );
-				collectionB.addBatch( [ itemB ] );
-				collectionB.addBatch( [ collectionA.remove( itemA ) ] );
+				collectionA.addMany( [ itemA ] );
+				collectionB.addMany( [ itemB ] );
+				collectionB.addMany( [ collectionA.remove( itemA ) ] );
 
 				expect( collectionA.length ).to.equal( 0 );
 				expect( collectionB.length ).to.equal( 2 );
@@ -318,9 +318,9 @@ describe( 'Collection', () => {
 				const itemA = {};
 				const itemB = {};
 
-				collectionA.addBatch( [ itemA ] );
-				collectionB.addBatch( [ itemB ] );
-				collectionB.addBatch( [ collectionA.remove( itemA ) ] );
+				collectionA.addMany( [ itemA ] );
+				collectionB.addMany( [ itemB ] );
+				collectionB.addMany( [ collectionA.remove( itemA ) ] );
 
 				expect( collectionA.length ).to.equal( 0 );
 				expect( collectionB.length ).to.equal( 2 );
@@ -336,8 +336,8 @@ describe( 'Collection', () => {
 			const collectionB = new Collection();
 			const item = {};
 
-			collectionA.addBatch( [ item ] );
-			collectionB.addBatch( [ item ] );
+			collectionA.addMany( [ item ] );
+			collectionB.addMany( [ item ] );
 
 			expect( collectionA.length ).to.equal( 1 );
 			expect( collectionB.length ).to.equal( 1 );
@@ -350,7 +350,7 @@ describe( 'Collection', () => {
 
 			collection.on( 'add', spy );
 
-			collection.addBatch( [ item ] );
+			collection.addMany( [ item ] );
 
 			sinon.assert.calledWithExactly( spy, sinon.match.has( 'source', collection ), item, 0 );
 		} );
@@ -361,7 +361,7 @@ describe( 'Collection', () => {
 
 			collection.on( 'add', spy );
 
-			collection.addBatch( items );
+			collection.addMany( items );
 
 			sinon.assert.calledWithExactly( spy, sinon.match.has( 'source', collection ), items[ 0 ], 0 );
 			sinon.assert.calledWithExactly( spy, sinon.match.has( 'source', collection ), items[ 1 ], 1 );
@@ -372,13 +372,13 @@ describe( 'Collection', () => {
 		it( 'should fire the "add" event with the index argument', () => {
 			const spy = sinon.spy();
 
-			collection.addBatch( [ {} ] );
-			collection.addBatch( [ {} ] );
+			collection.addMany( [ {} ] );
+			collection.addMany( [ {} ] );
 
 			collection.on( 'add', spy );
 
 			const item = {};
-			collection.addBatch( [ item ], 1 );
+			collection.addMany( [ item ], 1 );
 
 			sinon.assert.calledWithExactly( spy, sinon.match.has( 'source', collection ), item, 1 );
 		} );
@@ -389,7 +389,7 @@ describe( 'Collection', () => {
 
 			collection.on( 'addBatch', spy );
 
-			collection.addBatch( items );
+			collection.addMany( items );
 
 			sinon.assert.calledWithExactly( spy, sinon.match.has( 'source', collection ), items, 0 );
 		} );
@@ -399,11 +399,11 @@ describe( 'Collection', () => {
 			const firstBatch = [ {}, {} ];
 			const secondBatch = [ {}, {} ];
 
-			collection.addBatch( firstBatch );
+			collection.addMany( firstBatch );
 
 			collection.on( 'addBatch', spy );
 
-			collection.addBatch( secondBatch, 1 );
+			collection.addMany( secondBatch, 1 );
 
 			sinon.assert.calledWithExactly( spy, sinon.match.has( 'source', collection ), secondBatch, 1 );
 		} );
@@ -414,10 +414,10 @@ describe( 'Collection', () => {
 			const item3 = getItem( 'baz' );
 			const item4 = getItem( 'abc' );
 
-			collection.addBatch( [ item1 ] );
-			collection.addBatch( [ item2 ], 0 );
-			collection.addBatch( [ item3 ], 1 );
-			collection.addBatch( [ item4 ], 3 );
+			collection.addMany( [ item1 ] );
+			collection.addMany( [ item2 ], 0 );
+			collection.addMany( [ item3 ], 1 );
+			collection.addMany( [ item4 ], 3 );
 
 			expect( collection.get( 0 ) ).to.equal( item2 );
 			expect( collection.get( 1 ) ).to.equal( item3 );
@@ -430,18 +430,18 @@ describe( 'Collection', () => {
 			const item2 = getItem( 'bar' );
 			const item3 = getItem( 'baz' );
 
-			collection.addBatch( [ item1 ] );
+			collection.addMany( [ item1 ] );
 
 			expectToThrowCKEditorError( () => {
-				collection.addBatch( [ item2 ], -1 );
+				collection.addMany( [ item2 ], -1 );
 			}, /^collection-add-item-invalid-index/ );
 
 			expectToThrowCKEditorError( () => {
-				collection.addBatch( [ item2 ], 2 );
+				collection.addMany( [ item2 ], 2 );
 			}, /^collection-add-item-invalid-index/ );
 
-			collection.addBatch( [ item2 ], 1 );
-			collection.addBatch( [ item3 ], 0 );
+			collection.addMany( [ item2 ], 1 );
+			collection.addMany( [ item3 ], 0 );
 
 			expect( collection.length ).to.equal( 3 );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature: Introduced the `Collection.addMany()` method for adding multiple items in a single call. Closes #7627.

Feature: Introduced the `Collection.change` event. See #7627.

---

### Additional information

With this I was also able to simplify `DocumentColorCollection` by using new `change` event.

`clear()` method uses almost the entire `remove()` logic except that it must not fire `change` for each removal. Thus I extracted a private base of `remove()` that can be reused in both cases.