### PR TITLE
Provide more context to block formatting function. Update tests.

### DIFF
--- a/packages/ckeditor5-autoformat/src/autoformat.js
+++ b/packages/ckeditor5-autoformat/src/autoformat.js
@@ -163,7 +163,14 @@ export default class Autoformat extends Plugin {
 	 */
 	_addCodeBlockAutoformats() {
 		if ( this.editor.commands.get( 'codeBlock' ) ) {
-			blockAutoformatEditing( this.editor, this, /^```$/, 'codeBlock' );
+			blockAutoformatEditing( this.editor, this, /^```$/, ( { blockToFormat } ) => {
+				// Prevent creating code blocks inside a numbered/bulleted lists (#8633).
+				if ( blockToFormat.is( 'element', 'listItem' ) ) {
+					return false;
+				}
+
+				this.editor.execute( 'codeBlock' );
+			} );
 		}
 	}
 }

--- a/packages/ckeditor5-autoformat/src/blockautoformatediting.js
+++ b/packages/ckeditor5-autoformat/src/blockautoformatediting.js
@@ -48,8 +48,9 @@ import first from '@ckeditor/ckeditor5-utils/src/first';
  * @param {RegExp} pattern The regular expression to execute on just inserted text. The regular expression is tested against the text
  * from the beginning until the caret position.
  * @param {Function|String} callbackOrCommand The callback to execute or the command to run when the text is matched.
- * In case of providing the callback, it receives the following parameter:
+ * In case of providing the callback, it receives the following parameters:
  * * {Object} match RegExp.exec() result of matching the pattern to inserted text.
+ * * {module:engine/model/element~Element} blockToFormat An element surrounding inserted text.
  */
 export default function blockAutoformatEditing( editor, plugin, pattern, callbackOrCommand ) {
 	let callback;

--- a/packages/ckeditor5-autoformat/src/blockautoformatediting.js
+++ b/packages/ckeditor5-autoformat/src/blockautoformatediting.js
@@ -49,7 +49,7 @@ import first from '@ckeditor/ckeditor5-utils/src/first';
  * from the beginning until the caret position.
  * @param {Function|String} callbackOrCommand The callback to execute or the command to run when the text is matched.
  * In case of providing the callback, it receives the following parameters:
- * * {Object} match RegExp.exec() result of matching the pattern to inserted text.
+ * * `Object` match RegExp.exec() result of matching the pattern to inserted text.
  * * {@link module:engine/model/element~Element} blockToFormat An element surrounding inserted text.
  */
 export default function blockAutoformatEditing( editor, plugin, pattern, callbackOrCommand ) {

--- a/packages/ckeditor5-autoformat/src/blockautoformatediting.js
+++ b/packages/ckeditor5-autoformat/src/blockautoformatediting.js
@@ -124,7 +124,7 @@ export default function blockAutoformatEditing( editor, plugin, pattern, callbac
 			const end = writer.createPositionAt( blockToFormat, match[ 0 ].length );
 			const range = new LiveRange( start, end );
 
-			const wasChanged = callback( { match } );
+			const wasChanged = callback( { match, blockToFormat } );
 
 			// Remove matched text.
 			if ( wasChanged !== false ) {

--- a/packages/ckeditor5-autoformat/src/blockautoformatediting.js
+++ b/packages/ckeditor5-autoformat/src/blockautoformatediting.js
@@ -50,7 +50,7 @@ import first from '@ckeditor/ckeditor5-utils/src/first';
  * @param {Function|String} callbackOrCommand The callback to execute or the command to run when the text is matched.
  * In case of providing the callback, it receives the following parameters:
  * * {Object} match RegExp.exec() result of matching the pattern to inserted text.
- * * {module:engine/model/element~Element} blockToFormat An element surrounding inserted text.
+ * * {@link module:engine/model/element~Element} blockToFormat An element surrounding inserted text.
  */
 export default function blockAutoformatEditing( editor, plugin, pattern, callbackOrCommand ) {
 	let callback;

--- a/packages/ckeditor5-autoformat/tests/autoformat.js
+++ b/packages/ckeditor5-autoformat/tests/autoformat.js
@@ -384,21 +384,21 @@ describe( 'Autoformat', () => {
 		} );
 
 		it( 'should not replace triple grave accents when inside numbered list', () => {
-			setData( model, '<listItem listIndent="0" listType="numbered">1. ``[]</listItem>' );
+			setData( model, '<listItem listIndent="0" listType="numbered">``[]</listItem>' );
 			model.change( writer => {
 				writer.insertText( '`', doc.selection.getFirstPosition() );
 			} );
 
-			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="numbered">1. ```[]</listItem>' );
+			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="numbered">```[]</listItem>' );
 		} );
 
 		it( 'should not replace triple grave accents when inside buletted list', () => {
-			setData( model, '<listItem listIndent="0" listType="bulleted">1. ``[]</listItem>' );
+			setData( model, '<listItem listIndent="0" listType="bulleted">``[]</listItem>' );
 			model.change( writer => {
 				writer.insertText( '`', doc.selection.getFirstPosition() );
 			} );
 
-			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="bulleted">1. ```[]</listItem>' );
+			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="bulleted">```[]</listItem>' );
 		} );
 	} );
 

--- a/packages/ckeditor5-autoformat/tests/blockautoformatediting.js
+++ b/packages/ckeditor5-autoformat/tests/blockautoformatediting.js
@@ -11,6 +11,7 @@ import Enter from '@ckeditor/ckeditor5-enter/src/enter';
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import Command from '@ckeditor/ckeditor5-core/src/command';
+import Element from '@ckeditor/ckeditor5-engine/src/model/element';
 
 describe( 'blockAutoformatEditing', () => {
 	let editor, model, doc, plugin;
@@ -99,6 +100,20 @@ describe( 'blockAutoformatEditing', () => {
 			} );
 
 			sinon.assert.calledOnce( spy );
+		} );
+
+		it( 'should run callback with proper parameters when the pattern is matched', () => {
+			const spy = testUtils.sinon.spy();
+			blockAutoformatEditing( editor, plugin, /^[*]\s$/, spy );
+
+			setData( model, '<paragraph>*[]</paragraph>' );
+			model.change( writer => {
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
+			} );
+
+			sinon.assert.calledWithMatch( spy, sinon.match.object );
+			sinon.assert.calledWithMatch( spy, sinon.match.has( 'match', sinon.match.array ) );
+			sinon.assert.calledWithMatch( spy, sinon.match.has( 'blockToFormat', sinon.match.instanceOf( Element ) ) );
 		} );
 
 		it( 'should not call the callback when the pattern is matched but the plugin is disabled', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (autoformat): Code block characters inside a list will not trigger autoformatting. Closes #8633.