### PR TITLE
Fix (utils): Fix memory leak in EventEmitterMixin

### DIFF
--- a/packages/ckeditor5-utils/src/emittermixin.js
+++ b/packages/ckeditor5-utils/src/emittermixin.js
@@ -156,6 +156,15 @@ const EmitterMixin = {
 		// All params provided. off() that single callback.
 		if ( callback ) {
 			removeCallback( emitter, event, callback );
+
+			const index = emitterInfo.callbacks[ event ].indexOf( callback );
+			if ( index !== -1 ) {
+				if ( emitterInfo.callbacks[ event ].length === 1 ) {
+					delete emitterInfo.callbacks[ event ];
+				} else {
+					emitterInfo.callbacks[ event ].splice( index, 1 );
+				}
+			}
 		}
 		// Only `emitter` and `event` provided. off() all callbacks for that event.
 		else if ( eventCallbacks ) {


### PR DESCRIPTION
`listenTo()` stores the callback under both the `_events` key and the `_listeningTo` key, but when invoked with a specific callback, `stopListening()` was only removing the entry under the `_events` key, holding the callback in memory.