### PR TITLE
#7996: Improved InputObserver with useful input event data properties

### DIFF
--- a/packages/ckeditor5-engine/src/view/observer/inputobserver.js
+++ b/packages/ckeditor5-engine/src/view/observer/inputobserver.js
@@ -8,11 +8,13 @@
  */
 
 import DomEventObserver from './domeventobserver';
+import DataTransfer from '../datatransfer';
 
 /**
  * Observer for events connected with data input.
  *
- * Note that this observer is attached by the {@link module:engine/view/view~View} and is available by default.
+ * **Note**: This observer is attached by {@link module:engine/view/view~View} and available by default in all
+ * editor instances.
  *
  * @extends module:engine/view/observer/domeventobserver~DomEventObserver
  */
@@ -24,21 +26,98 @@ export default class InputObserver extends DomEventObserver {
 	}
 
 	onDomEvent( domEvent ) {
-		this.fire( domEvent.type, domEvent );
+		const domTargetRanges = Array.from( domEvent.getTargetRanges() );
+		const view = this.view;
+
+		let dataTransfer = null;
+		let data = null;
+
+		if ( domEvent.dataTransfer ) {
+			dataTransfer = new DataTransfer( domEvent.dataTransfer );
+		}
+
+		if ( domEvent.data ) {
+			data = domEvent.data;
+		} else if ( dataTransfer ) {
+			data = dataTransfer.getData( 'text/plain' );
+		}
+
+		this.fire( domEvent.type, domEvent, {
+			data,
+			dataTransfer,
+			domTargetRanges,
+			targetRanges: domTargetRanges.map( domRange => view.domConverter.domRangeToView( domRange ) ),
+			inputType: domEvent.inputType
+		} );
 	}
 }
 
 /**
- * Fired before browser inputs (or deletes) some data.
+ * Fired before the web browser inputs, deletes, or formats some data.
  *
- * This event is available only on browsers which support DOM `beforeinput` event.
+ * **Note**: This event is available only in browsers which support the DOM [`beforeinput`](https://www.w3.org/TR/input-events-2/) event.
  *
- * Introduced by {@link module:engine/view/observer/inputobserver~InputObserver}.
- *
- * Note that because {@link module:engine/view/observer/inputobserver~InputObserver} is attached by the
- * {@link module:engine/view/view~View} this event is available by default.
+ * This event is introduced by {@link module:engine/view/observer/inputobserver~InputObserver} and available
+ * by default in all editor instances (attached by {@link module:engine/view/view~View}).
  *
  * @see module:engine/view/observer/inputobserver~InputObserver
  * @event module:engine/view/document~Document#event:beforeinput
- * @param {module:engine/view/observer/domeventdata~DomEventData} data Event data.
+ * @param {module:engine/view/observer/inputobserver~InputEventData} data Event data containing detailed information about the event.
+ */
+
+/**
+ * The value of the {@link module:engine/view/document~Document#event:beforeinput} event.
+ *
+ * @class module:engine/view/observer/inputobserver~InputEventData
+ * @extends module:engine/view/observer/domeventdata~DomEventData
+ */
+
+/**
+ * The data transfer instance of the input event. Corresponds to native `InputEvent#dataTransfer`.
+ *
+ * The value is `null` when no `dataTransfer` was passed along with the input event.
+ *
+ * @readonly
+ * @member {module:engine/view/datatransfer~DataTransfer|null} module:engine/view/observer/inputobserver~InputEventData#dataTransfer
+ */
+
+/**
+ * An array of target ranges passed along with the input event. Corresponds to the output of native `InputEvent#getTargetRanges()`.
+ *
+ * @readonly
+ * @member {Array.<Range>} module:engine/view/observer/inputobserver~InputEventData#domTargetRanges
+ */
+
+/**
+ * The type of the input event (e.g. "insertText" or "deleteWordBackward"). Corresponds to native `InputEvent#inputType`.
+ *
+ * @readonly
+ * @member {String} module:engine/view/observer/inputobserver~InputEventData#inputType
+ */
+
+/**
+ * Editing view ranges corresponding to
+ * {@link module:engine/view/observer/inputobserver~InputEventData#domTargetRanges DOM ranges} passed along with the input event.
+ *
+ * @readonly
+ * @member {Array.<module:engine/view/range~Range>} module:engine/view/observer/inputobserver~InputEventData#targetRanges
+ */
+
+/**
+ * A unified text data passed along with the input event. Depending on:
+ *
+ * * the web browser and input events implementation (for instance [Level 1](https://www.w3.org/TR/input-events-1/) or
+ * [Level 2](https://www.w3.org/TR/input-events-2/)),
+ * * {@link module:engine/view/observer/inputobserver~InputEventData#inputType input type}
+ *
+ * text data is sometimes passed in the `data` and sometimes in the `dataTransfer` property.
+ *
+ * * If `InputEvent#data` was set, this property reflects its value.
+ * * If `InputEvent#data` is unavailable, this property contains the `'text/plain'` data from
+ * {@link module:engine/view/observer/inputobserver~InputEventData#dataTransfer}.
+ * * If the event ({@link module:engine/view/observer/inputobserver~InputEventData#inputType input type})
+ * provides no data whatsoever, this property is `null`.
+ *
+ * @readonly
+ * @member {String|null} module:engine/view/observer/inputobserver~InputEventData#data
  */

