### PR TITLE
Handle removing the content between lists and updating `listStyle` attribute for merged items

### DIFF
--- a/packages/ckeditor5-list/src/liststylecommand.js
+++ b/packages/ckeditor5-list/src/liststylecommand.js
@@ -8,7 +8,7 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import TreeWalker from '@ckeditor/ckeditor5-engine/src/model/treewalker';
+import { getSiblingNodes } from './utils';
 
 /**
  * The list style command. It is used by the {@link module:list/liststyle~ListStyle list styles feature}.
@@ -114,84 +114,4 @@ export default class ListStyleCommand extends Command {
 
 		return numberedList.isEnabled || bulletedList.isEnabled;
 	}
-}
-
-// Returns an array with all `listItem` elements that represents the same list.
-//
-// It means that values for `listIndent`, `listType`, and `listStyle` for all items
-// are equal.
-//
-// @param {module:engine/model/position~Position} position Starting position.
-// @param {'forward'|'backward'} direction Walking direction.
-// @returns {Array.<module:engine/model/element~Element>
-function getSiblingNodes( position, direction ) {
-	const items = [];
-	const listItem = position.parent;
-	const walkerOptions = {
-		ignoreElementEnd: true,
-		startPosition: position,
-		shallow: true,
-		direction
-	};
-	const limitIndent = listItem.getAttribute( 'listIndent' );
-	const nodes = [ ...new TreeWalker( walkerOptions ) ]
-		.filter( value => value.item.is( 'element' ) )
-		.map( value => value.item );
-
-	for ( const element of nodes ) {
-		// If found something else than `listItem`, we're out of the list scope.
-		if ( !element.is( 'element', 'listItem' ) ) {
-			break;
-		}
-
-		// If current parsed item has lower indent that element that the element that was a starting point,
-		// it means we left a nested list. Abort searching items.
-		//
-		// ■ List item 1.       [listIndent=0]
-		//     ○ List item 2.[] [listIndent=1], limitIndent = 1,
-		//     ○ List item 3.   [listIndent=1]
-		// ■ List item 4.       [listIndent=0]
-		//
-		// Abort searching when leave nested list.
-		if ( element.getAttribute( 'listIndent' ) < limitIndent ) {
-			break;
-		}
-
-		// ■ List item 1.[]     [listIndent=0] limitIndent = 0,
-		//     ○ List item 2.   [listIndent=1]
-		//     ○ List item 3.   [listIndent=1]
-		// ■ List item 4.       [listIndent=0]
-		//
-		// Ignore nested lists.
-		if ( element.getAttribute( 'listIndent' ) > limitIndent ) {
-			continue;
-		}
-
-		// ■ List item 1.[]  [listType=bulleted]
-		// 1. List item 2.   [listType=numbered]
-		// 2.List item 3.    [listType=numbered]
-		//
-		// Abort searching when found a different kind of a list.
-		if ( element.getAttribute( 'listType' ) !== listItem.getAttribute( 'listType' ) ) {
-			break;
-		}
-
-		// ■ List item 1.[]  [listType=bulleted]
-		// ■ List item 2.    [listType=bulleted]
-		// ○ List item 3.    [listType=bulleted]
-		// ○ List item 4.    [listType=bulleted]
-		//
-		// Abort searching when found a different list style.
-		if ( element.getAttribute( 'listStyle' ) !== listItem.getAttribute( 'listStyle' ) ) {
-			break;
-		}
-
-		if ( direction === 'backward' ) {
-			items.unshift( element );
-		} else {
-			items.push( element );
-		}
-	}
-
-	return items;
 }

--- a/packages/ckeditor5-list/src/liststyleediting.js
+++ b/packages/ckeditor5-list/src/liststyleediting.js
@@ -67,7 +67,7 @@ export default class ListStyleEditing extends Plugin {
 		editor.conversion.for( 'upcast' ).add( upcastListItemStyle() );
 		editor.conversion.for( 'downcast' ).add( downcastListStyleAttribute() );
 
-		// Handle merging two separated lists into the single oen.
+		// Handle merging two separated lists into the single one.
 		this._mergeListStyleAttributeWhileMergingLists();
 	}
 

--- a/packages/ckeditor5-list/src/liststyleediting.js
+++ b/packages/ckeditor5-list/src/liststyleediting.js
@@ -119,6 +119,7 @@ export default class ListStyleEditing extends Plugin {
 		// and it' also a starting point when searching for items in the second list.
 		let firstMostOuterItem;
 
+		// Check whether the removed content is between two lists.
 		this.listenTo( model, 'deleteContent', ( evt, [ selection ] ) => {
 			const firstPosition = selection.getFirstPosition();
 			const lastPosition = selection.getLastPosition();
@@ -150,6 +151,7 @@ export default class ListStyleEditing extends Plugin {
 			}
 		}, { priority: 'high' } );
 
+		// If so, update the `listStyle` attribute for the second list.
 		this.listenTo( model, 'deleteContent', () => {
 			if ( !firstMostOuterItem ) {
 				return;

--- a/packages/ckeditor5-list/src/utils.js
+++ b/packages/ckeditor5-list/src/utils.js
@@ -207,6 +207,7 @@ export function positionAfterUiElements( viewPosition ) {
  * @param {Boolean} [options.sameIndent=false] Whether the sought sibling should have the same indentation.
  * @param {Boolean} [options.smallerIndent=false] Whether the sought sibling should have a smaller indentation.
  * @param {Number} [options.listIndent] The reference indentation.
+ * @param {'forward'|'backward'} [options.direction='backward'] Walking direction.
  * @returns {module:engine/model/item~Item|null}
  */
 export function getSiblingListItem( modelItem, options ) {
@@ -223,7 +224,11 @@ export function getSiblingListItem( modelItem, options ) {
 			return item;
 		}
 
-		item = item.previousSibling;
+		if ( options.direction === 'forward' ) {
+			item = item.nextSibling;
+		} else {
+			item = item.previousSibling;
+		}
 	}
 
 	return null;

