### PR TITLE
Improvements in chat with mentions

### DIFF
--- a/packages/ckeditor5-mention/docs/_snippets/examples/chat-with-mentions.html
+++ b/packages/ckeditor5-mention/docs/_snippets/examples/chat-with-mentions.html
@@ -119,6 +119,10 @@
 		border-top-right-radius: 0;
 	}
 
+	.chat .chat__editor.highlighted + .ck.ck-editor .ck-content {
+		animation: highlight 600ms ease-out;
+	}
+
 	/* ---- In–editor mention list --------------------------------------------------------------- */
 
 	.ck-mentions .mention__item {

--- a/packages/ckeditor5-mention/docs/_snippets/examples/chat-with-mentions.html
+++ b/packages/ckeditor5-mention/docs/_snippets/examples/chat-with-mentions.html
@@ -119,7 +119,7 @@
 		border-top-right-radius: 0;
 	}
 
-	.chat .chat__editor.highlighted + .ck.ck-editor .ck-content {
+	.chat .chat__editor + .ck.ck-editor .ck-content.highlighted {
 		animation: highlight 600ms ease-out;
 	}
 

--- a/packages/ckeditor5-mention/docs/_snippets/examples/chat-with-mentions.js
+++ b/packages/ckeditor5-mention/docs/_snippets/examples/chat-with-mentions.js
@@ -81,10 +81,14 @@ ClassicEditor
 			if ( !message ) {
 				editingView.change( writer => {
 					writer.addClass( 'highlighted', rootElement );
-					setTimeout( () => writer.removeClass( 'highlighted', rootElement ), 650 );
-
 					editingView.focus();
 				} );
+
+				setTimeout( () => {
+					editingView.change( writer => {
+						writer.removeClass( 'highlighted', rootElement );
+					} );
+				}, 650 );
 
 				return;
 			}

--- a/packages/ckeditor5-mention/docs/_snippets/examples/chat-with-mentions.js
+++ b/packages/ckeditor5-mention/docs/_snippets/examples/chat-with-mentions.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals console, window, document */
+/* globals console, window, document, setTimeout */
 
 import ClassicEditor from '@ckeditor/ckeditor5-build-classic/src/ckeditor';
 import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
@@ -73,6 +73,19 @@ ClassicEditor
 		// Clone the first message in the chat when "Send" is clicked, fill it with new data
 		// and append to the chat list.
 		document.querySelector( '.chat-send' ).addEventListener( 'click', () => {
+			const message = editor.getData();
+
+			if ( !message ) {
+				const editorContainer = editor.sourceElement;
+
+				editor.editing.view.focus();
+
+				editorContainer.classList.add( 'highlighted' );
+				setTimeout( () => editorContainer.classList.remove( 'highlighted' ), 650 );
+
+				return;
+			}
+
 			const clone = document.querySelector( '.chat__posts li' ).cloneNode( true );
 
 			clone.classList.add( 'new-post' );
@@ -85,9 +98,12 @@ ClassicEditor
 			mailtoUser.href = 'mailto:info@cksource.com';
 
 			clone.querySelector( '.chat__posts__post__time' ).textContent = 'just now';
-			clone.querySelector( '.chat__posts__post__content' ).innerHTML = editor.getData();
+			clone.querySelector( '.chat__posts__post__content' ).innerHTML = message;
 
 			document.querySelector( '.chat__posts' ).appendChild( clone );
+
+			editor.setData( '' );
+			editor.editing.view.focus();
 		} );
 	} )
 	.catch( err => {

--- a/packages/ckeditor5-mention/docs/_snippets/examples/chat-with-mentions.js
+++ b/packages/ckeditor5-mention/docs/_snippets/examples/chat-with-mentions.js
@@ -68,6 +68,9 @@ ClassicEditor
 		}
 	} )
 	.then( editor => {
+		const editingView = editor.editing.view;
+		const rootElement = editingView.document.getRoot();
+
 		window.editor = editor;
 
 		// Clone the first message in the chat when "Send" is clicked, fill it with new data
@@ -76,12 +79,12 @@ ClassicEditor
 			const message = editor.getData();
 
 			if ( !message ) {
-				const editorContainer = editor.sourceElement;
+				editingView.change( writer => {
+					writer.addClass( 'highlighted', rootElement );
+					setTimeout( () => writer.removeClass( 'highlighted', rootElement ), 650 );
 
-				editor.editing.view.focus();
-
-				editorContainer.classList.add( 'highlighted' );
-				setTimeout( () => editorContainer.classList.remove( 'highlighted' ), 650 );
+					editingView.focus();
+				} );
 
 				return;
 			}
@@ -103,7 +106,7 @@ ClassicEditor
 			document.querySelector( '.chat__posts' ).appendChild( clone );
 
 			editor.setData( '' );
-			editor.editing.view.focus();
+			editingView.focus();
 		} );
 	} )
 	.catch( err => {

--- a/packages/ckeditor5-mention/docs/examples/chat-with-mentions.md
+++ b/packages/ckeditor5-mention/docs/examples/chat-with-mentions.md
@@ -141,6 +141,10 @@ The HTML code of the application is listed below:
 		border-top-right-radius: 0;
 	}
 
+	.chat .chat__editor + .ck.ck-editor .ck-content.highlighted {
+		animation: highlight 600ms ease-out;
+	}
+
 	/* ---- In–editor mention list --------------------------------------------------------------- */
 
 	.ck-mentions .mention__item {
@@ -249,11 +253,27 @@ ClassicEditor
 		}
 	} )
 	.then( editor => {
+		const editingView = editor.editing.view;
+		const rootElement = editingView.document.getRoot();
+
 		window.editor = editor;
 
 		// Clone the first message in the chat when "Send" is clicked, fill it with new data
 		// and append to the chat list.
 		document.querySelector( '.chat-send' ).addEventListener( 'click', () => {
+			const message = editor.getData();
+
+			if ( !message ) {
+				editingView.change( writer => {
+					writer.addClass( 'highlighted', rootElement );
+					setTimeout( () => writer.removeClass( 'highlighted', rootElement ), 650 );
+
+					editingView.focus();
+				} );
+
+				return;
+			}
+
 			const clone = document.querySelector( '.chat__posts li' ).cloneNode( true );
 
 			clone.classList.add( 'new-post' );
@@ -266,9 +286,12 @@ ClassicEditor
 			mailtoUser.href = 'mailto:info@cksource.com';
 
 			clone.querySelector( '.chat__posts__post__time' ).textContent = 'just now';
-			clone.querySelector( '.chat__posts__post__content' ).innerHTML = editor.getData();
+			clone.querySelector( '.chat__posts__post__content' ).innerHTML = message;
 
 			document.querySelector( '.chat__posts' ).appendChild( clone );
+
+			editor.setData( '' );
+			editingView.focus();
 		} );
 	} )
 	.catch( err => {

--- a/packages/ckeditor5-mention/docs/examples/chat-with-mentions.md
+++ b/packages/ckeditor5-mention/docs/examples/chat-with-mentions.md
@@ -266,10 +266,14 @@ ClassicEditor
 			if ( !message ) {
 				editingView.change( writer => {
 					writer.addClass( 'highlighted', rootElement );
-					setTimeout( () => writer.removeClass( 'highlighted', rootElement ), 650 );
-
 					editingView.focus();
 				} );
+
+				setTimeout( () => {
+					editingView.change( writer => {
+						writer.removeClass( 'highlighted', rootElement );
+					} );
+				}, 650 );
 
 				return;
 			}

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.js
@@ -287,11 +287,13 @@ export default class ToolbarView extends View {
 			} else if ( name == '-' ) {
 				if ( this.options.shouldGroupWhenFull ) {
 					/**
-					 * Toolbar line breaks can only work the when the automatic button grouping is disabled in the toolbar configuration.
+					 * Toolbar line breaks (`-` items) can only work when the automatic button grouping
+					 * is disabled in the toolbar configuration.
 					 * To do this, set the `shouldNotGroupWhenFull` option to `true` in the editor configuration:
 					 *
 					 *		const config = {
 					 *			toolbar: {
+					 *				items: [ ... ],
 					 *				shouldNotGroupWhenFull: true
 					 *			}
 					 *		}


### PR DESCRIPTION
Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (mention): Clearing up and focusing the editor after sending a message, preventing the empty message from being sent. Closes #8147.