### PR TITLE
Allow loading `<font>` tag styling

### DIFF
--- a/packages/ckeditor5-font/docs/features/font.md
+++ b/packages/ckeditor5-font/docs/features/font.md
@@ -180,7 +180,7 @@ ClassicEditor
 
 ### Accepting all font sizes
 
-By default, all `font-size` values that are not specified in the `config.fontSize.options` are stripped. You can enable support for all font sizes by using the {@link module:font/fontfamily~FontFamilyConfig#supportAllValues `config.fontSize.supportAllValues`} option.
+By default, all `font-size` values that are not specified in the `config.fontSize.options` are stripped. You can enable support for all font sizes by using the {@link module:font/fontsize~FontSizeConfig#supportAllValues `config.fontSize.supportAllValues`} option.
 
 ```js
 ClassicEditor
@@ -496,6 +496,8 @@ The {@link module:font/fontbackgroundcolor~FontBackgroundColor} plugin registers
 ## Content compatibility
 
 The {@link module:font/font~Font} plugin provides basic support for deprecated `<font>` tag styling.
+
+While `<font color>` is always supported, to use `<font face>` and `<font size>` you need enable {@link module:font/fontfamily~FontFamilyConfig#supportAllValues `config.fontFamily.supportAllValues`} and {@link module:font/fontsize~FontSizeConfig#supportAllValues `config.fontSize.supportAllValues`} options respectively.
 
 Text formatted with `<font>` is accepted by the plugin, but the editor always returns the markup in modern format, i.e. one-way transformation.
 

--- a/packages/ckeditor5-font/docs/features/font.md
+++ b/packages/ckeditor5-font/docs/features/font.md
@@ -493,6 +493,17 @@ The {@link module:font/fontbackgroundcolor~FontBackgroundColor} plugin registers
 	We recommend using the official {@link framework/guides/development-tools#ckeditor-5-inspector CKEditor 5 inspector} for development and debugging. It will give you tons of useful information about the state of the editor such as internal data structures, selection, commands, and many more.
 </info-box>
 
+## Content compatibility
+
+The {@link module:font/font~Font} plugin provides basic support for deprecated `<font>` tag styling.
+
+<info-box>
+	Text formatted with `<font>` is accepted by the plugin, but the editor always returns the markup in modern format, i.e. one-way transformation.
+</info-box>
+
+More details on the `<font>` can be found in the [documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/font).
+
+
 ## Contribute
 
 The source code of the feature is available on GitHub in https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-font.

--- a/packages/ckeditor5-font/docs/features/font.md
+++ b/packages/ckeditor5-font/docs/features/font.md
@@ -495,11 +495,11 @@ The {@link module:font/fontbackgroundcolor~FontBackgroundColor} plugin registers
 
 ## Content compatibility
 
-The {@link module:font/font~Font} plugin provides basic support for deprecated `<font>` tag styling.
+The {@link module:font/font~Font} plugin provides basic support for the deprecated `<font>` tag.
 
-While `<font color>` is always supported, to use `<font face>` and `<font size>` you need to enable {@link module:font/fontfamily~FontFamilyConfig#supportAllValues `config.fontFamily.supportAllValues`} and {@link module:font/fontsize~FontSizeConfig#supportAllValues `config.fontSize.supportAllValues`} options respectively.
+While `<font color>` is always supported, to use `<font face>` and `<font size>` you need to enable the {@link module:font/fontfamily~FontFamilyConfig#supportAllValues `config.fontFamily.supportAllValues`} and {@link module:font/fontsize~FontSizeConfig#supportAllValues `config.fontSize.supportAllValues`} options respectively.
 
-Text formatted with `<font>` is accepted by the plugin, but the editor always returns the markup in modern format, i.e. one-way transformation.
+Text formatted with `<font>` is accepted by the plugin, but the editor always returns the markup in a modern format, so the transformation is one way only.
 
 
 ## Contribute

--- a/packages/ckeditor5-font/docs/features/font.md
+++ b/packages/ckeditor5-font/docs/features/font.md
@@ -497,7 +497,7 @@ The {@link module:font/fontbackgroundcolor~FontBackgroundColor} plugin registers
 
 The {@link module:font/font~Font} plugin provides basic support for deprecated `<font>` tag styling.
 
-While `<font color>` is always supported, to use `<font face>` and `<font size>` you need enable {@link module:font/fontfamily~FontFamilyConfig#supportAllValues `config.fontFamily.supportAllValues`} and {@link module:font/fontsize~FontSizeConfig#supportAllValues `config.fontSize.supportAllValues`} options respectively.
+While `<font color>` is always supported, to use `<font face>` and `<font size>` you need to enable {@link module:font/fontfamily~FontFamilyConfig#supportAllValues `config.fontFamily.supportAllValues`} and {@link module:font/fontsize~FontSizeConfig#supportAllValues `config.fontSize.supportAllValues`} options respectively.
 
 Text formatted with `<font>` is accepted by the plugin, but the editor always returns the markup in modern format, i.e. one-way transformation.
 

--- a/packages/ckeditor5-font/docs/features/font.md
+++ b/packages/ckeditor5-font/docs/features/font.md
@@ -497,11 +497,7 @@ The {@link module:font/fontbackgroundcolor~FontBackgroundColor} plugin registers
 
 The {@link module:font/font~Font} plugin provides basic support for deprecated `<font>` tag styling.
 
-<info-box>
-	Text formatted with `<font>` is accepted by the plugin, but the editor always returns the markup in modern format, i.e. one-way transformation.
-</info-box>
-
-More details on the `<font>` can be found in the [documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/font).
+Text formatted with `<font>` is accepted by the plugin, but the editor always returns the markup in modern format, i.e. one-way transformation.
 
 
 ## Contribute

--- a/packages/ckeditor5-font/src/fontcolor/fontcolorediting.js
+++ b/packages/ckeditor5-font/src/fontcolor/fontcolorediting.js
@@ -122,6 +122,20 @@ export default class FontColorEditing extends Plugin {
 
 		editor.commands.add( FONT_COLOR, new FontColorCommand( editor ) );
 
+		// Support `<font color="..">` formatting.
+		editor.conversion.for( 'upcast' ).elementToAttribute( {
+			view: {
+				name: 'font',
+				attributes: {
+					'color': /.*/
+				}
+			},
+			model: {
+				key: FONT_COLOR,
+				value: viewElement => viewElement.getAttribute( 'color' )
+			}
+		} );
+
 		// Allow the font color attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: FONT_COLOR } );
 

--- a/packages/ckeditor5-font/src/fontcolor/fontcolorediting.js
+++ b/packages/ckeditor5-font/src/fontcolor/fontcolorediting.js
@@ -127,7 +127,7 @@ export default class FontColorEditing extends Plugin {
 			view: {
 				name: 'font',
 				attributes: {
-					'color': /.*/
+					'color': /^#[0-9A-Fa-f]{6}|\w+$/
 				}
 			},
 			model: {

--- a/packages/ckeditor5-font/src/fontcolor/fontcolorediting.js
+++ b/packages/ckeditor5-font/src/fontcolor/fontcolorediting.js
@@ -120,7 +120,7 @@ export default class FontColorEditing extends Plugin {
 			view: {
 				name: 'font',
 				attributes: {
-					'color': /^#[0-9A-Fa-f]{6}|\w+$/
+					'color': /^#?\w+$/
 				}
 			},
 			model: {

--- a/packages/ckeditor5-font/src/fontcolor/fontcolorediting.js
+++ b/packages/ckeditor5-font/src/fontcolor/fontcolorediting.js
@@ -115,14 +115,7 @@ export default class FontColorEditing extends Plugin {
 			}
 		} );
 
-		editor.conversion.for( 'downcast' ).attributeToElement( {
-			model: FONT_COLOR,
-			view: renderDowncastElement( 'color' )
-		} );
-
-		editor.commands.add( FONT_COLOR, new FontColorCommand( editor ) );
-
-		// Support `<font color="..">` formatting.
+		// Support legacy `<font color="..">` formatting.
 		editor.conversion.for( 'upcast' ).elementToAttribute( {
 			view: {
 				name: 'font',
@@ -135,6 +128,13 @@ export default class FontColorEditing extends Plugin {
 				value: viewElement => viewElement.getAttribute( 'color' )
 			}
 		} );
+
+		editor.conversion.for( 'downcast' ).attributeToElement( {
+			model: FONT_COLOR,
+			view: renderDowncastElement( 'color' )
+		} );
+
+		editor.commands.add( FONT_COLOR, new FontColorCommand( editor ) );
 
 		// Allow the font color attribute on text nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: FONT_COLOR } );

--- a/packages/ckeditor5-font/src/fontfamily/fontfamilyediting.js
+++ b/packages/ckeditor5-font/src/fontfamily/fontfamilyediting.js
@@ -113,7 +113,7 @@ export default class FontFamilyEditing extends Plugin {
 	}
 
 	/**
-	 * Adds support for `<font size="..">` formatting.
+	 * Adds support for `<font face="..">` formatting.
 	 *
 	 * @private
 	 */

--- a/packages/ckeditor5-font/src/fontfamily/fontfamilyediting.js
+++ b/packages/ckeditor5-font/src/fontfamily/fontfamilyediting.js
@@ -74,6 +74,7 @@ export default class FontFamilyEditing extends Plugin {
 		// Set-up the two-way conversion.
 		if ( editor.config.get( 'fontFamily.supportAllValues' ) ) {
 			this._prepareAnyValueConverters();
+			this._prepareCompatibilityConverter();
 		} else {
 			editor.conversion.attributeToElement( definition );
 		}
@@ -107,6 +108,28 @@ export default class FontFamilyEditing extends Plugin {
 				styles: {
 					'font-family': /.*/
 				}
+			}
+		} );
+	}
+
+	/**
+	 * Support `<font size="..">` formatting.
+	 *
+	 * @private
+	 */
+	_prepareCompatibilityConverter() {
+		const editor = this.editor;
+
+		editor.conversion.for( 'upcast' ).elementToAttribute( {
+			view: {
+				name: 'font',
+				attributes: {
+					'face': /.*/
+				}
+			},
+			model: {
+				key: FONT_FAMILY,
+				value: viewElement => viewElement.getAttribute( 'face' )
 			}
 		} );
 	}

--- a/packages/ckeditor5-font/src/fontfamily/fontfamilyediting.js
+++ b/packages/ckeditor5-font/src/fontfamily/fontfamilyediting.js
@@ -113,7 +113,7 @@ export default class FontFamilyEditing extends Plugin {
 	}
 
 	/**
-	 * Support `<font size="..">` formatting.
+	 * Adds support for `<font size="..">` formatting.
 	 *
 	 * @private
 	 */

--- a/packages/ckeditor5-font/src/fontfamily/fontfamilyediting.js
+++ b/packages/ckeditor5-font/src/fontfamily/fontfamilyediting.js
@@ -113,7 +113,7 @@ export default class FontFamilyEditing extends Plugin {
 	}
 
 	/**
-	 * Adds support for `<font face="..">` formatting.
+	 * Adds support for legacy `<font face="..">` formatting.
 	 *
 	 * @private
 	 */

--- a/packages/ckeditor5-font/src/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeediting.js
@@ -153,7 +153,7 @@ export default class FontSizeEditing extends Plugin {
 	}
 
 	/**
-	 * Support `<font size="..">` formatting.
+	 * Adds support for `<font size="..">` formatting.
 	 *
 	 * @private
 	 */

--- a/packages/ckeditor5-font/src/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeediting.js
@@ -175,7 +175,7 @@ export default class FontSizeEditing extends Plugin {
 					const value = viewElement.getAttribute( 'size' );
 					const isRelative = value[ 0 ] === '-' || value[ 0 ] === '+';
 
-					let size = Number( value );
+					let size = parseInt( value, 10 );
 
 					if ( isRelative ) {
 						// Add relative size (which can be negative) to the default size = 3.

--- a/packages/ckeditor5-font/src/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeediting.js
@@ -166,17 +166,26 @@ export default class FontSizeEditing extends Plugin {
 				attributes: {
 					// Documentation mentions sizes from 1 to 7.
 					// To handle old content we support all values up to 999 (arbitrarily picked) but clamp it to the valid range.
-					'size': /^\d{1,3}$/
+					'size': /^[+-]?\d{1,3}$/
 				}
 			},
 			model: {
 				key: FONT_SIZE,
 				value: viewElement => {
-					const value = Number( viewElement.getAttribute( 'size' ) );
-					const maxSize = styleFontSize.length - 1;
-					const size = Math.min( Math.max( value, 0 ), maxSize );
+					const value = viewElement.getAttribute( 'size' );
+					const isRelative = value[ 0 ] === '-' || value[ 0 ] === '+';
 
-					return styleFontSize[ size ];
+					let size = Number( value );
+
+					if ( isRelative ) {
+						// Add relative size (which can be negative) to the default size = 3.
+						size = 3 + size;
+					}
+
+					const maxSize = styleFontSize.length - 1;
+					const clampedSize = Math.min( Math.max( size, 0 ), maxSize );
+
+					return styleFontSize[ clampedSize ];
 				}
 			}
 		} );

--- a/packages/ckeditor5-font/src/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeediting.js
@@ -153,7 +153,7 @@ export default class FontSizeEditing extends Plugin {
 	}
 
 	/**
-	 * Adds support for `<font size="..">` formatting.
+	 * Adds support for legacy `<font size="..">` formatting.
 	 *
 	 * @private
 	 */
@@ -164,16 +164,19 @@ export default class FontSizeEditing extends Plugin {
 			view: {
 				name: 'font',
 				attributes: {
-					// Size from 0 to 7.
-					'size': /^[0-7]$/
+					// Documentation mentions sizes from 1 to 7.
+					// To handle old content we support all values up to 999 (arbitrarily picked) but clamp it to the valid range.
+					'size': /^\d{1,3}$/
 				}
 			},
 			model: {
 				key: FONT_SIZE,
 				value: viewElement => {
-					const value = viewElement.getAttribute( 'size' );
+					const value = Number( viewElement.getAttribute( 'size' ) );
+					const maxSize = styleFontSize.length - 1;
+					const size = Math.min( Math.max( value, 0 ), maxSize );
 
-					return styleFontSize[ Number( value ) ];
+					return styleFontSize[ size ];
 				}
 			}
 		} );

--- a/packages/ckeditor5-font/src/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeediting.js
@@ -14,6 +14,18 @@ import FontSizeCommand from './fontsizecommand';
 import { normalizeOptions } from './utils';
 import { buildDefinition, FONT_SIZE } from '../utils';
 
+// Mapping of `<font size="..">` styling to CSS's `font-size` values.
+const styleFontSize = [
+	'x-small', // Size "0" equal to "1".
+	'x-small',
+	'small',
+	'medium',
+	'large',
+	'x-large',
+	'xx-large',
+	'xxx-large'
+];
+
 /**
  * The font size editing feature.
  *
@@ -77,6 +89,7 @@ export default class FontSizeEditing extends Plugin {
 		// Set-up the two-way conversion.
 		if ( supportAllValues ) {
 			this._prepareAnyValueConverters( definition );
+			this._prepareCompatibilityConverter();
 		} else {
 			editor.conversion.attributeToElement( definition );
 		}
@@ -134,6 +147,33 @@ export default class FontSizeEditing extends Plugin {
 				name: 'span',
 				styles: {
 					'font-size': /.*/
+				}
+			}
+		} );
+	}
+
+	/**
+	 * Support `<font size="..">` formatting.
+	 *
+	 * @private
+	 */
+	_prepareCompatibilityConverter() {
+		const editor = this.editor;
+
+		editor.conversion.for( 'upcast' ).elementToAttribute( {
+			view: {
+				name: 'font',
+				attributes: {
+					// Size from 0 to 7.
+					'size': /^[0-7]$/
+				}
+			},
+			model: {
+				key: FONT_SIZE,
+				value: viewElement => {
+					const value = viewElement.getAttribute( 'size' );
+
+					return styleFontSize[ Number( value ) ];
 				}
 			}
 		} );

--- a/packages/ckeditor5-font/src/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeediting.js
@@ -164,8 +164,9 @@ export default class FontSizeEditing extends Plugin {
 			view: {
 				name: 'font',
 				attributes: {
-					// Documentation mentions sizes from 1 to 7.
-					// To handle old content we support all values up to 999 (arbitrarily picked) but clamp it to the valid range.
+					// Documentation mentions sizes from 1 to 7. To handle old content we support all values
+					// up to 999 but clamp it to the valid range. Why 999? It should cover accidental values
+					// similar to percentage, e.g. 100%, 200% which could be the usual mistake for font size.
 					'size': /^[+-]?\d{1,3}$/
 				}
 			},

--- a/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
+++ b/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
@@ -265,5 +265,44 @@ describe( 'FontColorEditing', () => {
 				'<p>b<span style="color:#fff;">a</span>z</p>'
 			);
 		} );
+
+		it( 'should support <font color=".."> styling - #RRGGBB color', () => {
+			const data = '<p><font color="#ACABAA">foo</font><span style="font-size: 18px;color: rgb(10, 20, 30);">bar</span>o</p>';
+
+			editor.setData( data );
+
+			expect( getModelData( doc ) ).to.equal(
+				'<paragraph><$text fontColor="#ACABAA">[]foo</$text><$text fontColor="rgb(10,20,30)">bar</$text>o</paragraph>'
+			);
+			expect( editor.getData() ).to.equal(
+				'<p><span style="color:#ACABAA;">foo</span><span style="color:rgb(10,20,30);">bar</span>o</p>'
+			);
+		} );
+
+		it( 'should support <font color=".."> styling - named color', () => {
+			const data = '<p><font color="lightgreen">foo</font><span style="font-size: 18px;color: rgb(10, 20, 30);">bar</span>o</p>';
+
+			editor.setData( data );
+
+			expect( getModelData( doc ) ).to.equal(
+				'<paragraph><$text fontColor="lightgreen">[]foo</$text><$text fontColor="rgb(10,20,30)">bar</$text>o</paragraph>'
+			);
+			expect( editor.getData() ).to.equal(
+				'<p><span style="color:lightgreen;">foo</span><span style="color:rgb(10,20,30);">bar</span>o</p>'
+			);
+		} );
+
+		it( 'should support <font color=".."> styling - strip styling when color is incorrect', () => {
+			const data = '<p><font color="rgb(11, 22, 33)">foo</font><span style="font-size: 18px;color: rgb(10, 20, 30);">bar</span>o</p>';
+
+			editor.setData( data );
+
+			expect( getModelData( doc ) ).to.equal(
+				'<paragraph>[]foo<$text fontColor="rgb(10,20,30)">bar</$text>o</paragraph>'
+			);
+			expect( editor.getData() ).to.equal(
+				'<p>foo<span style="color:rgb(10,20,30);">bar</span>o</p>'
+			);
+		} );
 	} );
 } );

--- a/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
+++ b/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
@@ -279,6 +279,45 @@ describe( 'FontColorEditing', () => {
 			);
 		} );
 
+		it( 'should support <font color=".."> styling - RRGGBB color (no # prefix)', () => {
+			const data = '<p><font color="ACABAA">foo</font><span style="font-size: 18px;color: rgb(10, 20, 30);">bar</span>o</p>';
+
+			editor.setData( data );
+
+			expect( getModelData( doc ) ).to.equal(
+				'<paragraph><$text fontColor="ACABAA">[]foo</$text><$text fontColor="rgb(10,20,30)">bar</$text>o</paragraph>'
+			);
+			expect( editor.getData() ).to.equal(
+				'<p><span style="color:ACABAA;">foo</span><span style="color:rgb(10,20,30);">bar</span>o</p>'
+			);
+		} );
+
+		it( 'should support <font color=".."> styling - #RGB color', () => {
+			const data = '<p><font color="#FAF">foo</font><span style="font-size: 18px;color: rgb(10, 20, 30);">bar</span>o</p>';
+
+			editor.setData( data );
+
+			expect( getModelData( doc ) ).to.equal(
+				'<paragraph><$text fontColor="#FAF">[]foo</$text><$text fontColor="rgb(10,20,30)">bar</$text>o</paragraph>'
+			);
+			expect( editor.getData() ).to.equal(
+				'<p><span style="color:#FAF;">foo</span><span style="color:rgb(10,20,30);">bar</span>o</p>'
+			);
+		} );
+
+		it( 'should support <font color=".."> styling - RGB color (no # prefix)', () => {
+			const data = '<p><font color="FAF">foo</font><span style="font-size: 18px;color: rgb(10, 20, 30);">bar</span>o</p>';
+
+			editor.setData( data );
+
+			expect( getModelData( doc ) ).to.equal(
+				'<paragraph><$text fontColor="FAF">[]foo</$text><$text fontColor="rgb(10,20,30)">bar</$text>o</paragraph>'
+			);
+			expect( editor.getData() ).to.equal(
+				'<p><span style="color:FAF;">foo</span><span style="color:rgb(10,20,30);">bar</span>o</p>'
+			);
+		} );
+
 		it( 'should support <font color=".."> styling - named color', () => {
 			const data = '<p><font color="lightgreen">foo</font><span style="font-size: 18px;color: rgb(10, 20, 30);">bar</span>o</p>';
 

--- a/packages/ckeditor5-font/tests/fontfamily/fontfamilyediting.js
+++ b/packages/ckeditor5-font/tests/fontfamily/fontfamilyediting.js
@@ -141,7 +141,7 @@ describe( 'FontFamilyEditing', () => {
 					expect( editor.getData() ).to.equal( '<p>f<span style="font-family:Arial, sans-serif;">o</span>o</p>' );
 				} );
 
-				it( 'should support <font size=".."> styling', () => {
+				it( 'should support <font face=".."> styling', () => {
 					const data = '<p><font face="Arial,Verdana">foo</font><span style="font-family: Arial, sans-serif">bar</span></p>';
 
 					editor.setData( data );
@@ -306,7 +306,7 @@ describe( 'FontFamilyEditing', () => {
 			);
 		} );
 
-		it( 'should strip <font size=".."> styling when supportAllValues = false', () => {
+		it( 'should strip <font face=".."> styling when supportAllValues = false', () => {
 			const data = '<p><font face="Arial,Verdana">foo</font><span style="font-family: Arial">bar</span></p>';
 
 			editor.setData( data );

--- a/packages/ckeditor5-font/tests/fontfamily/fontfamilyediting.js
+++ b/packages/ckeditor5-font/tests/fontfamily/fontfamilyediting.js
@@ -140,6 +140,22 @@ describe( 'FontFamilyEditing', () => {
 
 					expect( editor.getData() ).to.equal( '<p>f<span style="font-family:Arial, sans-serif;">o</span>o</p>' );
 				} );
+
+				it( 'should support <font size=".."> styling', () => {
+					const data = '<p><font face="Arial,Verdana">foo</font><span style="font-family: Arial, sans-serif">bar</span></p>';
+
+					editor.setData( data );
+
+					expect( getModelData( doc ) ).to.equal(
+						'<paragraph>' +
+							'<$text fontFamily="Arial,Verdana">[]foo</$text><$text fontFamily="Arial, sans-serif">bar</$text>' +
+						'</paragraph>'
+					);
+
+					expect( editor.getData() ).to.equal(
+						'<p><span style="font-family:Arial,Verdana;">foo</span><span style="font-family:Arial, sans-serif;">bar</span></p>'
+					);
+				} );
 			} );
 		} );
 	} );
@@ -287,6 +303,20 @@ describe( 'FontFamilyEditing', () => {
 				'<p>f<span class="text-complex">o</span>o</p>' +
 				'<p>b<span class="text-complex">a</span>r</p>' +
 				'<p>b<span class="text-complex">a</span>z</p>'
+			);
+		} );
+
+		it( 'should strip <font size=".."> styling when supportAllValues = false', () => {
+			const data = '<p><font face="Arial,Verdana">foo</font><span style="font-family: Arial">bar</span></p>';
+
+			editor.setData( data );
+
+			expect( getModelData( doc ) ).to.equal(
+				'<paragraph>[]foo<$text fontFamily="complex">bar</$text></paragraph>'
+			);
+
+			expect( editor.getData() ).to.equal(
+				'<p>foo<span class="text-complex">bar</span></p>'
 			);
 		} );
 	} );

--- a/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
@@ -359,5 +359,19 @@ describe( 'FontSizeEditing', () => {
 				'<p>b<span class="text-complex">a</span>z</p>'
 			);
 		} );
+
+		it( 'should not convert <font size=".."> styling when supportAllValues is disabled', () => {
+			const data = '<font size="5">foo</font><span style="font-size: 18px">bar</span>';
+
+			editor.setData( data );
+
+			expect( getModelData( doc ) ).to.equal(
+				'<paragraph>[]foo<$text fontSize="18px">bar</$text></paragraph>'
+			);
+
+			expect( editor.getData() ).to.equal(
+				'<p>foo<span style="font-size:18px;">bar</span></p>'
+			);
+		} );
 	} );
 } );

--- a/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
@@ -121,6 +121,48 @@ describe( 'FontSizeEditing', () => {
 
 					expect( editor.getData() ).to.equal( '<p>f<span style="font-size:18px;">o</span>o</p>' );
 				} );
+
+				it( 'should convert <font size=".."> styling', () => {
+					const data = '<font size="5">foo</font><span style="font-size: 18px">bar</span>';
+
+					editor.setData( data );
+
+					expect( getModelData( doc ) ).to.equal(
+						'<paragraph><$text fontSize="x-large">[]foo</$text><$text fontSize="18px">bar</$text></paragraph>'
+					);
+
+					expect( editor.getData() ).to.equal(
+						'<p><span style="font-size:x-large;">foo</span><span style="font-size:18px;">bar</span></p>'
+					);
+				} );
+
+				it( 'should convert <font size=".."> styling - size = 0', () => {
+					const data = '<font size="0">foo</font><span style="font-size: 18px">bar</span>';
+
+					editor.setData( data );
+
+					expect( getModelData( doc ) ).to.equal(
+						'<paragraph><$text fontSize="x-small">[]foo</$text><$text fontSize="18px">bar</$text></paragraph>'
+					);
+
+					expect( editor.getData() ).to.equal(
+						'<p><span style="font-size:x-small;">foo</span><span style="font-size:18px;">bar</span></p>'
+					);
+				} );
+
+				it( 'should convert <font size=".."> styling - parameter outside of the range', () => {
+					const data = '<font size="8">foo</font><span style="font-size: 18px">bar</span>';
+
+					editor.setData( data );
+
+					expect( getModelData( doc ) ).to.equal(
+						'<paragraph>[]foo<$text fontSize="18px">bar</$text></paragraph>'
+					);
+
+					expect( editor.getData() ).to.equal(
+						'<p>foo<span style="font-size:18px;">bar</span></p>'
+					);
+				} );
 			} );
 
 			it( 'should throw an error if used with default configuration of the plugin', () => {

--- a/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
@@ -167,6 +167,62 @@ describe( 'FontSizeEditing', () => {
 					);
 				} );
 
+				it( 'should convert <font size=".."> styling - positive relative size', () => {
+					const data = '<font size="+3">foo</font><span style="font-size: 18px">bar</span>';
+
+					editor.setData( data );
+
+					expect( getModelData( doc ) ).to.equal(
+						'<paragraph><$text fontSize="xx-large">[]foo</$text><$text fontSize="18px">bar</$text></paragraph>'
+					);
+
+					expect( editor.getData() ).to.equal(
+						'<p><span style="font-size:xx-large;">foo</span><span style="font-size:18px;">bar</span></p>'
+					);
+				} );
+
+				it( 'should convert <font size=".."> styling - large positive relative size', () => {
+					const data = '<font size="+999">foo</font><span style="font-size: 18px">bar</span>';
+
+					editor.setData( data );
+
+					expect( getModelData( doc ) ).to.equal(
+						'<paragraph><$text fontSize="xxx-large">[]foo</$text><$text fontSize="18px">bar</$text></paragraph>'
+					);
+
+					expect( editor.getData() ).to.equal(
+						'<p><span style="font-size:xxx-large;">foo</span><span style="font-size:18px;">bar</span></p>'
+					);
+				} );
+
+				it( 'should convert <font size=".."> styling - negative relative size', () => {
+					const data = '<font size="-1">foo</font><span style="font-size: 18px">bar</span>';
+
+					editor.setData( data );
+
+					expect( getModelData( doc ) ).to.equal(
+						'<paragraph><$text fontSize="small">[]foo</$text><$text fontSize="18px">bar</$text></paragraph>'
+					);
+
+					expect( editor.getData() ).to.equal(
+						'<p><span style="font-size:small;">foo</span><span style="font-size:18px;">bar</span></p>'
+					);
+				} );
+
+				it( 'should convert <font size=".."> styling - large negative relative size', () => {
+					const data = '<font size="-999">foo</font><span style="font-size: 18px">bar</span>';
+
+					editor.setData( data );
+
+					expect( getModelData( doc ) ).to.equal(
+						'<paragraph><$text fontSize="x-small">[]foo</$text><$text fontSize="18px">bar</$text></paragraph>'
+					);
+
+					expect( editor.getData() ).to.equal(
+						'<p><span style="font-size:x-small;">foo</span><span style="font-size:18px;">bar</span></p>'
+					);
+				} );
+
 				it( 'should not convert <font size=".."> styling - parameter outside of the range', () => {
 					const data = '<font size="1000">foo</font><span style="font-size: 18px">bar</span>';
 

--- a/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
@@ -150,8 +150,25 @@ describe( 'FontSizeEditing', () => {
 					);
 				} );
 
-				it( 'should convert <font size=".."> styling - parameter outside of the range', () => {
-					const data = '<font size="8">foo</font><span style="font-size: 18px">bar</span>';
+				// TODO: handle big sizes 		[ ]
+				// TODO: handle relative sizing	[ ]
+
+				it( 'should convert <font size=".."> styling - large value clamped to size 7 equivalent', () => {
+					const data = '<font size="999">foo</font><span style="font-size: 18px">bar</span>';
+
+					editor.setData( data );
+
+					expect( getModelData( doc ) ).to.equal(
+						'<paragraph><$text fontSize="xxx-large">[]foo</$text><$text fontSize="18px">bar</$text></paragraph>'
+					);
+
+					expect( editor.getData() ).to.equal(
+						'<p><span style="font-size:xxx-large;">foo</span><span style="font-size:18px;">bar</span></p>'
+					);
+				} );
+
+				it( 'should not convert <font size=".."> styling - parameter outside of the range', () => {
+					const data = '<font size="1000">foo</font><span style="font-size: 18px">bar</span>';
 
 					editor.setData( data );
 

--- a/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
@@ -150,9 +150,6 @@ describe( 'FontSizeEditing', () => {
 					);
 				} );
 
-				// TODO: handle big sizes 		[ ]
-				// TODO: handle relative sizing	[ ]
-
 				it( 'should convert <font size=".."> styling - large value clamped to size 7 equivalent', () => {
 					const data = '<font size="999">foo</font><span style="font-size: 18px">bar</span>';
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (font): Add `<font>` styling compatibility. Closes #8621.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
