### PR TITLE
Docs: structure updated. [skip ci]

### DIFF
--- a/packages/ckeditor5-block-quote/docs/features/block-quote.md
+++ b/packages/ckeditor5-block-quote/docs/features/block-quote.md
@@ -13,6 +13,13 @@ Use the editor below to see the block quote plugin in action.
 
 {@snippet features/block-quote}
 
+## Related features
+
+Here are some other CKEditor 5 features that you can use similarly to the block quote plugin to structure your text better:
+
+* The {@link features/indent block indentation feature} allows you to set indentation for text blocks such as paragraphs or lists.
+* The {@link features/code-blocks code block feature} allows for insertion of various code listings.
+
 ## Installation
 
 To add this feature to your rich-text editor, install the [`@ckeditor/ckeditor5-block-quote`](https://www.npmjs.com/package/@ckeditor/ckeditor5-block-quote) package:
@@ -39,15 +46,8 @@ ClassicEditor
 	Read more about {@link builds/guides/integration/installing-plugins installing plugins}.
 </info-box>
 
-## Related features
-
-Here are some other CKEditor 5 features that you can use similarly to the block quote plugin to structure your text better:
-
-* The {@link features/indent block indentation feature} allows you to set indentation for text blocks such as paragraphs or lists.
-* The {@link features/code-blocks code block feature} allows for insertion of various code listings.
-
 ## Common API
- 
+
 The {@link module:block-quote/blockquote~BlockQuote} plugin registers:
 
 * the `'blockQuote'` UI button component implemented by the {@link module:block-quote/blockquoteui~BlockQuoteUI block quote UI feature},

--- a/packages/ckeditor5-page-break/docs/features/page-break.md
+++ b/packages/ckeditor5-page-break/docs/features/page-break.md
@@ -15,6 +15,14 @@ Use the editor to see the {@link module:page-break/pagebreak~PageBreak} plugin i
 
 {@snippet features/page-break}
 
+## Related features
+
+Here are some useful CKEditor 5 features that you can use together with the page break plugin for an all-around paged editing experience:
+
+* The [pagination feature](https://ckeditor.com/docs/ckeditor5/latest/features/pagination.html) allows you to see where page breaks would be after the document is [exported to PDF](https://ckeditor.com/docs/ckeditor5/latest/features/export-pdf.html) or [to Word](https://ckeditor.com/docs/ckeditor5/latest/features/export-word.html).
+* The [export to Word](https://ckeditor.com/docs/ckeditor5/latest/features/export-word.html) feature will allow you to generate editable, paged `.docx` files out of your editor-created content.
+* The [export to PDF](https://ckeditor.com/docs/ckeditor5/latest/features/export-pdf.html) feature will allow you to generate portable, paged PDF files out of your editor-created content.
+
 ## Installation
 
 To add this feature to your rich-text editor, install the [`@ckeditor/ckeditor5-page-break`](https://www.npmjs.com/package/@ckeditor/ckeditor5-page-break) package:
@@ -40,14 +48,6 @@ ClassicEditor
 <info-box info>
 	Read more about {@link builds/guides/integration/installing-plugins installing plugins}.
 </info-box>
-
-## Related features
-
-Here are some useful CKEditor 5 features that you can use together with the page break plugin for an all-around paged editing experience:
-
-* The [pagination feature](https://ckeditor.com/docs/ckeditor5/latest/features/pagination.html) allows you to see where page breaks would be after the document is [exported to PDF](https://ckeditor.com/docs/ckeditor5/latest/features/export-pdf.html) or [to Word](https://ckeditor.com/docs/ckeditor5/latest/features/export-word.html).
-* The [export to Word](https://ckeditor.com/docs/ckeditor5/latest/features/export-word.html) feature will allow you to generate editable, paged `.docx` files out of your editor-created content.
-* The [export to PDF](https://ckeditor.com/docs/ckeditor5/latest/features/export-pdf.html) feature will allow you to generate portable, paged PDF files out of your editor-created content.
 
 ## Common API
 


### PR DESCRIPTION
"Related" section moved to a new position. No other changes made.