### PR TITLE
Docs: editor text replaced with an editor placeholder.

### DIFF
--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.html
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.html
@@ -1,3 +1,3 @@
 <div id="snippet-text-transformation-extended">
-	<p>Type here...</p>
+
 </div>

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.js
@@ -10,6 +10,7 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-text-transformation-extended' ), {
 		cloudServices: CS_CONFIG,
+		placeholder: 'Type here...',
 		toolbar: {
 			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.html
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.html
@@ -1,3 +1,3 @@
 <div id="snippet-text-transformation">
-	<p>Type here...</p>
+
 </div>

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
@@ -10,6 +10,7 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-text-transformation' ), {
 		cloudServices: CS_CONFIG,
+		placeholder: 'Type here...',
 		toolbar: {
 			viewportTopOffset: window.getViewportTopOffsetConfig()
 		}


### PR DESCRIPTION
Solid encouragement text inside the demos was replaced with editor placeholders for a better experience in the automatic text transformations guide.