### PR TITLE
Fix mistake in documentation

### DIFF
--- a/docs/builds/guides/integration/advanced-setup.md
+++ b/docs/builds/guides/integration/advanced-setup.md
@@ -576,7 +576,7 @@ const config = {
 ClassicEditor.defaultConfig = config;
 InlineEditor.defaultConfig = config;
 
-export default {
+export {
 	ClassicEditor, InlineEditor
 };
 ```


### PR DESCRIPTION
In order to be able to use the "super build" the way it is shown in the sample script (i.e. by creating the editor with `CKEDITOR.ClassicEditor`) you need to have the editor classes not exported using `export default { ... }` but just `export { ... }`. The reason is that, by using the former approach, you get the classes stored in the `default` property of `CKEDITOR` (and not in `CKEDITOR` itself).

<img width="407" alt="Schermata 2020-07-31 alle 22 55 34" src="https://user-images.githubusercontent.com/20324786/89076621-f3eea780-d380-11ea-8dd6-c26dc8afad34.png">
