### PR TITLE
Items baked into editor build can be removed from the toolbar now.

### DIFF
--- a/docs/_snippets/examples/multi-root-editor.js
+++ b/docs/_snippets/examples/multi-root-editor.js
@@ -285,7 +285,7 @@ class MultirootEditorUI extends EditorUI {
 		const view = this.view;
 		const toolbar = view.toolbar;
 
-		toolbar.fillFromConfig( this._toolbarConfig.items, this.componentFactory );
+		toolbar.fillFromConfig( this._toolbarConfig, this.componentFactory );
 
 		enableToolbarKeyboardFocus( {
 			origin: editor.editing.view,

--- a/docs/_snippets/examples/multi-root-editor.js
+++ b/docs/_snippets/examples/multi-root-editor.js
@@ -14,7 +14,6 @@ import setDataInElement from '@ckeditor/ckeditor5-utils/src/dom/setdatainelement
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import EditorUI from '@ckeditor/ckeditor5-core/src/editor/editorui';
 import enableToolbarKeyboardFocus from '@ckeditor/ckeditor5-ui/src/toolbar/enabletoolbarkeyboardfocus';
-import normalizeToolbarConfig from '@ckeditor/ckeditor5-ui/src/toolbar/normalizetoolbarconfig';
 import { enablePlaceholder } from '@ckeditor/ckeditor5-engine/src/view/placeholder';
 import EditorUIView from '@ckeditor/ckeditor5-ui/src/editorui/editoruiview';
 import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/inlineeditableuiview';
@@ -159,14 +158,6 @@ class MultirootEditorUI extends EditorUI {
 		 * @member {module:ui/editorui/editoruiview~EditorUIView} #view
 		 */
 		this.view = view;
-
-		/**
-		 * A normalized `config.toolbar` object.
-		 *
-		 * @type {Object}
-		 * @private
-		 */
-		this._toolbarConfig = normalizeToolbarConfig( editor.config.get( 'toolbar' ) );
 	}
 
 	/**
@@ -285,7 +276,7 @@ class MultirootEditorUI extends EditorUI {
 		const view = this.view;
 		const toolbar = view.toolbar;
 
-		toolbar.fillFromConfig( this._toolbarConfig, this.componentFactory );
+		toolbar.fillFromConfig( editor.config.get( 'toolbar' ), this.componentFactory );
 
 		enableToolbarKeyboardFocus( {
 			origin: editor.editing.view,

--- a/docs/builds/guides/integration/configuration.md
+++ b/docs/builds/guides/integration/configuration.md
@@ -51,7 +51,7 @@ ClassicEditor
 	} );
 ```
 <info-box>
-	Be careful when removing plugins from CKEditor builds using `config.removePlugins`. If removed plugins were providing toolbar buttons, the default toolbar configuration included in a build will become invalid. In such case you need to provide the {@link features/toolbar updated toolbar configuration} as in the example above.
+	Be careful when removing plugins from CKEditor builds using `config.removePlugins`. If removed plugins were providing toolbar buttons, the default toolbar configuration included in a build will become invalid. In such case you need to provide the {@link features/toolbar updated toolbar configuration} as in the example above or by providing only items that need to be removed using `config.toolbar.removeItems`.
 </info-box>
 
 ### List of plugins

--- a/docs/features/toolbar.md
+++ b/docs/features/toolbar.md
@@ -71,6 +71,8 @@ toolbar: {
 
  * **`items`** &ndash; An array of toolbar item names. Most of the components (buttons, dropdowns, etc.) which can be used as toolbar items are described under the {@link features/index Features} tab. A full list is defined in {@link module:ui/componentfactory~ComponentFactory editor.ui.componentFactory} and can be listed using the following snippet: `Array.from( editor.ui.componentFactory.names() )`. Besides button names, you can also use the dedicated separators for toolbar groups (`'|'`) and toolbar lines (`'-'`).
 
+ * **`removeItems`** &ndash; An array of toolbar item names. With this setting you can modify the default toolbar items of a bundle without the need of recreating it from scratch. If, after removing an item, toolbar will have two or more consecutive separators (`'|'`), the duplicates will be removed automatically.
+
  * **`viewportTopOffset`** &ndash; The offset (in pixels) from the top of the viewport used when positioning a sticky toolbar. Useful when a page with which the editor is being integrated has some other sticky or fixed elements (e.g. the top menu). Thanks to setting the toolbar offset, the toolbar will not be positioned underneath or above the page's UI.
 
  * **`shouldNotGroupWhenFull`** &ndash; When set to `true`, the toolbar will stop grouping items and let them wrap to the next line when there is not enough space to display them in a single row. This setting is `false` by default, which enables items grouping.

--- a/docs/features/toolbar.md
+++ b/docs/features/toolbar.md
@@ -71,7 +71,7 @@ toolbar: {
 
  * **`items`** &ndash; An array of toolbar item names. Most of the components (buttons, dropdowns, etc.) which can be used as toolbar items are described under the {@link features/index Features} tab. A full list is defined in {@link module:ui/componentfactory~ComponentFactory editor.ui.componentFactory} and can be listed using the following snippet: `Array.from( editor.ui.componentFactory.names() )`. Besides button names, you can also use the dedicated separators for toolbar groups (`'|'`) and toolbar lines (`'-'`).
 
- * **`removeItems`** &ndash; An array of toolbar item names. With this setting you can modify the default toolbar items of a bundle without the need of recreating it from scratch. If, after removing an item, toolbar will have two or more consecutive separators (`'|'`), the duplicates will be removed automatically.
+ * **`removeItems`** &ndash; An array of toolbar item names. With this setting you can modify the default toolbar configuration without the need of defining the entire list (you can specify a couple of buttons that you want to remove instead of specifying all the buttons you want to keep). If, after removing an item, toolbar will have two or more consecutive separators (`'|'`), the duplicates will be removed automatically.
 
  * **`viewportTopOffset`** &ndash; The offset (in pixels) from the top of the viewport used when positioning a sticky toolbar. Useful when a page with which the editor is being integrated has some other sticky or fixed elements (e.g. the top menu). Thanks to setting the toolbar offset, the toolbar will not be positioned underneath or above the page's UI.
 

--- a/docs/framework/guides/custom-editor-creator.md
+++ b/docs/framework/guides/custom-editor-creator.md
@@ -126,7 +126,6 @@ The `*EditorUI` class is the main UI class which initializes UI components (the 
 ```js
 import EditorUI from '@ckeditor/ckeditor5-core/src/editor/editorui';
 import enableToolbarKeyboardFocus from '@ckeditor/ckeditor5-ui/src/toolbar/enabletoolbarkeyboardfocus';
-import normalizeToolbarConfig from '@ckeditor/ckeditor5-ui/src/toolbar/normalizetoolbarconfig';
 import { enablePlaceholder } from '@ckeditor/ckeditor5-engine/src/view/placeholder';
 
 /**
@@ -151,14 +150,6 @@ class MultirootEditorUI extends EditorUI {
 		 * @member {module:ui/editorui/editoruiview~EditorUIView} #view
 		 */
 		this.view = view;
-
-		/**
-		 * A normalized `config.toolbar` object.
-		 *
-		 * @type {Object}
-		 * @private
-		 */
-		this._toolbarConfig = normalizeToolbarConfig( editor.config.get( 'toolbar' ) );
 	}
 
 	/**
@@ -276,7 +267,7 @@ class MultirootEditorUI extends EditorUI {
 		const view = this.view;
 		const toolbar = view.toolbar;
 
-		toolbar.fillFromConfig( this._toolbarConfig.items, this.componentFactory );
+		toolbar.fillFromConfig( editor.config.get( 'toolbar' ), this.componentFactory );
 
 		enableToolbarKeyboardFocus( {
 			origin: editor.editing.view,

--- a/packages/ckeditor5-build-classic/tests/ckeditor.js
+++ b/packages/ckeditor5-build-classic/tests/ckeditor.js
@@ -200,6 +200,21 @@ describe( 'ClassicEditor build', () => {
 					expect( editor.ui.view.stickyPanel.viewportTopOffset ).to.equal( 42 );
 				} );
 		} );
+
+		it( 'allows removing built-in toolbar items', () => {
+			return ClassicEditor
+				.create( editorElement, {
+					toolbar: {
+						removeItems: [ 'italic' ]
+					}
+				} )
+				.then( newEditor => {
+					editor = newEditor;
+
+					expect( editor.ui.view.toolbar.items.length ).to.equal( 16 );
+					expect( editor.ui.view.toolbar.items.find( item => item.label === 'Italic' ) ).to.be.undefined;
+				} );
+		} );
 	} );
 
 	describeMemoryUsage( () => {

--- a/packages/ckeditor5-editor-classic/src/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/src/classiceditorui.js
@@ -148,7 +148,7 @@ export default class ClassicEditorUI extends EditorUI {
 			view.stickyPanel.viewportTopOffset = this._toolbarConfig.viewportTopOffset;
 		}
 
-		view.toolbar.fillFromConfig( this._toolbarConfig.items, this.componentFactory );
+		view.toolbar.fillFromConfig( this._toolbarConfig, this.componentFactory );
 
 		enableToolbarKeyboardFocus( {
 			origin: editingView,

--- a/packages/ckeditor5-editor-classic/tests/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditorui.js
@@ -198,6 +198,24 @@ describe( 'ClassicEditorUI', () => {
 							return editor.destroy();
 						} );
 				} );
+
+				it( 'can be removed using config.toolbar.removeItems', () => {
+					return VirtualClassicTestEditor
+						.create( '', {
+							toolbar: {
+								items: [ 'foo', 'bar' ],
+								removeItems: [ 'bar' ]
+							}
+						} )
+						.then( editor => {
+							const items = editor.ui.view.toolbar.items;
+
+							expect( items.get( 0 ).name ).to.equal( 'foo' );
+							expect( items.length ).to.equal( 1 );
+
+							return editor.destroy();
+						} );
+				} );
 			} );
 		} );
 

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitorui.js
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitorui.js
@@ -9,7 +9,6 @@
 
 import EditorUI from '@ckeditor/ckeditor5-core/src/editor/editorui';
 import enableToolbarKeyboardFocus from '@ckeditor/ckeditor5-ui/src/toolbar/enabletoolbarkeyboardfocus';
-import normalizeToolbarConfig from '@ckeditor/ckeditor5-ui/src/toolbar/normalizetoolbarconfig';
 import { enablePlaceholder } from '@ckeditor/ckeditor5-engine/src/view/placeholder';
 
 /**
@@ -34,14 +33,6 @@ export default class DecoupledEditorUI extends EditorUI {
 		 * @member {module:ui/editorui/editoruiview~EditorUIView} #view
 		 */
 		this.view = view;
-
-		/**
-		 * A normalized `config.toolbar` object.
-		 *
-		 * @type {Object}
-		 * @private
-		 */
-		this._toolbarConfig = normalizeToolbarConfig( editor.config.get( 'toolbar' ) );
 	}
 
 	/**
@@ -114,7 +105,7 @@ export default class DecoupledEditorUI extends EditorUI {
 		const view = this.view;
 		const toolbar = view.toolbar;
 
-		toolbar.fillFromConfig( this._toolbarConfig, this.componentFactory );
+		toolbar.fillFromConfig( editor.config.get( 'toolbar' ), this.componentFactory );
 
 		enableToolbarKeyboardFocus( {
 			origin: editor.editing.view,

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitorui.js
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitorui.js
@@ -114,7 +114,7 @@ export default class DecoupledEditorUI extends EditorUI {
 		const view = this.view;
 		const toolbar = view.toolbar;
 
-		toolbar.fillFromConfig( this._toolbarConfig.items, this.componentFactory );
+		toolbar.fillFromConfig( this._toolbarConfig, this.componentFactory );
 
 		enableToolbarKeyboardFocus( {
 			origin: editor.editing.view,

--- a/packages/ckeditor5-editor-decoupled/tests/decouplededitorui.js
+++ b/packages/ckeditor5-editor-decoupled/tests/decouplededitorui.js
@@ -170,6 +170,24 @@ describe( 'DecoupledEditorUI', () => {
 							return editor.destroy();
 						} );
 				} );
+
+				it( 'can be removed using config.toolbar.removeItems', () => {
+					return VirtualDecoupledTestEditor
+						.create( '', {
+							toolbar: {
+								items: [ 'foo', 'bar' ],
+								removeItems: [ 'bar' ]
+							}
+						} )
+						.then( editor => {
+							const items = editor.ui.view.toolbar.items;
+
+							expect( items.get( 0 ).name ).to.equal( 'foo' );
+							expect( items.length ).to.equal( 1 );
+
+							return editor.destroy();
+						} );
+				} );
 			} );
 		} );
 

--- a/packages/ckeditor5-editor-inline/src/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/src/inlineeditorui.js
@@ -142,7 +142,7 @@ export default class InlineEditorUI extends EditorUI {
 			}
 		} );
 
-		toolbar.fillFromConfig( this._toolbarConfig.items, this.componentFactory );
+		toolbar.fillFromConfig( this._toolbarConfig, this.componentFactory );
 
 		enableToolbarKeyboardFocus( {
 			origin: editingView,

--- a/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
@@ -223,6 +223,24 @@ describe( 'InlineEditorUI', () => {
 						return editor.destroy();
 					} );
 			} );
+
+			it( 'can be removed using config.toolbar.removeItems', () => {
+				return VirtualInlineTestEditor
+					.create( '', {
+						toolbar: {
+							items: [ 'foo', 'bar' ],
+							removeItems: [ 'bar' ]
+						}
+					} )
+					.then( editor => {
+						const items = editor.ui.view.toolbar.items;
+
+						expect( items.get( 0 ).name ).to.equal( 'foo' );
+						expect( items.length ).to.equal( 1 );
+
+						return editor.destroy();
+					} );
+			} );
 		} );
 
 		it( 'initializes keyboard navigation between view#toolbar and view#editable', () => {

--- a/packages/ckeditor5-ui/src/toolbar/balloon/balloontoolbar.js
+++ b/packages/ckeditor5-ui/src/toolbar/balloon/balloontoolbar.js
@@ -185,7 +185,7 @@ export default class BalloonToolbar extends Plugin {
 	afterInit() {
 		const factory = this.editor.ui.componentFactory;
 
-		this.toolbarView.fillFromConfig( this._balloonConfig.items, factory );
+		this.toolbarView.fillFromConfig( this._balloonConfig, factory );
 	}
 
 	/**

--- a/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.js
+++ b/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.js
@@ -179,7 +179,7 @@ export default class BlockToolbar extends Plugin {
 		const factory = this.editor.ui.componentFactory;
 		const config = this._blockToolbarConfig;
 
-		this.toolbarView.fillFromConfig( config.items, factory );
+		this.toolbarView.fillFromConfig( config, factory );
 
 		// Hide panel before executing each button in the panel.
 		for ( const item of this.toolbarView.items ) {

--- a/packages/ckeditor5-ui/src/toolbar/normalizetoolbarconfig.js
+++ b/packages/ckeditor5-ui/src/toolbar/normalizetoolbarconfig.js
@@ -18,6 +18,7 @@
  *
  *		toolbar: {
  *			items: [ 'heading', 'bold', 'italic', 'link', ... ],
+ *			removeItems: [ 'bold' ],
  *			...
  *		}
  *
@@ -31,17 +32,20 @@
 export default function normalizeToolbarConfig( config ) {
 	if ( Array.isArray( config ) ) {
 		return {
-			items: config
+			items: config,
+			removeItems: []
 		};
 	}
 
 	if ( !config ) {
 		return {
-			items: []
+			items: [],
+			removeItems: []
 		};
 	}
 
 	return Object.assign( {
-		items: []
+		items: [],
+		removeItems: []
 	}, config );
 }

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.js
@@ -286,10 +286,10 @@ export default class ToolbarView extends View {
 
 		const itemsToAdd = config.items
 			.filter( name => {
-				// Ignore separators and dividers for now.
 				if ( name === '|' || name === '-' ) {
 					return true;
 				}
+
 				// Items listed in `config.removeItems` should not be added to the toolbar.
 				if ( config.removeItems.indexOf( name ) !== -1 ) {
 					return false;
@@ -321,7 +321,7 @@ export default class ToolbarView extends View {
 
 				return true;
 			} )
-			// After cleanup in previous step, we can end up with redundant separators. We remove them here.
+			// After cleanup in the previous step, we can end up with duplicated or trailing separators. We remove them here.
 			.filter( ( name, idx, items ) => {
 				// Filter only separators.
 				if ( name !== '|' ) {

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.js
@@ -285,14 +285,41 @@ export default class ToolbarView extends View {
 		const config = normalizeToolbarConfig( itemsOrConfig );
 
 		const itemsToAdd = config.items
-			.filter( name => {
-				if ( name === '|' || name === '-' ) {
+			.filter( ( name, idx, items ) => {
+				if ( name === '|' ) {
 					return true;
 				}
 
 				// Items listed in `config.removeItems` should not be added to the toolbar.
 				if ( config.removeItems.indexOf( name ) !== -1 ) {
 					return false;
+				}
+
+				if ( name === '-' ) {
+					// Toolbar line breaks must not be rendered when toolbar grouping is enabled.
+					if ( this.options.shouldGroupWhenFull ) {
+						/**
+						 * Toolbar line breaks (`-` items) can only work when the automatic button grouping
+						 * is disabled in the toolbar configuration.
+						 * To do this, set the `shouldNotGroupWhenFull` option to `true` in the editor configuration:
+						 *
+						 *		const config = {
+						 *			toolbar: {
+						 *				items: [ ... ],
+						 *				shouldNotGroupWhenFull: true
+						 *			}
+						 *		}
+						 *
+						 * Learn more about {@link module:core/editor/editorconfig~EditorConfig#toolbar toolbar configuration}.
+						 *
+						 * @error toolbarview-line-break-ignored-when-grouping-items
+						 */
+						logWarning( 'toolbarview-line-break-ignored-when-grouping-items', items );
+
+						return false;
+					}
+
+					return true;
 				}
 
 				// For the items that cannot be instantiated we are sending warning message. We also filter them out.
