### PR TITLE
Fix z-index for the toolbar dropdown panels.

### DIFF
--- a/packages/ckeditor5-ui/theme/components/dropdown/dropdown.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/dropdown.css
@@ -65,3 +65,11 @@
 		}
 	}
 }
+
+/*
+ * Toolbar dropdown panels should be always above the UI (eg. other dropdown panels) from the editor's content.
+ * See https://github.com/ckeditor/ckeditor5/issues/7874
+ */
+.ck.ck-toolbar .ck-dropdown__panel {
+	z-index: var(--ck-z-toolbar-dropdown-panel);
+}

--- a/packages/ckeditor5-ui/theme/globals/_zindex.css
+++ b/packages/ckeditor5-ui/theme/globals/_zindex.css
@@ -6,4 +6,5 @@
 :root {
 	--ck-z-default: 1;
 	--ck-z-modal: calc( var(--ck-z-default) + 999 );
+	--ck-z-toolbar-dropdown-panel: calc( var(--ck-z-modal) + 1 );
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (ui): Dropdown panels from the editor's main toolbar should be always above the contextual balloons from the editor's content. Closes #7874.