--- a/packages/ckeditor5-list/src/utils.js
+++ b/packages/ckeditor5-list/src/utils.js
@@ -9,6 +9,7 @@
 
 import { getFillerOffset } from '@ckeditor/ckeditor5-engine/src/view/containerelement';
 import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
+import TreeWalker from '@ckeditor/ckeditor5-engine/src/model/treewalker';
 
 /**
  * Creates a list item {@link module:engine/view/containerelement~ContainerElement}.
@@ -282,6 +283,87 @@ export function findNestedList( viewElement ) {
 	}
 
 	return null;
+}
+
+/**
+ * Returns an array with all `listItem` elements that represents the same list.
+ *
+ * It means that values for `listIndent`, `listType`, and `listStyle` for all items are equal.
+ *
+ * @param {module:engine/model/position~Position} position Starting position.
+ * @param {'forward'|'backward'} direction Walking direction.
+ * @returns {Array.<module:engine/model/element~Element>
+ */
+export function getSiblingNodes( position, direction ) {
+	const items = [];
+	const listItem = position.parent;
+	const walkerOptions = {
+		ignoreElementEnd: true,
+		startPosition: position,
+		shallow: true,
+		direction
+	};
+	const limitIndent = listItem.getAttribute( 'listIndent' );
+	const nodes = [ ...new TreeWalker( walkerOptions ) ]
+		.filter( value => value.item.is( 'element' ) )
+		.map( value => value.item );
+
+	for ( const element of nodes ) {
+		// If found something else than `listItem`, we're out of the list scope.
+		if ( !element.is( 'element', 'listItem' ) ) {
+			break;
+		}
+
+		// If current parsed item has lower indent that element that the element that was a starting point,
+		// it means we left a nested list. Abort searching items.
+		//
+		// ■ List item 1.       [listIndent=0]
+		//     ○ List item 2.[] [listIndent=1], limitIndent = 1,
+		//     ○ List item 3.   [listIndent=1]
+		// ■ List item 4.       [listIndent=0]
+		//
+		// Abort searching when leave nested list.
+		if ( element.getAttribute( 'listIndent' ) < limitIndent ) {
+			break;
+		}
+
+		// ■ List item 1.[]     [listIndent=0] limitIndent = 0,
+		//     ○ List item 2.   [listIndent=1]
+		//     ○ List item 3.   [listIndent=1]
+		// ■ List item 4.       [listIndent=0]
+		//
+		// Ignore nested lists.
+		if ( element.getAttribute( 'listIndent' ) > limitIndent ) {
+			continue;
+		}
+
+		// ■ List item 1.[]  [listType=bulleted]
+		// 1. List item 2.   [listType=numbered]
+		// 2.List item 3.    [listType=numbered]
+		//
+		// Abort searching when found a different kind of a list.
+		if ( element.getAttribute( 'listType' ) !== listItem.getAttribute( 'listType' ) ) {
+			break;
+		}
+
+		// ■ List item 1.[]  [listType=bulleted]
+		// ■ List item 2.    [listType=bulleted]
+		// ○ List item 3.    [listType=bulleted]
+		// ○ List item 4.    [listType=bulleted]
+		//
+		// Abort searching when found a different list style.
+		if ( element.getAttribute( 'listStyle' ) !== listItem.getAttribute( 'listStyle' ) ) {
+			break;
+		}
+
+		if ( direction === 'backward' ) {
+			items.unshift( element );
+		} else {
+			items.push( element );
+		}
+	}
+
+	return items;
 }
 
 // Implementation of getFillerOffset for view list item element.

