### PR TITLE
Add WEBP support to autoimage

### DIFF
--- a/packages/ckeditor5-image/src/autoimage.js
+++ b/packages/ckeditor5-image/src/autoimage.js
@@ -17,7 +17,7 @@ import { insertImage } from './image/utils';
 
 // Implements the pattern: http(s)://(www.)example.com/path/to/resource.ext?query=params&maybe=too.
 const IMAGE_URL_REGEXP = new RegExp( String( /^(http(s)?:\/\/)?[\w-]+(\.[\w-]+)+[\w._~:/?#[\]@!$&'()*+,;=%-]+/.source +
-	/\.(jpg|jpeg|png|gif|ico|JPG|JPEG|PNG|GIF|ICO)\??[\w._~:/#[\]@!$&'()*+,;=%-]*$/.source ) );
+	/\.(jpg|jpeg|png|gif|ico|webp|JPG|JPEG|PNG|GIF|ICO|WEBP)\??[\w._~:/#[\]@!$&'()*+,;=%-]*$/.source ) );
 
 /**
  * The auto-image plugin. It recognizes image links in the pasted content and embeds

--- a/packages/ckeditor5-image/tests/autoimage.js
+++ b/packages/ckeditor5-image/tests/autoimage.js
@@ -133,7 +133,6 @@ describe( 'AutoImage - integration', () => {
 				'http://www.example.com',
 				'https://example.com',
 				'http://www.example.com/image.svg',
-				'http://www.example.com/image.webp',
 				'http://www.example.com/image.mp3',
 				'http://www.example.com/image.exe',
 				'http://www.example.com/image.txt',


### PR DESCRIPTION
Other autoimage.js: Adds WEBP support to the inline pasting of images from source URLs.