### PR TITLE
Improved line to paragraph/soft break retention when pasting from plain text

### DIFF
--- a/packages/ckeditor5-clipboard/src/utils/plaintexttohtml.js
+++ b/packages/ckeditor5-clipboard/src/utils/plaintexttohtml.js
@@ -18,15 +18,17 @@ export default function plainTextToHtml( text ) {
 		// Encode <>.
 		.replace( /</g, '&lt;' )
 		.replace( />/g, '&gt;' )
-		// Creates paragraphs for every line breaks.
-		.replace( /\n/g, '</p><p>' )
+		// Creates a paragraph for each double line break.
+		.replace( /\r?\n\r?\n/g, '</p><p>' )
+		// Creates a line break for each single line break.
+		.replace( /\r?\n/g, '<br>' )
 		// Preserve trailing spaces (only the first and last one – the rest is handled below).
 		.replace( /^\s/, '&nbsp;' )
 		.replace( /\s$/, '&nbsp;' )
 		// Preserve other subsequent spaces now.
 		.replace( /\s\s/g, ' &nbsp;' );
 
-	if ( text.indexOf( '</p><p>' ) > -1 ) {
+	if ( text.includes( '</p><p>' ) || text.includes( '<br>' ) ) {
 		// If we created paragraphs above, add the trailing ones.
 		text = `<p>${ text }</p>`;
 	}

--- a/packages/ckeditor5-clipboard/tests/clipboard.js
+++ b/packages/ckeditor5-clipboard/tests/clipboard.js
@@ -112,7 +112,7 @@ describe( 'Clipboard feature', () => {
 				clipboardPlugin.on( 'inputTransformation', ( evt, data ) => {
 					expect( data.content ).is.instanceOf( ViewDocumentFragment );
 					expect( data.dataTransfer ).to.equal( dataTransferMock );
-					expect( stringifyView( data.content ) ).to.equal( '<p>x</p><p></p><p>y  z</p>' );
+					expect( stringifyView( data.content ) ).to.equal( '<p>x</p><p>y  z</p>' );
 
 					done();
 				} );

--- a/packages/ckeditor5-clipboard/tests/utils/plaintexttohtml.js
+++ b/packages/ckeditor5-clipboard/tests/utils/plaintexttohtml.js
@@ -27,17 +27,7 @@ describe( 'plainTextToHtml()', () => {
 	} );
 
 	it( 'turns combination of different amount of line breaks to paragraphs', () => {
-		const input = `a
-
-b
-c
-
-
-
-d
-e`;
-
-		expect( plainTextToHtml( input ) ).to.equal( '<p>a</p><p>b<br>c</p><p></p><p>d<br>e</p>' );
+		expect( plainTextToHtml( 'a\n\nb\nc\n\n\n\nd\ne' ) ).to.equal( '<p>a</p><p>b<br>c</p><p></p><p>d<br>e</p>' );
 	} );
 
 	it( 'preserves trailing spaces', () => {

--- a/packages/ckeditor5-clipboard/tests/utils/plaintexttohtml.js
+++ b/packages/ckeditor5-clipboard/tests/utils/plaintexttohtml.js
@@ -10,16 +10,34 @@ describe( 'plainTextToHtml()', () => {
 		expect( plainTextToHtml( 'x y <z>' ) ).to.equal( 'x y &lt;z&gt;' );
 	} );
 
-	it( 'turns a single line break into paragraphs', () => {
-		expect( plainTextToHtml( 'x\ny\nz' ) ).to.equal( '<p>x</p><p>y</p><p>z</p>' );
+	it( 'turns double line breaks into paragraphs (Linux/Mac EOL style)', () => {
+		expect( plainTextToHtml( 'x\n\ny\n\nz' ) ).to.equal( '<p>x</p><p>y</p><p>z</p>' );
 	} );
 
-	it( 'turns double line breaks into paragraphs', () => {
-		expect( plainTextToHtml( 'x\n\ny\n\nz' ) ).to.equal( '<p>x</p><p></p><p>y</p><p></p><p>z</p>' );
+	it( 'turns double line breaks into paragraphs (Windows EOL style)', () => {
+		expect( plainTextToHtml( 'x\r\n\r\ny\r\n\r\nz' ) ).to.equal( '<p>x</p><p>y</p><p>z</p>' );
+	} );
+
+	it( 'turns single line breaks into soft breaks (Linux/Mac EOL style)', () => {
+		expect( plainTextToHtml( 'x\ny\nz' ) ).to.equal( '<p>x<br>y<br>z</p>' );
+	} );
+
+	it( 'turns single line breaks into soft breaks (Windows EOL style)', () => {
+		expect( plainTextToHtml( 'x\r\ny\r\nz' ) ).to.equal( '<p>x<br>y<br>z</p>' );
 	} );
 
 	it( 'turns combination of different amount of line breaks to paragraphs', () => {
-		expect( plainTextToHtml( 'a\nb\n\nc\n\n\nd' ) ).to.equal( '<p>a</p><p>b</p><p></p><p>c</p><p></p><p></p><p>d</p>' );
+		const input = `a
+
+b
+c
+
+
+
+d
+e`;
+
+		expect( plainTextToHtml( input ) ).to.equal( '<p>a</p><p>b<br>c</p><p></p><p>d<br>e</p>' );
 	} );
 
 	it( 'preserves trailing spaces', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (clipboard): Improved line to paragraph/soft break retention when pasting from plain text. Closes #7884.

MINOR BREAKING CHANGE (clipboard): When pasting plain text each double line break is now treated as a paragraph separator, while single line break is converted into a soft break. Formerly every single line break was treated as a paragraph separation.

---

### Additional information

While working on it I found #8045.