### PR TITLE
Removing focus outline in "insert image via URL" form.

### DIFF
--- a/packages/ckeditor5-image/theme/imageinsertformrowview.css
+++ b/packages/ckeditor5-image/theme/imageinsertformrowview.css
@@ -3,6 +3,12 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+.ck.ck-image-insert-form {
+	&:focus {
+		outline: none;
+	}
+}
+
 .ck.ck-form__row {
 	display: flex;
 	flex-direction: row;

--- a/packages/ckeditor5-image/theme/imageinsertformrowview.css
+++ b/packages/ckeditor5-image/theme/imageinsertformrowview.css
@@ -5,6 +5,7 @@
 
 .ck.ck-image-insert-form {
 	&:focus {
+		/* See: https://github.com/ckeditor/ckeditor5/issues/4773 */
 		outline: none;
 	}
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/form.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/form.css
@@ -7,7 +7,7 @@
 	padding: 0 0 var(--ck-spacing-large);
 
 	&:focus {
-		/* https://github.com/ckeditor/ckeditor5-link/issues/90 */
+		/* See: https://github.com/ckeditor/ckeditor5/issues/4773 */
 		outline: none;
 	}
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/responsive-form/responsiveform.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/responsive-form/responsiveform.css
@@ -14,7 +14,7 @@
 	padding: var(--ck-spacing-standard);
 
 	&:focus {
-		/* https://github.com/ckeditor/ckeditor5-link/issues/90 */
+		/* See: https://github.com/ckeditor/ckeditor5/issues/4773 */
 		outline: none;
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (image): Removing focus outline in "insert image via URL" form.. Closes #7973.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._