### PR TITLE
Fixed docs due to invalid dependency versions in `ckeditor5-watchdog`

### DIFF
--- a/packages/ckeditor5-watchdog/package.json
+++ b/packages/ckeditor5-watchdog/package.json
@@ -18,8 +18,8 @@
     "@ckeditor/ckeditor5-dev-utils": "^24.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^25.0.0",
     "@ckeditor/ckeditor5-paragraph": "^25.0.0",
-    "@ckeditor/ckeditor5-theme-lark": "24.0.0",
-    "@ckeditor/ckeditor5-utils": "24.0.0",
+    "@ckeditor/ckeditor5-theme-lark": "^25.0.0",
+    "@ckeditor/ckeditor5-utils": "^25.0.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"
   },


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Fixed docs due to invalid dependency versions in `ckeditor5-watchdog`. Closes #8980.
