### PR TITLE
Fixed Rect results for a sequenced range

### DIFF
--- a/packages/ckeditor5-utils/src/dom/rect.js
+++ b/packages/ckeditor5-utils/src/dom/rect.js
@@ -414,7 +414,7 @@ export default class Rect {
 		boundingRectData.width = boundingRectData.right - boundingRectData.left;
 		boundingRectData.height = boundingRectData.bottom - boundingRectData.top;
 
-		return boundingRectData;
+		return new Rect( boundingRectData );
 	}
 }
 

--- a/packages/ckeditor5-utils/src/dom/rect.js
+++ b/packages/ckeditor5-utils/src/dom/rect.js
@@ -78,7 +78,8 @@ export default class Rect {
 			// @if CK_DEBUG // }
 
 			if ( isSourceRange ) {
-				copyRangeRectProperties( this, source );
+				const rangeRects = Rect.getDomRangeRects( source );
+				copyRectProperties( this, Rect.getBoundingRect( rangeRects ) );
 			} else {
 				copyRectProperties( this, source.getBoundingClientRect() );
 			}
@@ -381,6 +382,40 @@ export default class Rect {
 
 		return rects;
 	}
+
+	/**
+	 * Returns a bounding rectangle that contains all the given `rects`.
+	 *
+	 * @param {Iterable.<module:utils/dom/rect~Rect>} rects A list of rectangles that should be contained in the result rectangle.
+	 * @returns {module:utils/dom/rect~Rect|null} Bounding rectangle or `null` if no `rects` were given.
+	 */
+	static getBoundingRect( rects ) {
+		const boundingRectData = {
+			left: Number.POSITIVE_INFINITY,
+			top: Number.POSITIVE_INFINITY,
+			right: Number.NEGATIVE_INFINITY,
+			bottom: Number.NEGATIVE_INFINITY
+		};
+		let rectangleCount = 0;
+
+		for ( const rect of rects ) {
+			rectangleCount++;
+
+			boundingRectData.left = Math.min( boundingRectData.left, rect.left );
+			boundingRectData.top = Math.min( boundingRectData.top, rect.top );
+			boundingRectData.right = Math.max( boundingRectData.right, rect.right );
+			boundingRectData.bottom = Math.max( boundingRectData.bottom, rect.bottom );
+		}
+
+		if ( rectangleCount == 0 ) {
+			return null;
+		}
+
+		boundingRectData.width = boundingRectData.right - boundingRectData.left;
+		boundingRectData.height = boundingRectData.bottom - boundingRectData.top;
+
+		return boundingRectData;
+	}
 }
 
 // Acquires all the rect properties from the passed source.
@@ -405,26 +440,4 @@ function isBody( elementOrRange ) {
 	}
 
 	return elementOrRange === elementOrRange.ownerDocument.body;
-}
-
-// Copies size properties from the `source` to the `rect`.
-//
-// @private
-// @param {module:utils/dom/rect~Rect} rect Target rect.
-// @param {Range} source
-function copyRangeRectProperties( rect, source ) {
-	const rangeRects = Rect.getDomRangeRects( source );
-	const combinedRect = rangeRects[ 0 ];
-
-	for ( let i = 1; i < rangeRects.length; i++ ) {
-		combinedRect.right = Math.max( combinedRect.right, rangeRects[ i ].right );
-		combinedRect.left = Math.min( combinedRect.left, rangeRects[ i ].left );
-		combinedRect.bottom = Math.max( combinedRect.bottom, rangeRects[ i ].bottom );
-		combinedRect.top = Math.min( combinedRect.top, rangeRects[ i ].top );
-	}
-
-	combinedRect.width = combinedRect.right - combinedRect.left;
-	combinedRect.height = combinedRect.bottom - combinedRect.top;
-
-	copyRectProperties( rect, combinedRect );
 }

