### PR TITLE
#8145 : Fixed handling of multiple selected blocks in Model#deleteContent().

### DIFF
--- a/packages/ckeditor5-engine/src/model/utils/deletecontent.js
+++ b/packages/ckeditor5-engine/src/model/utils/deletecontent.js
@@ -84,8 +84,8 @@ export default function deleteContent( model, selection, options = {} ) {
 		const [ startPosition, endPosition ] = getLivePositionsForSelectedBlocks( selRange );
 
 		// 2. Remove the content if there is any.
-		if ( !selRange.start.isTouching( selRange.end ) ) {
-			writer.remove( selRange );
+		if ( !startPosition.isTouching( endPosition ) ) {
+			writer.remove( writer.createRange( startPosition, endPosition ) );
 		}
 
 		// 3. Merge elements in the right branch to the elements in the left branch.

--- a/packages/ckeditor5-engine/tests/model/utils/deletecontent.js
+++ b/packages/ckeditor5-engine/tests/model/utils/deletecontent.js
@@ -250,6 +250,12 @@ describe( 'DataController utils', () => {
 			);
 
 			test(
+				'do not remove end block if selection ends at start position of it (multiple paragraphs)',
+				'<paragraph>x</paragraph><paragraph>[foo</paragraph><paragraph>a</paragraph><paragraph>]bar</paragraph>',
+				'<paragraph>x</paragraph><paragraph>[]</paragraph><paragraph>bar</paragraph>'
+			);
+
+			test(
 				'removes empty element (merges it into second element)',
 				'<paragraph>x</paragraph><paragraph>[</paragraph><paragraph>]bar</paragraph><paragraph>y</paragraph>',
 				'<paragraph>x</paragraph><paragraph>[]bar</paragraph><paragraph>y</paragraph>'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): `Model#deleteContent()` should properly remove blocks when the selection is spanning multiple blocks. Closes #8145.

---

### Additional information