### PR TITLE
#7679: The config.image.resizeOptions should have the default value.

### DIFF
--- a/packages/ckeditor5-image/src/imageresize.js
+++ b/packages/ckeditor5-image/src/imageresize.js
@@ -139,22 +139,22 @@ export default class ImageResize extends Plugin {
  *					resizeUnit: "%",
  *					resizeOptions: [ {
  *						name: 'imageResize:original',
- *						value: null
+ *						value: null,
  *						icon: 'original'
  *					},
  *					{
  *						name: 'imageResize:25',
- *						value: '25'
+ *						value: '25',
  *						icon: 'small'
  *					},
  *					{
  *						name: 'imageResize:50',
- *						value: '50'
+ *						value: '50',
  *						icon: 'medium'
  *					},
  *					{
  *						name: 'imageResize:75',
- *						value: '75'
+ *						value: '75',
  *						icon: 'large'
  *					} ],
  *					toolbar: [ 'imageResize:25', 'imageResize:50', 'imageResize:75', 'imageResize:original', ... ],
@@ -196,6 +196,33 @@ export default class ImageResize extends Plugin {
  *			} )
  *			.then( ... )
  *			.catch( ... );
+ *
+ * **Default value**
+ *
+ * The following configuration is used by default:
+ *
+ *		resizeOptions = [
+ *			{
+ *				name: 'imageResize:original',
+ *				value: null,
+ *				icon: 'original'
+ *			},
+ *			{
+ *				name: 'imageResize:25',
+ *				value: '25',
+ *				icon: 'small'
+ *			},
+ *			{
+ *				name: 'imageResize:50',
+ *				value: '50',
+ *				icon: 'medium'
+ *			},
+ *			{
+ *				name: 'imageResize:75',
+ *				value: '75',
+ *				icon: 'large'
+ *			}
+ *		];
  *
  * @member {Array.<module:image/imageresize/imageresizebuttons~ImageResizeOption>} module:image/image~ImageConfig#resizeOptions
  */

--- a/packages/ckeditor5-image/src/imageresize/imageresizebuttons.js
+++ b/packages/ckeditor5-image/src/imageresize/imageresizebuttons.js
@@ -66,7 +66,7 @@ export default class ImageResizeButtons extends Plugin {
 		 * @type {module:image/image~ImageConfig#resizeUnit}
 		 * @default '%'
 		 */
-		this._resizeUnit = editor.config.get( 'image.resizeUnit' ) || '%';
+		this._resizeUnit = editor.config.get( 'image.resizeUnit' );
 	}
 
 	/**
@@ -76,10 +76,6 @@ export default class ImageResizeButtons extends Plugin {
 		const editor = this.editor;
 		const options = editor.config.get( 'image.resizeOptions' );
 		const command = editor.commands.get( 'imageResize' );
-
-		if ( !options ) {
-			return;
-		}
 
 		this.bind( 'isEnabled' ).to( command );
 

--- a/packages/ckeditor5-image/src/imageresize/imageresizeediting.js
+++ b/packages/ckeditor5-image/src/imageresize/imageresizeediting.js
@@ -29,6 +29,37 @@ export default class ImageResizeEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
+	constructor( editor ) {
+		super( editor );
+
+		editor.config.define( 'image', {
+			resizeUnit: '%',
+			resizeOptions: [ {
+				name: 'imageResize:original',
+				value: null,
+				icon: 'original'
+			},
+			{
+				name: 'imageResize:25',
+				value: '25',
+				icon: 'small'
+			},
+			{
+				name: 'imageResize:50',
+				value: '50',
+				icon: 'medium'
+			},
+			{
+				name: 'imageResize:75',
+				value: '75',
+				icon: 'large'
+			} ]
+		} );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
 	init() {
 		const editor = this.editor;
 		const command = new ImageResizeCommand( editor );

--- a/packages/ckeditor5-image/src/imageresize/imageresizehandles.js
+++ b/packages/ckeditor5-image/src/imageresize/imageresizehandles.js
@@ -48,7 +48,7 @@ export default class ImageResizeHandles extends Plugin {
 			const resizer = editor.plugins
 				.get( WidgetResize )
 				.attachTo( {
-					unit: editor.config.get( 'image.resizeUnit' ) || '%',
+					unit: editor.config.get( 'image.resizeUnit' ),
 
 					modelElement: data.item,
 					viewElement: widget,

--- a/packages/ckeditor5-image/tests/imageresize/imageresizebuttons.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizebuttons.js
@@ -96,23 +96,6 @@ describe( 'ImageResizeButtons', () => {
 
 			expect( plugin.isEnabled ).to.be.false;
 		} );
-
-		it( 'should not register a dropdown or buttons if no resize options passed', async () => {
-			const editor = await ClassicTestEditor
-				.create( editorElement, {
-					plugins: [ Image, ImageStyle, Paragraph, Undo, Table, ImageResizeButtons ],
-					image: {
-						resizeUnit: 'px'
-					}
-				} );
-
-			const resizeOptions = editor.config.get( 'image.resizeOptions' );
-
-			expect( resizeOptions ).to.be.undefined;
-			expect( editor.ui.componentFactory.has( 'imageResize' ) ).to.be.false;
-
-			await editor.destroy();
-		} );
 	} );
 
 	describe( 'resize options dropdown', () => {

--- a/packages/ckeditor5-image/tests/imageresize/imageresizeediting.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizeediting.js
@@ -45,6 +45,41 @@ describe( 'ImageResizeEditing', () => {
 		expect( ImageResizeEditing.pluginName ).to.equal( 'ImageResizeEditing' );
 	} );
 
+	describe( 'constructor()', () => {
+		beforeEach( async () => {
+			editor = await createEditor( {
+				plugins: [ Paragraph, Image, ImageStyle, ImageResizeEditing ]
+			} );
+		} );
+
+		it( 'should define the default value for config.image.resizeUnit', () => {
+			expect( editor.config.get( 'image.resizeUnit' ) ).to.equal( '%' );
+		} );
+
+		it( 'should define the default value for config.image.resizeOptions', () => {
+			expect( editor.config.get( 'image.resizeOptions' ) ).to.deep.equal( [ {
+				name: 'imageResize:original',
+				value: null,
+				icon: 'original'
+			},
+			{
+				name: 'imageResize:25',
+				value: '25',
+				icon: 'small'
+			},
+			{
+				name: 'imageResize:50',
+				value: '50',
+				icon: 'medium'
+			},
+			{
+				name: 'imageResize:75',
+				value: '75',
+				icon: 'large'
+			} ] );
+		} );
+	} );
+
 	describe( 'conversion', () => {
 		beforeEach( async () => {
 			editor = await createEditor();


### PR DESCRIPTION
## Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (image): The `config.image.resizeOptions` should have the default value. Closes #7679.