### PR TITLE
Handle alignment with classes

### DIFF
--- a/packages/ckeditor5-alignment/docs/features/text-alignment.md
+++ b/packages/ckeditor5-alignment/docs/features/text-alignment.md
@@ -22,6 +22,8 @@ There are more CKEditor 5 features that can help you organize your content:
 
 ## Configuring alignment options
 
+TODO: Update docs
+
 It is possible to configure which alignment options are available in the editor by setting the {@link module:alignment/alignment~AlignmentConfig#options `alignment.options`} configuration option. You can choose from `'left'`, `'right'`, `'center'` and `'justify'`.
 
 <info-box>

--- a/packages/ckeditor5-alignment/docs/features/text-alignment.md
+++ b/packages/ckeditor5-alignment/docs/features/text-alignment.md
@@ -22,7 +22,7 @@ There are more CKEditor 5 features that can help you organize your content:
 
 ## Configuring alignment options
 
-TODO: Update docs
+### Alignment options
 
 It is possible to configure which alignment options are available in the editor by setting the {@link module:alignment/alignment~AlignmentConfig#options `alignment.options`} configuration option. You can choose from `'left'`, `'right'`, `'center'` and `'justify'`.
 
@@ -47,6 +47,31 @@ ClassicEditor
 ```
 
 {@snippet features/custom-text-alignment-options}
+
+### Assigning class to alignment option
+
+By default alignment sets the style inline. If you wish to style the alignment by yourself, you can specify class names by using {@link module:alignment/alignment~AlignmentConfig#classNames `alignment.classNames`}  and style it using CSS.
+
+<info-box>
+	Make sure to specify the same number of classes as the number of values in {@link module:alignment/alignment~AlignmentConfig#options `alignment.options`}. If the {@link module:alignment/alignment~AlignmentConfig#options `alignment.options`} are not specified, they are equal to `[ 'left', 'right', 'center', 'justify' ]`, therefore you have to provide 4 class names.
+</info-box>
+
+The following configuration will set `.my-align-left` and `.my-align-right` to left and right alignment respectively.
+
+```js
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		alignment: {
+			options: [ 'left', 'right' ],
+			classNames: [ 'my-align-left', 'my-align-right' ]
+		},
+		toolbar: [
+			'heading', '|', 'bulletedList', 'numberedList', 'alignment', 'undo', 'redo'
+		]
+	} )
+	.then( ... )
+	.catch( ... );
+```
 
 ## Configuring the toolbar
 

--- a/packages/ckeditor5-alignment/docs/features/text-alignment.md
+++ b/packages/ckeditor5-alignment/docs/features/text-alignment.md
@@ -50,7 +50,7 @@ ClassicEditor
 
 ### Using classes instead of inline style
 
-By default alignment is set inline using `text-align` CSS property. If you wish to style the alignment by yourself, you can specify class names by using {@link module:alignment/alignment~AlignmentConfig#classNames `config.alignment.classNames`}  and style it using CSS.
+By default alignment is set inline using `text-align` CSS property. If you wish the feature to output more semantic content that uses classes instead of inline styles, you can specify class names by using the {@link module:alignment/alignment~AlignmentConfig#classNames `config.alignment.classNames`} option and style them by using a stylesheet.
 
 <info-box>
 	Make sure to specify the same number of classes as the number of values in {@link module:alignment/alignment~AlignmentConfig#options `config.alignment.options`}. If the {@link module:alignment/alignment~AlignmentConfig#options `config.alignment.options`} are not specified, they are equal to `[ 'left', 'right', 'center', 'justify' ]`, therefore you have to provide 4 class names.

--- a/packages/ckeditor5-alignment/docs/features/text-alignment.md
+++ b/packages/ckeditor5-alignment/docs/features/text-alignment.md
@@ -22,7 +22,7 @@ There are more CKEditor 5 features that can help you organize your content:
 
 ## Configuring alignment options
 
-### Alignment options
+### Defining available options
 
 It is possible to configure which alignment options are available in the editor by setting the {@link module:alignment/alignment~AlignmentConfig#options `alignment.options`} configuration option. You can choose from `'left'`, `'right'`, `'center'` and `'justify'`.
 
@@ -48,12 +48,12 @@ ClassicEditor
 
 {@snippet features/custom-text-alignment-options}
 
-### Assigning class to alignment option
+### Using classes instead of inline style
 
-By default alignment sets the style inline. If you wish to style the alignment by yourself, you can specify class names by using {@link module:alignment/alignment~AlignmentConfig#classNames `alignment.classNames`}  and style it using CSS.
+By default alignment is set inline using `text-align` CSS property. If you wish to style the alignment by yourself, you can specify class names by using {@link module:alignment/alignment~AlignmentConfig#classNames `config.alignment.classNames`}  and style it using CSS.
 
 <info-box>
-	Make sure to specify the same number of classes as the number of values in {@link module:alignment/alignment~AlignmentConfig#options `alignment.options`}. If the {@link module:alignment/alignment~AlignmentConfig#options `alignment.options`} are not specified, they are equal to `[ 'left', 'right', 'center', 'justify' ]`, therefore you have to provide 4 class names.
+	Make sure to specify the same number of classes as the number of values in {@link module:alignment/alignment~AlignmentConfig#options `config.alignment.options`}. If the {@link module:alignment/alignment~AlignmentConfig#options `config.alignment.options`} are not specified, they are equal to `[ 'left', 'right', 'center', 'justify' ]`, therefore you have to provide 4 class names.
 </info-box>
 
 The following configuration will set `.my-align-left` and `.my-align-right` to left and right alignment respectively.

--- a/packages/ckeditor5-alignment/docs/features/text-alignment.md
+++ b/packages/ckeditor5-alignment/docs/features/text-alignment.md
@@ -56,7 +56,7 @@ By default alignment is set inline using `text-align` CSS property. If you wish 
 	Once you decide to use classes for the alignment, you must define `className` for **all** alignment entries in {@link module:alignment/alignment~AlignmentConfig#options `config.alignment.options`}.
 </info-box>
 
-The following configuration will set `.my-align-left` and `.my-align-right` to left and right alignment respectively.
+The following configuration will set `.my-align-left` and `.my-align-right` to left and right alignment, respectively.
 
 ```js
 ClassicEditor

--- a/packages/ckeditor5-alignment/docs/features/text-alignment.md
+++ b/packages/ckeditor5-alignment/docs/features/text-alignment.md
@@ -50,7 +50,7 @@ ClassicEditor
 
 ### Using classes instead of inline style
 