--- a/packages/ckeditor5-list/src/utils.js
+++ b/packages/ckeditor5-list/src/utils.js
@@ -292,7 +292,7 @@ export function findNestedList( viewElement ) {
  *
  * @param {module:engine/model/position~Position} position Starting position.
  * @param {'forward'|'backward'} direction Walking direction.
- * @returns {Array.<module:engine/model/element~Element>
+ * @returns {Array.<module:engine/model/element~Element>}
  */
 export function getSiblingNodes( position, direction ) {
 	const items = [];

--- a/packages/ckeditor5-list/tests/liststyleediting.js
+++ b/packages/ckeditor5-list/tests/liststyleediting.js
@@ -5,13 +5,14 @@
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Typing from '@ckeditor/ckeditor5-typing/src/typing';
+import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
-import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
+
 import ListStyleEditing from '../src/liststyleediting';
 import TodoListEditing from '../src/todolistediting';
 import ListStyleCommand from '../src/liststylecommand';
-import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 
 describe( 'ListStyleEditing', () => {
 	let editor, model, view;

--- a/packages/ckeditor5-list/tests/liststyleediting.js
+++ b/packages/ckeditor5-list/tests/liststyleediting.js
@@ -11,6 +11,7 @@ import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
 import ListStyleEditing from '../src/liststyleediting';
 import TodoListEditing from '../src/todolistediting';
 import ListStyleCommand from '../src/liststylecommand';
+import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 
 describe( 'ListStyleEditing', () => {
 	let editor, model, view;
@@ -891,6 +892,266 @@ describe( 'ListStyleEditing', () => {
 					'<listItem listIndent="0" listStyle="circle" listType="bulleted">Bar</listItem>'
 				);
 			} );
+		} );
+
+		describe( 'removing content between two lists', () => {
+			let editor, model;
+
+			beforeEach( () => {
+				return VirtualTestEditor
+					.create( {
+						plugins: [ Paragraph, ListStyleEditing, Typing ]
+					} )
+					.then( newEditor => {
+						editor = newEditor;
+						model = editor.model;
+					} );
+			} );
+
+			afterEach( () => {
+				return editor.destroy();
+			} );
+
+			it( 'should not do anything while removing a letter inside a listItem', () => {
+				setModelData( model,
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">2.[]</listItem>' +
+					'<paragraph></paragraph>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.</listItem>'
+				);
+
+				editor.execute( 'delete' );
+
+				expect( getModelData( model ) ).to.equal(
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">2[]</listItem>' +
+					'<paragraph></paragraph>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.</listItem>'
+				);
+			} );
+
+			it( 'should not do anything if there is a non-listItem before the removed content', () => {
+				setModelData( model,
+					'<paragraph>Foo</paragraph>' +
+					'<paragraph>[]</paragraph>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.</listItem>'
+				);
+
+				editor.execute( 'delete' );
+
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>Foo[]</paragraph>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.</listItem>'
+				);
+			} );
+
+			it( 'should not do anything if there is a non-listItem after the removed content', () => {
+				setModelData( model,
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.</listItem>' +
+					'<paragraph>[]</paragraph>' +
+					'<paragraph>Foo</paragraph>'
+				);
+
+				editor.execute( 'delete' );
+
+				expect( getModelData( model ) ).to.equal(
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.[]</listItem>' +
+					'<paragraph>Foo</paragraph>'
+				);
+			} );
+
+			it( 'should not do anything if there is no element after the removed content', () => {
+				setModelData( model,
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.</listItem>' +
+					'<paragraph>[]</paragraph>'
+				);
+
+				editor.execute( 'delete' );
+
+				expect( getModelData( model ) ).to.equal(
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.[]</listItem>'
+				);
+			} );
+
+			it(
+				'should modify the the `listStyle` attribute for the merged (second) list when removing content between those lists',
+				() => {
+					setModelData( model,
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">2.</listItem>' +
+						'<paragraph>[]</paragraph>' +
+						'<listItem listIndent="0" listStyle="circle" listType="bulleted">1.</listItem>' +
+						'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.</listItem>'
+					);
+
+					editor.execute( 'delete' );
+
+					expect( getModelData( model ) ).to.equal(
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">2.[]</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">2.</listItem>'
+					);
+				}
+			);
+
+			it( 'should read the `listStyle` attribute from the most outer list', () => {
+				setModelData( model,
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">2.</listItem>' +
+					'<listItem listIndent="1" listStyle="numbered" listType="decimal">2.1.</listItem>' +
+					'<listItem listIndent="2" listStyle="default" listType="default">2.1.1</listItem>' +
+					'<paragraph>[]</paragraph>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.</listItem>'
+				);
+
+				editor.execute( 'delete' );
+
+				expect( getModelData( model ) ).to.equal(
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">2.</listItem>' +
+					'<listItem listIndent="1" listStyle="numbered" listType="decimal">2.1.</listItem>' +
+					'<listItem listIndent="2" listStyle="default" listType="default">2.1.1[]</listItem>' +
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">2.</listItem>'
+				);
+			} );
+
+			it(
+				'should not modify the the `listStyle` attribute for the merged (second) list if merging different `listType` attribute',
+				() => {
+					setModelData( model,
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">2.</listItem>' +
+						'<paragraph>[]</paragraph>' +
+						'<listItem listIndent="0" listStyle="decimal" listType="numbered">1.</listItem>' +
+						'<listItem listIndent="0" listStyle="decimal" listType="numbered">2.</listItem>'
+					);
+
+					editor.execute( 'delete' );
+
+					expect( getModelData( model ) ).to.equal(
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">2.[]</listItem>' +
+						'<listItem listIndent="0" listStyle="decimal" listType="numbered">1.</listItem>' +
+						'<listItem listIndent="0" listStyle="decimal" listType="numbered">2.</listItem>'
+					);
+				}
+			);
+
+			it(
+				'should modify the the `listStyle` attribute for the merged (second) list when removing content from both lists',
+				() => {
+					setModelData( model,
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">2.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">[3.</listItem>' +
+						'<paragraph>Foo</paragraph>' +
+						'<listItem listIndent="0" listStyle="circle" listType="bulleted">1.]</listItem>' +
+						'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.</listItem>'
+					);
+
+					editor.execute( 'delete' );
+
+					expect( getModelData( model ) ).to.equal(
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">2.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">[]</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">2.</listItem>'
+					);
+				}
+			);
+
+			it(
+				'should modify the the `listStyle` attribute for the merged (second) list when typing over content from both lists',
+				() => {
+					setModelData( model,
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">2.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">[3.</listItem>' +
+						'<paragraph>Foo</paragraph>' +
+						'<listItem listIndent="0" listStyle="circle" listType="bulleted">1.]</listItem>' +
+						'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.</listItem>'
+					);
+
+					editor.execute( 'input', { text: 'Foo' } );
+
+					expect( getModelData( model ) ).to.equal(
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">2.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">Foo[]</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">2.</listItem>'
+					);
+				}
+			);
+
+			it(
+				'should not modify the the `listStyle` if lists were not merged but the content was partially removed',
+				() => {
+					setModelData( model,
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">111.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">222.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">[333.</listItem>' +
+						'<paragraph>Foo</paragraph>' +
+						'<listItem listIndent="0" listStyle="circle" listType="bulleted">1]11.</listItem>' +
+						'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.</listItem>'
+					);
+
+					editor.execute( 'delete' );
+
+					expect( getModelData( model ) ).to.equal(
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">111.</listItem>' +
+						'<listItem listIndent="0" listStyle="square" listType="bulleted">222.</listItem>' +
+						'<listItem listIndent="0" listStyle="circle" listType="bulleted">[]11.</listItem>' +
+						'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.</listItem>'
+					);
+				}
+			);
+
+			it( 'should not do anything while typing in a list item', () => {
+				setModelData( model,
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">2.[]</listItem>' +
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">3.</listItem>' +
+					'<paragraph></paragraph>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.</listItem>'
+				);
+
+				const modelChangeStub = sinon.stub( model, 'change' ).callThrough();
+
+				simulateTyping( ' Foo' );
+
+				// Each character calls `editor.model.change()`.
+				expect( modelChangeStub.callCount ).to.equal( 4 );
+
+				expect( getModelData( model ) ).to.equal(
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">2. Foo[]</listItem>' +
+					'<listItem listIndent="0" listStyle="square" listType="bulleted">3.</listItem>' +
+					'<paragraph></paragraph>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">1.</listItem>' +
+					'<listItem listIndent="0" listStyle="circle" listType="bulleted">2.</listItem>'
+				);
+			} );
+
+			function simulateTyping( text ) {
+				// While typing, every character is an atomic change.
+				text.split( '' ).forEach( character => {
+					editor.execute( 'input', {
+						text: character
+					} );
+				} );
+			}
 		} );
 	} );
 } );

--- a/packages/ckeditor5-list/tests/utils.js
+++ b/packages/ckeditor5-list/tests/utils.js
@@ -5,7 +5,11 @@
 
 import ViewContainerElement from '@ckeditor/ckeditor5-engine/src/view/containerelement';
 import ViewDowncastWriter from '@ckeditor/ckeditor5-engine/src/view/downcastwriter';
-import { createViewListItemElement } from '../src/utils';
+import { createViewListItemElement, getSiblingListItem, getSiblingNodes } from '../src/utils';
+import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
+import ListEditing from '../src/listediting';
+import ListStyleEditing from '../src/liststyleediting';
 
 describe( 'utils', () => {
 	let writer;
@@ -131,6 +135,315 @@ describe( 'utils', () => {
 					expect( item.getFillerOffset() ).to.be.null;
 				} );
 			} );
+		} );
+	} );
+
+	describe( 'getSiblingListItem()', () => {
+		let editor, model, document;
+
+		beforeEach( () => {
+			return VirtualTestEditor.create( { plugins: [ ListEditing ] } )
+				.then( newEditor => {
+					editor = newEditor;
+					model = editor.model;
+					document = model.document;
+				} );
+		} );
+
+		afterEach( () => {
+			return editor.destroy();
+		} );
+
+		it( 'should return the passed element if it matches the criteria (sameIndent, listIndent=0)', () => {
+			setData( model,
+				'<listItem listType="bulleted" listIndent="0">0.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">1.</listItem>' + // Starting item, wanted item.
+				'<listItem listType="bulleted" listIndent="0">2.</listItem>'
+			);
+
+			const listItem = document.getRoot().getChild( 1 );
+			const foundElement = getSiblingListItem( listItem, {
+				sameIndent: true,
+				listIndent: 0
+			} );
+
+			expect( foundElement ).to.equal( document.getRoot().getChild( 1 ) );
+		} );
+
+		it( 'should return the passed element if it matches the criteria (sameIndent, listIndent=0, direction="forward")', () => {
+			setData( model,
+				'<listItem listType="bulleted" listIndent="0">0.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">1.</listItem>' + // Starting item, wanted item.
+				'<listItem listType="bulleted" listIndent="0">2.</listItem>'
+			);
+
+			const listItem = document.getRoot().getChild( 1 );
+			const foundElement = getSiblingListItem( listItem, {
+				sameIndent: true,
+				listIndent: 0,
+				direction: 'forward'
+			} );
+
+			expect( foundElement ).to.equal( document.getRoot().getChild( 1 ) );
+		} );
+
+		it( 'should return the first listItem that matches criteria (sameIndent, listIndent=1)', () => {
+			setData( model,
+				'<listItem listType="bulleted" listIndent="0">0.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">1.</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">1.1</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">1.2</listItem>' + // Wanted item.
+				'<listItem listType="bulleted" listIndent="0">2.</listItem>' + // Starting item.
+				'<listItem listType="bulleted" listIndent="1">2.1.</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">2.2.</listItem>'
+			);
+
+			const listItem = document.getRoot().getChild( 5 );
+			const foundElement = getSiblingListItem( listItem.previousSibling, {
+				sameIndent: true,
+				listIndent: 1
+			} );
+
+			expect( foundElement ).to.equal( document.getRoot().getChild( 3 ) );
+		} );
+
+		it( 'should return the first listItem that matches criteria (sameIndent, listIndent=1, direction="forward")', () => {
+			setData( model,
+				'<listItem listType="bulleted" listIndent="0">0.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">1.</listItem>' + // Starting item.
+				'<listItem listType="bulleted" listIndent="0">2.</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">2.1.</listItem>' + // Wanted item.
+				'<listItem listType="bulleted" listIndent="1">2.2.</listItem>'
+			);
+
+			const listItem = document.getRoot().getChild( 1 );
+			const foundElement = getSiblingListItem( listItem.nextSibling, {
+				sameIndent: true,
+				listIndent: 1,
+				direction: 'forward'
+			} );
+
+			expect( foundElement ).to.equal( document.getRoot().getChild( 3 ) );
+		} );
+
+		it( 'should return the first listItem that matches criteria (smallerIndent, listIndent=1)', () => {
+			setData( model,
+				'<listItem listType="bulleted" listIndent="0">0.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">1.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">2.</listItem>' + // Wanted item.
+				'<listItem listType="bulleted" listIndent="1">2.1.</listItem>' + // Starting item.
+				'<listItem listType="bulleted" listIndent="1">2.2.</listItem>'
+			);
+
+			const listItem = document.getRoot().getChild( 4 );
+			const foundElement = getSiblingListItem( listItem, {
+				smallerIndent: true,
+				listIndent: 1
+			} );
+
+			expect( foundElement ).to.equal( document.getRoot().getChild( 2 ) );
+		} );
+
+		it( 'should return the first listItem that matches criteria (smallerIndent, listIndent=1, direction="forward")', () => {
+			setData( model,
+				'<listItem listType="bulleted" listIndent="0">0.</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">0.1.</listItem>' + // Starting item.
+				'<listItem listType="bulleted" listIndent="1">0.2.</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">0.3.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">1.</listItem>' // Wanted item.
+			);
+
+			const listItem = document.getRoot().getChild( 1 );
+			const foundElement = getSiblingListItem( listItem, {
+				smallerIndent: true,
+				listIndent: 1,
+				direction: 'forward'
+			} );
+
+			expect( foundElement ).to.equal( document.getRoot().getChild( 4 ) );
+		} );
+	} );
+
+	describe( 'getSiblingNodes()', () => {
+		let editor, model, document;
+
+		beforeEach( () => {
+			return VirtualTestEditor.create( { plugins: [ ListStyleEditing ] } )
+				.then( newEditor => {
+					editor = newEditor;
+					model = editor.model;
+					document = model.document;
+				} );
+		} );
+
+		afterEach( () => {
+			return editor.destroy();
+		} );
+
+		it( 'should return all listItems above the current selection position (direction="backward")', () => {
+			setData( model,
+				'<listItem listType="bulleted" listIndent="0">0.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">1.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">[]2.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">3.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">4.</listItem>'
+			);
+
+			expect( getSiblingNodes( document.selection.getFirstPosition(), 'backward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 0 ),
+				document.getRoot().getChild( 1 ),
+				document.getRoot().getChild( 2 )
+			] );
+		} );
+
+		it( 'should return all listItems below the current selection position (direction="forward")', () => {
+			setData( model,
+				'<listItem listType="bulleted" listIndent="0">0.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">1.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">[]2.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">3.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">4.</listItem>'
+			);
+
+			expect( getSiblingNodes( document.selection.getFirstPosition(), 'forward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 3 ),
+				document.getRoot().getChild( 4 )
+			] );
+		} );
+
+		it( 'should break searching when spotted a non-listItem element (direction="backward")', () => {
+			setData( model,
+				'<listItem listType="bulleted" listIndent="0">0.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">1.</listItem>' +
+				'<paragraph>Foo</paragraph>' +
+				'<listItem listType="bulleted" listIndent="0">2.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">3.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">4.[].</listItem>'
+			);
+
+			expect( getSiblingNodes( document.selection.getFirstPosition(), 'backward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 3 ),
+				document.getRoot().getChild( 4 ),
+				document.getRoot().getChild( 5 )
+			] );
+		} );
+
+		it( 'should break searching when spotted a non-listItem element (direction="forward")', () => {
+			setData( model,
+				'<listItem listType="bulleted" listIndent="0">[]0.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">1.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">2.</listItem>' +
+				'<paragraph>Foo</paragraph>' +
+				'<listItem listType="bulleted" listIndent="0">3.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">4.</listItem>'
+			);
+
+			expect( getSiblingNodes( document.selection.getFirstPosition(), 'forward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 1 ),
+				document.getRoot().getChild( 2 )
+			] );
+		} );
+
+		it( 'should break searching when spotted a different value for the `listType` attribute (direction="backward")', () => {
+			setData( model,
+				'<listItem listType="bulleted" listIndent="0">0.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">1.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">2.</listItem>' +
+				'<listItem listType="numbered" listIndent="0">Numbered item.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">3.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">[]4.</listItem>'
+			);
+
+			expect( getSiblingNodes( document.selection.getFirstPosition(), 'backward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 4 ),
+				document.getRoot().getChild( 5 )
+			] );
+		} );
+
+		it( 'should break searching when spotted a different value for the `listType` attribute (direction="forward")', () => {
+			setData( model,
+				'<listItem listType="bulleted" listIndent="0">[]0.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">1.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">2.</listItem>' +
+				'<listItem listType="numbered" listIndent="0">Numbered item.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">3.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">4.</listItem>'
+			);
+
+			expect( getSiblingNodes( document.selection.getFirstPosition(), 'forward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 1 ),
+				document.getRoot().getChild( 2 )
+			] );
+		} );
+
+		it( 'should break searching when spotted a different value for the `listStyle` attribute (direction="backward")', () => {
+			setData( model,
+				'<listItem listType="bulleted" listStyle="disc" listIndent="0">0.</listItem>' +
+				'<listItem listType="bulleted" listStyle="disc" listIndent="0">1.</listItem>' +
+				'<listItem listType="bulleted" listStyle="disc" listIndent="0">2.</listItem>' +
+				'<listItem listType="bulleted" listStyle="square" listIndent="0">Broken item.</listItem>' +
+				'<listItem listType="bulleted" listStyle="disc" listIndent="0">3.</listItem>' +
+				'<listItem listType="bulleted" listStyle="disc" listIndent="0">[]4.</listItem>'
+			);
+
+			expect( getSiblingNodes( document.selection.getFirstPosition(), 'backward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 4 ),
+				document.getRoot().getChild( 5 )
+			] );
+		} );
+
+		it( 'should break searching when spotted a different value for the `listStyle` attribute (direction="forward")', () => {
+			setData( model,
+				'<listItem listType="bulleted" listStyle="disc" listIndent="0">[]0.</listItem>' +
+				'<listItem listType="bulleted" listStyle="disc" listIndent="0">1.</listItem>' +
+				'<listItem listType="bulleted" listStyle="disc" listIndent="0">2.</listItem>' +
+				'<listItem listType="bulleted" listStyle="square" listIndent="0">Broken item.</listItem>' +
+				'<listItem listType="bulleted" listStyle="disc" listIndent="0">3.</listItem>' +
+				'<listItem listType="bulleted" listStyle="disc" listIndent="0">4.</listItem>'
+			);
+
+			expect( getSiblingNodes( document.selection.getFirstPosition(), 'forward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 1 ),
+				document.getRoot().getChild( 2 )
+			] );
+		} );
+
+		it( 'should ignore nested items (looking for listIndent=0)', () => {
+			setData( model,
+				'<listItem listType="bulleted" listIndent="0">[]0.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">1.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">2.</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">2.1.</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">2.2.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">3.</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">3.1.</listItem>' +
+				'<listItem listType="bulleted" listIndent="2">3.1.1.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">4.</listItem>'
+			);
+
+			expect( getSiblingNodes( document.selection.getFirstPosition(), 'forward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 1 ),
+				document.getRoot().getChild( 2 ),
+				document.getRoot().getChild( 5 ),
+				document.getRoot().getChild( 8 )
+			] );
+		} );
+
+		it( 'should break when spotted an outer list (looking for listIndent=1)', () => {
+			setData( model,
+				'<listItem listType="bulleted" listIndent="0">0.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">1.</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">[]1.1.</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">1.2.</listItem>' +
+				'<listItem listType="bulleted" listIndent="1">1.3.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">2.</listItem>' +
+				'<listItem listType="bulleted" listIndent="0">3.</listItem>'
+			);
+
+			expect( getSiblingNodes( document.selection.getFirstPosition(), 'forward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 3 ),
+				document.getRoot().getChild( 4 )
+			] );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-list/tests/utils.js
+++ b/packages/ckeditor5-list/tests/utils.js
@@ -5,11 +5,13 @@
 
 import ViewContainerElement from '@ckeditor/ckeditor5-engine/src/view/containerelement';
 import ViewDowncastWriter from '@ckeditor/ckeditor5-engine/src/view/downcastwriter';
-import { createViewListItemElement, getSiblingListItem, getSiblingNodes } from '../src/utils';
 import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
+
 import ListEditing from '../src/listediting';
 import ListStyleEditing from '../src/liststyleediting';
+
+import { createViewListItemElement, getSiblingListItem, getSiblingNodes } from '../src/utils';
 
 describe( 'utils', () => {
 	let writer;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

**Two commit messages that depends on the time when we will close the PR.**

---

Internal: Handle removing the content between lists and updating `listStyle` attribute for merged items. Closes #7879.

_☝️ In case when we merge it into the current iteration._

---

_👇  In case when it will be merged somewhen._

Fix (list): When removing the content between two lists items, the lists will be merged into the single list. The second list should adjust its value for the `listStyle` attribute based on the most outer `listItem` in the first list. Closes #7879.
