### PR TITLE
Use same format for error name in attachLinkToDocumentation as in CKEditorError

### DIFF
--- a/packages/ckeditor5-core/src/plugincollection.js
+++ b/packages/ckeditor5-core/src/plugincollection.js
@@ -117,6 +117,12 @@ export default class PluginCollection {
 		const plugin = this._plugins.get( key );
 
 		if ( !plugin ) {
+			let pluginName = key;
+
+			if ( typeof key == 'function' ) {
+				pluginName = key.pluginName || key.name;
+			}
+
 			/**
 			 * The plugin is not loaded and could not be obtained.
 			 *
@@ -131,15 +137,7 @@ export default class PluginCollection {
 			 * @error plugincollection-plugin-not-loaded
 			 * @param {String} plugin The name of the plugin which is not loaded.
 			 */
-			const errorMsg = 'plugincollection-plugin-not-loaded: The requested plugin is not loaded.';
-
-			let pluginName = key;
-
-			if ( typeof key == 'function' ) {
-				pluginName = key.pluginName || key.name;
-			}
-
-			throw new CKEditorError( errorMsg, this._context, { plugin: pluginName } );
+			throw new CKEditorError( 'plugincollection-plugin-not-loaded', this._context, { plugin: pluginName } );
 		}
 
 		return plugin;

--- a/packages/ckeditor5-core/src/plugincollection.js
+++ b/packages/ckeditor5-core/src/plugincollection.js
@@ -206,12 +206,12 @@ export default class PluginCollection {
 			 * @error plugincollection-plugin-not-found
 			 * @param {Array.<String>} plugins The name of the plugins which could not be loaded.
 			 */
-			const errorMsg = 'plugincollection-plugin-not-found: Some plugins are not available and could not be loaded.';
+			const errorId = 'plugincollection-plugin-not-found';
 
-			// Log the error so it's more visible on the console. Hopefully, for better DX.
-			console.error( attachLinkToDocumentation( errorMsg ), { plugins: missingPlugins } );
+			// Log the error, so it's more visible on the console. Hopefully, for better DX.
+			console.error( attachLinkToDocumentation( errorId ), { plugins: missingPlugins } );
 
-			return Promise.reject( new CKEditorError( errorMsg, context, { plugins: missingPlugins } ) );
+			return Promise.reject( new CKEditorError( errorId, context, { plugins: missingPlugins } ) );
 		}
 
 		return Promise.all( pluginConstructors.map( loadPlugin ) )
@@ -251,9 +251,7 @@ export default class PluginCollection {
 					 * @error plugincollection-load
 					 * @param {String} plugin The name of the plugin that could not be loaded.
 					 */
-					console.error( attachLinkToDocumentation(
-						'plugincollection-load: It was not possible to load the plugin.'
-					), { plugin: PluginConstructor } );
+					console.error( attachLinkToDocumentation( 'plugincollection-load' ), { plugin: PluginConstructor } );
 
 					throw err;
 				} );

--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
@@ -349,13 +349,7 @@ export default class UpcastHelpers extends ConversionHelpers {
 		 *
 		 * @error upcast-helpers-element-to-marker-deprecated
 		 */
-		console.warn(
-			attachLinkToDocumentation(
-				'upcast-helpers-element-to-marker-deprecated: ' +
-				'The UpcastHelpers#elementToMarker() method was deprecated and will be removed in the near future. ' +
-				'Please use UpcastHelpers#dataToMarker() instead.'
-			)
-		);
+		console.warn( attachLinkToDocumentation( 'upcast-helpers-element-to-marker-deprecated' ) );
 
 		return this.add( upcastElementToMarker( config ) );
 	}

