### PR TITLE
Fixing showing button separators in inappropriate places

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/responsive-form/responsiveform.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/responsive-form/responsiveform.css
@@ -69,7 +69,9 @@
 					border-right: 1px solid var(--ck-color-base-border);
 				}
 			}
+		}
 
+		& > .ck-button:nth-last-child(2) {
 			&::after {
 				border-right: 1px solid var(--ck-color-base-border);
 			}

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/responsive-form/responsiveform.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/responsive-form/responsiveform.css
@@ -6,7 +6,7 @@
 @import "@ckeditor/ckeditor5-ui/theme/mixins/_rwd.css";
 @import "@ckeditor/ckeditor5-ui/theme/mixins/_dir.css";
 
-.ck-vertical-form .ck-button::after {
+.ck-vertical-form > .ck-button:nth-last-child(2)::after {
 	border-right: 1px solid var(--ck-color-base-border);
 }
 
@@ -48,8 +48,9 @@
 			}
 		}
 
-		/* 'button' selector must be used because those styles shouldn't be added to other elements, like 'a'. Example in LinkActionsView. */
-		& button.ck-button {
+		/* Styles for two last buttons in the form (save&cancel, edit&unlink, etc.). */
+		& > .ck-button:nth-last-child(1),
+		& > .ck-button:nth-last-child(2) {
 			padding: var(--ck-spacing-standard);
 			margin-top: var(--ck-spacing-standard);
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (theme-lark): Fixing showing button separators in inappropriate places. Closes #8296.

---

### Additional information

Follow-up of [#7704](https://github.com/ckeditor/ckeditor5/issues/7704).