### PR TITLE
doc: update external ui doc with EditorUiView render details

### DIFF
--- a/packages/ckeditor5-ui/docs/framework/guides/external-ui.md
+++ b/packages/ckeditor5-ui/docs/framework/guides/external-ui.md
@@ -255,7 +255,8 @@ class BootstrapEditorUI extends EditorUI {
 
 		// References to the toolbar buttons for further usage. See #_setupBootstrapToolbarButtons.
 		view.toolbarButtons = {};
-
+		// Render the view to the body.
+		this._view.render();
 		[ 'bold', 'italic', 'underline', 'undo', 'redo' ].forEach( name => {
 			// Retrieve the jQuery object corresponding with the button in the DOM.
 			view.toolbarButtons[ name ] = view.element.find( `#${ name }` );


### PR DESCRIPTION
When I tried to render a `ContextualBalloon` for the `Mention` plugin, it was not rendering because the custom editor couldn't find the view in the document to attach to. 

I'm not sure whether this is the correct way, the purpose of this PR is to confirm whether this was a bug or is there a better way so that `ContextualBalloon` itself will call the `attachToDom` function.


---

### Additional information

**encountered issue:**
When I tried to render a `ContextualBalloon` for the `Mention` plugin, it was not rendering because the custom editor couldn't find the view in the document to attach to. 


**assumptions you had to make:**
- This is the best place to call the render which will in turn call the attachToDom.
- ContextualBalloon plugin expects the `.ck-body-wrapper` element to be present in the doc.
- This is not an issue in DecoupledEditor and all because it extends from EditorUIView?
