### PR TITLE
#6444: Balloon toolbar should reposition and ungroup items correctly when the window resizes

### DIFF
--- a/packages/ckeditor5-ui/src/toolbar/balloon/balloontoolbar.js
+++ b/packages/ckeditor5-ui/src/toolbar/balloon/balloontoolbar.js
@@ -165,6 +165,15 @@ export default class BalloonToolbar extends Plugin {
 				} );
 			} );
 		}
+
+		// Listen to the toolbar view and whenever it changes its geometry due to some items being
+		// grouped or ungrouped, update the position of the balloon because a shorter/longer toolbar
+		// means the balloon could be pointing at the wrong place. Once updated, the balloon will point
+		// at the right selection in the content again.
+		// https://github.com/ckeditor/ckeditor5/issues/6444
+		this.listenTo( this.toolbarView, 'groupedItemsUpdate', () => {
+			this._updatePosition();
+		} );
 	}
 
 	/**
@@ -236,7 +245,7 @@ export default class BalloonToolbar extends Plugin {
 
 		// Update the toolbar position when the editor ui should be refreshed.
 		this.listenTo( this.editor.ui, 'update', () => {
-			this._balloon.updatePosition( this._getBalloonPositionData() );
+			this._updatePosition();
 		} );
 
 		// Add the toolbar to the common editor contextual balloon.
@@ -298,6 +307,18 @@ export default class BalloonToolbar extends Plugin {
 			},
 			positions: getBalloonPositions( isBackward )
 		};
+	}
+
+	/**
+	 * Updates the position of the {@link #_balloon} to make up for changes:
+	 *
+	 * * in the geometry of the selection it is attached to (e.g. the selection moved in the viewport or expanded or shrunk),
+	 * * or the geometry of the balloon toolbar itself (e.g. the toolbar has grouped or ungrouped some items and it is shorter or longer).
+	 *
+	 * @private
+	 */
+	_updatePosition() {
+		this._balloon.updatePosition( this._getBalloonPositionData() );
 	}
 
 	/**

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.js
@@ -304,6 +304,19 @@ export default class ToolbarView extends View {
 			}
 		} ).filter( item => item !== undefined ) );
 	}
+
+	/**
+	 * Fired when some toolbar {@link #items} were grouped or ungrouped as a result of some change
+	 * in the toolbar geometry.
+	 *
+	 * **Note**: This event is always fired **once** regardless of the number of items that were be
+	 * grouped or ungrouped at a time.
+	 *
+	 * **Note**: This event is fired only if the items grouping functionality was enabled in
+	 * the first place (see {@link module:ui/toolbar/toolbarview~ToolbarOptions#shouldGroupWhenFull}).
+	 *
+	 * @event groupedItemsUpdate
+	 */
 }
 
 /**
@@ -418,6 +431,14 @@ class DynamicGrouping {
 	 * is added to.
 	 */
 	constructor( view ) {
+		/**
+		 * A toolbar view this behavior belongs to.
+		 *
+		 * @readonly
+		 * @member {module:ui/toolbar~ToolbarView}
+		 */
+		this.view = view;
+
 		/**
 		 * A collection of toolbar children.
 		 *
@@ -644,6 +665,9 @@ class DynamicGrouping {
 			return;
 		}
 
+		// Remember how many items were initially grouped so at the it is possible to figure out if the number
+		// of grouped items has changed. If the number has changed, geometry of the toolbar has also changed.
+		const initialGroupedItemsCount = this.groupedItems.length;
 		let wereItemsGrouped;
 
 		// Group #items as long as some wrap to the next row. This will happen, for instance,
@@ -671,6 +695,10 @@ class DynamicGrouping {
 			if ( this._areItemsOverflowing ) {
 				this._groupLastItem();
 			}
+		}
+
+		if ( this.groupedItems.length !== initialGroupedItemsCount ) {
+			this.view.fire( 'groupedItemsUpdate' );
 		}
 	}
 

--- a/packages/ckeditor5-ui/tests/toolbar/balloon/balloontoolbar.js
+++ b/packages/ckeditor5-ui/tests/toolbar/balloon/balloontoolbar.js
@@ -361,6 +361,18 @@ describe( 'BalloonToolbar', () => {
 			sinon.assert.calledOnce( spy );
 		} );
 
+		it( 'should update the balloon position whenever #toolbarView fires the #groupedItemsUpdate (it changed its geometry)', () => {
+			setData( model, '<paragraph>b[a]r</paragraph>' );
+
+			const spy = sinon.spy( balloon, 'updatePosition' );
+
+			balloonToolbar.show();
+			sinon.assert.notCalled( spy );
+
+			balloonToolbar.toolbarView.fire( 'groupedItemsUpdate' );
+			sinon.assert.calledOnce( spy );
+		} );
+
 		it( 'should not add #toolbarView to the #_balloon more than once', () => {
 			setData( model, '<paragraph>b[a]r</paragraph>' );
 

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
@@ -828,6 +828,47 @@ describe( 'ToolbarView', () => {
 				expect( ungroupedItems ).to.have.length( 5 );
 				expect( groupedItems ).to.have.length( 0 );
 			} );
+
+			it( 'should fire the "groupedItemsUpdate" event on the toolbar when some item is grouped or ungrouped', () => {
+				const updateSpy = sinon.spy();
+
+				view.on( 'groupedItemsUpdate', updateSpy );
+
+				view.element.style.width = '200px';
+
+				view.items.add( focusable() );
+				view.items.add( focusable() );
+				view.items.add( focusable() );
+				view.items.add( focusable() );
+				view.items.add( focusable() );
+
+				resizeCallback( [ {
+					target: view.element,
+					contentRect: new Rect( view.element )
+				} ] );
+
+				sinon.assert.calledOnce( updateSpy );
+
+				// This 10px is not enough to ungroup an item.
+				view.element.style.width = '210px';
+
+				resizeCallback( [ {
+					target: view.element,
+					contentRect: new Rect( view.element )
+				} ] );
+
+				sinon.assert.calledOnce( updateSpy );
+
+				// But this is not enough to ungroup some items.
+				view.element.style.width = '300px';
+
+				resizeCallback( [ {
+					target: view.element,
+					contentRect: new Rect( view.element )
+				} ] );
+
+				sinon.assert.calledTwice( updateSpy );
+			} );
 		} );
 
 		describe( 'destroy()', () => {

--- a/packages/ckeditor5-utils/src/dom/resizeobserver.js
+++ b/packages/ckeditor5-utils/src/dom/resizeobserver.js
@@ -168,12 +168,6 @@ export default class ResizeObserver {
 
 		ResizeObserver._observerInstance = new ObserverConstructor( entries => {
 			for ( const entry of entries ) {
-				// Do not execute callbacks for elements that are invisible.
-				// https://github.com/ckeditor/ckeditor5/issues/6570
-				if ( !entry.target.offsetParent ) {
-					continue;
-				}
-
 				const callbacks = ResizeObserver._getElementCallbacks( entry.target );
 
 				if ( callbacks ) {

--- a/packages/ckeditor5-utils/tests/dom/resizeobserver.js
+++ b/packages/ckeditor5-utils/tests/dom/resizeobserver.js
@@ -114,61 +114,6 @@ describe( 'ResizeObserver()', () => {
 			observerA.destroy();
 		} );
 
-		it( 'should not react to resizing of an element if element is invisible', () => {
-			const callbackA = sinon.spy();
-			let resizeCallback;
-
-			testUtils.sinon.stub( global.window, 'ResizeObserver' ).callsFake( callback => {
-				resizeCallback = callback;
-
-				return {
-					observe() {},
-					unobserve() {}
-				};
-			} );
-
-			const observerA = new ResizeObserver( elementA, callbackA );
-
-			elementA.style.display = 'none';
-
-			resizeCallback( [
-				{ target: elementA }
-			] );
-
-			sinon.assert.notCalled( callbackA );
-
-			observerA.destroy();
-		} );
-
-		it( 'should not react to resizing of an element if element\'s parent is invisible', () => {
-			const callbackA = sinon.spy();
-			let resizeCallback;
-
-			testUtils.sinon.stub( global.window, 'ResizeObserver' ).callsFake( callback => {
-				resizeCallback = callback;
-
-				return {
-					observe() {},
-					unobserve() {}
-				};
-			} );
-
-			const observerA = new ResizeObserver( elementA, callbackA );
-			const parent = document.createElement( 'div' );
-			document.body.appendChild( parent );
-			parent.appendChild( elementA );
-			parent.style.display = 'none';
-
-			resizeCallback( [
-				{ target: elementA }
-			] );
-
-			sinon.assert.notCalled( callbackA );
-
-			parent.remove();
-			observerA.destroy();
-		} );
-
 		it( 'should be able to observe the same element along with other observers', () => {
 			const callbackA = sinon.spy();
 			const callbackB = sinon.spy();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix: Balloon toolbar should reposition and ungroup items correctly when the window resizes. Closes #6444.

---

### Additional information

This PR is another attempt at https://github.com/ckeditor/ckeditor5/pull/7721/files.  

There are 2 things in this PR (this is hard but here we go):

1.  A reverted `ResizeObserver` optimization (mentioned here https://github.com/ckeditor/ckeditor5/pull/7721#discussion_r461502549).   
      
    Without it (or... actually with it), the `previousWidth !== entry.contentRect.width` in this `ToolbarView` line https://github.com/ckeditor/ckeditor5/blob/i/6444-toolbar-reposition-on-regroup/packages/ckeditor5-ui/src/toolbar/toolbarview.js#L757 does not work.  
      
    The `ToolbarView` optimizes the number of `_updateGrouping()` calls so they only happen when:  
      
    \- it's the first resize in its lifetime (resize observer always hits when the toolbar first appears),  
    \- the element width changes (but not, for instance, its height) (:point\_left::point\_left::point\_left:  this one matters),  
    \- the update has been queued due to toolbar `maxWidth` change when the toolbar was invisible (editable resized when the toolbar was invisible)  
      
    When the mentioned `ResizeObserver` optimization is in place, the "toolbar visible"->"toolbar invisible" state change is lost (the observer callback is not called then). So `previousWidth` is actually a width **before** the toolbar disappeared. And when it re-appears, well... it's still the same, so the grouping is not updated.  
      
    So this one actually fixes #6444.  
     
2.  A new event fired by `ToolbarView` when it groups or ungroups its items (and `BalloonToolbar` making use of it).  
      
    When 1. is applied, the balloon toolbar does group/ungroup when it re-appears (GIF from #6444). That's fine.  
      
    But a side-effect of this grouping/ungrouping is that it changes its width and being positioned absolutely (to its upper left corner) the balloon triangle starts pointing to nothing (or nonsense) 😕 (see the GIF below).

    In other words: fixing 1. revealed 2.
      
    So the `BalloonToolbar` plugin must listen to the `ToolbarView` event and re-position itself once the geometry of the toolbar has changed (due to grouping/ungrouping).  
      
    **Side note:** At first I wanted to avoid the new event and make the `BalloonToolbar` use another resize observer (observing the toolbar element) and re-position based on this. But then I figured this may end in a race condition since   
      
    \- a toolbar internally uses a resize observer on itself to group/ungroup items,  
    \- there's this resize observer observing the editable that sets toolbar's `maxWidth`  
      
    If I added another resize observer, understanding which executed first and which last and whether the balloon repositioning happens before toolbar items grouping or after it would be a total mess. So an event is safer because it always happens after the internal toolbar's resize observer.

![](https://user-images.githubusercontent.com/1099479/88642621-020ea080-d0c1-11ea-80d1-a38eac3aafd4.gif)