### PR TITLE
Loosen up condition to allow Text elements.

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/modelconsumable.js
+++ b/packages/ckeditor5-engine/src/conversion/modelconsumable.js
@@ -7,8 +7,6 @@
  * @module engine/conversion/modelconsumable
  */
 
-import TextProxy from '../model/textproxy';
-
 /**
  * Manages a list of consumable values for {@link module:engine/model/item~Item model items}.
  *
@@ -131,7 +129,7 @@ export default class ModelConsumable {
 	add( item, type ) {
 		type = _normalizeConsumableType( type );
 
-		if ( item instanceof TextProxy ) {
+		if ( item && item.is && ( item.is( '$textProxy' ) || item.is( '$text' ) ) ) {
 			item = this._getSymbolForTextProxy( item );
 		}
 
@@ -160,7 +158,7 @@ export default class ModelConsumable {
 	consume( item, type ) {
 		type = _normalizeConsumableType( type );
 
-		if ( item instanceof TextProxy ) {
+		if ( item && item.is && ( item.is( '$textProxy' ) || item.is( '$text' ) ) ) {
 			item = this._getSymbolForTextProxy( item );
 		}
 
@@ -192,7 +190,7 @@ export default class ModelConsumable {
 	test( item, type ) {
 		type = _normalizeConsumableType( type );
 
-		if ( item instanceof TextProxy ) {
+		if ( item && item.is && ( item.is( '$textProxy' ) || item.is( '$text' ) ) ) {
 			item = this._getSymbolForTextProxy( item );
 		}
 
@@ -229,7 +227,7 @@ export default class ModelConsumable {
 	revert( item, type ) {
 		type = _normalizeConsumableType( type );
 
-		if ( item instanceof TextProxy ) {
+		if ( item && item.is && ( item.is( '$textProxy' ) || item.is( '$text' ) ) ) {
 			item = this._getSymbolForTextProxy( item );
 		}
 

--- a/packages/ckeditor5-engine/tests/conversion/modelconsumable.js
+++ b/packages/ckeditor5-engine/tests/conversion/modelconsumable.js
@@ -41,6 +41,14 @@ describe( 'ModelConsumable', () => {
 			expect( modelConsumable.test( modelTextProxy, 'type' ) ).to.be.true;
 		} );
 
+		it( 'should correctly add text instances', () => {
+			const modelText = new ModelText( 'foo' );
+
+			modelConsumable.add( modelText, 'type' );
+
+			expect( modelConsumable.test( modelText, 'type' ) ).to.be.true;
+		} );
+
 		it( 'should normalize type name', () => {
 			modelConsumable.add( modelElement, 'foo:bar:baz:abc' );
 
@@ -84,6 +92,17 @@ describe( 'ModelConsumable', () => {
 
 			expect( result ).to.be.true;
 			expect( modelConsumable.test( proxy1To4, 'type' ) ).to.be.false;
+		} );
+
+		it( 'should correctly consume text instances', () => {
+			const modelText = new ModelText( modelElement.getChild( 0 ) );
+
+			expect( modelConsumable.consume( modelText, 'type' ) ).to.be.false;
+
+			modelConsumable.add( modelText, 'type' );
+
+			expect( modelConsumable.consume( modelText, 'type' ) ).to.be.true;
+			expect( modelConsumable.test( modelText, 'type' ) ).to.be.false;
 		} );
 
 		it( 'should normalize type name', () => {
@@ -135,6 +154,18 @@ describe( 'ModelConsumable', () => {
 			expect( modelConsumable.test( modelTextProxy, 'type' ) ).to.be.true;
 		} );
 
+		it( 'should correctly revert text instances', () => {
+			const modelText = new ModelText( modelElement.getChild( 0 ) );
+
+			modelConsumable.add( modelText, 'type' );
+			modelConsumable.consume( modelText, 'type' );
+
+			const result = modelConsumable.revert( modelText, 'type' );
+
+			expect( result ).to.be.true;
+			expect( modelConsumable.test( modelText, 'type' ) ).to.be.true;
+		} );
+
 		it( 'should normalize type name', () => {
 			modelConsumable.add( modelElement, 'foo:bar:baz:abc' );
 			modelConsumable.consume( modelElement, 'foo:bar:baz' );
@@ -171,6 +202,17 @@ describe( 'ModelConsumable', () => {
 			expect( modelConsumable.test( proxy1To5, 'type' ) ).to.be.null;
 			expect( modelConsumable.test( proxyOther1To4, 'type' ) ).to.be.null;
 			expect( modelConsumable.test( equalProxy1To4, 'type' ) ).to.be.true;
+		} );
+
+		it( 'should correctly test for text instances', () => {
+			const modelText = new ModelText( modelElement.getChild( 0 ) );
+			const equalModelText = new ModelText( modelElement.getChild( 0 ) );
+
+			modelConsumable.add( modelText, 'type' );
+
+			expect( modelConsumable.test( modelText, 'type' ) ).to.be.true;
+			expect( modelConsumable.test( modelText, 'otherType' ) ).to.be.null;
+			expect( modelConsumable.test( equalModelText, 'type' ) ).to.be.true;
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): `ModelConsumable` now accepts `Text` elements. Closes #8179.