### PR TITLE
Do not pass conversionAPI to the `_toMentionAttribute()`.

### DIFF
--- a/packages/ckeditor5-mention/src/mentionediting.js
+++ b/packages/ckeditor5-mention/src/mentionediting.js
@@ -49,7 +49,7 @@ export default class MentionEditing extends Plugin {
 			},
 			model: {
 				key: 'mention',
-				value: _toMentionAttribute
+				value: viewElement => _toMentionAttribute( viewElement )
 			}
 		} );
 

--- a/packages/ckeditor5-mention/tests/mentionediting.js
+++ b/packages/ckeditor5-mention/tests/mentionediting.js
@@ -238,6 +238,20 @@ describe( 'MentionEditing', () => {
 			expect( editor.getData() ).to.equal( expectedView );
 			expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal( expectedView );
 		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/8370
+		it( 'should pass down only relevant attributes', () => {
+			editor.setData( '<p>foo<span class="mention" data-mention="@John">John</span></p>' );
+
+			const textNode = doc.getRoot().getChild( 0 ).getChild( 1 );
+			const attributeValue = textNode.getAttribute( 'mention' );
+
+			expect( Object.keys( attributeValue ) ).to.have.members( [
+				'id',
+				'uid',
+				'_text'
+			] );
+		} );
 	} );
 
 	describe( 'selection post-fixer', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (mention): Conversion API reference is no longer passed down to attribute props. Closes #8370.