### PR TITLE
Stop upcast conversion early when a model element is not available

### DIFF
--- a/packages/ckeditor5-image/src/imagestyle/converters.js
+++ b/packages/ckeditor5-image/src/imagestyle/converters.js
@@ -57,8 +57,9 @@ export function viewToModelStyleAttribute( styles ) {
 		const viewFigureElement = data.viewItem;
 		const modelImageElement = first( data.modelRange.getItems() );
 
-		// Check if `imageStyle` attribute is allowed for current element.
-		if ( !conversionApi.schema.checkAttribute( modelImageElement, 'imageStyle' ) ) {
+		// Check if `modelImageElement` exists (see: #8270) and `imageStyle` attribute is allowed
+		// for that element, otherwise stop conversion early.
+		if ( modelImageElement && !conversionApi.schema.checkAttribute( modelImageElement, 'imageStyle' ) ) {
 			return;
 		}
 

--- a/packages/ckeditor5-image/src/imagestyle/converters.js
+++ b/packages/ckeditor5-image/src/imagestyle/converters.js
@@ -57,8 +57,8 @@ export function viewToModelStyleAttribute( styles ) {
 		const viewFigureElement = data.viewItem;
 		const modelImageElement = first( data.modelRange.getItems() );
 
-		// Check if `modelImageElement` exists (see: #8270) and `imageStyle` attribute is allowed
-		// for that element, otherwise stop conversion early.
+		// Check if `modelImageElement` exists (see: https://github.com/ckeditor/ckeditor5/issues/8270)
+		// and `imageStyle` attribute is allowed for that element, otherwise stop conversion early.
 		if ( modelImageElement && !conversionApi.schema.checkAttribute( modelImageElement, 'imageStyle' ) ) {
 			return;
 		}

--- a/packages/ckeditor5-image/tests/imagestyle/imagestyleediting.js
+++ b/packages/ckeditor5-image/tests/imagestyle/imagestyleediting.js
@@ -4,6 +4,7 @@
  */
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
+import ImageResizeEditing from '../../src/imageresize/imageresizeediting';
 import ImageStyleEditing from '../../src/imagestyle/imagestyleediting';
 import ImageEditing from '../../src/image/imageediting';
 import ImageStyleCommand from '../../src/imagestyle/imagestylecommand';
@@ -248,6 +249,24 @@ describe( 'ImageStyleEditing', () => {
 			expect( getViewData( viewDocument, { withoutSelection: true } ) ).to.equal(
 				'<figure class="ck-widget image" contenteditable="false"><img src="/assets/sample.png"></img></figure>'
 			);
+		} );
+
+		// See: https://github.com/ckeditor/ckeditor5/issues/8270.
+		it( 'should stop conversion when model element is not found', () => {
+			return VirtualTestEditor
+				.create( {
+					plugins: [ ImageEditing, ImageResizeEditing, ImageStyleEditing ]
+				} )
+				.then( newEditor => {
+					editor = newEditor;
+
+					expect(
+						() => editor.setData( '<figure class="image image_resized" style="width:331px;"></figure>' )
+					).not.to.throw();
+
+					// No conversion has been done.
+					expect( editor.getData() ).to.equal( '' );
+				} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (image): Image plugins can be loaded in any order without causing an error. Closes #8270.
