### PR TITLE
Change token refresh mechanism to depend on the token expiration time

### DIFF
--- a/packages/ckeditor-cloud-services-core/package.json
+++ b/packages/ckeditor-cloud-services-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckeditor/ckeditor-cloud-services-core",
-  "version": "22.0.0",
+  "version": "22.0.1",
   "description": "CKEditor Cloud Services Core API.",
   "keywords": [
     "ckeditor5",

--- a/packages/ckeditor-cloud-services-core/package.json
+++ b/packages/ckeditor-cloud-services-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ckeditor/ckeditor-cloud-services-core",
-  "version": "22.0.1",
+  "version": "22.0.0",
   "description": "CKEditor Cloud Services Core API.",
   "keywords": [
     "ckeditor5",

--- a/packages/ckeditor-cloud-services-core/src/token/token.js
+++ b/packages/ckeditor-cloud-services-core/src/token/token.js
@@ -128,6 +128,12 @@ class Token {
 		clearTimeout( this._tokenRefreshTimeout );
 	}
 
+	/**
+	 * Checks whether the provided token follows the JSON Web Tokens (JWT) format.
+	 *
+	 * @protected
+	 * @param {String} tokenValue The token to validate.
+	 */
 	_validateTokenValue( tokenValue ) {
 		// The token must be a string.
 		const isString = typeof tokenValue === 'string';

--- a/packages/ckeditor-cloud-services-core/src/token/token.js
+++ b/packages/ckeditor-cloud-services-core/src/token/token.js
@@ -129,16 +129,19 @@ class Token {
 	}
 
 	_validateTokenValue( tokenValue ) {
-		// the token must be a string
+		// The token must be a string.
 		const isString = typeof tokenValue === 'string';
-		// the token must be a plain string without ""
+
+		// The token must be a plain string without quotes ("").
 		const isPlainString = !/^".*"$/.test( tokenValue );
-		// the token must be in the correct format - has 3 parts joined by dots
+
+		// JWT token contains 3 parts: header, payload, and signature.
+		// Each part is separated by a dot.
 		const isJWTFormat = isString && tokenValue.split( '.' ).length === 3;
 
-		if ( !( isString && isPlainString && isJWTFormat ) ) {
+		if ( !( isPlainString && isJWTFormat ) ) {
 			/**
-			 * A token value must be in JWT format.
+			 * The provided token must follow the [JSON Web Tokens](https://jwt.io/introduction/) format.
 			 *
 			 * @error token-not-in-jwt-format
 			 */

--- a/packages/ckeditor-cloud-services-core/src/token/token.js
+++ b/packages/ckeditor-cloud-services-core/src/token/token.js
@@ -112,8 +112,6 @@ class Token {
 				if ( this._options.autoRefresh ) {
 					this._registerRefreshTokenTimeout();
 				}
-
-				return this;
 			} )
 			.then( () => this );
 	}

--- a/packages/ckeditor-cloud-services-core/src/token/token.js
+++ b/packages/ckeditor-cloud-services-core/src/token/token.js
@@ -175,8 +175,8 @@ class Token {
 	 *
 	 * If the token parse fails, the default DEFAULT_TOKEN_REFRESH_TIMEOUT_TIME is returned.
 	 *
-	 * @returns {Number}
 	 * @protected
+	 * @returns {Number}
 	 */
 	_getTokenRefreshTimeoutTime() {
 		try {

--- a/packages/ckeditor-cloud-services-core/tests/token/token.js
+++ b/packages/ckeditor-cloud-services-core/tests/token/token.js
@@ -344,12 +344,10 @@ describe( 'Token', () => {
 	} );
 } );
 
-/**
- * Returns valid token for tests with given expiration time offset.
- *
- * @param timeOffset {Number}
- * @returns {String}
- */
+// Returns valid token for tests with given expiration time offset.
+//
+// @param {Number} [timeOffset=3600000]
+// @returns {String}
 function getTestTokenValue( timeOffset = 3600000 ) {
 	return `header.${ btoa( JSON.stringify( { exp: Date.now() + timeOffset } ) ) }.signature`;
 }

--- a/packages/ckeditor-cloud-services-core/tests/token/token.js
+++ b/packages/ckeditor-cloud-services-core/tests/token/token.js
@@ -95,6 +95,8 @@ describe( 'Token', () => {
 			await clock.tickAsync( 1800000 );
 
 			expect( requests ).to.be.empty;
+
+			clock.restore();
 		} );
 
 		it( 'should refresh token with time specified in token `exp` payload property', async () => {

--- a/packages/ckeditor-cloud-services-core/tests/token/token.js
+++ b/packages/ckeditor-cloud-services-core/tests/token/token.js
@@ -84,6 +84,19 @@ describe( 'Token', () => {
 				} );
 		} );
 
+		it( 'should not refresh token if autoRefresh is disabled in options', async () => {
+			const clock = sinon.useFakeTimers( { toFake: [ 'setTimeout' ] } );
+			const tokenInitValue = `header.${ btoa( JSON.stringify( { exp: Date.now() + 3600000 } ) ) }.signature`;
+
+			const token = new Token( 'http://token-endpoint', { initValue: tokenInitValue, autoRefresh: false } );
+
+			await token.init();
+
+			await clock.tickAsync( 1800000 );
+
+			expect( requests ).to.be.empty;
+		} );
+
 		it( 'should refresh token with time specified in token `exp` payload property', async () => {
 			const clock = sinon.useFakeTimers( { toFake: [ 'setTimeout' ] } );
 			const tokenInitValue = `header.${ btoa( JSON.stringify( { exp: Date.now() + 3600000 } ) ) }.signature`;
@@ -256,6 +269,17 @@ describe( 'Token', () => {
 			Token.create( 'http://token-endpoint', { autoRefresh: false } )
 				.then( token => {
 					expect( token.value ).to.equal( 'token-value' );
+
+					done();
+				} );
+
+			requests[ 0 ].respond( 200, '', 'token-value' );
+		} );
+
+		it( 'should use default options when none passed', done => {
+			Token.create( 'http://token-endpoint' )
+				.then( token => {
+					expect( token._options ).to.eql( { autoRefresh: true } );
 
 					done();
 				} );

--- a/packages/ckeditor-cloud-services-core/tests/uploadgateway/fileuploader.js
+++ b/packages/ckeditor-cloud-services-core/tests/uploadgateway/fileuploader.js
@@ -14,7 +14,8 @@ const BASE_64_FILE = 'data:image/gif;base64,R0lGODlhCQAJAPIAAGFhYZXK/1FRUf///' +
 	'9ra2gD/AAAAAAAAACH5BAEAAAUALAAAAAAJAAkAAAMYWFqwru2xERcYJLSNNWNBVimC5wjfaTkJADs=';
 
 describe( 'FileUploader', () => {
-	const token = new Token( 'url', { initValue: 'token', autoRefresh: false } );
+	const tokenInitValue = `header.${ btoa( JSON.stringify( { exp: Date.now() + 3600000 } ) ) }.signature`;
+	const token = new Token( 'url', { initValue: tokenInitValue, autoRefresh: false } );
 
 	let fileUploader;
 
@@ -116,9 +117,12 @@ describe( 'FileUploader', () => {
 					expect( request.url ).to.equal( API_ADDRESS );
 					expect( request.method ).to.equal( 'POST' );
 					expect( request.responseType ).to.equal( 'json' );
-					expect( request.requestHeaders ).to.be.deep.equal( { Authorization: 'token' } );
+					expect( request.requestHeaders ).to.be.deep.equal( { Authorization: tokenInitValue } );
 
 					done();
+				} )
+				.catch( err => {
+					console.log( err );
 				} );
 
 			request.respond( 200, { 'Content-Type': 'application/json' },

--- a/packages/ckeditor-cloud-services-core/tests/uploadgateway/uploadgateway.js
+++ b/packages/ckeditor-cloud-services-core/tests/uploadgateway/uploadgateway.js
@@ -3,13 +3,16 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+/* eslint-env browser */
+
 import FileUploader from '../../src/uploadgateway/fileuploader';
 import UploadGateway from '../../src/uploadgateway/uploadgateway';
 import Token from '../../src/token/token';
 import { expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 
 describe( 'UploadGateway', () => {
-	const token = new Token( 'url', { initValue: 'token', autoRefresh: false } );
+	const tokenInitValue = `header.${ btoa( JSON.stringify( { exp: Date.now() + 3600000 } ) ) }.signature`;
+	const token = new Token( 'url', { initValue: tokenInitValue, autoRefresh: false } );
 
 	describe( 'constructor()', () => {
 		it( 'should throw error when no token provided', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (cloud-services-core): Change tokens refreshing mechanism to depend on the token expiration time. 

---

### Tickets to close

Closes cksource/ckeditor5-internal#316.

_Do not paste it in the commit merge message!_

---

### Additional information

After these changes token should be refreshed after half of a difference between the token expiration time and the actual time.