### PR TITLE
Docs (editor-balloon): Fix package name / url

### DIFF
--- a/packages/ckeditor5-editor-balloon/README.md
+++ b/packages/ckeditor5-editor-balloon/README.md
@@ -7,7 +7,7 @@ CKEditor 5 balloon editor implementation
 
 The balloon editor implementation (Medium-like editor) for CKEditor 5.
 
-This package contains the [`BallonEditor`](https://ckeditor.com/docs/ckeditor5/latest/api/module_editor-balloon_ballooneditor-BallonEditor.html) class. Follow there to learn more about this type of editor and how to initialize it.
+This package contains the [`BalloonEditor`](https://ckeditor.com/docs/ckeditor5/latest/api/module_editor-balloon_ballooneditor-BalloonEditor.html) class. Follow there to learn more about this type of editor and how to initialize it.
 
 This package contains the source version of the balloon editor. This editor implementation is also available in the [balloon build](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-balloon). Read more about [CKEditor 5 Builds](https://ckeditor.com/docs/ckeditor5/latest/builds/index.html).
 


### PR DESCRIPTION
Closes #9126

Typo in `BalloonEditor` in `packages/ckeditor5-editor-balloon/README.md`