### PR TITLE
Fix (table): Support cells without children

### DIFF
--- a/packages/ckeditor5-table/src/converters/downcast.js
+++ b/packages/ckeditor5-table/src/converters/downcast.js
@@ -379,7 +379,7 @@ function createViewTableCellElement( tableSlot, tableAttributes, insertPosition,
 	conversionApi.mapper.bindElements( tableCell, cellElement );
 
 	// Additional requirement for data pipeline to have backward compatible data tables.
-	if ( !asWidget && !hasAnyAttribute( firstChild ) && isSingleParagraph ) {
+	if ( !asWidget && isSingleParagraph && !hasAnyAttribute( firstChild ) ) {
 		const innerParagraph = tableCell.getChild( 0 );
 
 		conversionApi.consumable.consume( innerParagraph, 'insert' );


### PR DESCRIPTION
Previously, it was possible for table cells to be entirely empty.
However, a recent change introduced in 93dbbf99 changed the evaluation order for table cell children.

This led to calling `hasAnyAttribute` on a null reference, which is not supported.

Move `isSingleParagraph` check prior to `hasAnyAttribute`. `isSingleParagraph` is correctly calculated because it relies on the `childCount` for the table cell.

Fixes #8941
Fixes #8917