### PR TITLE
Dependency checker improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "release:publish": "node ./scripts/release/publish.js",
     "switch-to-dev-dev": "sh ./scripts/switch-to-dev-dev.sh",
     "clean-up-svg-icons": "sh ./scripts/clean-up-svg-icons.sh",
-    "check-dependencies": "node node_modules/@ckeditor/ckeditor5-dev-tests/bin/check-dependencies.js"
+    "check-dependencies": "ckeditor5-dev-tests-check-dependencies"
   },
   "lint-staged": {
     "**/*.js": [
@@ -168,7 +168,7 @@
       "stylelint --quiet --allow-empty-input"
     ],
     "**/(*.{js,css}|package.json)": [
-      "yarn run check-dependencies"
+      "ckeditor5-dev-tests-check-dependencies --quiet"
     ]
   },
   "eslintIgnore": [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Dependency checker logs are limited to show only errors and warnings in `pre-commit` hook. See #8862.

---

### Additional information

The `--quiet` flag, which is now used in the `pre-commit` hook, has been added in https://github.com/ckeditor/ckeditor5-dev/pull/688.

**Important note**: this PR requires changes from `ckeditor5-dev` ☝🏻.
