### PR TITLE
Hide a toolbar tooltip when focusing the editable.

### DIFF
--- a/docs/_snippets/assets.js
+++ b/docs/_snippets/assets.js
@@ -85,7 +85,7 @@ window.attachTourBalloon = function( { target, text, tippyOptions } ) {
 		tooltip.hide();
 	} );
 
-	target.addEventListener( 'click', () => {
+	target.offsetParent.addEventListener( 'click', () => {
 		tooltip.hide();
 	} );
 };

--- a/docs/_snippets/assets.js
+++ b/docs/_snippets/assets.js
@@ -21,13 +21,15 @@ import './tour-balloon.css';
  *		// Using a comparison callback to search for an item.
  *		window.attachTourBalloon( {
  *			target: window.findToolbarItem( editor.ui.view.toolbar, item => item.label && item.label === 'Insert HTML' ),
- *			text: 'Tour text to help users discover the feature.'
+ *			text: 'Tour text to help users discover the feature.',
+ *			editor
  *		} );
  *
  *		// Using a toolbar item index.
  *		window.attachTourBalloon( {
  *			target: window.findToolbarItem( editor.ui.view.toolbar, 5 ),
- *			text: 'Tour text to help users discover the feature.'
+ *			text: 'Tour text to help users discover the feature.',
+ *			editor
  *		} );
  *
  *		// Specifying options of tippy.js, e.g. to customize the placement of the balloon.
@@ -35,6 +37,7 @@ import './tour-balloon.css';
  *		window.attachTourBalloon( {
  *			target: window.findToolbarItem( editor.ui.view.toolbar, 5 ),
  *			text: 'Tour text to help users discover the feature.',
+ *			editor,
  *			tippyOptions: {
  *				placement: 'bottom-start'
  *			}
@@ -43,9 +46,10 @@ import './tour-balloon.css';
  * @param {Object} options Balloon options.
  * @param {HTMLElement} options.target A DOM node the balloon will point to.
  * @param {String} options.text The description to be shown in the tooltip.
+ * @param {module:core/editor/editor~Editor} options.editor The editor instance.
  * @param {Object} [options.tippyOptions] Additional [configuration of tippy.js](https://atomiks.github.io/tippyjs/v6/all-props/).
  */
-window.attachTourBalloon = function( { target, text, tippyOptions } ) {
+window.attachTourBalloon = function( { target, text, editor, tippyOptions } ) {
 	if ( !target ) {
 		console.warn( '[attachTourBalloon] The target DOM node for the feature tour balloon does not exist.', { text } );
 
@@ -85,9 +89,17 @@ window.attachTourBalloon = function( { target, text, tippyOptions } ) {
 		tooltip.hide();
 	} );
 
-	target.offsetParent.addEventListener( 'click', () => {
+	target.addEventListener( 'click', () => {
 		tooltip.hide();
 	} );
+
+	for ( const root of editor.editing.view.document.roots ) {
+		root.once( 'change:isFocused', ( evt, name, isFocused ) => {
+			if ( isFocused ) {
+				tooltip.hide();
+			}
+		} );
+	}
 };
 
 /**

--- a/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote.js
+++ b/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote.js
@@ -36,7 +36,8 @@ ClassicEditor
 		// eslint-disable-next-line no-undef
 		setTimeout( () => window.attachTourBalloon( {
 			target: window.findToolbarItem( editor.ui.view.toolbar, item => item.label && item.label === 'Block quote' ),
-			text: 'Click to insert a block quote.'
+			text: 'Click to insert a block quote.',
+			editor
 		} ) );
 	} )
 	.catch( err => {

--- a/packages/ckeditor5-html-embed/docs/_snippets/features/html-embed.js
+++ b/packages/ckeditor5-html-embed/docs/_snippets/features/html-embed.js
@@ -166,7 +166,8 @@ ClassicEditor
 
 		window.attachTourBalloon( {
 			target: window.findToolbarItem( editor.ui.view.toolbar, item => item.label && item.label === 'Insert HTML' ),
-			text: 'Click here to insert new HTML snippet.'
+			text: 'Click here to insert new HTML snippet.',
+			editor
 		} );
 	} )
 	.catch( err => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (docs): Hide a toolbar tooltip when focusing the editable. Closes #8883.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._