### PR TITLE
Inserted URL with '%'-symbols is not transformed to Media Object

### DIFF
--- a/packages/ckeditor5-media-embed/src/automediaembed.js
+++ b/packages/ckeditor5-media-embed/src/automediaembed.js
@@ -16,7 +16,7 @@ import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 import { insertMedia } from './utils';
 
-const URL_REGEXP = /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=]+$/;
+const URL_REGEXP = /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-._~:/?#[\]@!$&'()*+,;=%]+$/;
 
 /**
  * The auto-media embed plugin. It recognizes media links in the pasted content and embeds

--- a/packages/ckeditor5-media-embed/tests/automediaembed.js
+++ b/packages/ckeditor5-media-embed/tests/automediaembed.js
@@ -398,6 +398,17 @@ describe( 'AutoMediaEmbed - integration', () => {
 					return newEditor.destroy();
 				} );
 		} );
+
+		it( 'works for URL with %-symbols', () => {
+			setData( editor.model, '<paragraph>[]</paragraph>' );
+			pasteHtml( editor, 'http://youtube.com/watch?v=H08tGjXNHO4%2' );
+
+			clock.tick( 100 );
+
+			expect( getData( editor.model ) ).to.equal(
+				'[<media url="http://youtube.com/watch?v=H08tGjXNHO4%2"></media>]'
+			);
+		} );
 	} );
 
 	describe( 'use real timers', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (media-embed): Allow URL with '%'-symbols for Media Object transformation. Closes #7488.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
