### PR TITLE
Fixed Typo: CSFR-Token -> CSRF-Token

### DIFF
--- a/packages/ckeditor5-upload/docs/features/simple-upload-adapter.md
+++ b/packages/ckeditor5-upload/docs/features/simple-upload-adapter.md
@@ -67,7 +67,7 @@ ClassicEditor
 
 			// Headers sent along with the XMLHttpRequest to the upload server.
 			headers: {
-				'X-CSRF-TOKEN': 'CSFR-Token',
+				'X-CSRF-TOKEN': 'CSRF-Token',
 				Authorization: 'Bearer <JSON Web Token>'
 			}
 		}


### PR DESCRIPTION
A simple commit just to fix typo of `CSFR-Token` to `CSRF-Token`

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Type: Message. Closes #000.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
