### PR TITLE
Link UI should not show up on Ctrl+K when LinkCommand is disabled

### DIFF
--- a/packages/ckeditor5-link/src/linkui.js
+++ b/packages/ckeditor5-link/src/linkui.js
@@ -219,7 +219,9 @@ export default class LinkUI extends Plugin {
 			// Prevent focusing the search bar in FF, Chrome and Edge. See https://github.com/ckeditor/ckeditor5/issues/4811.
 			cancel();
 
-			this._showUI( true );
+			if ( linkCommand.isEnabled ) {
+				this._showUI( true );
+			}
 		} );
 
 		editor.ui.componentFactory.add( 'link', locale => {

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -806,6 +806,7 @@ describe( 'LinkUI', () => {
 				preventDefault: sinon.spy(),
 				stopPropagation: sinon.spy()
 			} );
+
 			sinon.assert.notCalled( spy );
 		} );
 

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -795,6 +795,20 @@ describe( 'LinkUI', () => {
 			sinon.assert.calledWithExactly( spy, true );
 		} );
 
+		it( 'should not show the UI on Ctrl+K keystroke on content with LinkCommand disabled', () => {
+			const spy = testUtils.sinon.stub( linkUIFeature, '_showUI' ).returns( {} );
+			const command = editor.commands.get( 'link' );
+			command.isEnabled = false;
+
+			editor.keystrokes.press( {
+				keyCode: keyCodes.k,
+				ctrlKey: true,
+				preventDefault: sinon.spy(),
+				stopPropagation: sinon.spy()
+			} );
+			sinon.assert.notCalled( spy );
+		} );
+
 		it( 'should prevent default action on Ctrl+K keystroke', () => {
 			const preventDefaultSpy = sinon.spy();
 			const stopPropagationSpy = sinon.spy();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix: Do not show up Link UI on Ctrl+K when LinkCommand is disabled. Closes #7919.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
