### PR TITLE
Fix building documentation on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "svgo": "^1.3.2",
     "terser-webpack-plugin": "^3.0.2",
     "umberto": "^1.5.4",
+    "upath": "^2.0.0",
     "webpack": "^4.43.0"
   },
   "engines": {

--- a/scripts/docs/buildapi.js
+++ b/scripts/docs/buildapi.js
@@ -7,21 +7,19 @@
 
 'use strict';
 
-const path = require( 'path' );
-
 module.exports = function buildApiDocs() {
 	const ckeditor5Docs = require( '@ckeditor/ckeditor5-dev-docs' );
 
 	return ckeditor5Docs
 		.build( {
-			readmePath: path.join( process.cwd(), 'README.md' ),
+			readmePath: 'README.md',
 			sourceFiles: [
-				process.cwd() + '/packages/@(ckeditor|ckeditor5)-*/src/**/*.@(js|jsdoc)',
-				'!' + process.cwd() + '/packages/@(ckeditor|ckeditor5)-*/src/lib/**/*.js',
-				'!' + process.cwd() + '/packages/ckeditor5-build-*/src/**/*.js',
-				process.cwd() + '/external/*/packages/@(ckeditor|ckeditor5)-*/src/**/*.@(js|jsdoc)',
-				'!' + process.cwd() + '/external/*/packages/@(ckeditor|ckeditor5)-*/src/lib/**/*.js',
-				'!' + process.cwd() + '/external/*/packages/ckeditor5-build-*/src/**/*.js'
+				'packages/@(ckeditor|ckeditor5)-*/src/**/*.@(js|jsdoc)',
+				'!packages/@(ckeditor|ckeditor5)-*/src/lib/**/*.js',
+				'!packages/ckeditor5-build-*/src/**/*.js',
+				'external/*/packages/@(ckeditor|ckeditor5)-*/src/**/*.@(js|jsdoc)',
+				'!external/*/packages/@(ckeditor|ckeditor5)-*/src/lib/**/*.js',
+				'!external/*/packages/ckeditor5-build-*/src/**/*.js'
 			],
 			validateOnly: process.argv.includes( '--validate-only' ),
 			strict: process.argv.includes( '--strict' )

--- a/scripts/docs/buildapi.js
+++ b/scripts/docs/buildapi.js
@@ -12,6 +12,7 @@ module.exports = function buildApiDocs() {
 
 	return ckeditor5Docs
 		.build( {
+			// Patterns that do not start with '/' are mounted onto process.cwd() path by default.
 			readmePath: 'README.md',
 			sourceFiles: [
 				'packages/@(ckeditor|ckeditor5)-*/src/**/*.@(js|jsdoc)',

--- a/scripts/docs/snippetadapter.js
+++ b/scripts/docs/snippetadapter.js
@@ -6,6 +6,7 @@
 /* eslint-env node */
 
 const path = require( 'path' );
+const upath = require( 'upath' );
 const fs = require( 'fs' );
 const minimatch = require( 'minimatch' );
 const webpack = require( 'webpack' );
@@ -513,7 +514,8 @@ function readSnippetConfig( snippetSourcePath ) {
 }
 
 /**
- * Removes duplicated entries specified in `files` array and map those entires using `mapFunction`.
+ * Removes duplicated entries specified in `files` array, unifies path separators to always be `/`
+ * and then maps those entries using `mapFunction`.
  *
  * @param {Array.<String>} files Paths collection.
  * @param {Function} mapFunction Function that should return a string.
@@ -521,6 +523,7 @@ function readSnippetConfig( snippetSourcePath ) {
  */
 function getHTMLImports( files, mapFunction ) {
 	return [ ...new Set( files ) ]
+		.map( path => upath.normalize( path ) )
 		.map( mapFunction )
 		.join( '\n' )
 		.replace( /^\s+/, '' );

--- a/scripts/docs/snippetadapter.js
+++ b/scripts/docs/snippetadapter.js
@@ -282,7 +282,7 @@ function getConstantDefinitions( snippets ) {
 			knownPaths.add( directory );
 
 			const absolutePathToConstants = path.join( directory, 'docs', 'constants.js' );
-			const importPathToConstants = path.posix.relative( __dirname, absolutePathToConstants );
+			const importPathToConstants = path.relative( __dirname, absolutePathToConstants );
 
 			if ( fs.existsSync( absolutePathToConstants ) ) {
 				const packageConstantDefinitions = require( './' + importPathToConstants );
@@ -432,7 +432,7 @@ function getWebpackConfig( snippets, config ) {
 
 	for ( const snippetData of snippets ) {
 		if ( !webpackConfig.output.path ) {
-			webpackConfig.output.path = snippetData.outputPath;
+			webpackConfig.output.path = path.normalize( snippetData.outputPath );
 		}
 
 		if ( webpackConfig.entry[ snippetData.snippetName ] ) {
@@ -490,7 +490,8 @@ function getPackageDependenciesPaths() {
 	};
 
 	return glob.sync( 'packages/*/node_modules', globOptions )
-		.concat( glob.sync( 'external/*/packages/*/node_modules', globOptions ) );
+		.concat( glob.sync( 'external/*/packages/*/node_modules', globOptions ) )
+		.map( p => path.normalize( p ) );
 }
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix: Fixed building documentation on Windows. Closes #7212.

---

### Additional information

This PR is the 1 of 2 PRs that are needed to fix building documentation on Windows - the second one is https://github.com/cksource/umberto/pull/884.

#### TL;DR

It works on Linux and on Windows now! 🎉 

<img src="https://user-images.githubusercontent.com/56868128/97325046-da230a80-1872-11eb-9387-2b5e5ca5e465.png" width="600">

#### Details

The main problem was with mixed `/` and `\`, which were used in HTML links and paths on filesystem. After some investigation it turned out, that:
- we can't use methods from built-in `path` module, because they always produce paths with native separator,
- we can't use POSIX versions of methods from built-in `path` module (e.g. `path.posix.<methodName>`), [because of their unreliability and inconsistency](https://github.com/nodejs/node/issues/13683).

A lot of parts of code implicitly expect that the one and only valid path separator is `/`, so I've introduced `path` module replacement - the [`upath`](https://www.npmjs.com/package/upath) module - which unifies all paths to the same format, **always**! This solution works on Windows, because Windows accepts either own `\`, or `/` as path separator. One exception to this rule is that `webpack` also accepts both separators and automatically fixes inconsistencies, [but only for the `entry` option](https://github.com/webpack/webpack/issues/5327). All other configuration options require native path separators.  :unamused:

If you previously have built docs on Linux and now you want to check it on Windows, then...
- it will throw permission error, because Windows' version of `fs.readdirSync()` (used internally by the `glob` module) is not able to handle `build/docs/ckeditor5/latest` link created previously on Linux. To continue, simply remove this link manually (or the whole `build` folder).
- probably you will need `node-sass` binary for Windows. Instead of re-installing all dependencies, it is sufficient to just run `npm rebuild node-sass` and then just start `yarn docs` again.

To avoid such annoyances, simply choose one OS and stick to it, always.