### PR TITLE
Fix for placeholder inside node aligned to the right

### DIFF
--- a/packages/ckeditor5-engine/theme/placeholder.css
+++ b/packages/ckeditor5-engine/theme/placeholder.css
@@ -6,8 +6,12 @@
 /* See ckeditor/ckeditor5#936. */
 .ck.ck-placeholder,
 .ck .ck-placeholder {
+	position: relative;
+
 	&::before {
 		position: absolute;
+		left: 0;
+		right: 0;
 		content: attr(data-placeholder);
 
 		/* See ckeditor/ckeditor5#469. */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (engine): Placeholder should render properly in text elements aligned to the right. Closes #9048.

---

### Additional information