### PR TITLE
Added one more check whether the CC report should be send to Coveralls

### DIFF
--- a/scripts/continuous-integration-script.js
+++ b/scripts/continuous-integration-script.js
@@ -92,8 +92,7 @@ for ( const fullPackageName of packages ) {
 
 console.log( 'Uploading combined code coverage report…' );
 
-// Comparing "organization/ckeditor5" and "ckeditor/ckeditor5".
-if ( process.env.TRAVIS_PULL_REQUEST_SLUG === process.env.TRAVIS_REPO_SLUG ) {
+if ( shouldUploadCoverageReport() ) {
 	childProcess.execSync( 'npx coveralls < .out/combined_lcov.info' );
 } else {
 	console.log( 'Since the PR comes from the community, we do not upload code coverage report.' );
@@ -157,4 +156,10 @@ function appendCoverageReport() {
 			flag: 'as'
 		} );
 	} );
+}
+
+function shouldUploadCoverageReport() {
+	// If the repository slugs are different, the pull request comes from the community (forked repository).
+	// For such builds, sending the CC report will be disabled.
+	return ( process.env.TRAVIS_EVENT_TYPE !== 'pull_request' || process.env.TRAVIS_PULL_REQUEST_SLUG === process.env.TRAVIS_REPO_SLUG );
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Improved the check whether the CC report should be send to Coveralls. The previous solution did not consider normal builds (cron, push). See #7745.
