### PR TITLE
Fix the token refresh timeout time calculations

### DIFF
--- a/packages/ckeditor-cloud-services-core/src/token/token.js
+++ b/packages/ckeditor-cloud-services-core/src/token/token.js
@@ -173,7 +173,7 @@ class Token {
 	/**
 	 * Returns token refresh timeout time calculated from expire time in the token payload.
 	 *
-	 * If the token parse fails, the default DEFAULT_TOKEN_REFRESH_TIMEOUT_TIME is returned.
+	 * If the token parse fails or the token payload doesn't contain, the default DEFAULT_TOKEN_REFRESH_TIMEOUT_TIME is returned.
 	 *
 	 * @protected
 	 * @returns {Number}
@@ -182,7 +182,12 @@ class Token {
 		try {
 			const [ , binaryTokenPayload ] = this.value.split( '.' );
 			const { exp: tokenExpireTime } = JSON.parse( atob( binaryTokenPayload ) );
-			const tokenRefreshTimeoutTime = Math.floor( ( tokenExpireTime - Date.now() ) / 2 );
+
+			if ( !tokenExpireTime ) {
+				return DEFAULT_TOKEN_REFRESH_TIMEOUT_TIME;
+			}
+
+			const tokenRefreshTimeoutTime = Math.floor( ( ( tokenExpireTime * 1000 ) - Date.now() ) / 2 );
 
 			return tokenRefreshTimeoutTime;
 		} catch ( err ) {

--- a/packages/ckeditor-cloud-services-core/tests/token/token.js
+++ b/packages/ckeditor-cloud-services-core/tests/token/token.js
@@ -135,19 +135,19 @@ describe( 'Token', () => {
 			await token.init();
 
 			await clock.tickAsync( 1800000 );
-			requests[ 0 ].respond( 200, '', getTestTokenValue( 150000 ) );
+			requests[ 0 ].respond( 200, '', getTestTokenValue( 1500 ) );
 
-			await clock.tickAsync( 75000 );
-			requests[ 1 ].respond( 200, '', getTestTokenValue( 10000 ) );
+			await clock.tickAsync( 750000 );
+			requests[ 1 ].respond( 200, '', getTestTokenValue( 900 ) );
 
-			await clock.tickAsync( 5000 );
-			requests[ 2 ].respond( 200, '', getTestTokenValue( 2000 ) );
+			await clock.tickAsync( 450000 );
+			requests[ 2 ].respond( 200, '', getTestTokenValue( 450 ) );
 
-			await clock.tickAsync( 1000 );
-			requests[ 3 ].respond( 200, '', getTestTokenValue( 300 ) );
+			await clock.tickAsync( 225000 );
+			requests[ 3 ].respond( 200, '', getTestTokenValue( 20 ) );
 
-			await clock.tickAsync( 150 );
-			requests[ 4 ].respond( 200, '', getTestTokenValue( 300 ) );
+			await clock.tickAsync( 10000 );
+			requests[ 4 ].respond( 200, '', getTestTokenValue( 20 ) );
 
 			expect( requests.length ).to.equal( 5 );
 
@@ -172,6 +172,28 @@ describe( 'Token', () => {
 
 			clock.restore();
 		} );
+
+		it( 'should refresh the token with the default time if the token payload does not contain `exp` property', async () => {
+			const clock = sinon.useFakeTimers( { toFake: [ 'setTimeout' ] } );
+			const tokenValue = `header.${ btoa( JSON.stringify( {} ) ) }.signature`;
+
+			const token = new Token( 'http://token-endpoint', { initValue: tokenValue } );
+
+			await token.init();
+
+			await clock.tickAsync( 3600000 );
+			requests[ 0 ].respond( 200, '', tokenValue );
+
+			await clock.tickAsync( 3600000 );
+			requests[ 1 ].respond( 200, '', tokenValue );
+
+			await clock.tickAsync( 3600000 );
+			requests[ 2 ].respond( 200, '', tokenValue );
+
+			expect( requests.length ).to.equal( 3 );
+
+			clock.restore();
+		} );
 	} );
 
 	describe( 'destroy', () => {
@@ -184,11 +206,11 @@ describe( 'Token', () => {
 			await token.init();
 
 			await clock.tickAsync( 1800000 );
-			requests[ 0 ].respond( 200, '', getTestTokenValue( 150000 ) );
+			requests[ 0 ].respond( 200, '', getTestTokenValue( 1500 ) );
 			await clock.tickAsync( 100 );
 
-			await clock.tickAsync( 75000 );
-			requests[ 1 ].respond( 200, '', getTestTokenValue( 10000 ) );
+			await clock.tickAsync( 750000 );
+			requests[ 1 ].respond( 200, '', getTestTokenValue( 900 ) );
 			await clock.tickAsync( 100 );
 
 			token.destroy();
@@ -348,6 +370,6 @@ describe( 'Token', () => {
 //
 // @param {Number} [timeOffset=3600000]
 // @returns {String}
-function getTestTokenValue( timeOffset = 3600000 ) {
-	return `header.${ btoa( JSON.stringify( { exp: Date.now() + timeOffset } ) ) }.signature`;
+function getTestTokenValue( timeOffset = 3600 ) {
+	return `header.${ btoa( JSON.stringify( { exp: ( Math.floor( Date.now() / 1000 ) ) + timeOffset } ) ) }.signature`;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (cloud-services-core): Fix the token refresh timeout time calculations. 

---

### Tickets to close

Closes cksource/ckeditor5-internal#329.

_Do not paste it in the commit merge message!_

---

### Additional information

After these changes token should be properly refreshed after the default time (1 hour) if the token payload doesn't contain the `exp` property and refresh timeout time calculations should respect the fact that the `exp` property in the token payload is always in seconds.