### PR TITLE
Updated inverted theme.

### DIFF
--- a/packages/ckeditor5-theme-lark/docs/_snippets/examples/custom.css
+++ b/packages/ckeditor5-theme-lark/docs/_snippets/examples/custom.css
@@ -66,6 +66,9 @@
 	--ck-color-input-disabled-background: hsl(255, 4%, 21%);
 	--ck-color-input-disabled-border: hsl(250, 3%, 38%);
 	--ck-color-input-disabled-text: hsl(0, 0%, 78%);
+
+	/* -- Overrides the default .ck-labeled-field-view class colors. ---------------------------- */
+
 	--ck-color-labeled-field-label-background: var(--ck-custom-background);
 
 	/* -- Overrides the default .ck-list class colors. ------------------------------------------ */

--- a/packages/ckeditor5-theme-lark/docs/_snippets/examples/custom.css
+++ b/packages/ckeditor5-theme-lark/docs/_snippets/examples/custom.css
@@ -60,12 +60,13 @@
 
 	/* -- Overrides the default .ck-input class colors. ----------------------------------------- */
 
-	--ck-color-input-background: var(--ck-custom-foreground);
+	--ck-color-input-background: var(--ck-custom-background);
 	--ck-color-input-border: hsl(257, 3%, 43%);
 	--ck-color-input-text: hsl(0, 0%, 98%);
 	--ck-color-input-disabled-background: hsl(255, 4%, 21%);
 	--ck-color-input-disabled-border: hsl(250, 3%, 38%);
-	--ck-color-input-disabled-text: hsl(0, 0%, 46%);
+	--ck-color-input-disabled-text: hsl(0, 0%, 78%);
+	--ck-color-labeled-field-label-background: var(--ck-custom-background);
 
 	/* -- Overrides the default .ck-list class colors. ------------------------------------------ */
 

--- a/packages/ckeditor5-theme-lark/docs/framework/guides/theme-customization.md
+++ b/packages/ckeditor5-theme-lark/docs/framework/guides/theme-customization.md
@@ -126,12 +126,13 @@ The file containing custom variables will be named `custom.css` and it will look
 
 	/* -- Overrides the default .ck-input class colors. ----------------------------------------- */
 
-	--ck-color-input-background: var(--ck-custom-foreground);
+	--ck-color-input-background: var(--ck-custom-background);
 	--ck-color-input-border: hsl(257, 3%, 43%);
 	--ck-color-input-text: hsl(0, 0%, 98%);
 	--ck-color-input-disabled-background: hsl(255, 4%, 21%);
 	--ck-color-input-disabled-border: hsl(250, 3%, 38%);
-	--ck-color-input-disabled-text: hsl(0, 0%, 46%);
+	--ck-color-input-disabled-text: hsl(0, 0%, 78%);
+	--ck-color-labeled-field-label-background: var(--ck-custom-background);
 
 	/* -- Overrides the default .ck-list class colors. ------------------------------------------ */
 

--- a/packages/ckeditor5-theme-lark/docs/framework/guides/theme-customization.md
+++ b/packages/ckeditor5-theme-lark/docs/framework/guides/theme-customization.md
@@ -132,6 +132,9 @@ The file containing custom variables will be named `custom.css` and it will look
 	--ck-color-input-disabled-background: hsl(255, 4%, 21%);
 	--ck-color-input-disabled-border: hsl(250, 3%, 38%);
 	--ck-color-input-disabled-text: hsl(0, 0%, 78%);
+
+	/* -- Overrides the default .ck-labeled-field-view class colors. ---------------------------- */
+
 	--ck-color-labeled-field-label-background: var(--ck-custom-background);
 
 	/* -- Overrides the default .ck-list class colors. ------------------------------------------ */

--- a/packages/ckeditor5-theme-lark/tests/manual/inverted.html
+++ b/packages/ckeditor5-theme-lark/tests/manual/inverted.html
@@ -60,6 +60,9 @@
 		--ck-color-input-disabled-background: hsl(255, 4%, 21%);
 		--ck-color-input-disabled-border: hsl(250, 3%, 38%);
 		--ck-color-input-disabled-text: hsl(0, 0%, 78%);
+
+		/* -- Overrides the default .ck-labeled-field-view class colors. ---------------------------- */
+
 		--ck-color-labeled-field-label-background: var(--ck-custom-background);
 
 		/* -- Overrides the default .ck-list class colors ------------------------------------------- */

--- a/packages/ckeditor5-theme-lark/tests/manual/inverted.html
+++ b/packages/ckeditor5-theme-lark/tests/manual/inverted.html
@@ -54,12 +54,13 @@
 
 		/* -- Overrides the default .ck-input class colors ------------------------------------------ */
 
-		--ck-color-input-background: var(--ck-custom-foreground);
+		--ck-color-input-background: var(--ck-custom-background);
 		--ck-color-input-border: hsl(257, 3%, 43%);
 		--ck-color-input-text: hsl(0, 0%, 98%);
 		--ck-color-input-disabled-background: hsl(255, 4%, 21%);
 		--ck-color-input-disabled-border: hsl(250, 3%, 38%);
-		--ck-color-input-disabled-text: hsl(0, 0%, 46%);
+		--ck-color-input-disabled-text: hsl(0, 0%, 78%);
+		--ck-color-labeled-field-label-background: var(--ck-custom-background);
 
 		/* -- Overrides the default .ck-list class colors ------------------------------------------- */
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/labeledfield/labeledfieldview.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/labeledfield/labeledfieldview.css
@@ -9,6 +9,7 @@
 :root {
 	--ck-labeled-field-view-transition: .1s cubic-bezier(0, 0, 0.24, 0.95);
 	--ck-labeled-field-empty-unfocused-max-width: 100% - 2 * var(--ck-spacing-medium);
+	--ck-color-labeled-field-label-background: var(--ck-color-base-background);
 }
 
 .ck.ck-labeled-field-view {
@@ -34,7 +35,7 @@
 			/* By default, display the label scaled down above the field. */
 			transform: translate(var(--ck-spacing-medium), -6px) scale(.75);
 
-			background: var(--ck-color-base-background);
+			background: var(--ck-color-labeled-field-label-background);
 			padding: 0 calc(.5 * var(--ck-font-size-tiny));
 			line-height: initial;
 			font-weight: normal;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (theme-lark): Inverted theme should properly display labeled fields. Closes #8275.

---

### Additional information