### PR TITLE
The slack notification should be sent if failed while merging

### DIFF
--- a/.github/workflows/merge-stable.yml
+++ b/.github/workflows/merge-stable.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: rtCamp/action-slack-notify@v2.0.2
         id: error_message_slack
         name: Slack notification
-        if: (steps.merge_action.outputs.status != 201) && (steps.merge_action.outputs.status != 204)
+        if: ((steps.merge_action.outputs.status != 201) && (steps.merge_action.outputs.status != 204)) || failure()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: "cke5-ci"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: The slack notification should be sent if failed while merging. Closes #7839.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
