### PR TITLE
South position added to drop down panel positions.

### DIFF
--- a/packages/ckeditor5-special-characters/src/ui/specialcharactersnavigationview.js
+++ b/packages/ckeditor5-special-characters/src/ui/specialcharactersnavigationview.js
@@ -43,7 +43,6 @@ export default class SpecialCharactersNavigationView extends FormHeaderView {
 		 * @member {module:ui/dropdown/dropdownview~DropdownView}
 		 */
 		this.groupDropdownView = this._createGroupDropdown( groupNames );
-		this.groupDropdownView.panelPosition = locale.uiLanguageDirection === 'rtl' ? 'se' : 'sw';
 
 		/**
 		 * @inheritDoc

--- a/packages/ckeditor5-ui/src/dropdown/dropdownview.js
+++ b/packages/ckeditor5-ui/src/dropdown/dropdownview.js
@@ -313,12 +313,12 @@ export default class DropdownView extends View {
 	 * @private
 	 */
 	get _panelPositions() {
-		const { southEast, southWest, northEast, northWest } = DropdownView.defaultPanelPositions;
+		const { south, southEast, southWest, northEast, northWest } = DropdownView.defaultPanelPositions;
 
 		if ( this.locale.uiLanguageDirection === 'ltr' ) {
-			return [ southEast, southWest, northEast, northWest ];
+			return [ southEast, southWest, northEast, northWest, south ];
 		} else {
-			return [ southWest, southEast, northWest, northEast ];
+			return [ southWest, southEast, northWest, northEast, south ];
 		}
 	}
 }
@@ -372,6 +372,13 @@ export default class DropdownView extends View {
  * @member {Object} module:ui/dropdown/dropdownview~DropdownView.defaultPanelPositions
  */
 DropdownView.defaultPanelPositions = {
+	south: ( buttonRect, panelRect ) => {
+		return {
+			top: buttonRect.bottom,
+			left: buttonRect.left - panelRect.width / 2 + buttonRect.width / 2,
+			name: 's'
+		};
+	},
 	southEast: buttonRect => {
 		return {
 			top: buttonRect.bottom,

--- a/packages/ckeditor5-ui/theme/components/dropdown/dropdown.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/dropdown.css
@@ -45,7 +45,8 @@
 		}
 
 		&.ck-dropdown__panel_se,
-		&.ck-dropdown__panel_sw {
+		&.ck-dropdown__panel_sw,
+		&.ck-dropdown__panel_s {
 			/*
 			 * Using transform: translate3d( 0, 100%, 0 ) causes blurry dropdown on Chrome 67-78+ on non-retina displays.
 			 * See https://github.com/ckeditor/ckeditor5/issues/1053.
@@ -62,6 +63,10 @@
 		&.ck-dropdown__panel_nw,
 		&.ck-dropdown__panel_sw {
 			right: 0px;
+		}
+
+		&.ck-dropdown__panel_s {
+			transform: translateX(-50%)
 		}
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Bug (ui): Dropdown should take the south (center) position if no other fits. Closes #7700.