### PR TITLE
Not showing empty image caption if editor is in readOnly mode.

### DIFF
--- a/packages/ckeditor5-image/src/imagecaption/imagecaptionediting.js
+++ b/packages/ckeditor5-image/src/imagecaption/imagecaptionediting.js
@@ -115,7 +115,7 @@ export default class ImageCaptionEditing extends Plugin {
 		}
 
 		// Is currently any caption selected?
-		if ( viewCaption ) {
+		if ( viewCaption && !this.editor.isReadOnly ) {
 			// Was any caption selected before?
 			if ( lastCaption ) {
 				// Same caption as before?

--- a/packages/ckeditor5-image/tests/imagecaption/imagecaptionediting.js
+++ b/packages/ckeditor5-image/tests/imagecaption/imagecaptionediting.js
@@ -519,6 +519,20 @@ describe( 'ImageCaptionEditing', () => {
 			);
 		} );
 
+		it( 'should not show empty figcaption when image is selected but editor is in the readOnly mode', () => {
+			editor.isReadOnly = true;
+
+			setModelData( model, '[<image src="img.png"><caption></caption></image>]' );
+
+			expect( getViewData( view ) ).to.equal(
+				'[<figure class="ck-widget image" contenteditable="false">' +
+					'<img src="img.png"></img>' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-hidden ck-placeholder" ' +
+						'contenteditable="false" data-placeholder="Enter image caption"></figcaption>' +
+				'</figure>]'
+			);
+		} );
+
 		describe( 'undo/redo integration', () => {
 			it( 'should create view element after redo', () => {
 				setModelData( model, '<paragraph>foo</paragraph><image src=""><caption>[foo bar baz]</caption></image>' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (image): An empty image caption should be hidden if an editor is in the read-only mode. Closes #5168.