### PR TITLE
Media embed command is disabled when selected media is in a table cell

### DIFF
--- a/packages/ckeditor5-media-embed/src/mediaembedcommand.js
+++ b/packages/ckeditor5-media-embed/src/mediaembedcommand.js
@@ -35,7 +35,8 @@ export default class MediaEmbedCommand extends Command {
 
 		let parent = insertPosition.parent;
 
-		if ( parent.isEmpty && model.schema.isBlock( parent ) ) {
+		// The model.insertContent() will remove empty parent (unless it is a $root or a limit).
+		if ( parent.isEmpty && !model.schema.isLimit( parent ) ) {
 			parent = parent.parent;
 		}
 
@@ -68,4 +69,3 @@ export default class MediaEmbedCommand extends Command {
 		}
 	}
 }
-

--- a/packages/ckeditor5-media-embed/src/mediaembedcommand.js
+++ b/packages/ckeditor5-media-embed/src/mediaembedcommand.js
@@ -30,12 +30,12 @@ export default class MediaEmbedCommand extends Command {
 		const model = this.editor.model;
 		const selection = model.document.selection;
 		const schema = model.schema;
-		const position = selection.getFirstPosition();
+		const insertPosition = findOptimalInsertionPosition( selection, model );
 		const selectedMedia = getSelectedMediaModelWidget( selection );
 
-		let parent = position.parent;
+		let parent = insertPosition.parent;
 
-		if ( parent != parent.root ) {
+		if ( parent.isEmpty && model.schema.isBlock( parent ) ) {
 			parent = parent.parent;
 		}
 

--- a/packages/ckeditor5-media-embed/src/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/src/mediaembedediting.js
@@ -171,6 +171,7 @@ export default class MediaEmbedEditing extends Plugin {
 			isObject: true,
 			isBlock: true,
 			allowWhere: '$block',
+			allowIn: 'tableRow',
 			allowAttributes: [ 'url' ]
 		} );
 

--- a/packages/ckeditor5-media-embed/src/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/src/mediaembedediting.js
@@ -171,7 +171,6 @@ export default class MediaEmbedEditing extends Plugin {
 			isObject: true,
 			isBlock: true,
 			allowWhere: '$block',
-			allowIn: 'tableRow',
 			allowAttributes: [ 'url' ]
 		} );
 

--- a/packages/ckeditor5-media-embed/tests/insertmediacommand.js
+++ b/packages/ckeditor5-media-embed/tests/insertmediacommand.js
@@ -57,7 +57,7 @@ describe( 'MediaEmbedCommand', () => {
 			model.schema.extend( 'p', { allowIn: 'tableCell' } );
 			model.schema.extend( 'media', { allowIn: 'p' } );
 
-			setData( model, '<table><tableRow><tableCell><p>[<media></media>]</p></tableCell></tableRow></table>' );
+			setData( model, '<table><tableRow><tableCell>[<media></media>]</tableCell></tableRow></table>' );
 
 			expect( command.isEnabled ).to.be.true;
 		} );

--- a/packages/ckeditor5-media-embed/tests/insertmediacommand.js
+++ b/packages/ckeditor5-media-embed/tests/insertmediacommand.js
@@ -54,8 +54,7 @@ describe( 'MediaEmbedCommand', () => {
 			model.schema.register( 'table', { allowIn: '$root', isLimit: true, isObject: true, isBlock: true } );
 			model.schema.register( 'tableRow', { allowIn: 'table', isLimit: true } );
 			model.schema.register( 'tableCell', { allowIn: 'tableRow', isLimit: true, isSelectable: true } );
-			model.schema.extend( 'p', { allowIn: 'tableCell' } );
-			model.schema.extend( 'media', { allowIn: 'p' } );
+			model.schema.extend( 'media', { allowIn: 'tableCell' } );
 
 			setData( model, '<table><tableRow><tableCell>[<media></media>]</tableCell></tableRow></table>' );
 

--- a/packages/ckeditor5-media-embed/tests/insertmediacommand.js
+++ b/packages/ckeditor5-media-embed/tests/insertmediacommand.js
@@ -50,6 +50,29 @@ describe( 'MediaEmbedCommand', () => {
 			expect( command.isEnabled ).to.be.true;
 		} );
 
+		it( 'should be true if a media is selected in table cell', () => {
+			model.schema.register( 'table', { allowIn: '$root', isLimit: true, isObject: true, isBlock: true } );
+			model.schema.register( 'tableRow', { allowIn: 'table', isLimit: true } );
+			model.schema.register( 'tableCell', { allowIn: 'tableRow', isLimit: true, isSelectable: true } );
+			model.schema.extend( 'p', { allowIn: 'tableCell' } );
+			model.schema.extend( 'media', { allowIn: 'p' } );
+
+			setData( model, '<table><tableRow><tableCell><p>[<media></media>]</p></tableCell></tableRow></table>' );
+
+			expect( command.isEnabled ).to.be.true;
+		} );
+
+		it( 'should be true if in a table cell', () => {
+			model.schema.register( 'table', { allowIn: '$root', isLimit: true, isObject: true, isBlock: true } );
+			model.schema.register( 'tableRow', { allowIn: 'table', isLimit: true } );
+			model.schema.register( 'tableCell', { allowIn: 'tableRow', isLimit: true, isSelectable: true } );
+			model.schema.extend( '$block', { allowIn: 'tableCell' } );
+
+			setData( model, '<table><tableRow><tableCell><p>foo[]</p></tableCell></tableRow></table>' );
+
+			expect( command.isEnabled ).to.be.true;
+		} );
+
 		it( 'should be true when the selection directly in a block', () => {
 			model.schema.register( 'block', { inheritAllFrom: '$block' } );
 			model.schema.extend( '$text', { allowIn: 'block' } );

--- a/packages/ckeditor5-media-embed/tests/insertmediacommand.js
+++ b/packages/ckeditor5-media-embed/tests/insertmediacommand.js
@@ -50,7 +50,7 @@ describe( 'MediaEmbedCommand', () => {
 			expect( command.isEnabled ).to.be.true;
 		} );
 
-		it( 'should be true if a media is selected in table cell', () => {
+		it( 'should be true if a media is selected in a table cell', () => {
 			model.schema.register( 'table', { allowIn: '$root', isLimit: true, isObject: true, isBlock: true } );
 			model.schema.register( 'tableRow', { allowIn: 'table', isLimit: true } );
 			model.schema.register( 'tableCell', { allowIn: 'tableRow', isLimit: true, isSelectable: true } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (media-embed): Enable media embed command when selected media is in a table cell. Closes #7604.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
