### PR TITLE
Remove unnecessary processor initialization in editor

### DIFF
--- a/docs/_snippets/examples/multi-root-editor.js
+++ b/docs/_snippets/examples/multi-root-editor.js
@@ -8,7 +8,6 @@
 // Multiroot editor dependencies.
 import Editor from '@ckeditor/ckeditor5-core/src/editor/editor';
 import DataApiMixin from '@ckeditor/ckeditor5-core/src/editor/utils/dataapimixin';
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import getDataFromElement from '@ckeditor/ckeditor5-utils/src/dom/getdatafromelement';
 import setDataInElement from '@ckeditor/ckeditor5-utils/src/dom/setdatainelement';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
@@ -65,8 +64,6 @@ class MultirootEditor extends Editor {
 	 */
 	constructor( sourceElements, config ) {
 		super( config );
-
-		this.data.processor = new HtmlDataProcessor( this.data.viewDocument );
 
 		// Create root and UIView element for each editable container.
 		for ( const rootName of Object.keys( sourceElements ) ) {

--- a/docs/framework/guides/custom-editor-creator.md
+++ b/docs/framework/guides/custom-editor-creator.md
@@ -17,7 +17,6 @@ The `*Editor` class is the main class of each editor type. It initializes the wh
 ```js
 import Editor from '@ckeditor/ckeditor5-core/src/editor/editor';
 import DataApiMixin from '@ckeditor/ckeditor5-core/src/editor/utils/dataapimixin';
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import getDataFromElement from '@ckeditor/ckeditor5-utils/src/dom/getdatafromelement';
 import setDataInElement from '@ckeditor/ckeditor5-utils/src/dom/setdatainelement';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
@@ -47,8 +46,6 @@ class MultirootEditor extends Editor {
 	 */
 	constructor( sourceElements, config ) {
 		super( config );
-
-		this.data.processor = new HtmlDataProcessor( this.data.viewDocument );
 
 		// Create root and UIView element for each editable container.
 		for ( const rootName of Object.keys( sourceElements ) ) {

--- a/packages/ckeditor5-core/tests/_utils/classictesteditor.js
+++ b/packages/ckeditor5-core/tests/_utils/classictesteditor.js
@@ -6,7 +6,6 @@
 import Editor from '../../src/editor/editor';
 import ElementApiMixin from '../../src/editor/utils/elementapimixin';
 import DataApiMixin from '../../src/editor/utils/dataapimixin';
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import EditorUI from '../../src/editor/editorui';
 import BoxedEditorUIView from '@ckeditor/ckeditor5-ui/src/editorui/boxed/boxededitoruiview';
 import ElementReplacer from '@ckeditor/ckeditor5-utils/src/elementreplacer';
@@ -32,9 +31,6 @@ export default class ClassicTestEditor extends Editor {
 		if ( isElement( sourceElementOrData ) ) {
 			this.sourceElement = sourceElementOrData;
 		}
-
-		// Use the HTML data processor in this editor.
-		this.data.processor = new HtmlDataProcessor( this.data.viewDocument );
 
 		// Create the ("main") root element of the model tree.
 		this.model.document.createRoot();

--- a/packages/ckeditor5-core/tests/_utils/modeltesteditor.js
+++ b/packages/ckeditor5-core/tests/_utils/modeltesteditor.js
@@ -5,7 +5,6 @@
 
 import Editor from '../../src/editor/editor';
 import DataApiMixin from '../../src/editor/utils/dataapimixin';
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 
 /**
@@ -19,9 +18,6 @@ import mix from '@ckeditor/ckeditor5-utils/src/mix';
 export default class ModelTestEditor extends Editor {
 	constructor( config ) {
 		super( config );
-
-		// Use the HTML data processor in this editor.
-		this.data.processor = new HtmlDataProcessor( this.data.viewDocument );
 
 		// Disable editing pipeline.
 		this.editing.destroy();

--- a/packages/ckeditor5-core/tests/_utils/virtualtesteditor.js
+++ b/packages/ckeditor5-core/tests/_utils/virtualtesteditor.js
@@ -5,7 +5,6 @@
 
 import Editor from '../../src/editor/editor';
 import DataApiMixin from '../../src/editor/utils/dataapimixin';
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 
 /**
@@ -19,9 +18,6 @@ import mix from '@ckeditor/ckeditor5-utils/src/mix';
 export default class VirtualTestEditor extends Editor {
 	constructor( config ) {
 		super( config );
-
-		// Use the HTML data processor in this editor.
-		this.data.processor = new HtmlDataProcessor( this.data.viewDocument );
 
 		// Create the ("main") root element of the model tree.
 		this.model.document.createRoot();

--- a/packages/ckeditor5-core/tests/editor/utils/attachtoform.js
+++ b/packages/ckeditor5-core/tests/editor/utils/attachtoform.js
@@ -6,7 +6,6 @@
 import attachToForm from '../../../src/editor/utils/attachtoform';
 import ElementApiMixin from '../../../src/editor/utils/elementapimixin';
 import Editor from '../../../src/editor/editor';
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import { expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 
@@ -31,7 +30,6 @@ describe( 'attachToForm()', () => {
 		mix( CustomEditor, ElementApiMixin );
 
 		editor = new CustomEditor();
-		editor.data.processor = new HtmlDataProcessor( editor.data.viewDocument );
 		editor.model.document.createRoot();
 		editor.model.schema.extend( '$text', { allowIn: '$root' } );
 		editor.fire( 'ready' );

--- a/packages/ckeditor5-core/tests/editor/utils/dataapimixin.js
+++ b/packages/ckeditor5-core/tests/editor/utils/dataapimixin.js
@@ -5,7 +5,6 @@
 
 import DataApiMixin from '../../../src/editor/utils/dataapimixin';
 import Editor from '../../../src/editor/editor';
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import testUtils from '../../../tests/_utils/utils';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
@@ -18,7 +17,6 @@ describe( 'DataApiMixin', () => {
 		mix( CustomEditor, DataApiMixin );
 
 		editor = new CustomEditor();
-		editor.data.processor = new HtmlDataProcessor( editor.data.viewDocument );
 		editor.model.document.createRoot( '$root', 'main' );
 		editor.model.document.createRoot( '$root', 'secondRoot' );
 		editor.model.schema.extend( '$text', { allowIn: '$root' } );

--- a/packages/ckeditor5-core/tests/editor/utils/elementapimixin.js
+++ b/packages/ckeditor5-core/tests/editor/utils/elementapimixin.js
@@ -7,7 +7,6 @@
 
 import ElementApiMixin from '../../../src/editor/utils/elementapimixin';
 import Editor from '../../../src/editor/editor';
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import { expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 
@@ -21,7 +20,6 @@ describe( 'ElementApiMixin', () => {
 		mix( CustomEditor, ElementApiMixin );
 
 		editor = new CustomEditor();
-		editor.data.processor = new HtmlDataProcessor( editor.data.viewDocument );
 		editor.model.document.createRoot();
 		editor.model.schema.extend( '$text', { allowIn: '$root' } );
 		editor.fire( 'ready' ); // (#6139)

--- a/packages/ckeditor5-ui/docs/_snippets/examples/bootstrap-ui-inner.js
+++ b/packages/ckeditor5-ui/docs/_snippets/examples/bootstrap-ui-inner.js
@@ -10,7 +10,6 @@ import Editor from '@ckeditor/ckeditor5-core/src/editor/editor';
 import EditorUI from '@ckeditor/ckeditor5-core/src/editor/editorui';
 import EditorUIView from '@ckeditor/ckeditor5-ui/src/editorui/editoruiview';
 import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/inlineeditableuiview';
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import ElementReplacer from '@ckeditor/ckeditor5-utils/src/elementreplacer';
 
 // Interfaces to extend basic Editor API.
@@ -50,9 +49,6 @@ export default class BootstrapEditor extends Editor {
 
 		// Remember the element the editor is created with.
 		this.sourceElement = element;
-
-		// Use the HTML data processor in this editor.
-		this.data.processor = new HtmlDataProcessor( this.data.viewDocument );
 
 		// Create the ("main") root element of the model tree.
 		this.model.document.createRoot();

--- a/packages/ckeditor5-ui/docs/framework/guides/external-ui.md
+++ b/packages/ckeditor5-ui/docs/framework/guides/external-ui.md
@@ -23,7 +23,6 @@ import EditorUIView from '@ckeditor/ckeditor5-ui/src/editorui/editoruiview';
 import FocusTracker from '@ckeditor/ckeditor5-utils/src/focustracker';
 import ComponentFactory from '@ckeditor/ckeditor5-ui/src/componentfactory';
 import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/inlineeditableuiview';
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import ElementReplacer from '@ckeditor/ckeditor5-utils/src/elementreplacer';
 
 // Interfaces to extend the basic Editor API.
@@ -69,9 +68,6 @@ export default class BootstrapEditor extends Editor {
 
 		// Remember the element the editor is created with.
 		this.sourceElement = element;
-
-		// Use the HTML data processor in this editor.
-		this.data.processor = new HtmlDataProcessor( this.data.viewDocument );
 
 		// Create the ("main") root element of the model tree.
 		this.model.document.createRoot();

--- a/packages/ckeditor5-watchdog/tests/editorwatchdog.js
+++ b/packages/ckeditor5-watchdog/tests/editorwatchdog.js
@@ -10,7 +10,6 @@ import Editor from '@ckeditor/ckeditor5-core/src/editor/editor';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 
 // The error handling testing with mocha & chai is quite broken and hard to test.
 // sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
@@ -936,8 +935,6 @@ describe( 'EditorWatchdog', () => {
 			class MultiRootEditor extends Editor {
 				constructor( sourceElements, config ) {
 					super( config );
-
-					this.data.processor = new HtmlDataProcessor( this.data.viewDocument );
 
 					// Create a root for each source element.
 					for ( const rootName of Object.keys( sourceElements ) ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Tests: Remove unnecessary processor initialization. Closes #8834.

Docs: Remove unnecessary processor initialization in examples and snippets. Closes #8834.