### PR TITLE
Docs: markdown editor known issues

### DIFF
--- a/packages/ckeditor5-autoformat/docs/features/autoformat.md
+++ b/packages/ckeditor5-autoformat/docs/features/autoformat.md
@@ -90,6 +90,8 @@ The {@link module:autoformat/autoformat~Autoformat} feature bases on {@link modu
 You can use these tools to create your own autoformatters. Check the [`Autoformat` feature's code](https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-autoformat/src/autoformat.js) as an example.
 
 ## Known issues
+
+While the autoformatting feature is stable and ready to use, some issues were reported for it. Feel free to upvote 👍&nbsp; them on GitHub if they are important for you:
 * Using underscore inline (eg. variable names like `this_variable`) may result in italics. GitHub issue: [#2388](https://github.com/ckeditor/ckeditor5/issues/2388).
 * Pasting Markdown-formatted content does not automatically convert the pasted syntax markers into properly formatted content. GitHub issues: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
 * At the moment the feature does not support adding horizontal rules. GitHub issue: [#5720](https://github.com/ckeditor/ckeditor5/issues/5720).

--- a/packages/ckeditor5-autoformat/docs/features/autoformat.md
+++ b/packages/ckeditor5-autoformat/docs/features/autoformat.md
@@ -91,7 +91,7 @@ You can use these tools to create your own autoformatters. Check the [`Autoforma
 
 ## Known issues
 * Using underscore inline (eg. variable names like `this_variable`) may result in italics. GitHub issue: [#2388](https://github.com/ckeditor/ckeditor5/issues/2388).
-* Pasting Markdown-formatted content will not automatically convert the pasted syntax markers into properly formatted content currently. See these GitHub issues for possible future development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
+* Pasting Markdown-formatted content does not automatically convert the pasted syntax markers into properly formatted content. GitHub issues: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
 * The feature does not support adding horizontal rules currently. See this GitHub issue for possible future development: [#5720](https://github.com/ckeditor/ckeditor5/issues/5720).
 
 ## Contribute

--- a/packages/ckeditor5-autoformat/docs/features/autoformat.md
+++ b/packages/ckeditor5-autoformat/docs/features/autoformat.md
@@ -89,6 +89,11 @@ The {@link module:autoformat/autoformat~Autoformat} feature bases on {@link modu
 
 You can use these tools to create your own autoformatters. Check the [`Autoformat` feature's code](https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-autoformat/src/autoformat.js) as an example.
 
+## Known issues
+* Using underscore inline (eg. variable names like this_variable) may result in italics. GitHub issue: [#2388](https://github.com/ckeditor/ckeditor5/issues/2388).
+* Pasting Markdown-formatted content will not automatically convert the pasted syntax markers into properly formatted content currently. See these GitHub issues for possible future development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
+* The feature does not support adding horizontal rules currently. See this GitHub issue for possible future development: [#5720](https://github.com/ckeditor/ckeditor5/issues/5720).
+
 ## Contribute
 
 The source code of the feature is available on GitHub in https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-autoformat.

--- a/packages/ckeditor5-autoformat/docs/features/autoformat.md
+++ b/packages/ckeditor5-autoformat/docs/features/autoformat.md
@@ -92,7 +92,7 @@ You can use these tools to create your own autoformatters. Check the [`Autoforma
 ## Known issues
 * Using underscore inline (eg. variable names like `this_variable`) may result in italics. GitHub issue: [#2388](https://github.com/ckeditor/ckeditor5/issues/2388).
 * Pasting Markdown-formatted content does not automatically convert the pasted syntax markers into properly formatted content. GitHub issues: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
-* The feature does not support adding horizontal rules currently. See this GitHub issue for possible future development: [#5720](https://github.com/ckeditor/ckeditor5/issues/5720).
+* At the moment the feature does not support adding horizontal rules. GitHub issue: [#5720](https://github.com/ckeditor/ckeditor5/issues/5720).
 
 ## Contribute
 

--- a/packages/ckeditor5-autoformat/docs/features/autoformat.md
+++ b/packages/ckeditor5-autoformat/docs/features/autoformat.md
@@ -90,7 +90,7 @@ The {@link module:autoformat/autoformat~Autoformat} feature bases on {@link modu
 You can use these tools to create your own autoformatters. Check the [`Autoformat` feature's code](https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-autoformat/src/autoformat.js) as an example.
 
 ## Known issues
-* Using underscore inline (eg. variable names like this_variable) may result in italics. GitHub issue: [#2388](https://github.com/ckeditor/ckeditor5/issues/2388).
+* Using underscore inline (eg. variable names like `this_variable`) may result in italics. GitHub issue: [#2388](https://github.com/ckeditor/ckeditor5/issues/2388).
 * Pasting Markdown-formatted content will not automatically convert the pasted syntax markers into properly formatted content currently. See these GitHub issues for possible future development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
 * The feature does not support adding horizontal rules currently. See this GitHub issue for possible future development: [#5720](https://github.com/ckeditor/ckeditor5/issues/5720).
 

--- a/packages/ckeditor5-autoformat/docs/features/autoformat.md
+++ b/packages/ckeditor5-autoformat/docs/features/autoformat.md
@@ -95,6 +95,7 @@ While the autoformatting feature is stable and ready to use, some issues were re
 * Using underscore inline (eg. variable names like `this_variable`) may result in italics. GitHub issue: [#2388](https://github.com/ckeditor/ckeditor5/issues/2388).
 * Pasting Markdown-formatted content does not automatically convert the pasted syntax markers into properly formatted content. GitHub issues: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
 * At the moment the feature does not support adding horizontal rules. GitHub issue: [#5720](https://github.com/ckeditor/ckeditor5/issues/5720).
+* Setting a specific code block language is not supprted yet (it defaults to plain text on insertion). GitHub issue: [#8598](https://github.com/ckeditor/ckeditor5/issues/8598).
 
 ## Contribute
 

--- a/packages/ckeditor5-code-block/docs/features/code-blocks.md
+++ b/packages/ckeditor5-code-block/docs/features/code-blocks.md
@@ -14,7 +14,7 @@ The {@link module:code-block/codeblock~CodeBlock} feature allows inserting and e
 
 ## Demo
 
-Use the code block toolbar button and the type dropdown to insert a desired code block. Alternatively, start the line with `` ``` `` to format it as a code block thanks to the {@link features/autoformat autoformatting feature}.
+Use the code block toolbar button and the type dropdown to insert a desired code block. Alternatively, start the line with `` ``` `` to format it as a code block thanks to the {@link features/autoformat autoformatting feature}. To add a paragraph underneath a code block, just use the double caret function (press <kbd>Enter</kbd> twice).
 
 {@snippet features/code-block}
 

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
@@ -1,7 +1,7 @@
 <div id="snippet-markdown">
 
 <h2>The Markdown language</h2>
-<p>Markdown is a lightweight markup language that you can use to add formatting elements to plain text documents. Created by <a href="https://daringfireball.net/projects/markdown/" target="_blank">John Gruber</a> in 2004, Markdown is now one of the world&rsquo;s most popular markup languages.</p>
+<p>Markdown is a lightweight markup language that you can use to add formatting elements to plain text documents. Created by <a href="https://daringfireball.net/projects/markdown/" target="_blank">John Gruber</a> in <s>2003</s>2004, Markdown is now one of the world&rsquo;s most popular markup languages.</p>
 
 <hr />
 

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
@@ -3,6 +3,8 @@
 <h2>The Markdown language</h2>
 <p>Markdown is a lightweight markup language that you can use to add formatting elements to plain text documents. Created by <a href="https://daringfireball.net/projects/markdown/" target="_blank">John Gruber</a> in 2004, Markdown is now one of the world&rsquo;s most popular markup languages.</p>
 
+<hr />
+
 <h2>Editing with Markdown output</h2>
 <p>The <a href="https://ckeditor.com/">CKEditor 5 WYSIWYG</a> editor lets you use this flexible yet simple markup language in the GitHub flavor. The editor-produced Markdown output supports the most important features, like <a href="https://ckeditor.com/">links</a>, <strong>different</strong> kinds of <em>emphasis</em>, <code>inline code formatting</code> or code blocks:</p>
 

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
@@ -34,7 +34,7 @@
 	</li>
 </ul>
 
-<h2>Tables are supported, too</h2>
+<h2>Support for tables in Markdown</h2>
 <p>Bear in mind that Markdown has only very basic support for tables, so things like table styles or merged cells will not work.</p>
 
 <table border="1" cellpadding="1" cellspacing="1" style="width:500px">

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
@@ -34,6 +34,36 @@
 	</li>
 </ul>
 
+<h2>Tables are supported, too</h2>
+<p>BUt bear in mind, they get stripped of the formatting</p>
+
+<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+	<thead>
+		<tr>
+			<th scope="row">&nbsp;</th>
+			<th scope="col">Income</th>
+			<th scope="col">Revenue</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th scope="row">Walker 3</th>
+			<td style="text-align:center">$104.000</td>
+			<td style="text-align:center">15%</td>
+		</tr>
+		<tr>
+			<th scope="row">Stroller</th>
+			<td style="text-align:center">$12.000</td>
+			<td style="text-align:center">10%</td>
+		</tr>
+		<tr>
+			<th scope="row">Runner</th>
+			<td style="text-align:center">$97.500</td>
+			<td style="text-align:center">15%</td>
+		</tr>
+	</tbody>
+</table>
+
 </div>
 
 <p>Output:</p>

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
@@ -35,7 +35,7 @@
 </ul>
 
 <h2>Tables are supported, too</h2>
-<p>But bear in mind, they get stripped of the formatting</p>
+<p>Bear in mind that Markdown has only very basic support for tables, so things like table styles or merged cells will not work.</p>
 
 <table border="1" cellpadding="1" cellspacing="1" style="width:500px">
 	<thead>

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
@@ -35,7 +35,7 @@
 </ul>
 
 <h2>Tables are supported, too</h2>
-<p>BUt bear in mind, they get stripped of the formatting</p>
+<p>But bear in mind, they get stripped of the formatting</p>
 
 <table border="1" cellpadding="1" cellspacing="1" style="width:500px">
 	<thead>

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.js
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.js
@@ -13,13 +13,14 @@ import CodeBlock from '@ckeditor/ckeditor5-code-block/src/codeblock';
 import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
 import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
 import TodoList from '@ckeditor/ckeditor5-list/src/todolist';
+import HorizontalLine from '@ckeditor/ckeditor5-horizontal-line/src/horizontalline';
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 
 import Markdown from '@ckeditor/ckeditor5-markdown-gfm/src/markdown';
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-markdown' ), {
-		plugins: [ ArticlePluginSet, EasyImage, Markdown, Code, CodeBlock, TodoList, Strikethrough ],
+		plugins: [ ArticlePluginSet, EasyImage, Markdown, Code, CodeBlock, TodoList, Strikethrough, HorizontalLine ],
 		toolbar: [
 			'heading',
 			'|',
@@ -40,6 +41,7 @@ ClassicEditor
 			'|',
 			'imageUpload',
 			'blockQuote',
+			'horizontalLine',
 			'|',
 			'undo',
 			'redo'

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.js
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.js
@@ -10,6 +10,7 @@ import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor'
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 import EasyImage from '@ckeditor/ckeditor5-easy-image/src/easyimage';
 import CodeBlock from '@ckeditor/ckeditor5-code-block/src/codeblock';
+import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
 import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
 import TodoList from '@ckeditor/ckeditor5-list/src/todolist';
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
@@ -18,12 +19,13 @@ import Markdown from '@ckeditor/ckeditor5-markdown-gfm/src/markdown';
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-markdown' ), {
-		plugins: [ ArticlePluginSet, EasyImage, Markdown, Code, CodeBlock, TodoList ],
+		plugins: [ ArticlePluginSet, EasyImage, Markdown, Code, CodeBlock, TodoList, Strikethrough ],
 		toolbar: [
 			'heading',
 			'|',
 			'bold',
 			'italic',
+			'strikethrough',
 			'link',
 			'|',
 			'bulletedList',

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -92,7 +92,7 @@ While the Markdown plugin is stable and ready to use, some issues were reported 
 <info-box info>
 	Please bear in mind that the Markdown data processor does not support all rich text features. The [Markdown syntax](https://daringfireball.net/projects/markdown/syntax) is very simple and only supports limited formatting options.
 
-	This means than advanced formatting, like list styles, tables or page break markers will be stripped in the effecting data. These are not supported by Markdown and therefore cannot be reproduced. This is not a bug.
+	This means that advanced formatting like list styles, table styles or page break markers will be stripped in the effecting data. These are not supported by Markdown and therefore cannot be converted from HTML to Markdown.
 </info-box>
 
 

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -93,7 +93,7 @@ ClassicEditor
 
 While the Markdown plugin is stable and ready to use, some issues were reported for it. Feel free to upvote 👍&nbsp; them on GitHub if they are important for you:
 
-* The horizontal rule is not yet supported by the {@link features/autoformat autoformatting} feature but it gets output to Markdown nevertheless if inserted using the toolbar button.
+* The horizontal rule is not yet supported by the {@link features/autoformat autoformatting} feature but it gets output to Markdown nevertheless if inserted using the toolbar button. GitHub issue: [#5720](https://github.com/ckeditor/ckeditor5/issues/5720).
 * Pasting Markdown-formatted content does not automatically convert the pasted syntax markers into properly formatted content. GitHub issues: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
 * Tables will render as HTML output if there is no table head defined. GitHub issue: [#8575](https://github.com/ckeditor/ckeditor5/issues/8572).
 

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -5,6 +5,8 @@ category: features
 
 The {@link module:markdown-gfm/markdown~Markdown} plugin allows switching the default CKEditor 5 output from HTML to Markdown. This allows for producing lightweight text documents with a simple formatting syntax, widespread among the programming and development communities and popular in many environments (e.g. GitHub). Coupled with the {@link features/autoformat autoformatting} feature, it allows for the full-fledged Markdown WYSIWYG editing experience.
 
+Please remember that Markdown syntax is very simple and therefore this plugin does not support rich-text output, even if the formatting maybe applied to the content.
+
 <info-box info>
 	You can learn more about the possible practical applications of Markdown editing with CKEditor 5 in [this dedicated blog post depicting the idea, solutions and a case study](https://ckeditor.com/blog/CKEditor-5-the-best-open-source-Markdown-editor/).
 </info-box>
@@ -82,8 +84,15 @@ ClassicEditor
 ```
 
 ## Known issues
-* The Markdown output strips any page break markers. These are not supported by Markdown and therefore cannot be reproduced.
+* The feature does not support adding horizontal rules currently, therefore any horizontal line swill be stripped in the output. See this GitHub issue for possible future development: [#5720](https://github.com/ckeditor/ckeditor5/issues/5720).
 * Pasting Markdown-formatted content will not automatically convert the pasted syntax markers into properly formatted content currently. See these GitHub issues for possible future development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
+
+<info-box info>
+	Please bear in mind that the Markdown output processor will not produce any rich-text content. The [Markdown syntax](https://daringfireball.net/projects/markdown/syntax) is very simple and only supports limited formatting.
+
+	This means than advanced formatting, like list styles, tables or page break markers will be stripped in the effecting data. These are not supported by Markdown and therefore cannot be reproduced. This is not a bug.
+</info-box>
+
 
 ## Contribute
 

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -72,6 +72,10 @@ ClassicEditor
 
 ```
 
+## Known issues
+* The Markdown output strips any page break markers. These are not supported by Markdown and cannot be reproduced.
+* Pasting Markdown-formatted content will not automatically convert the pasted syntax markers into properly formatted content; instead it will act as if plain text was pasted. GitHub issue: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321).
+
 ## Contribute
 
 The source code of this feature is available on GitHub in https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-markdown-gfm.

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -94,7 +94,7 @@ ClassicEditor
 While the Markdown plugin is stable and ready to use, some issues were reported for it. Feel free to upvote 👍&nbsp; them on GitHub if they are important for you:
 
 * The horizontal rule is not yet supported by the {@link features/autoformat autoformatting} feature but it gets output to Markdown nevertheless if inserted using the toolbar button.
-* Pasting Markdown-formatted content does not automatically convert the pasted syntax markers into properly formatted content. See these GitHub issues for possible future development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
+* Pasting Markdown-formatted content does not automatically convert the pasted syntax markers into properly formatted content. GitHub issues: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
 * Tables will render as HTML output if there is no table head defined. GitHub issue: [#8575](https://github.com/ckeditor/ckeditor5/issues/8572).
 
 ## Contribute

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -84,8 +84,8 @@ ClassicEditor
 ```
 
 ## Known issues
-* The feature does not support adding horizontal rules currently, therefore any horizontal line swill be stripped in the output. See this GitHub issue for possible future development: [#5720](https://github.com/ckeditor/ckeditor5/issues/5720).
 * Pasting Markdown-formatted content will not automatically convert the pasted syntax markers into properly formatted content currently. See these GitHub issues for possible future development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
+* The horizontal rule is not supported by the {@link features/autoformat autoformatting} but it does get output if inserted via WYSIWYG interface.
 
 <info-box info>
 	Please bear in mind that the Markdown output processor will not produce any rich-text content. The [Markdown syntax](https://daringfireball.net/projects/markdown/syntax) is very simple and only supports limited formatting.

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -87,7 +87,7 @@ ClassicEditor
 While the Markdown plugin is stable and ready to use, some issues were reported for it. Feel free to upvote 👍 them on GitHub if they are important for you:
 
 * Pasting Markdown-formatted content does not automatically convert the pasted syntax markers into properly formatted content. See these GitHub issues for possible future development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
-* The horizontal rule is not supported by the {@link features/autoformat autoformatting} but it does get output if inserted via WYSIWYG interface.
+* The horizontal rule is not supported by the {@link features/autoformat autoformatting} feature but it gets output to Markdown if inserted using the toolbar button.
 
 <info-box info>
 	Please bear in mind that the Markdown output processor will not produce any rich-text content. The [Markdown syntax](https://daringfireball.net/projects/markdown/syntax) is very simple and only supports limited formatting.

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -5,7 +5,7 @@ category: features
 
 The {@link module:markdown-gfm/markdown~Markdown} plugin allows switching the default CKEditor 5 output from HTML to Markdown. This allows for producing lightweight text documents with a simple formatting syntax, widespread among the programming and development communities and popular in many environments (e.g. GitHub). Coupled with the {@link features/autoformat autoformatting} feature, it allows for the full-fledged Markdown WYSIWYG editing experience.
 
-Please remember that Markdown syntax is very simple and therefore this plugin does not support rich-text output, even if the formatting maybe applied to the content.
+Please remember that Markdown syntax is very simple and it does not cover all the rich-text features. Some features provided by CKEditor 5 will thus work as intended only when output to HTML as they have no Markdown equivalent.
 
 <info-box info>
 	You can learn more about the possible practical applications of Markdown editing with CKEditor 5 in [this dedicated blog post depicting the idea, solutions and a case study](https://ckeditor.com/blog/CKEditor-5-the-best-open-source-Markdown-editor/).

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -73,8 +73,7 @@ ClassicEditor
 ```
 
 ## Known issues
-* The Markdown output strips any page break markers. These are not supported by Markdown and cannot be reproduced.
-* Pasting Markdown-formatted content will not automatically convert the pasted syntax markers into properly formatted content; instead it will act as if plain text was pasted. See these GitHub issues for development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
+* The Markdown output strips any page break markers. These are not supported by Markdown and therefore cannot be reproduced.
 
 ## Contribute
 

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -95,7 +95,7 @@ While the Markdown plugin is stable and ready to use, some issues were reported 
 
 * The horizontal rule is not yet supported by the {@link features/autoformat autoformatting} feature but it gets output to Markdown nevertheless if inserted using the toolbar button.
 * Pasting Markdown-formatted content does not automatically convert the pasted syntax markers into properly formatted content. See these GitHub issues for possible future development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
-* Tables would render as HTML output if there is no table head defined. See the current status of this issue on GitHub: [#8575](https://github.com/ckeditor/ckeditor5/issues/8572).
+* Tables will render as HTML output if there is no table head defined. GitHub issue: [#8575](https://github.com/ckeditor/ckeditor5/issues/8572).
 
 ## Contribute
 

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -90,7 +90,7 @@ While the Markdown plugin is stable and ready to use, some issues were reported 
 * The horizontal rule is not supported by the {@link features/autoformat autoformatting} feature but it gets output to Markdown if inserted using the toolbar button.
 
 <info-box info>
-	Please bear in mind that the Markdown output processor will not produce any rich-text content. The [Markdown syntax](https://daringfireball.net/projects/markdown/syntax) is very simple and only supports limited formatting.
+	Please bear in mind that the Markdown data processor does not support all rich text features. The [Markdown syntax](https://daringfireball.net/projects/markdown/syntax) is very simple and only supports limited formatting options.
 
 	This means than advanced formatting, like list styles, tables or page break markers will be stripped in the effecting data. These are not supported by Markdown and therefore cannot be reproduced. This is not a bug.
 </info-box>

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -74,7 +74,7 @@ ClassicEditor
 
 ## Known issues
 * The Markdown output strips any page break markers. These are not supported by Markdown and cannot be reproduced.
-* Pasting Markdown-formatted content will not automatically convert the pasted syntax markers into properly formatted content; instead it will act as if plain text was pasted. GitHub issue: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321).
+* Pasting Markdown-formatted content will not automatically convert the pasted syntax markers into properly formatted content; instead it will act as if plain text was pasted. See these GitHub issues for development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
 
 ## Contribute
 

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -74,6 +74,7 @@ ClassicEditor
 
 ## Known issues
 * The Markdown output strips any page break markers. These are not supported by Markdown and therefore cannot be reproduced.
+* Pasting Markdown-formatted content will not automatically convert the pasted syntax markers into properly formatted content currently. See these GitHub issues for possible future development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
 
 ## Contribute
 

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -84,7 +84,9 @@ ClassicEditor
 ```
 
 ## Known issues
-* Pasting Markdown-formatted content will not automatically convert the pasted syntax markers into properly formatted content currently. See these GitHub issues for possible future development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
+While the Markdown plugin is stable and ready to use, some issues were reported for it. Feel free to upvote 👍 them on GitHub if they are important for you:
+
+* Pasting Markdown-formatted content does not automatically convert the pasted syntax markers into properly formatted content. See these GitHub issues for possible future development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
 * The horizontal rule is not supported by the {@link features/autoformat autoformatting} but it does get output if inserted via WYSIWYG interface.
 
 <info-box info>

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -84,10 +84,6 @@ ClassicEditor
 ```
 
 ## Known issues
-While the Markdown plugin is stable and ready to use, some issues were reported for it. Feel free to upvote 👍 them on GitHub if they are important for you:
-
-* Pasting Markdown-formatted content does not automatically convert the pasted syntax markers into properly formatted content. See these GitHub issues for possible future development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
-* The horizontal rule is not supported by the {@link features/autoformat autoformatting} feature but it gets output to Markdown if inserted using the toolbar button.
 
 <info-box info>
 	Please bear in mind that the Markdown data processor does not support all rich text features. The [Markdown syntax](https://daringfireball.net/projects/markdown/syntax) is very simple and only supports limited formatting options.
@@ -95,6 +91,11 @@ While the Markdown plugin is stable and ready to use, some issues were reported 
 	This means that advanced formatting like list styles, table styles or page break markers will be stripped in the effecting data. These are not supported by Markdown and therefore cannot be converted from HTML to Markdown.
 </info-box>
 
+While the Markdown plugin is stable and ready to use, some issues were reported for it. Feel free to upvote 👍&nbsp; them on GitHub if they are important for you:
+
+* The horizontal rule is not yet supported by the {@link features/autoformat autoformatting} feature but it gets output to Markdown nevertheless if inserted using the toolbar button.
+* Pasting Markdown-formatted content does not automatically convert the pasted syntax markers into properly formatted content. See these GitHub issues for possible future development: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
+* Tables would render as HTML output if there is no table head defined. See the current status of this issue on GitHub: [#8575](https://github.com/ckeditor/ckeditor5/issues/8572).
 
 ## Contribute
 


### PR DESCRIPTION
Adding known issues to the Markdown output guide and the Autoformatting (input) guide.

Closes: #8520 

May also close: #5721 (this is the final instalment in a series of improvements to Markdown-related guides).