--- a/packages/ckeditor5-utils/src/dom/rect.js
+++ b/packages/ckeditor5-utils/src/dom/rect.js
@@ -78,7 +78,7 @@ export default class Rect {
 			// @if CK_DEBUG // }
 
 			if ( isSourceRange ) {
-				copyRectProperties( this, Rect.getDomRangeRects( source )[ 0 ] );
+				copyRangeRectProperties( this, source );
 			} else {
 				copyRectProperties( this, source.getBoundingClientRect() );
 			}
@@ -405,4 +405,26 @@ function isBody( elementOrRange ) {
 	}
 
 	return elementOrRange === elementOrRange.ownerDocument.body;
+}
+
+// Copies size properties from the `source` to the `rect`.
+//
+// @private
+// @param {module:utils/dom/rect~Rect} rect Target rect.
+// @param {Range} source
+function copyRangeRectProperties( rect, source ) {
+	const rangeRects = Rect.getDomRangeRects( source );
+	const combinedRect = rangeRects[ 0 ];
+
+	for ( let i = 1; i < rangeRects.length; i++ ) {
+		combinedRect.right = Math.max( combinedRect.right, rangeRects[ i ].right );
+		combinedRect.left = Math.min( combinedRect.left, rangeRects[ i ].left );
+		combinedRect.bottom = Math.max( combinedRect.bottom, rangeRects[ i ].bottom );
+		combinedRect.top = Math.min( combinedRect.top, rangeRects[ i ].top );
+	}
+
+	combinedRect.width = combinedRect.right - combinedRect.left;
+	combinedRect.height = combinedRect.bottom - combinedRect.top;
+
+	copyRectProperties( rect, combinedRect );
 }

--- a/packages/ckeditor5-utils/tests/dom/rect.js
+++ b/packages/ckeditor5-utils/tests/dom/rect.js
@@ -52,6 +52,62 @@ describe( 'Rect', () => {
 			assertRect( new Rect( range ), geometry );
 		} );
 