--- a/packages/ckeditor5-image/src/imagestyle/utils.js
+++ b/packages/ckeditor5-image/src/imagestyle/utils.js
@@ -116,8 +116,14 @@ function _normalizeStyle( style ) {
 		}
 		// If it's just a name but none of the defaults, warn because probably it's a mistake.
 		else {
+			/**
+			 * There is no such image style of given name.
+			 *
+			 * @error image-style-not-found
+		 	 * @param {String} name Name of a missing style name.
+			 */
 			console.warn(
-				attachLinkToDocumentation( 'image-style-not-found: There is no such image style of given name.' ),
+				attachLinkToDocumentation( 'image-style-not-found' ),
 				{ name: styleName }
 			);
 

--- a/packages/ckeditor5-media-embed/src/mediaregistry.js
+++ b/packages/ckeditor5-media-embed/src/mediaregistry.js
@@ -46,11 +46,9 @@ export default class MediaRegistry {
 					 * has no name and will not be used by the editor. In order to get this media
 					 * provider working, double check your editor configuration.
 					 *
-					 * @warning media-embed-no-provider-name
+					 * @error media-embed-no-provider-name
 					 */
-					console.warn( attachLinkToDocumentation(
-						'media-embed-no-provider-name: The configured media provider has no name and cannot be used.'
-					), { provider } );
+					console.warn( attachLinkToDocumentation( 'media-embed-no-provider-name' ), { provider } );
 
 					return false;
 				}

--- a/packages/ckeditor5-media-embed/tests/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedediting.js
@@ -74,7 +74,7 @@ describe( 'MediaEmbedEditing', () => {
 						providers: [ provider ]
 					} ).then( () => {
 						expect( consoleWarnStub.calledOnce ).to.equal( true );
-						expect( consoleWarnStub.firstCall.args[ 0 ] ).to.match( /^media-embed-no-provider-name:/ );
+						expect( consoleWarnStub.firstCall.args[ 0 ] ).to.match( /^media-embed-no-provider-name/ );
 						expect( consoleWarnStub.firstCall.args[ 1 ].provider ).to.deep.equal( provider );
 					} );
 				} );
@@ -333,7 +333,7 @@ describe( 'MediaEmbedEditing', () => {
 						extraProviders: [ provider ]
 					} ).then( () => {
 						expect( consoleWarnStub.calledOnce ).to.equal( true );
-						expect( consoleWarnStub.firstCall.args[ 0 ] ).to.match( /^media-embed-no-provider-name:/ );
+						expect( consoleWarnStub.firstCall.args[ 0 ] ).to.match( /^media-embed-no-provider-name/ );
 						expect( consoleWarnStub.firstCall.args[ 1 ].provider ).to.deep.equal( provider );
 					} );
 				} );

--- a/packages/ckeditor5-media-embed/tests/mediaembedtoolbar.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedtoolbar.js
@@ -250,7 +250,7 @@ describe( 'MediaEmbedToolbar - integration with BalloonEditor', () => {
 
 			expect( widgetToolbarRepository._toolbarDefinitions.get( 'mediaEmbed' ) ).to.be.undefined;
 			expect( consoleWarnStub.calledOnce ).to.equal( true );
-			expect( consoleWarnStub.firstCall.args[ 0 ] ).to.match( /^widget-toolbar-no-items:/ );
+			expect( consoleWarnStub.firstCall.args[ 0 ] ).to.match( /^widget-toolbar-no-items/ );
 
 			element.remove();
 			return editor.destroy();

--- a/packages/ckeditor5-mention/src/mentionui.js
+++ b/packages/ckeditor5-mention/src/mentionui.js
@@ -349,7 +349,7 @@ export default class MentionUI extends Plugin {
 				 *
 				 * @error mention-feed-callback-error
 				 */
-				console.warn( attachLinkToDocumentation( 'mention-feed-callback-error: Could not obtain mention autocomplete feed.' ) );
+				console.warn( attachLinkToDocumentation( 'mention-feed-callback-error' ) );
 			} );
 	}
 

