### PR TITLE
Add information about supported Angular versions in the Angular guide

### DIFF
--- a/docs/builds/guides/frameworks/angular.md
+++ b/docs/builds/guides/frameworks/angular.md
@@ -16,6 +16,13 @@ Currently, the CKEditor 5 component for Angular supports integrating CKEditor 5 
 	While there is no support to integrate CKEditor 5 from source yet, you can still {@link builds/guides/development/custom-builds create a custom build of CKEditor 5} and include it in your Angular application.
 </info-box>
 
+## Supported Angular versions
+
+Because of breaking changes in the Angular library output format, the `ckeditor5-angular` package is released in the following versions to support various Angular ecosystems:
+
+- `1.x.x` - for Angular 5-8 apps, the support will end when the official support for Angular 8 is dropped (November 2020),
+- `2.x.x` - for Angular 9+ apps, actively supported.
+
 ## Quick start
 
 In your existing Angular project, install the [CKEditor 5 WYSIWYG editor component for Angular](https://www.npmjs.com/package/@ckeditor/ckeditor5-angular):

--- a/docs/builds/guides/frameworks/angular.md
+++ b/docs/builds/guides/frameworks/angular.md
@@ -23,7 +23,7 @@ Because of the breaking changes in the Angular library output format, the `ckedi
 * Version `1.x.x` &ndash; For **Angular 5-8** apps. Support for this version will end when the official support for Angular 8 is dropped (planned date: November 2020),
 * Version `2.x.x` &ndash; For **Angular 9+** apps. This version is currently actively supported.
 
-All versions are [listed on NPM](https://www.npmjs.com/package/@ckeditor/ckeditor5-angular), where they can be pulled from.
+All available versions are [listed on NPM](https://www.npmjs.com/package/@ckeditor/ckeditor5-angular), where they can be pulled from.
 
 ## Quick start
 

--- a/docs/builds/guides/frameworks/angular.md
+++ b/docs/builds/guides/frameworks/angular.md
@@ -20,10 +20,10 @@ Currently, the CKEditor 5 component for Angular supports integrating CKEditor 5 
 
 Because of the breaking changes in the Angular library output format, the `ckeditor5-angular` package is released in the following versions to support various Angular ecosystems:
 
-* Versions `1.x.x` &ndash; For **Angular 5-8** apps. Support for this version will end when the official support for Angular 8 is dropped (planned date: November 2020),
-* Versions `2.x.x` &ndash; For **Angular 9+** apps. This version is currently actively supported.
+* Versions `1.x.x` &ndash; For **Angular 5-8** applications. Support for this version will end when the official support for Angular 8 is dropped (planned date: November 2020),
+* Versions `2.x.x` &ndash; For **Angular 9.1+** applications. This version is currently actively supported.
 
-All available versions are [listed on NPM](https://www.npmjs.com/package/@ckeditor/ckeditor5-angular), where they can be pulled from.
+All available versions are [listed on npm](https://www.npmjs.com/package/@ckeditor/ckeditor5-angular), where they can be pulled from.
 
 ## Quick start
 

--- a/docs/builds/guides/frameworks/angular.md
+++ b/docs/builds/guides/frameworks/angular.md
@@ -18,10 +18,10 @@ Currently, the CKEditor 5 component for Angular supports integrating CKEditor 5 
 
 ## Supported Angular versions
 
-Because of breaking changes in the Angular library output format, the `ckeditor5-angular` package is released in the following versions to support various Angular ecosystems:
+Because of the breaking changes in the Angular library output format, the `ckeditor5-angular` package is released in the following versions to support various Angular ecosystems:
 
-- `1.x.x` - for Angular 5-8 apps, the support will end when the official support for Angular 8 is dropped (November 2020),
-- `2.x.x` - for Angular 9+ apps, actively supported.
+* Version `1.x.x` &ndash; For **Angular 5-8** apps. Support for this version will end when the official support for Angular 8 is dropped (planned date: November 2020),
+* Version `2.x.x` &ndash; For **Angular 9+** apps. This version is currently actively supported.
 
 ## Quick start
 

--- a/docs/builds/guides/frameworks/angular.md
+++ b/docs/builds/guides/frameworks/angular.md
@@ -20,8 +20,8 @@ Currently, the CKEditor 5 component for Angular supports integrating CKEditor 5 
 
 Because of the breaking changes in the Angular library output format, the `ckeditor5-angular` package is released in the following versions to support various Angular ecosystems:
 
-* Version `1.x.x` &ndash; For **Angular 5-8** apps. Support for this version will end when the official support for Angular 8 is dropped (planned date: November 2020),
-* Version `2.x.x` &ndash; For **Angular 9+** apps. This version is currently actively supported.
+* Versions `1.x.x` &ndash; For **Angular 5-8** apps. Support for this version will end when the official support for Angular 8 is dropped (planned date: November 2020),
+* Versions `2.x.x` &ndash; For **Angular 9+** apps. This version is currently actively supported.
 
 All available versions are [listed on NPM](https://www.npmjs.com/package/@ckeditor/ckeditor5-angular), where they can be pulled from.
 

--- a/docs/builds/guides/frameworks/angular.md
+++ b/docs/builds/guides/frameworks/angular.md
@@ -23,6 +23,8 @@ Because of the breaking changes in the Angular library output format, the `ckedi
 * Version `1.x.x` &ndash; For **Angular 5-8** apps. Support for this version will end when the official support for Angular 8 is dropped (planned date: November 2020),
 * Version `2.x.x` &ndash; For **Angular 9+** apps. This version is currently actively supported.
 
+All versions are [listed on NPM](https://www.npmjs.com/package/@ckeditor/ckeditor5-angular), where they can be pulled from.
+
 ## Quick start
 
 In your existing Angular project, install the [CKEditor 5 WYSIWYG editor component for Angular](https://www.npmjs.com/package/@ckeditor/ckeditor5-angular):


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Added information about supported Angular versions in the Angular guide. Closes ckeditor/ckeditor5-angular#227.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._