--- a/packages/ckeditor5-engine/src/view/observer/inputobserver.js
+++ b/packages/ckeditor5-engine/src/view/observer/inputobserver.js
@@ -26,7 +26,7 @@ export default class InputObserver extends DomEventObserver {
 	}
 
 	onDomEvent( domEvent ) {
-		const domTargetRanges = Array.from( domEvent.getTargetRanges() );
+		const domTargetRanges = domEvent.getTargetRanges();
 		const view = this.view;
 
 		let dataTransfer = null;

--- a/packages/ckeditor5-engine/src/view/view.js
+++ b/packages/ckeditor5-engine/src/view/view.js
@@ -29,7 +29,6 @@ import { scrollViewportToShowTarget } from '@ckeditor/ckeditor5-utils/src/dom/sc
 import { injectUiElementHandling } from './uielement';
 import { injectQuirksHandling } from './filler';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
-import env from '@ckeditor/ckeditor5-utils/src/env';
 
 /**
  * Editor's view controller class. Its main responsibility is DOM - View management for editing purposes, to provide
@@ -184,10 +183,7 @@ export default class View {
 		this.addObserver( KeyObserver );
 		this.addObserver( FakeSelectionObserver );
 		this.addObserver( CompositionObserver );
-
-		if ( env.isAndroid ) {
-			this.addObserver( InputObserver );
-		}
+		this.addObserver( InputObserver );
 
 		// Inject quirks handlers.
 		injectQuirksHandling( this );

--- a/packages/ckeditor5-engine/tests/view/observer/inputobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/inputobserver.js
@@ -5,48 +5,192 @@
 
 import InputObserver from '../../../src/view/observer/inputobserver';
 import View from '../../../src/view/view';
-import env from '@ckeditor/ckeditor5-utils/src/env';
+import createViewRoot from '../_utils/createroot';
+import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 import { StylesProcessor } from '../../../src/view/stylesmap';
+import DataTransfer from '../../../src/view/datatransfer';
 
 describe( 'InputObserver', () => {
-	const oldEnvIsAndroid = env.isAndroid;
-
-	let view, viewDocument, observer;
-
-	before( () => {
-		env.isAndroid = true;
-	} );
+	let domEditable, view, viewRoot, viewDocument, observer, evtData, beforeInputSpy;
 
 	beforeEach( () => {
 		view = new View( new StylesProcessor() );
 		viewDocument = view.document;
+		domEditable = global.document.createElement( 'div' );
+		viewRoot = createViewRoot( viewDocument );
+
+		view.attachDomRoot( domEditable );
+
+		// <p>foo</p>
+		view.change( writer => {
+			const paragraph = writer.createContainerElement( 'p' );
+			const text = writer.createText( 'foo' );
+
+			writer.insert( writer.createPositionAt( paragraph, 0 ), text );
+			writer.insert( writer.createPositionAt( viewRoot, 0 ), paragraph );
+		} );
+
 		observer = view.getObserver( InputObserver );
+
+		beforeInputSpy = sinon.spy();
+		viewDocument.on( 'beforeinput', beforeInputSpy );
 	} );
 
 	afterEach( () => {
 		view.destroy();
-	} );
-
-	after( () => {
-		env.isAndroid = oldEnvIsAndroid;
+		domEditable.remove();
 	} );
 
 	it( 'should define domEventType', () => {
 		expect( observer.domEventType ).to.contains( 'beforeinput' );
 	} );
 
-	it( 'should fire beforeinput with dom event data', () => {
-		const spy = sinon.spy();
+	it( 'should fire the #beforeinput once for every DOM event', () => {
+		fireMockNativeBeforeInput();
 
-		viewDocument.on( 'beforeinput', spy );
-
-		const domEvtData = {
-			type: 'beforeinput'
-		};
-
-		observer.onDomEvent( domEvtData );
-
-		expect( spy.calledOnce ).to.be.true;
-		expect( spy.args[ 0 ][ 1 ].domEvent ).to.equal( domEvtData );
+		sinon.assert.calledOnce( beforeInputSpy );
 	} );
+
+	describe( 'event data', () => {
+		it( 'should contain #eventType', () => {
+			fireMockNativeBeforeInput( {
+				inputType: 'foo'
+			} );
+
+			expect( evtData.inputType ).to.equal( 'foo' );
+		} );
+
+		describe( '#dataTransfer', () => {
+			it( 'should be an instance of DataTransfer if the DOM event passes data transfer', () => {
+				const dataTransferMock = sinon.stub();
+
+				dataTransferMock.withArgs( 'foo/bar' ).returns( 'baz' );
+
+				fireMockNativeBeforeInput( {
+					dataTransfer: {
+						getData: dataTransferMock
+					}
+				} );
+
+				expect( evtData.dataTransfer ).to.be.instanceOf( DataTransfer );
+				expect( evtData.dataTransfer.getData( 'foo/bar' ) ).to.equal( 'baz' );
+			} );
+
+			it( 'should be "null" if no data transfer was provided by the DOM event', () => {
+				fireMockNativeBeforeInput();
+
+				expect( evtData.dataTransfer ).to.be.null;
+			} );
+		} );
+
+		describe( '#domTargetRanges', () => {
+			it( 'should be an array of native DOM ranges', () => {
+				const domRange1 = global.document.createRange();
+				const domRange2 = global.document.createRange();
+
+				// [<p>foo</p>]
+				domRange1.selectNodeContents( domEditable );
+				// <p>[fo]o</p>
+				domRange2.setStart( domEditable.firstChild.firstChild, 0 );
+				domRange2.setEnd( domEditable.firstChild.firstChild, 2 );
+
+				fireMockNativeBeforeInput( {
+					getTargetRanges: () => [ domRange1, domRange2 ]
+				} );
+
+				expect( evtData.domTargetRanges ).to.have.ordered.members( [ domRange1, domRange2 ] );
+			} );
+
+			it( 'should be an empty array if there are no native DOM ranges', () => {
+				fireMockNativeBeforeInput( {
+					getTargetRanges: () => []
+				} );
+
+				expect( evtData.domTargetRanges ).to.be.empty;
+			} );
+		} );
+
+		describe( '#targetRanges', () => {
+			it( 'should be an empty array if there are no native DOM ranges', () => {
+				fireMockNativeBeforeInput( {
+					getTargetRanges: () => []
+				} );
+
+				expect( evtData.targetRanges ).to.be.empty;
+			} );
+
+			it( 'should provide editing view ranges corresponding to DOM ranges passed along with the DOM event', () => {
+				const domRange1 = global.document.createRange();
+				const domRange2 = global.document.createRange();
+
+				// [<p>foo</p>]
+				domRange1.selectNodeContents( domEditable );
+				// <p>[fo]o</p>
+				domRange2.setStart( domEditable.firstChild.firstChild, 0 );
+				domRange2.setEnd( domEditable.firstChild.firstChild, 2 );
+
+				fireMockNativeBeforeInput( {
+					getTargetRanges: () => [ domRange1, domRange2 ]
+				} );
+
+				expect( evtData.targetRanges ).to.have.length( 2 );
+
+				const viewRange1 = evtData.targetRanges[ 0 ];
+				const viewRange2 = evtData.targetRanges[ 1 ];
+
+				expect( viewRange1.start.parent ).to.equal( viewRoot );
+				expect( viewRange1.start.offset ).to.equal( 0 );
+				expect( viewRange1.end.parent ).to.equal( viewRoot );
+				expect( viewRange1.end.offset ).to.equal( 1 );
+
+				expect( viewRange2.start.parent ).to.equal( viewRoot.getChild( 0 ).getChild( 0 ) );
+				expect( viewRange2.start.offset ).to.equal( 0 );
+				expect( viewRange2.end.parent ).to.equal( viewRoot.getChild( 0 ).getChild( 0 ) );
+				expect( viewRange2.end.offset ).to.equal( 2 );
+			} );
+		} );
+
+		describe( '#data', () => {
+			it( 'should reflect InputEvent#data (when available)', () => {
+				fireMockNativeBeforeInput( {
+					data: 'foo'
+				} );
+
+				expect( evtData.data ).to.equal( 'foo' );
+			} );
+
+			it( 'should attempt to use text/plain from #dataTransfer if InputEvent#data is unavailable', () => {
+				const dataTransferMock = sinon.stub();
+
+				dataTransferMock.withArgs( 'text/plain' ).returns( 'bar' );
+
+				fireMockNativeBeforeInput( {
+					data: null,
+					dataTransfer: {
+						getData: dataTransferMock
+					}
+				} );
+
+				expect( evtData.data ).to.equal( 'bar' );
+			} );
+
+			it( 'should be "null" if both InputEvent#data and InputEvent#dataTransfer are unavailable', () => {
+				fireMockNativeBeforeInput( {
+					data: null,
+					dataTransfer: null
+				} );
+
+				expect( evtData.data ).to.be.null;
+			} );
+		} );
+	} );
+
+	function fireMockNativeBeforeInput( domEvtMock ) {
+		observer.onDomEvent( Object.assign( {
+			type: 'beforeinput',
+			getTargetRanges: () => []
+		}, domEvtMock ) );
+
+		evtData = beforeInputSpy.firstCall.args[ 1 ];
+	}
 } );

--- a/packages/ckeditor5-engine/tests/view/observer/inputobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/inputobserver.js
@@ -3,12 +3,14 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import InputObserver from '../../../src/view/observer/inputobserver';
-import View from '../../../src/view/view';
-import createViewRoot from '../_utils/createroot';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
-import { StylesProcessor } from '../../../src/view/stylesmap';
+
+import InputObserver from '../../../src/view/observer/inputobserver';
 import DataTransfer from '../../../src/view/datatransfer';
+import View from '../../../src/view/view';
+import { StylesProcessor } from '../../../src/view/stylesmap';
+
+import createViewRoot from '../_utils/createroot';
 
 describe( 'InputObserver', () => {
 	let domEditable, view, viewRoot, viewDocument, observer, evtData, beforeInputSpy;

--- a/packages/ckeditor5-engine/tests/view/observer/inputobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/inputobserver.js
@@ -7,6 +7,7 @@ import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
 import InputObserver from '../../../src/view/observer/inputobserver';
 import DataTransfer from '../../../src/view/datatransfer';
+import Range from '../../../src/view/range';
 import View from '../../../src/view/view';
 import { StylesProcessor } from '../../../src/view/stylesmap';
 
@@ -139,6 +140,9 @@ describe( 'InputObserver', () => {
 
 				const viewRange1 = evtData.targetRanges[ 0 ];
 				const viewRange2 = evtData.targetRanges[ 1 ];
+
+				expect( viewRange1 ).to.be.instanceOf( Range );
+				expect( viewRange2 ).to.be.instanceOf( Range );
 
 				expect( viewRange1.start.parent ).to.equal( viewRoot );
 				expect( viewRange1.start.offset ).to.equal( 0 );

--- a/packages/ckeditor5-engine/tests/view/view/view.js
+++ b/packages/ckeditor5-engine/tests/view/view/view.js
@@ -31,7 +31,7 @@ import env from '@ckeditor/ckeditor5-utils/src/env';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 describe( 'view', () => {
-	const DEFAULT_OBSERVERS_COUNT = 6;
+	const DEFAULT_OBSERVERS_COUNT = 7;
 	let domRoot, view, viewDocument, ObserverMock, instantiated, enabled, ObserverMockGlobalCount;
 
 	beforeEach( () => {
@@ -87,17 +87,7 @@ describe( 'view', () => {
 		expect( view.getObserver( KeyObserver ) ).to.be.instanceof( KeyObserver );
 		expect( view.getObserver( FakeSelectionObserver ) ).to.be.instanceof( FakeSelectionObserver );
 		expect( view.getObserver( CompositionObserver ) ).to.be.instanceof( CompositionObserver );
-	} );
-
-	it( 'should add InputObserver on Android devices', () => {
-		const oldEnvIsAndroid = env.isAndroid;
-		env.isAndroid = true;
-
-		const newView = new View( new StylesProcessor() );
-		expect( newView.getObserver( InputObserver ) ).to.be.instanceof( InputObserver );
-
-		env.isAndroid = oldEnvIsAndroid;
-		newView.destroy();
+		expect( view.getObserver( InputObserver ) ).to.be.instanceof( InputObserver );
 	} );
 
 	describe( 'attachDomRoot()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (engine): Improved `InputObserver` with useful input event data properties. Closes #7996.

Other (clipboard): Moved the `DataTransfer` helper class to ckeditor5-engine (see #7996).

Internal (image): Updated import paths and docs since the `DataTransfer` helper class has been moved to [ckeditor5-engine](https://www.npmjs.com/package/@ckeditor/ckeditor5-engine) (see #7996).

MINOR BREAKING CHANGE (clipboard): The `DataTransfer` helper class has been moved to [ckeditor5-engine](https://www.npmjs.com/package/@ckeditor/ckeditor5-engine). Please update the import path in your integrations to `'@ckeditor/ckeditor5-engine/src/view/datatransfer'` (see #7996).

---

### Additional information

\-