### PR TITLE
Overriding Safari's disabled input opacity.

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-html-embed/htmlembed.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-html-embed/htmlembed.css
@@ -8,6 +8,9 @@
 	--ck-html-embed-source-height: 10em;
 	--ck-html-embed-unfocused-outline-width: 1px;
 	--ck-html-embed-content-min-height: calc(var(--ck-icon-size) + var(--ck-spacing-standard));
+
+	--ck-html-embed-source-disabled-background: var(--ck-color-base-foreground);
+	--ck-html-embed-source-disabled-color: hsl(0deg 0% 45%);
 }
 
 /* The feature container. */
@@ -117,8 +120,12 @@
 		direction: ltr;
 
 		&[disabled] {
-			background: hsl(0deg 0% 97%);
-			color: hsl(0deg 0% 56%);
+			background: var(--ck-html-embed-source-disabled-background);
+			color: var(--ck-html-embed-source-disabled-color);
+
+			/* Safari needs this for the proper text color in disabled input. */
+			-webkit-text-fill-color: var(--ck-html-embed-source-disabled-color);
+			opacity: 1;
 		}
 	}
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-html-embed/htmlembed.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-html-embed/htmlembed.css
@@ -123,7 +123,7 @@
 			background: var(--ck-html-embed-source-disabled-background);
 			color: var(--ck-html-embed-source-disabled-color);
 
-			/* Safari needs this for the proper text color in disabled input. */
+			/* Safari needs this for the proper text color in disabled input (https://github.com/ckeditor/ckeditor5/issues/8320). */
 			-webkit-text-fill-color: var(--ck-html-embed-source-disabled-color);
 			opacity: 1;
 		}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (html-embed): The raw HTML text in disabled input in iOS Safari should be the same color as in other browsers. Closes #8320.

---

### Additional information

I also slightly increased the contrast, so it meets the WCAG AA requirements.