### PR TITLE
Docs: Fixed incorrect snippet in the editing engine guide

### DIFF
--- a/docs/framework/guides/architecture/editing-engine.md
+++ b/docs/framework/guides/architecture/editing-engine.md
@@ -260,8 +260,8 @@ The view may need to be changed manually if the cause of such change is not repr
 For that, just like in the model, you should use the `change()` block (of the view) in which you will have access to the view downcast writer.
 
 ```js
-editor.data.view.change( writer => {
-	writer.insert( position1, writer.createText( 'foo' ) );
+editor.editing.view.change( writer => {
+	writer.insert( position, writer.createText( 'foo' ) );
 } );
 ```
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Fixed incorrect snippet in the editing engine guide. Closes #8477.