### PR TITLE
Update angular.md

### DIFF
--- a/docs/builds/guides/frameworks/angular.md
+++ b/docs/builds/guides/frameworks/angular.md
@@ -273,6 +273,10 @@ export class MyComponent {
 
 ### `watchdog`
 
+<info-box>
+	The watchdog is built into the Angular Component, so importing the ContextWatchdog is not needed
+</info-box>
+
 An instance of the {@link module:watchdog/contextwatchdog~ContextWatchdog `ContextWatchdog`} class that is responsible for providing the same context to multiple editor instances and restarting the whole structure in case of crashes.
 
 ```ts


### PR DESCRIPTION
Based on comments in https://github.com/ckeditor/ckeditor5-angular/issues/211#issuecomment-644862143 it sounds like the watchdog is already added to the Angular component. It's possible this entire section needs to be removed, however, I wanted to add a note that would prevent future users from trying to add this ContextWatchdog to their own components. FWIW, I also receive an error stating the ContextWatchdog method is not a constructor, which led me to discovering the comment. 

Thanks in advance for you time and everything you all do with CKEditor! Love the editor.

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Type (ckeditor/ckeditor5): Adds an info box to ward users away from the watchdog input property.

---

### Additional information

When I tried to implement the watchdog for multiple editors on a single component, I found comments that indicated this is handled for me with the Angular 5+ CKEditor component.
