### PR TITLE
Expect autoformat delimiters to have a space character preceding them.

### DIFF
--- a/packages/ckeditor5-autoformat/src/autoformat.js
+++ b/packages/ckeditor5-autoformat/src/autoformat.js
@@ -80,8 +80,8 @@ export default class Autoformat extends Plugin {
 		if ( commands.get( 'bold' ) ) {
 			const boldCallback = getCallbackFunctionForInlineAutoformat( this.editor, 'bold' );
 
-			inlineAutoformatEditing( this.editor, this, /(\*\*)([^*]+)(\*\*)$/g, boldCallback );
-			inlineAutoformatEditing( this.editor, this, /(__)([^_]+)(__)$/g, boldCallback );
+			inlineAutoformatEditing( this.editor, this, /(?:^|\s)(\*\*)([^*]+)(\*\*)$/g, boldCallback );
+			inlineAutoformatEditing( this.editor, this, /(?:^|\s)(__)([^_]+)(__)$/g, boldCallback );
 		}
 
 		if ( commands.get( 'italic' ) ) {
@@ -89,8 +89,8 @@ export default class Autoformat extends Plugin {
 
 			// The italic autoformatter cannot be triggered by the bold markers, so we need to check the
 			// text before the pattern (e.g. `(?:^|[^\*])`).
-			inlineAutoformatEditing( this.editor, this, /(?:^|[^*])(\*)([^*_]+)(\*)$/g, italicCallback );
-			inlineAutoformatEditing( this.editor, this, /(?:^|[^_])(_)([^_]+)(_)$/g, italicCallback );
+			inlineAutoformatEditing( this.editor, this, /(?:^|\s)(\*)([^*_]+)(\*)$/g, italicCallback );
+			inlineAutoformatEditing( this.editor, this, /(?:^|\s)(_)([^_]+)(_)$/g, italicCallback );
 		}
 
 		if ( commands.get( 'code' ) ) {

--- a/packages/ckeditor5-autoformat/tests/autoformat.js
+++ b/packages/ckeditor5-autoformat/tests/autoformat.js
@@ -485,28 +485,64 @@ describe( 'Autoformat', () => {
 			expect( getData( model ) ).to.equal( '<paragraph>**foobar**[]</paragraph>' );
 		} );
 
+		describe( 'should not format', () => {
+			it( '* without space preceding it', () => {
+				setData( model, '<paragraph>fo*ob*ar[]</paragraph>' );
+
+				model.change( writer => {
+					writer.insertText( '*', doc.selection.getFirstPosition() );
+				} );
+
+				expect( getData( model ) ).to
+					.equal( '<paragraph>fo*ob*ar*[]</paragraph>' );
+			} );
+
+			it( '__ without space preceding it', () => {
+				setData( model, '<paragraph>fo__ob__ar_[]</paragraph>' );
+
+				model.change( writer => {
+					writer.insertText( '_', doc.selection.getFirstPosition() );
+				} );
+
+				expect( getData( model ) ).to
+					.equal( '<paragraph>fo__ob__ar__[]</paragraph>' );
+			} );
+
+			// https://github.com/ckeditor/ckeditor5/issues/2388
+			it( 'snake_case sentences', () => {
+				setData( model, '<paragraph>foo_bar baz[]</paragraph>' );
+
+				model.change( writer => {
+					writer.insertText( '_', doc.selection.getFirstPosition() );
+				} );
+
+				expect( getData( model ) ).to
+					.equal( '<paragraph>foo_bar baz_[]</paragraph>' );
+			} );
+		} );
+
 		describe( 'with code element', () => {
 			describe( 'should not format (inside)', () => {
 				it( '* inside', () => {
-					setData( model, '<paragraph><$text code="true">fo*obar[]</$text></paragraph>' );
+					setData( model, '<paragraph><$text code="true">fo *obar[]</$text></paragraph>' );
 
 					model.change( writer => {
 						writer.insertText( '*', { code: true }, doc.selection.getFirstPosition() );
 					} );
 
 					expect( getData( model ) ).to
-						.equal( '<paragraph><$text code="true">fo*obar*[]</$text></paragraph>' );
+						.equal( '<paragraph><$text code="true">fo *obar*[]</$text></paragraph>' );
 				} );
 
 				it( '__ inside', () => {
-					setData( model, '<paragraph><$text code="true">fo__obar_[]</$text></paragraph>' );
+					setData( model, '<paragraph><$text code="true">fo __obar_[]</$text></paragraph>' );
 
 					model.change( writer => {
 						writer.insertText( '_', { code: true }, doc.selection.getFirstPosition() );
 					} );
 
 					expect( getData( model ) ).to
-						.equal( '<paragraph><$text code="true">fo__obar__[]</$text></paragraph>' );
+						.equal( '<paragraph><$text code="true">fo __obar__[]</$text></paragraph>' );
 				} );
 
 				it( '~~ inside', () => {
@@ -534,24 +570,24 @@ describe( 'Autoformat', () => {
 
 			describe( 'should not format (across)', () => {
 				it( '* across', () => {
-					setData( model, '<paragraph><$text code="true">fo*o</$text>bar[]</paragraph>' );
+					setData( model, '<paragraph><$text code="true">fo *o</$text>bar[]</paragraph>' );
 
 					model.change( writer => {
 						writer.insertText( '*', doc.selection.getFirstPosition() );
 					} );
 
 					expect( getData( model ) ).to
-						.equal( '<paragraph><$text code="true">fo*o</$text>bar*[]</paragraph>' );
+						.equal( '<paragraph><$text code="true">fo *o</$text>bar*[]</paragraph>' );
 				} );
 				it( '__ across', () => {
-					setData( model, '<paragraph><$text code="true">fo__o</$text>bar_[]</paragraph>' );
+					setData( model, '<paragraph><$text code="true">fo __o</$text>bar_[]</paragraph>' );
 
 					model.change( writer => {
 						writer.insertText( '_', doc.selection.getFirstPosition() );
 					} );
 
 					expect( getData( model ) ).to
-						.equal( '<paragraph><$text code="true">fo__o</$text>bar__[]</paragraph>' );
+						.equal( '<paragraph><$text code="true">fo __o</$text>bar__[]</paragraph>' );
 				} );
 				it( '~~ across', () => {
 					setData( model, '<paragraph><$text code="true">fo~~o</$text>bar~[]</paragraph>' );
@@ -577,24 +613,24 @@ describe( 'Autoformat', () => {
 
 			describe( 'should format', () => {
 				it( '* after', () => {
-					setData( model, '<paragraph><$text code="true">fo*o</$text>b*ar[]</paragraph>' );
+					setData( model, '<paragraph><$text code="true">fo*o</$text>b *ar[]</paragraph>' );
 
 					model.change( writer => {
 						writer.insertText( '*', doc.selection.getFirstPosition() );
 					} );
 
 					expect( getData( model ) ).to
-						.equal( '<paragraph><$text code="true">fo*o</$text>b<$text italic="true">ar</$text>[]</paragraph>' );
+						.equal( '<paragraph><$text code="true">fo*o</$text>b <$text italic="true">ar</$text>[]</paragraph>' );
 				} );
 				it( '__ after', () => {
-					setData( model, '<paragraph><$text code="true">fo__o</$text>b__ar_[]</paragraph>' );
+					setData( model, '<paragraph><$text code="true">fo__o</$text>b __ar_[]</paragraph>' );
 
 					model.change( writer => {
 						writer.insertText( '_', doc.selection.getFirstPosition() );
 					} );
 
 					expect( getData( model ) ).to
-						.equal( '<paragraph><$text code="true">fo__o</$text>b<$text bold="true">ar</$text>[]</paragraph>' );
+						.equal( '<paragraph><$text code="true">fo__o</$text>b <$text bold="true">ar</$text>[]</paragraph>' );
 				} );
 				it( '~~ after', () => {
 					setData( model, '<paragraph><$text code="true">fo~~o</$text>b~~ar~[]</paragraph>' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (autoformat): Formatting will not be applied to snake_case anymore. Closes #2388.
