### PR TITLE
Pasting a list into another list (fix list-style attr)

### DIFF
--- a/packages/ckeditor5-list/package.json
+++ b/packages/ckeditor5-list/package.json
@@ -10,7 +10,6 @@
     "ckeditor5-plugin"
   ],
   "dependencies": {
-    "@ckeditor/ckeditor5-clipboard": "^23.0.0",
     "@ckeditor/ckeditor5-core": "^23.0.0",
     "@ckeditor/ckeditor5-engine": "^23.0.0",
     "@ckeditor/ckeditor5-paragraph": "^23.0.0",
@@ -20,6 +19,7 @@
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^23.0.0",
     "@ckeditor/ckeditor5-block-quote": "^23.0.0",
+    "@ckeditor/ckeditor5-clipboard": "^23.0.0",
     "@ckeditor/ckeditor5-essentials": "^23.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^23.0.0",
     "@ckeditor/ckeditor5-enter": "^23.0.0",

--- a/packages/ckeditor5-list/package.json
+++ b/packages/ckeditor5-list/package.json
@@ -10,6 +10,7 @@
     "ckeditor5-plugin"
   ],
   "dependencies": {
+    "@ckeditor/ckeditor5-clipboard": "^23.0.0",
     "@ckeditor/ckeditor5-core": "^23.0.0",
     "@ckeditor/ckeditor5-engine": "^23.0.0",
     "@ckeditor/ckeditor5-paragraph": "^23.0.0",
@@ -19,7 +20,6 @@
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^23.0.0",
     "@ckeditor/ckeditor5-block-quote": "^23.0.0",
-    "@ckeditor/ckeditor5-clipboard": "^23.0.0",
     "@ckeditor/ckeditor5-essentials": "^23.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^23.0.0",
     "@ckeditor/ckeditor5-enter": "^23.0.0",

--- a/packages/ckeditor5-list/src/liststyleediting.js
+++ b/packages/ckeditor5-list/src/liststyleediting.js
@@ -522,68 +522,68 @@ function fixListStyleAttributeOnListItemElements( editor ) {
 
 		return wasFixed;
 	};
+}
 
