### PR TITLE
Docs: Fix link in CKFinder page

### DIFF
--- a/packages/ckeditor5-ckfinder/docs/features/ckfinder.md
+++ b/packages/ckeditor5-ckfinder/docs/features/ckfinder.md
@@ -37,7 +37,7 @@ This feature can be used in the rich-text editor in two different ways:
 
 ### Image upload only
 
-This demo shows the integration where the file manager's server connector handles [the image upload](#configuring-the-full-integration) only:
+This demo shows the integration where the file manager's server connector handles [the image upload](#configuring-the-image-upload-only) only:
 
 * Paste the image directly into the rich-text editor content and it will be automatically uploaded using the server-side connector.
 * Use the "Insert image" button in the toolbar to insert an image.


### PR DESCRIPTION
### Fix bug in [CKFinder documentation page](https://ckeditor.com/docs/ckeditor5/latest/features/image-upload/ckfinder.html)

Type: Fix link on documentation

---

### Additional information

The link doesn't redirect on the good information.
