### PR TITLE
Improved removing content after a link element

### DIFF
--- a/packages/ckeditor5-link/src/linkediting.js
+++ b/packages/ckeditor5-link/src/linkediting.js
@@ -444,7 +444,7 @@ export default class LinkEditing extends Plugin {
 	 * the {@link module:typing/twostepcaretmovement~TwoStepCaretMovement} plugin is active and
 	 * the selection has the "linkHref" attribute due to overriden gravity (at the end), the `linkHref` attribute should stay untouched.
 	 *
-	 * The purpose of this action is to allow removing the link label and keep the selection outside the link.
+	 * The purpose of this action is to allow removing the link text and keep the selection outside the link.
 	 *
 	 * See https://github.com/ckeditor/ckeditor5/issues/7521.
 	 *

--- a/packages/ckeditor5-link/src/linkediting.js
+++ b/packages/ckeditor5-link/src/linkediting.js
@@ -436,11 +436,11 @@ export default class LinkEditing extends Plugin {
 
 	/**
 	 * Starts listening to {@link module:engine/model/model~Model#deleteContent} and checks whether
-	 * removing a content after a link element.
+	 * removing a content right after the "linkHref" attribute.
 	 *
 	 * If so, the selection should not preserve the `linkHref` attribute. However, if
-	 * {@link module:typing/twostepcaretmovement~TwoStepCaretMovement} plugin is activated and
-	 * the selection is inside the link, at the end, the `linkHref` attribute should stay untouched.
+	 * the {@link module:typing/twostepcaretmovement~TwoStepCaretMovement} plugin is active and
+	 * the selection has the "linkHref" attribute due to overriden gravity (at the end), the `linkHref` attribute should stay untouched.
 	 *
 	 * The purpose of this action is to allow removing the link label and keep the selection outside the link.
 	 *

--- a/packages/ckeditor5-link/src/linkediting.js
+++ b/packages/ckeditor5-link/src/linkediting.js
@@ -119,7 +119,7 @@ export default class LinkEditing extends Plugin {
 		this._enableTypingOverLink();
 
 		// Handle removing the content after the link element.
-		this._enableRemovingLinkAttributesWhileRemovingEndOfLink();
+		this._handleDeleteContentAfterLink();
 	}
 
 	/**
@@ -450,7 +450,7 @@ export default class LinkEditing extends Plugin {
 	 *
 	 * @private
 	 */
-	_enableRemovingLinkAttributesWhileRemovingEndOfLink() {
+	_handleDeleteContentAfterLink() {
 		const editor = this.editor;
 		const model = editor.model;
 		const selection = model.document.selection;

--- a/packages/ckeditor5-link/src/linkediting.js
+++ b/packages/ckeditor5-link/src/linkediting.js
@@ -227,6 +227,7 @@ export default class LinkEditing extends Plugin {
 		const editor = this.editor;
 		const model = editor.model;
 		const selection = model.document.selection;
+		const linkCommand = editor.commands.get( 'link' );
 
 		this.listenTo( model, 'insertContent', () => {
 			const nodeBefore = selection.anchor.nodeBefore;
@@ -296,7 +297,7 @@ export default class LinkEditing extends Plugin {
 			}
 
 			model.change( writer => {
-				removeLinkAttributesFromSelection( writer, editor.commands.get( 'link' ) );
+				removeLinkAttributesFromSelection( writer, linkCommand.manualDecorators );
 			} );
 		}, { priority: 'low' } );
 	}
@@ -314,6 +315,7 @@ export default class LinkEditing extends Plugin {
 	 */
 	_enableClickingAfterLink() {
 		const editor = this.editor;
+		const linkCommand = editor.commands.get( 'link' );
 
 		editor.editing.view.addObserver( MouseObserver );
 
@@ -352,7 +354,7 @@ export default class LinkEditing extends Plugin {
 			// If so, remove the `linkHref` attribute.
 			if ( position.isTouching( linkRange.start ) || position.isTouching( linkRange.end ) ) {
 				editor.model.change( writer => {
-					removeLinkAttributesFromSelection( writer, editor.commands.get( 'link' ) );
+					removeLinkAttributesFromSelection( writer, linkCommand.manualDecorators );
 				} );
 			}
 		} );
@@ -453,6 +455,7 @@ export default class LinkEditing extends Plugin {
 		const model = editor.model;
 		const selection = model.document.selection;
 		const view = editor.editing.view;
+		const linkCommand = editor.commands.get( 'link' );
 
 		// A flag whether attributes `linkHref` attribute should be preserved.
 		let shouldPreserveAttributes = false;
@@ -501,7 +504,7 @@ export default class LinkEditing extends Plugin {
 
 			// Use `model.enqueueChange()` in order to execute the callback at the end of the changes process.
 			editor.model.enqueueChange( writer => {
-				removeLinkAttributesFromSelection( writer, editor.commands.get( 'link' ) );
+				removeLinkAttributesFromSelection( writer, linkCommand.manualDecorators );
 			} );
 		}, { priority: 'low' } );
 	}
@@ -512,12 +515,12 @@ export default class LinkEditing extends Plugin {
 // but also all decorator attributes (they have dynamic names).
 //
 // @param {module:engine/model/writer~Writer} writer
-// @param {module:link/linkcommand~LinkCommand} linkCommand
-function removeLinkAttributesFromSelection( writer, linkCommand ) {
+// @param {module:utils/collection~Collection} manualDecorators
+function removeLinkAttributesFromSelection( writer, manualDecorators ) {
 	writer.removeSelectionAttribute( 'linkHref' );
 
-	for ( const manualDecorator of linkCommand.manualDecorators ) {
-		writer.removeSelectionAttribute( manualDecorator.id );
+	for ( const decorator of manualDecorators ) {
+		writer.removeSelectionAttribute( decorator.id );
 	}
 }
 

--- a/packages/ckeditor5-link/src/linkediting.js
+++ b/packages/ckeditor5-link/src/linkediting.js
@@ -17,7 +17,6 @@ import LinkCommand from './linkcommand';
 import UnlinkCommand from './unlinkcommand';
 import ManualDecorator from './utils/manualdecorator';
 import findAttributeRange from '@ckeditor/ckeditor5-typing/src/utils/findattributerange';
-import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import { createLinkElement, ensureSafeUrl, getLocalizedDecorators, normalizeDecorators } from './utils';
 
 import '../theme/link.css';
@@ -454,19 +453,10 @@ export default class LinkEditing extends Plugin {
 		const editor = this.editor;
 		const model = editor.model;
 		const selection = model.document.selection;
-		const view = editor.editing.view;
 		const linkCommand = editor.commands.get( 'link' );
 
 		// A flag whether attributes `linkHref` attribute should be preserved.
 		let shouldPreserveAttributes = false;
-
-		// A flag whether the `Backspace` key was pressed.
-		let hasBackspacePressed = false;
-
-		// Detect pressing `Backspace`.
-		this.listenTo( view.document, 'delete', ( evt, data ) => {
-			hasBackspacePressed = data.domEvent.keyCode === keyCodes.backspace;
-		}, { priority: 'high' } );
 
 		// Before removing the content, check whether the selection is inside a link or at the end of link but with 2-SCM enabled.
 		// If so, we want to preserve link attributes.
@@ -490,13 +480,6 @@ export default class LinkEditing extends Plugin {
 
 		// After removing the content, check whether the current selection should preserve the `linkHref` attribute.
 		this.listenTo( model, 'deleteContent', () => {
-			// If didn't press `Backspace`.
-			if ( !hasBackspacePressed ) {
-				return;
-			}
-
-			hasBackspacePressed = false;
-
 			// Disable the mechanism if inside a link (`<$text url="foo">F[]oo</$text>` or <$text url="foo">Foo[]</$text>`).
 			if ( shouldPreserveAttributes ) {
 				return;

--- a/packages/ckeditor5-link/tests/linkediting.js
+++ b/packages/ckeditor5-link/tests/linkediting.js
@@ -1469,6 +1469,50 @@ describe( 'LinkEditing', () => {
 			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">Ba</$text>[]</paragraph>' );
 		} );
 
+		it( 'should not preserve the `linkHref` attribute when deleting content after the link (decorators check)', () => {
+			setModelData( model,
+				'<paragraph>' +
+					'This is ' +
+					'<$text linkIsFoo="true" linkIsBar="true" linkHref="foo">Foo</$text>' +
+					' []from ' +
+					'<$text linkHref="bar">Bar</$text>' +
+					'.' +
+				'</paragraph>'
+			);
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial "linkHref" state' ).to.equal( false );
+			expect( model.document.selection.hasAttribute( 'linkIsFoo' ), 'initial "linkIsFoo" state' ).to.equal( false );
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial "linkHref" state' ).to.equal( false );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.backspace,
+				preventDefault: () => {}
+			} ) );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link ("linkHref")' ).to.equal( false );
+			expect( model.document.selection.hasAttribute( 'linkIsFoo' ), 'removing space after the link ("linkIsFoo")' ).to.equal( false );
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link ("linkHref")' ).to.equal( false );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.backspace,
+				preventDefault: () => {}
+			} ) );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing a character the link ("linkHref")' ).to.equal( false );
+			expect( model.document.selection.hasAttribute( 'linkIsFoo' ), 'removing a character the link ("linkIsFoo")' ).to.equal( false );
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing a character the link ("linkHref")' ).to.equal( false );
+
+			expect( getModelData( model ) ).to.equal(
+				'<paragraph>' +
+					'This is ' +
+					'<$text linkHref="foo" linkIsBar="true" linkIsFoo="true">Fo</$text>' +
+					'[]from ' +
+					'<$text linkHref="bar">Bar</$text>' +
+					'.' +
+				'</paragraph>'
+			);
+		} );
+
 		it( 'should preserve the `linkHref` attribute when deleting content while the selection is at the end of the link', () => {
 			setModelData( model, '<paragraph>Foo <$text linkHref="url">Bar []</$text></paragraph>' );
 

--- a/packages/ckeditor5-link/tests/linkediting.js
+++ b/packages/ckeditor5-link/tests/linkediting.js
@@ -1448,7 +1448,7 @@ describe( 'LinkEditing', () => {
 			await editor.destroy();
 		} );
 
-		it( 'should not preserve the `linkHref` attribute when deleting content after the link (Backspace check)', () => {
+		it( 'should not preserve the `linkHref` attribute when deleting content after the link', () => {
 			setModelData( model, '<paragraph>Foo <$text linkHref="url">Bar</$text> []</paragraph>' );
 
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( false );
@@ -1467,27 +1467,6 @@ describe( 'LinkEditing', () => {
 
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing a character in the link' ).to.equal( false );
 			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">Ba</$text>[]</paragraph>' );
-		} );
-
-		it( 'should not preserve the `linkHref` attribute when deleting content after the link (Delete check)', () => {
-			setModelData( model, '<paragraph>Foo <$text linkHref="url">Bar</$text>[ ]</paragraph>' );
-
-			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( false );
-
-			view.document.fire( 'delete', new DomEventData( view.document, {
-				keyCode: keyCodes.delete,
-				preventDefault: () => {}
-			}, { direction: 'forward' } ) );
-
-			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( false );
-
-			view.document.fire( 'delete', new DomEventData( view.document, {
-				keyCode: keyCodes.backspace,
-				preventDefault: () => {}
-			}, { direction: 'forward' } ) );
-
-			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing a character in the link' ).to.equal( false );
-			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">Bar</$text>[]</paragraph>' );
 		} );
 
 		it( 'should not preserve the `linkHref` attribute when deleting content after the link (decorators check)', () => {
@@ -1555,7 +1534,7 @@ describe( 'LinkEditing', () => {
 			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">Ba[]</$text></paragraph>' );
 		} );
 
-		it( 'should preserve the `linkHref` attribute when deleting content while the selection is inside the link (Backspace)', () => {
+		it( 'should preserve the `linkHref` attribute when deleting content while the selection is inside the link', () => {
 			setModelData( model, '<paragraph>Foo <$text linkHref="url">A long URLLs[] description</$text></paragraph>' );
 
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( true );
@@ -1576,27 +1555,6 @@ describe( 'LinkEditing', () => {
 			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">A long URL[] description</$text></paragraph>' );
 		} );
 
-		it( 'should preserve the `linkHref` attribute when deleting content while the selection is inside the link (Delete)', () => {
-			setModelData( model, '<paragraph>Foo <$text linkHref="url">A long URL[]Ls description</$text></paragraph>' );
-
-			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( true );
-
-			view.document.fire( 'delete', new DomEventData( view.document, {
-				keyCode: keyCodes.delete,
-				preventDefault: () => {}
-			}, { direction: 'forward' } ) );
-
-			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( true );
-
-			view.document.fire( 'delete', new DomEventData( view.document, {
-				keyCode: keyCodes.delete,
-				preventDefault: () => {}
-			}, { direction: 'forward' } ) );
-
-			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing a character in the link' ).to.equal( true );
-			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">A long URL[] description</$text></paragraph>' );
-		} );
-
 		it( 'should do nothing if there is no `linkHref` attribute', () => {
 			setModelData( model, '<paragraph>Foo <$text bold="true">Bolded.</$text> []Bar</paragraph>' );
 
@@ -1611,6 +1569,21 @@ describe( 'LinkEditing', () => {
 			} ) );
 
 			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text bold="true">Bolded[]</$text>Bar</paragraph>' );
+		} );
+
+		it( 'should preserve the `linkHref` attribute when deleting content using "Delete" key', () => {
+			setModelData( model, '<paragraph>Foo <$text linkHref="url">Bar</$text>[ ]</paragraph>' );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( false );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.delete,
+				preventDefault: () => {}
+			}, { direction: 'forward' } ) );
+
+			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">Bar[]</$text></paragraph>' );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( true );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-link/tests/linkediting.js
+++ b/packages/ckeditor5-link/tests/linkediting.js
@@ -1448,7 +1448,7 @@ describe( 'LinkEditing', () => {
 			await editor.destroy();
 		} );
 
-		it( 'should not preserve the `linkHref` attribute when deleting content after the link', () => {
+		it( 'should not preserve the `linkHref` attribute when deleting content after the link (Backspace check)', () => {
 			setModelData( model, '<paragraph>Foo <$text linkHref="url">Bar</$text> []</paragraph>' );
 
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( false );
@@ -1467,6 +1467,27 @@ describe( 'LinkEditing', () => {
 
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing a character in the link' ).to.equal( false );
 			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">Ba</$text>[]</paragraph>' );
+		} );
+
+		it( 'should not preserve the `linkHref` attribute when deleting content after the link (Delete check)', () => {
+			setModelData( model, '<paragraph>Foo <$text linkHref="url">Bar</$text>[ ]</paragraph>' );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( false );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.delete,
+				preventDefault: () => {}
+			}, { direction: 'forward' } ) );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( false );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.backspace,
+				preventDefault: () => {}
+			}, { direction: 'forward' } ) );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing a character in the link' ).to.equal( false );
+			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">Bar</$text>[]</paragraph>' );
 		} );
 
 		it( 'should not preserve the `linkHref` attribute when deleting content after the link (decorators check)', () => {
@@ -1534,7 +1555,7 @@ describe( 'LinkEditing', () => {
 			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">Ba[]</$text></paragraph>' );
 		} );
 
-		it( 'should preserve the `linkHref` attribute when deleting content while the selection is inside the link', () => {
+		it( 'should preserve the `linkHref` attribute when deleting content while the selection is inside the link (Backspace)', () => {
 			setModelData( model, '<paragraph>Foo <$text linkHref="url">A long URLLs[] description</$text></paragraph>' );
 
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( true );
@@ -1555,6 +1576,27 @@ describe( 'LinkEditing', () => {
 			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">A long URL[] description</$text></paragraph>' );
 		} );
 
+		it( 'should preserve the `linkHref` attribute when deleting content while the selection is inside the link (Delete)', () => {
+			setModelData( model, '<paragraph>Foo <$text linkHref="url">A long URL[]Ls description</$text></paragraph>' );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( true );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.delete,
+				preventDefault: () => {}
+			}, { direction: 'forward' } ) );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( true );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.delete,
+				preventDefault: () => {}
+			}, { direction: 'forward' } ) );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing a character in the link' ).to.equal( true );
+			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">A long URL[] description</$text></paragraph>' );
+		} );
+
 		it( 'should do nothing if there is no `linkHref` attribute', () => {
 			setModelData( model, '<paragraph>Foo <$text bold="true">Bolded.</$text> []Bar</paragraph>' );
 
@@ -1569,21 +1611,6 @@ describe( 'LinkEditing', () => {
 			} ) );
 
 			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text bold="true">Bolded[]</$text>Bar</paragraph>' );
-		} );
-
-		it( 'should preserve the `linkHref` attribute when deleting content using "Delete" key', () => {
-			setModelData( model, '<paragraph>Foo <$text linkHref="url">Bar</$text>[ ]</paragraph>' );
-
-			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( false );
-
-			view.document.fire( 'delete', new DomEventData( view.document, {
-				keyCode: keyCodes.delete,
-				preventDefault: () => {}
-			}, { direction: 'forward' } ) );
-
-			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">Bar[]</$text></paragraph>' );
-
-			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( true );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-link/tests/linkediting.js
+++ b/packages/ckeditor5-link/tests/linkediting.js
@@ -17,6 +17,7 @@ import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventd
 import ImageEditing from '@ckeditor/ckeditor5-image/src/image/imageediting';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Input from '@ckeditor/ckeditor5-typing/src/input';
+import Delete from '@ckeditor/ckeditor5-typing/src/delete';
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
@@ -1405,5 +1406,140 @@ describe( 'LinkEditing', () => {
 				setData() {}
 			};
 		}
+	} );
+
+	// https://github.com/ckeditor/ckeditor5/issues/7521
+	describe( 'removing a character before the link element', () => {
+		let editor;
+
+		beforeEach( async () => {
+			editor = await ClassicTestEditor.create( element, {
+				plugins: [ Paragraph, LinkEditing, Delete, BoldEditing ],
+				link: {
+					decorators: {
+						isFoo: {
+							mode: 'manual',
+							label: 'Foo',
+							attributes: {
+								class: 'foo'
+							}
+						},
+						isBar: {
+							mode: 'manual',
+							label: 'Bar',
+							attributes: {
+								target: '_blank'
+							}
+						}
+					}
+				}
+			} );
+
+			model = editor.model;
+			view = editor.editing.view;
+
+			model.schema.extend( '$text', {
+				allowIn: '$root',
+				allowAttributes: [ 'linkIsFoo', 'linkIsBar' ]
+			} );
+		} );
+
+		afterEach( async () => {
+			await editor.destroy();
+		} );
+
+		it( 'should not preserve the `linkHref` attribute when deleting content after the link', () => {
+			setModelData( model, '<paragraph>Foo <$text linkHref="url">Bar</$text> []</paragraph>' );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( false );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.backspace,
+				preventDefault: () => {}
+			} ) );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( false );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.backspace,
+				preventDefault: () => {}
+			} ) );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing a character in the link' ).to.equal( false );
+			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">Ba</$text>[]</paragraph>' );
+		} );
+
+		it( 'should preserve the `linkHref` attribute when deleting content while the selection is at the end of the link', () => {
+			setModelData( model, '<paragraph>Foo <$text linkHref="url">Bar []</$text></paragraph>' );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( true );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.backspace,
+				preventDefault: () => {}
+			} ) );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( true );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.backspace,
+				preventDefault: () => {}
+			} ) );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing a character in the link' ).to.equal( true );
+			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">Ba[]</$text></paragraph>' );
+		} );
+
+		it( 'should preserve the `linkHref` attribute when deleting content while the selection is inside the link', () => {
+			setModelData( model, '<paragraph>Foo <$text linkHref="url">A long URLLs[] description</$text></paragraph>' );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( true );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.backspace,
+				preventDefault: () => {}
+			} ) );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( true );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.backspace,
+				preventDefault: () => {}
+			} ) );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing a character in the link' ).to.equal( true );
+			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">A long URL[] description</$text></paragraph>' );
+		} );
+
+		it( 'should do nothing if there is no `linkHref` attribute', () => {
+			setModelData( model, '<paragraph>Foo <$text bold="true">Bolded.</$text> []Bar</paragraph>' );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.backspace,
+				preventDefault: () => {}
+			} ) );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.backspace,
+				preventDefault: () => {}
+			} ) );
+
+			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text bold="true">Bolded[]</$text>Bar</paragraph>' );
+		} );
+
+		it( 'should preserve the `linkHref` attribute when deleting content using "Delete" key', () => {
+			setModelData( model, '<paragraph>Foo <$text linkHref="url">Bar</$text>[ ]</paragraph>' );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( false );
+
+			view.document.fire( 'delete', new DomEventData( view.document, {
+				keyCode: keyCodes.delete,
+				preventDefault: () => {}
+			}, { direction: 'forward' } ) );
+
+			expect( getModelData( model ) ).to.equal( '<paragraph>Foo <$text linkHref="url">Bar[]</$text></paragraph>' );
+
+			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( true );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (link): When removing the content after a link element, the selection will not preserve the `linkHref` attribute (and decorators if specified). However, if the selection is placed in the link element (in the middle or at the end), those attributes will be preserved. Closes #7521.
