### PR TITLE
ToolbarLineBreakView should not be rendered when grouping is enabled.

### DIFF
--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.js
@@ -303,9 +303,9 @@ export default class ToolbarView extends View {
 					 * @error toolbarview-line-break-ignored-when-grouping-items
 					 */
 					logWarning( 'toolbarview-line-break-ignored-when-grouping-items', config );
+				} else {
+					return new ToolbarLineBreakView();
 				}
-
-				return new ToolbarLineBreakView();
 			} else if ( factory.has( name ) ) {
 				return factory.create( name );
 			} else {

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
@@ -480,6 +480,9 @@ describe( 'ToolbarView', () => {
 		} );
 
 		it( 'does not render line separator when the button grouping option is enabled', () => {
+			// Catch warn to stop tests from failing in production mode.
+			sinon.stub( console, 'warn' );
+
 			view.options.shouldGroupWhenFull = true;
 
 			view.fillFromConfig( [ 'foo', '-', 'bar' ], factory );

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
@@ -478,6 +478,18 @@ describe( 'ToolbarView', () => {
 				sinon.match.string // Link to the documentation.
 			);
 		} );
+
+		it( 'does not render line separator when the button grouping option is enabled', () => {
+			view.options.shouldGroupWhenFull = true;
+
+			view.fillFromConfig( [ 'foo', '-', 'bar' ], factory );
+
+			const items = view.items;
+
+			expect( items ).to.have.length( 2 );
+			expect( items.get( 0 ).name ).to.equal( 'foo' );
+			expect( items.get( 1 ).name ).to.equal( 'bar' );
+		} );
 	} );
 
 	describe( 'toolbar with static items', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (ui): A `'-'` divider will not be rendered when grouping is enabled. Closes #8582.
