### PR TITLE
CloudServices Plugin should allow for registering multiple token endpoints

### DIFF
--- a/packages/ckeditor5-cloud-services/package.json
+++ b/packages/ckeditor5-cloud-services/package.json
@@ -10,7 +10,8 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor-cloud-services-core": "^23.1.0",
-    "@ckeditor/ckeditor5-core": "^23.1.0"
+    "@ckeditor/ckeditor5-core": "^23.1.0",
+    "@ckeditor/ckeditor5-utils": "^23.1.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-editor-classic": "^23.1.0"

--- a/packages/ckeditor5-cloud-services/src/cloudservices.js
+++ b/packages/ckeditor5-cloud-services/src/cloudservices.js
@@ -76,7 +76,11 @@ export default class CloudServices extends ContextPlugin {
 			return;
 		}
 
-		return this.registerTokenUrl( this.tokenUrl, true );
+		this.token = new CloudServices.Token( this.tokenUrl );
+
+		this._tokens.set( this.tokenUrl, this.token );
+
+		return this.token.init();
 	}
 
 	/**
@@ -84,10 +88,10 @@ export default class CloudServices extends ContextPlugin {
 	 * {@link module:cloud-services/cloudservices~CloudServicesConfig#tokenUrl} for more details.
 	 *
 	 * @param {String|Function} tokenUrl The authentication token URL for CKEditor Cloud Services or a callback to the token value promise.
-	 * @param {Boolean} [isDefault=false] Whether this should be a default authentication token provider.
 	 * @returns {Promise.<module:cloud-services-core/token~Token>}
 	 */