--- a/packages/ckeditor5-mention/tests/mentionui.js
+++ b/packages/ckeditor5-mention/tests/mentionui.js
@@ -1249,7 +1249,7 @@ describe( 'MentionUI', () => {
 						expect( panelView.isVisible, 'panel is hidden' ).to.be.false;
 						expect( editor.model.markers.has( 'mention' ), 'there is no marker' ).to.be.false;
 
-						sinon.assert.calledWithExactly( warnSpy, sinon.match( /^mention-feed-callback-error:/ ) );
+						sinon.assert.calledWithExactly( warnSpy, sinon.match( /^mention-feed-callback-error/ ) );
 						sinon.assert.calledOnce( eventSpy );
 					} );
 			} );

--- a/packages/ckeditor5-table/src/tablewalker.js
+++ b/packages/ckeditor5-table/src/tablewalker.js
@@ -532,7 +532,7 @@ class TableSlot {
  */
 
 // @if CK_DEBUG // function throwMissingGetterError( getterName ) {
-// @if CK_DEBUG //		throw new CKEditorError( 'tableslot-getter-removed: This TableSlot getter does not exist anymore.', this, {
+// @if CK_DEBUG //		throw new CKEditorError( 'tableslot-getter-removed', this, {
 // @if CK_DEBUG //			getterName
 // @if CK_DEBUG //		} );
 // @if CK_DEBUG // }

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.js
@@ -299,8 +299,7 @@ export default class ToolbarView extends View {
 				 * @error toolbarview-item-unavailable
 				 * @param {String} name The name of the component.
 				 */
-				console.warn( attachLinkToDocumentation(
-					'toolbarview-item-unavailable: The requested toolbar item is unavailable.' ), { name } );
+				console.warn( attachLinkToDocumentation( 'toolbarview-item-unavailable' ), { name } );
 			}
 		} ).filter( item => item !== undefined ) );
 	}

--- a/packages/ckeditor5-upload/src/adapters/simpleuploadadapter.js
+++ b/packages/ckeditor5-upload/src/adapters/simpleuploadadapter.js
@@ -69,11 +69,9 @@ export default class SimpleUploadAdapter extends Plugin {
 			 * configuration required by the {@link module:upload/adapters/simpleuploadadapter~SimpleUploadAdapter `SimpleUploadAdapter`}
 			 * is missing. Make sure the correct URL is specified for the image upload to work properly.
 			 *
-			 * @error simple-upload-adapter-missing-uploadUrl
+			 * @error simple-upload-adapter-missing-uploadurl
 			 */
-			console.warn( attachLinkToDocumentation(
-				'simple-upload-adapter-missing-uploadUrl: Missing the "uploadUrl" property in the "simpleUpload" editor configuration.'
-			) );
+			console.warn( attachLinkToDocumentation( 'simple-upload-adapter-missing-uploadurl' ) );
 
 			return;
 		}

--- a/packages/ckeditor5-upload/src/filerepository.js
+++ b/packages/ckeditor5-upload/src/filerepository.js
@@ -172,9 +172,7 @@ export default class FileRepository extends Plugin {
 			 *
 			 * @error filerepository-no-upload-adapter
 			 */
-			console.warn( attachLinkToDocumentation(
-				'filerepository-no-upload-adapter: Upload adapter is not defined.'
-			) );
+			console.warn( attachLinkToDocumentation( 'filerepository-no-upload-adapter' ) );
 
 			return null;
 		}

