### PR TITLE
Fixed rendering editor placeholder inside page break widget.

### DIFF
--- a/packages/ckeditor5-page-break/src/pagebreakediting.js
+++ b/packages/ckeditor5-page-break/src/pagebreakediting.js
@@ -67,14 +67,11 @@ export default class PageBreakEditing extends Plugin {
 			view: ( modelElement, { writer } ) => {
 				const label = t( 'Page break' );
 				const viewWrapper = writer.createContainerElement( 'div' );
-				const viewLabelElement = writer.createUIElement(
+				const viewLabelElement = writer.createRawElement(
 					'span',
 					{ class: 'page-break__label' },
-					function( domDocument ) {
-						const domElement = this.toDomElement( domDocument );
+					function( domElement ) {
 						domElement.innerText = t( 'Page break' );
-
-						return domElement;
 					}
 				);
 

--- a/packages/ckeditor5-page-break/tests/pagebreakediting.js
+++ b/packages/ckeditor5-page-break/tests/pagebreakediting.js
@@ -57,7 +57,7 @@ describe( 'PageBreakEditing', () => {
 		setModelData( model, '[<pageBreak></pageBreak>]' );
 		const textNode = viewDocument.getRoot().getChild( 0 ).getChild( 0 );
 
-		expect( textNode.is( 'uiElement' ) ).to.be.true;
+		expect( textNode.is( 'rawElement' ) ).to.be.true;
 		expect( textNode.hasClass( 'page-break__label' ) ).to.be.true;
 	} );
 
@@ -268,7 +268,7 @@ describe( 'PageBreakEditing', () => {
 					'<div class="ck-widget page-break" contenteditable="false"><span class="page-break__label"></span></div>'
 				);
 
-				expect( getViewData( view, { withoutSelection: true, renderUIElements: true } ) ).to.equal(
+				expect( getViewData( view, { withoutSelection: true, renderRawElements: true } ) ).to.equal(
 					'<div class="ck-widget page-break" contenteditable="false"><span class="page-break__label">Page break</span></div>'
 				);
 			} );

--- a/packages/ckeditor5-page-break/tests/pagebreakediting.js
+++ b/packages/ckeditor5-page-break/tests/pagebreakediting.js
@@ -53,12 +53,12 @@ describe( 'PageBreakEditing', () => {
 	// https://github.com/ckeditor/ckeditor5/issues/8788.
 	// Proper integration testing of this is too complex.
 	// Making sure the label is no longer a regular text element should be enough.
-	it( 'should have label as a UIElement', () => {
+	it( 'should have label as a RawElement', () => {
 		setModelData( model, '[<pageBreak></pageBreak>]' );
-		const textNode = viewDocument.getRoot().getChild( 0 ).getChild( 0 );
+		const element = viewDocument.getRoot().getChild( 0 ).getChild( 0 );
 
-		expect( textNode.is( 'rawElement' ) ).to.be.true;
-		expect( textNode.hasClass( 'page-break__label' ) ).to.be.true;
+		expect( element.is( 'rawElement' ) ).to.be.true;
+		expect( element.hasClass( 'page-break__label' ) ).to.be.true;
 	} );
 
 	describe( 'conversion in data pipeline', () => {

--- a/packages/ckeditor5-page-break/tests/pagebreakediting.js
+++ b/packages/ckeditor5-page-break/tests/pagebreakediting.js
@@ -50,7 +50,8 @@ describe( 'PageBreakEditing', () => {
 		expect( editor.commands.get( 'pageBreak' ) ).to.be.instanceOf( PageBreakCommand );
 	} );
 
-	// https://github.com/ckeditor/ckeditor5/issues/8788.
+	// https://github.com/ckeditor/ckeditor5/issues/8880.
+	// (Formerly it was a UIElement https://github.com/ckeditor/ckeditor5/issues/8788)
 	// Proper integration testing of this is too complex.
 	// Making sure the label is no longer a regular text element should be enough.
 	it( 'should have label as a RawElement', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (page-break): Fixed rendering editor placeholder inside page break widget. Closes #8880.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._