-By default alignment is set inline using `text-align` CSS property. If you wish the feature to output more semantic content that uses classes instead of inline styles, you can specify class names by using the {@link module:alignment/alignment~AlignmentConfig#classNames `config.alignment.classNames`} option and style them by using a stylesheet.
+By default alignment is set inline using `text-align` CSS property. If you wish the feature to output more semantic content that uses classes instead of inline styles, you can specify class names by using the  `config.alignment.classNames` option and style them by using a stylesheet.
 
 <info-box>
 	Make sure to specify the same number of classes as the number of values in {@link module:alignment/alignment~AlignmentConfig#options `config.alignment.options`}. If the {@link module:alignment/alignment~AlignmentConfig#options `config.alignment.options`} are not specified, they are equal to `[ 'left', 'right', 'center', 'justify' ]`, therefore you have to provide 4 class names.

--- a/packages/ckeditor5-alignment/docs/features/text-alignment.md
+++ b/packages/ckeditor5-alignment/docs/features/text-alignment.md
@@ -50,10 +50,10 @@ ClassicEditor
 
 ### Using classes instead of inline style
 
-By default alignment is set inline using `text-align` CSS property. If you wish the feature to output more semantic content that uses classes instead of inline styles, you can specify class names by using the  `config.alignment.classNames` option and style them by using a stylesheet.
+By default alignment is set inline using `text-align` CSS property. If you wish the feature to output more semantic content that uses classes instead of inline styles, you can specify class names by using the  `className` property in `config.alignment.options` and style them by using a stylesheet.
 
 <info-box>
-	Make sure to specify the same number of classes as the number of values in {@link module:alignment/alignment~AlignmentConfig#options `config.alignment.options`}. If the {@link module:alignment/alignment~AlignmentConfig#options `config.alignment.options`} are not specified, they are equal to `[ 'left', 'right', 'center', 'justify' ]`, therefore you have to provide 4 class names.
+	Once you decide to use classes for the alignment, you must define `className` for **all** alignment entries in {@link module:alignment/alignment~AlignmentConfig#options `config.alignment.options`}.
 </info-box>
 
 The following configuration will set `.my-align-left` and `.my-align-right` to left and right alignment respectively.
@@ -62,8 +62,10 @@ The following configuration will set `.my-align-left` and `.my-align-right` to l
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		alignment: {
-			options: [ 'left', 'right' ],
-			classNames: [ 'my-align-left', 'my-align-right' ]
+			options: [
+				{ name: 'left', className: 'my-align-left' },
+				{ name: 'right', className: 'my-align-right' }
+			]
 		},
 		toolbar: [
 			'heading', '|', 'bulletedList', 'numberedList', 'alignment', 'undo', 'redo'

--- a/packages/ckeditor5-alignment/src/alignment.js
+++ b/packages/ckeditor5-alignment/src/alignment.js
@@ -65,6 +65,24 @@ export default class Alignment extends Plugin {
  */
 
 /**
+ * Class names to match {@link module:alignment/alignment~AlignmentConfig#options alignment options}.
+ *
+ * **Note:** The same number of classes should be provided as the number of `alignment.options`.
+ *
+ *		ClassicEditor
+ *			.create( editorElement, {
+ *				alignment: {
+ *					options: [ 'left', 'right' ],
+ *					classNames: [ 'my-align-left', 'my-align-right' ]
+ *				}
+ *			} )
+ *			.then( ... )
+ *			.catch( ... );
+ *
+ * @member {Array.<String>} module:alignment/alignment~AlignmentConfig#classNames
+ */
+
+/**
  * Available alignment options.
  *
  * The available options are: `'left'`, `'right'`, `'center'` and `'justify'`. Other values are ignored.

--- a/packages/ckeditor5-alignment/src/alignment.js
+++ b/packages/ckeditor5-alignment/src/alignment.js
@@ -67,7 +67,7 @@ export default class Alignment extends Plugin {
 /**
  * Class names to match {@link module:alignment/alignment~AlignmentConfig#options alignment options}.
  *
- * **Note:** The same number of classes should be provided as the number of `alignment.options`.
+ * **Note:** The same number of classes should be provided as the number of `config.alignment.options`.
  *
  *		ClassicEditor
  *			.create( editorElement, {

--- a/packages/ckeditor5-alignment/src/alignment.js
+++ b/packages/ckeditor5-alignment/src/alignment.js
@@ -91,8 +91,8 @@ export default class Alignment extends Plugin {
  *			.create( editorElement, {
  *				alignment: {
  *					options: [
- *						{ name: 'left', className: 'foo-align-left' },
- *						{ name: 'right', className: 'foo-align-right' }
+ *						{ name: 'left', className: 'my-align-left' },
+ *						{ name: 'right', className: 'my-align-right' }
  *					]
  *				}
  *			} )

--- a/packages/ckeditor5-alignment/src/alignment.js
+++ b/packages/ckeditor5-alignment/src/alignment.js
@@ -65,24 +65,6 @@ export default class Alignment extends Plugin {
  */
 
 /**
- * Class names to match {@link module:alignment/alignment~AlignmentConfig#options alignment options}.
- *
- * **Note:** The same number of classes should be provided as the number of `config.alignment.options`.
- *
- *		ClassicEditor
- *			.create( editorElement, {
- *				alignment: {
- *					options: [ 'left', 'right' ],
- *					classNames: [ 'my-align-left', 'my-align-right' ]
- *				}
- *			} )
- *			.then( ... )
- *			.catch( ... );
- *
- * @member {Array.<String>} module:alignment/alignment~AlignmentConfig#classNames
- */
-
-/**
  * Available alignment options.
  *
  * The available options are: `'left'`, `'right'`, `'center'` and `'justify'`. Other values are ignored.
@@ -95,6 +77,23 @@ export default class Alignment extends Plugin {
  *			.create( editorElement, {
  *				alignment: {
  *					options: [ 'left', 'right' ]
+ *				}
+ *			} )
+ *			.then( ... )
+ *			.catch( ... );
+ *
+ * By default the alignment is set inline using `text-align` CSS property. To further customize the alignment you can
+ * provide names of classes for each alignment option using `className` property.
+ *
+ * **Note:** Once you define `className` property for one option, you need to specify it for all other options.
+ *
+ *		ClassicEditor
+ *			.create( editorElement, {
+ *				alignment: {
+ *					options: [
+ *						{ name: 'left', className: 'foo-align-left' },
+ *						{ name: 'right', className: 'foo-align-right' }
+ *					]
  *				}
  *			} )
  *			.then( ... )

--- a/packages/ckeditor5-alignment/src/alignment.js
+++ b/packages/ckeditor5-alignment/src/alignment.js
@@ -101,5 +101,5 @@ export default class Alignment extends Plugin {
  *
  * See the demo of {@glink features/text-alignment#configuring-alignment-options custom alignment options}.
  *
- * @member {Array.<String>} module:alignment/alignment~AlignmentConfig#options
+ * @member {Array.<String|module:alignment/alignmentediting~AlignmentFormat>} module:alignment/alignment~AlignmentConfig#options
  */

--- a/packages/ckeditor5-alignment/src/alignmentediting.js
+++ b/packages/ckeditor5-alignment/src/alignmentediting.js
@@ -57,7 +57,7 @@ export default class AlignmentEditing extends Plugin {
 			 * The number of items in `alignment.classNames` should match number of items in `alignment.options`.
 			 *
 			 * @error alignment-config-classnames-not-matching
-			 * // TODO Fix params
+			 * @param {Array.<String>} enabledOptions Available alignment options set in config.
 			 * @param {Array.<String>} classNameConfig Classes listed in the config.
 			 */
 			throw new CKEditorError( 'alignment-config-classnames-not-matching', null, { enabledOptions, classNameConfig } );

--- a/packages/ckeditor5-alignment/src/alignmentediting.js
+++ b/packages/ckeditor5-alignment/src/alignmentediting.js
@@ -150,7 +150,7 @@ function _buildUpcastInlineDefinitions( options ) {
 	return definitions;
 }
 
-// Prepare conversion definitions for both upcast and downcast.
+// Prepare conversion definitions for upcast and downcast alignment with classes.
 // @private
 function _buildClassDefinition( options, alignmentClassNames ) {
 	const definition = {

--- a/packages/ckeditor5-alignment/src/alignmentediting.js
+++ b/packages/ckeditor5-alignment/src/alignmentediting.js
@@ -87,11 +87,11 @@ function buildDowncastInlineDefinition( options ) {
 		view: {}
 	};
 
-	for ( const option of options ) {
-		definition.view[ option.name ] = {
+	for ( const { name } of options ) {
+		definition.view[ name ] = {
 			key: 'style',
 			value: {
-				'text-align': option.name
+				'text-align': name
 			}
 		};
 	}
@@ -104,17 +104,17 @@ function buildDowncastInlineDefinition( options ) {
 function buildUpcastInlineDefinitions( options ) {
 	const definitions = [];
 
-	for ( const option of options ) {
+	for ( const { name } of options ) {
 		definitions.push( {
 			view: {
 				key: 'style',
 				value: {
-					'text-align': option.name
+					'text-align': name
 				}
 			},
 			model: {
 				key: 'alignment',
-				value: option.name
+				value: name
 			}
 		} );
 	}

--- a/packages/ckeditor5-alignment/src/alignmentediting.js
+++ b/packages/ckeditor5-alignment/src/alignmentediting.js
@@ -51,9 +51,6 @@ export default class AlignmentEditing extends Plugin {
 			option => isSupported( option.name ) && !isDefault( option.name, locale )
 		);
 
-		// Converters for inline alignment need only alignment name.
-		const optionNamesToConvert = optionsToConvert.map( option => option.name );
-
 		// Once there is at least one `className` defined, we switch to alignment with classes.
 		const shouldUseClasses = optionsToConvert.some( option => !!option.className );
 
@@ -63,17 +60,13 @@ export default class AlignmentEditing extends Plugin {
 
 		if ( shouldUseClasses ) {
 			// Downcast to only to classes.
-			const definition = buildClassDefinition( optionsToConvert );
-
-			editor.conversion.attributeToAttribute( definition );
+			editor.conversion.attributeToAttribute( buildClassDefinition( optionsToConvert ) );
 		} else {
 			// Downcast inline styles.
-			const definition = buildDowncastInlineDefinition( optionNamesToConvert );
-
-			editor.conversion.for( 'downcast' ).attributeToAttribute( definition );
+			editor.conversion.for( 'downcast' ).attributeToAttribute( buildDowncastInlineDefinition( optionsToConvert ) );
 		}
 
-		const upcastInlineDefinitions = buildUpcastInlineDefinitions( optionNamesToConvert );
+		const upcastInlineDefinitions = buildUpcastInlineDefinitions( optionsToConvert );
 
 		// Always upcast from inline styles.
 		for ( const definition of upcastInlineDefinitions ) {
@@ -86,11 +79,12 @@ export default class AlignmentEditing extends Plugin {
 
 // Prepare downcast conversion definition for inline alignment styling.
 // @private
-function buildDowncastInlineDefinition( optionNames ) {
+function buildDowncastInlineDefinition( options ) {
+	const optionNames = options.map( option => option.name );
 	const definition = {
 		model: {
 			key: 'alignment',
-			values: optionNames.slice()
+			values: optionNames
 		},
 		view: {}
 	};
@@ -109,7 +103,8 @@ function buildDowncastInlineDefinition( optionNames ) {
 
 // Prepare upcast definitions for inline alignment styles.
 // @private
-function buildUpcastInlineDefinitions( optionNames ) {
+function buildUpcastInlineDefinitions( options ) {
+	const optionNames = options.map( option => option.name );
 	const definitions = [];
 
 	for ( const name of optionNames ) {
@@ -136,7 +131,7 @@ function buildClassDefinition( options ) {
 	const definition = {
 		model: {
 			key: 'alignment',
-			values: options.map( option => option.name ).slice()
+			values: options.map( option => option.name )
 		},
 		view: {}
 	};
@@ -151,3 +146,18 @@ function buildClassDefinition( options ) {
 	return definition;
 }
 
+/**
+ * The alignment configuration format descriptor.
+ *
+ *		const alignmentFormat = {
+ *			name: 'right',
+ *			className: 'my-align-right-class'
+ *		}
+ *
+ * @typedef {Object} module:alignment/alignmentediting~AlignmentFormat
+ *
+ * @property {'left'|'right'|'center'|'justify'} name One of the alignment names options.
+ *
+ * @property {String} className The CSS class used to represent the style in the view.
+ * Used to override default, inline styling for alignment.
+ */

--- a/packages/ckeditor5-alignment/src/alignmentediting.js
+++ b/packages/ckeditor5-alignment/src/alignmentediting.js
@@ -59,7 +59,6 @@ export default class AlignmentEditing extends Plugin {
 		editor.model.schema.setAttributeProperties( 'alignment', { isFormatting: true } );
 
 		if ( shouldUseClasses ) {
-			// Downcast to only to classes.
 			editor.conversion.attributeToAttribute( buildClassDefinition( optionsToConvert ) );
 		} else {
 			// Downcast inline styles.
@@ -80,20 +79,19 @@ export default class AlignmentEditing extends Plugin {
 // Prepare downcast conversion definition for inline alignment styling.
 // @private
 function buildDowncastInlineDefinition( options ) {
-	const optionNames = options.map( option => option.name );
 	const definition = {
 		model: {
 			key: 'alignment',
-			values: optionNames
+			values: options.map( option => option.name )
 		},
 		view: {}
 	};
 
-	for ( const name of optionNames ) {
-		definition.view[ name ] = {
+	for ( const option of options ) {
+		definition.view[ option.name ] = {
 			key: 'style',
 			value: {
-				'text-align': name
+				'text-align': option.name
 			}
 		};
 	}
@@ -104,20 +102,19 @@ function buildDowncastInlineDefinition( options ) {
 // Prepare upcast definitions for inline alignment styles.
 // @private
 function buildUpcastInlineDefinitions( options ) {
-	const optionNames = options.map( option => option.name );
 	const definitions = [];
 
-	for ( const name of optionNames ) {
+	for ( const option of options ) {
 		definitions.push( {
 			view: {
 				key: 'style',
 				value: {
-					'text-align': name
+					'text-align': option.name
 				}
 			},
 			model: {
 				key: 'alignment',
-				value: name
+				value: option.name
 			}
 		} );
 	}

--- a/packages/ckeditor5-alignment/src/alignmentediting.js
+++ b/packages/ckeditor5-alignment/src/alignmentediting.js
@@ -10,7 +10,7 @@
 import { Plugin } from 'ckeditor5/src/core';
 
 import AlignmentCommand from './alignmentcommand';
-import { defaultConfig, isDefault, isSupported, normalizeAlignmentOptions } from './utils';
+import { isDefault, isSupported, normalizeAlignmentOptions, supportedOptions } from './utils';
 
 /**
  * The alignment editing feature. It introduces the {@link module:alignment/alignmentcommand~AlignmentCommand command} and adds
@@ -32,7 +32,7 @@ export default class AlignmentEditing extends Plugin {
 		super( editor );
 
 		editor.config.define( 'alignment', {
-			options: [ ...defaultConfig ]
+			options: [ ...supportedOptions.map( option => ( { name: option } ) ) ]
 		} );
 	}
 

--- a/packages/ckeditor5-alignment/src/alignmentediting.js
+++ b/packages/ckeditor5-alignment/src/alignmentediting.js
@@ -120,20 +120,17 @@ function buildUpcastInlineDefinitions( options ) {
 	const definitions = [];
 
 	for ( const option of options ) {
-		const view = {
-			key: 'style',
-			value: {
-				'text-align': option
-			}
-		};
-		const model = {
-			key: 'alignment',
-			value: option
-		};
-
 		definitions.push( {
-			view,
-			model
+			view: {
+				key: 'style',
+				value: {
+					'text-align': option
+				}
+			},
+			model: {
+				key: 'alignment',
+				value: option
+			}
 		} );
 	}
 

--- a/packages/ckeditor5-alignment/src/alignmentediting.js
+++ b/packages/ckeditor5-alignment/src/alignmentediting.js
@@ -144,7 +144,7 @@ function buildClassDefinition( options ) {
 	for ( const option of options ) {
 		definition.view[ option.name ] = {
 			key: 'class',
-			value: [ option.className ]
+			value: option.className
 		};
 	}
 

--- a/packages/ckeditor5-alignment/src/alignmentui.js
+++ b/packages/ckeditor5-alignment/src/alignmentui.js
@@ -10,7 +10,7 @@
 import { Plugin, icons } from 'ckeditor5/src/core';
 import { ButtonView, createDropdown, addToolbarToDropdown } from 'ckeditor5/src/ui';
 
-import { isSupported } from './utils';
+import { isSupported, normalizeAlignmentOptions } from './utils';
 
 const iconsMap = new Map( [
 	[ 'left', icons.alignLeft ],
@@ -67,9 +67,10 @@ export default class AlignmentUI extends Plugin {
 		const editor = this.editor;
 		const componentFactory = editor.ui.componentFactory;
 		const t = editor.t;
-		const options = editor.config.get( 'alignment.options' );
+		const options = normalizeAlignmentOptions( editor.config.get( 'alignment.options' ) );
 
 		options
+			.map( option => option.name )
 			.filter( isSupported )
 			.forEach( option => this._addButton( option ) );
 
@@ -77,7 +78,7 @@ export default class AlignmentUI extends Plugin {
 			const dropdownView = createDropdown( locale );
 
 			// Add existing alignment buttons to dropdown's toolbar.
-			const buttons = options.map( option => componentFactory.create( `alignment:${ option }` ) );
+			const buttons = options.map( option => componentFactory.create( `alignment:${ option.name }` ) );
 			addToolbarToDropdown( dropdownView, buttons );
 
 			// Configure dropdown properties an behavior.

--- a/packages/ckeditor5-alignment/src/utils.js
+++ b/packages/ckeditor5-alignment/src/utils.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import { CKEditorError } from '../../../src/utils';
+import { CKEditorError } from 'ckeditor5/src/utils';
 
 /**
  * @module alignment/utils
@@ -57,7 +57,7 @@ export function isDefault( alignment, locale ) {
  * @param {Array.<String|Object>} configuredOptions Alignment plugin configuration.
  * @returns {Array.<Object>} Normalized object holding the configuration.
  */
-export function normalizeAlignmentOptions( configuredOptions = [] ) {
+export function normalizeAlignmentOptions( configuredOptions ) {
 	const normalizedOptions = configuredOptions
 		.map( option => {
 			let optionObj;
@@ -78,13 +78,13 @@ export function normalizeAlignmentOptions( configuredOptions = [] ) {
 
 		if ( nameAlreadyExists ) {
 			/**
-				 * The same `name` in one of the `alignment.options` was already declared.
-				 * Each `name` representing one alignment option can be set exactly once.
-				 *
-				 * @error alignment-config-name-already-defined
-				 * @param {Object} option First option that declares given `name`.
-				 * @param {Array.<String|Object>} allOptions Contents of `alignment.options`.
-				 */
+			 * The same `name` in one of the `alignment.options` was already declared.
+			 * Each `name` representing one alignment option can be set exactly once.
+			 *
+			 * @error alignment-config-name-already-defined
+			 * @param {Object} option First option that declares given `name`.
+			 * @param {Array.<String|Object>} allOptions Contents of `alignment.options`.
+			 */
 			throw new CKEditorError( 'alignment-config-name-already-defined', { option, allOptions } );
 		}
 
@@ -93,7 +93,7 @@ export function normalizeAlignmentOptions( configuredOptions = [] ) {
 			const classNameAlreadyExists = succeedingOptions.some( item => item.className == option.className );
 
 			if ( classNameAlreadyExists ) {
-			/**
+				/**
 				 * The same `className` in one of the `alignment.options` was already declared.
 				 *
 				 * @error alignment-config-classname-already-defined

--- a/packages/ckeditor5-alignment/src/utils.js
+++ b/packages/ckeditor5-alignment/src/utils.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import { CKEditorError } from 'ckeditor5/src/utils';
+import { CKEditorError, logWarning } from 'ckeditor5/src/utils';
 
 /**
  * @module alignment/utils
@@ -65,10 +65,27 @@ export function normalizeAlignmentOptions( configuredOptions ) {
 			if ( typeof option == 'string' ) {
 				optionObj = { name: option };
 			} else {
-				optionObj = { ...optionNameToOptionMap[ option ], ...option };
+				optionObj = { ...optionNameToOptionMap[ option.name ], ...option };
 			}
 
 			return optionObj;
+		} )
+		// Remove all unknown options.
+		.filter( option => {
+			const isNameValid = !!supportedOptions.includes( option.name );
+			if ( !isNameValid ) {
+				/**
+				 * The `name` in one of the `alignment.options` is not recognized.
+				 * The available options are: `'left'`, `'right'`, `'center'` and `'justify'`.
+				 *
+				 * @error alignment-config-name-not-recognized
+				 * @param {Object} option Options with unknown value of the `name` property.
+				 * @param {Array.<String|module:alignment/alignmentediting~AlignmentFormat>} allOptions Contents of `alignment.options`.
+				 */
+				logWarning( 'alignment-config-name-not-recognized', { option, supportedOptions } );
+			}
+
+			return isNameValid;
 		} );
 
 	// Validate resulting config.
@@ -83,7 +100,7 @@ export function normalizeAlignmentOptions( configuredOptions ) {
 			 *
 			 * @error alignment-config-name-already-defined
 			 * @param {Object} option First option that declares given `name`.
-			 * @param {Array.<String|Object>} allOptions Contents of `alignment.options`.
+			 * @param {Array.<String|module:alignment/alignmentediting~AlignmentFormat>} allOptions Contents of `alignment.options`.
 			 */
 			throw new CKEditorError( 'alignment-config-name-already-defined', { option, allOptions } );
 		}
@@ -98,7 +115,7 @@ export function normalizeAlignmentOptions( configuredOptions ) {
 				 *
 				 * @error alignment-config-classname-already-defined
 				 * @param {Object} option First option that declares given `className`.
-				 * @param {Array.<String|Object>} allOptions Contents of `alignment.options`.
+				 * @param {Array.<String|module:alignment/alignmentediting~AlignmentFormat>} allOptions  Contents of `alignment.options`.
 				 */
 				throw new CKEditorError( 'alignment-config-classname-already-defined', { option, allOptions } );
 			}

--- a/packages/ckeditor5-alignment/src/utils.js
+++ b/packages/ckeditor5-alignment/src/utils.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+import { CKEditorError } from '../../../src/utils';
+
 /**
  * @module alignment/utils
  */
@@ -16,6 +18,11 @@
  * * `'justify'`
  */
 export const supportedOptions = [ 'left', 'right', 'center', 'justify' ];
+export const defaultOptions = supportedOptions.map( option => {
+	return Object.assign( {}, {
+		name: option
+	} );
+} );
 
 /**
  * Checks whether the passed option is supported by {@link module:alignment/alignmentediting~AlignmentEditing}.
@@ -43,4 +50,42 @@ export function isDefault( alignment, locale ) {
 	} else {
 		return alignment === 'left';
 	}
+}
+
+export function normalizeAlignmentOptions( configuredOptions = [] ) {
+	return configuredOptions.map( ( option, index, options ) => {
+		let optionObj;
+
+		if ( typeof option == 'string' ) {
+			optionObj = Object.assign( {}, { name: option } );
+		} else {
+			optionObj = Object.assign( {}, defaultOptions[ index ], option );
+		}
+
+		const succeedingOptions = options.slice( index + 1 );
+		const nameAlreadyExists = succeedingOptions.some( item => {
+			const optionName = item.name || item;
+
+			return optionName == optionObj.name;
+		} );
+
+		if ( nameAlreadyExists ) {
+			// TODO: Fill in api docs.
+			// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
+			throw new CKEditorError( 'alignment-config-name-already-defined' );
+		}
+
+		const classNameAlreadyExists = optionObj.className && succeedingOptions.some(
+			// The `item.className` can be undefined. We shouldn't count it as a duplicate.
+			item => item.className && item.className == optionObj.className
+		);
+
+		if ( classNameAlreadyExists ) {
+			// TODO: Fill in api docs.
+			// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
+			throw new CKEditorError( 'alignment-config-classname-already-defined' );
+		}
+
+		return optionObj;
+	} );
 }

--- a/packages/ckeditor5-alignment/src/utils.js
+++ b/packages/ckeditor5-alignment/src/utils.js
@@ -52,40 +52,49 @@ export function isDefault( alignment, locale ) {
 	}
 }
 
+/**
+ * Brings the configuration to the common form, an array of objects.
+ *
+ * @param {Array.<String|Object>} configuredOptions Alignment plugin configuration.
+ * @returns {Array.<Object>} Normalized object holding the configuration.
+ */
 export function normalizeAlignmentOptions( configuredOptions = [] ) {
-	return configuredOptions.map( ( option, index, options ) => {
-		let optionObj;
+	return configuredOptions.map( normalizeOption );
+}
 
-		if ( typeof option == 'string' ) {
-			optionObj = Object.assign( {}, { name: option } );
-		} else {
-			optionObj = Object.assign( {}, defaultOptions[ index ], option );
-		}
+// @private
+function normalizeOption( option, index, allOptions ) {
+	let optionObj;
 
-		const succeedingOptions = options.slice( index + 1 );
-		const nameAlreadyExists = succeedingOptions.some( item => {
-			const optionName = item.name || item;
+	if ( typeof option == 'string' ) {
+		optionObj = Object.assign( {}, { name: option } );
+	} else {
+		optionObj = Object.assign( {}, defaultOptions[ index ], option );
+	}
 
-			return optionName == optionObj.name;
-		} );
+	const succeedingOptions = allOptions.slice( index + 1 );
+	const nameAlreadyExists = succeedingOptions.some( item => {
+		const optionName = item.name || item;
 
-		if ( nameAlreadyExists ) {
-			// TODO: Fill in api docs.
-			// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
-			throw new CKEditorError( 'alignment-config-name-already-defined' );
-		}
-
-		const classNameAlreadyExists = optionObj.className && succeedingOptions.some(
-			// The `item.className` can be undefined. We shouldn't count it as a duplicate.
-			item => item.className && item.className == optionObj.className
-		);
-
-		if ( classNameAlreadyExists ) {
-			// TODO: Fill in api docs.
-			// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
-			throw new CKEditorError( 'alignment-config-classname-already-defined' );
-		}
-
-		return optionObj;
+		return optionName == optionObj.name;
 	} );
+
+	if ( nameAlreadyExists ) {
+		// TODO: Fill in api docs.
+		// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
+		throw new CKEditorError( 'alignment-config-name-already-defined' );
+	}
+
+	const classNameAlreadyExists = optionObj.className && succeedingOptions.some(
+		// The `item.className` can be undefined. We shouldn't count it as a duplicate.
+		item => item.className && item.className == optionObj.className
+	);
+
+	if ( classNameAlreadyExists ) {
+		// TODO: Fill in api docs.
+		// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
+		throw new CKEditorError( 'alignment-config-classname-already-defined' );
+	}
+
+	return optionObj;
 }

--- a/packages/ckeditor5-alignment/src/utils.js
+++ b/packages/ckeditor5-alignment/src/utils.js
@@ -19,10 +19,6 @@ import { CKEditorError, logWarning } from 'ckeditor5/src/utils';
  */
 export const supportedOptions = [ 'left', 'right', 'center', 'justify' ];
 
-const optionNameToOptionMap = Object.fromEntries(
-	supportedOptions.map( option => [ option, { name: option } ] )
-);
-
 /**
  * Checks whether the passed option is supported by {@link module:alignment/alignmentediting~AlignmentEditing}.
  *
@@ -65,7 +61,7 @@ export function normalizeAlignmentOptions( configuredOptions ) {
 			if ( typeof option == 'string' ) {
 				result = { name: option };
 			} else {
-				result = { ...optionNameToOptionMap[ option.name ], ...option };
+				result = option;
 			}
 
 			return result;

--- a/packages/ckeditor5-alignment/src/utils.js
+++ b/packages/ckeditor5-alignment/src/utils.js
@@ -73,27 +73,40 @@ function normalizeOption( option, index, allOptions ) {
 	}
 
 	const succeedingOptions = allOptions.slice( index + 1 );
-	const nameAlreadyExists = succeedingOptions.some( item => {
-		const optionName = item.name || item;
+	const nameAlreadyExists = succeedingOptions.some(
+		item => {
+			const optionName = item.name || item;
 
-		return optionName == optionObj.name;
-	} );
+			return optionName == optionObj.name;
+		} );
 
 	if ( nameAlreadyExists ) {
-		// TODO: Fill in api docs.
-		// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
-		throw new CKEditorError( 'alignment-config-name-already-defined' );
+		/**
+		 * The same `name` in one of the `alignment.options` was already declared.
+		 * Each `name` representing one alignment option can be set exactly once.
+		 *
+		 * @error alignment-config-name-already-defined
+		 * @param {Object} option First option that declares given `name`.
+		 * @param {Array.<String|Object>} allOptions Contents of `alignment.options`.
+		 */
+		throw new CKEditorError( 'alignment-config-name-already-defined', { option, allOptions } );
 	}
 
 	const classNameAlreadyExists = optionObj.className && succeedingOptions.some(
 		// The `item.className` can be undefined. We shouldn't count it as a duplicate.
-		item => item.className && item.className == optionObj.className
+		item => item.className &&
+				item.className == optionObj.className
 	);
 
 	if ( classNameAlreadyExists ) {
-		// TODO: Fill in api docs.
-		// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
-		throw new CKEditorError( 'alignment-config-classname-already-defined' );
+		/**
+		 * The same `className` in one of the `alignment.options` was already declared.
+		 *
+		 * @error alignment-config-classname-already-defined
+		 * @param {Object} option First option that declares given `className`.
+		 * @param {Array.<String|Object>} allOptions Contents of `alignment.options`.
+		 */
+		throw new CKEditorError( 'alignment-config-classname-already-defined', { option, allOptions } );
 	}
 
 	return optionObj;

--- a/packages/ckeditor5-alignment/src/utils.js
+++ b/packages/ckeditor5-alignment/src/utils.js
@@ -92,11 +92,11 @@ export function normalizeAlignmentOptions( configuredOptions = [] ) {
 			throw new CKEditorError( 'alignment-config-name-already-defined', { option, allOptions } );
 		}
 
-		// The `item.className` can be undefined. We shouldn't count it as a duplicate.
-		const classNameAlreadyExists = option.className &&
-			succeedingOptions.some( item => item.className && item.className == option.className );
+		// The `className` property is present. Check for duplicates then.
+		if ( option.className ) {
+			const classNameAlreadyExists = succeedingOptions.some( item => item.className == option.className );
 
-		if ( classNameAlreadyExists ) {
+			if ( classNameAlreadyExists ) {
 			/**
 				 * The same `className` in one of the `alignment.options` was already declared.
 				 *
@@ -104,7 +104,8 @@ export function normalizeAlignmentOptions( configuredOptions = [] ) {
 				 * @param {Object} option First option that declares given `className`.
 				 * @param {Array.<String|Object>} allOptions Contents of `alignment.options`.
 				 */
-			throw new CKEditorError( 'alignment-config-classname-already-defined', { option, allOptions } );
+				throw new CKEditorError( 'alignment-config-classname-already-defined', { option, allOptions } );
+			}
 		}
 	} );
 

--- a/packages/ckeditor5-alignment/src/utils.js
+++ b/packages/ckeditor5-alignment/src/utils.js
@@ -18,11 +18,10 @@ import { CKEditorError } from '../../../src/utils';
  * * `'justify'`
  */
 export const supportedOptions = [ 'left', 'right', 'center', 'justify' ];
-export const defaultConfig = supportedOptions.map( option => {
-	return {
-		name: option
-	};
-} );
+
+const optionNameToOptionMap = Object.fromEntries(
+	supportedOptions.map( option => [ option, { name: option } ] )
+);
 
 /**
  * Checks whether the passed option is supported by {@link module:alignment/alignmentediting~AlignmentEditing}.
@@ -59,8 +58,6 @@ export function isDefault( alignment, locale ) {
  * @returns {Array.<Object>} Normalized object holding the configuration.
  */
 export function normalizeAlignmentOptions( configuredOptions = [] ) {
-	const optionNameToOptionMap = new Map( defaultConfig.map( option => [ option.name, option ] ) );
-
 	const normalizedOptions = configuredOptions
 		.map( option => {
 			let optionObj;
@@ -77,7 +74,6 @@ export function normalizeAlignmentOptions( configuredOptions = [] ) {
 	// Validate resulting config.
 	normalizedOptions.forEach( ( option, index, allOptions ) => {
 		const succeedingOptions = allOptions.slice( index + 1 );
-
 		const nameAlreadyExists = succeedingOptions.some( item => item.name == option.name );
 
 		if ( nameAlreadyExists ) {

--- a/packages/ckeditor5-alignment/tests/alignmentediting.js
+++ b/packages/ckeditor5-alignment/tests/alignmentediting.js
@@ -138,6 +138,33 @@ describe( 'AlignmentEditing', () => {
 						return newEditor.destroy();
 					} );
 			} );
+
+			it( 'uses class when alignment.classNames is set', async () => {
+				return VirtualTestEditor
+					.create( {
+						language: {
+							content: 'ar'
+						},
+						plugins: [ AlignmentEditing, Paragraph ],
+						alignment: {
+							classNames: [ 'foo-left', 'foo-right', 'foo-center', 'foo-justify' ]
+						}
+					} )
+					.then( newEditor => {
+						const model = newEditor.model;
+
+						setModelData( model, '<paragraph>[]x</paragraph>' );
+
+						expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+						newEditor.execute( 'alignment', { value: 'left' } );
+
+						expect( getModelData( model ) ).to.equal( '<paragraph alignment="left">[]x</paragraph>' );
+						expect( newEditor.getData() ).to.equal( '<p class="foo-left">x</p>' );
+
+						return newEditor.destroy();
+					} );
+			} );
 		} );
 
 		it( 'adds a converter to the view pipeline for removing attribute', () => {
@@ -148,6 +175,30 @@ describe( 'AlignmentEditing', () => {
 			editor.execute( 'alignment' );
 
 			expect( editor.getData() ).to.equal( '<p>x</p>' );
+		} );
+
+		it( 'uses class when alignment.classNames is set', async () => {
+			return VirtualTestEditor
+				.create( {
+					plugins: [ AlignmentEditing, Paragraph ],
+					alignment: {
+						classNames: [ 'foo-left', 'foo-right', 'foo-center', 'foo-justify' ]
+					}
+				} )
+				.then( newEditor => {
+					const model = newEditor.model;
+
+					setModelData( model, '<paragraph alignment="center">[]x</paragraph>' );
+
+					expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
+
+					newEditor.execute( 'alignment', { value: 'left' } );
+
+					expect( getModelData( model ) ).to.equal( '<paragraph>[]x</paragraph>' );
+					expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+					return newEditor.destroy();
+				} );
 		} );
 	} );
 
@@ -175,6 +226,33 @@ describe( 'AlignmentEditing', () => {
 			editor.execute( 'alignment', { value: 'center' } );
 
 			expect( editor.getData() ).to.equal( '<p style="text-align:center;">x</p>' );
+		} );
+
+		it( 'uses class when alignment.classNames is set', async () => {
+			return VirtualTestEditor
+				.create( {
+					language: {
+						content: 'ar'
+					},
+					plugins: [ AlignmentEditing, Paragraph ],
+					alignment: {
+						classNames: [ 'foo-left', 'foo-right', 'foo-center', 'foo-justify' ]
+					}
+				} )
+				.then( newEditor => {
+					const model = newEditor.model;
+
+					setModelData( model, '<paragraph>[]x</paragraph>' );
+
+					expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+					newEditor.execute( 'alignment', { value: 'center' } );
+
+					expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
+					expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
+
+					return newEditor.destroy();
+				} );
 		} );
 	} );
 
@@ -236,6 +314,30 @@ describe( 'AlignmentEditing', () => {
 					} );
 			} );
 		} );
+
+		it( 'uses class when alignment.classNames is set', async () => {
+			return VirtualTestEditor
+				.create( {
+					plugins: [ AlignmentEditing, Paragraph ],
+					alignment: {
+						classNames: [ 'foo-left', 'foo-right', 'foo-center', 'foo-justify' ]
+					}
+				} )
+				.then( newEditor => {
+					const model = newEditor.model;
+
+					setModelData( model, '<paragraph>[]x</paragraph>' );
+
+					expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+					newEditor.execute( 'alignment', { value: 'right' } );
+
+					expect( getModelData( model ) ).to.equal( '<paragraph alignment="right">[]x</paragraph>' );
+					expect( newEditor.getData() ).to.equal( '<p class="foo-right">x</p>' );
+
+					return newEditor.destroy();
+				} );
+		} );
 	} );
 
 	describe( 'justify alignment', () => {
@@ -252,6 +354,30 @@ describe( 'AlignmentEditing', () => {
 			setModelData( model, '<paragraph alignment="justify">[]x</paragraph>' );
 
 			expect( editor.getData() ).to.equal( '<p style="text-align:justify;">x</p>' );
+		} );
+
+		it( 'uses class when alignment.classNames is set', async () => {
+			return VirtualTestEditor
+				.create( {
+					plugins: [ AlignmentEditing, Paragraph ],
+					alignment: {
+						classNames: [ 'foo-left', 'foo-right', 'foo-center', 'foo-justify' ]
+					}
+				} )
+				.then( newEditor => {
+					const model = newEditor.model;
+
+					setModelData( model, '<paragraph>[]x</paragraph>' );
+
+					expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+					newEditor.execute( 'alignment', { value: 'justify' } );
+
+					expect( getModelData( model ) ).to.equal( '<paragraph alignment="justify">[]x</paragraph>' );
+					expect( newEditor.getData() ).to.equal( '<p class="foo-justify">x</p>' );
+
+					return newEditor.destroy();
+				} );
 		} );
 	} );
 
@@ -314,9 +440,6 @@ describe( 'AlignmentEditing', () => {
 				try {
 					await VirtualTestEditor
 						.create( {
-							language: {
-								content: 'ar'
-							},
 							plugins: [ AlignmentEditing, Paragraph ],
 							alignment: {
 								classNames: [ 'foo-left', 'foo-right', 'foo-center', 'foo-justify', 'foo-extra' ]
@@ -332,9 +455,6 @@ describe( 'AlignmentEditing', () => {
 				try {
 					await VirtualTestEditor
 						.create( {
-							language: {
-								content: 'ar'
-							},
 							plugins: [ AlignmentEditing, Paragraph ],
 							alignment: {
 								classNames: [ 'foo-left', 'foo-right', 'foo-center' ]
@@ -350,9 +470,6 @@ describe( 'AlignmentEditing', () => {
 				try {
 					await VirtualTestEditor
 						.create( {
-							language: {
-								content: 'ar'
-							},
 							plugins: [ AlignmentEditing, Paragraph ],
 							alignment: {
 								classNames: {}
@@ -367,23 +484,41 @@ describe( 'AlignmentEditing', () => {
 			it( 'should map limited options to limited set of classes', () => {
 				return VirtualTestEditor
 					.create( {
-						language: {
-							content: 'ar'
-						},
 						plugins: [ AlignmentEditing, Paragraph ],
 						alignment: {
 							options: [ 'left', 'center' ],
-							classNames: [ 'foo-left', 'foo-right' ]
+							classNames: [ 'foo-left', 'foo-center' ]
 						}
 					} )
 					.then( newEditor => {
 						const model = newEditor.model;
-						const data = '<p style="text-align:left;">x</p>';
+						const data = '<p style="text-align:center;">x</p>';
 
 						newEditor.setData( data );
 
-						expect( getModelData( model ) ).to.equal( '<paragraph alignment="left">[]x</paragraph>' );
-						expect( newEditor.getData() ).to.equal( '<p class="foo-left">x</p>' );
+						expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
+						expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
+
+						return newEditor.destroy();
+					} );
+			} );
+
+			it( 'should map classes to default options', () => {
+				return VirtualTestEditor
+					.create( {
+						plugins: [ AlignmentEditing, Paragraph ],
+						alignment: {
+							classNames: [ 'foo-left', 'foo-right', 'foo-center', 'foo-justify' ]
+						}
+					} )
+					.then( newEditor => {
+						const model = newEditor.model;
+						const data = '<p style="text-align:center;">x</p>';
+
+						newEditor.setData( data );
+
+						expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
+						expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
 
 						return newEditor.destroy();
 					} );

--- a/packages/ckeditor5-alignment/tests/alignmentediting.js
+++ b/packages/ckeditor5-alignment/tests/alignmentediting.js
@@ -301,6 +301,13 @@ describe( 'AlignmentEditing', () => {
 				} );
 			} );
 		} );
+
+		// TODO:
+		// * Can work without class names (backwards-compatible).
+		// * Incorrect length of params.
+		// * Not an array.
+		// * Limited options should map to limited set of classes.
+		describe( 'classNames', () => {} );
 	} );
 } );
 

--- a/packages/ckeditor5-alignment/tests/alignmentediting.js
+++ b/packages/ckeditor5-alignment/tests/alignmentediting.js
@@ -304,8 +304,10 @@ describe( 'AlignmentEditing', () => {
 		} );
 
 		describe( 'classNames', () => {
-			it( 'default value', () => {
-				expect( editor.config.get( 'alignment.classNames' ) ).to.deep.equal( [ ] );
+			describe( 'default value', () => {
+				it( 'should be set', () => {
+					expect( editor.config.get( 'alignment.classNames' ) ).to.deep.equal( [ ] );
+				} );
 			} );
 
 			it( 'should throw when there are too many classes', async () => {

--- a/packages/ckeditor5-alignment/tests/alignmentediting.js
+++ b/packages/ckeditor5-alignment/tests/alignmentediting.js
@@ -153,8 +153,6 @@ describe( 'AlignmentEditing', () => {
 
 				setModelData( model, '<paragraph>[]x</paragraph>' );
 
-				expect( newEditor.getData() ).to.equal( '<p>x</p>' );
-
 				newEditor.execute( 'alignment', { value: 'left' } );
 
 				expect( getModelData( model ) ).to.equal( '<paragraph alignment="left">[]x</paragraph>' );
@@ -248,8 +246,6 @@ describe( 'AlignmentEditing', () => {
 
 			setModelData( model, '<paragraph>[]x</paragraph>' );
 
-			expect( newEditor.getData() ).to.equal( '<p>x</p>' );
-
 			newEditor.execute( 'alignment', { value: 'center' } );
 
 			expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
@@ -331,8 +327,6 @@ describe( 'AlignmentEditing', () => {
 
 			setModelData( model, '<paragraph>[]x</paragraph>' );
 
-			expect( newEditor.getData() ).to.equal( '<p>x</p>' );
-
 			newEditor.execute( 'alignment', { value: 'right' } );
 
 			expect( getModelData( model ) ).to.equal( '<paragraph alignment="right">[]x</paragraph>' );
@@ -374,8 +368,6 @@ describe( 'AlignmentEditing', () => {
 			const model = newEditor.model;
 
 			setModelData( model, '<paragraph>[]x</paragraph>' );
-
-			expect( newEditor.getData() ).to.equal( '<p>x</p>' );
 
 			newEditor.execute( 'alignment', { value: 'justify' } );
 

--- a/packages/ckeditor5-alignment/tests/alignmentediting.js
+++ b/packages/ckeditor5-alignment/tests/alignmentediting.js
@@ -17,15 +17,14 @@ import { CKEditorError } from '../../../src/utils';
 describe( 'AlignmentEditing', () => {
 	let editor, model;
 
-	beforeEach( () => {
-		return VirtualTestEditor
+	beforeEach( async () => {
+		const newEditor = await VirtualTestEditor
 			.create( {
 				plugins: [ AlignmentEditing, Paragraph ]
-			} )
-			.then( newEditor => {
-				editor = newEditor;
-				model = editor.model;
 			} );
+
+		editor = newEditor;
+		model = editor.model;
 	} );
 
 	afterEach( () => {
@@ -51,15 +50,14 @@ describe( 'AlignmentEditing', () => {
 	} );
 
 	describe( 'integration', () => {
-		beforeEach( () => {
-			return VirtualTestEditor
+		beforeEach( async () => {
+			const newEditor = await VirtualTestEditor
 				.create( {
 					plugins: [ AlignmentEditing, ImageCaptionEditing, Paragraph, ListEditing, HeadingEditing ]
-				} )
-				.then( newEditor => {
-					editor = newEditor;
-					model = editor.model;
 				} );
+
+			editor = newEditor;
+			model = editor.model;
 		} );
 
 		it( 'is allowed on paragraph', () => {
@@ -100,70 +98,69 @@ describe( 'AlignmentEditing', () => {
 		} );
 
 		describe( 'RTL content', () => {
-			it( 'adds converters to the data pipeline', () => {
-				return VirtualTestEditor
+			it( 'adds converters to the data pipeline', async () => {
+				const newEditor = await VirtualTestEditor
 					.create( {
 						language: {
 							content: 'ar'
 						},
 						plugins: [ AlignmentEditing, Paragraph ]
-					} )
-					.then( newEditor => {
-						const model = newEditor.model;
-						const data = '<p style="text-align:left;">x</p>';
-
-						newEditor.setData( data );
-
-						expect( getModelData( model ) ).to.equal( '<paragraph alignment="left">[]x</paragraph>' );
-						expect( newEditor.getData() ).to.equal( '<p style="text-align:left;">x</p>' );
-
-						return newEditor.destroy();
 					} );
+				const model = newEditor.model;
+				const data = '<p style="text-align:left;">x</p>';
+
+				newEditor.setData( data );
+
+				expect( getModelData( model ) ).to.equal( '<paragraph alignment="left">[]x</paragraph>' );
+				expect( newEditor.getData() ).to.equal( '<p style="text-align:left;">x</p>' );
+
+				return newEditor.destroy();
 			} );
 
-			it( 'adds a converter to the view pipeline', () => {
-				return VirtualTestEditor
+			it( 'adds a converter to the view pipeline', async () => {
+				const newEditor = await VirtualTestEditor
 					.create( {
 						language: {
 							content: 'ar'
 						},
 						plugins: [ AlignmentEditing, Paragraph ]
-					} )
-					.then( newEditor => {
-						const model = newEditor.model;
-
-						setModelData( model, '<paragraph alignment="left">[]x</paragraph>' );
-						expect( newEditor.getData() ).to.equal( '<p style="text-align:left;">x</p>' );
-
-						return newEditor.destroy();
 					} );
+				const model = newEditor.model;
+
+				setModelData( model, '<paragraph alignment="left">[]x</paragraph>' );
+				expect( newEditor.getData() ).to.equal( '<p style="text-align:left;">x</p>' );
+
+				return newEditor.destroy();
 			} );
 
 			it( 'uses class when alignment.classNames is set', async () => {
-				return VirtualTestEditor
+				const newEditor = await VirtualTestEditor
 					.create( {
 						language: {
 							content: 'ar'
 						},
 						plugins: [ AlignmentEditing, Paragraph ],
 						alignment: {
-							classNames: [ 'foo-left', 'foo-right', 'foo-center', 'foo-justify' ]
+							options: [
+								{ name: 'left', className: 'foo-left' },
+								{ name: 'right', className: 'foo-right' },
+								{ name: 'center', className: 'foo-center' },
+								{ name: 'justify', className: 'foo-justify' }
+							]
 						}
-					} )
-					.then( newEditor => {
-						const model = newEditor.model;
-
-						setModelData( model, '<paragraph>[]x</paragraph>' );
-
-						expect( newEditor.getData() ).to.equal( '<p>x</p>' );
-
-						newEditor.execute( 'alignment', { value: 'left' } );
-
-						expect( getModelData( model ) ).to.equal( '<paragraph alignment="left">[]x</paragraph>' );
-						expect( newEditor.getData() ).to.equal( '<p class="foo-left">x</p>' );
-
-						return newEditor.destroy();
 					} );
+				const model = newEditor.model;
+
+				setModelData( model, '<paragraph>[]x</paragraph>' );
+
+				expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+				newEditor.execute( 'alignment', { value: 'left' } );
+
+				expect( getModelData( model ) ).to.equal( '<paragraph alignment="left">[]x</paragraph>' );
+				expect( newEditor.getData() ).to.equal( '<p class="foo-left">x</p>' );
+
+				return newEditor.destroy();
 			} );
 		} );
 
@@ -178,27 +175,30 @@ describe( 'AlignmentEditing', () => {
 		} );
 
 		it( 'uses class when alignment.classNames is set', async () => {
-			return VirtualTestEditor
+			const newEditor = await VirtualTestEditor
 				.create( {
 					plugins: [ AlignmentEditing, Paragraph ],
 					alignment: {
-						classNames: [ 'foo-left', 'foo-right', 'foo-center', 'foo-justify' ]
+						options: [
+							{ name: 'left', className: 'foo-left' },
+							{ name: 'right', className: 'foo-right' },
+							{ name: 'center', className: 'foo-center' },
+							{ name: 'justify', className: 'foo-justify' }
+						]
 					}
-				} )
-				.then( newEditor => {
-					const model = newEditor.model;
-
-					setModelData( model, '<paragraph alignment="center">[]x</paragraph>' );
-
-					expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
-
-					newEditor.execute( 'alignment', { value: 'left' } );
-
-					expect( getModelData( model ) ).to.equal( '<paragraph>[]x</paragraph>' );
-					expect( newEditor.getData() ).to.equal( '<p>x</p>' );
-
-					return newEditor.destroy();
 				} );
+			const model = newEditor.model;
+
+			setModelData( model, '<paragraph alignment="center">[]x</paragraph>' );
+
+			expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
+
+			newEditor.execute( 'alignment', { value: 'left' } );
+
+			expect( getModelData( model ) ).to.equal( '<paragraph>[]x</paragraph>' );
+			expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+			return newEditor.destroy();
 		} );
 	} );
 
@@ -229,30 +229,33 @@ describe( 'AlignmentEditing', () => {
 		} );
 
 		it( 'uses class when alignment.classNames is set', async () => {
-			return VirtualTestEditor
+			const newEditor = await VirtualTestEditor
 				.create( {
 					language: {
 						content: 'ar'
 					},
 					plugins: [ AlignmentEditing, Paragraph ],
 					alignment: {
-						classNames: [ 'foo-left', 'foo-right', 'foo-center', 'foo-justify' ]
+						options: [
+							{ name: 'left', className: 'foo-left' },
+							{ name: 'right', className: 'foo-right' },
+							{ name: 'center', className: 'foo-center' },
+							{ name: 'justify', className: 'foo-justify' }
+						]
 					}
-				} )
-				.then( newEditor => {
-					const model = newEditor.model;
-
-					setModelData( model, '<paragraph>[]x</paragraph>' );
-
-					expect( newEditor.getData() ).to.equal( '<p>x</p>' );
-
-					newEditor.execute( 'alignment', { value: 'center' } );
-
-					expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
-					expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
-
-					return newEditor.destroy();
 				} );
+			const model = newEditor.model;
+
+			setModelData( model, '<paragraph>[]x</paragraph>' );
+
+			expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+			newEditor.execute( 'alignment', { value: 'center' } );
+
+			expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
+			expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
+
+			return newEditor.destroy();
 		} );
 	} );
 
@@ -275,68 +278,67 @@ describe( 'AlignmentEditing', () => {
 		} );
 
 		describe( 'RTL content', () => {
-			it( 'adds converters to the data pipeline', () => {
-				return VirtualTestEditor
+			it( 'adds converters to the data pipeline', async () => {
+				const newEditor = await VirtualTestEditor
 					.create( {
 						language: {
 							content: 'ar'
 						},
 						plugins: [ AlignmentEditing, Paragraph ]
-					} )
-					.then( newEditor => {
-						const model = newEditor.model;
-						const data = '<p style="text-align:right;">x</p>';
-
-						newEditor.setData( data );
-
-						expect( getModelData( model ) ).to.equal( '<paragraph>[]x</paragraph>' );
-						expect( newEditor.getData() ).to.equal( '<p>x</p>' );
-
-						return newEditor.destroy();
 					} );
+				const model = newEditor.model;
+				const data = '<p style="text-align:right;">x</p>';
+
+				newEditor.setData( data );
+
+				expect( getModelData( model ) ).to.equal( '<paragraph>[]x</paragraph>' );
+				expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+				return newEditor.destroy();
 			} );
 
-			it( 'adds a converter to the view pipeline', () => {
-				return VirtualTestEditor
+			it( 'adds a converter to the view pipeline', async () => {
+				const newEditor = await VirtualTestEditor
 					.create( {
 						language: {
 							content: 'ar'
 						},
 						plugins: [ AlignmentEditing, Paragraph ]
-					} )
-					.then( newEditor => {
-						const model = newEditor.model;
-
-						setModelData( model, '<paragraph alignment="right">[]x</paragraph>' );
-						expect( newEditor.getData() ).to.equal( '<p>x</p>' );
-
-						return newEditor.destroy();
 					} );
+				const model = newEditor.model;
+
+				setModelData( model, '<paragraph alignment="right">[]x</paragraph>' );
+				expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+				return newEditor.destroy();
 			} );
 		} );
 
 		it( 'uses class when alignment.classNames is set', async () => {
-			return VirtualTestEditor
+			const newEditor = await VirtualTestEditor
 				.create( {
 					plugins: [ AlignmentEditing, Paragraph ],
 					alignment: {
-						classNames: [ 'foo-left', 'foo-right', 'foo-center', 'foo-justify' ]
+						options: [
+							{ name: 'left', className: 'foo-left' },
+							{ name: 'right', className: 'foo-right' },
+							{ name: 'center', className: 'foo-center' },
+							{ name: 'justify', className: 'foo-justify' }
+						]
 					}
-				} )
-				.then( newEditor => {
-					const model = newEditor.model;
-
-					setModelData( model, '<paragraph>[]x</paragraph>' );
-
-					expect( newEditor.getData() ).to.equal( '<p>x</p>' );
-
-					newEditor.execute( 'alignment', { value: 'right' } );
-
-					expect( getModelData( model ) ).to.equal( '<paragraph alignment="right">[]x</paragraph>' );
-					expect( newEditor.getData() ).to.equal( '<p class="foo-right">x</p>' );
-
-					return newEditor.destroy();
 				} );
+			const model = newEditor.model;
+
+			setModelData( model, '<paragraph>[]x</paragraph>' );
+
+			expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+			newEditor.execute( 'alignment', { value: 'right' } );
+
+			expect( getModelData( model ) ).to.equal( '<paragraph alignment="right">[]x</paragraph>' );
+			expect( newEditor.getData() ).to.equal( '<p class="foo-right">x</p>' );
+
+			return newEditor.destroy();
 		} );
 	} );
 
@@ -357,27 +359,30 @@ describe( 'AlignmentEditing', () => {
 		} );
 
 		it( 'uses class when alignment.classNames is set', async () => {
-			return VirtualTestEditor
+			const newEditor = await VirtualTestEditor
 				.create( {
 					plugins: [ AlignmentEditing, Paragraph ],
 					alignment: {
-						classNames: [ 'foo-left', 'foo-right', 'foo-center', 'foo-justify' ]
+						options: [
+							{ name: 'left', className: 'foo-left' },
+							{ name: 'right', className: 'foo-right' },
+							{ name: 'center', className: 'foo-center' },
+							{ name: 'justify', className: 'foo-justify' }
+						]
 					}
-				} )
-				.then( newEditor => {
-					const model = newEditor.model;
-
-					setModelData( model, '<paragraph>[]x</paragraph>' );
-
-					expect( newEditor.getData() ).to.equal( '<p>x</p>' );
-
-					newEditor.execute( 'alignment', { value: 'justify' } );
-
-					expect( getModelData( model ) ).to.equal( '<paragraph alignment="justify">[]x</paragraph>' );
-					expect( newEditor.getData() ).to.equal( '<p class="foo-justify">x</p>' );
-
-					return newEditor.destroy();
 				} );
+			const model = newEditor.model;
+
+			setModelData( model, '<paragraph>[]x</paragraph>' );
+
+			expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+			newEditor.execute( 'alignment', { value: 'justify' } );
+
+			expect( getModelData( model ) ).to.equal( '<paragraph alignment="justify">[]x</paragraph>' );
+			expect( newEditor.getData() ).to.equal( '<p class="foo-justify">x</p>' );
+
+			return newEditor.destroy();
 		} );
 	} );
 
@@ -424,7 +429,14 @@ describe( 'AlignmentEditing', () => {
 		describe( 'options', () => {
 			describe( 'default value', () => {
 				it( 'should be set', () => {
-					expect( editor.config.get( 'alignment.options' ) ).to.deep.equal( [ 'left', 'right', 'center', 'justify' ] );
+					expect( editor.config.get( 'alignment.options' ) ).to.deep.equal(
+						[
+							{ name: 'left' },
+							{ name: 'right' },
+							{ name: 'center' },
+							{ name: 'justify' }
+						]
+					);
 				} );
 			} );
 		} );
@@ -436,92 +448,95 @@ describe( 'AlignmentEditing', () => {
 				} );
 			} );
 
-			it( 'should throw when there are too many classes', async () => {
+			it( 'should throw when options are repeated - repeated name', async () => {
+				let error;
+
 				try {
 					await VirtualTestEditor
 						.create( {
 							plugins: [ AlignmentEditing, Paragraph ],
 							alignment: {
-								classNames: [ 'foo-left', 'foo-right', 'foo-center', 'foo-justify', 'foo-extra' ]
+								options: [
+									{ name: 'left', className: 'foo-left' },
+									'left'
+								]
 							}
 						} );
-				} catch ( error ) {
-					expect( error.constructor ).to.equal( CKEditorError );
-					expect( error ).to.match( /alignment-config-classnames-not-matching/ );
+				} catch ( err ) {
+					error = err;
 				}
+
+				expect( error.constructor ).to.equal( CKEditorError );
+				expect( error ).to.match( /alignment-config-name-already-defined/ );
 			} );
 
-			it( 'should throw when there are fewer classes than alignment options', async () => {
+			it( 'should throw when options are repeated - repeated className', async () => {
+				let error;
+
 				try {
 					await VirtualTestEditor
 						.create( {
 							plugins: [ AlignmentEditing, Paragraph ],
 							alignment: {
-								classNames: [ 'foo-left', 'foo-right', 'foo-center' ]
+								options: [
+									'left',
+									{ name: 'right', className: 'foo-right' },
+									{ name: 'center', className: 'foo-right' }
+								]
 							}
 						} );
-				} catch ( error ) {
-					expect( error.constructor ).to.equal( CKEditorError );
-					expect( error ).to.match( /alignment-config-classnames-not-matching/ );
+				} catch ( err ) {
+					error = err;
 				}
+
+				expect( error.constructor ).to.equal( CKEditorError );
+				expect( error ).to.match( /alignment-config-classname-already-defined/ );
 			} );
 
-			it( 'should throw when classNames are not an array', async () => {
-				try {
-					await VirtualTestEditor
-						.create( {
-							plugins: [ AlignmentEditing, Paragraph ],
-							alignment: {
-								classNames: {}
-							}
-						} );
-				} catch ( error ) {
-					expect( error.constructor ).to.equal( CKEditorError );
-					expect( error ).to.match( /alignment-config-classnames-not-matching/ );
-				}
-			} );
-
-			it( 'should map limited options to limited set of classes', () => {
-				return VirtualTestEditor
+			it( 'should map limited options to limited set of classes', async () => {
+				const newEditor = await VirtualTestEditor
 					.create( {
 						plugins: [ AlignmentEditing, Paragraph ],
 						alignment: {
-							options: [ 'left', 'center' ],
-							classNames: [ 'foo-left', 'foo-center' ]
+							options: [
+								{ name: 'left', className: 'foo-left' },
+								{ name: 'center', className: 'foo-center' }
+							]
 						}
-					} )
-					.then( newEditor => {
-						const model = newEditor.model;
-						const data = '<p style="text-align:center;">x</p>';
-
-						newEditor.setData( data );
-
-						expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
-						expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
-
-						return newEditor.destroy();
 					} );
+				const model = newEditor.model;
+				const data = '<p style="text-align:center;">x</p>';
+
+				newEditor.setData( data );
+
+				expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
+				expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
+
+				return newEditor.destroy();
 			} );
 
-			it( 'should map classes to default options', () => {
-				return VirtualTestEditor
+			it( 'should map classes to default options', async () => {
+				const newEditor = await VirtualTestEditor
 					.create( {
 						plugins: [ AlignmentEditing, Paragraph ],
 						alignment: {
-							classNames: [ 'foo-left', 'foo-right', 'foo-center', 'foo-justify' ]
+							options: [
+								{ name: 'left', className: 'foo-left' },
+								{ name: 'right', className: 'foo-right' },
+								{ name: 'center', className: 'foo-center' },
+								{ name: 'justify', className: 'foo-justify' }
+							]
 						}
-					} )
-					.then( newEditor => {
-						const model = newEditor.model;
-						const data = '<p style="text-align:center;">x</p>';
-
-						newEditor.setData( data );
-
-						expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
-						expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
-
-						return newEditor.destroy();
 					} );
+				const model = newEditor.model;
+				const data = '<p style="text-align:center;">x</p>';
+
+				newEditor.setData( data );
+
+				expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
+				expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
+
+				return newEditor.destroy();
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-alignment/tests/alignmentediting.js
+++ b/packages/ckeditor5-alignment/tests/alignmentediting.js
@@ -133,7 +133,7 @@ describe( 'AlignmentEditing', () => {
 				return newEditor.destroy();
 			} );
 
-			it( 'uses class when alignment.classNames is set', async () => {
+			it( 'uses class when classNames is set', async () => {
 				const newEditor = await VirtualTestEditor
 					.create( {
 						language: {
@@ -172,7 +172,7 @@ describe( 'AlignmentEditing', () => {
 			expect( editor.getData() ).to.equal( '<p>x</p>' );
 		} );
 
-		it( 'uses class when alignment.classNames is set', async () => {
+		it( 'uses class when classNames is set', async () => {
 			const newEditor = await VirtualTestEditor
 				.create( {
 					plugins: [ AlignmentEditing, Paragraph ],
@@ -226,7 +226,7 @@ describe( 'AlignmentEditing', () => {
 			expect( editor.getData() ).to.equal( '<p style="text-align:center;">x</p>' );
 		} );
 
-		it( 'uses class when alignment.classNames is set', async () => {
+		it( 'uses class when classNames is set', async () => {
 			const newEditor = await VirtualTestEditor
 				.create( {
 					language: {
@@ -310,7 +310,7 @@ describe( 'AlignmentEditing', () => {
 			} );
 		} );
 
-		it( 'uses class when alignment.classNames is set', async () => {
+		it( 'uses class when classNames is set', async () => {
 			const newEditor = await VirtualTestEditor
 				.create( {
 					plugins: [ AlignmentEditing, Paragraph ],
@@ -352,7 +352,7 @@ describe( 'AlignmentEditing', () => {
 			expect( editor.getData() ).to.equal( '<p style="text-align:justify;">x</p>' );
 		} );
 
-		it( 'uses class when alignment.classNames is set', async () => {
+		it( 'uses class when classNames is set', async () => {
 			const newEditor = await VirtualTestEditor
 				.create( {
 					plugins: [ AlignmentEditing, Paragraph ],
@@ -431,98 +431,74 @@ describe( 'AlignmentEditing', () => {
 					);
 				} );
 			} );
-		} );
 
-		describe( 'classNames', () => {
-			it( 'should throw when options are repeated - repeated name', async () => {
-				let error;
+			describe( 'className property', () => {
+				it( 'should throw when options are repeated - repeated name', async () => {
+					let error;
 
-				try {
-					await VirtualTestEditor
+					try {
+						await VirtualTestEditor
+							.create( {
+								plugins: [ AlignmentEditing, Paragraph ],
+								alignment: {
+									options: [
+										{ name: 'left', className: 'foo-left' },
+										'left'
+									]
+								}
+							} );
+					} catch ( err ) {
+						error = err;
+					}
+
+					expect( error.constructor ).to.equal( CKEditorError );
+					expect( error ).to.match( /alignment-config-name-already-defined/ );
+				} );
+
+				it( 'should throw when options are repeated - repeated className', async () => {
+					let error;
+
+					try {
+						await VirtualTestEditor
+							.create( {
+								plugins: [ AlignmentEditing, Paragraph ],
+								alignment: {
+									options: [
+										{ name: 'right', className: 'foo-right' },
+										'left',
+										{ name: 'center', className: 'foo-right' }
+									]
+								}
+							} );
+					} catch ( err ) {
+						error = err;
+					}
+
+					expect( error.constructor ).to.equal( CKEditorError );
+					expect( error ).to.match( /alignment-config-classname-already-defined/ );
+				} );
+
+				it( 'should map limited options to limited set of classes', async () => {
+					const newEditor = await VirtualTestEditor
 						.create( {
 							plugins: [ AlignmentEditing, Paragraph ],
 							alignment: {
 								options: [
-									{ name: 'left', className: 'foo-left' },
-									'left'
+									{ name: 'center', className: 'foo-center' },
+									{ name: 'left', className: 'foo-left' }
 								]
 							}
 						} );
-				} catch ( err ) {
-					error = err;
-				}
+					const model = newEditor.model;
+					const data = '<p style="text-align:center;">x</p>';
 
-				expect( error.constructor ).to.equal( CKEditorError );
-				expect( error ).to.match( /alignment-config-name-already-defined/ );
-			} );
+					newEditor.setData( data );
 
-			it( 'should throw when options are repeated - repeated className', async () => {
-				let error;
+					expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
+					expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
 
-				try {
-					await VirtualTestEditor
-						.create( {
-							plugins: [ AlignmentEditing, Paragraph ],
-							alignment: {
-								options: [
-									'left',
-									{ name: 'right', className: 'foo-right' },
-									{ name: 'center', className: 'foo-right' }
-								]
-							}
-						} );
-				} catch ( err ) {
-					error = err;
-				}
-
-				expect( error.constructor ).to.equal( CKEditorError );
-				expect( error ).to.match( /alignment-config-classname-already-defined/ );
-			} );
-
-			it( 'should map limited options to limited set of classes', async () => {
-				const newEditor = await VirtualTestEditor
-					.create( {
-						plugins: [ AlignmentEditing, Paragraph ],
-						alignment: {
-							options: [
-								{ name: 'left', className: 'foo-left' },
-								{ name: 'center', className: 'foo-center' }
-							]
-						}
-					} );
-				const model = newEditor.model;
-				const data = '<p style="text-align:center;">x</p>';
-
-				newEditor.setData( data );
-
-				expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
-				expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
-
-				return newEditor.destroy();
-			} );
-
-			it( 'should map classes to default options', async () => {
-				const newEditor = await VirtualTestEditor
-					.create( {
-						plugins: [ AlignmentEditing, Paragraph ],
-						alignment: {
-							options: [
-								{ name: 'left', className: 'foo-left' },
-								{ name: 'right', className: 'foo-right' },
-								{ name: 'center', className: 'foo-center' },
-								{ name: 'justify', className: 'foo-justify' }
-							]
-						}
-					} );
-				const model = newEditor.model;
-				const data = '<p style="text-align:center;">x</p>';
-
-				newEditor.setData( data );
-
-				expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
-				expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
-
-				return newEditor.destroy();
+					return newEditor.destroy();
+				} );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-alignment/tests/alignmentediting.js
+++ b/packages/ckeditor5-alignment/tests/alignmentediting.js
@@ -434,12 +434,6 @@ describe( 'AlignmentEditing', () => {
 		} );
 
 		describe( 'classNames', () => {
-			describe( 'default value', () => {
-				it( 'should be set', () => {
-					expect( editor.config.get( 'alignment.classNames' ) ).to.deep.equal( [ ] );
-				} );
-			} );
-
 			it( 'should throw when options are repeated - repeated name', async () => {
 				let error;
 

--- a/packages/ckeditor5-alignment/tests/alignmentediting.js
+++ b/packages/ckeditor5-alignment/tests/alignmentediting.js
@@ -12,18 +12,16 @@ import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtest
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 import AlignmentCommand from '../src/alignmentcommand';
-import { CKEditorError } from 'ckeditor5/src/utils';
 
 describe( 'AlignmentEditing', () => {
 	let editor, model;
 
 	beforeEach( async () => {
-		const newEditor = await VirtualTestEditor
+		editor = await VirtualTestEditor
 			.create( {
 				plugins: [ AlignmentEditing, Paragraph ]
 			} );
 
-		editor = newEditor;
 		model = editor.model;
 	} );
 
@@ -95,6 +93,58 @@ describe( 'AlignmentEditing', () => {
 
 				expect( editor.getData() ).to.equal( '<p>x</p>' );
 			} );
+
+			describe( 'className', () => {
+				it( 'adds converters to the data pipeline', async () => {
+					const newEditor = await VirtualTestEditor
+						.create( {
+							plugins: [ AlignmentEditing, Paragraph ],
+							alignment: {
+								options: [
+									{ name: 'left', className: 'foo-left' },
+									{ name: 'right', className: 'foo-right' },
+									{ name: 'center', className: 'foo-center' },
+									{ name: 'justify', className: 'foo-justify' }
+								]
+							}
+						} );
+					const model = newEditor.model;
+					const data = '<p class="foo-left">x</p>';
+
+					newEditor.setData( data );
+
+					expect( getModelData( model ) ).to.equal( '<paragraph>[]x</paragraph>' );
+
+					return newEditor.destroy();
+				} );
+
+				it( 'adds a converter to the view pipeline', async () => {
+					const newEditor = await VirtualTestEditor
+						.create( {
+							plugins: [ AlignmentEditing, Paragraph ],
+							alignment: {
+								options: [
+									{ name: 'left', className: 'foo-left' },
+									{ name: 'right', className: 'foo-right' },
+									{ name: 'center', className: 'foo-center' },
+									{ name: 'justify', className: 'foo-justify' }
+								]
+							}
+						} );
+					const model = newEditor.model;
+
+					setModelData( model, '<paragraph alignment="center">[]x</paragraph>' );
+
+					expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
+
+					newEditor.execute( 'alignment', { value: 'left' } );
+
+					expect( getModelData( model ) ).to.equal( '<paragraph>[]x</paragraph>' );
+					expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+					return newEditor.destroy();
+				} );
+			} );
 		} );
 
 		describe( 'RTL content', () => {
@@ -133,32 +183,60 @@ describe( 'AlignmentEditing', () => {
 				return newEditor.destroy();
 			} );
 
-			it( 'uses class when classNames is set', async () => {
-				const newEditor = await VirtualTestEditor
-					.create( {
-						language: {
-							content: 'ar'
-						},
-						plugins: [ AlignmentEditing, Paragraph ],
-						alignment: {
-							options: [
-								{ name: 'left', className: 'foo-left' },
-								{ name: 'right', className: 'foo-right' },
-								{ name: 'center', className: 'foo-center' },
-								{ name: 'justify', className: 'foo-justify' }
-							]
-						}
-					} );
-				const model = newEditor.model;
+			describe( 'className', () => {
+				it( 'adds a converter to the view pipeline', async () => {
+					const newEditor = await VirtualTestEditor
+						.create( {
+							language: {
+								content: 'ar'
+							},
+							plugins: [ AlignmentEditing, Paragraph ],
+							alignment: {
+								options: [
+									{ name: 'left', className: 'foo-left' },
+									{ name: 'right', className: 'foo-right' },
+									{ name: 'center', className: 'foo-center' },
+									{ name: 'justify', className: 'foo-justify' }
+								]
+							}
+						} );
+					const model = newEditor.model;
 
-				setModelData( model, '<paragraph>[]x</paragraph>' );
+					setModelData( model, '<paragraph>[]x</paragraph>' );
 
-				newEditor.execute( 'alignment', { value: 'left' } );
+					newEditor.execute( 'alignment', { value: 'left' } );
 
-				expect( getModelData( model ) ).to.equal( '<paragraph alignment="left">[]x</paragraph>' );
-				expect( newEditor.getData() ).to.equal( '<p class="foo-left">x</p>' );
+					expect( getModelData( model ) ).to.equal( '<paragraph alignment="left">[]x</paragraph>' );
+					expect( newEditor.getData() ).to.equal( '<p class="foo-left">x</p>' );
 
-				return newEditor.destroy();
+					return newEditor.destroy();
+				} );
+
+				it( 'adds converters to the data pipeline', async () => {
+					const newEditor = await VirtualTestEditor
+						.create( {
+							language: {
+								content: 'ar'
+							},
+							plugins: [ AlignmentEditing, Paragraph ],
+							alignment: {
+								options: [
+									{ name: 'left', className: 'foo-left' },
+									{ name: 'right', className: 'foo-right' },
+									{ name: 'center', className: 'foo-center' },
+									{ name: 'justify', className: 'foo-justify' }
+								]
+							}
+						} );
+					const model = newEditor.model;
+					const data = '<p style="text-align:left;">x</p>';
+
+					newEditor.setData( data );
+
+					expect( getModelData( model ) ).to.equal( '<paragraph alignment="left">[]x</paragraph>' );
+
+					return newEditor.destroy();
+				} );
 			} );
 		} );
 
@@ -170,33 +248,6 @@ describe( 'AlignmentEditing', () => {
 			editor.execute( 'alignment' );
 
 			expect( editor.getData() ).to.equal( '<p>x</p>' );
-		} );
-
-		it( 'uses class when classNames is set', async () => {
-			const newEditor = await VirtualTestEditor
-				.create( {
-					plugins: [ AlignmentEditing, Paragraph ],
-					alignment: {
-						options: [
-							{ name: 'left', className: 'foo-left' },
-							{ name: 'right', className: 'foo-right' },
-							{ name: 'center', className: 'foo-center' },
-							{ name: 'justify', className: 'foo-justify' }
-						]
-					}
-				} );
-			const model = newEditor.model;
-
-			setModelData( model, '<paragraph alignment="center">[]x</paragraph>' );
-
-			expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
-
-			newEditor.execute( 'alignment', { value: 'left' } );
-
-			expect( getModelData( model ) ).to.equal( '<paragraph>[]x</paragraph>' );
-			expect( newEditor.getData() ).to.equal( '<p>x</p>' );
-
-			return newEditor.destroy();
 		} );
 	} );
 
@@ -226,32 +277,54 @@ describe( 'AlignmentEditing', () => {
 			expect( editor.getData() ).to.equal( '<p style="text-align:center;">x</p>' );
 		} );
 
-		it( 'uses class when classNames is set', async () => {
-			const newEditor = await VirtualTestEditor
-				.create( {
-					language: {
-						content: 'ar'
-					},
-					plugins: [ AlignmentEditing, Paragraph ],
-					alignment: {
-						options: [
-							{ name: 'left', className: 'foo-left' },
-							{ name: 'right', className: 'foo-right' },
-							{ name: 'center', className: 'foo-center' },
-							{ name: 'justify', className: 'foo-justify' }
-						]
-					}
-				} );
-			const model = newEditor.model;
+		describe( 'className', () => {
+			it( 'adds a converter to the view pipeline', async () => {
+				const newEditor = await VirtualTestEditor
+					.create( {
+						plugins: [ AlignmentEditing, Paragraph ],
+						alignment: {
+							options: [
+								{ name: 'left', className: 'foo-left' },
+								{ name: 'right', className: 'foo-right' },
+								{ name: 'center', className: 'foo-center' },
+								{ name: 'justify', className: 'foo-justify' }
+							]
+						}
+					} );
+				const model = newEditor.model;
 
-			setModelData( model, '<paragraph>[]x</paragraph>' );
+				setModelData( model, '<paragraph>[]x</paragraph>' );
 
-			newEditor.execute( 'alignment', { value: 'center' } );
+				newEditor.execute( 'alignment', { value: 'center' } );
 
-			expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
-			expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
+				expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
+				expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
 
-			return newEditor.destroy();
+				return newEditor.destroy();
+			} );
+
+			it( 'adds converters to the data pipeline', async () => {
+				const newEditor = await VirtualTestEditor
+					.create( {
+						plugins: [ AlignmentEditing, Paragraph ],
+						alignment: {
+							options: [
+								{ name: 'left', className: 'foo-left' },
+								{ name: 'right', className: 'foo-right' },
+								{ name: 'center', className: 'foo-center' },
+								{ name: 'justify', className: 'foo-justify' }
+							]
+						}
+					} );
+				const model = newEditor.model;
+				const data = '<p class="foo-center">x</p>';
+
+				newEditor.setData( data );
+
+				expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
+
+				return newEditor.destroy();
+			} );
 		} );
 	} );
 
@@ -270,6 +343,56 @@ describe( 'AlignmentEditing', () => {
 				setModelData( model, '<paragraph alignment="right">[]x</paragraph>' );
 
 				expect( editor.getData() ).to.equal( '<p style="text-align:right;">x</p>' );
+			} );
+
+			describe( 'className', () => {
+				it( 'adds a converter to the view pipeline', async () => {
+					const newEditor = await VirtualTestEditor
+						.create( {
+							plugins: [ AlignmentEditing, Paragraph ],
+							alignment: {
+								options: [
+									{ name: 'left', className: 'foo-left' },
+									{ name: 'right', className: 'foo-right' },
+									{ name: 'center', className: 'foo-center' },
+									{ name: 'justify', className: 'foo-justify' }
+								]
+							}
+						} );
+					const model = newEditor.model;
+
+					setModelData( model, '<paragraph>[]x</paragraph>' );
+
+					newEditor.execute( 'alignment', { value: 'right' } );
+
+					expect( getModelData( model ) ).to.equal( '<paragraph alignment="right">[]x</paragraph>' );
+					expect( newEditor.getData() ).to.equal( '<p class="foo-right">x</p>' );
+
+					return newEditor.destroy();
+				} );
+
+				it( 'adds converters to the data pipeline', async () => {
+					const newEditor = await VirtualTestEditor
+						.create( {
+							plugins: [ AlignmentEditing, Paragraph ],
+							alignment: {
+								options: [
+									{ name: 'left', className: 'foo-left' },
+									{ name: 'right', className: 'foo-right' },
+									{ name: 'center', className: 'foo-center' },
+									{ name: 'justify', className: 'foo-justify' }
+								]
+							}
+						} );
+					const model = newEditor.model;
+					const data = '<p class="foo-right">x</p>';
+
+					newEditor.setData( data );
+
+					expect( getModelData( model ) ).to.equal( '<paragraph alignment="right">[]x</paragraph>' );
+
+					return newEditor.destroy();
+				} );
 			} );
 		} );
 
@@ -308,31 +431,62 @@ describe( 'AlignmentEditing', () => {
 
 				return newEditor.destroy();
 			} );
-		} );
 
-		it( 'uses class when classNames is set', async () => {
-			const newEditor = await VirtualTestEditor
-				.create( {
-					plugins: [ AlignmentEditing, Paragraph ],
-					alignment: {
-						options: [
-							{ name: 'left', className: 'foo-left' },
-							{ name: 'right', className: 'foo-right' },
-							{ name: 'center', className: 'foo-center' },
-							{ name: 'justify', className: 'foo-justify' }
-						]
-					}
+			describe( 'className', () => {
+				it( 'adds a converter to the view pipeline', async () => {
+					const newEditor = await VirtualTestEditor
+						.create( {
+							language: {
+								content: 'ar'
+							},
+							plugins: [ AlignmentEditing, Paragraph ],
+							alignment: {
+								options: [
+									{ name: 'left', className: 'foo-left' },
+									{ name: 'right', className: 'foo-right' },
+									{ name: 'center', className: 'foo-center' },
+									{ name: 'justify', className: 'foo-justify' }
+								]
+							}
+						} );
+					const model = newEditor.model;
+
+					setModelData( model, '<paragraph>[]x</paragraph>' );
+
+					newEditor.execute( 'alignment', { value: 'right' } );
+
+					expect( getModelData( model ) ).to.equal( '<paragraph>[]x</paragraph>' );
+					expect( newEditor.getData() ).to.equal( '<p>x</p>' );
+
+					return newEditor.destroy();
 				} );
-			const model = newEditor.model;
 
-			setModelData( model, '<paragraph>[]x</paragraph>' );
+				it( 'adds converters to the data pipeline', async () => {
+					const newEditor = await VirtualTestEditor
+						.create( {
+							language: {
+								content: 'ar'
+							},
+							plugins: [ AlignmentEditing, Paragraph ],
+							alignment: {
+								options: [
+									{ name: 'left', className: 'foo-left' },
+									{ name: 'right', className: 'foo-right' },
+									{ name: 'center', className: 'foo-center' },
+									{ name: 'justify', className: 'foo-justify' }
+								]
+							}
+						} );
+					const model = newEditor.model;
+					const data = '<p class="foo-right">x</p>';
 
-			newEditor.execute( 'alignment', { value: 'right' } );
+					newEditor.setData( data );
 
-			expect( getModelData( model ) ).to.equal( '<paragraph alignment="right">[]x</paragraph>' );
-			expect( newEditor.getData() ).to.equal( '<p class="foo-right">x</p>' );
+					expect( getModelData( model ) ).to.equal( '<paragraph>[]x</paragraph>' );
 
-			return newEditor.destroy();
+					return newEditor.destroy();
+				} );
+			} );
 		} );
 	} );
 
@@ -352,29 +506,54 @@ describe( 'AlignmentEditing', () => {
 			expect( editor.getData() ).to.equal( '<p style="text-align:justify;">x</p>' );
 		} );
 
-		it( 'uses class when classNames is set', async () => {
-			const newEditor = await VirtualTestEditor
-				.create( {
-					plugins: [ AlignmentEditing, Paragraph ],
-					alignment: {
-						options: [
-							{ name: 'left', className: 'foo-left' },
-							{ name: 'right', className: 'foo-right' },
-							{ name: 'center', className: 'foo-center' },
-							{ name: 'justify', className: 'foo-justify' }
-						]
-					}
-				} );
-			const model = newEditor.model;
+		describe( 'className', () => {
+			it( 'adds a converter to the view pipeline', async () => {
+				const newEditor = await VirtualTestEditor
+					.create( {
+						plugins: [ AlignmentEditing, Paragraph ],
+						alignment: {
+							options: [
+								{ name: 'left', className: 'foo-left' },
+								{ name: 'right', className: 'foo-right' },
+								{ name: 'center', className: 'foo-center' },
+								{ name: 'justify', className: 'foo-justify' }
+							]
+						}
+					} );
+				const model = newEditor.model;
 
-			setModelData( model, '<paragraph>[]x</paragraph>' );
+				setModelData( model, '<paragraph>[]x</paragraph>' );
 
-			newEditor.execute( 'alignment', { value: 'justify' } );
+				newEditor.execute( 'alignment', { value: 'justify' } );
 
-			expect( getModelData( model ) ).to.equal( '<paragraph alignment="justify">[]x</paragraph>' );
-			expect( newEditor.getData() ).to.equal( '<p class="foo-justify">x</p>' );
+				expect( getModelData( model ) ).to.equal( '<paragraph alignment="justify">[]x</paragraph>' );
+				expect( newEditor.getData() ).to.equal( '<p class="foo-justify">x</p>' );
 
-			return newEditor.destroy();
+				return newEditor.destroy();
+			} );
+
+			it( 'adds converters to the data pipeline', async () => {
+				const newEditor = await VirtualTestEditor
+					.create( {
+						plugins: [ AlignmentEditing, Paragraph ],
+						alignment: {
+							options: [
+								{ name: 'left', className: 'foo-left' },
+								{ name: 'right', className: 'foo-right' },
+								{ name: 'center', className: 'foo-center' },
+								{ name: 'justify', className: 'foo-justify' }
+							]
+						}
+					} );
+				const model = newEditor.model;
+				const data = '<p class="foo-justify">x</p>';
+
+				newEditor.setData( data );
+
+				expect( getModelData( model ) ).to.equal( '<paragraph alignment="justify">[]x</paragraph>' );
+
+				return newEditor.destroy();
+			} );
 		} );
 	} );
 
@@ -429,75 +608,6 @@ describe( 'AlignmentEditing', () => {
 							{ name: 'justify' }
 						]
 					);
-				} );
-			} );
-
-			describe( 'className property', () => {
-				it( 'should throw when options are repeated - repeated name', async () => {
-					let error;
-
-					try {
-						await VirtualTestEditor
-							.create( {
-								plugins: [ AlignmentEditing, Paragraph ],
-								alignment: {
-									options: [
-										{ name: 'left', className: 'foo-left' },
-										'left'
-									]
-								}
-							} );
-					} catch ( err ) {
-						error = err;
-					}
-
-					expect( error.constructor ).to.equal( CKEditorError );
-					expect( error ).to.match( /alignment-config-name-already-defined/ );
-				} );
-
-				it( 'should throw when options are repeated - repeated className', async () => {
-					let error;
-
-					try {
-						await VirtualTestEditor
-							.create( {
-								plugins: [ AlignmentEditing, Paragraph ],
-								alignment: {
-									options: [
-										{ name: 'right', className: 'foo-right' },
-										'left',
-										{ name: 'center', className: 'foo-right' }
-									]
-								}
-							} );
-					} catch ( err ) {
-						error = err;
-					}
-
-					expect( error.constructor ).to.equal( CKEditorError );
-					expect( error ).to.match( /alignment-config-classname-already-defined/ );
-				} );
-
-				it( 'should map limited options to limited set of classes', async () => {
-					const newEditor = await VirtualTestEditor
-						.create( {
-							plugins: [ AlignmentEditing, Paragraph ],
-							alignment: {
-								options: [
-									{ name: 'center', className: 'foo-center' },
-									{ name: 'left', className: 'foo-left' }
-								]
-							}
-						} );
-					const model = newEditor.model;
-					const data = '<p style="text-align:center;">x</p>';
-
-					newEditor.setData( data );
-
-					expect( getModelData( model ) ).to.equal( '<paragraph alignment="center">[]x</paragraph>' );
-					expect( newEditor.getData() ).to.equal( '<p class="foo-center">x</p>' );
-
-					return newEditor.destroy();
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-alignment/tests/alignmentediting.js
+++ b/packages/ckeditor5-alignment/tests/alignmentediting.js
@@ -12,7 +12,7 @@ import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtest
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 import AlignmentCommand from '../src/alignmentcommand';
-import { CKEditorError } from '../../../src/utils';
+import { CKEditorError } from 'ckeditor5/src/utils';
 
 describe( 'AlignmentEditing', () => {
 	let editor, model;

--- a/packages/ckeditor5-alignment/tests/alignmentediting.js
+++ b/packages/ckeditor5-alignment/tests/alignmentediting.js
@@ -49,12 +49,11 @@ describe( 'AlignmentEditing', () => {
 
 	describe( 'integration', () => {
 		beforeEach( async () => {
-			const newEditor = await VirtualTestEditor
+			const editor = await VirtualTestEditor
 				.create( {
 					plugins: [ AlignmentEditing, ImageCaptionEditing, Paragraph, ListEditing, HeadingEditing ]
 				} );
 
-			editor = newEditor;
 			model = editor.model;
 		} );
 

--- a/packages/ckeditor5-alignment/tests/manual/alignment.js
+++ b/packages/ckeditor5-alignment/tests/manual/alignment.js
@@ -16,7 +16,6 @@ ClassicEditor
 			'heading', '|', 'alignment', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
 		],
 		alignment: {
-			// classNames: [ 'ckx-align-left', 'ckx-align-right' ], // , 'ckx-align-center', 'ckx-align-justify' ],
 			options: [ 'left', 'center' ]
 		}
 	} )

--- a/packages/ckeditor5-alignment/tests/manual/alignment.js
+++ b/packages/ckeditor5-alignment/tests/manual/alignment.js
@@ -14,10 +14,7 @@ ClassicEditor
 		plugins: [ ArticlePluginSet, Alignment ],
 		toolbar: [
 			'heading', '|', 'alignment', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
-		],
-		alignment: {
-			options: [ 'left', 'center' ]
-		}
+		]
 	} )
 	.then( editor => {
 		window.editor = editor;

--- a/packages/ckeditor5-alignment/tests/manual/alignment.js
+++ b/packages/ckeditor5-alignment/tests/manual/alignment.js
@@ -14,7 +14,11 @@ ClassicEditor
 		plugins: [ ArticlePluginSet, Alignment ],
 		toolbar: [
 			'heading', '|', 'alignment', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
-		]
+		],
+		alignment: {
+			// classNames: [ 'ckx-align-left', 'ckx-align-right' ], // , 'ckx-align-center', 'ckx-align-justify' ],
+			options: [ 'left', 'center' ]
+		}
 	} )
 	.then( editor => {
 		window.editor = editor;

--- a/packages/ckeditor5-alignment/tests/utils.js
+++ b/packages/ckeditor5-alignment/tests/utils.js
@@ -3,7 +3,8 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import { isDefault, isSupported, supportedOptions } from '../src/utils';
+import { CKEditorError } from '../../../src/utils';
+import { isDefault, isSupported, supportedOptions, normalizeAlignmentOptions } from '../src/utils';
 
 describe( 'utils', () => {
 	describe( 'isDefault()', () => {
@@ -45,6 +46,89 @@ describe( 'utils', () => {
 	describe( 'supportedOptions', () => {
 		it( 'should be set', () => {
 			expect( supportedOptions ).to.deep.equal( [ 'left', 'right', 'center', 'justify' ] );
+		} );
+	} );
+
+	describe( 'normalizeAlignmentOptions', () => {
+		it( 'does nothing when no parameters are provided', () => {
+			expect( () => normalizeAlignmentOptions() ).not.to.throw();
+		} );
+
+		it( 'throws when the name already exists', () => {
+			const config = [
+				'center',
+				{
+					name: 'center'
+				}
+			];
+			let error;
+
+			try {
+				normalizeAlignmentOptions( config );
+			} catch ( err ) {
+				error = err;
+			}
+
+			expect( error.constructor ).to.equal( CKEditorError );
+			expect( error ).to.match( /alignment-config-name-already-defined/ );
+		} );
+
+		it( 'throws when the className already exists', () => {
+			const config = [
+				'left',
+				{
+					name: 'center',
+					className: 'foo-center'
+				},
+				{
+					name: 'justify',
+					className: 'foo-center'
+				}
+			];
+			let error;
+
+			try {
+				normalizeAlignmentOptions( config );
+			} catch ( err ) {
+				error = err;
+			}
+
+			expect( error.constructor ).to.equal( CKEditorError );
+			expect( error ).to.match( /alignment-config-classname-already-defined/ );
+		} );
+
+		it( 'normalizes mixed input into an config array of objects', () => {
+			const config = [
+				'left',
+				{
+					name: 'right'
+				},
+				'center',
+				{
+					name: 'justify',
+					className: 'foo-center'
+				}
+			];
+
+			const result = normalizeAlignmentOptions( config );
+
+			expect( result ).to.deep.equal(
+				[
+					{
+						'name': 'left'
+					},
+					{
+						'name': 'right'
+					},
+					{
+						'name': 'center'
+					},
+					{
+						'className': 'foo-center',
+						'name': 'justify'
+					}
+				]
+			);
 		} );
 	} );
 } );

--- a/packages/ckeditor5-alignment/tests/utils.js
+++ b/packages/ckeditor5-alignment/tests/utils.js
@@ -60,10 +60,7 @@ describe( 'utils', () => {
 				'left',
 				{ name: 'right' },
 				'center',
-				{
-					name: 'justify',
-					className: 'foo-center'
-				}
+				{ name: 'justify' }
 			];
 
 			const result = normalizeAlignmentOptions( config );
@@ -73,15 +70,12 @@ describe( 'utils', () => {
 					{ 'name': 'left' },
 					{ 'name': 'right' },
 					{ 'name': 'center' },
-					{
-						'className': 'foo-center',
-						'name': 'justify'
-					}
+					{ 'name': 'justify' }
 				]
 			);
 		} );
 
-		it( 'should warn if the name is not recognized', () => {
+		it( 'warns if the name is not recognized', () => {
 			testUtils.sinon.stub( console, 'warn' );
 
 			const config = [
@@ -94,8 +88,7 @@ describe( 'utils', () => {
 			] );
 
 			const params = {
-				option: { name: 'center1' },
-				supportedOptions: [ 'left', 'right', 'center', 'justify' ]
+				option: { name: 'center1' }
 			};
 
 			sinon.assert.calledOnce( console.warn );
@@ -104,6 +97,23 @@ describe( 'utils', () => {
 				params,
 				sinon.match.string // Link to the documentation
 			);
+		} );
+
+		it( 'throws when the className is not defined for all options', () => {
+			const config = [
+				'left',
+				{ name: 'center', className: 'foo-center' }
+			];
+			let error;
+
+			try {
+				normalizeAlignmentOptions( config );
+			} catch ( err ) {
+				error = err;
+			}
+
+			expect( error.constructor ).to.equal( CKEditorError );
+			expect( error ).to.match( /alignment-config-classnames-are-missing/ );
 		} );
 
 		it( 'throws when the name already exists', () => {
@@ -125,7 +135,6 @@ describe( 'utils', () => {
 
 		it( 'throws when the className already exists', () => {
 			const config = [
-				'left',
 				{
 					name: 'center',
 					className: 'foo-center'

--- a/packages/ckeditor5-alignment/tests/utils.js
+++ b/packages/ckeditor5-alignment/tests/utils.js
@@ -51,7 +51,47 @@ describe( 'utils', () => {
 
 	describe( 'normalizeAlignmentOptions', () => {
 		it( 'does nothing when no parameters are provided', () => {
-			expect( () => normalizeAlignmentOptions() ).not.to.throw();
+			let result;
+
+			expect( () => {
+				result = normalizeAlignmentOptions();
+			} ).not.to.throw();
+
+			expect( result ).to.deep.equal( [ ] );
+		} );
+
+		it( 'normalizes mixed input into an config array of objects', () => {
+			const config = [
+				'left',
+				{
+					name: 'right'
+				},
+				'center',
+				{
+					name: 'justify',
+					className: 'foo-center'
+				}
+			];
+
+			const result = normalizeAlignmentOptions( config );
+
+			expect( result ).to.deep.equal(
+				[
+					{
+						'name': 'left'
+					},
+					{
+						'name': 'right'
+					},
+					{
+						'name': 'center'
+					},
+					{
+						'className': 'foo-center',
+						'name': 'justify'
+					}
+				]
+			);
 		} );
 
 		it( 'throws when the name already exists', () => {
@@ -95,40 +135,6 @@ describe( 'utils', () => {
 
 			expect( error.constructor ).to.equal( CKEditorError );
 			expect( error ).to.match( /alignment-config-classname-already-defined/ );
-		} );
-
-		it( 'normalizes mixed input into an config array of objects', () => {
-			const config = [
-				'left',
-				{
-					name: 'right'
-				},
-				'center',
-				{
-					name: 'justify',
-					className: 'foo-center'
-				}
-			];
-
-			const result = normalizeAlignmentOptions( config );
-
-			expect( result ).to.deep.equal(
-				[
-					{
-						'name': 'left'
-					},
-					{
-						'name': 'right'
-					},
-					{
-						'name': 'center'
-					},
-					{
-						'className': 'foo-center',
-						'name': 'justify'
-					}
-				]
-			);
 		} );
 	} );
 } );

--- a/packages/ckeditor5-alignment/tests/utils.js
+++ b/packages/ckeditor5-alignment/tests/utils.js
@@ -3,10 +3,15 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import { CKEditorError } from '../../../src/utils';
+/* globals console */
+
+import { CKEditorError } from 'ckeditor5/src/utils';
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import { isDefault, isSupported, supportedOptions, normalizeAlignmentOptions } from '../src/utils';
 
 describe( 'utils', () => {
+	testUtils.createSinonSandbox();
+
 	describe( 'isDefault()', () => {
 		it( 'should return true for "left" alignment only (LTR)', () => {
 			const locale = {
@@ -53,9 +58,7 @@ describe( 'utils', () => {
 		it( 'normalizes mixed input into an config array of objects', () => {
 			const config = [
 				'left',
-				{
-					name: 'right'
-				},
+				{ name: 'right' },
 				'center',
 				{
 					name: 'justify',
@@ -67,15 +70,9 @@ describe( 'utils', () => {
 
 			expect( result ).to.deep.equal(
 				[
-					{
-						'name': 'left'
-					},
-					{
-						'name': 'right'
-					},
-					{
-						'name': 'center'
-					},
+					{ 'name': 'left' },
+					{ 'name': 'right' },
+					{ 'name': 'center' },
 					{
 						'className': 'foo-center',
 						'name': 'justify'
@@ -84,12 +81,35 @@ describe( 'utils', () => {
 			);
 		} );
 
+		it( 'should warn if the name is not recognized', () => {
+			testUtils.sinon.stub( console, 'warn' );
+
+			const config = [
+				'left',
+				{ name: 'center1' }
+			];
+
+			expect( normalizeAlignmentOptions( config ) ).to.deep.equal( [
+				{ name: 'left' }
+			] );
+
+			const params = {
+				option: { name: 'center1' },
+				supportedOptions: [ 'left', 'right', 'center', 'justify' ]
+			};
+
+			sinon.assert.calledOnce( console.warn );
+			sinon.assert.calledWithExactly( console.warn,
+				sinon.match( /^alignment-config-name-not-recognized/ ),
+				params,
+				sinon.match.string // Link to the documentation
+			);
+		} );
+
 		it( 'throws when the name already exists', () => {
 			const config = [
 				'center',
-				{
-					name: 'center'
-				}
+				{ name: 'center' }
 			];
 			let error;
 

--- a/packages/ckeditor5-alignment/tests/utils.js
+++ b/packages/ckeditor5-alignment/tests/utils.js
@@ -50,16 +50,6 @@ describe( 'utils', () => {
 	} );
 
 	describe( 'normalizeAlignmentOptions', () => {
-		it( 'does nothing when no parameters are provided', () => {
-			let result;
-
-			expect( () => {
-				result = normalizeAlignmentOptions();
-			} ).not.to.throw();
-
-			expect( result ).to.deep.equal( [ ] );
-		} );
-
 		it( 'normalizes mixed input into an config array of objects', () => {
 			const config = [
 				'left',

--- a/packages/ckeditor5-engine/src/conversion/conversion.js
+++ b/packages/ckeditor5-engine/src/conversion/conversion.js
@@ -227,7 +227,7 @@ export default class Conversion {
 	 *		editor.conversion.elementToElement( {
 	 *			model: 'heading',
 	 *			view: 'h2',
-	 *			// Convert "headling-like" paragraphs to headings.
+	 *			// Convert "heading-like" paragraphs to headings.
 	 *			upcastAlso: viewElement => {
 	 *				const fontSize = viewElement.getStyle( 'font-size' );
 	 *


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (alignment): Add option to use classes instead of inline styles. Closes #8516.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
