### PR TITLE
Use npm in favor of yarn for consistency

### DIFF
--- a/docs/builds/guides/integration/advanced-setup.md
+++ b/docs/builds/guides/integration/advanced-setup.md
@@ -602,7 +602,7 @@ index c57e371..04fc9fe 100644
 Once you changed the `src/ckeditor.js` and `webpack.config.js` files it is time to rebuild the build:
 
 ```bash
-yarn run build
+npm run build
 ```
 
 Finally, when webpack finishes compiling your super build, you can change the `samples/index.html` file to test both editors:


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Use npm in favor of yarn in the advanced setup for consistency 

---

### Additional information

Assumed that you want to use npm instead of yarn given that in most places you are using npm.