### PR TITLE
i/7983: Prevent showing an error on pressing "enter" when autolink is selected.

### DIFF
--- a/packages/ckeditor5-link/src/autolink.js
+++ b/packages/ckeditor5-link/src/autolink.js
@@ -147,6 +147,10 @@ export default class AutoLink extends Plugin {
 		enterCommand.on( 'execute', () => {
 			const position = model.document.selection.getFirstPosition();
 
+			if ( !position.parent.previousSibling ) {
+				return;
+			}
+
 			const rangeToCheck = model.createRange(
 				model.createPositionAt( position.parent.previousSibling, 0 ),
 				model.createPositionAt( position.parent.previousSibling, 'end' )

--- a/packages/ckeditor5-link/src/autolink.js
+++ b/packages/ckeditor5-link/src/autolink.js
@@ -151,10 +151,7 @@ export default class AutoLink extends Plugin {
 				return;
 			}
 
-			const rangeToCheck = model.createRange(
-				model.createPositionAt( position.parent.previousSibling, 0 ),
-				model.createPositionAt( position.parent.previousSibling, 'end' )
-			);
+			const rangeToCheck = model.createRangeIn( position.parent.previousSibling );
 
 			this._checkAndApplyAutoLinkOnRange( rangeToCheck );
 		} );

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -110,6 +110,26 @@ describe( 'AutoLink', () => {
 			);
 		} );
 
+		it( 'does not add linkHref attribute on enter when the link is selected', () => {
+			setData( model, '<paragraph>[https://www.cksource.com]</paragraph>' );
+
+			editor.execute( 'enter' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph>[]</paragraph>'
+			);
+		} );
+
+		it( 'does not add linkHref attribute on enter when the whole paragraph containing the link is selected', () => {
+			setData( model, '<paragraph>[This feature also works with e-mail addresses: https://www.cksource.com]</paragraph>' );
+
+			editor.execute( 'enter' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph>[]</paragraph>'
+			);
+		} );
+
 		it( 'adds linkHref attribute to a text link after space (inside paragraph)', () => {
 			setData( model, '<paragraph>Foo Bar [] Baz</paragraph>' );
 

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -130,23 +130,33 @@ describe( 'AutoLink', () => {
 			);
 		} );
 
+		it( 'adds linkHref attribute on enter when the link (that contains www) is partially selected (end)', () => {
+			setData( model, '<paragraph>https://www.ckso[urce.com]</paragraph>' );
+
+			editor.execute( 'enter' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph><$text linkHref="https://www.ckso">https://www.ckso</$text></paragraph><paragraph>[]</paragraph>'
+			);
+		} );
+
+		it( 'does not add linkHref attribute on enter when the link (that does not contain www) is partially selected (end)', () => {
+			setData( model, '<paragraph>https://ckso[urce.com]</paragraph>' );
+
+			editor.execute( 'enter' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph>https://ckso</paragraph><paragraph>[]</paragraph>'
+			);
+		} );
+
 		it( 'does not add linkHref attribute on enter when the link is partially selected (beginning)', () => {
 			setData( model, '<paragraph>[https://www.ckso]urce.com</paragraph>' );
 
 			editor.execute( 'enter' );
 
 			expect( getData( model ) ).to.equal(
-				'<paragraph>[]</paragraph>'
-			);
-		} );
-
-		it( 'does not add linkHref attribute on enter when the link is partially selected (end)', () => {
-			setData( model, '<paragraph>https://www.ckso[urce.com]</paragraph>' );
-
-			editor.execute( 'enter' );
-
-			expect( getData( model ) ).to.equal(
-				'<paragraph>[]</paragraph>'
+				'<paragraph></paragraph><paragraph>[]urce.com</paragraph>'
 			);
 		} );
 

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -130,6 +130,26 @@ describe( 'AutoLink', () => {
 			);
 		} );
 
+		it( 'does not add linkHref attribute on enter when the link is partially selected (beginning)', () => {
+			setData( model, '<paragraph>[https://www.ckso]urce.com</paragraph>' );
+
+			editor.execute( 'enter' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph>[]</paragraph>'
+			);
+		} );
+
+		it( 'does not add linkHref attribute on enter when the link is partially selected (end)', () => {
+			setData( model, '<paragraph>https://www.ckso[urce.com]</paragraph>' );
+
+			editor.execute( 'enter' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph>[]</paragraph>'
+			);
+		} );
+
 		it( 'adds linkHref attribute to a text link after space (inside paragraph)', () => {
 			setData( model, '<paragraph>Foo Bar [] Baz</paragraph>' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (link): Prevented throwing an error on pressing the <kbd>enter</kbd> key when non-collapsed selection is on autolink. Closes #7983.