### PR TITLE
The spawnSync() method needs shell to work on Win

### DIFF
--- a/scripts/dll/build-dlls.js
+++ b/scripts/dll/build-dlls.js
@@ -33,6 +33,7 @@ if ( IS_DEVELOPMENT_MODE ) {
 
 childProcess.spawnSync( 'webpack', webpackArguments, {
 	encoding: 'utf8',
+	shell: true,
 	cwd: ROOT_DIRECTORY,
 	stdio: 'inherit',
 	stderr: 'inherit'
@@ -51,6 +52,7 @@ if ( IS_DEVELOPMENT_MODE ) {
 
 childProcess.spawnSync( 'node', nodeArguments, {
 	encoding: 'utf8',
+	shell: true,
 	cwd: ROOT_DIRECTORY,
 	stdio: 'inherit',
 	stderr: 'inherit'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other: Fixed `yarn build:dll` on Windows. Closes #8746.

---

As noted in a very old Node issue https://github.com/nodejs/node-v0.x-archive/issues/2318, we need the `shell: true` option for `spawn()` or `spawnSync()` methods to make them work on Windows.