### PR TITLE
Adjusted "Using React in widget" guide to changes in <CKEditor> component

### DIFF
--- a/docs/_snippets/framework/tutorials/using-react-in-widget.html
+++ b/docs/_snippets/framework/tutorials/using-react-in-widget.html
@@ -265,7 +265,7 @@ class App extends React.Component {
 		};
 
 		this.handleEditorDataChange = this.handleEditorDataChange.bind( this );
-		this.handleEditorInit = this.handleEditorInit.bind( this );
+		this.handleEditorReady = this.handleEditorReady.bind( this );
 	}
 
 	// A handler executed when the user types or modifies the editor content.
@@ -278,7 +278,7 @@ class App extends React.Component {
 
 	// A handler executed when the editor has been initialized and is ready.
 	// It synchronizes the initial data state and saves the reference to the editor instance.
-	handleEditorInit( editor ) {
+	handleEditorReady( editor ) {
 		this.editor = editor;
 
 		this.setState( {
@@ -300,7 +300,7 @@ class App extends React.Component {
 					data={this.state.editorData}
 					config={this.editorConfig}
 					onChange={this.handleEditorDataChange}
-					onInit={this.handleEditorInit}
+					onReady={this.handleEditorReady}
 				/>
 
 				<h4>Editor data</h4>

--- a/docs/_snippets/framework/tutorials/using-react-in-widget.js
+++ b/docs/_snippets/framework/tutorials/using-react-in-widget.js
@@ -12,7 +12,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 // The official <CKEditor> component for React.
-import CKEditor from '@ckeditor/ckeditor5-react';
+import { CKEditor } from '@ckeditor/ckeditor5-react';
 
 // The base editor class and features required to run the editor.
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';

--- a/docs/framework/guides/tutorials/using-react-in-a-widget.md
+++ b/docs/framework/guides/tutorials/using-react-in-a-widget.md
@@ -586,7 +586,7 @@ class App extends React.Component {
 		};
 
 		this.handleEditorDataChange = this.handleEditorDataChange.bind( this );
-		this.handleEditorInit = this.handleEditorInit.bind( this );
+		this.handleEditorReady = this.handleEditorReady.bind( this );
 	}
 
 	// A handler executed when the user types or modifies the editor content.
@@ -599,7 +599,7 @@ class App extends React.Component {
 
 	// A handler executed when the editor has been initialized and is ready.
 	// It synchronizes the initial data state and saves the reference to the editor instance.
-	handleEditorInit( editor ) {
+	handleEditorReady( editor ) {
 		this.editor = editor;
 
 		this.setState( {
@@ -625,7 +625,7 @@ class App extends React.Component {
 					data={this.state.editorData}
 					config={this.editorConfig}
 					onChange={this.handleEditorDataChange}
-					onInit={this.handleEditorInit}
+					onReady={this.handleEditorReady}
 				/>
 
 				<h3>Editor data</h3>
@@ -997,7 +997,7 @@ class App extends React.Component {
 		};
 
 		this.handleEditorDataChange = this.handleEditorDataChange.bind( this );
-		this.handleEditorInit = this.handleEditorInit.bind( this );
+		this.handleEditorReady = this.handleEditorReady.bind( this );
 	}
 
 	// A handler executed when the user types or modifies the editor content.
@@ -1010,7 +1010,7 @@ class App extends React.Component {
 
 	// A handler executed when the editor has been initialized and is ready.
 	// It synchronizes the initial data state and saves the reference to the editor instance.
-	handleEditorInit( editor ) {
+	handleEditorReady( editor ) {
 		this.editor = editor;
 
 		this.setState( {
@@ -1036,7 +1036,7 @@ class App extends React.Component {
 					data={this.state.editorData}
 					config={this.editorConfig}
 					onChange={this.handleEditorDataChange}
-					onInit={this.handleEditorInit}
+					onReady={this.handleEditorReady}
 				/>
 
 				<h3>Editor data</h3>

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@ckeditor/ckeditor5-export-word": ">=1.0.0",
     "@ckeditor/ckeditor5-inspector": "^2.2.0",
     "@ckeditor/ckeditor5-pagination": ">=1.0.0",
-    "@ckeditor/ckeditor5-react": "^2.1.0",
+    "@ckeditor/ckeditor5-react": "^3.0.0",
     "@ckeditor/ckeditor5-real-time-collaboration": "^23.0.0",
     "@ckeditor/ckeditor5-track-changes": "^23.0.0",
     "@webspellchecker/wproofreader-ckeditor5": "^1.0.5",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Adjusted the "Using React in widget" guide to the latest changes in the `@ckeditor/ckeditor5-react` package.

---

### Additional information

It should be merged after releasing the new version of the react integration package.