-	// Checks whether the `listStyle` attribute should be copied from the `baseItem` element.
-	//
-	// The attribute should be copied if the inserted element does not have defined it and
-	// the value for the element is other than default in the base element.
-	//
-	// @param {module:engine/model/element~Element|null} baseItem
-	// @param {module:engine/model/element~Element} itemToChange
-	// @returns {Boolean}
-	function shouldInheritListType( baseItem, itemToChange ) {
-		if ( !baseItem ) {
-			return false;
-		}
-
-		const baseListStyle = baseItem.getAttribute( 'listStyle' );
-
-		if ( !baseListStyle ) {
-			return false;
-		}
-
-		if ( baseListStyle === DEFAULT_LIST_TYPE ) {
-			return false;
-		}
-
-		if ( baseItem.getAttribute( 'listType' ) !== itemToChange.getAttribute( 'listType' ) ) {
-			return false;
-		}
-
-		return true;
+// Checks whether the `listStyle` attribute should be copied from the `baseItem` element.
+//
+// The attribute should be copied if the inserted element does not have defined it and
+// the value for the element is other than default in the base element.
+//
+// @param {module:engine/model/element~Element|null} baseItem
+// @param {module:engine/model/element~Element} itemToChange
+// @returns {Boolean}
+function shouldInheritListType( baseItem, itemToChange ) {
+	if ( !baseItem ) {
+		return false;
 	}
 
-	// Checks whether the `listStyle` attribute should be copied from previous list item.
-	//
-	// The attribute should be copied if there's a mismatch of styles of the pasted list into a nested list.
-	// Top-level lists are not normalized as we allow side-by-side list of different types.
-	//
-	// @param {module:engine/model/element~Element|null} previousItem
-	// @param {module:engine/model/element~Element} itemToChange
-	// @returns {Boolean}
-	function shouldInheritListTypeFromPreviousItem( previousItem, itemToChange ) {
-		if ( !previousItem || !previousItem.is( 'element', 'listItem' ) ) {
-			return false;
-		}
+	const baseListStyle = baseItem.getAttribute( 'listStyle' );
 
-		if ( itemToChange.getAttribute( 'listType' ) !== previousItem.getAttribute( 'listType' ) ) {
-			return false;
-		}
-
-		const previousItemIndent = previousItem.getAttribute( 'listIndent' );
-
-		if ( previousItemIndent < 1 || previousItemIndent !== itemToChange.getAttribute( 'listIndent' ) ) {
-			return false;
-		}
-
-		const previousItemListStyle = previousItem.getAttribute( 'listStyle' );
-
-		if ( !previousItemListStyle || previousItemListStyle === itemToChange.getAttribute( 'listStyle' ) ) {
-			return false;
-		}
-
-		return true;
+	if ( !baseListStyle ) {
+		return false;
 	}
+
+	if ( baseListStyle === DEFAULT_LIST_TYPE ) {
+		return false;
+	}
+
+	if ( baseItem.getAttribute( 'listType' ) !== itemToChange.getAttribute( 'listType' ) ) {
+		return false;
+	}
+
+	return true;
+}
+
+// Checks whether the `listStyle` attribute should be copied from previous list item.
+//
+// The attribute should be copied if there's a mismatch of styles of the pasted list into a nested list.
+// Top-level lists are not normalized as we allow side-by-side list of different types.
+//
+// @param {module:engine/model/element~Element|null} previousItem
+// @param {module:engine/model/element~Element} itemToChange
+// @returns {Boolean}
+function shouldInheritListTypeFromPreviousItem( previousItem, itemToChange ) {
+	if ( !previousItem || !previousItem.is( 'element', 'listItem' ) ) {
+		return false;
+	}
+
+	if ( itemToChange.getAttribute( 'listType' ) !== previousItem.getAttribute( 'listType' ) ) {
+		return false;
+	}
+
+	const previousItemIndent = previousItem.getAttribute( 'listIndent' );
+
+	if ( previousItemIndent < 1 || previousItemIndent !== itemToChange.getAttribute( 'listIndent' ) ) {
+		return false;
+	}
+
+	const previousItemListStyle = previousItem.getAttribute( 'listStyle' );
+
+	if ( !previousItemListStyle || previousItemListStyle === itemToChange.getAttribute( 'listStyle' ) ) {
+		return false;
+	}
+
+	return true;
 }
 
 // Removes the `listStyle` attribute from "todo" list items.

--- a/packages/ckeditor5-list/src/liststyleediting.js
+++ b/packages/ckeditor5-list/src/liststyleediting.js
@@ -8,6 +8,7 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import ListEditing from './listediting';
 import ListStyleCommand from './liststylecommand';
 import { getSiblingListItem, getSiblingNodes } from './utils';
@@ -29,7 +30,7 @@ export default class ListStyleEditing extends Plugin {
 	 * @inheritDoc
 	 */
 	static get requires() {
-		return [ ListEditing ];
+		return [ ListEditing, Clipboard ];
 	}
 
 	/**
@@ -437,6 +438,13 @@ function fixListAfterOutdentListCommand( editor ) {
 // @param {module:core/editor/editor~Editor} editor
 // @returns {Function}
 function fixListStyleAttributeOnListItemElements( editor ) {
+	// A flag that determines whether the inserted content comes from the clipboard.
+	let contentFromClipboard;
+
+	editor.listenTo( editor.plugins.get( Clipboard ), 'inputTransformation', () => {
+		contentFromClipboard = true;
+	} );
+
 	return writer => {
 		let wasFixed = false;
 
@@ -448,6 +456,45 @@ function fixListStyleAttributeOnListItemElements( editor ) {
 
 		if ( !insertedListItems.length ) {
 			return wasFixed;
+		}
+
+		// Adjust the `listStyle` attribute for inserted (pasted) items. See #8160.
+		//
+		// ■ List item 1. // [listStyle="square", listType="bulleted"]
+		//     ○ List item 1.1. // [listStyle="circle", listType="bulleted"]
+		//     ○ [] (selection is here)
+		//
+		// Then, pasting a list with different attributes (listStyle, listType):
+		//
+		// 1. First. // [listStyle="decimal", listType="numbered"]
+		// 2. Second // [listStyle="decimal", listType="numbered"]
+		//
+		// The `listType` attribute will be corrected by the `ListEditing` converters.
+		// We need to adjust the `listStyle` attribute. Expected structure:
+		//
+		// ■ List item 1. // [listStyle="square", listType="bulleted"]
+		//     ○ List item 1.1. // [listStyle="circle", listType="bulleted"]
+		//     ○ First. // [listStyle="circle", listType="bulleted"]
+		//     ○ Second // [listStyle="circle", listType="bulleted"]
+		const firstPreviousSibling = insertedListItems[ 0 ].previousSibling;
+
+		if ( firstPreviousSibling && contentFromClipboard ) {
+			contentFromClipboard = false;
+
+			const listIndent = firstPreviousSibling.getAttribute( 'listIndent' );
+			const listStyle = firstPreviousSibling.getAttribute( 'listStyle' );
+
+			const itemsToUpdate = insertedListItems.filter( i => {
+				return i.getAttribute( 'listIndent' ) === listIndent && i.getAttribute( 'listStyle' ) !== listStyle;
+			} );
+
+			if ( itemsToUpdate.length ) {
+				for ( const item of itemsToUpdate ) {
+					writer.setAttribute( 'listStyle', listStyle, item );
+				}
+
+				return true;
+			}
 		}
 
 		// Check whether the last inserted element is next to the `listItem` element.

--- a/packages/ckeditor5-list/tests/liststylecommand.js
+++ b/packages/ckeditor5-list/tests/liststylecommand.js
@@ -96,7 +96,7 @@ describe( 'ListStyleCommand', () => {
 		it( 'should return the value of `listStyle` attribute for the selection inside a nested list', () => {
 			setData( model,
 				'<listItem listIndent="0" listType="bulleted" listStyle="square">1.</listItem>' +
-				'<listItem listIndent="0" listType="bulleted" listStyle="disc">1.1.[]</listItem>' +
+				'<listItem listIndent="1" listType="bulleted" listStyle="disc">1.1.[]</listItem>' +
 				'<listItem listIndent="0" listType="bulleted" listStyle="square">2.</listItem>'
 			);
 
@@ -106,7 +106,7 @@ describe( 'ListStyleCommand', () => {
 		it( 'should return the value of `listStyle` attribute from a list where the selection starts (selection over nested list)', () => {
 			setData( model,
 				'<listItem listIndent="0" listType="bulleted" listStyle="square">1.</listItem>' +
-				'<listItem listIndent="0" listType="bulleted" listStyle="disc">1.1.[</listItem>' +
+				'<listItem listIndent="1" listType="bulleted" listStyle="disc">1.1.[</listItem>' +
 				'<listItem listIndent="0" listType="bulleted" listStyle="square">2.]</listItem>'
 			);
 

--- a/packages/ckeditor5-list/tests/liststyleediting.js
+++ b/packages/ckeditor5-list/tests/liststyleediting.js
@@ -1465,7 +1465,7 @@ describe( 'ListStyleEditing', () => {
 		} );
 
 		// #8160
-		describe( 'pasting a into another list', () => {
+		describe( 'pasting a list into another list', () => {
 			let element;
 
 			beforeEach( () => {

--- a/packages/ckeditor5-list/tests/liststyleediting.js
+++ b/packages/ckeditor5-list/tests/liststyleediting.js
@@ -9,23 +9,21 @@ import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtest
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 
 import ListStyleEditing from '../src/liststyleediting';
 import TodoListEditing from '../src/todolistediting';
 import ListStyleCommand from '../src/liststylecommand';
-import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 
 describe( 'ListStyleEditing', () => {
-	let editor, model, view, element;
+	let editor, model, view;
 
 	beforeEach( () => {
-		element = document.createElement( 'div' );
-		document.body.append( element );
-
-		return ClassicTestEditor
-			.create( element, {
+		return VirtualTestEditor
+			.create( {
 				plugins: [ Paragraph, ListStyleEditing, UndoEditing ]
 			} )
 			.then( newEditor => {
@@ -36,10 +34,7 @@ describe( 'ListStyleEditing', () => {
 	} );
 
 	afterEach( () => {
-		return editor.destroy()
-			.then( () => {
-				element.remove();
-			} );
+		return editor.destroy();
 	} );
 
 	it( 'should have pluginName', () => {
@@ -1471,6 +1466,29 @@ describe( 'ListStyleEditing', () => {
 
 		// #8160
 		describe( 'pasting a into another list', () => {
+			let element;
+
+			beforeEach( () => {
+				element = document.createElement( 'div' );
+				document.body.append( element );
+
+				return ClassicTestEditor
+					.create( element, {
+						plugins: [ Paragraph, Clipboard, ListStyleEditing, UndoEditing ]
+					} )
+					.then( newEditor => {
+						editor = newEditor;
+						model = editor.model;
+					} );
+			} );
+
+			afterEach( () => {
+				return editor.destroy()
+					.then( () => {
+						element.remove();
+					} );
+			} );
+
 			it( 'should inherit attributes from the previous sibling element (collapsed selection)', () => {
 				setModelData( model,
 					'<listItem listIndent="0" listStyle="circle" listType="bulleted">Foo</listItem>' +


### PR DESCRIPTION
#7959 # Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (list): List styles will be inherited correctly when pasting a list into another list. Closes #8160.

---

### Additional information

_I know, I used the best solution for detecting that content comes from pasting… How could we improve that?_
