### PR TITLE
Docs: adjust clipboard-plugin code example

### DIFF
--- a/packages/ckeditor5-clipboard/docs/framework/guides/deep-dive/clipboard.md
+++ b/packages/ckeditor5-clipboard/docs/framework/guides/deep-dive/clipboard.md
@@ -139,7 +139,7 @@ class PastePlainText extends Plugin {
 
 			const dataTransfer = data.dataTransfer;
 			let content = plainTextToHtml( dataTransfer.getData( 'text/plain' ) );
-			content = clipboardPlugin._htmlDataProcessor.toView( content );
+			content = this.editor.data.htmlProcessor.toView( content );
 			clipboardPlugin.fire( 'inputTransformation', { content, dataTransfer } );
 			editingView.scrollToTheSelection();
 


### PR DESCRIPTION
Docs (Clipboard): Update documentation for Clipboard Plugin. 

The adjustment was made based on this commit [98497ba2](https://github.com/ckeditor/ckeditor5/commit/98497ba29fe6d4192dc83957541163f4aabaea6d#diff-d4ee57467063e9e54c58a6a214f33fbf0298b67457dcb2757bf94c2616a97930) where `this._htmlDataProcessor` was removed.
