### PR TITLE
I/8798 disable commands embed html

### DIFF
--- a/packages/ckeditor5-horizontal-line/src/horizontallinecommand.js
+++ b/packages/ckeditor5-horizontal-line/src/horizontallinecommand.js
@@ -8,7 +8,7 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import { findOptimalInsertionPosition } from '@ckeditor/ckeditor5-widget/src/utils';
+import { findOptimalInsertionPosition, checkSelectionOnObject } from '@ckeditor/ckeditor5-widget/src/utils';
 
 /**
  * The horizontal line command.
@@ -84,17 +84,6 @@ function isHorizontalLineAllowedInParent( selection, schema, model ) {
 	const parent = getInsertHorizontalLineParent( selection, model );
 
 	return schema.checkChild( parent, 'horizontalLine' );
-}
-
-// Checks if the selection is on object.
-//
-// @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} selection
-// @param {module:engine/model/schema~Schema} schema
-// @returns {Boolean}
-function checkSelectionOnObject( selection, schema ) {
-	const selectedElement = selection.getSelectedElement();
-
-	return selectedElement && schema.isObject( selectedElement );
 }
 
 // Returns a node that will be used to insert a horizontal line with `model.insertContent` to check if the horizontal line can be

--- a/packages/ckeditor5-html-embed/package.json
+++ b/packages/ckeditor5-html-embed/package.json
@@ -20,6 +20,8 @@
     "@ckeditor/ckeditor5-editor-classic": "^24.0.0",
     "@ckeditor/ckeditor5-engine": "^24.0.0",
     "@ckeditor/ckeditor5-paragraph": "^24.0.0",
+    "@ckeditor/ckeditor5-media-embed": "^24.0.0",
+    "@ckeditor/ckeditor5-table": "^24.0.0",
     "@ckeditor/ckeditor5-clipboard": "^24.0.0",
     "lodash-es": "^4.17.15",
     "sanitize-html": "^2.1.0"

--- a/packages/ckeditor5-html-embed/src/inserthtmlembedcommand.js
+++ b/packages/ckeditor5-html-embed/src/inserthtmlembedcommand.js
@@ -8,7 +8,7 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import { findOptimalInsertionPosition } from '@ckeditor/ckeditor5-widget/src/utils';
+import { findOptimalInsertionPosition, checkSelectionOnObject } from '@ckeditor/ckeditor5-widget/src/utils';
 
 /**
  * The insert HTML embed element command.
@@ -68,17 +68,6 @@ function isHtmlEmbedAllowedInParent( selection, schema, model ) {
 	const parent = getInsertPageBreakParent( selection, model );
 
 	return schema.checkChild( parent, 'rawHtml' );
-}
-
-// Checks if the selection is on object.
-//
-// @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} selection
-// @param {module:engine/model/schema~Schema} schema
-// @returns {Boolean}
-function checkSelectionOnObject( selection, schema ) {
-	const selectedElement = selection.getSelectedElement();
-
-	return selectedElement && schema.isObject( selectedElement );
 }
 
 // Returns a node that will be used to insert a page break with `model.insertContent` to check if a html embed element can be placed there.

--- a/packages/ckeditor5-html-embed/tests/manual/htmlembed.js
+++ b/packages/ckeditor5-html-embed/tests/manual/htmlembed.js
@@ -9,6 +9,8 @@ import sanitizeHtml from 'sanitize-html';
 import { clone } from 'lodash-es';
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import MediaEmbed from '@ckeditor/ckeditor5-media-embed/src/mediaembed';
+import Table from '@ckeditor/ckeditor5-table/src/table';
 import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
 import HtmlEmbed from '../../src/htmlembed';
 
@@ -73,11 +75,11 @@ async function reloadEditor( config = {} ) {
 
 	config = {
 		...config,
-		plugins: [ ArticlePluginSet, HtmlEmbed, Code ],
+		plugins: [ ArticlePluginSet, HtmlEmbed, Code, MediaEmbed, Table ],
 		toolbar: [
 			'heading', '|', 'bold', 'italic', 'link', '|',
 			'bulletedList', 'numberedList', 'blockQuote', 'insertTable', '|',
-			'undo', 'redo', '|', 'htmlEmbed'
+			'undo', 'redo', '|', 'htmlEmbed', 'mediaEmbed'
 		],
 		image: {
 			toolbar: [ 'imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative' ]

--- a/packages/ckeditor5-html-embed/tests/manual/htmlembed.md
+++ b/packages/ckeditor5-html-embed/tests/manual/htmlembed.md
@@ -41,3 +41,7 @@ elements or attributes may be not rendered in the editing view. However, they st
 You can disable the preview mode and have the `textarea` element that will be blocked or enabled (depends on feature state).
 
 For toggling the state (edit source / see preview), click the icon in the right-top corner.
+
+---
+
+If the HTML snippet is selected none of the commands for inserting an object should be enabled (media, html-embed, table).

--- a/packages/ckeditor5-image/src/image/utils.js
+++ b/packages/ckeditor5-image/src/image/utils.js
@@ -7,7 +7,7 @@
  * @module image/image/utils
  */
 
