### PR TITLE
Docs: adding autolink to productivity features. [skip ci]

### DIFF
--- a/packages/ckeditor5-autoformat/docs/features/autoformat.md
+++ b/packages/ckeditor5-autoformat/docs/features/autoformat.md
@@ -44,7 +44,7 @@ In addition to enabling automatic text formatting, you may want to check the fol
 
 * {@link features/text-transformation Automatic text transformation} &ndash; Enables automatic turning snippets such as `(tm)` into `™` and `"foo"` into `“foo”`.
 * {@link features/link#autolink-feature Autolink} &ndash; Turns the links and email addresses typed or pasted into the editor into active URLs.
-* {@link features/mentions Mentions} &ndash; It brings support for smart autocompletion.
+* {@link features/mentions Mentions} &ndash; Brings support for smart autocompletion.
 
 ## Installation
 

--- a/packages/ckeditor5-autoformat/docs/features/autoformat.md
+++ b/packages/ckeditor5-autoformat/docs/features/autoformat.md
@@ -43,6 +43,7 @@ Example:
 In addition to enabling automatic text formatting, you may want to check the following productivity features:
 
 * {@link features/text-transformation Automatic text transformation} &ndash; It enables automatic turning snippets such as `(tm)` into `™` and `"foo"` into `“foo”`.
+* {@link features/link#autolink-feature Autolink} &ndash; Turns the links typed or pasted into editor into active URLs.
 * {@link features/mentions Mentions} &ndash; It brings support for smart autocompletion.
 
 ## Installation

--- a/packages/ckeditor5-autoformat/docs/features/autoformat.md
+++ b/packages/ckeditor5-autoformat/docs/features/autoformat.md
@@ -43,7 +43,7 @@ Example:
 In addition to enabling automatic text formatting, you may want to check the following productivity features:
 
 * {@link features/text-transformation Automatic text transformation} &ndash; Enables automatic turning snippets such as `(tm)` into `™` and `"foo"` into `“foo”`.
-* {@link features/link#autolink-feature Autolink} &ndash; Turns the links typed or pasted into editor into active URLs.
+* {@link features/link#autolink-feature Autolink} &ndash; Turns the links and email addresses typed or pasted into the editor into active URLs.
 * {@link features/mentions Mentions} &ndash; It brings support for smart autocompletion.
 
 ## Installation

--- a/packages/ckeditor5-autoformat/docs/features/autoformat.md
+++ b/packages/ckeditor5-autoformat/docs/features/autoformat.md
@@ -42,7 +42,7 @@ Example:
 
 In addition to enabling automatic text formatting, you may want to check the following productivity features:
 
-* {@link features/text-transformation Automatic text transformation} &ndash; It enables automatic turning snippets such as `(tm)` into `™` and `"foo"` into `“foo”`.
+* {@link features/text-transformation Automatic text transformation} &ndash; Enables automatic turning snippets such as `(tm)` into `™` and `"foo"` into `“foo”`.
 * {@link features/link#autolink-feature Autolink} &ndash; Turns the links typed or pasted into editor into active URLs.
 * {@link features/mentions Mentions} &ndash; It brings support for smart autocompletion.
 

--- a/packages/ckeditor5-mention/docs/features/mentions.md
+++ b/packages/ckeditor5-mention/docs/features/mentions.md
@@ -23,7 +23,7 @@ You can type the "@" character to invoke the mention autocomplete UI. The demo b
 
 In addition to enabling mentions, you may want to check the following productivity features:
 
-* {@link features/text-transformation Automatic text transformation} &ndash; It allows to automatically turn snippets such as `(tm)` into `™` and `"foo"` into `“foo”`.
+* {@link features/text-transformation Automatic text transformation} &ndash; Allows to automatically turn snippets such as `(tm)` into `™` and `"foo"` into `“foo”`.
 * {@link features/link#autolink-feature Autolink} &ndash; Turns the links and email addresses typed or pasted into the editor into active URLs.
 * {@link features/autoformat Autoformatting} &ndash; It allows to quickly apply formatting to the content you are writing.
 

--- a/packages/ckeditor5-mention/docs/features/mentions.md
+++ b/packages/ckeditor5-mention/docs/features/mentions.md
@@ -24,7 +24,7 @@ You can type the "@" character to invoke the mention autocomplete UI. The demo b
 In addition to enabling mentions, you may want to check the following productivity features:
 
 * {@link features/text-transformation Automatic text transformation} &ndash; It allows to automatically turn snippets such as `(tm)` into `™` and `"foo"` into `“foo”`.
-* {@link features/link#autolink-feature Autolink} &ndash; Turns the links typed or pasted into editor into active URLs.
+* {@link features/link#autolink-feature Autolink} &ndash; Turns the links and email addresses typed or pasted into the editor into active URLs.
 * {@link features/autoformat Autoformatting} &ndash; It allows to quickly apply formatting to the content you are writing.
 
 ## Configuration

--- a/packages/ckeditor5-mention/docs/features/mentions.md
+++ b/packages/ckeditor5-mention/docs/features/mentions.md
@@ -24,6 +24,7 @@ You can type the "@" character to invoke the mention autocomplete UI. The demo b
 In addition to enabling mentions, you may want to check the following productivity features:
 
 * {@link features/text-transformation Automatic text transformation} &ndash; It allows to automatically turn snippets such as `(tm)` into `™` and `"foo"` into `“foo”`.
+* {@link features/link#autolink-feature Autolink} &ndash; Turns the links typed or pasted into editor into active URLs.
 * {@link features/autoformat Autoformatting} &ndash; It allows to quickly apply formatting to the content you are writing.
 
 ## Configuration

--- a/packages/ckeditor5-mention/docs/features/mentions.md
+++ b/packages/ckeditor5-mention/docs/features/mentions.md
@@ -25,7 +25,7 @@ In addition to enabling mentions, you may want to check the following productivi
 
 * {@link features/text-transformation Automatic text transformation} &ndash; Allows to automatically turn snippets such as `(tm)` into `™` and `"foo"` into `“foo”`.
 * {@link features/link#autolink-feature Autolink} &ndash; Turns the links and email addresses typed or pasted into the editor into active URLs.
-* {@link features/autoformat Autoformatting} &ndash; It allows to quickly apply formatting to the content you are writing.
+* {@link features/autoformat Autoformatting} &ndash; Allows to quickly apply formatting to the content you are writing.
 
 ## Configuration
 

--- a/packages/ckeditor5-typing/docs/features/text-transformation.md
+++ b/packages/ckeditor5-typing/docs/features/text-transformation.md
@@ -54,7 +54,7 @@ Type snippets such as `(c)`, `3/4`, `!=`, `---`, `"foo"` into the rich-text edit
 
 In addition to enabling automatic text transformations, you may want to check the following productivity features:
 
-* {@link features/autoformat Autoformatting} &ndash; It allows to quickly apply formatting to the content you are writing.
+* {@link features/autoformat Autoformatting} &ndash; Allows to quickly apply formatting to the content you are writing.
 * {@link features/link#autolink-feature Autolink} &ndash; Turns the links and email addresses typed or pasted into the editor into active URLs.
 * {@link features/mentions Mentions} &ndash; It brings support for smart autocompletion.
 

--- a/packages/ckeditor5-typing/docs/features/text-transformation.md
+++ b/packages/ckeditor5-typing/docs/features/text-transformation.md
@@ -55,7 +55,7 @@ Type snippets such as `(c)`, `3/4`, `!=`, `---`, `"foo"` into the rich-text edit
 In addition to enabling automatic text transformations, you may want to check the following productivity features:
 
 * {@link features/autoformat Autoformatting} &ndash; It allows to quickly apply formatting to the content you are writing.
-* {@link features/link#autolink-feature Autolink} &ndash; Turns the links typed or pasted into editor into active URLs.
+* {@link features/link#autolink-feature Autolink} &ndash; Turns the links and email addresses typed or pasted into the editor into active URLs.
 * {@link features/mentions Mentions} &ndash; It brings support for smart autocompletion.
 
 ## Configuring transformations

--- a/packages/ckeditor5-typing/docs/features/text-transformation.md
+++ b/packages/ckeditor5-typing/docs/features/text-transformation.md
@@ -55,6 +55,7 @@ Type snippets such as `(c)`, `3/4`, `!=`, `---`, `"foo"` into the rich-text edit
 In addition to enabling automatic text transformations, you may want to check the following productivity features:
 
 * {@link features/autoformat Autoformatting} &ndash; It allows to quickly apply formatting to the content you are writing.
+* {@link features/link#autolink-feature Autolink} &ndash; Turns the links typed or pasted into editor into active URLs.
 * {@link features/mentions Mentions} &ndash; It brings support for smart autocompletion.
 
 ## Configuring transformations

--- a/packages/ckeditor5-typing/docs/features/text-transformation.md
+++ b/packages/ckeditor5-typing/docs/features/text-transformation.md
@@ -56,7 +56,7 @@ In addition to enabling automatic text transformations, you may want to check th
 
 * {@link features/autoformat Autoformatting} &ndash; Allows to quickly apply formatting to the content you are writing.
 * {@link features/link#autolink-feature Autolink} &ndash; Turns the links and email addresses typed or pasted into the editor into active URLs.
-* {@link features/mentions Mentions} &ndash; It brings support for smart autocompletion.
+* {@link features/mentions Mentions} &ndash; Brings support for smart autocompletion.
 
 ## Configuring transformations
 


### PR DESCRIPTION
Adding autolink to productivity features list in mentions, automatic text transformations and autoformatting.