### PR TITLE
i/7813: Let the size of the widget follow its width's change

### DIFF
--- a/packages/ckeditor5-widget/src/widgetresize/resizerstate.js
+++ b/packages/ckeditor5-widget/src/widgetresize/resizerstate.js
@@ -117,7 +117,7 @@ export default class ResizeState {
 
 		this.activeHandlePosition = getHandlePosition( domResizeHandle );
 
-		this._referenceCoordinates = getAbsoluteBoundaryPoint( domHandleHost, getOppositePosition( this.activeHandlePosition ) );
+		this._referenceCoordinates = getAbsoluteBoundaryPoint( domHandleHost, this.activeHandlePosition );
 
 		this.originalWidth = clientRect.width;
 		this.originalHeight = clientRect.height;
@@ -201,19 +201,4 @@ function getHandlePosition( domHandle ) {
 			return position;
 		}
 	}
-}
-
-// @private
-// @param {String} position Like `"top-left"`.
-// @returns {String} Inverted `position`, e.g. it returns `"bottom-right"` if `"top-left"` was given as `position`.
-function getOppositePosition( position ) {
-	const parts = position.split( '-' );
-	const replacements = {
-		top: 'bottom',
-		bottom: 'top',
-		left: 'right',
-		right: 'left'
-	};
-
-	return `${ replacements[ parts[ 0 ] ] }-${ replacements[ parts[ 1 ] ] }`;
 }

--- a/packages/ckeditor5-widget/tests/widgetresize.js
+++ b/packages/ckeditor5-widget/tests/widgetresize.js
@@ -217,19 +217,19 @@ describe( 'WidgetResize', () => {
 			it( 'enlarges correctly with left-bottom handler', generateResizeTest( {
 				usedHandle: 'bottom-left',
 				movePointerBy: { x: -10, y: 10 },
-				expectedWidth: '120px'
+				expectedWidth: '110px'
 			} ) );
 
 			it( 'enlarges correctly with right-bottom handler', generateResizeTest( {
 				usedHandle: 'bottom-right',
 				movePointerBy: { x: 10, y: 10 },
-				expectedWidth: '120px'
+				expectedWidth: '110px'
 			} ) );
 
 			it( 'enlarges correctly with right-bottom handler, y axis only', generateResizeTest( {
 				usedHandle: 'bottom-right',
 				movePointerBy: { x: 0, y: 20 },
-				expectedWidth: '140px'
+				expectedWidth: '100px'
 			} ) );
 
 			it( 'enlarges correctly with right-bottom handler, x axis only', generateResizeTest( {
@@ -279,7 +279,7 @@ describe( 'WidgetResize', () => {
 			it( 'enlarges correctly with right-bottom handler, y axis only', generateResizeTest( {
 				usedHandle: 'bottom-right',
 				movePointerBy: { x: 0, y: 10 },
-				expectedWidth: '120px'
+				expectedWidth: '100px'
 			} ) );
 
 			it( 'enlarges correctly with left-bottom handler, x axis only', generateResizeTest( {
@@ -291,7 +291,7 @@ describe( 'WidgetResize', () => {
 			it( 'enlarges correctly with left-bottom handler, y axis only', generateResizeTest( {
 				usedHandle: 'bottom-left',
 				movePointerBy: { x: 0, y: 10 },
-				expectedWidth: '120px'
+				expectedWidth: '100px'
 			} ) );
 
 			// --- top handlers ---
@@ -305,7 +305,7 @@ describe( 'WidgetResize', () => {
 			it( 'enlarges correctly with left-top handler, y axis only', generateResizeTest( {
 				usedHandle: 'top-left',
 				movePointerBy: { x: 0, y: -10 },
-				expectedWidth: '120px'
+				expectedWidth: '100px'
 			} ) );
 
 			it( 'enlarges correctly with right-top handler', generateResizeTest( {
@@ -317,7 +317,7 @@ describe( 'WidgetResize', () => {
 			it( 'enlarges correctly with right-top handler, y axis only', generateResizeTest( {
 				usedHandle: 'top-right',
 				movePointerBy: { x: 0, y: -10 },
-				expectedWidth: '120px'
+				expectedWidth: '100px'
 			} ) );
 		} );
 	} );
@@ -370,7 +370,7 @@ describe( 'WidgetResize', () => {
 			it( 'enlarges correctly with bottom-right handler', generateResizeTest( {
 				usedHandle: 'bottom-right',
 				movePointerBy: { x: 0, y: 5 },
-				expectedWidth: '27.5%'
+				expectedWidth: '25%'
 			} ) );
 
 			it( 'enlarges correctly an image with unsupported width unit', () => {
@@ -381,7 +381,7 @@ describe( 'WidgetResize', () => {
 				generateResizeTest( {
 					usedHandle: 'bottom-right',
 					movePointerBy: { x: 0, y: 5 },
-					expectedWidth: '36.67%'
+					expectedWidth: '33.33%'
 				} )();
 			} );
 		} );
@@ -442,7 +442,7 @@ describe( 'WidgetResize', () => {
 
 			const usedHandle = 'bottom-right';
 			const pointerDifference = { x: -10, y: -10 };
-			const expectedWidth = '20%';
+			const expectedWidth = '25%';
 
 			const domParts = getWidgetDomParts( editor, widget, usedHandle );
 			const resizeHost = domParts.widget.querySelector( '.sub-div' );

--- a/packages/ckeditor5-widget/tests/widgetresize/resizer.js
+++ b/packages/ckeditor5-widget/tests/widgetresize/resizer.js
@@ -173,8 +173,8 @@ describe( 'Resizer', () => {
 				originalWidthPercents: 10,
 				aspectRatio: 1,
 				_referenceCoordinates: {
-					x: 0,
-					y: 0
+					x: 40,
+					y: 40
 				},
 				activeHandlePosition: 'bottom-right'
 			};


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Change: Let the size of the widget follow its width's  #7813 

---
### Additional information

1. Change the function `_proposeNewSize`. Now we will calculate the width, height and scale of the widget as an x-axis variation.
2. Remove the functon `getOppositePosition`. Now the `_referenceCoordinates` is where the mouse points, not diagonally.
3. Fixed the unit test about this change.