### PR TITLE
Fixed crash after text nodes got merged in insertContent while inserting a link

### DIFF
--- a/packages/ckeditor5-link/src/linkcommand.js
+++ b/packages/ckeditor5-link/src/linkcommand.js
@@ -198,12 +198,11 @@ export default class LinkCommand extends Command {
 						attributes.set( item, true );
 					} );
 
-					const node = writer.createText( href, attributes );
-
-					model.insertContent( node, position );
+					const { end: positionAfter } = model.insertContent( writer.createText( href, attributes ), position );
 
 					// Put the selection at the end of the inserted link.
-					writer.setSelection( writer.createPositionAfter( node ) );
+					// Using end of range returned from insertContent in case nodes with the same attributes got merged.
+					writer.setSelection( positionAfter );
 				}
 
 				// Remove the `linkHref` attribute and all link decorators from the selection.

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -401,6 +401,17 @@ describe( 'LinkCommand', () => {
 
 				expect( getData( model ) ).to.equal( '<p>foo[]bar</p>' );
 			} );
+
+			// https://github.com/ckeditor/ckeditor5/issues/8210
+			it( 'should insert text with `linkHref` attribute just after text node with the same `linkHref` attribute', () => {
+				setData( model, '<$text linkHref="url">foo</$text>[]bar' );
+
+				model.change( writer => writer.overrideSelectionGravity() );
+
+				command.execute( 'url' );
+
+				expect( getData( model ) ).to.equal( '<$text linkHref="url">foourl</$text>[]bar' );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (link): Editor should not crash after inserting a link with the same href just after the link. Closes #8210.

---

### Additional information