### PR TITLE
Fake selection marker for collapsed and non-collapsed selections for link UI should be converted separately

### DIFF
--- a/packages/ckeditor5-link/src/linkui.js
+++ b/packages/ckeditor5-link/src/linkui.js
@@ -665,7 +665,7 @@ export default class LinkUI extends Plugin {
 			} else {
 				if ( range.start.isAtEnd ) {
 					const startPosition = range.start.getLastMatchingPosition(
-						( { item } ) => !model.schema.checkAttribute( item, 'linkHref' ),
+						( { item } ) => !item.is( '$text' ) && !item.is( '$textProxy' ) && !model.schema.isLimit( item ),
 						{ boundaries: range }
 					);
 

--- a/packages/ckeditor5-link/src/linkui.js
+++ b/packages/ckeditor5-link/src/linkui.js
@@ -664,13 +664,15 @@ export default class LinkUI extends Plugin {
 				writer.updateMarker( VISUAL_SELECTION_MARKER_NAME, { range } );
 			} else {
 				if ( range.start.isAtEnd ) {
-					const focus = model.document.selection.focus;
-					const nextValidRange = getNextValidRange( range, focus, writer );
+					const startPosition = range.start.getLastMatchingPosition(
+						( { item } ) => !model.schema.checkAttribute( item, 'linkHref' ),
+						{ boundaries: range }
+					);
 
 					writer.addMarker( VISUAL_SELECTION_MARKER_NAME, {
 						usingOperation: false,
 						affectsData: false,
-						range: nextValidRange
+						range: writer.createRange( startPosition, range.end )
 					} );
 				} else {
 					writer.addMarker( VISUAL_SELECTION_MARKER_NAME, {
@@ -706,28 +708,4 @@ export default class LinkUI extends Plugin {
 // @returns {module:engine/view/attributeelement~AttributeElement|null} Link element at the position or null.
 function findLinkElementAncestor( position ) {
 	return position.getAncestors().find( ancestor => isLinkElement( ancestor ) );
-}
-
-// Returns next valid range for the fake visual selection marker.
-//
-// @private
-// @param {module:engine/model/range~Range} range Current range.
-// @param {module:engine/model/position~Position} focus Selection focus.
-// @param {module:engine/model/writer~Writer} writer Writer.
-// @returns {module:engine/model/range~Range} New valid range for the fake visual selection marker.
-function getNextValidRange( range, focus, writer ) {
-	const nextStartPath = [ range.start.path[ 0 ] + 1, 0 ];
-	const nextStartPosition = writer.createPositionFromPath( range.start.root, nextStartPath, 'toNext' );
-	const nextRange = writer.createRange( nextStartPosition, range.end );
-
-	// Block creating a potential next valid range over the current range end.
-	if ( nextRange.start.path[ 0 ] > range.end.path[ 0 ] ) {
-		return writer.createRange( focus );
-	}
-
-	if ( nextStartPosition.isAtStart && nextStartPosition.isAtEnd ) {
-		return getNextValidRange( nextRange, focus, writer );
-	}
-
-	return nextRange;
 }

--- a/packages/ckeditor5-link/src/linkui.js
+++ b/packages/ckeditor5-link/src/linkui.js
@@ -665,7 +665,7 @@ export default class LinkUI extends Plugin {
 			} else {
 				if ( range.start.isAtEnd ) {
 					const startPosition = range.start.getLastMatchingPosition(
-						( { item } ) => !item.is( '$text' ) && !item.is( '$textProxy' ) && !model.schema.isLimit( item ),
+						( { item } ) => !model.schema.isContent( item ),
 						{ boundaries: range }
 					);
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (link): Fake selection marker for collapsed and non-collapsed selections for link UI should be converted separately. Closes #8092.

---

### Additional information

The problem with downcasting `link-ui` marker was that two separate converters were defined for the same marker:

*   `markerToHighlight` - for the non collapsed selection.
*   `markerToElement` - for the collapsed selection (but this converter also works correctly for non collapsed selection - it inserts elements at both ends of the marker range).