+		it( 'should accept Range (non–collapsed, sequenced horizontally)', () => {
+			const firstGeometry = geometry;
+			const secondGeometry = Object.assign( {}, geometry, {
+				right: 50,
+				left: 40,
+				width: 10
+			} );
+
+			const range = document.createRange();
+			range.selectNode( document.body );
+			sinon.stub( range, 'getClientRects' ).returns( [ firstGeometry, secondGeometry ] );
+
+			const expectedGeometry = Object.assign( {}, geometry, {
+				width: 30,
+				right: 50
+			} );
+
+			assertRect( new Rect( range ), expectedGeometry );
+		} );
+
+		it( 'should accept Range (non–collapsed, sequenced vertically)', () => {
+			const firstGeometry = geometry;
+			const secondGeometry = Object.assign( {}, geometry, {
+				top: 30,
+				bottom: 40
+			} );
+
+			const range = document.createRange();
+			range.selectNode( document.body );
+			sinon.stub( range, 'getClientRects' ).returns( [ firstGeometry, secondGeometry ] );
+
+			const expectedGeometry = Object.assign( {}, geometry, {
+				height: 30,
+				bottom: 40
+			} );
+
+			assertRect( new Rect( range ), expectedGeometry );
+		} );
+
+		it( 'should calculate rect of a range with multiple inline elements correctly (integration)', () => {
+			const wrapper = document.createElement( 'p' );
+			wrapper.innerHTML = 'aa<a href="url">b<span>cccccc</span>dd</a>ee';
+			document.body.appendChild( wrapper );
+
+			const domRange = document.createRange();
+			// aa[bccccccdd]ee
+			domRange.setStart( wrapper.childNodes[ 0 ], 2 );
+			domRange.setEnd( wrapper.childNodes[ 2 ], 0 );
+
+			const rect = new Rect( domRange );
+			const expectedWidth = domRange.getBoundingClientRect().width;
+
+			expect( expectedWidth, 'expected width is valid' ).to.be.greaterThan( 0 );
+			expect( rect.width ).to.eql( expectedWidth );
+		} );
+
 		// https://github.com/ckeditor/ckeditor5-utils/issues/153
 		it( 'should accept Range (collapsed)', () => {
 			const range = document.createRange();

--- a/packages/ckeditor5-utils/tests/dom/rect.js
+++ b/packages/ckeditor5-utils/tests/dom/rect.js
@@ -91,23 +91,6 @@ describe( 'Rect', () => {
 			assertRect( new Rect( range ), expectedGeometry );
 		} );
 
-		it( 'should calculate rect of a range with multiple inline elements correctly (integration)', () => {
-			const wrapper = document.createElement( 'p' );
-			wrapper.innerHTML = 'aa<a href="url">b<span>cccccc</span>dd</a>ee';
-			document.body.appendChild( wrapper );
-
-			const domRange = document.createRange();
-			// aa[bccccccdd]ee
-			domRange.setStart( wrapper.childNodes[ 0 ], 2 );
-			domRange.setEnd( wrapper.childNodes[ 2 ], 0 );
-
-			const rect = new Rect( domRange );
-			const expectedWidth = domRange.getBoundingClientRect().width;
-
-			expect( expectedWidth, 'expected width is valid' ).to.be.greaterThan( 0 );
-			expect( rect.width ).to.eql( expectedWidth );
-		} );
-
 		// https://github.com/ckeditor/ckeditor5-utils/issues/153
 		it( 'should accept Range (collapsed)', () => {
 			const range = document.createRange();

--- a/packages/ckeditor5-utils/tests/dom/rect.js
+++ b/packages/ckeditor5-utils/tests/dom/rect.js
@@ -1092,6 +1092,48 @@ describe( 'Rect', () => {
 			assertRect( rects[ 0 ], expectedGeometry );
 		} );
 	} );
+
+	describe( 'getBoundingRect()', () => {
+		it( 'should not return a rect instance when no rectangles were given', () => {
+			expect( Rect.getBoundingRect( [] ) ).to.be.null;
+		} );
+
+		it( 'should calculate proper rectangle when multiple rectangles were given', () => {
+			const rects = [
+				new Rect( geometry ),
+				new Rect( {
+					top: 10,
+					right: 100,
+					bottom: 20,
+					left: 80,
+					width: 20,
+					height: 10
+				} ),
+				new Rect( {
+					top: 50,
+					right: 50,
+					bottom: 60,
+					left: 30,
+					width: 20,
+					height: 10
+				} )
+			];
+
+			assertRect( Rect.getBoundingRect( rects ), {
+				top: 10,
+				right: 100,
+				bottom: 60,
+				left: 20,
+				width: 80,
+				height: 50
+			} );
+		} );
+
+		it( 'should calculate proper rectangle when a single rectangles was given', () => {
+			const rectangles = new Set( [ new Rect( geometry ) ] );
+			assertRect( Rect.getBoundingRect( rectangles ), geometry );
+		} );
+	} );
 } );
 
 function assertRect( rect, expected ) {

--- a/packages/ckeditor5-utils/tests/dom/rect.js
+++ b/packages/ckeditor5-utils/tests/dom/rect.js
@@ -1133,6 +1133,11 @@ describe( 'Rect', () => {
 			const rectangles = new Set( [ new Rect( geometry ) ] );
 			assertRect( Rect.getBoundingRect( rectangles ), geometry );
 		} );
+
+		it( 'should return proper type', () => {
+			const rectangles = new Set( [ new Rect( geometry ) ] );
+			expect( Rect.getBoundingRect( rectangles ) ).to.be.instanceOf( Rect );
+		} );
 	} );
 } );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (utils): `Rect` utility returns wrong sizes in case of a sequenced range. Closes #7838. 

Feature (utils): Introduced the `Rect#getBoundingRect()` method that returns a `Rect` instance containing all other rectangles. Closes #7858.

---

### Additional information

Initially I was even tempted to simplify it and use `Range.getBoundingClientRect()` to do the computation for us, but then I saw a plethora of issues that this method not always give reliable results:

*   #4969
*   #4952