### PR TITLE
The `supportAllValues` for `font-size` doesn't work with nested elements

### DIFF
--- a/packages/ckeditor5-font/src/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeediting.js
@@ -131,7 +131,10 @@ export default class FontSizeEditing extends Plugin {
 				value: viewElement => viewElement.getStyle( 'font-size' )
 			},
 			view: {
-				name: 'span'
+				name: 'span',
+				styles: {
+					'font-size': /.*/
+				}
 			}
 		} );
 	}

--- a/packages/ckeditor5-font/tests/fontfamily/fontfamilyediting.js
+++ b/packages/ckeditor5-font/tests/fontfamily/fontfamilyediting.js
@@ -130,6 +130,16 @@ describe( 'FontFamilyEditing', () => {
 
 					expect( editor.getData() ).to.equal( data );
 				} );
+
+				it( 'should convert from a nested element', () => {
+					const data = '<p>f<span><span><span><span style="font-family: Arial, sans-serif">o</span></span></span></span>o</p>';
+
+					editor.setData( data );
+
+					expect( getModelData( doc ) ).to.equal( '<paragraph>[]f<$text fontFamily="Arial, sans-serif">o</$text>o</paragraph>' );
+
+					expect( editor.getData() ).to.equal( '<p>f<span style="font-family:Arial, sans-serif;">o</span>o</p>' );
+				} );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
@@ -111,6 +111,16 @@ describe( 'FontSizeEditing', () => {
 
 					expect( editor.getData() ).to.equal( '<p>f<span style="font-size:18px;">o</span>o</p>' );
 				} );
+
+				it( 'should convert from a nested element', () => {
+					const data = '<p>f<span><span><span><span style="font-size: 18px">o</span></span></span></span>o</p>';
+
+					editor.setData( data );
+
+					expect( getModelData( doc ) ).to.equal( '<paragraph>[]f<$text fontSize="18px">o</$text>o</paragraph>' );
+
+					expect( editor.getData() ).to.equal( '<p>f<span style="font-size:18px;">o</span>o</p>' );
+				} );
 			} );
 
 			it( 'should throw an error if used with default configuration of the plugin', () => {

--- a/packages/ckeditor5-font/tests/manual/tickets/8233/1.html
+++ b/packages/ckeditor5-font/tests/manual/tickets/8233/1.html
@@ -1,0 +1,5 @@
+<div id="editor">
+	<p>
+		<span style="font-family: 'Lucida Sans Unicode', 'Lucida Grande', sans-serif"><span style="font-size: 28px">LUCIDA, 28px</span></span>
+	</p>
+</div>

--- a/packages/ckeditor5-font/tests/manual/tickets/8233/1.js
+++ b/packages/ckeditor5-font/tests/manual/tickets/8233/1.js
@@ -1,0 +1,34 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals window, document, console */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import FontSize from '../../../../src/fontsize';
+import FontFamily from '../../../../src/fontfamily';
+
+const config = {
+	plugins: [ ArticlePluginSet, FontSize, FontFamily ],
+	toolbar: [
+		'heading', '|', 'fontFamily', 'fontSize', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
+	],
+	fontSize: {
+		options: [ 10, 12, 14, 'default', 18, 20, 22 ],
+		supportAllValues: true
+	},
+	fontFamily: {
+		supportAllValues: true
+	}
+};
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), config )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( error => {
+		console.error( error.stack );
+	} );

--- a/packages/ckeditor5-font/tests/manual/tickets/8233/1.md
+++ b/packages/ckeditor5-font/tests/manual/tickets/8233/1.md
@@ -1,0 +1,7 @@
+## The supportAllValues doesn't work with nested elements [#8233](https://github.com/ckeditor/ckeditor5/issues/8233)
+
+1. Open CKEditor Inspector (if not already opened) and go to `View` tab.
+
+**Expected result**: the `<span>` element has both `font-family` **and** `font-size` styles.
+
+**Unexpected result**: the `<span>` element lost nested `font-size` style.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (font): Fixed the `supportAllValues` configuration for `font-size` to work with nested elements. Closes #8233.
