### PR TITLE
Increase specificity of code styles to enforce 2SCM highlight in the …

### DIFF
--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -53,6 +53,15 @@ It breaks CKEditor 5 (see how <p><code>[]</code></p> looks). */
 	display: none !important; /* Firefox is very stubborn. */
 }
 
+/* Umberto has some high specificity rules - for code highlight we need even more.. */
+.ck.ck-content code:not(.hljs) {
+	background-color: hsla(0, 0%, 78%, 0.3);
+}
+
+.ck-content code.ck-code_selected:not(.hljs) {
+	background-color: hsla(0, 0%, 78%, 0.5);
+}
+
 /* Restore default browser styles for <sub> and <sup>. */
 .ck.ck-content sub {
 	vertical-align: sub;

--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -53,11 +53,14 @@ It breaks CKEditor 5 (see how <p><code>[]</code></p> looks). */
 	display: none !important; /* Firefox is very stubborn. */
 }
 
-/* Umberto has some high specificity rules - for code highlight we need even more.. */
+/* Umberto has some high specificity rules - for code highlight we need even more.
+  See https://github.com/ckeditor/ckeditor5/issues/7671 */
 .ck.ck-content code:not(.hljs) {
 	background-color: hsla(0, 0%, 78%, 0.3);
 }
 
+/* The same as above, but for 2SCM highlight.
+  See https://github.com/ckeditor/ckeditor5/issues/7671 */
 .ck-content code.ck-code_selected:not(.hljs) {
 	background-color: hsla(0, 0%, 78%, 0.5);
 }

--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -53,18 +53,6 @@ It breaks CKEditor 5 (see how <p><code>[]</code></p> looks). */
 	display: none !important; /* Firefox is very stubborn. */
 }
 
-/* Umberto has some high specificity rules - for code highlight we need even more.
-  See https://github.com/ckeditor/ckeditor5/issues/7671 */
-.ck.ck-content code:not(.hljs) {
-	background-color: hsla(0, 0%, 78%, 0.3);
-}
-
-/* The same as above, but for 2SCM highlight.
-  See https://github.com/ckeditor/ckeditor5/issues/7671 */
-.ck-content code.ck-code_selected:not(.hljs) {
-	background-color: hsla(0, 0%, 78%, 0.5);
-}
-
 /* Restore default browser styles for <sub> and <sup>. */
 .ck.ck-content sub {
 	vertical-align: sub;

--- a/packages/ckeditor5-basic-styles/theme/code.css
+++ b/packages/ckeditor5-basic-styles/theme/code.css
@@ -9,6 +9,6 @@
 	border-radius: 2px;
 }
 
-.ck .ck-code_selected {
+.ck.ck-editor__editable .ck-code_selected  {
 	background-color: hsla(0, 0%, 78%, 0.5);
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (code): Increase the specificity of code styles to enforce 2SCM highlight in the docs. Closes #7671.

---

### Additional information

Just to double check if it is a proper solution:

![Screenshot from 2020-07-23 11-57-05](https://user-images.githubusercontent.com/247363/88274333-d44de400-ccdb-11ea-9d89-bb1a4b73ee7d.png)

