### PR TITLE
Placeholder should not be visible if there are multiple elements in the root

### DIFF
--- a/packages/ckeditor5-engine/src/view/placeholder.js
+++ b/packages/ckeditor5-engine/src/view/placeholder.js
@@ -229,7 +229,10 @@ function updatePlaceholder( writer, element, config ) {
 		wasViewModified = true;
 	}
 
-	if ( needsPlaceholder( hostElement, config.keepOnFocus ) ) {
+	// If the host element is not a direct host then placeholder is needed only when there is only one element.
+	const isOnlyChild = isDirectHost || element.childCount == 1;
+
+	if ( isOnlyChild && needsPlaceholder( hostElement, config.keepOnFocus ) ) {
 		if ( showPlaceholder( writer, hostElement ) ) {
 			wasViewModified = true;
 		}
@@ -248,7 +251,7 @@ function updatePlaceholder( writer, element, config ) {
 // @param {module:engine/view/element~Element} parent
 // @returns {module:engine/view/element~Element|null}
 function getChildPlaceholderHostSubstitute( parent ) {
-	if ( parent.childCount === 1 ) {
+	if ( parent.childCount ) {
 		const firstChild = parent.getChild( 0 );
 
 		if ( firstChild.is( 'element' ) && !firstChild.is( 'uiElement' ) ) {

--- a/packages/ckeditor5-engine/tests/view/placeholder.js
+++ b/packages/ckeditor5-engine/tests/view/placeholder.js
@@ -236,7 +236,7 @@ describe( 'placeholder', () => {
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 
-		it( 'should not set attributes/class when multiple children (isDirectHost=false)', () => {
+		it( 'should not set class when multiple children (isDirectHost=false)', () => {
 			setData( view, '<p></p><p></p>' );
 			viewDocument.isFocused = false;
 
@@ -247,7 +247,39 @@ describe( 'placeholder', () => {
 				isDirectHost: false
 			} );
 
+			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.true;
+			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.false;
+		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/9009
+		it( 'should not set class when multiple children and some other element has content (isDirectHost=false)', () => {
+			setData( view, '<p></p><p>foobar</p>' );
+			viewDocument.isFocused = false;
+
+			enablePlaceholder( {
+				view,
+				element: viewRoot,
+				text: 'foo bar baz',
+				isDirectHost: false
+			} );
+
+			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.true;
+			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.false;
+		} );
+
+		it( 'should not set class when there is no children (isDirectHost=false)', () => {
+			setData( view, '<p></p><p>foobar</p>' );
+			viewDocument.isFocused = false;
+
+			enablePlaceholder( {
+				view,
+				element: viewRoot.getChild( 0 ),
+				text: 'foo bar baz',
+				isDirectHost: false
+			} );
+
 			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.false;
+			expect( viewRoot.getChild( 0 ).isEmpty ).to.be.true;
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (placeholder): Placeholder should not be visible if there are multiple elements in the root. Closes #9009.

---

### Additional information