-import { findOptimalInsertionPosition, isWidget, toWidget } from '@ckeditor/ckeditor5-widget/src/utils';
+import { findOptimalInsertionPosition, checkSelectionOnObject, isWidget, toWidget } from '@ckeditor/ckeditor5-widget/src/utils';
 
 /**
  * Converts a given {@link module:engine/view/element~Element} to an image widget:
@@ -140,15 +140,6 @@ function isImageAllowedInParent( selection, schema, model ) {
 	const parent = getInsertImageParent( selection, model );
 
 	return schema.checkChild( parent, 'image' );
-}
-
-// Check if selection is on object.
-//
-// @returns {Boolean}
-function checkSelectionOnObject( selection, schema ) {
-	const selectedElement = selection.getSelectedElement();
-
-	return selectedElement && schema.isObject( selectedElement );
 }
 
 // Checks if selection is placed in other image (ie. in caption).

--- a/packages/ckeditor5-media-embed/src/mediaembedcommand.js
+++ b/packages/ckeditor5-media-embed/src/mediaembedcommand.js
@@ -8,7 +8,7 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import { findOptimalInsertionPosition } from '@ckeditor/ckeditor5-widget/src/utils';
+import { findOptimalInsertionPosition, checkSelectionOnObject } from '@ckeditor/ckeditor5-widget/src/utils';
 import { getSelectedMediaModelWidget, insertMedia } from './utils';
 
 /**
@@ -30,18 +30,13 @@ export default class MediaEmbedCommand extends Command {
 		const model = this.editor.model;
 		const selection = model.document.selection;
 		const schema = model.schema;
-		const insertPosition = findOptimalInsertionPosition( selection, model );
 		const selectedMedia = getSelectedMediaModelWidget( selection );
 
-		let parent = insertPosition.parent;
-
-		// The model.insertContent() will remove empty parent (unless it is a $root or a limit).
-		if ( parent.isEmpty && !model.schema.isLimit( parent ) ) {
-			parent = parent.parent;
-		}
-
 		this.value = selectedMedia ? selectedMedia.getAttribute( 'url' ) : null;
-		this.isEnabled = schema.checkChild( parent, 'media' );
+
+		this.isEnabled = isMedia( selection ) ||
+			isAllowedInParent( selection, model ) &&
+			!checkSelectionOnObject( selection, schema );
 	}
 
 	/**
@@ -68,4 +63,30 @@ export default class MediaEmbedCommand extends Command {
 			insertMedia( model, url, insertPosition );
 		}
 	}
+}
+
+// Checks if the table is allowed in the parent.
+//
+// @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} selection
+// @param {module:engine/model/schema~Schema} schema
+// @returns {Boolean}
+function isAllowedInParent( selection, model ) {
+	const insertPosition = findOptimalInsertionPosition( selection, model );
+	let parent = insertPosition.parent;
+
+	// The model.insertContent() will remove empty parent (unless it is a $root or a limit).
+	if ( parent.isEmpty && !model.schema.isLimit( parent ) ) {
+		parent = parent.parent;
+	}
+
+	return model.schema.checkChild( parent, 'media' );
+}
+
+// Checks if the media object is selected.
+//
+// @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} selection
+// @returns {Boolean}
+function isMedia( selection ) {
+	const element = selection.getSelectedElement();
+	return element && element.name === 'media' || false;
 }

--- a/packages/ckeditor5-media-embed/src/mediaembedcommand.js
+++ b/packages/ckeditor5-media-embed/src/mediaembedcommand.js
@@ -34,7 +34,7 @@ export default class MediaEmbedCommand extends Command {
 
 		this.value = selectedMedia ? selectedMedia.getAttribute( 'url' ) : null;
 
-		this.isEnabled = isMedia( selection ) ||
+		this.isEnabled = isMediaSelected( selection ) ||
 			isAllowedInParent( selection, model ) &&
 			!checkSelectionOnObject( selection, schema );
 	}
@@ -86,7 +86,7 @@ function isAllowedInParent( selection, model ) {
 //
 // @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} selection
 // @returns {Boolean}
-function isMedia( selection ) {
+function isMediaSelected( selection ) {
 	const element = selection.getSelectedElement();
 	return element && element.name === 'media' || false;
 }

--- a/packages/ckeditor5-media-embed/src/mediaembedcommand.js
+++ b/packages/ckeditor5-media-embed/src/mediaembedcommand.js
@@ -88,5 +88,5 @@ function isAllowedInParent( selection, model ) {
 // @returns {Boolean}
 function isMediaSelected( selection ) {
 	const element = selection.getSelectedElement();
-	return element && element.name === 'media' || false;
+	return !!element && element.name === 'media';
 }

--- a/packages/ckeditor5-media-embed/tests/insertmediacommand.js
+++ b/packages/ckeditor5-media-embed/tests/insertmediacommand.js
@@ -88,6 +88,20 @@ describe( 'MediaEmbedCommand', () => {
 			setData( model, '<block><limit>foo[]</limit></block>' );
 			expect( command.isEnabled ).to.be.false;
 		} );
+
+		it( 'should be true if a non-object element is selected', () => {
+			model.schema.register( 'element', { allowIn: '$root', isSelectable: true } );
+
+			setData( model, '[<element></element>]' );
+			expect( command.isEnabled ).to.be.true;
+		} );
+
+		it( 'should be false if a non-media object is selected', () => {
+			model.schema.register( 'image', { isObject: true, isBlock: true, allowWhere: '$block' } );
+
+			setData( model, '[<image src="http://ckeditor.com"></image>]' );
+			expect( command.isEnabled ).to.be.false;
+		} );
 	} );
 
 	describe( 'value', () => {

--- a/packages/ckeditor5-page-break/src/pagebreakcommand.js
+++ b/packages/ckeditor5-page-break/src/pagebreakcommand.js
@@ -8,7 +8,7 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import { findOptimalInsertionPosition } from '@ckeditor/ckeditor5-widget/src/utils';
+import { findOptimalInsertionPosition, checkSelectionOnObject } from '@ckeditor/ckeditor5-widget/src/utils';
 
 /**
  * The page break command.
@@ -84,17 +84,6 @@ function isPageBreakAllowedInParent( selection, schema, model ) {
 	const parent = getInsertPageBreakParent( selection, model );
 
 	return schema.checkChild( parent, 'pageBreak' );
-}
-
-// Checks if the selection is on object.
-//
-// @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} selection
-// @param {module:engine/model/schema~Schema} schema
-// @returns {Boolean}
-function checkSelectionOnObject( selection, schema ) {
-	const selectedElement = selection.getSelectedElement();
-
-	return selectedElement && schema.isObject( selectedElement );
 }
 
 // Returns a node that will be used to insert a page break with `model.insertContent` to check if the page break can be placed there.

--- a/packages/ckeditor5-table/src/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/src/commands/inserttablecommand.js
@@ -8,7 +8,7 @@
  */
 
 import Command from '@ckeditor/ckeditor5-core/src/command';
