### PR TITLE
Introducing DataProcessor#registerRawContentElementMatcher()

### DIFF
--- a/packages/ckeditor5-engine/src/dataprocessor/dataprocessor.jsdoc
+++ b/packages/ckeditor5-engine/src/dataprocessor/dataprocessor.jsdoc
@@ -44,7 +44,7 @@
  * and it's content should be converted to {@link module:engine/view/element~Element#getCustomProperty view element custom property}
  * `"$rawContent"` while converting {@link #toView to view}.
  *
- * @method #registerRawContentElementMatcher
+ * @method #registerRawContentMatcher
  * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching all view elements whose content should
  * be treated as plain text.
  */

--- a/packages/ckeditor5-engine/src/dataprocessor/dataprocessor.jsdoc
+++ b/packages/ckeditor5-engine/src/dataprocessor/dataprocessor.jsdoc
@@ -38,3 +38,12 @@
  * @param {*} data The data to be processed.
  * @returns {module:engine/view/documentfragment~DocumentFragment}
  */
+
+/**
+ * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as a plain text
+ * and processed as a single {@link module:engine/view/text~Text} node while converting {@link #toView}.
+ *
+ * @method #registerPlainContentElementMatcher
+ * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching all view elements whose content should
+ * be treated as plain text.
+ */

--- a/packages/ckeditor5-engine/src/dataprocessor/dataprocessor.jsdoc
+++ b/packages/ckeditor5-engine/src/dataprocessor/dataprocessor.jsdoc
@@ -40,10 +40,11 @@
  */
 
 /**
- * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as a plain text
- * and processed as a single {@link module:engine/view/text~Text} node while converting {@link #toView}.
+ * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as a raw data
+ * and it's content should be converted to {@link module:engine/view/element~Element#getCustomProperty view element custom property}
+ * `"$rawContent"` while converting {@link #toView to view}.
  *
- * @method #registerPlainContentElementMatcher
+ * @method #registerRawContentElementMatcher
  * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching all view elements whose content should
  * be treated as plain text.
  */

--- a/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js
+++ b/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js
@@ -89,8 +89,8 @@ export default class HtmlDataProcessor {
 	 * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching all view elements whose content should
 	 * be treated as a raw data.
 	 */
-	registerRawContentElementMatcher( pattern ) {
-		this._domConverter.registerRawContentElementMatcher( pattern );
+	registerRawContentMatcher( pattern ) {
+		this._domConverter.registerRawContentMatcher( pattern );
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js
+++ b/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js
@@ -80,6 +80,17 @@ export default class HtmlDataProcessor {
 	}
 
 	/**
+	 * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as a plain text
+	 * and not processed during conversion from DOM to view elements.
+	 *
+	 * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching all view elements whose content should
+	 * be treated as plain text.
+	 */
+	registerPlainContentElementMatcher( pattern ) {
+		this._domConverter.registerPlainContentElementMatcher( pattern );
+	}
+
+	/**
 	 * Converts an HTML string to its DOM representation. Returns a document fragment containing nodes parsed from
 	 * the provided data.
 	 *

--- a/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js
+++ b/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js
@@ -80,14 +80,17 @@ export default class HtmlDataProcessor {
 	}
 
 	/**
-	 * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as a plain text
+	 * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as a raw data
 	 * and not processed during conversion from DOM to view elements.
 	 *
+	 * The raw data can be later accessed by {@link module:engine/view/element~Element#getCustomProperty view element custom property}
+	 * `"$rawContent"`.
+	 *
 	 * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching all view elements whose content should
-	 * be treated as plain text.
+	 * be treated as a raw data.
 	 */
-	registerPlainContentElementMatcher( pattern ) {
-		this._domConverter.registerPlainContentElementMatcher( pattern );
+	registerRawContentElementMatcher( pattern ) {
+		this._domConverter.registerRawContentElementMatcher( pattern );
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.js
+++ b/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.js
@@ -106,8 +106,8 @@ export default class XmlDataProcessor {
 	 * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching all view elements whose content should
 	 * be treated as a raw data.
 	 */
-	registerRawContentElementMatcher( pattern ) {
-		this._domConverter.registerRawContentElementMatcher( pattern );
+	registerRawContentMatcher( pattern ) {
+		this._domConverter.registerRawContentMatcher( pattern );
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.js
+++ b/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.js
@@ -97,6 +97,17 @@ export default class XmlDataProcessor {
 	}
 
 	/**
+	 * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as a plain text
+	 * and not processed during conversion from XML to view elements.
+	 *
+	 * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching all view elements whose content should
+	 * be treated as plain text.
+	 */
+	registerPlainContentElementMatcher( pattern ) {
+		this._domConverter.registerPlainContentElementMatcher( pattern );
+	}
+
+	/**
 	 * Converts an XML string to its DOM representation. Returns a document fragment containing nodes parsed from
 	 * the provided data.
 	 *

--- a/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.js
+++ b/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.js
@@ -97,14 +97,17 @@ export default class XmlDataProcessor {
 	}
 
 	/**
-	 * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as a plain text
+	 * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as a raw data
 	 * and not processed during conversion from XML to view elements.
 	 *
+	 * The raw data can be later accessed by {@link module:engine/view/element~Element#getCustomProperty view element custom property}
+	 * `"$rawContent"`.
+	 *
 	 * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching all view elements whose content should
-	 * be treated as plain text.
+	 * be treated as a raw data.
 	 */
-	registerPlainContentElementMatcher( pattern ) {
-		this._domConverter.registerPlainContentElementMatcher( pattern );
+	registerRawContentElementMatcher( pattern ) {
+		this._domConverter.registerRawContentElementMatcher( pattern );
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -133,7 +133,7 @@ export default class DomConverter {
 		 * Set of encountered raw content DOM nodes. It is used for preventing left trimming of the following text node.
 		 *
 		 * @private
-		 * @type {WeakSet<Node>}
+		 * @type {WeakSet.<Node>}
 		 */
 		this._encounteredRawContentDomNodes = new WeakSet();
 	}

--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -121,12 +121,13 @@ export default class DomConverter {
 		this._fakeSelectionMapping = new WeakMap();
 
 		/**
-		 * TODO
+		 * Matcher for view elements whose content should be treated as a plain text
+		 * and not processed during conversion from DOM nodes to view elements.
 		 *
 		 * @private
 		 * @type {module:engine/view/matcher~Matcher}
 		 */
-		this._cdataElementMatcher = new Matcher();
+		this._plainContentElementMatcher = new Matcher();
 	}
 
 	/**
@@ -456,7 +457,7 @@ export default class DomConverter {
 				}
 
 				// Treat this element's content as CDATA if it was registered as such.
-				if ( options.withChildren !== false && this._cdataElementMatcher.match( viewElement ) ) {
+				if ( options.withChildren !== false && this._plainContentElementMatcher.match( viewElement ) ) {
 					viewElement._appendChild( new ViewText( this.document, domNode.innerHTML ) );
 
 					return viewElement;
@@ -925,6 +926,20 @@ export default class DomConverter {
 	isDomSelectionCorrect( domSelection ) {
 		return this._isDomSelectionPositionCorrect( domSelection.anchorNode, domSelection.anchorOffset ) &&
 			this._isDomSelectionPositionCorrect( domSelection.focusNode, domSelection.focusOffset );
+	}
+
+	/**
+	 * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as a plain text
+	 * and not processed during conversion from DOM nodes to view elements.
+	 *
+	 * This is affecting how {@link module:engine/view/domconverter~DomConverter#domToView} and
+	 * {@link module:engine/view/domconverter~DomConverter#domChildrenToView} processes DOM nodes.
+	 *
+	 * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching all view elements whose content should
+	 * be treated as plain text.
+	 */
+	registerPlainContentElementMatcher( pattern ) {
+		this._plainContentElementMatcher.add( pattern );
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -949,7 +949,7 @@ export default class DomConverter {
 	 * The raw data can be later accessed by {@link module:engine/view/element~Element#getCustomProperty view element custom property}
 	 * `"$rawContent"`.
 	 *
-	 * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching all view elements whose content should
+	 * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching view element which content should
 	 * be treated as a raw data.
 	 */
 	registerRawContentElementMatcher( pattern ) {

--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -952,7 +952,7 @@ export default class DomConverter {
 	 * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching view element which content should
 	 * be treated as a raw data.
 	 */
-	registerRawContentElementMatcher( pattern ) {
+	registerRawContentMatcher( pattern ) {
 		this._rawContentElementMatcher.add( pattern );
 	}
 

--- a/packages/ckeditor5-engine/tests/dataprocessor/htmldataprocessor.js
+++ b/packages/ckeditor5-engine/tests/dataprocessor/htmldataprocessor.js
@@ -115,9 +115,9 @@ describe( 'HtmlDataProcessor', () => {
 		} );
 	} );
 
-	describe( 'registerRawContentElementMatcher()', () => {
+	describe( 'registerRawContentMatcher()', () => {
 		it( 'should handle elements matching to MatcherPattern as elements with raw content', () => {
-			dataProcessor.registerRawContentElementMatcher( { name: 'div', classes: 'raw' } );
+			dataProcessor.registerRawContentMatcher( { name: 'div', classes: 'raw' } );
 
 			const fragment = dataProcessor.toView(
 				'<p>foo</p>' +

--- a/packages/ckeditor5-engine/tests/dataprocessor/htmldataprocessor.js
+++ b/packages/ckeditor5-engine/tests/dataprocessor/htmldataprocessor.js
@@ -114,4 +114,23 @@ describe( 'HtmlDataProcessor', () => {
 			expect( dataProcessor.toData( fragment ) ).to.equal( '<p>foo</p><p>bar</p>' );
 		} );
 	} );
+
+	describe( 'registerRawContentElementMatcher()', () => {
+		it( 'should handle elements matching to MatcherPattern as elements with raw content', () => {
+			dataProcessor.registerRawContentElementMatcher( { name: 'div', classes: 'raw' } );
+
+			const fragment = dataProcessor.toView(
+				'<p>foo</p>' +
+				'<div class="raw">' +
+					'<!-- 123 -->' +
+					' abc ' +
+					'<!-- 456 -->' +
+				'</div>' +
+				'<p>bar</p>'
+			);
+
+			expect( stringify( fragment ) ).to.equal( '<p>foo</p><div class="raw"></div><p>bar</p>' );
+			expect( fragment.getChild( 1 ).getCustomProperty( '$rawContent' ) ).to.equal( '<!-- 123 --> abc <!-- 456 -->' );
+		} );
+	} );
 } );

--- a/packages/ckeditor5-engine/tests/dataprocessor/xmldataprocessor.js
+++ b/packages/ckeditor5-engine/tests/dataprocessor/xmldataprocessor.js
@@ -104,9 +104,9 @@ describe( 'XmlDataProcessor', () => {
 		} );
 	} );
 
-	describe( 'registerRawContentElementMatcher()', () => {
+	describe( 'registerRawContentMatcher()', () => {
 		it( 'should handle elements matching to MatcherPattern as elements with raw content', () => {
-			dataProcessor.registerRawContentElementMatcher( { name: 'div', classes: 'raw' } );
+			dataProcessor.registerRawContentMatcher( { name: 'div', classes: 'raw' } );
 
 			const fragment = dataProcessor.toView(
 				'<p>foo</p>' +

--- a/packages/ckeditor5-engine/tests/dataprocessor/xmldataprocessor.js
+++ b/packages/ckeditor5-engine/tests/dataprocessor/xmldataprocessor.js
@@ -103,4 +103,23 @@ describe( 'XmlDataProcessor', () => {
 			expect( dataProcessor.toData( fragment ) ).to.equal( '<p>foo</p><p>bar</p>' );
 		} );
 	} );
+
+	describe( 'registerRawContentElementMatcher()', () => {
+		it( 'should handle elements matching to MatcherPattern as elements with raw content', () => {
+			dataProcessor.registerRawContentElementMatcher( { name: 'div', classes: 'raw' } );
+
+			const fragment = dataProcessor.toView(
+				'<p>foo</p>' +
+				'<div class="raw">' +
+					'<!-- 123 -->' +
+					' abc ' +
+					'<!-- 456 -->' +
+				'</div>' +
+				'<p>bar</p>'
+			);
+
+			expect( stringify( fragment ) ).to.equal( '<p>foo</p><div class="raw"></div><p>bar</p>' );
+			expect( fragment.getChild( 1 ).getCustomProperty( '$rawContent' ) ).to.equal( '<!-- 123 --> abc <!-- 456 -->' );
+		} );
+	} );
 } );

--- a/packages/ckeditor5-engine/tests/view/domconverter/dom-to-view.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/dom-to-view.js
@@ -159,7 +159,7 @@ describe( 'DomConverter', () => {
 		} );
 
 		it( 'should assign $rawContent custom property for view elements registered as raw content elements', () => {
-			converter.registerRawContentElementMatcher( {
+			converter.registerRawContentMatcher( {
 				name: 'div',
 				classes: 'raw-content-container'
 			} );
@@ -678,7 +678,7 @@ describe( 'DomConverter', () => {
 			} );
 
 			it( 'not before or after raw content inline element', () => {
-				converter.registerRawContentElementMatcher( {
+				converter.registerRawContentMatcher( {
 					name: 'span'
 				} );
 

--- a/packages/ckeditor5-engine/tests/view/domconverter/dom-to-view.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/dom-to-view.js
@@ -158,42 +158,6 @@ describe( 'DomConverter', () => {
 			expect( viewFragment2 ).to.equal( viewFragment );
 		} );
 
-		it( 'should assign $rawContent custom property for view elements registered as raw content elements', () => {
-			converter.registerRawContentMatcher( {
-				name: 'div',
-				classes: 'raw-content-container'
-			} );
-
-			const domDiv = createElement( document, 'div', {}, [
-				createElement( document, 'img' ),
-				createElement( document, 'div', { 'class': 'raw-content-container' }, [
-					document.createComment( ' foo ' ),
-					createElement( document, 'img' ),
-					document.createTextNode( 'bar\n123' )
-				] ),
-				createElement( document, 'div', {}, [
-					document.createComment( 'foo' ),
-					createElement( document, 'img' ),
-					document.createTextNode( 'bar\n123' )
-				] ),
-				document.createTextNode( 'abc' )
-			] );
-
-			const viewDiv = converter.domToView( domDiv );
-
-			expect( viewDiv ).to.be.an.instanceof( ViewElement );
-			expect( viewDiv.name ).to.equal( 'div' );
-
-			expect( viewDiv.childCount ).to.equal( 4 );
-			expect( viewDiv.getChild( 0 ).name ).to.equal( 'img' );
-			expect( viewDiv.getChild( 1 ).getCustomProperty( '$rawContent' ) ).to.equal( '<!-- foo --><img>bar\n123' );
-			expect( viewDiv.getChild( 2 ).getCustomProperty( '$rawContent' ) ).to.be.undefined;
-			expect( viewDiv.getChild( 2 ).childCount ).to.equal( 2 );
-			expect( viewDiv.getChild( 2 ).getChild( 0 ).name ).to.equal( 'img' );
-			expect( viewDiv.getChild( 2 ).getChild( 1 ).data ).to.equal( 'bar 123' );
-			expect( viewDiv.getChild( 3 ).data ).to.equal( 'abc' );
-		} );
-
 		it( 'should return null for block filler', () => {
 			// eslint-disable-next-line new-cap
 			const domFiller = BR_FILLER( document );
@@ -675,26 +639,6 @@ describe( 'DomConverter', () => {
 
 				expect( viewP.childCount ).to.equal( 2 );
 				expect( viewP.getChild( 0 ).getChild( 0 ).data ).to.equal( 'foo ' );
-			} );
-
-			it( 'not before or after raw content inline element', () => {
-				converter.registerRawContentMatcher( {
-					name: 'span'
-				} );
-
-				const domP = createElement( document, 'p', {}, [
-					document.createTextNode( '  foo  ' ),
-					createElement( document, 'span', {}, [
-						document.createTextNode( '  abc  ' )
-					] ),
-					document.createTextNode( '  bar  ' )
-				] );
-
-				const viewP = converter.domToView( domP );
-
-				expect( viewP.childCount ).to.equal( 3 );
-				expect( viewP.getChild( 0 ).data ).to.equal( 'foo ' );
-				expect( viewP.getChild( 2 ).data ).to.equal( ' bar' );
 			} );
 
 			//

--- a/packages/ckeditor5-engine/tests/view/domconverter/rawcontent.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/rawcontent.js
@@ -1,0 +1,246 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals document */
+
+import DomConverter from '../../../src/view/domconverter';
+import ViewDocument from '../../../src/view/document';
+import ViewElement from '../../../src/view/element';
+import { StylesProcessor } from '../../../src/view/stylesmap';
+
+import createElement from '@ckeditor/ckeditor5-utils/src/dom/createelement';
+
+describe( 'DOMConverter raw content matcher', () => {
+	let converter, viewDocument;
+
+	beforeEach( () => {
+		viewDocument = new ViewDocument( new StylesProcessor() );
+		converter = new DomConverter( viewDocument );
+	} );
+
+	describe( 'domToView()', () => {
+		describe( 'assign $rawContent custom property for view elements registered as raw content elements', () => {
+			it( 'should handle exact match of an element name and classes', () => {
+				converter.registerRawContentMatcher( {
+					name: 'div',
+					classes: 'raw-content-container'
+				} );
+
+				const domDiv = createElement( document, 'div', {}, [
+					createElement( document, 'img' ),
+					createElement( document, 'div', { 'class': 'raw-content-container' }, [
+						document.createComment( ' foo ' ),
+						createElement( document, 'img' ),
+						document.createTextNode( 'bar\n123' )
+					] ),
+					createElement( document, 'div', {}, [
+						document.createComment( 'foo' ),
+						createElement( document, 'img' ),
+						document.createTextNode( 'bar\n123' )
+					] ),
+					document.createTextNode( 'abc' )
+				] );
+
+				const viewDiv = converter.domToView( domDiv );
+
+				expect( viewDiv ).to.be.an.instanceof( ViewElement );
+				expect( viewDiv.name ).to.equal( 'div' );
+
+				expect( viewDiv.childCount ).to.equal( 4 );
+				expect( viewDiv.getChild( 0 ).name ).to.equal( 'img' );
+				expect( viewDiv.getChild( 1 ).getCustomProperty( '$rawContent' ) ).to.equal( '<!-- foo --><img>bar\n123' );
+				expect( viewDiv.getChild( 2 ).getCustomProperty( '$rawContent' ) ).to.be.undefined;
+				expect( viewDiv.getChild( 2 ).childCount ).to.equal( 2 );
+				expect( viewDiv.getChild( 2 ).getChild( 0 ).name ).to.equal( 'img' );
+				expect( viewDiv.getChild( 2 ).getChild( 1 ).data ).to.equal( 'bar 123' );
+				expect( viewDiv.getChild( 3 ).data ).to.equal( 'abc' );
+			} );
+
+			it( 'should handle elements with more classes, styles and attributes not required by the matcher pattern', () => {
+				converter.registerRawContentMatcher( {
+					name: 'div',
+					classes: 'raw-content-container'
+				} );
+
+				const domDiv = createElement( document, 'div', {}, [
+					createElement( document, 'img' ),
+					createElement( document, 'div', {
+						'class': 'raw-content-container',
+						'style': 'border: 1px solid red',
+						'data-foo': 'bar'
+					}, [
+						document.createComment( ' foo ' ),
+						createElement( document, 'img' ),
+						document.createTextNode( 'bar\n123' )
+					] ),
+					createElement( document, 'div', {}, [
+						document.createComment( 'foo' ),
+						createElement( document, 'img' ),
+						document.createTextNode( 'bar\n123' )
+					] ),
+					document.createTextNode( 'abc' )
+				] );
+
+				const viewDiv = converter.domToView( domDiv );
+
+				expect( viewDiv ).to.be.an.instanceof( ViewElement );
+				expect( viewDiv.name ).to.equal( 'div' );
+
+				expect( viewDiv.childCount ).to.equal( 4 );
+				expect( viewDiv.getChild( 0 ).name ).to.equal( 'img' );
+				expect( viewDiv.getChild( 1 ).getCustomProperty( '$rawContent' ) ).to.equal( '<!-- foo --><img>bar\n123' );
+				expect( viewDiv.getChild( 2 ).getCustomProperty( '$rawContent' ) ).to.be.undefined;
+				expect( viewDiv.getChild( 2 ).childCount ).to.equal( 2 );
+				expect( viewDiv.getChild( 2 ).getChild( 0 ).name ).to.equal( 'img' );
+				expect( viewDiv.getChild( 2 ).getChild( 1 ).data ).to.equal( 'bar 123' );
+				expect( viewDiv.getChild( 3 ).data ).to.equal( 'abc' );
+			} );
+
+			it( 'should handle multiple matchers (but nested ones should not be matched)', () => {
+				converter.registerRawContentMatcher( {
+					name: 'div',
+					classes: 'raw-content-container'
+				} );
+
+				converter.registerRawContentMatcher( {
+					name: 'span',
+					attributes: {
+						'data-foo': 'bar'
+					}
+				} );
+
+				const domDiv = createElement( document, 'div', {}, [
+					createElement( document, 'img' ),
+					createElement( document, 'div', {
+						'class': 'raw-content-container',
+						'style': 'border: 1px solid red',
+						'data-foo': 'bar'
+					}, [
+						document.createComment( ' foo ' ),
+						createElement( document, 'img' ),
+						createElement( document, 'span', {
+							'data-foo': 'bar'
+						}, [
+							document.createTextNode( 'nested span' )
+						] ),
+						document.createTextNode( 'bar\n123' )
+					] ),
+					createElement( document, 'div', {}, [
+						document.createComment( 'foo' ),
+						createElement( document, 'img' ),
+						document.createTextNode( 'bar\n123' )
+					] ),
+					createElement( document, 'span', { 'data-foo': 'bar' }, 'some span' ),
+					createElement( document, 'span', {}, 'other span' ),
+					document.createTextNode( 'abc' )
+				] );
+
+				const viewDiv = converter.domToView( domDiv );
+
+				expect( viewDiv ).to.be.an.instanceof( ViewElement );
+				expect( viewDiv.name ).to.equal( 'div' );
+
+				expect( viewDiv.childCount ).to.equal( 6 );
+				expect( viewDiv.getChild( 0 ).name ).to.equal( 'img' );
+				expect( viewDiv.getChild( 1 ).getCustomProperty( '$rawContent' ) ).to.equal(
+					'<!-- foo --><img><span data-foo="bar">nested span</span>bar\n123'
+				);
+				expect( viewDiv.getChild( 2 ).getCustomProperty( '$rawContent' ) ).to.be.undefined;
+				expect( viewDiv.getChild( 2 ).childCount ).to.equal( 2 );
+				expect( viewDiv.getChild( 2 ).getChild( 0 ).name ).to.equal( 'img' );
+				expect( viewDiv.getChild( 2 ).getChild( 1 ).data ).to.equal( 'bar 123' );
+				expect( viewDiv.getChild( 3 ).getCustomProperty( '$rawContent' ) ).to.equal( 'some span' );
+				expect( viewDiv.getChild( 4 ).name ).to.equal( 'span' );
+				expect( viewDiv.getChild( 4 ).getChild( 0 ).data ).to.equal( 'other span' );
+				expect( viewDiv.getChild( 5 ).data ).to.equal( 'abc' );
+			} );
+
+			it( 'should handle elements by an attribute or class only', () => {
+				converter.registerRawContentMatcher( {
+					classes: 'raw-content-container'
+				} );
+
+				converter.registerRawContentMatcher( {
+					attributes: {
+						'data-foo': 'bar'
+					}
+				} );
+
+				const domDiv = createElement( document, 'div', {}, [
+					createElement( document, 'img' ),
+					createElement( document, 'div', {
+						'class': 'raw-content-container'
+					}, [
+						document.createComment( ' foo ' ),
+						createElement( document, 'img' ),
+						document.createTextNode( 'bar\n123' )
+					] ),
+					createElement( document, 'div', {
+						'data-foo': 'bar'
+					}, [
+						document.createComment( 'bar' ),
+						document.createTextNode( '123' )
+					] ),
+					document.createTextNode( 'abc' )
+				] );
+
+				const viewDiv = converter.domToView( domDiv );
+
+				expect( viewDiv ).to.be.an.instanceof( ViewElement );
+				expect( viewDiv.name ).to.equal( 'div' );
+
+				expect( viewDiv.childCount ).to.equal( 4 );
+				expect( viewDiv.getChild( 0 ).name ).to.equal( 'img' );
+				expect( viewDiv.getChild( 1 ).getCustomProperty( '$rawContent' ) ).to.equal( '<!-- foo --><img>bar\n123' );
+				expect( viewDiv.getChild( 2 ).getCustomProperty( '$rawContent' ) ).to.equal( '<!--bar-->123' );
+				expect( viewDiv.getChild( 3 ).data ).to.equal( 'abc' );
+			} );
+		} );
+
+		describe( 'whitespace trimming', () => {
+			it( 'should not trim whitespaces before or after raw content inline element', () => {
+				converter.registerRawContentMatcher( {
+					name: 'span'
+				} );
+
+				const domP = createElement( document, 'p', {}, [
+					document.createTextNode( '  foo  ' ),
+					createElement( document, 'span', {}, '  abc  ' ),
+					document.createTextNode( '  bar  ' )
+				] );
+
+				const viewP = converter.domToView( domP );
+
+				expect( viewP.childCount ).to.equal( 3 );
+				expect( viewP.getChild( 0 ).data ).to.equal( 'foo ' );
+				expect( viewP.getChild( 1 ).getCustomProperty( '$rawContent' ) ).to.equal( '  abc  ' );
+				expect( viewP.getChild( 2 ).data ).to.equal( ' bar' );
+			} );
+
+			it( 'should not trim whitespaces before or after raw content inline element with deeper nesting', () => {
+				converter.registerRawContentMatcher( {
+					name: 'span'
+				} );
+
+				const domP = createElement( document, 'p', {}, [
+					document.createTextNode( '  foo  ' ),
+					createElement( document, 'span', {}, [
+						createElement( document, 'span', {}, [
+							document.createTextNode( '  abc  ' )
+						] )
+					] ),
+					document.createTextNode( '  bar  ' )
+				] );
+
+				const viewP = converter.domToView( domP );
+
+				expect( viewP.childCount ).to.equal( 3 );
+				expect( viewP.getChild( 0 ).data ).to.equal( 'foo ' );
+				expect( viewP.getChild( 1 ).getCustomProperty( '$rawContent' ) ).to.equal( '<span>  abc  </span>' );
+				expect( viewP.getChild( 2 ).data ).to.equal( ' bar' );
+			} );
+		} );
+	} );
+} );

--- a/packages/ckeditor5-html-embed/src/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/src/htmlembedediting.js
@@ -8,8 +8,6 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
-import UpcastWriter from '@ckeditor/ckeditor5-engine/src/view/upcastwriter';
 import { logWarning } from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import { toWidget } from '@ckeditor/ckeditor5-widget/src/utils';
 import InsertHtmlEmbedCommand from './inserthtmlembedcommand';
@@ -94,8 +92,12 @@ export default class HtmlEmbedEditing extends Plugin {
 		const view = editor.editing.view;
 
 		const htmlEmbedConfig = editor.config.get( 'htmlEmbed' );
-		const upcastWriter = new UpcastWriter( view.document );
-		const htmlProcessor = new HtmlDataProcessor( view.document );
+
+		// TODO find best place for this (probably HtmlDataProcessor method).
+		editor.data.processor._domConverter._cdataElementMatcher.add( {
+			name: 'div',
+			classes: 'raw-html-embed'
+		} );
 
 		editor.conversion.for( 'upcast' ).elementToElement( {
 			view: {
@@ -103,13 +105,9 @@ export default class HtmlEmbedEditing extends Plugin {
 				classes: 'raw-html-embed'
 			},
 			model: ( viewElement, { writer } ) => {
-				// Note: The below line has a side-effect – the children are *moved* to the DF so
-				// viewElement becomes empty. It's fine here.
-				const fragment = upcastWriter.createDocumentFragment( viewElement.getChildren() );
-				const innerHtml = htmlProcessor.toData( fragment );
-
+				// TODO comment
 				return writer.createElement( 'rawHtml', {
-					value: innerHtml
+					value: viewElement.getChild( 0 ).data
 				} );
 			}
 		} );

--- a/packages/ckeditor5-html-embed/src/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/src/htmlembedediting.js
@@ -94,7 +94,7 @@ export default class HtmlEmbedEditing extends Plugin {
 		const htmlEmbedConfig = editor.config.get( 'htmlEmbed' );
 
 		// Register div.raw-html-embed as a plain content element so all it's content will be provided as Text node while data upcasting.
-		editor.data.processor.registerPlainContentElementMatcher( {
+		editor.data.processor.registerRawContentElementMatcher( {
 			name: 'div',
 			classes: 'raw-html-embed'
 		} );
@@ -107,7 +107,7 @@ export default class HtmlEmbedEditing extends Plugin {
 			model: ( viewElement, { writer } ) => {
 				// The div.raw-html-embed is registered as a plain content element, so all it's content is available as a single Text node.
 				return writer.createElement( 'rawHtml', {
-					value: viewElement.getChild( 0 ).data
+					value: viewElement.getCustomProperty( '$rawContent' )
 				} );
 			}
 		} );

--- a/packages/ckeditor5-html-embed/src/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/src/htmlembedediting.js
@@ -93,7 +93,8 @@ export default class HtmlEmbedEditing extends Plugin {
 
 		const htmlEmbedConfig = editor.config.get( 'htmlEmbed' );
 
-		// Register div.raw-html-embed as a plain content element so all it's content will be provided as Text node while data upcasting.
+		// Register div.raw-html-embed as a raw content element so all of it's content will be provided
+		// as a view element's custom property while data upcasting.
 		editor.data.processor.registerRawContentElementMatcher( {
 			name: 'div',
 			classes: 'raw-html-embed'
@@ -105,7 +106,8 @@ export default class HtmlEmbedEditing extends Plugin {
 				classes: 'raw-html-embed'
 			},
 			model: ( viewElement, { writer } ) => {
-				// The div.raw-html-embed is registered as a plain content element, so all it's content is available as a single Text node.
+				// The div.raw-html-embed is registered as a raw content element,
+				// so all it's content is available in a custom property.
 				return writer.createElement( 'rawHtml', {
 					value: viewElement.getCustomProperty( '$rawContent' )
 				} );

--- a/packages/ckeditor5-html-embed/src/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/src/htmlembedediting.js
@@ -93,8 +93,8 @@ export default class HtmlEmbedEditing extends Plugin {
 
 		const htmlEmbedConfig = editor.config.get( 'htmlEmbed' );
 
-		// TODO find best place for this (probably HtmlDataProcessor method).
-		editor.data.processor._domConverter._cdataElementMatcher.add( {
+		// Register div.raw-html-embed as a plain content element so all it's content will be provided as Text node while data upcasting.
+		editor.data.processor.registerPlainContentElementMatcher( {
 			name: 'div',
 			classes: 'raw-html-embed'
 		} );
@@ -105,7 +105,7 @@ export default class HtmlEmbedEditing extends Plugin {
 				classes: 'raw-html-embed'
 			},
 			model: ( viewElement, { writer } ) => {
-				// TODO comment
+				// The div.raw-html-embed is registered as a plain content element, so all it's content is available as a single Text node.
 				return writer.createElement( 'rawHtml', {
 					value: viewElement.getChild( 0 ).data
 				} );

--- a/packages/ckeditor5-html-embed/src/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/src/htmlembedediting.js
@@ -95,7 +95,7 @@ export default class HtmlEmbedEditing extends Plugin {
 
 		// Register div.raw-html-embed as a raw content element so all of it's content will be provided
 		// as a view element's custom property while data upcasting.
-		editor.data.processor.registerRawContentElementMatcher( {
+		editor.data.processor.registerRawContentMatcher( {
 			name: 'div',
 			classes: 'raw-html-embed'
 		} );

--- a/packages/ckeditor5-html-embed/tests/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/tests/htmlembedediting.js
@@ -225,6 +225,28 @@ describe( 'HtmlEmbedEditing', () => {
 					'</div>'
 				);
 			} );
+
+			it( 'should convert innerHTML (and preserve comments and raw data formatting) of div.raw-html-embed', () => {
+				const rawContent = [
+					'	<!-- foo -->',
+					'	<p>',
+					'		<b>Foo B.</b>',
+					'		<!-- abc -->',
+					'		<i>Foo I.</i>',
+					'	</p>',
+					'	<!-- bar -->'
+				].join( '\n' );
+
+				editor.setData(
+					'<div class="raw-html-embed">' +
+						rawContent +
+					'</div>'
+				);
+
+				const rawHtml = model.document.getRoot().getChild( 0 );
+
+				expect( rawHtml.getAttribute( 'value' ) ).to.equal( rawContent );
+			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-html-embed/tests/manual/htmlembed.html
+++ b/packages/ckeditor5-html-embed/tests/manual/htmlembed.html
@@ -9,6 +9,22 @@
 </p>
 
 <div id="editor">
+
+	<div class="raw-html-embed"><h2>CKEditor 5 on socials</h2><div class="\&quot;raw-html-embed\&quot;"><blockquote class="\&quot;twitter-tweet\&quot;"><p dir="\&quot;ltr\&quot;" lang="\&quot;en\&quot;">Keeping CKEditor 5 integrations tidy and free of bugs 🐛 The new release for the official <a href="\&quot;https://twitter.com/hashtag/Angular?src=hash&amp;ref_src=twsrc%5Etfw\&quot;">#Angular</a> WYSIWYG editor component works with Angular 9.1 and above. <a href="\&quot;https://t.co/Umag7F9dq0\&quot;">https://t.co/Umag7F9dq0</a> <a href="\&quot;https://t.co/cIPy5fFSDn\&quot;">pic.twitter.com/cIPy5fFSDn</a></p>— CKEditor Ecosystem (@ckeditor) <a href="\&quot;https://twitter.com/ckeditor/status/1318575258153160707?ref_src=twsrc%5Etfw\&quot;">October 20, 2020</a></blockquote><script charset="\&quot;utf-8\&quot;" src="\&quot;https://platform.twitter.com/widgets.js\&quot;" async="\&quot;\&quot;"></script></div><div class="\&quot;raw-html-embed\&quot;"><iframe allowfullscreen="\&quot;\&quot;" allow="\&quot;accelerometer;" autoplay;="" clipboard-write;="" encrypted-media;="" gyroscope;="" picture-in-picture\"="" frameborder="\&quot;0\&quot;" src="\&quot;https://www.youtube-nocookie.com/embed/DgM5DfAPQTI\&quot;" height="\&quot;315\&quot;" width="\&quot;560\&quot;"></iframe></div><p>Psst, we're tracking ya!</p><div class="\&quot;raw-html-embed\&quot;"><script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){ (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o), m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m) })(window,document,'script','https://www.google-analytics.com/analytics.js','ga'); ga('create', 'UA-XXXXX-Y', 'auto'); ga('send', 'pageview'); </script></div></div>
+
+	<div class="raw-html-embed">
+		<!-- comment -->
+		<div id="aaaa">fooo</div>
+		<!-- end -->
+	</div>
+
+	<div class="raw-html-embed">
+		<!-- comment -->
+		<div id=\"zzzz\">bar</div>
+		<!-- end -->
+	</div>
+
+	<!--
 	<h3><code>&lt;video&gt;</code> tag as HTML snippet</h3>
 		<div class="raw-html-embed">
 			<video width="320" height="240" controls>
@@ -154,4 +170,5 @@
 			</tbody>
 		</table>
 	</div>
+	-->
 </div>

--- a/packages/ckeditor5-html-embed/tests/manual/htmlembed.html
+++ b/packages/ckeditor5-html-embed/tests/manual/htmlembed.html
@@ -9,22 +9,6 @@
 </p>
 
 <div id="editor">
-
-	<div class="raw-html-embed"><h2>CKEditor 5 on socials</h2><div class="\&quot;raw-html-embed\&quot;"><blockquote class="\&quot;twitter-tweet\&quot;"><p dir="\&quot;ltr\&quot;" lang="\&quot;en\&quot;">Keeping CKEditor 5 integrations tidy and free of bugs 🐛 The new release for the official <a href="\&quot;https://twitter.com/hashtag/Angular?src=hash&amp;ref_src=twsrc%5Etfw\&quot;">#Angular</a> WYSIWYG editor component works with Angular 9.1 and above. <a href="\&quot;https://t.co/Umag7F9dq0\&quot;">https://t.co/Umag7F9dq0</a> <a href="\&quot;https://t.co/cIPy5fFSDn\&quot;">pic.twitter.com/cIPy5fFSDn</a></p>— CKEditor Ecosystem (@ckeditor) <a href="\&quot;https://twitter.com/ckeditor/status/1318575258153160707?ref_src=twsrc%5Etfw\&quot;">October 20, 2020</a></blockquote><script charset="\&quot;utf-8\&quot;" src="\&quot;https://platform.twitter.com/widgets.js\&quot;" async="\&quot;\&quot;"></script></div><div class="\&quot;raw-html-embed\&quot;"><iframe allowfullscreen="\&quot;\&quot;" allow="\&quot;accelerometer;" autoplay;="" clipboard-write;="" encrypted-media;="" gyroscope;="" picture-in-picture\"="" frameborder="\&quot;0\&quot;" src="\&quot;https://www.youtube-nocookie.com/embed/DgM5DfAPQTI\&quot;" height="\&quot;315\&quot;" width="\&quot;560\&quot;"></iframe></div><p>Psst, we're tracking ya!</p><div class="\&quot;raw-html-embed\&quot;"><script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){ (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o), m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m) })(window,document,'script','https://www.google-analytics.com/analytics.js','ga'); ga('create', 'UA-XXXXX-Y', 'auto'); ga('send', 'pageview'); </script></div></div>
-
-	<div class="raw-html-embed">
-		<!-- comment -->
-		<div id="aaaa">fooo</div>
-		<!-- end -->
-	</div>
-
-	<div class="raw-html-embed">
-		<!-- comment -->
-		<div id=\"zzzz\">bar</div>
-		<!-- end -->
-	</div>
-
-	<!--
 	<h3><code>&lt;video&gt;</code> tag as HTML snippet</h3>
 		<div class="raw-html-embed">
 			<video width="320" height="240" controls>
@@ -170,5 +154,11 @@
 			</tbody>
 		</table>
 	</div>
-	-->
+
+	<h3>HTML comments in HTML snippet</h3>
+	<div class="raw-html-embed">
+		<!-- comment -->
+		<div id="aaaa">fooo</div>
+		<!-- end -->
+	</div>
 </div>

--- a/packages/ckeditor5-markdown-gfm/src/gfmdataprocessor.js
+++ b/packages/ckeditor5-markdown-gfm/src/gfmdataprocessor.js
@@ -80,7 +80,7 @@ export default class GFMDataProcessor {
 	 * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching all view elements whose content should
 	 * be treated as a raw data.
 	 */
-	registerRawContentElementMatcher( pattern ) {
-		this._htmlDP.registerRawContentElementMatcher( pattern );
+	registerRawContentMatcher( pattern ) {
+		this._htmlDP.registerRawContentMatcher( pattern );
 	}
 }

--- a/packages/ckeditor5-markdown-gfm/src/gfmdataprocessor.js
+++ b/packages/ckeditor5-markdown-gfm/src/gfmdataprocessor.js
@@ -71,13 +71,16 @@ export default class GFMDataProcessor {
 	}
 
 	/**
-	 * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as a plain text
+	 * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as a raw data
 	 * and not processed during conversion from Markdown to view elements.
 	 *
+	 * The raw data can be later accessed by {@link module:engine/view/element~Element#getCustomProperty view element custom property}
+	 * `"$rawContent"`.
+	 *
 	 * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching all view elements whose content should
-	 * be treated as plain text.
+	 * be treated as a raw data.
 	 */
-	registerPlainContentElementMatcher( pattern ) {
-		this._htmlDP.registerPlainContentElementMatcher( pattern );
+	registerRawContentElementMatcher( pattern ) {
+		this._htmlDP.registerRawContentElementMatcher( pattern );
 	}
 }

--- a/packages/ckeditor5-markdown-gfm/src/gfmdataprocessor.js
+++ b/packages/ckeditor5-markdown-gfm/src/gfmdataprocessor.js
@@ -69,4 +69,15 @@ export default class GFMDataProcessor {
 		const html = this._htmlDP.toData( viewFragment );
 		return html2markdown( html );
 	}
+
+	/**
+	 * Registers a {@link module:engine/view/matcher~MatcherPattern} for view elements whose content should be treated as a plain text
+	 * and not processed during conversion from Markdown to view elements.
+	 *
+	 * @param {module:engine/view/matcher~MatcherPattern} pattern Pattern matching all view elements whose content should
+	 * be treated as plain text.
+	 */
+	registerPlainContentElementMatcher( pattern ) {
+		this._htmlDP.registerPlainContentElementMatcher( pattern );
+	}
 }

--- a/packages/ckeditor5-markdown-gfm/tests/_utils/utils.js
+++ b/packages/ckeditor5-markdown-gfm/tests/_utils/utils.js
@@ -17,6 +17,7 @@ import { StylesProcessor } from '@ckeditor/ckeditor5-engine/src/view/stylesmap';
  * @param {Object} [options] Additional options.
  * @param {Function} [options.setup] A function that receives the data processor instance before its execution.
  * markdown string (which will be used if this parameter is not provided).
+ * @returns {module:engine/view/documentfragment~DocumentFragment}
  */
 export function testDataProcessor( markdown, viewString, normalizedMarkdown, options ) {
 	const viewDocument = new ViewDocument( new StylesProcessor() );
@@ -37,6 +38,8 @@ export function testDataProcessor( markdown, viewString, normalizedMarkdown, opt
 	const normalized = typeof normalizedMarkdown !== 'undefined' ? normalizedMarkdown : markdown;
 
 	expect( cleanMarkdown( dataProcessor.toData( viewFragment ) ) ).to.equal( normalized );
+
+	return viewFragment;
 }
 
 function cleanHtml( html ) {

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/code.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/code.js
@@ -313,7 +313,7 @@ describe( 'GFMDataProcessor', () => {
 			);
 		} );
 
-		it( 'should support #registerRawContentElementMatcher()', () => {
+		it( 'should support #registerRawContentMatcher()', () => {
 			const viewFragment = testDataProcessor(
 				[
 					'```raw',
@@ -328,7 +328,7 @@ describe( 'GFMDataProcessor', () => {
 
 				{
 					setup( processor ) {
-						processor.registerRawContentElementMatcher( {
+						processor.registerRawContentMatcher( {
 							name: 'code',
 							classes: 'language-raw'
 						} );

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/code.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/code.js
@@ -312,5 +312,36 @@ describe( 'GFMDataProcessor', () => {
 				'</code></pre>'
 			);
 		} );
+
+		it( 'should support #registerRawContentElementMatcher()', () => {
+			const viewFragment = testDataProcessor(
+				[
+					'```raw',
+					'var a = \'hello\';',
+					'console.log(a + \' world\');',
+					'```'
+				].join( '\n' ),
+
+				'<pre><code class="language-raw"></code></pre>',
+
+				'',
+
+				{
+					setup( processor ) {
+						processor.registerRawContentElementMatcher( {
+							name: 'code',
+							classes: 'language-raw'
+						} );
+					}
+				}
+			);
+
+			expect( viewFragment.getChild( 0 ).getChild( 0 ).getCustomProperty( '$rawContent' ) ).to.equal(
+				[
+					'var a = \'hello\';',
+					'console.log(a + \' world\');'
+				].join( '\n' )
+			);
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (engine): Introducing `DataProcessor#registerRawContentMatcher()`. 

Fix (html-embed): Editor should not crash after inserting a broken HTML. Closes #8323.

Fix (engine): `DomConverter` should not trim whitespaces in nodes that are siblings to inline raw content elements (e.g. MathML). Closes #5870.

---

### Additional information