### PR TITLE
Supporting batchType option in the setData method.

### DIFF
--- a/packages/ckeditor5-engine/src/dev-utils/model.js
+++ b/packages/ckeditor5-engine/src/dev-utils/model.js
@@ -128,7 +128,13 @@ export function setData( model, data, options = {} ) {
 		modelDocumentFragment = parsedResult;
 	}
 
-	model.change( writer => {
+	if ( typeof options.batchType === 'string' ) {
+		model.enqueueChange( options.batchType, writeToModel );
+	} else {
+		model.change( writeToModel );
+	}
+
+	function writeToModel( writer ) {
 		// Replace existing model in document by new one.
 		writer.remove( writer.createRangeIn( modelRoot ) );
 		writer.insert( modelDocumentFragment, modelRoot );
@@ -154,7 +160,7 @@ export function setData( model, data, options = {} ) {
 				writer.setSelectionAttribute( selection.getAttributes() );
 			}
 		}
-	} );
+	};
 }
 
 // Set parse as setData private method - needed for testing/spying.

--- a/packages/ckeditor5-engine/src/dev-utils/model.js
+++ b/packages/ckeditor5-engine/src/dev-utils/model.js
@@ -102,7 +102,7 @@ getData._stringify = stringify;
  * name will be used.
  * @param {Array<Object>} [options.selectionAttributes] A list of attributes which will be passed to the selection.
  * @param {Boolean} [options.lastRangeBackward=false] If set to `true`, the last range will be added as backward.
- * @param {String} [options.batchType='transparent'] Batch type used for inserting elements.
+ * @param {String} [options.batchType='default'] Batch type used for inserting elements.
  * See {@link module:engine/model/batch~Batch#type}.
  */
 export function setData( model, data, options = {} ) {

--- a/packages/ckeditor5-engine/src/dev-utils/model.js
+++ b/packages/ckeditor5-engine/src/dev-utils/model.js
@@ -160,7 +160,7 @@ export function setData( model, data, options = {} ) {
 				writer.setSelectionAttribute( selection.getAttributes() );
 			}
 		}
-	};
+	}
 }
 
 // Set parse as setData private method - needed for testing/spying.

--- a/packages/ckeditor5-engine/tests/dev-utils/model.js
+++ b/packages/ckeditor5-engine/tests/dev-utils/model.js
@@ -130,6 +130,22 @@ describe( 'model test utils', () => {
 			expect( args[ 0 ] ).to.equal( data );
 		} );
 
+		it( 'should use model#enqueueChange method if the batchType option was provided', () => {
+			const changeSpy = sinon.spy( model, 'enqueueChange' );
+			const batchType = 'default';
+			setData( model, 'text', { batchType } );
+
+			sinon.assert.calledTwice( changeSpy );
+			sinon.assert.calledWith( changeSpy, batchType );
+		} );
+
+		it( 'should use model#change method if no batchType option was provided', () => {
+			const changeSpy = sinon.spy( model, 'change' );
+			setData( model, 'text', {} );
+
+			sinon.assert.calledOnce( changeSpy );
+		} );
+
 		it( 'should insert text', () => {
 			testUtils( 'this is test text', '[]this is test text' );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): The setData method in dev-utils/model should support the batchType option. Closes #7947.