### PR TITLE
Selection stops searching for attributes when spotted an inline element

### DIFF
--- a/packages/ckeditor5-engine/src/model/documentselection.js
+++ b/packages/ckeditor5-engine/src/model/documentselection.js
@@ -1095,7 +1095,7 @@ class LiveSelection extends Selection {
 			if ( !this.isGravityOverridden && !attrs ) {
 				let node = nodeBefore;
 
-				while ( node && !attrs ) {
+				while ( node && !schema.isInline( node ) && !attrs ) {
 					node = node.previousSibling;
 					attrs = getAttrsIfCharacter( node );
 				}
@@ -1105,7 +1105,7 @@ class LiveSelection extends Selection {
 			if ( !attrs ) {
 				let node = nodeAfter;
 
-				while ( node && !attrs ) {
+				while ( node && !schema.isInline( node ) && !attrs ) {
 					node = node.nextSibling;
 					attrs = getAttrsIfCharacter( node );
 				}

--- a/packages/ckeditor5-engine/tests/model/documentselection.js
+++ b/packages/ckeditor5-engine/tests/model/documentselection.js
@@ -1218,6 +1218,32 @@ describe( 'DocumentSelection', () => {
 				expect( emptyP.getAttribute( fooStoreAttrKey ) ).to.equal( 'bar' );
 			} );
 		} );
+
+		// #7459
+		describe( 'ignores inline elements while reading surrounding attributes', () => {
+			beforeEach( () => {
+				model.schema.register( 'softBreak', {
+					allowWhere: '$text',
+					isInline: true
+				} );
+			} );
+
+			it( 'should not inherit attributes from a node before an inline element', () => {
+				setData( model, '<p><$text bold="true">Caption for the image.</$text><softBreak></softBreak>[]</p>' );
+
+				expect( selection.hasAttribute( 'bold' ) ).to.equal( false );
+			} );
+
+			it( 'should not inherit attributes from a node after an inline element (override gravity)', () => {
+				setData( model, '<p>[]<softBreak></softBreak><$text bold="true">Caption for the image.</$text></p>' );
+
+				const overrideGravityUid = selection._overrideGravity();
+
+				expect( selection.hasAttribute( 'bold' ) ).to.equal( false );
+
+				selection._restoreGravity( overrideGravityUid );
+			} );
+		} );
 	} );
 
 	describe( '_overrideGravity()', () => {

--- a/packages/ckeditor5-engine/tests/model/documentselection.js
+++ b/packages/ckeditor5-engine/tests/model/documentselection.js
@@ -1229,13 +1229,13 @@ describe( 'DocumentSelection', () => {
 			} );
 
 			it( 'should not inherit attributes from a node before an inline element', () => {
-				setData( model, '<p><$text bold="true">Caption for the image.</$text><softBreak></softBreak>[]</p>' );
+				setData( model, '<p><$text bold="true">Foo Bar.</$text><softBreak></softBreak>[]</p>' );
 
 				expect( selection.hasAttribute( 'bold' ) ).to.equal( false );
 			} );
 
 			it( 'should not inherit attributes from a node after an inline element (override gravity)', () => {
-				setData( model, '<p>[]<softBreak></softBreak><$text bold="true">Caption for the image.</$text></p>' );
+				setData( model, '<p>[]<softBreak></softBreak><$text bold="true">Foo Bar.</$text></p>' );
 
 				const overrideGravityUid = selection._overrideGravity();
 

--- a/packages/ckeditor5-enter/package.json
+++ b/packages/ckeditor5-enter/package.json
@@ -18,6 +18,7 @@
     "@ckeditor/ckeditor5-basic-styles": "^20.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^20.0.0",
     "@ckeditor/ckeditor5-heading": "^20.0.0",
+    "@ckeditor/ckeditor5-link": "^20.0.0",
     "@ckeditor/ckeditor5-paragraph": "^20.0.0",
     "@ckeditor/ckeditor5-typing": "^20.0.0",
     "@ckeditor/ckeditor5-undo": "^20.0.0"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): Selection will not inherit attributes if spotted an inline element while searching for a node from which attributes could be copied. Closes #7459.

Tests (enter): Added an integration test that covers a bug with copying attributes from a node before an inline element. See #7459.
