### PR TITLE
Docs: adding services to MathType guide.

### DIFF
--- a/docs/features/math-equations.md
+++ b/docs/features/math-equations.md
@@ -72,7 +72,7 @@ ClassicEditor
 
 ## Customizing MathType service
 
-It is possible to use different services for MathType support. There are several ways to deploy it in the CKEditor 5 framework environment. The following instructions will allow you to customize MathType Web Integration services CKEditor 5.
+It is possible to use different services for MathType support. There are several ways to deploy it in the CKEditor 5 framework environment. The following instructions will allow you to customize MathType Web Integration services for CKEditor 5.
 
 ### Java
 
@@ -82,7 +82,7 @@ To install the Java services follow the steps below:
 
 2. Deploy the **pluginwiris_engine war** file.
 
-3. #Add `mathTypeParameters` to CKEditor5 with the below configuration:
+3. Add `mathTypeParameters` to CKEditor5 with the configuration shown below:
 
     ```js
     ClassicEditor.create( document.querySelector( '#example' ), {
@@ -112,9 +112,9 @@ To install the PHP services follow the steps below:
 
 1. Download the [MathType Web Integration Services - PHP](http://www.wiris.com/en/plugins/services/download) package.
 
-2. Copy the generic_wiris/integration folder into your project. For this example we are assuming that the services are located at DOCUMENT_ROOT/php-services/
+2. Copy the **generic_wiris/integration** folder into your project. For this example we are assuming that the services are located at *DOCUMENT_ROOT/php-services/*
 
-3. #Add `mathTypeParameters` to CKEditor5 with the below configuration:
+3. Add `mathTypeParameters` to CKEditor5 with the following configuration:
 
     ```js
     ClassicEditor.create( document.querySelector( '#example' ), {
@@ -144,9 +144,9 @@ To install the PHP services follow the steps below:
 
 1. Download the [MathType Web Integration Services - Aspx](http://www.wiris.com/en/plugins/services/download) package.
 
-2. Copy the generic_wiris/integration folder into your project. For this example we are assuming that the services are located at DOCUMENT_ROOT/aspx-services/
+2. Copy the **generic_wiris/integration** folder into your project. For this example we are assuming that the services are located at *DOCUMENT_ROOT/aspx-services/*
 
-3. #Add `mathTypeParameters` to CKEditor5 with the below configuration:
+3. Add `mathTypeParameters` to CKEditor5 with this configuration:
 
     ```js
     ClassicEditor.create( document.querySelector( '#example' ), {
@@ -181,7 +181,9 @@ To install the Ruby on Rails services follow the steps below:
     ```
         gem install -l wirispluginengine.gem
     ```
-3. #Add `mathTypeParameters` to CKEditor5 with the below configuration:
+
+3. Add `mathTypeParameters` to CKEditor5 with the configuration below:
+
 
     ```js
     ClassicEditor.create( document.querySelector( '#example' ), {

--- a/docs/features/math-equations.md
+++ b/docs/features/math-equations.md
@@ -69,3 +69,138 @@ ClassicEditor
 <info-box info>
 	Read more about {@link builds/guides/integration/installing-plugins installing plugins}.
 </info-box>
+
+## Customizing MathType service
+
+It is possible to use different services for MathType support. There are several ways to deploy it in the CKEditor 5 framework environment. The following instructions will allow you to customize MathType Web Integration services CKEditor 5.
+
+### Java
+
+To install the Java services follow the steps below:
+
+1. Download the [MathType Web Integration Services - Java](http://www.wiris.com/en/plugins/services/download) package.
+
+2. Deploy the **pluginwiris_engine war** file.
+
+3. #Add `mathTypeParameters` to CKEditor5 with the below configuration:
+
+    ```js
+    ClassicEditor.create( document.querySelector( '#example' ), {
+            plugins: [ ..., MathType, ... ],
+            toolbar: {
+                items: [
+                    ...,
+                    'MathType',
+                    'ChemType',
+                    ...,
+                ]
+            },
+            language: 'en',
+            // MathType Parameters
+            mathTypeParameters : {
+                serviceProviderProperties : {
+                    URI : '/pluginwiris_engine/app/configurationjs',
+                    server : 'java'
+                }
+            }
+    }
+    ```
+
+### PHP
+
+To install the PHP services follow the steps below:
+
+1. Download the [MathType Web Integration Services - PHP](http://www.wiris.com/en/plugins/services/download) package.
+
+2. Copy the generic_wiris/integration folder into your project. For this example we are assuming that the services are located at DOCUMENT_ROOT/php-services/
+
+3. #Add `mathTypeParameters` to CKEditor5 with the below configuration:
+
+    ```js
+    ClassicEditor.create( document.querySelector( '#example' ), {
+            plugins: [ ..., MathType, ... ],
+            toolbar: {
+                items: [
+                    ...,
+                    'MathType',
+                    'ChemType',
+                    ...,
+                ]
+            },
+            language: 'en',
+            // MathType Parameters
+            mathTypeParameters : {
+                serviceProviderProperties : {
+                    URI : 'http://localhost/php-services/integration',
+                    server : 'php'
+                }
+            }
+    }
+    ```
+
+### .NET
+
+To install the PHP services follow the steps below:
+
+1. Download the [MathType Web Integration Services - Aspx](http://www.wiris.com/en/plugins/services/download) package.
+
+2. Copy the generic_wiris/integration folder into your project. For this example we are assuming that the services are located at DOCUMENT_ROOT/aspx-services/
+
+3. #Add `mathTypeParameters` to CKEditor5 with the below configuration:
+
+    ```js
+    ClassicEditor.create( document.querySelector( '#example' ), {
+            plugins: [ ..., MathType, ... ],
+            toolbar: {
+                items: [
+                    ...,
+                    'MathType',
+                    'ChemType',
+                    ...,
+                ]
+            },
+            language: 'en',
+            // MathType Parameters
+            mathTypeParameters : {
+                serviceProviderProperties : {
+                    URI : 'http://localhost/aspx-services/integration',
+                    server : 'aspx'
+                }
+            }
+    }
+    ```
+
+### Ruby on Rails
+
+To install the Ruby on Rails services follow the steps below:
+
+1. Download the [MathType Web Integration Services - Ruby on Rails](http://www.wiris.com/en/plugins/services/download) package.
+
+2. Instal the **wirispluginengine.gem** gem.
+
+    ```
+        gem install -l wirispluginengine.gem
+    ```
+3. #Add `mathTypeParameters` to CKEditor5 with the below configuration:
+
+    ```js
+    ClassicEditor.create( document.querySelector( '#example' ), {
+            plugins: [ ..., MathType, ... ],
+            toolbar: {
+                items: [
+                    ...,
+                    'MathType',
+                    'ChemType',
+                    ...,
+                ]
+            },
+            language: 'en',
+            // MathType Parameters
+            mathTypeParameters : {
+                serviceProviderProperties : {
+                    URI : '/wirispluginengine/integrationn',
+                    server : 'ruby'
+                }
+            }
+    }
+    ```

--- a/docs/features/math-equations.md
+++ b/docs/features/math-equations.md
@@ -72,11 +72,11 @@ ClassicEditor
 
 ## Customizing MathType service
 
-It is possible to use different services for MathType support. There are several ways to deploy it in the CKEditor 5 framework environment. The following instructions will allow you to customize MathType Web Integration services for CKEditor 5.
+It is possible to use different services for MathType support. There are several ways to deploy it in the CKEditor 5 environment. The following instructions will allow you to customize MathType Web Integration services for CKEditor 5.
 
 ### Java
 
-To install the Java services follow the steps below:
+To install the Java service follow the steps below:
 
 1. Download the [MathType Web Integration Services - Java](http://www.wiris.com/en/plugins/services/download) package.
 
@@ -108,11 +108,11 @@ To install the Java services follow the steps below:
 
 ### PHP
 
-To install the PHP services follow the steps below:
+To install the PHP service follow the steps below:
 
 1. Download the [MathType Web Integration Services - PHP](http://www.wiris.com/en/plugins/services/download) package.
 
-2. Copy the **generic_wiris/integration** folder into your project. For this example we are assuming that the services are located at *DOCUMENT_ROOT/php-services/*
+2. Copy the **generic_wiris/integration** folder into your project. In this example it was assumed the services are located at *DOCUMENT_ROOT/php-services/*
 
 3. Add `mathTypeParameters` to CKEditor5 with the following configuration:
 
@@ -140,11 +140,11 @@ To install the PHP services follow the steps below:
 
 ### .NET
 
-To install the PHP services follow the steps below:
+To install the .NET service follow the steps below:
 
 1. Download the [MathType Web Integration Services - Aspx](http://www.wiris.com/en/plugins/services/download) package.
 
-2. Copy the **generic_wiris/integration** folder into your project. For this example we are assuming that the services are located at *DOCUMENT_ROOT/aspx-services/*
+2. Copy the **generic_wiris/integration** folder into your project. In this example it was assumed the services are located at *DOCUMENT_ROOT/aspx-services/*
 
 3. Add `mathTypeParameters` to CKEditor5 with this configuration:
 
@@ -172,7 +172,7 @@ To install the PHP services follow the steps below:
 
 ### Ruby on Rails
 
-To install the Ruby on Rails services follow the steps below:
+To install the Ruby on Rails service follow the steps below:
 
 1. Download the [MathType Web Integration Services - Ruby on Rails](http://www.wiris.com/en/plugins/services/download) package.
 


### PR DESCRIPTION
Closes #6054.

Adding install informations for Java, PHP, .NET and RoR services to the MathType guide.