### PR TITLE
Fixed collection-get-invalid-arg error

### DIFF
--- a/packages/ckeditor5-watchdog/src/editorwatchdog.js
+++ b/packages/ckeditor5-watchdog/src/editorwatchdog.js
@@ -283,7 +283,7 @@ export default class EditorWatchdog extends Watchdog {
 		const data = {};
 
 		for ( const rootName of this._editor.model.document.getRootNames() ) {
-			data[ rootName ] = this._editor.data.get( { rootName } );
+			data[ rootName ] = this._editor.data.get( rootName );
 		}
 
 		return data;

--- a/packages/ckeditor5-watchdog/tests/editorwatchdog.js
+++ b/packages/ckeditor5-watchdog/tests/editorwatchdog.js
@@ -970,7 +970,7 @@ describe( 'EditorWatchdog', () => {
 				plugins: [ Paragraph ]
 			} );
 
-			expect( watchdog.editor.data.get( { rootName: 'header' } ) ).to.equal( '<p>Foo</p>' );
+			expect( watchdog.editor.data.get( 'header' ) ).to.equal( '<p>Foo</p>' );
 
 			const restartSpy = sinon.spy();
 
@@ -984,7 +984,7 @@ describe( 'EditorWatchdog', () => {
 
 			sinon.assert.calledOnce( restartSpy );
 
-			expect( watchdog.editor.data.get( { rootName: 'header' } ) ).to.equal( '<p>Foo</p>' );
+			expect( watchdog.editor.data.get( 'header' ) ).to.equal( '<p>Foo</p>' );
 
 			await watchdog.destroy();
 		} );


### PR DESCRIPTION
Fix (watchdog): Pass rootName value directly to the get() function in Watchdog, as CKEditor accepts only a string or a number as a key to retrieve an item. Closes #9019.

---

### Additional information

None.
