### PR TITLE
Horizontal line/Page break can be selected without other plugins using Widget plugin

### DIFF
--- a/packages/ckeditor5-horizontal-line/src/horizontalline.js
+++ b/packages/ckeditor5-horizontal-line/src/horizontalline.js
@@ -8,6 +8,7 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 import HorizontalLineEditing from './horizontallineediting';
 import HorizontalLineUI from './horizontallineui';
 
@@ -25,7 +26,7 @@ export default class HorizontalLine extends Plugin {
 	 * @inheritDoc
 	 */
 	static get requires() {
-		return [ HorizontalLineEditing, HorizontalLineUI ];
+		return [ HorizontalLineEditing, HorizontalLineUI, Widget ];
 	}
 
 	/**

--- a/packages/ckeditor5-horizontal-line/tests/horizontalline.js
+++ b/packages/ckeditor5-horizontal-line/tests/horizontalline.js
@@ -3,13 +3,15 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+import Widget from '@ckeditor/ckeditor5-widget/src/widget';
+
 import HorizontalLine from '../src/horizontalline';
 import HorizontalLineEditing from '../src/horizontallineediting';
 import HorizontalLineUI from '../src/horizontallineui';
 
 describe( 'HorizontalLine', () => {
-	it( 'should require HorizontalLineEditing and HorizontalLineUI', () => {
-		expect( HorizontalLine.requires ).to.deep.equal( [ HorizontalLineEditing, HorizontalLineUI ] );
+	it( 'should require HorizontalLineEditing, HorizontalLineUI and Widget', () => {
+		expect( HorizontalLine.requires ).to.deep.equal( [ HorizontalLineEditing, HorizontalLineUI, Widget ] );
 	} );
 
 	it( 'should be named', () => {

--- a/packages/ckeditor5-page-break/src/pagebreak.js
+++ b/packages/ckeditor5-page-break/src/pagebreak.js
@@ -8,6 +8,7 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 import PageBreakEditing from './pagebreakediting';
 import PageBreakUI from './pagebreakui';
 
@@ -25,7 +26,7 @@ export default class PageBreak extends Plugin {
 	 * @inheritDoc
 	 */
 	static get requires() {
-		return [ PageBreakEditing, PageBreakUI ];
+		return [ PageBreakEditing, PageBreakUI, Widget ];
 	}
 
 	/**

--- a/packages/ckeditor5-page-break/tests/pagebreak.js
+++ b/packages/ckeditor5-page-break/tests/pagebreak.js
@@ -3,13 +3,15 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+import Widget from '@ckeditor/ckeditor5-widget/src/widget';
+
 import PageBreak from '../src/pagebreak';
 import PageBreakEditing from '../src/pagebreakediting';
 import PageBreakUI from '../src/pagebreakui';
 
 describe( 'PageBreak', () => {
-	it( 'should require PageBreakEditing and PageBreakUI', () => {
-		expect( PageBreak.requires ).to.deep.equal( [ PageBreakEditing, PageBreakUI ] );
+	it( 'should require PageBreakEditing, PageBreakUI and Widget', () => {
+		expect( PageBreak.requires ).to.deep.equal( [ PageBreakEditing, PageBreakUI, Widget ] );
 	} );
 
 	it( 'should be named', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (horizontal-line): Horizontal line can be selected when no other package uses Widget. Closes #8825.

Fix (page-break): Page break can be selected when no other package uses Widget. Closes #8825.