### PR TITLE
chore(ckeditor5-upload): Fix typo

### DIFF
--- a/packages/ckeditor5-upload/src/filerepository.js
+++ b/packages/ckeditor5-upload/src/filerepository.js
@@ -152,7 +152,7 @@ export default class FileRepository extends Plugin {
 			 * You need to enable an upload adapter in order to be able to upload files.
 			 *
 			 * This warning shows up when {@link module:upload/filerepository~FileRepository} is being used
-			 * without {@link #createUploadAdapter definining an upload adapter}.
+			 * without {@link #createUploadAdapter defining an upload adapter}.
 			 *
 			 * **If you see this warning when using one of the {@glink builds/index CKEditor 5 Builds}**
 			 * it means that you did not configure any of the upload adapters available by default in those builds.


### PR DESCRIPTION
Closes #9127

Fix typo in https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/error-codes.html#error-filerepository-no-upload-adapter