### PR TITLE
Fixed unused or misplaced dependencies and added dependency checker to Husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@ckeditor/ckeditor5-comments": ">=24.0.0",
     "@ckeditor/ckeditor5-dev-docs": "^24.0.0",
     "@ckeditor/ckeditor5-dev-env": "^24.0.0",
-    "@ckeditor/ckeditor5-dev-tests": "^23.3.0",
+    "@ckeditor/ckeditor5-dev-tests": "^24.0.0",
     "@ckeditor/ckeditor5-dev-utils": "^24.0.0",
     "@ckeditor/ckeditor5-dev-webpack-plugin": "^24.0.0",
     "@ckeditor/ckeditor5-export-pdf": ">=1.0.0",

--- a/package.json
+++ b/package.json
@@ -157,7 +157,8 @@
     "release:bump-version": "node ./scripts/release/bump-versions.js",
     "release:publish": "node ./scripts/release/publish.js",
     "switch-to-dev-dev": "sh ./scripts/switch-to-dev-dev.sh",
-    "clean-up-svg-icons": "sh ./scripts/clean-up-svg-icons.sh"
+    "clean-up-svg-icons": "sh ./scripts/clean-up-svg-icons.sh",
+    "check-dependencies": "node node_modules/@ckeditor/ckeditor5-dev-tests/bin/check-dependencies.js"
   },
   "lint-staged": {
     "**/*.js": [
@@ -165,6 +166,9 @@
     ],
     "**/*.css": [
       "stylelint --quiet --allow-empty-input"
+    ],
+    "**/(*.{js,css}|package.json)": [
+      "yarn run check-dependencies"
     ]
   },
   "eslintIgnore": [

--- a/packages/ckeditor5-alignment/package.json
+++ b/packages/ckeditor5-alignment/package.json
@@ -11,7 +11,8 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^24.0.0",
-    "@ckeditor/ckeditor5-ui": "^24.0.0"
+    "@ckeditor/ckeditor5-ui": "^24.0.0",
+    "@ckeditor/ckeditor5-utils": "^24.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-block-quote": "^24.0.0",
@@ -22,8 +23,7 @@
     "@ckeditor/ckeditor5-image": "^24.0.0",
     "@ckeditor/ckeditor5-list": "^24.0.0",
     "@ckeditor/ckeditor5-paragraph": "^24.0.0",
-    "@ckeditor/ckeditor5-typing": "^24.0.0",
-    "@ckeditor/ckeditor5-utils": "^24.0.0"
+    "@ckeditor/ckeditor5-typing": "^24.0.0"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-autoformat/package.json
+++ b/packages/ckeditor5-autoformat/package.json
@@ -11,20 +11,20 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^24.0.0",
-    "@ckeditor/ckeditor5-typing": "^24.0.0"
+    "@ckeditor/ckeditor5-engine": "^24.0.0",
+    "@ckeditor/ckeditor5-utils": "^24.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^24.0.0",
     "@ckeditor/ckeditor5-block-quote": "^24.0.0",
     "@ckeditor/ckeditor5-code-block": "^24.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
-    "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-enter": "^24.0.0",
     "@ckeditor/ckeditor5-heading": "^24.0.0",
     "@ckeditor/ckeditor5-list": "^24.0.0",
     "@ckeditor/ckeditor5-paragraph": "^24.0.0",
-    "@ckeditor/ckeditor5-undo": "^24.0.0",
-    "@ckeditor/ckeditor5-utils": "^24.0.0"
+    "@ckeditor/ckeditor5-typing": "^24.0.0",
+    "@ckeditor/ckeditor5-undo": "^24.0.0"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-basic-styles/package.json
+++ b/packages/ckeditor5-basic-styles/package.json
@@ -19,7 +19,6 @@
     "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-essentials": "^24.0.0",
     "@ckeditor/ckeditor5-paragraph": "^24.0.0",
-    "@ckeditor/ckeditor5-remove-format": "^24.0.0",
     "@ckeditor/ckeditor5-utils": "^24.0.0"
   },
   "engines": {

--- a/packages/ckeditor5-build-balloon-block/package.json
+++ b/packages/ckeditor5-build-balloon-block/package.json
@@ -24,15 +24,12 @@
   "files": [
     "build"
   ],
-  "devDependencies": {
+  "dependencies": {
     "@ckeditor/ckeditor5-adapter-ckfinder": "^24.0.0",
     "@ckeditor/ckeditor5-autoformat": "^24.0.0",
     "@ckeditor/ckeditor5-basic-styles": "^24.0.0",
     "@ckeditor/ckeditor5-block-quote": "^24.0.0",
     "@ckeditor/ckeditor5-ckfinder": "^24.0.0",
-    "@ckeditor/ckeditor5-core": "^24.0.0",
-    "@ckeditor/ckeditor5-dev-utils": "^20.0.0",
-    "@ckeditor/ckeditor5-dev-webpack-plugin": "^20.0.0",
     "@ckeditor/ckeditor5-easy-image": "^24.0.0",
     "@ckeditor/ckeditor5-editor-balloon": "^24.0.0",
     "@ckeditor/ckeditor5-essentials": "^24.0.0",
@@ -46,14 +43,19 @@
     "@ckeditor/ckeditor5-paste-from-office": "^24.0.0",
     "@ckeditor/ckeditor5-table": "^24.0.0",
     "@ckeditor/ckeditor5-typing": "^24.0.0",
-    "@ckeditor/ckeditor5-theme-lark": "^24.0.0",
     "@ckeditor/ckeditor5-ui": "^24.0.0",
+    "webpack-cli": "^3.3.11"
+  },
+  "devDependencies": {
+    "@ckeditor/ckeditor5-core": "^24.0.0",
+    "@ckeditor/ckeditor5-dev-utils": "^20.0.0",
+    "@ckeditor/ckeditor5-dev-webpack-plugin": "^20.0.0",
+    "@ckeditor/ckeditor5-theme-lark": "^24.0.0",
     "postcss-loader": "^3.0.0",
     "raw-loader": "^4.0.1",
     "style-loader": "^1.2.1",
     "terser-webpack-plugin": "^3.0.2",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.11"
+    "webpack": "^4.43.0"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-build-balloon/package.json
+++ b/packages/ckeditor5-build-balloon/package.json
@@ -24,15 +24,12 @@
   "files": [
     "build"
   ],
-  "devDependencies": {
+  "dependencies": {
     "@ckeditor/ckeditor5-adapter-ckfinder": "^24.0.0",
     "@ckeditor/ckeditor5-autoformat": "^24.0.0",
     "@ckeditor/ckeditor5-basic-styles": "^24.0.0",
     "@ckeditor/ckeditor5-block-quote": "^24.0.0",
     "@ckeditor/ckeditor5-ckfinder": "^24.0.0",
-    "@ckeditor/ckeditor5-core": "^24.0.0",
-    "@ckeditor/ckeditor5-dev-utils": "^20.0.0",
-    "@ckeditor/ckeditor5-dev-webpack-plugin": "^20.0.0",
     "@ckeditor/ckeditor5-easy-image": "^24.0.0",
     "@ckeditor/ckeditor5-editor-balloon": "^24.0.0",
     "@ckeditor/ckeditor5-essentials": "^24.0.0",
@@ -46,13 +43,18 @@
     "@ckeditor/ckeditor5-paste-from-office": "^24.0.0",
     "@ckeditor/ckeditor5-table": "^24.0.0",
     "@ckeditor/ckeditor5-typing": "^24.0.0",
+    "webpack-cli": "^3.3.11"
+  },
+  "devDependencies": {
+    "@ckeditor/ckeditor5-core": "^24.0.0",
+    "@ckeditor/ckeditor5-dev-utils": "^20.0.0",
+    "@ckeditor/ckeditor5-dev-webpack-plugin": "^20.0.0",
     "@ckeditor/ckeditor5-theme-lark": "^24.0.0",
     "postcss-loader": "^3.0.0",
     "raw-loader": "^4.0.1",
     "style-loader": "^1.2.1",
     "terser-webpack-plugin": "^3.0.2",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.11"
+    "webpack": "^4.43.0"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-build-classic/package.json
+++ b/packages/ckeditor5-build-classic/package.json
@@ -24,15 +24,12 @@
   "files": [
     "build"
   ],
-  "devDependencies": {
+  "dependencies": {
     "@ckeditor/ckeditor5-adapter-ckfinder": "^24.0.0",
     "@ckeditor/ckeditor5-autoformat": "^24.0.0",
     "@ckeditor/ckeditor5-basic-styles": "^24.0.0",
     "@ckeditor/ckeditor5-block-quote": "^24.0.0",
     "@ckeditor/ckeditor5-ckfinder": "^24.0.0",
-    "@ckeditor/ckeditor5-core": "^24.0.0",
-    "@ckeditor/ckeditor5-dev-utils": "^20.0.0",
-    "@ckeditor/ckeditor5-dev-webpack-plugin": "^20.0.0",
     "@ckeditor/ckeditor5-easy-image": "^24.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
     "@ckeditor/ckeditor5-essentials": "^24.0.0",
@@ -46,13 +43,18 @@
     "@ckeditor/ckeditor5-paste-from-office": "^24.0.0",
     "@ckeditor/ckeditor5-table": "^24.0.0",
     "@ckeditor/ckeditor5-typing": "^24.0.0",
+    "webpack-cli": "^3.3.11"
+  },
+  "devDependencies": {
+    "@ckeditor/ckeditor5-core": "^24.0.0",
+    "@ckeditor/ckeditor5-dev-utils": "^20.0.0",
+    "@ckeditor/ckeditor5-dev-webpack-plugin": "^20.0.0",
     "@ckeditor/ckeditor5-theme-lark": "^24.0.0",
     "postcss-loader": "^3.0.0",
     "raw-loader": "^4.0.1",
     "style-loader": "^1.2.1",
     "terser-webpack-plugin": "^3.0.2",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.11"
+    "webpack": "^4.43.0"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-build-decoupled-document/package.json
+++ b/packages/ckeditor5-build-decoupled-document/package.json
@@ -24,22 +24,18 @@
   "files": [
     "build"
   ],
-  "devDependencies": {
+  "dependencies": {
     "@ckeditor/ckeditor5-adapter-ckfinder": "^24.0.0",
     "@ckeditor/ckeditor5-alignment": "^24.0.0",
     "@ckeditor/ckeditor5-autoformat": "^24.0.0",
     "@ckeditor/ckeditor5-basic-styles": "^24.0.0",
     "@ckeditor/ckeditor5-block-quote": "^24.0.0",
     "@ckeditor/ckeditor5-ckfinder": "^24.0.0",
-    "@ckeditor/ckeditor5-core": "^24.0.0",
-    "@ckeditor/ckeditor5-dev-utils": "^20.0.0",
-    "@ckeditor/ckeditor5-dev-webpack-plugin": "^20.0.0",
     "@ckeditor/ckeditor5-easy-image": "^24.0.0",
     "@ckeditor/ckeditor5-editor-decoupled": "^24.0.0",
     "@ckeditor/ckeditor5-essentials": "^24.0.0",
     "@ckeditor/ckeditor5-font": "^24.0.0",
     "@ckeditor/ckeditor5-heading": "^24.0.0",
-    "@ckeditor/ckeditor5-highlight": "^24.0.0",
     "@ckeditor/ckeditor5-image": "^24.0.0",
     "@ckeditor/ckeditor5-indent": "^24.0.0",
     "@ckeditor/ckeditor5-link": "^24.0.0",
@@ -49,13 +45,18 @@
     "@ckeditor/ckeditor5-paste-from-office": "^24.0.0",
     "@ckeditor/ckeditor5-table": "^24.0.0",
     "@ckeditor/ckeditor5-typing": "^24.0.0",
+    "webpack-cli": "^3.3.11"
+  },
+  "devDependencies": {
+    "@ckeditor/ckeditor5-core": "^24.0.0",
+    "@ckeditor/ckeditor5-dev-utils": "^20.0.0",
+    "@ckeditor/ckeditor5-dev-webpack-plugin": "^20.0.0",
     "@ckeditor/ckeditor5-theme-lark": "^24.0.0",
     "postcss-loader": "^3.0.0",
     "raw-loader": "^4.0.1",
     "style-loader": "^1.2.1",
     "terser-webpack-plugin": "^3.0.2",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.11"
+    "webpack": "^4.43.0"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-build-inline/package.json
+++ b/packages/ckeditor5-build-inline/package.json
@@ -24,15 +24,12 @@
   "files": [
     "build"
   ],
-  "devDependencies": {
+  "dependencies": {
     "@ckeditor/ckeditor5-adapter-ckfinder": "^24.0.0",
     "@ckeditor/ckeditor5-autoformat": "^24.0.0",
     "@ckeditor/ckeditor5-basic-styles": "^24.0.0",
     "@ckeditor/ckeditor5-block-quote": "^24.0.0",
     "@ckeditor/ckeditor5-ckfinder": "^24.0.0",
-    "@ckeditor/ckeditor5-core": "^24.0.0",
-    "@ckeditor/ckeditor5-dev-utils": "^20.0.0",
-    "@ckeditor/ckeditor5-dev-webpack-plugin": "^20.0.0",
     "@ckeditor/ckeditor5-easy-image": "^24.0.0",
     "@ckeditor/ckeditor5-editor-inline": "^24.0.0",
     "@ckeditor/ckeditor5-essentials": "^24.0.0",
@@ -46,13 +43,18 @@
     "@ckeditor/ckeditor5-paste-from-office": "^24.0.0",
     "@ckeditor/ckeditor5-table": "^24.0.0",
     "@ckeditor/ckeditor5-typing": "^24.0.0",
+    "webpack-cli": "^3.3.11"
+  },
+  "devDependencies": {
+    "@ckeditor/ckeditor5-core": "^24.0.0",
+    "@ckeditor/ckeditor5-dev-utils": "^20.0.0",
+    "@ckeditor/ckeditor5-dev-webpack-plugin": "^20.0.0",
     "@ckeditor/ckeditor5-theme-lark": "^24.0.0",
     "postcss-loader": "^3.0.0",
     "raw-loader": "^4.0.1",
     "style-loader": "^1.2.1",
     "terser-webpack-plugin": "^3.0.2",
-    "webpack": "^4.43.0",
-    "webpack-cli": "^3.3.11"
+    "webpack": "^4.43.0"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-ckfinder/package.json
+++ b/packages/ckeditor5-ckfinder/package.json
@@ -14,14 +14,14 @@
     "@ckeditor/ckeditor5-core": "^24.0.0",
     "@ckeditor/ckeditor5-image": "^24.0.0",
     "@ckeditor/ckeditor5-link": "^24.0.0",
-    "@ckeditor/ckeditor5-ui": "^24.0.0"
+    "@ckeditor/ckeditor5-ui": "^24.0.0",
+    "@ckeditor/ckeditor5-utils": "^24.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
     "@ckeditor/ckeditor5-clipboard": "^24.0.0",
     "@ckeditor/ckeditor5-engine": "^24.0.0",
-    "@ckeditor/ckeditor5-paragraph": "^24.0.0",
-    "@ckeditor/ckeditor5-utils": "^24.0.0"
+    "@ckeditor/ckeditor5-paragraph": "^24.0.0"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-code-block/package.json
+++ b/packages/ckeditor5-code-block/package.json
@@ -13,8 +13,7 @@
     "@ckeditor/ckeditor5-core": "^24.0.0",
     "@ckeditor/ckeditor5-enter": "^24.0.0",
     "@ckeditor/ckeditor5-ui": "^24.0.0",
-    "@ckeditor/ckeditor5-utils": "^24.0.0",
-    "lodash-es": "^4.17.15"
+    "@ckeditor/ckeditor5-utils": "^24.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-alignment": "^24.0.0",

--- a/packages/ckeditor5-core/package.json
+++ b/packages/ckeditor5-core/package.json
@@ -22,6 +22,7 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-engine": "^24.0.0",
+    "@ckeditor/ckeditor5-ui": "^24.0.0",
     "@ckeditor/ckeditor5-utils": "^24.0.0",
     "lodash-es": "^4.17.15"
   },
@@ -38,8 +39,7 @@
     "@ckeditor/ckeditor5-list": "^24.0.0",
     "@ckeditor/ckeditor5-media-embed": "^24.0.0",
     "@ckeditor/ckeditor5-paragraph": "^24.0.0",
-    "@ckeditor/ckeditor5-table": "^24.0.0",
-    "@ckeditor/ckeditor5-ui": "^24.0.0"
+    "@ckeditor/ckeditor5-table": "^24.0.0"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-font/package.json
+++ b/packages/ckeditor5-font/package.json
@@ -11,12 +11,12 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^24.0.0",
+    "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-ui": "^24.0.0",
     "@ckeditor/ckeditor5-utils": "^24.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
-    "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-highlight": "^24.0.0",
     "@ckeditor/ckeditor5-paragraph": "^24.0.0"
   },

--- a/packages/ckeditor5-heading/package.json
+++ b/packages/ckeditor5-heading/package.json
@@ -11,6 +11,7 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^24.0.0",
+    "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-paragraph": "^24.0.0",
     "@ckeditor/ckeditor5-ui": "^24.0.0",
     "@ckeditor/ckeditor5-utils": "^24.0.0"
@@ -21,7 +22,6 @@
     "@ckeditor/ckeditor5-block-quote": "^24.0.0",
     "@ckeditor/ckeditor5-clipboard": "^24.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
-    "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-enter": "^24.0.0",
     "@ckeditor/ckeditor5-image": "^24.0.0",
     "@ckeditor/ckeditor5-typing": "^24.0.0",

--- a/packages/ckeditor5-horizontal-line/package.json
+++ b/packages/ckeditor5-horizontal-line/package.json
@@ -20,8 +20,7 @@
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
     "@ckeditor/ckeditor5-easy-image": "^24.0.0",
     "@ckeditor/ckeditor5-image": "^24.0.0",
-    "@ckeditor/ckeditor5-paragraph": "^24.0.0",
-    "@ckeditor/ckeditor5-utils": "^24.0.0"
+    "@ckeditor/ckeditor5-paragraph": "^24.0.0"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-html-embed/package.json
+++ b/packages/ckeditor5-html-embed/package.json
@@ -11,7 +11,6 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^24.0.0",
-    "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-ui": "^24.0.0",
     "@ckeditor/ckeditor5-utils": "^24.0.0",
     "@ckeditor/ckeditor5-widget": "^24.0.0"
@@ -19,6 +18,7 @@
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^24.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
+    "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-paragraph": "^24.0.0",
     "@ckeditor/ckeditor5-clipboard": "^24.0.0",
     "lodash-es": "^4.17.15",

--- a/packages/ckeditor5-image/package.json
+++ b/packages/ckeditor5-image/package.json
@@ -14,13 +14,13 @@
     "@ckeditor/ckeditor5-core": "^24.0.0",
     "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-ui": "^24.0.0",
+    "@ckeditor/ckeditor5-undo": "^24.0.0",
     "@ckeditor/ckeditor5-upload": "^24.0.0",
     "@ckeditor/ckeditor5-utils": "^24.0.0",
     "@ckeditor/ckeditor5-widget": "^24.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^24.0.0",
-    "@ckeditor/ckeditor5-block-quote": "^24.0.0",
     "@ckeditor/ckeditor5-cloud-services": "^24.0.0",
     "@ckeditor/ckeditor5-ckfinder": "^24.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
@@ -33,8 +33,7 @@
     "@ckeditor/ckeditor5-list": "^24.0.0",
     "@ckeditor/ckeditor5-paragraph": "^24.0.0",
     "@ckeditor/ckeditor5-table": "^24.0.0",
-    "@ckeditor/ckeditor5-typing": "^24.0.0",
-    "@ckeditor/ckeditor5-undo": "^24.0.0"
+    "@ckeditor/ckeditor5-typing": "^24.0.0"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-indent/package.json
+++ b/packages/ckeditor5-indent/package.json
@@ -11,14 +11,14 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^24.0.0",
+    "@ckeditor/ckeditor5-engine": "^24.0.0",
+    "@ckeditor/ckeditor5-ui": "^24.0.0",
     "@ckeditor/ckeditor5-utils": "^24.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
-    "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-heading": "^24.0.0",
-    "@ckeditor/ckeditor5-paragraph": "^24.0.0",
-    "@ckeditor/ckeditor5-ui": "^24.0.0"
+    "@ckeditor/ckeditor5-paragraph": "^24.0.0"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-markdown-gfm/package.json
+++ b/packages/ckeditor5-markdown-gfm/package.json
@@ -10,16 +10,18 @@
     "ckeditor5-plugin"
   ],
   "dependencies": {
-    "@ckeditor/ckeditor5-basic-styles": "^24.0.0",
-    "@ckeditor/ckeditor5-code-block": "^24.0.0",
     "@ckeditor/ckeditor5-core": "^24.0.0",
-    "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
     "@ckeditor/ckeditor5-engine": "^24.0.0",
-    "@ckeditor/ckeditor5-list": "^24.0.0",
-    "@ckeditor/ckeditor5-table": "^24.0.0",
     "marked": "1.1.1",
     "turndown": "^6.0.0",
     "turndown-plugin-gfm": "^1.0.2"
+  },
+  "devDependencies": {
+    "@ckeditor/ckeditor5-basic-styles": "^24.0.0",
+    "@ckeditor/ckeditor5-code-block": "^24.0.0",
+    "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
+    "@ckeditor/ckeditor5-list": "^24.0.0",
+    "@ckeditor/ckeditor5-table": "^24.0.0"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-media-embed/package.json
+++ b/packages/ckeditor5-media-embed/package.json
@@ -13,7 +13,6 @@
     "@ckeditor/ckeditor5-clipboard": "^24.0.0",
     "@ckeditor/ckeditor5-core": "^24.0.0",
     "@ckeditor/ckeditor5-engine": "^24.0.0",
-    "@ckeditor/ckeditor5-image": "^24.0.0",
     "@ckeditor/ckeditor5-ui": "^24.0.0",
     "@ckeditor/ckeditor5-undo": "^24.0.0",
     "@ckeditor/ckeditor5-utils": "^24.0.0",
@@ -23,8 +22,8 @@
     "@ckeditor/ckeditor5-basic-styles": "^24.0.0",
     "@ckeditor/ckeditor5-editor-balloon": "^24.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
+    "@ckeditor/ckeditor5-image": "^24.0.0",
     "@ckeditor/ckeditor5-link": "^24.0.0",
-    "@ckeditor/ckeditor5-list": "^24.0.0",
     "@ckeditor/ckeditor5-paragraph": "^24.0.0",
     "@ckeditor/ckeditor5-typing": "^24.0.0",
     "@ckeditor/ckeditor5-table": "^24.0.0"

--- a/packages/ckeditor5-page-break/package.json
+++ b/packages/ckeditor5-page-break/package.json
@@ -20,8 +20,7 @@
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
     "@ckeditor/ckeditor5-easy-image": "^24.0.0",
     "@ckeditor/ckeditor5-image": "^24.0.0",
-    "@ckeditor/ckeditor5-paragraph": "^24.0.0",
-    "@ckeditor/ckeditor5-utils": "^24.0.0"
+    "@ckeditor/ckeditor5-paragraph": "^24.0.0"
   },
   "engines": {
     "node": ">=12.0.0",

--- a/packages/ckeditor5-restricted-editing/package.json
+++ b/packages/ckeditor5-restricted-editing/package.json
@@ -10,19 +10,19 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^24.0.0",
-    "@ckeditor/ckeditor5-ui": "^24.0.0"
+    "@ckeditor/ckeditor5-engine": "^24.0.0",
+    "@ckeditor/ckeditor5-ui": "^24.0.0",
+    "@ckeditor/ckeditor5-utils": "^24.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^24.0.0",
     "@ckeditor/ckeditor5-block-quote": "^24.0.0",
     "@ckeditor/ckeditor5-clipboard": "^24.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
-    "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-link": "^24.0.0",
     "@ckeditor/ckeditor5-paragraph": "^24.0.0",
     "@ckeditor/ckeditor5-table": "^24.0.0",
     "@ckeditor/ckeditor5-typing": "^24.0.0",
-    "@ckeditor/ckeditor5-utils": "^24.0.0",
     "@ckeditor/ckeditor5-undo": "^24.0.0"
   },
   "engines": {

--- a/packages/ckeditor5-table/package.json
+++ b/packages/ckeditor5-table/package.json
@@ -11,6 +11,7 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^24.0.0",
+    "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-ui": "^24.0.0",
     "@ckeditor/ckeditor5-utils": "^24.0.0",
     "@ckeditor/ckeditor5-widget": "^24.0.0",
@@ -21,7 +22,6 @@
     "@ckeditor/ckeditor5-block-quote": "^24.0.0",
     "@ckeditor/ckeditor5-clipboard": "^24.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
-    "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-horizontal-line": "^24.0.0",
     "@ckeditor/ckeditor5-image": "^24.0.0",
     "@ckeditor/ckeditor5-indent": "^24.0.0",

--- a/packages/ckeditor5-theme-lark/package.json
+++ b/packages/ckeditor5-theme-lark/package.json
@@ -9,13 +9,9 @@
     "ckeditor5-theme"
   ],
   "dependencies": {
-    "@ckeditor/ckeditor5-ui": "^24.0.0"
-  },
-  "devDependencies": {
-    "@ckeditor/ckeditor5-alignment": "^24.0.0",
     "@ckeditor/ckeditor5-basic-styles": "^24.0.0",
-    "@ckeditor/ckeditor5-code-block": "^24.0.0",
     "@ckeditor/ckeditor5-ckfinder": "^24.0.0",
+    "@ckeditor/ckeditor5-code-block": "^24.0.0",
     "@ckeditor/ckeditor5-core": "^24.0.0",
     "@ckeditor/ckeditor5-editor-balloon": "^24.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
@@ -33,6 +29,7 @@
     "@ckeditor/ckeditor5-restricted-editing": "^24.0.0",
     "@ckeditor/ckeditor5-select-all": "^24.0.0",
     "@ckeditor/ckeditor5-special-characters": "^24.0.0",
+    "@ckeditor/ckeditor5-ui": "^24.0.0",
     "@ckeditor/ckeditor5-undo": "^24.0.0",
     "@ckeditor/ckeditor5-utils": "^24.0.0",
     "@ckeditor/ckeditor5-table": "^24.0.0"

--- a/packages/ckeditor5-watchdog/package.json
+++ b/packages/ckeditor5-watchdog/package.json
@@ -15,7 +15,6 @@
   "devDependencies": {
     "@ckeditor/ckeditor5-core": "^24.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
-    "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-paragraph": "^24.0.0"
   },
   "engines": {

--- a/packages/ckeditor5-word-count/package.json
+++ b/packages/ckeditor5-word-count/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^24.0.0",
     "@ckeditor/ckeditor5-ui": "^24.0.0",
+    "@ckeditor/ckeditor5-utils": "^24.0.0",
     "lodash-es": "^4.17.15"
   },
   "devDependencies": {
@@ -24,7 +25,6 @@
     "@ckeditor/ckeditor5-list": "^24.0.0",
     "@ckeditor/ckeditor5-paragraph": "^24.0.0",
     "@ckeditor/ckeditor5-table": "^24.0.0",
-    "@ckeditor/ckeditor5-utils": "^24.0.0",
     "@ckeditor/ckeditor5-image": "^24.0.0"
   },
   "engines": {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Fixed unused or misplaced dependencies and added dependency checker to Husky. See: #8817.

---

### Additional information

Fixes and improvements in dependency checker are done in https://github.com/ckeditor/ckeditor5-dev/pull/687. This PR only contains fixes found by improved dependency checker.

**Important note**: as this PR adds dependency checker to Husky in `pre-commit` hook, before merging this PR new version of `ckeditor5-dev` (containing improved dependency checker) must be released and used in `ckeditor5` repo. Otherwise, the old dependency checker will not be able to handle absolute paths provided by `lint-staged` and will crash.