### PR TITLE
Fixed a case where link balloon would point invalid place after browser scroll or resize

### DIFF
--- a/packages/ckeditor5-link/src/linkui.js
+++ b/packages/ckeditor5-link/src/linkui.js
@@ -588,12 +588,21 @@ export default class LinkUI extends Plugin {
 		const view = this.editor.editing.view;
 		const viewDocument = view.document;
 		const targetLink = this._getSelectedLinkElement();
+		const model = this.editor.model;
+		const range = model.markers.has( VISUAL_SELECTION_MARKER_NAME ) ?
+			model.markers.get( VISUAL_SELECTION_MARKER_NAME ) : viewDocument.selection.getFirstRange();
+
+		// console.log( '_getBalloonPositionData() to', targetLink ? targetLink : range ); // this bit seems to be fine
+
+		// if ( model.markers.has( VISUAL_SELECTION_MARKER_NAME ) ) {
+		//	console.log( 'there is a marker' );
+		// }
 
 		const target = targetLink ?
 			// When selection is inside link element, then attach panel to this element.
 			view.domConverter.mapViewToDom( targetLink ) :
 			// Otherwise attach panel to the selection.
-			view.domConverter.viewRangeToDom( viewDocument.selection.getFirstRange() );
+			view.domConverter.viewRangeToDom( range );
 
 		return { target };
 	}
@@ -644,6 +653,8 @@ export default class LinkUI extends Plugin {
 	 */
 	_showFakeVisualSelection() {
 		const model = this.editor.model;
+
+		// console.log( '_showFakeVisualSelection()' );
 
 		model.change( writer => {
 			if ( model.markers.has( VISUAL_SELECTION_MARKER_NAME ) ) {

--- a/packages/ckeditor5-link/src/linkui.js
+++ b/packages/ckeditor5-link/src/linkui.js
@@ -587,19 +587,14 @@ export default class LinkUI extends Plugin {
 	 */
 	_getBalloonPositionData() {
 		const view = this.editor.editing.view;
+		const model = this.editor.model;
 		const viewDocument = view.document;
 		const targetLink = this._getSelectedLinkElement();
-		const model = this.editor.model;
-		// const range = model.markers.has( VISUAL_SELECTION_MARKER_NAME ) ?
-		// 	model.markers.get( VISUAL_SELECTION_MARKER_NAME ).getRange() : viewDocument.selection.getFirstRange();
-		let range;
-
-		if ( model.markers.has( VISUAL_SELECTION_MARKER_NAME ) ) {
-			range = model.markers.get( VISUAL_SELECTION_MARKER_NAME ).getRange();
-			range = this.editor.editing.mapper.toViewRange( range );
-		} else {
-			range = viewDocument.selection.getFirstRange();
-		}
+		const range = model.markers.has( VISUAL_SELECTION_MARKER_NAME ) ?
+			// There are cases when we highlight selection using a marker (#7705, #4721).
+			this.editor.editing.mapper.toViewRange( model.markers.get( VISUAL_SELECTION_MARKER_NAME ).getRange() ) :
+			// If no markers are available refer to a regular selection.
+			viewDocument.selection.getFirstRange();
 
 		const target = targetLink ?
 			// When selection is inside link element, then attach panel to this element.

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -162,6 +162,23 @@ describe( 'LinkUI', () => {
 			} );
 		} );
 
+		it( 'should pass a proper position target to the balloon toolbar', () => {
+			setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
+
+			linkUIFeature._showUI();
+
+			const markerModelRange = editor.model.markers.get( 'link-ui' ).getRange();
+			const markerViewRange = editor.editing.mapper.toViewRange( markerModelRange );
+			const domRange = editor.editing.view.domConverter.viewRangeToDom( markerViewRange );
+
+			expect( balloonAddSpy.calledWithExactly( {
+				view: formView,
+				position: {
+					target: domRange
+				}
+			} ), 'spy arguments' ).to.be.true;
+		} );
+
 		it( 'should add #actionsView to the balloon and attach the balloon to the link element when collapsed selection is inside ' +
 			'that link',
 		() => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (link): Fixed a case where link balloon would point invalid place after browser scroll or resize. Closes #7705.

---

### Additional information

#### ⚠ Blocked by #7838 ⚠

Though this PR fixes the source problem, it hits another bug where invalid Rect is returned for a range containing multiple client rects (in this case it's caused by adding extra span for marker, which results with more than 4 client rects for me on Chrome).