### PR TITLE
#8321: Added a label and and outline to the html embed widgets to improve contrast.

### DIFF
--- a/packages/ckeditor5-html-embed/src/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/src/htmlembedediting.js
@@ -207,6 +207,7 @@ export default class HtmlEmbedEditing extends Plugin {
 
 				writer.setCustomProperty( 'rawHtmlApi', rawHtmlApi, viewContainer );
 				writer.setCustomProperty( 'rawHtml', true, viewContainer );
+				writer.setAttribute( 'data-html-embed-label', t( 'HTML snippet' ), viewContainer );
 
 				return toWidget( viewContainer, writer, {
 					widgetLabel: t( 'HTML snippet' ),

--- a/packages/ckeditor5-html-embed/src/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/src/htmlembedediting.js
@@ -132,7 +132,8 @@ export default class HtmlEmbedEditing extends Plugin {
 				let domContentWrapper, state, props;
 
 				const viewContainer = writer.createContainerElement( 'div', {
-					class: 'raw-html-embed'
+					class: 'raw-html-embed',
+					'data-html-embed-label': t( 'HTML snippet' )
 				} );
 				// Widget cannot be a raw element because the widget system would not be able
 				// to add its UI to it. Thus, we need this wrapper.
@@ -207,7 +208,6 @@ export default class HtmlEmbedEditing extends Plugin {
 
 				writer.setCustomProperty( 'rawHtmlApi', rawHtmlApi, viewContainer );
 				writer.setCustomProperty( 'rawHtml', true, viewContainer );
-				writer.setAttribute( 'data-html-embed-label', t( 'HTML snippet' ), viewContainer );
 
 				return toWidget( viewContainer, writer, {
 					widgetLabel: t( 'HTML snippet' ),

--- a/packages/ckeditor5-html-embed/tests/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/tests/htmlembedediting.js
@@ -242,6 +242,13 @@ describe( 'HtmlEmbedEditing', () => {
 				expect( contentWrapper.hasClass( 'raw-html-embed__content-wrapper' ) );
 			} );
 
+			it( 'the widget should have the data-html-embed-label attribute for the CSS label', () => {
+				setModelData( model, '<rawHtml></rawHtml>' );
+				const widget = viewDocument.getRoot().getChild( 0 );
+
+				expect( widget.getAttribute( 'data-html-embed-label' ) ).to.equal( 'HTML snippet' );
+			} );
+
 			it( 'the main element should expose rawHtmlApi custom property', () => {
 				setModelData( model, '<rawHtml></rawHtml>' );
 				const widget = viewDocument.getRoot().getChild( 0 );

--- a/packages/ckeditor5-html-embed/theme/htmlembed.css
+++ b/packages/ckeditor5-html-embed/theme/htmlembed.css
@@ -13,6 +13,9 @@
 
 	&::before {
 		position: absolute;
+
+		/* Make sure the content does not cover the label. */
+		z-index: 1;
 	}
 
 	/* ----- Emebed internals --------------------------------------------------------------------- */

--- a/packages/ckeditor5-html-embed/theme/htmlembed.css
+++ b/packages/ckeditor5-html-embed/theme/htmlembed.css
@@ -32,4 +32,8 @@
 .ck-content .raw-html-embed {
 	/* Give the embed some air. */
 	margin: 1em auto;
+
+	/* Give the html embed some minimal width in the content to prevent them
+	from being "squashed" in tight spaces, e.g. in table cells (https://github.com/ckeditor/ckeditor5/issues/8331) */
+	min-width: 15em;
 }

--- a/packages/ckeditor5-html-embed/theme/htmlembed.css
+++ b/packages/ckeditor5-html-embed/theme/htmlembed.css
@@ -9,6 +9,14 @@
 	margin: 1em auto;
 	position: relative;
 
+	/* ----- Emebed label in the upper left corner ----------------------------------------------- */
+
+	&::before {
+		position: absolute;
+	}
+
+	/* ----- Emebed internals --------------------------------------------------------------------- */
+
 	/* The switch mode button wrapper. */
 	& .raw-html-embed__buttons-wrapper {
 		position: absolute;

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-html-embed/htmlembed.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-html-embed/htmlembed.css
@@ -6,6 +6,7 @@
 :root {
 	--ck-html-embed-content-width: calc(100% - 1.5 * var(--ck-icon-size));
 	--ck-html-embed-source-height: 10em;
+	--ck-html-embed-unfocused-outline-width: 1px;
 	--ck-html-embed-content-min-height: calc(var(--ck-icon-size) + var(--ck-spacing-standard));
 }
 
@@ -13,6 +14,47 @@
 .ck-widget.raw-html-embed {
 	font-size: var(--ck-font-size-base);
 	background-color: var(--ck-color-base-foreground);
+
+	&:not(.ck-widget_selected):not(:hover) {
+		outline: var(--ck-html-embed-unfocused-outline-width) dashed var(--ck-color-widget-blurred-border);
+	}
+
+	& .ck-widget__type-around .ck-widget__type-around__button.ck-widget__type-around__button_before {
+		margin-left: 50px;
+	}
+
+	/* ----- Emebed label in the upper left corner ----------------------------------------------- */
+
+	&::before {
+		content: attr(data-html-embed-label);
+		top: calc(-1 * var(--ck-html-embed-unfocused-outline-width));
+		left: var(--ck-spacing-standard);
+		background: hsl(0deg 0% 60%);
+		transition: background var(--ck-widget-handler-animation-duration) var(--ck-widget-handler-animation-curve);
+		padding: calc(var(--ck-spacing-tiny) + var(--ck-html-embed-unfocused-outline-width)) var(--ck-spacing-small) var(--ck-spacing-tiny);
+		border-radius: 0 0 var(--ck-border-radius) var(--ck-border-radius);
+		color: var(--ck-color-base-background);
+		font-size: var(--ck-font-size-tiny);
+		font-family: var(--ck-font-face);
+	}
+
+	@nest .ck.ck-editor__editable.ck-blurred &.ck-widget_selected::before {
+		top: 0px;
+		padding: var(--ck-spacing-tiny) var(--ck-spacing-small);
+	}
+
+	@nest .ck.ck-editor__editable:not(.ck-blurred) &.ck-widget_selected::before {
+		top: 0;
+		padding: var(--ck-spacing-tiny) var(--ck-spacing-small);
+		background: var(--ck-color-focus-border);
+	}
+
+	@nest .ck.ck-editor__editable &:not(.ck-widget_selected):hover::before {
+		top: 0px;
+		padding: var(--ck-spacing-tiny) var(--ck-spacing-small);
+	}
+
+	/* ----- Emebed internals --------------------------------------------------------------------- */
 
 	& .raw-html-embed__content-wrapper {
 		padding: var(--ck-spacing-standard);


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Added a label and an outline to the HTML embed widget to improve contrast. Closes #8321.

---

### Additional information

There's a problem with the widget type around button. I moved if by some offset to avoid collisions but it could be that in some languages "HTML snippet" will translate to some long string and it will overlap with the button. I don't see any easy way to anticipate this, though.