### PR TITLE
Docs: edit incorrect tag name

### DIFF
--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/element-reconversion.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/element-reconversion.md
@@ -115,7 +115,7 @@ In this example implementation you will implement a "card" box which is displaye
 A simplified model markup for the side card looks as follows:
 
 ```html
-<sideCardSection cardType="info" cardURL="https://ckeditor.com/">
+<sideCard cardType="info" cardURL="https://ckeditor.com/">
 	<sideCardTitle>The title</sideCardTitle>
 	<sideCardSection>
 		<paragraph>The content</paragraph>


### PR DESCRIPTION


### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))


---

### Additional information

change from
`<sideCardSection cardType="info" cardURL="https://ckeditor.com/">...</sideCard>`
to
`<sideCard cardType="info" cardURL="https://ckeditor.com/">...</sideCard>`
