### PR TITLE
Support for the --strict flag

### DIFF
--- a/scripts/docs/build-docs.js
+++ b/scripts/docs/build-docs.js
@@ -27,12 +27,7 @@ function buildDocs() {
 	if ( skipApi ) {
 		promise = Promise.resolve();
 	} else {
-		promise = buildApiDocs()
-			.catch( err => {
-				console.error( err );
-
-				process.exitCode = 1;
-			} );
+		promise = buildApiDocs();
 	}
 
 	promise
@@ -45,6 +40,11 @@ function buildDocs() {
 				watch,
 				verbose
 			} );
+		} )
+		.catch( err => {
+			console.error( err );
+
+			process.exitCode = 1;
 		} );
 }
 

--- a/scripts/docs/buildapi.js
+++ b/scripts/docs/buildapi.js
@@ -23,6 +23,7 @@ module.exports = function buildApiDocs() {
 				'!' + process.cwd() + '/external/*/packages/@(ckeditor|ckeditor5)-*/src/lib/**/*.js',
 				'!' + process.cwd() + '/external/*/packages/ckeditor5-build-*/src/**/*.js'
 			],
-			validateOnly: process.argv.includes( '--validate-only' )
+			validateOnly: process.argv.includes( '--validate-only' ),
+			strict: process.argv.includes( '--strict' )
 		} );
 };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Moved the `catch()` block to the "main process" while building docs. Support for the `--strict` flag. Closes #7994.

---

### Additional information

Requires: https://github.com/ckeditor/ckeditor5-dev/pull/670
