### PR TITLE
#7633: Resizer#redraw() should not change the editing view unless a different size should be set

### DIFF
--- a/packages/ckeditor5-widget/tests/widgetresize/resizer.js
+++ b/packages/ckeditor5-widget/tests/widgetresize/resizer.js
@@ -131,6 +131,36 @@ describe( 'Resizer', () => {
 			// Cleanup.
 			renderedElement.remove();
 		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/7633
+		it( 'should not cause changes in the view unless the host size actually changed', () => {
+			const resizerInstance = createResizer( {
+				getHandleHost: widgetWrapper => widgetWrapper
+			} );
+
+			resizerInstance.attach();
+			const renderedElement = resizerInstance._viewResizerWrapper.render( document );
+
+			document.body.appendChild( renderedElement );
+
+			const viewChangeSpy = sinon.spy( editor.editing.view, 'change' );
+
+			resizerInstance.redraw();
+			sinon.assert.calledOnce( viewChangeSpy );
+
+			resizerInstance.redraw();
+			sinon.assert.calledOnce( viewChangeSpy );
+
+			const host = resizerInstance._getHandleHost();
+
+			host.style.width = '123px';
+
+			resizerInstance.redraw();
+			sinon.assert.calledTwice( viewChangeSpy );
+
+			// Cleanup.
+			renderedElement.remove();
+		} );
 	} );
 
 	describe( '_proposeNewSize()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix: `Resizer#redraw()` should not change the editing view unless a different size should be set. Closes #7633.