### PR TITLE
Allow dynamic updates to the text transformations

### DIFF
--- a/packages/ckeditor5-typing/src/texttransformation.js
+++ b/packages/ckeditor5-typing/src/texttransformation.js
@@ -106,6 +106,11 @@ export default class TextTransformation extends Plugin {
 			this.isEnabled = !modelSelection.anchor.parent.is( 'element', 'codeBlock' );
 		} );
 
+		this.on( 'change:transformations', ( evt, propertyName, newValue ) => {
+			this.normalizedTransformations = normalizeTransformations( newValue ) || [];
+		} );
+		this.set( 'transformations', this.editor.config.get( 'typing.transformations' ) );
+
 		this._enableTransformationWatchers();
 	}
 
@@ -118,10 +123,9 @@ export default class TextTransformation extends Plugin {
 		const editor = this.editor;
 		const model = editor.model;
 		const input = editor.plugins.get( 'Input' );
-		const normalizedTransformations = normalizeTransformations( editor.config.get( 'typing.transformations' ) );
 
 		const testCallback = text => {
-			for ( const normalizedTransformation of normalizedTransformations ) {
+			for ( const normalizedTransformation of this.normalizedTransformations ) {
 				const from = normalizedTransformation.from;
 				const match = from.test( text );
 

--- a/packages/ckeditor5-typing/tests/texttransformation.js
+++ b/packages/ckeditor5-typing/tests/texttransformation.js
@@ -234,6 +234,67 @@ describe( 'Text transformation feature', () => {
 			} );
 		} );
 
+		it( 'should allow updating rules', () => {
+			return createEditorInstance( {
+				typing: {
+					include: [ 'symbols' ],
+					transformations: {
+						extra: [
+							{ from: 'CKE', to: 'CKEditor' }
+						]
+					}
+				}
+			} ).then( () => {
+				setData( model, '<paragraph>[]</paragraph>' );
+
+				simulateTyping( 'CKE' );
+
+				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>CKEditor</paragraph>' );
+
+				const plugin = editor.plugins.get( 'TextTransformation' );
+				plugin.transformations = {
+					include: [ 'symbols' ],
+					extra: [
+						{ from: 'CKE', to: 'CKEd' }
+					]
+				};
+
+				simulateTyping( ' CKE' );
+				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>CKEditor CKEd</paragraph>' );
+			} );
+		} );
+
+		it( 'should allow adding new rules', () => {
+			return createEditorInstance( {
+				typing: {
+					include: [ 'symbols' ],
+					transformations: {
+						extra: [
+							{ from: 'CKE', to: 'CKEditor' }
+						]
+					}
+				}
+			} ).then( () => {
+				setData( model, '<paragraph>[]</paragraph>' );
+
+				simulateTyping( 'CKE' );
+
+				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>CKEditor</paragraph>' );
+
+				const plugin = editor.plugins.get( 'TextTransformation' );
+				plugin.transformations = {
+					include: [ 'symbols' ],
+					extra: [
+						{ from: 'CKE', to: 'CKEditor' },
+						{ from: 'foo', to: 'bar' }
+					]
+				};
+
+				simulateTyping( ' foo' );
+				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<paragraph>CKEditor bar</paragraph>' );
+			} );
+		} );
+
 		it( 'should allow adding own rules with RegExp object', () => {
 			return createEditorInstance( {
 				typing: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6553,7 +6553,7 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
-"jsdoc@github:ckeditor/jsdoc#fixed-trailing-comment-doclets":
+jsdoc@ckeditor/jsdoc#fixed-trailing-comment-doclets:
   version "3.6.4"
   resolved "https://codeload.github.com/ckeditor/jsdoc/tar.gz/cb34eb2c1b4051103bbb2e802f8319633d820f56"
   dependencies:
@@ -6572,7 +6572,7 @@ jsbn@~0.1.0:
     taffydb "2.6.2"
     underscore "~1.10.2"
 
-"jsdoc@github:ckeditor/jsdoc#node12":
+jsdoc@ckeditor/jsdoc#node12:
   version "3.4.3"
   resolved "https://codeload.github.com/ckeditor/jsdoc/tar.gz/e6c213ab53c20457d2778953a6d3fc54311f9a67"
   dependencies:


### PR DESCRIPTION
Opening this PR for discussion.

In our application we want to allow the user to configure their own set of text transformations, and be able to apply those changes to already-instantiated editors. So we want a way to dynamically update the available transformations in an editor.

This PR is a proof-of-concept, but setting a property directly on the plugin may not fit with CKEditor's design patterns. Other options I can think of:

1. Implement a method on the plugin to set the transformations, rather than a settable property
2. Allow [TextTransformationConfig#extra](https://ckeditor.com/docs/ckeditor5/latest/api/module_typing_texttransformation-TextTransformationConfig.html#member-extra) to either be an array or be a function callback.

(2) seems like the closest to other CKEditor features, e.g. the [MentionFeed#feed](https://ckeditor.com/docs/ckeditor5/latest/api/module_mention_mention-MentionFeed.html#member-feed). For our use case, there is no need to support async callbacks, but I could see an argument for it.

Any feedback on this? We're willing to do some more work to develop this idea into something merge-able if someone can share thoughts on the right direction to go.