### PR TITLE
Widget required in html-embed plugin.

### DIFF
--- a/packages/ckeditor5-html-embed/src/htmlembed.js
+++ b/packages/ckeditor5-html-embed/src/htmlembed.js
@@ -10,6 +10,7 @@
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import HtmlEmbedEditing from './htmlembedediting';
 import HtmlEmbedUI from './htmlembedui';
+import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 
 /**
  * The HTML embed feature.
@@ -25,7 +26,7 @@ export default class HtmlEmbed extends Plugin {
 	 * @inheritDoc
 	 */
 	static get requires() {
-		return [ HtmlEmbedEditing, HtmlEmbedUI ];
+		return [ HtmlEmbedEditing, HtmlEmbedUI, Widget ];
 	}
 
 	/**

--- a/packages/ckeditor5-html-embed/tests/htmlembed.js
+++ b/packages/ckeditor5-html-embed/tests/htmlembed.js
@@ -6,10 +6,11 @@
 import HtmlEmbed from '../src/htmlembed';
 import HtmlEmbedUI from '../src/htmlembedui';
 import HtmlEmbedEditing from '../src/htmlembedediting';
+import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 
 describe( 'HtmlEmbed', () => {
-	it( 'should require HtmlEmbedEditing and HtmlEmbedUI', () => {
-		expect( HtmlEmbed.requires ).to.deep.equal( [ HtmlEmbedEditing, HtmlEmbedUI ] );
+	it( 'should require HtmlEmbedEditing, HtmlEmbedUI and Widget', () => {
+		expect( HtmlEmbed.requires ).to.deep.equal( [ HtmlEmbedEditing, HtmlEmbedUI, Widget ] );
 	} );
 
 	it( 'should be named', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (html-embed): HTML embed should be selectable if no other widget plugins are installed. Closes #8720.