### PR TITLE
#7828: DomEmitterMixin should pass "passive" option for listener

### DIFF
--- a/packages/ckeditor5-utils/src/dom/emittermixin.js
+++ b/packages/ckeditor5-utils/src/dom/emittermixin.js
@@ -187,10 +187,15 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 			return;
 		}
 
-		const domListener = this._createDomListener( event, !!options.useCapture );
+		const listenerOptions = options.useCapture || options.usePassive ? {
+			capture: !!options.useCapture,
+			passive: !!options.usePassive
+		} : false;
+
+		const domListener = this._createDomListener( event, listenerOptions );
 
 		// Attach the native DOM listener to DOM Node.
-		this._domNode.addEventListener( event, domListener, !!options.useCapture );
+		this._domNode.addEventListener( event, domListener, listenerOptions );
 
 		if ( !this._domListeners ) {
 			this._domListeners = {};

--- a/packages/ckeditor5-utils/src/dom/emittermixin.js
+++ b/packages/ckeditor5-utils/src/dom/emittermixin.js
@@ -179,6 +179,7 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 	 * @param {Object} [options={}] Additional options.
 	 * @param {Boolean} [options.useCapture=false] Indicates that events of this type will be dispatched to the registered
 	 * listener before being dispatched to any EventTarget beneath it in the DOM tree.
+	 * @param {Boolean} [options.usePassive=false] Indicates that the function specified by listener will never call preventDefault().
 	 */
 	attach( event, callback, options = {} ) {
 		// If the DOM Listener for given event already exist it is pointless
@@ -232,10 +233,12 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 	 * @private
 	 * @method module:utils/dom/emittermixin~ProxyEmitter#_createDomListener
 	 * @param {String} event The name of the event.
-	 * @param {Boolean} useCapture Indicates whether the listener was created for capturing event.
+	 * @param {Object} [options] Additional options.
+	 * @param {Boolean} [options.capture=false] Indicates whether the listener was created for capturing event.
+	 * @param {Boolean} [options.passive=false] Indicates that the function specified by listener will never call preventDefault().
 	 * @returns {Function} The DOM listener callback.
 	 */
-	_createDomListener( event, useCapture ) {
+	_createDomListener( event, options ) {
 		const domListener = domEvt => {
 			this.fire( event, domEvt );
 		};
@@ -244,7 +247,7 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 		// detach it from the DOM Node, when it is no longer necessary.
 		// See: {@link detach}.
 		domListener.removeListener = () => {
-			this._domNode.removeEventListener( event, domListener, useCapture );
+			this._domNode.removeEventListener( event, domListener, options );
 			delete this._domListeners[ event ];
 		};
 

--- a/packages/ckeditor5-utils/src/dom/emittermixin.js
+++ b/packages/ckeditor5-utils/src/dom/emittermixin.js
@@ -49,6 +49,8 @@ const DomEmitterMixin = extend( {}, EmitterMixin, {
 	 * order they were added.
 	 * @param {Boolean} [options.useCapture=false] Indicates that events of this type will be dispatched to the registered
 	 * listener before being dispatched to any EventTarget beneath it in the DOM tree.
+	 * @param {Boolean} [options.usePassive=false] Indicates that the function specified by listener will never call preventDefault()
+	 * and prevents blocking browser's main thread by this event handler.
 	 */
 	listenTo( emitter, ...rest ) {
 		// Check if emitter is an instance of DOM Node. If so, replace the argument with
@@ -179,7 +181,8 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 	 * @param {Object} [options={}] Additional options.
 	 * @param {Boolean} [options.useCapture=false] Indicates that events of this type will be dispatched to the registered
 	 * listener before being dispatched to any EventTarget beneath it in the DOM tree.
-	 * @param {Boolean} [options.usePassive=false] Indicates that the function specified by listener will never call preventDefault().
+	 * @param {Boolean} [options.usePassive=false] Indicates that the function specified by listener will never call preventDefault()
+	 * and prevents blocking browser's main thread by this event handler.
 	 */
 	attach( event, callback, options = {} ) {
 		// If the DOM Listener for given event already exist it is pointless
@@ -188,10 +191,10 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 			return;
 		}
 
-		const listenerOptions = options.useCapture || options.usePassive ? {
+		const listenerOptions = {
 			capture: !!options.useCapture,
 			passive: !!options.usePassive
-		} : false;
+		};
 
 		const domListener = this._createDomListener( event, listenerOptions );
 
@@ -235,7 +238,8 @@ extend( ProxyEmitter.prototype, EmitterMixin, {
 	 * @param {String} event The name of the event.
 	 * @param {Object} [options] Additional options.
 	 * @param {Boolean} [options.capture=false] Indicates whether the listener was created for capturing event.
-	 * @param {Boolean} [options.passive=false] Indicates that the function specified by listener will never call preventDefault().
+	 * @param {Boolean} [options.passive=false] Indicates that the function specified by listener will never call preventDefault()
+	 * and prevents blocking browser's main thread by this event handler.
 	 * @returns {Function} The DOM listener callback.
 	 */
 	_createDomListener( event, options ) {

--- a/packages/ckeditor5-utils/tests/dom/emittermixin.js
+++ b/packages/ckeditor5-utils/tests/dom/emittermixin.js
@@ -113,6 +113,32 @@ describe( 'DomEmitterMixin', () => {
 				sinon.assert.calledOnce( spy );
 			} );
 		} );
+
+		describe( 'event passive handling', () => {
+			it( 'should not use passive mode by default', () => {
+				const spy = sinon.spy( node, 'addEventListener' );
+
+				domEmitter.listenTo( node, 'test', () => {} );
+
+				expect( spy.calledWith( 'test', sinon.match.func, sinon.match.falsy ) ).to.be.true;
+			} );
+
+			it( 'should optionally use passive mode', () => {
+				const spy = sinon.spy( node, 'addEventListener' );
+
+				domEmitter.listenTo( node, 'test', () => {}, { usePassive: true } );
+
+				expect( spy.calledWith( 'test', sinon.match.func, sinon.match( { passive: true } ) ) ).to.be.true;
+			} );
+
+			it( 'should not get activated for event capturing (if not desired)', () => {
+				const spy = sinon.spy( node, 'addEventListener' );
+
+				domEmitter.listenTo( node, 'test', () => {}, { useCapture: true } );
+
+				expect( spy.calledWith( 'test', sinon.match.func, sinon.match( { capture: true, passive: false } ) ) ).to.be.true;
+			} );
+		} );
 	} );
 
 	describe( 'stopListening', () => {

--- a/packages/ckeditor5-utils/tests/dom/emittermixin.js
+++ b/packages/ckeditor5-utils/tests/dom/emittermixin.js
@@ -120,7 +120,7 @@ describe( 'DomEmitterMixin', () => {
 
 				domEmitter.listenTo( node, 'test', () => {} );
 
-				expect( spy.calledWith( 'test', sinon.match.func, sinon.match.falsy ) ).to.be.true;
+				expect( spy.calledWith( 'test', sinon.match.func, sinon.match( { capture: false, passive: false } ) ) ).to.be.true;
 			} );
 
 			it( 'should optionally use passive mode', () => {
@@ -128,7 +128,7 @@ describe( 'DomEmitterMixin', () => {
 
 				domEmitter.listenTo( node, 'test', () => {}, { usePassive: true } );
 
-				expect( spy.calledWith( 'test', sinon.match.func, sinon.match( { passive: true } ) ) ).to.be.true;
+				expect( spy.calledWith( 'test', sinon.match.func, sinon.match( { capture: false, passive: true } ) ) ).to.be.true;
 			} );
 
 			it( 'should not get activated for event capturing (if not desired)', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (utils): DomEmitterMixin should support the `passive` option to `addEventListener`. Closes #7828.

---

### Additional information