### PR TITLE
Docs: Reintroduce latest MathType version

### DIFF
--- a/docs/_snippets/features/mathtype.html
+++ b/docs/_snippets/features/mathtype.html
@@ -3,17 +3,3 @@
 
 	<p><math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi><mo>=</mo><mfrac><mrow><mo>-</mo><mi>b</mi><mo>&#177;</mo><msqrt><msup><mi>b</mi><mn>2</mn></msup><mo>-</mo><mn>4</mn><mi>a</mi><mi>c</mi></msqrt></mrow><mrow><mn>2</mn><mi>a</mi></mrow></mfrac></math></p>
 </div>
-
-<script>
-	(() => {
-		const linkElement = document.createElement( 'link' );
-		linkElement.href = 'https://ckeditor.com/docs/ckeditor5/21.0.0/snippets/features/mathtype/snippet.css';
-		linkElement.type = 'text/css';
-		linkElement.rel = 'stylesheet';
-		linkElement.dataset[ 'cke' ] = 'true';
-
-		document.head.appendChild( linkElement );
-	})()
-</script>
-<script src="https://ckeditor.com/docs/ckeditor5/21.0.0/assets/snippet.js"></script>
-<script src="https://ckeditor.com/docs/ckeditor5/21.0.0/snippets/features/mathtype/snippet.js"></script>

--- a/docs/_snippets/features/mathtype.js
+++ b/docs/_snippets/features/mathtype.js
@@ -3,4 +3,65 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* Content removed as a workaround in #7944. Should be restored once the upstream is fixed. */
+/* globals window, document, console */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import EasyImage from '@ckeditor/ckeditor5-easy-image/src/easyimage';
+import MathType from '@wiris/mathtype-ckeditor5';
+import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
+
+ClassicEditor
+	.create( document.querySelector( '#mathtype-editor' ), {
+		plugins: [
+			ArticlePluginSet,
+			EasyImage,
+			MathType
+		],
+		toolbar: {
+			items: [
+				'heading',
+				'|',
+				'bold',
+				'italic',
+				'bulletedList',
+				'numberedList',
+				'|',
+				'outdent',
+				'indent',
+				'|',
+				'MathType',
+				'ChemType',
+				'|',
+				'blockQuote',
+				'link',
+				'mediaEmbed',
+				'insertTable',
+				'|',
+				'undo',
+				'redo'
+			],
+			viewportTopOffset: window.getViewportTopOffsetConfig()
+		},
+		image: {
+			styles: [
+				'full',
+				'alignLeft',
+				'alignRight'
+			],
+			toolbar: [
+				'imageStyle:alignLeft',
+				'imageStyle:full',
+				'imageStyle:alignRight',
+				'|',
+				'imageTextAlternative'
+			]
+		},
+		table: {
+			contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ]
+		},
+		cloudServices: CS_CONFIG
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@ckeditor/ckeditor5-real-time-collaboration": "^23.0.0",
     "@ckeditor/ckeditor5-track-changes": "^23.0.0",
     "@webspellchecker/wproofreader-ckeditor5": "^1.0.5",
-    "@wiris/mathtype-ckeditor5": "7.20.0",
+    "@wiris/mathtype-ckeditor5": "^7.24.0",
     "babel-standalone": "^6.26.0",
     "coveralls": "^3.1.0",
     "css-loader": "^3.5.3",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (ckeditor5): Reintroduce the latest MathType version. Closes #8198.

---

### Additional information

To reintroduce latest MathType version in the docs not only commit `3997ba3a` has to be reverted (merged previously in #7944), but additionally also `@wiris/mathtype-ckeditor5` package has to be updated to at least version `7.24.0`, becaue only from this version this package contain the fix (in the internal MathType dependency `@wiris/mathtype-html-integration-devkit@1.4.1`).