### PR TITLE
Docs (ckeditor5): Fixed a link to the export to PDF feature

### DIFF
--- a/docs/builds/guides/migrate.md
+++ b/docs/builds/guides/migrate.md
@@ -337,7 +337,7 @@ Note: The number of options was reduced on purpose. We understood that configuri
 			<a href="../../../../ckeditor4/latest/api/CKEDITOR_config.html#cfg-exportPdf_fileName">exportPdf_fileName</a> <br><a href="../../../../ckeditor4/latest/api/CKEDITOR_config.html#cfg-exportPdf_options">exportPdf_options</a> <br> <a href="../../../../ckeditor4/latest/api/CKEDITOR_config.html#cfg-exportPdf_service">exportPdf_service</a> <br> <a href="../../../../ckeditor4/latest/api/CKEDITOR_config.html#cfg-exportPdf_stylesheets">exportPdf_stylesheets</a> <br> <a href="../../../../ckeditor4/latest/api/CKEDITOR_config.html#cfg-exportPdf_tokenUrl">exportPdf_tokenUrl</a> <br>
 			</td>
 			<td>
-				Refer to the {@link features/export-pdf Export to PDF feature} guide to learn more about about configuring the HTML to PDF converter in CKEditor 5.
+				Refer to the [Export to PDF feature](https://ckeditor.com/docs/ckeditor5/latest/features/export-pdf.html) guide to learn more about about configuring the HTML to PDF converter in CKEditor 5.
 			</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (ckeditor5): Fixed a link to the export to PDF feature. Closes #8060.