### PR TITLE
#9091: Got rid of the heading style overrides in favor of less inclusive heading styles in Umberto

### DIFF
--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -213,13 +213,6 @@ It breaks CKEditor 5 (see how <p><code>[]</code></p> looks). */
 	margin-bottom: 1.5rem;
 }
 
-/* https://github.com/ckeditor/ckeditor5/issues/896 */
-.live-snippet .ck.ck-content h2,
-.live-snippet .ck.ck-content h3,
-.live-snippet .ck.ck-content h4 {
-	position: static;
-}
-
 /* https://github.com/ckeditor/ckeditor5/issues/899 */
 .live-snippet .ck-dropdown .ck.ck-list {
 	margin: 0;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (ckeditor5): Got rid of the heading style overrides in favor of less inclusive heading styles in Umberto. Closes #9091.

---

### Additional information

Requires cksource/umberto#900.