### PR TITLE
Use isArrowKeyCode from ckeditor5-utils package

### DIFF
--- a/packages/ckeditor5-engine/src/view/observer/fakeselectionobserver.js
+++ b/packages/ckeditor5-engine/src/view/observer/fakeselectionobserver.js
@@ -9,7 +9,7 @@
 
 import Observer from './observer';
 import ViewSelection from '../selection';
-import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
+import { keyCodes, isArrowKeyCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import { debounce } from 'lodash-es';
 
 /**
@@ -49,7 +49,7 @@ export default class FakeSelectionObserver extends Observer {
 		document.on( 'keydown', ( eventInfo, data ) => {
 			const selection = document.selection;
 
-			if ( selection.isFake && _isArrowKeyCode( data.keyCode ) && this.isEnabled ) {
+			if ( selection.isFake && isArrowKeyCode( data.keyCode ) && this.isEnabled ) {
 				// Prevents default key down handling - no selection change will occur.
 				data.preventDefault();
 
@@ -110,16 +110,3 @@ export default class FakeSelectionObserver extends Observer {
 		this._fireSelectionChangeDoneDebounced( data );
 	}
 }
-
-// Checks if one of the arrow keys is pressed.
-//
-// @private
-// @param {Number} keyCode
-// @returns {Boolean}
-function _isArrowKeyCode( keyCode ) {
-	return keyCode == keyCodes.arrowright ||
-		keyCode == keyCodes.arrowleft ||
-		keyCode == keyCodes.arrowup ||
-		keyCode == keyCodes.arrowdown;
-}
-


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (engine): Use `isArrowKeyCode` from `ckeditor5-utils` package. Closes #6648.

---

### Additional information

`isArrowKeyCode` method is available since https://github.com/ckeditor/ckeditor5/commit/eb8dd9f0e616cd5d15c3dc673508679d3061f547#diff-e6250bd96c3f473fa2ca5e514f412797R138 and there was only 1 place where it wasn't used. Unit tests are already created for it.