-	registerTokenUrl( tokenUrl, isDefault = false ) {
+	registerTokenUrl( tokenUrl ) {
+		// Reuse Token instance in case of multiple features using the same tokenUrl.
 		if ( this._tokens.has( tokenUrl ) ) {
 			return Promise.resolve( this.getTokenFor( tokenUrl ) );
 		}
@@ -95,19 +99,6 @@ export default class CloudServices extends ContextPlugin {
 		const token = new CloudServices.Token( tokenUrl );
 
 		this._tokens.set( tokenUrl, token );
-
-		if ( isDefault ) {
-			if ( this.token ) {
-				/**
-				 * Default token provider can't be replaced.
-				 *
-				 * @error cloudservices-default-token-override
-				 */
-				throw new CKEditorError( 'cloudservices-default-token-override', this );
-			}
-
-			this.token = token;
-		}
 
 		return token.init();
 	}

--- a/packages/ckeditor5-cloud-services/src/cloudservices.js
+++ b/packages/ckeditor5-cloud-services/src/cloudservices.js
@@ -9,6 +9,7 @@
 
 import ContextPlugin from '@ckeditor/ckeditor5-core/src/contextplugin';
 import Token from '@ckeditor/ckeditor-cloud-services-core/src/token/token';
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 /**
  * Plugin introducing integration between CKEditor 5 and CKEditor Cloud Services .
@@ -39,6 +40,14 @@ export default class CloudServices extends ContextPlugin {
 		}
 
 		/**
+		 * Map of `Token` object instances keyed by `tokenUrl`s.
+		 *
+		 * @private
+		 * @type {Map.<String, module:cloud-services-core/token~Token>}
+		 */
+		this._tokens = new Map();
+
+		/**
 		 * The authentication token URL for CKEditor Cloud Services or a callback to the token value promise. See the
 		 * {@link module:cloud-services/cloudservices~CloudServicesConfig#tokenUrl} for more details.
 		 *
@@ -58,7 +67,7 @@ export default class CloudServices extends ContextPlugin {
 		 * Its value is `null` when {@link module:cloud-services/cloudservices~CloudServicesConfig#tokenUrl} is not provided.
 		 *
 		 * @readonly
-		 * @member {Object|null} #token
+		 * @member {module:cloud-services-core/token~Token|null} #token
 		 */
 
 		if ( !this.tokenUrl ) {
@@ -67,9 +76,61 @@ export default class CloudServices extends ContextPlugin {
 			return;
 		}
 
-		this.token = new CloudServices.Token( this.tokenUrl );
+		return this.registerTokenUrl( this.tokenUrl, true );
+	}
 
-		return this.token.init();
+	/**
+	 * Registers an additional authentication token URL for CKEditor Cloud Services or a callback to the token value promise. See the
+	 * {@link module:cloud-services/cloudservices~CloudServicesConfig#tokenUrl} for more details.
+	 *
+	 * @param {String|Function} tokenUrl The authentication token URL for CKEditor Cloud Services or a callback to the token value promise.
+	 * @param {Boolean} [isDefault=false] Whether this should be a default authentication token provider.
+	 * @returns {Promise.<module:cloud-services-core/token~Token>}
+	 */
+	registerTokenUrl( tokenUrl, isDefault = false ) {
+		if ( this._tokens.has( tokenUrl ) ) {
+			return Promise.resolve( this.getTokenFor( tokenUrl ) );
+		}
+
+		const token = new CloudServices.Token( tokenUrl );
+
+		this._tokens.set( tokenUrl, token );
+
+		if ( isDefault ) {
+			if ( this.token ) {
+				/**
+				 * Default token provider can't be replaced.
+				 *
+				 * @error cloudservices-default-token-override
+				 */
+				throw new CKEditorError( 'cloudservices-default-token-override', this );
+			}
+
+			this.token = token;
+		}
+
+		return token.init();
+	}
+
+	/**
+	 * Returns authentication token provider previously registered by {@link #registerTokenUrl}.
+	 *
+	 * @param {String|Function} tokenUrl The authentication token URL for CKEditor Cloud Services or a callback to the token value promise.
+	 * @returns {module:cloud-services-core/token~Token}
+	 */
+	getTokenFor( tokenUrl ) {
+		const token = this._tokens.get( tokenUrl );
+
+		if ( !token ) {
+			/**
+			 * Provided `tokenUrl` was not registered by {@link module:cloud-services/cloudservices~CloudServices#registerTokenUrl}.
+			 *
+			 * @error cloudservices-token-not-registered
+			 */
+			throw new CKEditorError( 'cloudservices-token-not-registered', this );
+		}
+
+		return token;
 	}
 
 	/**
@@ -78,8 +139,8 @@ export default class CloudServices extends ContextPlugin {
 	destroy() {
 		super.destroy();
 
-		if ( this.token ) {
-			this.token.destroy();
+		for ( const token of this._tokens.values() ) {
+			token.destroy();
 		}
 	}
 }

--- a/packages/ckeditor5-cloud-services/tests/cloudservices.js
+++ b/packages/ckeditor5-cloud-services/tests/cloudservices.js
@@ -9,6 +9,7 @@ import CloudServices from '../src/cloudservices';
 import Context from '@ckeditor/ckeditor5-core/src/context';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import TokenMock from './_utils/tokenmock';
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 const Token = CloudServices.Token;
 
@@ -134,6 +135,106 @@ describe( 'CloudServices', () => {
 
 				return context.destroy();
 			} );
+		} );
+	} );
+
+	describe( 'registerTokenUrl()', () => {
+		it( 'should allow adding additional tokenUrl', async () => {
+			CloudServices.Token.initialToken = 'initial-token';
+
+			const context = await Context.create( {
+				plugins: [ CloudServices ],
+				cloudServices: {
+					tokenUrl: 'http://token-endpoint'
+				}
+			} );
+
+			CloudServices.Token.initialToken = 'another-token';
+
+			const cloudServicesPlugin = context.plugins.get( CloudServices );
+			const extraToken = await cloudServicesPlugin.registerTokenUrl( 'http://another-token-endpoint' );
+
+			expect( cloudServicesPlugin.token.value ).to.equal( 'initial-token' );
+			expect( extraToken.value ).to.equal( 'another-token' );
+
+			await context.destroy();
+		} );
+
+		it( 'should not allow overriding the default token', async () => {
+			CloudServices.Token.initialToken = 'initial-token';
+
+			const context = await Context.create( {
+				plugins: [ CloudServices ],
+				cloudServices: {
+					tokenUrl: 'http://token-endpoint'
+				}
+			} );
+
+			const cloudServicesPlugin = context.plugins.get( CloudServices );
+
+			expect( () => {
+				cloudServicesPlugin.registerTokenUrl( 'http://another-token-endpoint', true );
+			} ).to.throw(
+				CKEditorError,
+				'cloudservices-default-token-override'
+			);
+
+			await context.destroy();
+		} );
+
+		it( 'should return already registered token', async () => {
+			const context = await Context.create( {
+				plugins: [ CloudServices ],
+				cloudServices: {
+					tokenUrl: 'http://token-endpoint'
+				}
+			} );
+
+			const cloudServicesPlugin = context.plugins.get( CloudServices );
+			const token = await cloudServicesPlugin.registerTokenUrl( 'http://token-endpoint' );
+
+			expect( token ).to.equal( cloudServicesPlugin.token );
+
+			await context.destroy();
+		} );
+	} );
+
+	describe( 'getTokenFor()', () => {
+		it( 'should return token for registered tokenUrl', async () => {
+			const context = await Context.create( {
+				plugins: [ CloudServices ],
+				cloudServices: {
+					tokenUrl: 'http://token-endpoint'
+				}
+			} );
+
+			const cloudServicesPlugin = context.plugins.get( CloudServices );
+			const token = await cloudServicesPlugin.registerTokenUrl( 'http://token-endpoint' );
+			const token2 = cloudServicesPlugin.getTokenFor( 'http://token-endpoint' );
+
+			expect( token ).to.equal( token2 );
+
+			await context.destroy();
+		} );
+
+		it( 'should throw for not registered tokenUrl', async () => {
+			const context = await Context.create( {
+				plugins: [ CloudServices ],
+				cloudServices: {
+					tokenUrl: 'http://token-endpoint'
+				}
+			} );
+
+			const cloudServicesPlugin = context.plugins.get( CloudServices );
+
+			expect( () => {
+				cloudServicesPlugin.getTokenFor( 'http://another-token-endpoint' );
+			} ).to.throw(
+				CKEditorError,
+				'cloudservices-token-not-registered'
+			);
+
+			await context.destroy();
 		} );
 	} );
 

--- a/packages/ckeditor5-cloud-services/tests/cloudservices.js
+++ b/packages/ckeditor5-cloud-services/tests/cloudservices.js
@@ -160,28 +160,6 @@ describe( 'CloudServices', () => {
 			await context.destroy();
 		} );
 
-		it( 'should not allow overriding the default token', async () => {
-			CloudServices.Token.initialToken = 'initial-token';
-
-			const context = await Context.create( {
-				plugins: [ CloudServices ],
-				cloudServices: {
-					tokenUrl: 'http://token-endpoint'
-				}
-			} );
-
-			const cloudServicesPlugin = context.plugins.get( CloudServices );
-
-			expect( () => {
-				cloudServicesPlugin.registerTokenUrl( 'http://another-token-endpoint', true );
-			} ).to.throw(
-				CKEditorError,
-				'cloudservices-default-token-override'
-			);
-
-			await context.destroy();
-		} );
-
 		it( 'should return already registered token', async () => {
 			const context = await Context.create( {
 				plugins: [ CloudServices ],


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (cloud-services): CloudServices Plugin should allow for registering multiple token endpoints. 

---

### Additional information