@@ -335,30 +362,10 @@ export default class ToolbarView extends View {
 				return !( isFirst || isLast || isDuplicated );
 			} )
 			// Instantiate toolbar items.
-			.map( ( name, idx, items ) => {
+			.map( name => {
 				if ( name === '|' ) {
 					return new ToolbarSeparatorView();
 				} else if ( name === '-' ) {
-					if ( this.options.shouldGroupWhenFull ) {
-						/**
-						 * Toolbar line breaks (`-` items) can only work when the automatic button grouping
-						 * is disabled in the toolbar configuration.
-						 * To do this, set the `shouldNotGroupWhenFull` option to `true` in the editor configuration:
-						 *
-						 *		const config = {
-						 *			toolbar: {
-						 *				items: [ ... ],
-						 *				shouldNotGroupWhenFull: true
-						 *			}
-						 *		}
-						 *
-						 * Learn more about {@link module:core/editor/editorconfig~EditorConfig#toolbar toolbar configuration}.
-						 *
-						 * @error toolbarview-line-break-ignored-when-grouping-items
-						 */
-						logWarning( 'toolbarview-line-break-ignored-when-grouping-items', items );
-					}
-
 					return new ToolbarLineBreakView();
 				}
 

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.js
@@ -297,6 +297,7 @@ export default class ToolbarView extends View {
 
 				if ( name === '-' ) {
 					// Toolbar line breaks must not be rendered when toolbar grouping is enabled.
+					// (https://github.com/ckeditor/ckeditor5/issues/8582)
 					if ( this.options.shouldGroupWhenFull ) {
 						/**
 						 * Toolbar line breaks (`-` items) can only work when the automatic button grouping

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.js
@@ -313,7 +313,7 @@ export default class ToolbarView extends View {
 					 *
 					 * @error toolbarview-line-break-ignored-when-grouping-items
 					 */
-					logWarning( 'toolbarview-line-break-ignored-when-grouping-items', itemsOrConfig );
+					logWarning( 'toolbarview-line-break-ignored-when-grouping-items', items );
 				}
 			} else if ( factory.has( name ) ) {
 				return factory.create( name );

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.js
@@ -285,18 +285,17 @@ export default class ToolbarView extends View {
 		const config = normalizeToolbarConfig( itemsOrConfig );
 
 		const itemsToAdd = config.items
-			// Items listed in `config.removeItems` should not be added to the toolbar.
-			// For the items that cannot be instantiated we are sending warning message.
 			.filter( name => {
 				// Ignore separators and dividers for now.
 				if ( name === '|' || name === '-' ) {
 					return true;
 				}
-
+				// Items listed in `config.removeItems` should not be added to the toolbar.
 				if ( config.removeItems.indexOf( name ) !== -1 ) {
 					return false;
 				}
 
+				// For the items that cannot be instantiated we are sending warning message. We also filter them out.
 				if ( !factory.has( name ) ) {
 					/**
 					 * There was a problem processing the configuration of the toolbar. The item with the given
@@ -322,9 +321,9 @@ export default class ToolbarView extends View {
 
 				return true;
 			} )
-			// Separators at the start and end of toolbar should be removed, as well as duplicated ones.
-			// This can happen after removing items listed in `config.removeItems` or if an item cannot be created.
+			// After cleanup in previous step, we can end up with redundant separators. We remove them here.
 			.filter( ( name, idx, items ) => {
+				// Filter only separators.
 				if ( name !== '|' ) {
 					return true;
 				}

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.js
@@ -375,14 +375,17 @@ export default class ToolbarView extends View {
 		const nonSeparatorPredicate = item => ( item !== '-' && item !== '|' );
 		const count = items.length;
 
+		// Find an index of the first item that is not a separator.
 		const firstCommandItem = items.findIndex( nonSeparatorPredicate );
+
+		// Search from the end of the list, then convert found index back to the original direction.
 		const lastCommandItem = count - items
 			.slice()
 			.reverse()
 			.findIndex( nonSeparatorPredicate );
 
 		return items
-			// Return items without leading and trailing separators.
+			// Return items without the leading and trailing separators.
 			.slice( firstCommandItem, lastCommandItem )
 			// Remove duplicated separators.
 			.filter( ( name, idx, items ) => {

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.js
@@ -382,7 +382,9 @@ export default class ToolbarView extends View {
 			.findIndex( nonSeparatorPredicate );
 
 		return items
+			// Return items without leading and trailing separators.
 			.slice( firstCommandItem, lastCommandItem )
+			// Remove duplicated separators.
 			.filter( ( name, idx, items ) => {
 				// Filter only separators.
 				if ( nonSeparatorPredicate( name ) ) {

--- a/packages/ckeditor5-ui/tests/toolbar/normalizetoolbarconfig.js
+++ b/packages/ckeditor5-ui/tests/toolbar/normalizetoolbarconfig.js
@@ -7,11 +7,16 @@ import normalizeToolbarConfig from '../../src/toolbar/normalizetoolbarconfig';
 
 describe( 'normalizeToolbarConfig()', () => {
 	it( 'normalizes the config specified as an Array', () => {
-		const cfg = [ 'foo', 'bar' ];
-		const normalized = normalizeToolbarConfig( cfg );
+		const items = [ 'foo', 'bar' ];
+		const normalized = normalizeToolbarConfig( items );
 
 		expect( normalized ).to.be.an( 'object' );
-		expect( normalized.items ).to.deep.equal( cfg );
+		expect( normalized ).to.deep.equal(
+			{
+				items,
+				removeItems: []
+			}
+		);
 	} );
 
 	it( 'passes through an already normalized config', () => {
@@ -21,7 +26,9 @@ describe( 'normalizeToolbarConfig()', () => {
 		};
 		const normalized = normalizeToolbarConfig( cfg );
 
-		expect( normalized ).to.deep.equal( cfg );
+		expect( normalized ).to.deep.equal(
+			Object.assign( { removeItems: [] }, cfg )
+		);
 	} );
 
 	it( 'adds missing items property', () => {
@@ -33,6 +40,7 @@ describe( 'normalizeToolbarConfig()', () => {
 
 		expect( normalized ).to.deep.equal( {
 			items: [],
+			removeItems: [],
 			foo: 'bar'
 		} );
 		expect( normalized ).to.not.equal( cfg ); // Make sure we don't modify an existing obj.
@@ -43,5 +51,6 @@ describe( 'normalizeToolbarConfig()', () => {
 
 		expect( normalized ).to.be.an( 'object' );
 		expect( normalized.items ).to.be.an( 'array' ).of.length( 0 );
+		expect( normalized.removeItems ).to.be.an( 'array' ).of.length( 0 );
 	} );
 } );

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
@@ -481,11 +481,11 @@ describe( 'ToolbarView', () => {
 			);
 
 			const items = view.items;
-			expect( items ).to.have.length( 4 );
-			expect( items.get( 0 ) ).to.be.instanceOf( ToolbarSeparatorView );
-			expect( items.get( 1 ).name ).to.equal( 'foo' );
-			expect( items.get( 2 ) ).to.be.instanceOf( ToolbarSeparatorView );
-			expect( items.get( 3 ).name ).to.equal( 'foo' );
+
+			expect( items ).to.have.length( 3 );
+			expect( items.get( 0 ).name ).to.equal( 'foo' );
+			expect( items.get( 1 ) ).to.be.instanceOf( ToolbarSeparatorView );
+			expect( items.get( 2 ).name ).to.equal( 'foo' );
 		} );
 
 		it( 'warns if there is no such component in the factory', () => {

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
@@ -535,6 +535,7 @@ describe( 'ToolbarView', () => {
 			);
 		} );
 
+		// https://github.com/ckeditor/ckeditor5/issues/8582
 		it( 'does not render line separator when the button grouping option is enabled', () => {
 			// Catch warn to stop tests from failing in production mode.
 			sinon.stub( console, 'warn' );

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
@@ -447,6 +447,47 @@ describe( 'ToolbarView', () => {
 			expect( items.get( 4 ).name ).to.equal( 'foo' );
 		} );
 
+		it( 'accepts configuration object', () => {
+			view.fillFromConfig( { items: [ 'foo', 'bar', 'foo' ] }, factory );
+
+			const items = view.items;
+			expect( items ).to.have.length( 3 );
+			expect( items.get( 0 ).name ).to.equal( 'foo' );
+			expect( items.get( 1 ).name ).to.equal( 'bar' );
+			expect( items.get( 2 ).name ).to.equal( 'foo' );
+		} );
+
+		it( 'removes items listed in `removeItems`', () => {
+			view.fillFromConfig(
+				{
+					items: [ 'foo', 'bar', 'foo' ],
+					removeItems: [ 'foo' ]
+				},
+				factory
+			);
+
+			const items = view.items;
+			expect( items ).to.have.length( 1 );
+			expect( items.get( 0 ).name ).to.equal( 'bar' );
+		} );
+
+		it( 'deduplicate consecutive separators after removing items listed in `removeItems`', () => {
+			view.fillFromConfig(
+				{
+					items: [ '|', '|', 'foo', '|', 'bar', '|', 'foo' ],
+					removeItems: [ 'bar' ]
+				},
+				factory
+			);
+
+			const items = view.items;
+			expect( items ).to.have.length( 4 );
+			expect( items.get( 0 ) ).to.be.instanceOf( ToolbarSeparatorView );
+			expect( items.get( 1 ).name ).to.equal( 'foo' );
+			expect( items.get( 2 ) ).to.be.instanceOf( ToolbarSeparatorView );
+			expect( items.get( 3 ).name ).to.equal( 'foo' );
+		} );
+
 		it( 'warns if there is no such component in the factory', () => {
 			const items = view.items;
 			const consoleWarnStub = sinon.stub( console, 'warn' );

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
@@ -488,6 +488,22 @@ describe( 'ToolbarView', () => {
 			expect( items.get( 2 ).name ).to.equal( 'foo' );
 		} );
 
+		it( 'removes separators at the beginning and end of item list', () => {
+			view.fillFromConfig(
+				{
+					items: [ '|', '|', 'foo', '|', 'bar', '|' ]
+				},
+				factory
+			);
+
+			const items = view.items;
+
+			expect( items ).to.have.length( 3 );
+			expect( items.get( 0 ).name ).to.equal( 'foo' );
+			expect( items.get( 1 ) ).to.be.instanceOf( ToolbarSeparatorView );
+			expect( items.get( 2 ).name ).to.equal( 'bar' );
+		} );
+
 		it( 'warns if there is no such component in the factory', () => {
 			const items = view.items;
 			const consoleWarnStub = sinon.stub( console, 'warn' );

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
@@ -438,7 +438,6 @@ describe( 'ToolbarView', () => {
 			view.fillFromConfig( [ 'foo', '-', 'bar', '|', 'foo' ], factory );
 
 			const items = view.items;
-
 			expect( items ).to.have.length( 5 );
 			expect( items.get( 0 ).name ).to.equal( 'foo' );
 			expect( items.get( 1 ) ).to.be.instanceOf( ToolbarLineBreakView );

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
@@ -471,7 +471,7 @@ describe( 'ToolbarView', () => {
 			expect( items.get( 0 ).name ).to.equal( 'bar' );
 		} );
 
-		it( 'deduplicate consecutive separators after removing items listed in `removeItems`', () => {
+		it( 'deduplicates consecutive separators after removing items listed in `removeItems`', () => {
 			view.fillFromConfig(
 				{
 					items: [ '|', '|', 'foo', '|', 'bar', '|', 'foo' ],

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
@@ -487,7 +487,24 @@ describe( 'ToolbarView', () => {
 			expect( items.get( 2 ).name ).to.equal( 'foo' );
 		} );
 
-		it( 'removes separators at the beginning and end of item list', () => {
+		it( 'deduplicates consecutive separators after removing items listed in `removeItems` 2', () => {
+			view.fillFromConfig(
+				{
+					items: [ '|', '-', '|', '-', 'foo', '|', 'bar', '|', 'foo' ],
+					removeItems: [ 'bar' ]
+				},
+				factory
+			);
+
+			const items = view.items;
+
+			expect( items ).to.have.length( 3 );
+			expect( items.get( 0 ).name ).to.equal( 'foo' );
+			expect( items.get( 1 ) ).to.be.instanceOf( ToolbarSeparatorView );
+			expect( items.get( 2 ).name ).to.equal( 'foo' );
+		} );
+
+		it( 'removes trailing and leading separators from the item list', () => {
 			view.fillFromConfig(
 				{
 					items: [ '|', '|', 'foo', '|', 'bar', '|' ]
@@ -500,6 +517,22 @@ describe( 'ToolbarView', () => {
 			expect( items ).to.have.length( 3 );
 			expect( items.get( 0 ).name ).to.equal( 'foo' );
 			expect( items.get( 1 ) ).to.be.instanceOf( ToolbarSeparatorView );
+			expect( items.get( 2 ).name ).to.equal( 'bar' );
+		} );
+
+		it( 'removes trailing and leading separators from the item list 2', () => {
+			view.fillFromConfig(
+				{
+					items: [ '-', '-', 'foo', '-', 'bar', '-' ]
+				},
+				factory
+			);
+
+			const items = view.items;
+
+			expect( items ).to.have.length( 3 );
+			expect( items.get( 0 ).name ).to.equal( 'foo' );
+			expect( items.get( 1 ) ).to.be.instanceOf( ToolbarLineBreakView );
 			expect( items.get( 2 ).name ).to.equal( 'bar' );
 		} );
 

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
@@ -470,7 +470,7 @@ describe( 'ToolbarView', () => {
 			expect( items.get( 0 ).name ).to.equal( 'bar' );
 		} );
 
-		it( 'deduplicates consecutive separators after removing items listed in `removeItems`', () => {
+		it( 'deduplicates consecutive separators after removing items listed in `removeItems` - the vertical separator case (`|`)', () => {
 			view.fillFromConfig(
 				{
 					items: [ '|', '|', 'foo', '|', 'bar', '|', 'foo' ],
@@ -487,10 +487,10 @@ describe( 'ToolbarView', () => {
 			expect( items.get( 2 ).name ).to.equal( 'foo' );
 		} );
 
-		it( 'deduplicates consecutive separators after removing items listed in `removeItems` 2', () => {
+		it( 'deduplicates consecutive separators after removing items listed in `removeItems` - the line break case (`-`)', () => {
 			view.fillFromConfig(
 				{
-					items: [ '|', '-', '|', '-', 'foo', '|', 'bar', '|', 'foo' ],
+					items: [ '-', '-', 'foo', '-', 'bar', '-', 'foo' ],
 					removeItems: [ 'bar' ]
 				},
 				factory
@@ -500,11 +500,11 @@ describe( 'ToolbarView', () => {
 
 			expect( items ).to.have.length( 3 );
 			expect( items.get( 0 ).name ).to.equal( 'foo' );
-			expect( items.get( 1 ) ).to.be.instanceOf( ToolbarSeparatorView );
+			expect( items.get( 1 ) ).to.be.instanceOf( ToolbarLineBreakView );
 			expect( items.get( 2 ).name ).to.equal( 'foo' );
 		} );
 
-		it( 'removes trailing and leading separators from the item list', () => {
+		it( 'removes trailing and leading separators from the item list - the vertical separator case (`|`)', () => {
 			view.fillFromConfig(
 				{
 					items: [ '|', '|', 'foo', '|', 'bar', '|' ]
@@ -520,7 +520,7 @@ describe( 'ToolbarView', () => {
 			expect( items.get( 2 ).name ).to.equal( 'bar' );
 		} );
 
-		it( 'removes trailing and leading separators from the item list 2', () => {
+		it( 'removes trailing and leading separators from the item list - the line break case (`-`)', () => {
 			view.fillFromConfig(
 				{
 					items: [ '-', '-', 'foo', '-', 'bar', '-' ]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (ui): Items baked into editor bundles can be removed from the toolbar now. Closes #7945.

Docs: Updated docs/builds/guides/integration/configuration.md with new configuration setting.

MINOR BREAKING CHANGE (ui): Configuration passed to `ToolbarView.fillFromConfig()` will be stripped off of leading, trailing, and duplicated separators (`'|'` and `'-'`).

---

### Additional information

The `ToolbarView.fillFromConfig()` should accept two types of parameters, an array, and an object. This is done to prevent breaking changes in the public API.