### PR TITLE
Fixed missing bracket in docs.

### DIFF
--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/schema.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/schema.md
@@ -434,7 +434,7 @@ These listeners can be added either by listening directly to the {@link module:e
 For instance, the block quote feature defines such a listener to disallow nested `<blockQuote>` structures:
 
 ```js
-schema.addChildCheck( context, childDefinition ) => {
+schema.addChildCheck( ( context, childDefinition ) => {
 	// Note that the context is automatically normalized to a SchemaContext instance and
 	// the child to its definition (SchemaCompiledItemDefinition).
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (engine): Fixed missing bracket.