### PR TITLE
Non-tagged elements will not blow up the list style feature

### DIFF
--- a/packages/ckeditor5-list/src/liststyleediting.js
+++ b/packages/ckeditor5-list/src/liststyleediting.js
@@ -213,7 +213,7 @@ function upcastListItemStyle() {
 		dispatcher.on( 'element:li', ( evt, data, conversionApi ) => {
 			const listParent = data.viewItem.parent;
 			const listStyle = listParent.getStyle( 'list-style-type' ) || DEFAULT_LIST_TYPE;
-			const listItem = data.modelRange.start.nodeAfter;
+			const listItem = data.modelRange.start.nodeAfter || data.modelRange.end.nodeBefore;
 
 			conversionApi.writer.setAttribute( 'listStyle', listStyle, listItem );
 		}, { priority: 'low' } );

--- a/packages/ckeditor5-list/tests/liststyleediting.js
+++ b/packages/ckeditor5-list/tests/liststyleediting.js
@@ -333,6 +333,43 @@ describe( 'ListStyleEditing', () => {
 					'<paragraph>Paragraph.</paragraph>'
 				);
 			} );
+
+			// See: #8262.
+			describe( 'list conversion with surrounding text nodes', () => {
+				let editor;
+
+				beforeEach( () => {
+					return VirtualTestEditor
+						.create( {
+							plugins: [ ListStyleEditing ]
+						} )
+						.then( newEditor => {
+							editor = newEditor;
+						} );
+				} );
+
+				afterEach( () => {
+					return editor.destroy();
+				} );
+
+				it( 'should convert a list if raw text is before the list', () => {
+					editor.setData( 'Foo<ul><li>Foo</li></ul>' );
+
+					expect( editor.getData() ).to.equal( '<p>Foo</p><ul><li>Foo</li></ul>' );
+				} );
+
+				it( 'should convert a list if raw text is after the list', () => {
+					editor.setData( '<ul><li>Foo</li></ul>Foo' );
+
+					expect( editor.getData() ).to.equal( '<ul><li>Foo</li></ul><p>Foo</p>' );
+				} );
+
+				it( 'should convert a list if it is surrender by two text nodes', () => {
+					editor.setData( 'Foo<ul><li>Foo</li></ul>Foo' );
+
+					expect( editor.getData() ).to.equal( '<p>Foo</p><ul><li>Foo</li></ul><p>Foo</p>' );
+				} );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (list): The list conversion will not throw an error if the list element is being surrounded by the non-tagged elements (text nodes). Closes #8262.

