### PR TITLE
The editing root should remain focused when saving changes in the embed

### DIFF
--- a/packages/ckeditor5-html-embed/src/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/src/htmlembedediting.js
@@ -166,7 +166,7 @@ export default class HtmlEmbedEditing extends Plugin {
 						// it's enough to update the model – the entire widget will be reconverted.
 						if ( newValue !== state.getRawHtmlValue() ) {
 							editor.execute( 'updateHtmlEmbed', newValue );
-							editor.focus();
+							editor.editing.view.focus();
 						} else {
 							this.cancel();
 						}
@@ -177,7 +177,7 @@ export default class HtmlEmbedEditing extends Plugin {
 						} );
 
 						renderContent( { domElement: domContentWrapper, editor, state, props } );
-						editor.focus();
+						editor.editing.view.focus();
 
 						view.change( writer => {
 							writer.removeAttribute( 'data-cke-ignore-events', viewContentWrapper );

--- a/packages/ckeditor5-html-embed/src/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/src/htmlembedediting.js
@@ -166,6 +166,7 @@ export default class HtmlEmbedEditing extends Plugin {
 						// it's enough to update the model – the entire widget will be reconverted.
 						if ( newValue !== state.getRawHtmlValue() ) {
 							editor.execute( 'updateHtmlEmbed', newValue );
+							editor.editing.view.focus();
 						} else {
 							this.cancel();
 						}
@@ -176,6 +177,7 @@ export default class HtmlEmbedEditing extends Plugin {
 						} );
 
 						renderContent( { domElement: domContentWrapper, editor, state, props } );
+						editor.editing.view.focus();
 
 						view.change( writer => {
 							writer.removeAttribute( 'data-cke-ignore-events', viewContentWrapper );

--- a/packages/ckeditor5-html-embed/src/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/src/htmlembedediting.js
@@ -166,7 +166,7 @@ export default class HtmlEmbedEditing extends Plugin {
 						// it's enough to update the model – the entire widget will be reconverted.
 						if ( newValue !== state.getRawHtmlValue() ) {
 							editor.execute( 'updateHtmlEmbed', newValue );
-							editor.editing.view.focus();
+							editor.focus();
 						} else {
 							this.cancel();
 						}
@@ -177,7 +177,7 @@ export default class HtmlEmbedEditing extends Plugin {
 						} );
 
 						renderContent( { domElement: domContentWrapper, editor, state, props } );
-						editor.editing.view.focus();
+						editor.focus();
 
 						view.change( writer => {
 							writer.removeAttribute( 'data-cke-ignore-events', viewContentWrapper );

--- a/packages/ckeditor5-html-embed/tests/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/tests/htmlembedediting.js
@@ -357,7 +357,7 @@ describe( 'HtmlEmbedEditing', () => {
 				const widget = viewDocument.getRoot().getChild( 0 );
 				const contentWrapper = widget.getChild( 1 );
 				const domContentWrapper = editor.editing.view.domConverter.mapViewToDom( contentWrapper );
-				const spy = sinon.spy( editor, 'focus' );
+				const spy = sinon.spy( editor.editing.view, 'focus' );
 
 				widget.getCustomProperty( 'rawHtmlApi' ).makeEditable();
 
@@ -412,7 +412,7 @@ describe( 'HtmlEmbedEditing', () => {
 				const widget = viewDocument.getRoot().getChild( 0 );
 				const contentWrapper = widget.getChild( 1 );
 				const domContentWrapper = editor.editing.view.domConverter.mapViewToDom( contentWrapper );
-				const spy = sinon.spy( editor, 'focus' );
+				const spy = sinon.spy( editor.editing.view, 'focus' );
 
 				widget.getCustomProperty( 'rawHtmlApi' ).makeEditable();
 

--- a/packages/ckeditor5-html-embed/tests/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/tests/htmlembedediting.js
@@ -352,6 +352,21 @@ describe( 'HtmlEmbedEditing', () => {
 				expect( domContentWrapper.querySelectorAll( '.raw-html-embed__edit-button' ) ).to.have.lengthOf( 1 );
 			} );
 
+			it( 'does not lose editor focus after saving changes', () => {
+				setModelData( model, '<rawHtml value="foo"></rawHtml>' );
+				const widget = viewDocument.getRoot().getChild( 0 );
+				const contentWrapper = widget.getChild( 1 );
+				const domContentWrapper = editor.editing.view.domConverter.mapViewToDom( contentWrapper );
+				const spy = sinon.spy( editor.editing.view, 'focus' );
+
+				widget.getCustomProperty( 'rawHtmlApi' ).makeEditable();
+
+				domContentWrapper.querySelector( 'textarea' ).value = 'Foo Bar.';
+				domContentWrapper.querySelector( '.raw-html-embed__save-button' ).click();
+
+				sinon.assert.calledOnce( spy );
+			} );
+
 			it( 'does not update the model state after saving the same changes', () => {
 				setModelData( model, '<rawHtml value="foo"></rawHtml>' );
 				const widget = viewDocument.getRoot().getChild( 0 );
@@ -390,6 +405,20 @@ describe( 'HtmlEmbedEditing', () => {
 
 				expect( domContentWrapper.querySelector( 'textarea.raw-html-embed__source' ).value ).to.equal( 'foo' );
 				expect( domContentWrapper.querySelector( 'textarea.raw-html-embed__source' ).disabled ).to.be.true;
+			} );
+
+			it( 'does not lose editor focus after canceling editing', () => {
+				setModelData( model, '<rawHtml value="foo"></rawHtml>' );
+				const widget = viewDocument.getRoot().getChild( 0 );
+				const contentWrapper = widget.getChild( 1 );
+				const domContentWrapper = editor.editing.view.domConverter.mapViewToDom( contentWrapper );
+				const spy = sinon.spy( editor.editing.view, 'focus' );
+
+				widget.getCustomProperty( 'rawHtmlApi' ).makeEditable();
+
+				domContentWrapper.querySelector( '.raw-html-embed__cancel-button' ).click();
+
+				sinon.assert.calledOnce( spy );
 			} );
 
 			describe( 'rawHtmlApi.makeEditable()', () => {

--- a/packages/ckeditor5-html-embed/tests/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/tests/htmlembedediting.js
@@ -357,7 +357,7 @@ describe( 'HtmlEmbedEditing', () => {
 				const widget = viewDocument.getRoot().getChild( 0 );
 				const contentWrapper = widget.getChild( 1 );
 				const domContentWrapper = editor.editing.view.domConverter.mapViewToDom( contentWrapper );
-				const spy = sinon.spy( editor.editing.view, 'focus' );
+				const spy = sinon.spy( editor, 'focus' );
 
 				widget.getCustomProperty( 'rawHtmlApi' ).makeEditable();
 
@@ -412,7 +412,7 @@ describe( 'HtmlEmbedEditing', () => {
 				const widget = viewDocument.getRoot().getChild( 0 );
 				const contentWrapper = widget.getChild( 1 );
 				const domContentWrapper = editor.editing.view.domConverter.mapViewToDom( contentWrapper );
-				const spy = sinon.spy( editor.editing.view, 'focus' );
+				const spy = sinon.spy( editor, 'focus' );
 
 				widget.getCustomProperty( 'rawHtmlApi' ).makeEditable();
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (html-embed): The editing root should remain focused when saving changes in the embed. Closes #8318.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._