### PR TITLE
#2358: Block indentation should be recognized as a formatting attribute

### DIFF
--- a/packages/ckeditor5-indent/src/indentblock.js
+++ b/packages/ckeditor5-indent/src/indentblock.js
@@ -88,6 +88,8 @@ export default class IndentBlock extends Plugin {
 			}
 		} );
 
+		schema.setAttributeProperties( 'blockIndent', { isFormatting: true } );
+
 		indentCommand.registerChildCommand( editor.commands.get( 'indentBlock' ) );
 		outdentCommand.registerChildCommand( editor.commands.get( 'outdentBlock' ) );
 	}

--- a/packages/ckeditor5-indent/tests/indentblock.js
+++ b/packages/ckeditor5-indent/tests/indentblock.js
@@ -44,6 +44,8 @@ describe( 'IndentBlock', () => {
 				expect( model.schema.checkAttribute( [ 'heading1' ], 'blockIndent' ) ).to.be.true;
 				expect( model.schema.checkAttribute( [ 'heading2' ], 'blockIndent' ) ).to.be.true;
 				expect( model.schema.checkAttribute( [ 'heading3' ], 'blockIndent' ) ).to.be.true;
+
+				expect( model.schema.getAttributeProperties( 'blockIndent' ) ).to.deep.equal( { isFormatting: true } );
 			} );
 	} );
 

--- a/packages/ckeditor5-remove-format/src/removeformatcommand.js
+++ b/packages/ckeditor5-remove-format/src/removeformatcommand.js
@@ -70,11 +70,19 @@ export default class RemoveFormatCommand extends Command {
 			return !!first( this._getFormattingAttributes( item, schema ) );
 		};
 
+		// Check formatting on selected items that are not blocks.
 		for ( const curRange of selection.getRanges() ) {
 			for ( const item of curRange.getItems() ) {
-				if ( itemHasRemovableFormatting( item ) ) {
+				if ( !schema.isBlock( item ) && itemHasRemovableFormatting( item ) ) {
 					yield item;
 				}
+			}
+		}
+
+		// Check formatting from selected blocks.
+		for ( const block of selection.getSelectedBlocks() ) {
+			if ( itemHasRemovableFormatting( block ) ) {
+				yield block;
 			}
 		}
 

--- a/packages/ckeditor5-remove-format/tests/removeformatcommand.js
+++ b/packages/ckeditor5-remove-format/tests/removeformatcommand.js
@@ -24,7 +24,8 @@ describe( 'RemoveFormatCommand', () => {
 				editor.commands.add( 'removeFormat', command );
 
 				model.schema.register( 'p', {
-					inheritAllFrom: '$block'
+					inheritAllFrom: '$block',
+					allowAttributes: 'someBlockFormatting'
 				} );
 
 				model.schema.addAttributeCheck( ( ctx, attributeName ) => {
@@ -43,6 +44,10 @@ describe( 'RemoveFormatCommand', () => {
 				} );
 
 				model.schema.setAttributeProperties( 'bold', {
+					isFormatting: true
+				} );
+
+				model.schema.setAttributeProperties( 'someBlockFormatting', {
 					isFormatting: true
 				} );
 			} );
@@ -94,6 +99,16 @@ describe( 'RemoveFormatCommand', () => {
 					}
 				},
 				assert: () => expectEnabledPropertyToBe( true )
+			},
+
+			'state with block formatting': {
+				input: '<p someBlockFormatting="foo">f[oo</p><p>]bar</p>',
+				assert: () => expectEnabledPropertyToBe( true )
+			},
+
+			'state with block formatting (collapsed selection)': {
+				input: '<p someBlockFormatting="foo">f[]oo</p>',
+				assert: () => expectEnabledPropertyToBe( true )
 			}
 		};
 
@@ -140,7 +155,18 @@ describe( 'RemoveFormatCommand', () => {
 					expect( model.document.selection.hasAttribute( 'bold' ) ).to.equal( false );
 					expect( model.document.selection.hasAttribute( 'irrelevant' ) ).to.equal( true );
 				}
+			},
+
+			'state with block formatting': {
+				input: '<p someBlockFormatting="foo">f[oo</p><p someBlockFormatting="bar">]bar</p>',
+				assert: () => expectModelToBeEqual( '<p>f[oo</p><p someBlockFormatting="bar">]bar</p>' )
+			},
+
+			'state with block formatting (collapsed selection)': {
+				input: '<p someBlockFormatting="foo">f[]oo</p><p someBlockFormatting="bar">bar</p>',
+				assert: () => expectModelToBeEqual( '<p>f[]oo</p><p someBlockFormatting="bar">bar</p>' )
 			}
+
 		};
 
 		generateTypicalUseCases( cases, {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (indent): Block indentation should be recognized as a formatting attribute. Closes #2358.

Other (remove-format): Block formatting should be removed if selection is inside that block. 

---

### Additional information