### PR TITLE
Cleaned up usage of the `t()` function for one interpolated argument.

### DIFF
--- a/packages/ckeditor5-ui/src/editableui/inline/inlineeditableuiview.js
+++ b/packages/ckeditor5-ui/src/editableui/inline/inlineeditableuiview.js
@@ -47,7 +47,7 @@ export default class InlineEditableUIView extends EditableUIView {
 		editingView.change( writer => {
 			const viewRoot = editingView.document.getRoot( this.name );
 
-			writer.setAttribute( 'aria-label', t( 'Rich Text Editor, %0', [ this.name ] ), viewRoot );
+			writer.setAttribute( 'aria-label', t( 'Rich Text Editor, %0', this.name ), viewRoot );
 		} );
 	}
 }

--- a/packages/ckeditor5-utils/tests/locale.js
+++ b/packages/ckeditor5-utils/tests/locale.js
@@ -157,9 +157,9 @@ describe( 'Locale', () => {
 		it( 'should translate a message supporting plural forms', () => {
 			const t = locale.t;
 
-			expect( t( { string: 'bar', plural: '%0 bars' }, [ 1 ] ), 1 ).to.equal( 'bar_pl_0' );
-			expect( t( { string: 'bar', plural: '%0 bars' }, [ 2 ] ), 2 ).to.equal( '2 bar_pl_1' );
-			expect( t( { string: 'bar', plural: '%0 bars' }, [ 5 ] ), 3 ).to.equal( '5 bar_pl_2' );
+			expect( t( { string: 'bar', plural: '%0 bars' }, 1 ), 1 ).to.equal( 'bar_pl_0' );
+			expect( t( { string: 'bar', plural: '%0 bars' }, 2 ), 2 ).to.equal( '2 bar_pl_1' );
+			expect( t( { string: 'bar', plural: '%0 bars' }, 5 ), 3 ).to.equal( '5 bar_pl_2' );
 		} );
 
 		it( 'should translate a message supporting plural forms with a message id if it was passed', () => {
@@ -181,13 +181,13 @@ describe( 'Locale', () => {
 		it( 'should interpolate a message with provided values', () => {
 			const t = locale.t;
 
-			expect( t( '%0 - %0', [ 'foo' ] ) ).to.equal( 'foo - foo' );
+			expect( t( '%0 - %0', 'foo' ) ).to.equal( 'foo - foo' );
 			expect( t( '%1 - %0 - %2', [ 'a', 'b', 'c' ] ) ).to.equal( 'b - a - c' );
 
 			// Those test make sure that if %0 is really to be used, then it's going to work.
 			// It'd be a super rare case if one would need to use %0 and at the same time interpolate something.
 			expect( t( '%1 - %0 - %2' ) ).to.equal( '%1 - %0 - %2' );
-			expect( t( '%1 - %0 - %2', [ 'a' ] ) ).to.equal( '%1 - a - %2' );
+			expect( t( '%1 - %0 - %2', 'a' ) ).to.equal( '%1 - a - %2' );
 		} );
 
 		it( 'should interpolate a message with a provided value (shorthand version)', () => {

--- a/packages/ckeditor5-word-count/src/wordcount.js
+++ b/packages/ckeditor5-word-count/src/wordcount.js
@@ -203,7 +203,7 @@ export default class WordCount extends Plugin {
 
 			if ( displayWords || displayWords === undefined ) {
 				this.bind( '_wordsLabel' ).to( this, 'words', words => {
-					return t( 'Words: %0', [ words ] );
+					return t( 'Words: %0', words );
 				} );
 
 				children.push( {
@@ -221,7 +221,7 @@ export default class WordCount extends Plugin {
 
 			if ( displayCharacters || displayCharacters === undefined ) {
 				this.bind( '_charactersLabel' ).to( this, 'characters', words => {
-					return t( 'Characters: %0', [ words ] );
+					return t( 'Characters: %0', words );
 				} );
 
 				children.push( {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Cleaned up usage of the \`t()\` function for one interpolated argument. Closes #6645.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._