-import { findOptimalInsertionPosition } from '@ckeditor/ckeditor5-widget/src/utils';
+import { findOptimalInsertionPosition, checkSelectionOnObject } from '@ckeditor/ckeditor5-widget/src/utils';
 
 /**
  * The insert table command.
@@ -30,9 +30,8 @@ export default class InsertTableCommand extends Command {
 		const selection = model.document.selection;
 		const schema = model.schema;
 
-		const validParent = getInsertTableParent( selection.getFirstPosition() );
-
-		this.isEnabled = schema.checkChild( validParent, 'table' );
+		this.isEnabled = isAllowedInParent( selection, schema ) &&
+			!checkSelectionOnObject( selection, schema );
 	}
 
 	/**
@@ -64,11 +63,14 @@ export default class InsertTableCommand extends Command {
 	}
 }
 
-// Returns valid parent to insert table
+// Checks if the table is allowed in the parent.
 //
-// @param {module:engine/model/position} position
-function getInsertTableParent( position ) {
-	const parent = position.parent;
+// @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} selection
+// @param {module:engine/model/schema~Schema} schema
+// @returns {Boolean}
+function isAllowedInParent( selection, schema ) {
+	const positionParent = selection.getFirstPosition().parent;
+	const validParent = positionParent === positionParent.root ? positionParent : positionParent.parent;
 
-	return parent === parent.root ? parent : parent.parent;
+	return schema.checkChild( validParent, 'table' );
 }

--- a/packages/ckeditor5-table/tests/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/tests/commands/inserttablecommand.js
@@ -32,7 +32,7 @@ describe( 'InsertTableCommand', () => {
 		return editor.destroy();
 	} );
 
-	describe.only( 'isEnabled', () => {
+	describe( 'isEnabled', () => {
 		describe( 'when selection is collapsed', () => {
 			it( 'should be true if in a root', () => {
 				setData( model, '[]' );
@@ -64,9 +64,9 @@ describe( 'InsertTableCommand', () => {
 			} );
 
 			it( 'should be true if a non-object element is selected', () => {
-				model.schema.register( 'softBreak', { allowWhere: '$text', isInline: true } );
+				model.schema.register( 'element', { allowIn: '$root', isSelectable: true } );
 
-				setData( model, '<paragraph>Fo[<softBreak></softBreak>]o</paragraph>' );
+				setData( model, '[<element></element>]' );
 				expect( command.isEnabled ).to.be.true;
 			} );
 		} );

--- a/packages/ckeditor5-table/tests/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/tests/commands/inserttablecommand.js
@@ -32,8 +32,13 @@ describe( 'InsertTableCommand', () => {
 		return editor.destroy();
 	} );
 
-	describe( 'isEnabled', () => {
+	describe.only( 'isEnabled', () => {
 		describe( 'when selection is collapsed', () => {
+			it( 'should be true if in a root', () => {
+				setData( model, '[]' );
+				expect( command.isEnabled ).to.be.true;
+			} );
+
 			it( 'should be true if in paragraph', () => {
 				setData( model, '<paragraph>foo[]</paragraph>' );
 				expect( command.isEnabled ).to.be.true;
@@ -42,6 +47,27 @@ describe( 'InsertTableCommand', () => {
 			it( 'should be false if in table', () => {
 				setData( model, '<table><tableRow><tableCell><paragraph>foo[]</paragraph></tableCell></tableRow></table>' );
 				expect( command.isEnabled ).to.be.false;
+			} );
+		} );
+
+		describe( 'when selection is not collapsed', () => {
+			it( 'should be false if an object is selected', () => {
+				model.schema.register( 'media', { isObject: true, isBlock: true, allowWhere: '$block' } );
+
+				setData( model, '[<media url="http://ckeditor.com"></media>]' );
+				expect( command.isEnabled ).to.be.false;
+			} );
+
+			it( 'should be true if in a paragraph', () => {
+				setData( model, '<paragraph>[Foo]</paragraph>' );
+				expect( command.isEnabled ).to.be.true;
+			} );
+
+			it( 'should be true if a non-object element is selected', () => {
+				model.schema.register( 'softBreak', { allowWhere: '$text', isInline: true } );
+
+				setData( model, '<paragraph>Fo[<softBreak></softBreak>]o</paragraph>' );
+				expect( command.isEnabled ).to.be.true;
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-widget/src/utils.js
+++ b/packages/ckeditor5-widget/src/utils.js
@@ -305,6 +305,19 @@ export function findOptimalInsertionPosition( selection, model ) {
 }
 
 /**
+ * Checks if the selection is on object.
+ *
+ * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} selection
+ * @param {module:engine/model/schema~Schema} schema
+ * @returns {Boolean}
+*/
+export function checkSelectionOnObject( selection, schema ) {
+	const selectedElement = selection.getSelectedElement();
+
+	return selectedElement && schema.isObject( selectedElement ) || false;
+}
+
+/**
  * A util to be used in order to map view positions to correct model positions when implementing a widget
  * which renders non-empty view element for an empty model element.
  *

--- a/packages/ckeditor5-widget/src/utils.js
+++ b/packages/ckeditor5-widget/src/utils.js
@@ -305,7 +305,7 @@ export function findOptimalInsertionPosition( selection, model ) {
 }
 
 /**
- * Checks if the selection is on object.
+ * Checks if the selection is on an object.
  *
  * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} selection
  * @param {module:engine/model/schema~Schema} schema
@@ -314,7 +314,7 @@ export function findOptimalInsertionPosition( selection, model ) {
 export function checkSelectionOnObject( selection, schema ) {
 	const selectedElement = selection.getSelectedElement();
 
-	return selectedElement && schema.isObject( selectedElement ) || false;
+	return !!selectedElement && schema.isObject( selectedElement );
 }
 
 /**

--- a/packages/ckeditor5-widget/tests/utils.js
+++ b/packages/ckeditor5-widget/tests/utils.js
@@ -19,6 +19,7 @@ import {
 	toWidgetEditable,
 	setHighlightHandling,
 	findOptimalInsertionPosition,
+	checkSelectionOnObject,
 	viewToModelPositionOutsideModelElement,
 	WIDGET_CLASS_NAME,
 	centeredBalloonPositionForLongWidgets
@@ -499,6 +500,58 @@ describe( 'widget utils', () => {
 
 				expect( pos.path ).to.deep.equal( [ 2 ] );
 			} );
+		} );
+	} );
+
+	describe( 'checkSelectionOnObject()', () => {
+		let model;
+
+		beforeEach( () => {
+			model = new Model();
+
+			model.document.createRoot();
+
+			model.schema.register( 'image', {
+				allowIn: '$root',
+				isObject: true,
+				isBlock: true
+			} );
+
+			model.schema.register( 'paragraph', {
+				inheritAllFrom: '$block'
+			} );
+
+			model.schema.register( 'softBreak', {
+				allowWhere: '$text',
+				isInline: true
+			} );
+		} );
+
+		it( 'should return false if no element is selected', () => {
+			setData( model, '<paragraph>[]</paragraph><image></image>' );
+
+			const selection = model.document.selection;
+			const isSelectionOnObject = checkSelectionOnObject( selection, model.schema );
+
+			expect( isSelectionOnObject ).to.be.false;
+		} );
+
+		it( 'should return false if the selection is not on the object', () => {
+			setData( model, '<paragraph>Fo[<softBreak></softBreak>]o</paragraph><image></image>' );
+
+			const selection = model.document.selection;
+			const isSelectionOnObject = checkSelectionOnObject( selection, model.schema );
+
+			expect( isSelectionOnObject ).to.be.false;
+		} );
+
+		it( 'should return true if the selection is on the object', () => {
+			setData( model, '<paragraph></paragraph>[<image></image>]' );
+
+			const selection = model.document.selection;
+			const isSelectionOnObject = checkSelectionOnObject( selection, model.schema );
+
+			expect( isSelectionOnObject ).to.be.true;
 		} );
 	} );
 

--- a/packages/ckeditor5-widget/tests/utils.js
+++ b/packages/ckeditor5-widget/tests/utils.js
@@ -521,14 +521,14 @@ describe( 'widget utils', () => {
 				inheritAllFrom: '$block'
 			} );
 
-			model.schema.register( 'softBreak', {
-				allowWhere: '$text',
-				isInline: true
+			model.schema.register( 'element', {
+				allowIn: '$root',
+				isSelectable: true
 			} );
 		} );
 
 		it( 'should return false if no element is selected', () => {
-			setData( model, '<paragraph>[]</paragraph><image></image>' );
+			setData( model, '<paragraph>[]</paragraph>' );
 
 			const selection = model.document.selection;
 			const isSelectionOnObject = checkSelectionOnObject( selection, model.schema );
@@ -537,7 +537,7 @@ describe( 'widget utils', () => {
 		} );
 
 		it( 'should return false if the selection is not on the object', () => {
-			setData( model, '<paragraph>Fo[<softBreak></softBreak>]o</paragraph><image></image>' );
+			setData( model, '[<element></element>]' );
 
 			const selection = model.document.selection;
 			const isSelectionOnObject = checkSelectionOnObject( selection, model.schema );

--- a/packages/ckeditor5-widget/tests/utils.js
+++ b/packages/ckeditor5-widget/tests/utils.js
@@ -525,6 +525,10 @@ describe( 'widget utils', () => {
 				allowIn: '$root',
 				isSelectable: true
 			} );
+
+			model.schema.extend( '$text', {
+				allowIn: 'image'
+			} );
 		} );
 
 		it( 'should return false if no element is selected', () => {
@@ -536,7 +540,7 @@ describe( 'widget utils', () => {
 			expect( isSelectionOnObject ).to.be.false;
 		} );
 
-		it( 'should return false if the selection is not on the object', () => {
+		it( 'should return false if the selection is not on an object', () => {
 			setData( model, '[<element></element>]' );
 
 			const selection = model.document.selection;
@@ -545,13 +549,31 @@ describe( 'widget utils', () => {
 			expect( isSelectionOnObject ).to.be.false;
 		} );
 
-		it( 'should return true if the selection is on the object', () => {
+		it( 'should return true if the selection is on an object', () => {
 			setData( model, '<paragraph></paragraph>[<image></image>]' );
 
 			const selection = model.document.selection;
 			const isSelectionOnObject = checkSelectionOnObject( selection, model.schema );
 
 			expect( isSelectionOnObject ).to.be.true;
+		} );
+
+		it( 'should return false if the selection contains an object', () => {
+			setData( model, '<paragraph>fo[o</paragraph><image></image><paragraph>ba]r</paragraph>' );
+
+			const selection = model.document.selection;
+			const isSelectionOnObject = checkSelectionOnObject( selection, model.schema );
+
+			expect( isSelectionOnObject ).to.be.false;
+		} );
+
+		it( 'should return false if the selection is nested in an object', () => {
+			setData( model, '<image>[foo]</image>' );
+
+			const selection = model.document.selection;
+			const isSelectionOnObject = checkSelectionOnObject( selection, model.schema );
+
+			expect( isSelectionOnObject ).to.be.false;
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): The `insertTable` command should be disabled if any object is selected. Closes #8798.  

Fix (media-embed): The `insertMediaEmbed` command should be disabled if any non-media object is selected. See #8798.

Other (widget): The `checkSelectionOnObject` function should be exported by the `@ckeditor/ckeditor5-widget/src/utils package`. See #8798.

Tests (html-embed): The manual test should show the insert table and insert media buttons and describe their correct state. See #8798.