### PR TITLE
Remove warnings about unsupported code block languages in the docs

### DIFF
--- a/packages/ckeditor5-code-block/docs/_snippets/features/code-block-custom-languages.html
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/code-block-custom-languages.html
@@ -1,6 +1,6 @@
-<div id="snippet-custom-languages">
-	<p>Put some text in the <code>&lt;body&gt;</code>:</p>
-<pre><code class="language-html"><body>Hello world!</body></code></pre>
-	<p>Then set the font color:</p>
-<pre><code class="language-css">body { color: red }</code></pre>
-</div>
+<textarea id="snippet-custom-languages">
+	&lt;p>Put some text in the &lt;code>&lt;body&gt;&lt;/code>:&lt;/p>
+&lt;pre>&lt;code class="language-html">&lt;body>Hello world!&lt;/body>&lt;/code>&lt;/pre>
+	&lt;p>Then set the font color:&lt;/p>
+&lt;pre>&lt;code class="language-css">body { color: red }&lt;/code>&lt;/pre>
+</textarea>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (code-block): Removed warnings about unsupported code block languages in the docs. Closes #7925.

---

### Additional information

As mentioned in https://github.com/cksource/umberto/issues/838#issuecomment-559036170, this is a workaround for a bug in Umberto.
