### PR TITLE
Soft breaks are now properly placed in plain text clipboard data representation by the editor

### DIFF
--- a/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.js
+++ b/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.js
@@ -27,6 +27,9 @@ export default function viewToPlainText( viewItem ) {
 	} else if ( viewItem.is( 'element', 'img' ) && viewItem.hasAttribute( 'alt' ) ) {
 		// Special case for images - use alt attribute if it is provided.
 		text = viewItem.getAttribute( 'alt' );
+	} else if ( viewItem.is( 'element', 'br' ) ) {
+		// A soft break should be converted into a single line break (#8045).
+		text = '\n';
 	} else {
 		// Other elements are document fragments, attribute elements or container elements.
 		// They don't have their own text value, so convert their children.

--- a/packages/ckeditor5-clipboard/tests/utils/viewtoplaintext.js
+++ b/packages/ckeditor5-clipboard/tests/utils/viewtoplaintext.js
@@ -34,6 +34,22 @@ describe( 'viewToPlainText()', () => {
 		);
 	} );
 
+	it( 'should turn a soft break into a single empty line', () => {
+		testViewToPlainText(
+			'<container:p>Foo<empty:br />Bar</container:p>',
+
+			'Foo\nBar'
+		);
+	} );
+
+	it( 'should turn multiple soft breaks into empty lines', () => {
+		testViewToPlainText(
+			'<container:p>Foo<empty:br /><empty:br />Bar</container:p>',
+
+			'Foo\n\nBar'
+		);
+	} );
+
 	it( 'should output alt attribute of image elements', () => {
 		testViewToPlainText(
 			'<container:p>Foo</container:p>' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (clipboard): Soft breaks are now properly placed in plain text clipboard data representation by the editor. Closes #8045.