--- a/packages/ckeditor5-upload/tests/adapters/simpleuploadadapter.js
+++ b/packages/ckeditor5-upload/tests/adapters/simpleuploadadapter.js
@@ -120,7 +120,7 @@ describe( 'SimpleUploadAdapter', () => {
 				} )
 				.then( editor => {
 					expect( consoleWarnStub.callCount ).to.equal( 1 );
-					expect( consoleWarnStub.firstCall.args[ 0 ] ).to.match( /^simple-upload-adapter-missing-uploadUrl/ );
+					expect( consoleWarnStub.firstCall.args[ 0 ] ).to.match( /^simple-upload-adapter-missing-uploadurl/ );
 
 					const fileRepository = editor.plugins.get( FileRepository );
 

--- a/packages/ckeditor5-upload/tests/filerepository.js
+++ b/packages/ckeditor5-upload/tests/filerepository.js
@@ -178,7 +178,7 @@ describe( 'FileRepository', () => {
 			sinon.assert.calledOnce( consoleWarnStub );
 			sinon.assert.calledWithExactly(
 				consoleWarnStub,
-				sinon.match( 'filerepository-no-upload-adapter: Upload adapter is not defined.' )
+				sinon.match( /^filerepository-no-upload-adapter/ )
 			);
 		} );
 

--- a/packages/ckeditor5-utils/src/ckeditorerror.js
+++ b/packages/ckeditor5-utils/src/ckeditorerror.js
@@ -33,7 +33,7 @@ export const DOCUMENTATION_URL =
  *		 * @param pluginName The name of the plugin that could not be loaded.
  *		 * @param moduleName The name of the module which tried to load this plugin.
  *		 * /
- *		throw new CKEditorError( 'plugin-load: It was not possible to load the "{$pluginName}" plugin in module "{$moduleName}', {
+ *		throw new CKEditorError( 'plugin-load', {
  *			pluginName: 'foo',
  *			moduleName: 'bar'
  *		} );
@@ -44,9 +44,8 @@ export default class CKEditorError extends Error {
 	/**
 	 * Creates an instance of the CKEditorError class.
 	 *
-	 * @param {String} message The error message in an `error-name: Error message.` format.
-	 * During the minification process the "Error message" part will be removed to limit the code size
-	 * and a link to this error documentation will be added to the `message`.
+	 * @param {String} errorName The error id in an `error-name` format. A link to this error documentation page will be added
+	 * to the thrown error's `message`.
 	 * @param {Object|null} context A context of the error by which the {@link module:watchdog/watchdog~Watchdog watchdog}
 	 * is able to determine which editor crashed. It should be an editor instance or a property connected to it. It can be also
 	 * a `null` value if the editor should not be restarted in case of the error (e.g. during the editor initialization).
@@ -56,8 +55,8 @@ export default class CKEditorError extends Error {
 	 * will be appended to the error message, so the data are quickly visible in the console. The original
 	 * data object will also be later available under the {@link #data} property.
 	 */
-	constructor( message, context, data ) {
-		message = attachLinkToDocumentation( message );
+	constructor( errorName, context, data ) {
+		let message = attachLinkToDocumentation( errorName );
 
 		if ( data ) {
 			message += ' ' + JSON.stringify( data );
@@ -138,9 +137,9 @@ export default class CKEditorError extends Error {
  *		  * /
  *		 console.warn( attachLinkToDocumentation( 'toolbarview-item-unavailable' ), { name } );
  *
- * @param {String} id Error id to be linked.
+ * @param {String} errorName Error name to be linked.
  * @returns {String}
  */
-export function attachLinkToDocumentation( id ) {
-	return id + ` Read more: ${ DOCUMENTATION_URL }#error-${ id }\n`;
+export function attachLinkToDocumentation( errorName ) {
+	return errorName + ` Read more: ${ DOCUMENTATION_URL }#error-${ errorName }\n`;
 }

--- a/packages/ckeditor5-utils/src/ckeditorerror.js
+++ b/packages/ckeditor5-utils/src/ckeditorerror.js
@@ -136,19 +136,11 @@ export default class CKEditorError extends Error {
  *		  * @error toolbarview-item-unavailable
  *		  * @param {String} name The name of the component.
  *		  * /
- *		 console.warn( attachLinkToDocumentation(
- *		 	'toolbarview-item-unavailable: The requested toolbar item is unavailable.' ), { name } );
+ *		 console.warn( attachLinkToDocumentation( 'toolbarview-item-unavailable' ), { name } );
  *
- * @param {String} message Message to be logged.
+ * @param {String} id Error id to be linked.
  * @returns {String}
  */
-export function attachLinkToDocumentation( message ) {
-	// The link to documentation should work with console.warn format: "message-id: Explanation message." and single error id.
-	const matchedErrorName = message.match( /^([a-z0-9]+-[a-z-0-9]+):?/ );
-
-	if ( !matchedErrorName ) {
-		return message;
-	}
-
-	return message + ` Read more: ${ DOCUMENTATION_URL }#error-${ matchedErrorName[ 1 ] }\n`;
+export function attachLinkToDocumentation( id ) {
+	return id + ` Read more: ${ DOCUMENTATION_URL }#error-${ id }\n`;
 }

--- a/packages/ckeditor5-utils/tests/ckeditorerror.js
+++ b/packages/ckeditor5-utils/tests/ckeditorerror.js
@@ -33,7 +33,10 @@ describe( 'CKEditorError', () => {
 		const data = { bar: 1 };
 		const error = new CKEditorError( 'foo', null, data );
 
-		expect( error ).to.have.property( 'message', 'foo {"bar":1}' );
+		expect( error ).to.have.property(
+			'message',
+			`foo Read more: ${ DOCUMENTATION_URL }#error-foo\n {"bar":1}`
+		);
 		expect( error ).to.have.property( 'data', data );
 	} );
 
@@ -59,7 +62,10 @@ describe( 'CKEditorError', () => {
 		};
 		const error = new CKEditorError( 'foo', null, data );
 
-		expect( error ).to.have.property( 'message', 'foo {"bar":"a","bom":{"x":1},"bim":10}' );
+		expect( error ).to.have.property(
+			'message',
+			`foo Read more: ${ DOCUMENTATION_URL }#error-foo\n {"bar":"a","bom":{"x":1},"bim":10}`
+		);
 		expect( error ).to.have.property( 'data', data );
 	} );
 

--- a/packages/ckeditor5-watchdog/tests/editorwatchdog.js
+++ b/packages/ckeditor5-watchdog/tests/editorwatchdog.js
@@ -817,7 +817,7 @@ describe( 'EditorWatchdog', () => {
 						expect( watchdog.crashes[ 0 ].lineno ).to.be.a( 'number' );
 						expect( watchdog.crashes[ 0 ].colno ).to.be.a( 'number' );
 
-						expect( watchdog.crashes[ 1 ].message ).to.equal( 'bar' );
+						expect( watchdog.crashes[ 1 ].message ).to.match( /^bar/ );
 
 						watchdog.destroy().then( res );
 					} );

--- a/packages/ckeditor5-widget/src/widgettoolbarrepository.js
+++ b/packages/ckeditor5-widget/src/widgettoolbarrepository.js
@@ -135,7 +135,7 @@ export default class WidgetToolbarRepository extends Plugin {
 			 * @error widget-toolbar-no-items
 			 */
 			console.warn(
-				attachLinkToDocumentation( 'widget-toolbar-no-items: Trying to register a toolbar without items.' ), { toolbarId }
+				attachLinkToDocumentation( 'widget-toolbar-no-items' ), { toolbarId }
 			);
 
 			return;

--- a/packages/ckeditor5-widget/tests/widgettoolbarrepository.js
+++ b/packages/ckeditor5-widget/tests/widgettoolbarrepository.js
@@ -138,7 +138,7 @@ describe( 'WidgetToolbarRepository', () => {
 			expect( widgetToolbarRepository._toolbarDefinitions.get( 'fake' ) ).to.be.undefined;
 
 			expect( consoleWarnStub.calledOnce ).to.equal( true );
-			expect( consoleWarnStub.firstCall.args[ 0 ] ).to.match( /^widget-toolbar-no-items:/ );
+			expect( consoleWarnStub.firstCall.args[ 0 ] ).to.match( /^widget-toolbar-no-items/ );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Use same format for error name in attachLinkToDocumentation as in CKEditorError. Closes #8097.

---

### Additional information

*   I've added this to ESLint rule as well: ckeditor/eslint-plugin-ckeditor5-rules#1.