### PR TITLE
Added a code that will help identify the source of infinite selection loop

### DIFF
--- a/packages/ckeditor5-engine/tests/common.js
+++ b/packages/ckeditor5-engine/tests/common.js
@@ -1,0 +1,22 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global console */
+
+// eslint-disable-next-line mocha/no-top-level-hooks
+before( () => {
+	// This is a temporary special handling for https://github.com/ckeditor/ckeditor5/issues/8263
+	// The goal is to show which test case(s) exactly causes the "Selection change observer detected an infinite rendering loop." warn
+	// and reduced engine code coverage.
+	const originalWarn = console.warn;
+
+	console.warn = function( ...args ) {
+		if ( args[ 0 ] == 'Selection change observer detected an infinite rendering loop.' ) {
+			throw new Error( 'Detected unwelcome "Selection change observer detected an infinite rendering loop." warning.' );
+		}
+
+		return originalWarn.apply( args );
+	};
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Tests (engine): Added the detection for infinite selection rendering loop. See #8263.

---

### Additional information

This is the first step that might show us what is wrong with the test. The trick is to proxy `console.warn` so that it fails if infinite selection loop message is detected (see https://github.com/ckeditor/ckeditor5/issues/8263#issuecomment-708964548).

It's acceptable that it will cause the entire test run to fail - we get a fail from CI anyway (due to lacking CC if infinite rendering is happening).