### PR TITLE
Rewrote the DLL builds guide

### DIFF
--- a/docs/builds/guides/development/dll-builds.md
+++ b/docs/builds/guides/development/dll-builds.md
@@ -8,20 +8,20 @@ order: 30
 
 The purpose of a DLL build is to allow adding plugins to an editor build without having to rebuild (recompile) the build itself.
 
-SO far, the two most common integration methods include:
+So far, the two most common integration methods included:
 
 * Using pre-compiled builds. This can be either one of the official builds or a custom build. In this case, adding a plugin requires recompiling the entire build.
 * Integrating the editor from source. In this case, if you want to add a plugin, your application needs to be recompiled.
 
 In some advanced use cases, the list of available plugins cannot be limited &mdash; it should be possible to add plugins without any access to Node.js. In other words, plugins should be built (compiled) separately from the editor's core.
 
-That is where DLL builds come to the rescue.
+This is where the DLL builds come to the rescue.
 
-DLL builds are based on the [DLL webpack](https://webpack.js.org/plugins/dll-plugin/) plugin that provides a CKEditor 5 base DLL and a set of [DLL consumer plugins](https://webpack.js.org/plugins/dll-plugin/#dllreferenceplugin).
+DLL builds are based on the [DLL webpack](https://webpack.js.org/plugins/dll-plugin/) plugin that provides a CKEditor 5 **base DLL** and a set of **[DLL consumer plugins](https://webpack.js.org/plugins/dll-plugin/#dllreferenceplugin)**.
 
 Currently, CKEditor 5 does not come with a ready-to-use DLL build. Using this integration method requires creating it on your own, based on the tools available in the {@link framework/guides/contributing/development-environment CKEditor 5 development environment}.
 
-Follow the [Ship CKEditor 5 DLLs](https://github.com/ckeditor/ckeditor5/issues/9145) issue for updates (and add 👍).
+Follow the [Ship CKEditor 5 DLLs](https://github.com/ckeditor/ckeditor5/issues/9145) issue for updates (and add 👍&nbsp;).
 
 ## Anatomy of a DLL build
 
@@ -30,7 +30,7 @@ A DLL build of the editor consists of two parts:
 * **Base DLL build**. It is a single JavaScript file that combines contents of several core CKEditor 5 packages: utils, core, engine, ui, clipboard, enter, paragraph, select-all, typing, undo, upload, and widget. These packages are either the framework core, or are features used by nearly all editor installations.
 * **DLL-compatible package builds**. Every package that is not part of the Base DLL build is built into a DLL-compatible JavaScript file.
 
-In order to load an editor you need to use the base DLL build plus several DLL-compatible package builds. You will see how to do that later on.git
+In order to load an editor you need to use the base DLL build plus several DLL-compatible package builds. You will see how to do that later on.
 
 ## Creating a DLL build
 
@@ -47,7 +47,7 @@ This is it.
 
 ## Using a DLL build
 
-The exact way to use a DLL build will depend on your system. Presented in this guide is the simplest method that uses `<script>` tags.
+The exact way to use a DLL build will depend on your system. Presented in this guide is the simplest method that uses the `<script>` tags.
 
 In order to run the editor you need to load the necessary files (base DLL + editor creator + features). These files expose their content in the `CKEditor5` global, using the following format:
 

--- a/docs/builds/guides/development/dll-builds.md
+++ b/docs/builds/guides/development/dll-builds.md
@@ -6,50 +6,50 @@ order: 30
 
 # CKEditor 5 DLL builds
 
-The purpose of a DLL build is to allow adding plugins to an editor build without rebuilding (recompiling) the build itself.
+The purpose of a DLL build is to allow adding plugins to an editor build without having to rebuild (recompile) the build itself.
 
-The two most common integration method include:
+SO far, the two most common integration methods include:
 
-* Using pre-compiled builds. This can be either one of the official builds or a custom build. In thi case, adding a plugin requires recompiling the entire build.
+* Using pre-compiled builds. This can be either one of the official builds or a custom build. In this case, adding a plugin requires recompiling the entire build.
 * Integrating the editor from source. In this case, if you want to add a plugin, your application needs to be recompiled.
 
-In some advanced use cases, the list of available plugins cannot be limited &mdash; it should be possible to add plugins without any access Node.js. In other words, plugins should be built (compiled) separately from the editor's core.
+In some advanced use cases, the list of available plugins cannot be limited &mdash; it should be possible to add plugins without any access to Node.js. In other words, plugins should be built (compiled) separately from the editor's core.
 
 That is where DLL builds come to the rescue.
 
-DLL builds are based on [DLL webpack plugin](https://webpack.js.org/plugins/dll-plugin/) to provide a CKEditor 5 base DLL and a set of [DLL consumer plugins](https://webpack.js.org/plugins/dll-plugin/#dllreferenceplugin).
+DLL builds are based on the [DLL webpack](https://webpack.js.org/plugins/dll-plugin/) plugin that provides a CKEditor 5 base DLL and a set of [DLL consumer plugins](https://webpack.js.org/plugins/dll-plugin/#dllreferenceplugin).
 
-Currently, CKEditor 5 does not come with a ready-to-use DLL build. Using this integration method requires creating it on your own based on the tools available in the {@link framework/guides/contributing/development-environment CKEditor 5 development environment}.
+Currently, CKEditor 5 does not come with a ready-to-use DLL build. Using this integration method requires creating it on your own, based on the tools available in the {@link framework/guides/contributing/development-environment CKEditor 5 development environment}.
 
-Follow (and add 👍) to [Ship CKEditor 5 DLLs](https://github.com/ckeditor/ckeditor5/issues/9145) for updates.
+Follow the [Ship CKEditor 5 DLLs](https://github.com/ckeditor/ckeditor5/issues/9145) issue for updates (and add 👍).
 
 ## Anatomy of a DLL build
 
 A DLL build of the editor consists of two parts:
 
-* **Base DLL build**. It is a single JavaScript file that combines contents of a several core CKEditor 5 packages: utils, core, engine, ui, clipboard, enter, paragraph, select-all, typing, undo, upload, widget. These packages are either the core of the framework, or are features used by nearly all editor installations.
+* **Base DLL build**. It is a single JavaScript file that combines contents of several core CKEditor 5 packages: utils, core, engine, ui, clipboard, enter, paragraph, select-all, typing, undo, upload, and widget. These packages are either the framework core, or are features used by nearly all editor installations.
 * **DLL-compatible package builds**. Every package that is not part of the Base DLL build is built into a DLL-compatible JavaScript file.
 
-In order to load an editor you need to use the base DLL build plus several DLL-compatible package builds. We will show how to do that later on.
+In order to load an editor you need to use the base DLL build plus several DLL-compatible package builds. You will see how to do that later on.git
 
 ## Creating a DLL build
 
-In order to create your own base DLL build and DLL-compatible package builds you need to:
+In order to create your own base DLL build and DLL-compatible packages builds, all you need to is:
 
 1. Setup the {@link framework/guides/contributing/development-environment CKEditor 5 development environment} locally.
 2. Run `npm run dll:build`.
-
-Voila!
 
 The base DLL build can be found in `./build/ckeditor5-dll.js`.
 
 The DLL-compatible builds of other packages can be found in `./packages/ckeditor5-*/build/<pkg-name>.js`. For example: `./packages/ckeditor5-image/build/image.js`.
 
+This is it.
+
 ## Using a DLL build
 
-The exact way to use a DLL build will depend on your system. We will focus here on the simplest method that uses `<script>` tags.
+The exact way to use a DLL build will depend on your system. Presented in this guide is the simplest method that uses `<script>` tags.
 
-In order to run the editor you need to load the necessary files (base DLL + editor creator + features). Those files expose their content in the `CKEditor5` global using the following format:
+In order to run the editor you need to load the necessary files (base DLL + editor creator + features). These files expose their content in the `CKEditor5` global, using the following format:
 
 ```
 CKEditor5.packageName.moduleName

--- a/docs/builds/guides/development/dll-builds.md
+++ b/docs/builds/guides/development/dll-builds.md
@@ -1,168 +1,108 @@
 ---
-menu-title: DLL
+menu-title: DLL builds
 category: builds-development
 order: 30
 ---
 
 # CKEditor 5 DLL builds
 
-CKEditor 5 can be integrated into the application using DLL compatible builds. A DLL builds uses [DLL webpack plugin](https://webpack.js.org/plugins/dll-plugin/) to provide a CKEditor 5 base DLL and set of [DLL consumer plugins](https://webpack.js.org/plugins/dll-plugin/#dllreferenceplugin). In contrary to the approach of {@link builds/guides/development/custom-builds creating custom builds}, when using DLL builds you don't have to build everything from sources. To use CKEditor 5 base DLL and editor features you need to add proper `<scritp>` tags to the page.
+The purpose of a DLL build is to allow adding plugins to an editor build without rebuilding (recompiling) the build itself.
 
-A minimal example of an editor using `ClassicEditor` build is presented below:
+The two most common integration method include:
 
-```html
-<html>
-<head>
-	<title>Example CKEditor 5 DLL page</title>
-</head>
-<body>
-<div id="editor"></div>
+* Using pre-compiled builds. This can be either one of the official builds or a custom build. In thi case, adding a plugin requires recompiling the entire build.
+* Integrating the editor from source. In this case, if you want to add a plugin, your application needs to be recompiled.
 
-<!-- This adds the CKEditor5.dll() in the global scope, so it is possible to reference its contents -->
-<script src="/path/to/ckeditor5-dll.js"></script>
+In some advanced use cases, the list of available plugins cannot be limited &mdash; it should be possible to add plugins without any access Node.js. In other words, plugins should be built (compiled) separately from the editor's core.
 
-<!-- Those are stripped-down editors with Essentials plugins loaded from a DLL, exposed on CKEditor global -->
-<script src="/path/to/dll-classic.js"></script>
+That is where DLL builds come to the rescue.
 
-<!-- Editor features as DLL consumer builds exposed as CKEditor5[featureName] -->
-<script src="/path/to/dll-basic-styles.js"></script>
+DLL builds are based on [DLL webpack plugin](https://webpack.js.org/plugins/dll-plugin/) to provide a CKEditor 5 base DLL and a set of [DLL consumer plugins](https://webpack.js.org/plugins/dll-plugin/#dllreferenceplugin).
 
-<script>
-	// Use ClassicEditor and BasicStyles from the CKEditor 5 global object.
-	const { ClassicEditor, basicStyles } = CKEditor5;
-	const { Bold, Italic } = basicStyles;
+Currently, CKEditor 5 does not come with a ready-to-use DLL build. Using this integration method requires creating it on your own based on the tools available in the {@link framework/guides/contributing/development-environment CKEditor 5 development environment}.
 
-	const config = {
-		// All required essentials plugins are bundled into the editor.
-		extraPlugins: [ Bold, Italic ],
-		toolbar: [
-			'bold',
-			'italic',
-			'|',
-			'undo',
-			'redo'
-		]
-	};
+Follow (and add 👍) to [Ship CKEditor 5 DLLs](https://github.com/ckeditor/ckeditor5/issues/9145) for updates.
 
-	// ClassicEditor is exposed by the ckeditor5-dll-classic:
-	ClassicEditor.create( document.querySelector( '#editor' ), config )
-			.then( editor => {
-				window.editor = editor;
-			} );
-</script>
-</body>
-</html>
+## Anatomy of a DLL build
+
+A DLL build of the editor consists of two parts:
+
+* **Base DLL build**. It is a single JavaScript file that combines contents of a several core CKEditor 5 packages: utils, core, engine, ui, clipboard, enter, paragraph, select-all, typing, undo, upload, widget. These packages are either the core of the framework, or are features used by nearly all editor installations.
+* **DLL-compatible package builds**. Every package that is not part of the Base DLL build is built into a DLL-compatible JavaScript file.
+
+In order to load an editor you need to use the base DLL build plus several DLL-compatible package builds. We will show how to do that later on.
+
+## Creating a DLL build
+
+In order to create your own base DLL build and DLL-compatible package builds you need to:
+
+1. Setup the {@link framework/guides/contributing/development-environment CKEditor 5 development environment} locally.
+2. Run `npm run dll:build`.
+
+Voila!
+
+The base DLL build can be found in `./build/ckeditor5-dll.js`.
+
+The DLL-compatible builds of other packages can be found in `./packages/ckeditor5-*/build/<pkg-name>.js`. For example: `./packages/ckeditor5-image/build/image.js`.
+
+## Using a DLL build
+
+The exact way to use a DLL build will depend on your system. We will focus here on the simplest method that uses `<script>` tags.
+
+In order to run the editor you need to load the necessary files (base DLL + editor creator + features). Those files expose their content in the `CKEditor5` global using the following format:
+
+```
+CKEditor5.packageName.moduleName
 ```
 
-<info-box>
-	The DLL builds bundles full plugins code even if not used by the editor. To create a size-optimized file use a {@link builds/guides/development/custom-builds creating custom build}.
-</info-box>
-
-## DLL packages anatomy
-
-To use DLL compatible editor you need to use the base DLL build, a DLL-consumer editor build, and a DLL-consumer editor features build for every package.
-
-### Base DLL bundle
-
-The base DLL build contains:
-
-* Core editor plugins:
-	* `@ckeditor/ckeditor5-engine`
-	* `@ckeditor/ckeditor5-core`
-	* `@ckeditor/ckeditor5-ui`
-	* `@ckeditor/ckeditor5-utils`
-* The essential plugins:
-	* `@ckeditor/ckeditor5-enter`
-	* `@ckeditor/ckeditor5-paragraph`
-	* `@ckeditor/ckeditor5-select-all`
-	* `@ckeditor/ckeditor5-typing`
-	* `@ckeditor/ckeditor5-undo`
-	* `@ckeditor/ckeditor5-widget`
-* Other, frequently required plugins:
-	* `@ckeditor/ckeditor5-upload`
-
-### The editor bundles
-
-Each DLL-consumer editor build has a limited set of bundled features that are required for a base editing experience:
-
-```js
-const builtinPlugins = [
-	Clipboard,
-	Enter,
-	Paragraph,
-	SelectAll,
-	ShiftEnter,
-	Typing,
-	Undo
-];
-```
-
-<info-box>
-	The DLL-consumer editor builds differ from standard editor builds and do not bundle any other feature.
-</info-box>
-
-### The editor features bundles
-
-As explained above, the editor dll build contains only bare minimum set of plugins required to provide plain-text editing. To add other features, like bold, table, or image you need to add them to the editor configuration and attach their `<script>` tags to the webpage.
-
-Every package is build as `build/feature-name.js` in their npm repository.
-
-An example classic editor build configuration using dll bundles:
+For example:
 
 ```html
-<!-- This adds the CKEditor5.dll() in the global scope, so it is possible to reference its contents -->
-<script src="/path/to/ckeditor5/build/ckeditor5-dll.js"></script>
+<!-- Base DLL build. -->
+<!-- Note: it includes ckeditor5-paragraph too. -->
+<script src="path/to/ckeditor5/build/ckeditor5-dll.js"></script>
 
-<!-- Those are stripped-down editors with Essentials plugins loaded from a DLL, exposed on CKEditor global -->
-<script src="/path/to/@ckeditor/ckeditor5-dll-classic/build/classic.js"></script>
+<!-- DLL-compatible build of ckeditor5-editor-classic. -->
+<script src="path/to/ckeditor5/packages/ckeditor5-editor-classic/build/editor-classic.js"></script>
 
-<!-- Editor features as DLL consumer builds exposed as CKEditor5[featureName] -->
-<script src="/path/to/@ckeditor/ckeditor5-adapter-ckfinder/build/adapter-ckfinder.js"></script>
-<script src="/path/to/@ckeditor/ckeditor5-autoformat/build/autoformat.js"></script>
-<script src="/path/to/@ckeditor/ckeditor5-basic-styles/build/basic-styles.js"></script>
-<script src="/path/to/@ckeditor/ckeditor5-block-quote/build/block-quote.js"></script>
-<script src="/path/to/@ckeditor/ckeditor5-ckfinder/build/ckfinder.js"></script>
-<script src="/path/to/@ckeditor/ckeditor5-easy-image/build/easy-image.js"></script>
-<script src="/path/to/@ckeditor/ckeditor5-heading/build/heading.js"></script>
-<script src="/path/to/@ckeditor/ckeditor5-image/build/image.js"></script>
-<script src="/path/to/@ckeditor/ckeditor5-indent/build/indent.js"></script>
-<script src="/path/to/@ckeditor/ckeditor5-link/build/link.js"></script>
-<script src="/path/to/@ckeditor/ckeditor5-list/build/list.js"></script>
-<script src="/path/to/@ckeditor/ckeditor5-media-embed/build/media-embed.js"></script>
-<script src="/path/to/@ckeditor/ckeditor5-paste-from-office/build/paste-from-office.js"></script>
-<script src="/path/to/@ckeditor/ckeditor5-table/build/table.js"></script>
+<!-- DLL-compatible builds of editor features. -->
+<script src="path/to/ckeditor5/packages/ckeditor5-autoformat/build/autoformat.js"></script>
+<script src="path/to/ckeditor5/packages/ckeditor5-basic-styles/build/basic-styles.js"></script>
+<script src="path/to/ckeditor5/packages/ckeditor5-block-quote/build/block-quote.js"></script>
+<script src="path/to/ckeditor5/packages/ckeditor5-essentials/build/essentials.js"></script>
+<script src="path/to/ckeditor5/packages/ckeditor5-heading/build/heading.js"></script>
+<script src="path/to/ckeditor5/packages/ckeditor5-image/build/image.js"></script>
+<script src="path/to/ckeditor5/packages/ckeditor5-indent/build/indent.js"></script>
+<script src="path/to/ckeditor5/packages/ckeditor5-link/build/link.js"></script>
+<script src="path/to/ckeditor5/packages/ckeditor5-list/build/list.js"></script>
+<script src="path/to/ckeditor5/packages/ckeditor5-media-embed/build/media-embed.js"></script>
+<script src="path/to/ckeditor5/packages/ckeditor5-paste-from-office/build/paste-from-office.js"></script>
+<script src="path/to/ckeditor5/packages/ckeditor5-table/build/table.js"></script>
 
 <script>
-	const {
-		ClassicEditor, autoformat, basicStyles, ckfinder, blockQuote, easyImage,
-		heading, image, indent, link, list, table, mediaEmbed, pasteFromOffice
-	} = CKEditor5;
-
 	const config = {
-		// All required essentials plugins are bundled into the editor.
-		extraPlugins: [
-			basicStyles.Bold,
-			basicStyles.Italic
-			ckfinder.UploadAdapter,
-			autoformat.Autoformat,
-			basicStyles.Bold,
-			basicStyles.Italic,
-			blockQuote.BlockQuote,
-			ckfinder.CKFinder,
-			easyImage.EasyImage,
-			heading.Heading,
-			image.Image,
-			image.ImageCaption,
-			image.ImageStyle,
-			image.ImageToolbar,
-			image.ImageUpload,
-			indent.Indent,
-			link.Link,
-			list.List,
-			mediaEmbed.MediaEmbed,
-			pasteFromOffice.PasteFromOffice,
-			table.Table,
-			table.TableToolbar
+		plugins: [
+			CKEditor5.basicStyles.Bold,
+			CKEditor5.basicStyles.Italic,
+			CKEditor5.autoformat.Autoformat,
+			CKEditor5.basicStyles.Bold,
+			CKEditor5.basicStyles.Italic,
+			CKEditor5.blockQuote.BlockQuote,
+			CKEditor5.essentials.Essentials,
+			CKEditor5.heading.Heading,
+			CKEditor5.image.Image,
+			CKEditor5.image.ImageCaption,
+			CKEditor5.image.ImageStyle,
+			CKEditor5.image.ImageToolbar,
+			CKEditor5.image.ImageUpload,
+			CKEditor5.indent.Indent,
+			CKEditor5.link.Link,
+			CKEditor5.list.List,
+			CKEditor5.mediaEmbed.MediaEmbed,
+			CKEditor5.paragraph.Paragraph,
+			CKEditor5.pasteFromOffice.PasteFromOffice,
+			CKEditor5.table.Table,
+			CKEditor5.table.TableToolbar
 		],
 		toolbar: {
 			items: [
@@ -202,277 +142,19 @@ An example classic editor build configuration using dll bundles:
 		}
 	};
 
-	// ClassicEditor is exposed by the `@ckeditor/ckeditor5-dll-classic` package.
-	ClassicEditor.create( document.querySelector( '#editor' ), config )
-			.then( editor => {
-				window.editor = editor;
-			} );
-</script>
-```
-
-## DLL developer guide
-
-The CKEditor 5 DLL build can be used to add plugins to existing editor build in two ways:
-
-1. Using webpack to create a DLL consumer plugin.
-2. Using DLL directly from a script.
-
-TODO: Mention about using the `@ckeditor/ckeditor5-dev-utils` package.
-
-### Creating DLL consumer plugins
-
-To create a DLL consumer plugin using webpack you need to use provide DLL manifest in your build:
-
-```js
-
-const path = require( 'path' );
-const webpack = require( 'webpack' );
-
-module.exports = {
-	mode: 'development',
-	optimization: {
-		minimize: false,
-		moduleIds: 'named'
-	},
-	entry: {
-		path: path.resolve( __dirname, 'src/dllconsumerplugin.js' )
-	},
-	output: {
-		path: path.resolve( __dirname, 'build' ),
-		filename: 'dll-consumer-plugin.js',
-		library: 'DLLConsumerPlugin',
-		libraryTarget: 'umd',
-		libraryExport: 'default'
-	},
-	plugins: [
-		new webpack.DllReferencePlugin( {
-			manifest: require( 'node_modules/ckeditor5/build/ckeditor5-dll.manifest.json' ),
-			scope: 'ckeditor5/src'
-		} )
-	]
-};
-```
-
-In the above example webpack config we use [`DLLReferencePlugin`](https://webpack.js.org/plugins/dll-plugin/#dllreferenceplugin) to tell the bundler that all packages from `ckeditor5/src` will be loaded during the run-time using the `window.CKEditor5.dll()`. Every imported dependency from base CKEditor 5 DLL should be loaded from `ckeditor5` package:
-
-```js
-import { Plugin, Command } from 'ckeditor5/src/core';
-import { ButtonView } from 'ckeditor5/src/ui';
-
-class ExampleCommand extends Command {
-	execute() {
-		const model = this.editor.model;
-
-		model.change( writer => {
-			model.insertContent( writer.createText( 'The cake is a lie!' ) );
-		} );
-	}
-}
-
-class DLLConsumerPlugin extends Plugin {
-	constructor( editor ) {
-		super( editor );
-
-		editor.commands.add( 'example-command', new ExampleCommand( editor ) );
-
-		editor.ui.componentFactory.add( 'example-button', locale => {
-			const button = new ButtonView( locale );
-
-			const command = editor.commands.get( 'example-command' );
-
-			button.set( {
-				withText: true,
-				icon: false,
-				label: 'Click me!'
-			} );
-
-			button.bind( 'isEnabled' ).to( command );
-
-			button.on( 'execute', () => editor.execute( 'example-command' ) );
-
-			return button;
-		} );
-	}
-}
-
-export default DLLConsumerPlugin;
-```
-
-After building your plugin using webpack, you can then use it together with the editor DLL build:
-
-```html
-<!-- This adds the CKEditor5.dll() in the global scope, so it is possible to reference its contents -->
-<script src="./node_modules/ckeditor5/build/ckeditor5-dll.js"></script>
-
-<!-- Those are stripped-down editors with Essentials plugins loaded from a DLL, exposed on CKEditor global -->
-<script src="./node_modules/@ckeditor/ckeditor5-dll-classic/build/dll-classic.js"></script>
-
-<!-- Editor features as DLL consumer builds exposed as CKEditor5[FeatureName] -->
-<script src="./node_modules/@ckeditor/ckeditor5-basic-styles/build/basic-styles.js"></script>
-
-<!-- Finally, this is a end-user plugin that uses DLL -->
-<script src="./build/dll-consumer-plugin.js"></script>
-
-<script>
-	// Import Bold, Italic from the CKEditor 5 global.
-	const { ClassicEditor, basicStyles } = CKEditor5;
-	const { Bold, Italic } = basicStyles;
-
-	const config = {
-		extraPlugins: [
-			Bold,
-			Italic,
-			DLLConsumerPlugin // exposed by the dll-consumer-plugin.js
-		],
-		toolbar: [
-			'bold',
-			'italic',
-			'|',
-			'htmlEmbed',
-			'|',
-			'example-button',
-			'|',
-			'undo',
-			'redo'
-		]
-	};
-
-	// ClassicEditor is exposed by the ckeditor5-dll-classic:
-	ClassicEditor.create( document.querySelector( '#editor-classic' ), config )
+	CKEditor5.editorClassic.ClassicEditor
+		.create( document.querySelector( '#editor' ), config )
 		.then( editor => {
 			window.editor = editor;
 		} );
-
-</script>
 ```
 
-### Using DLL directly from a script.
+<!--
 
-The code bundled in the DLL can be used directly in a `<script>` tag:
+## Known limitations
 
-```html
-<!-- This adds the CKEditor5.dll() in the global scope, so it is possible to reference its contents -->
-<script src="./node_modules/ckeditor5/build/ckeditor5-dll.js"></script>
+## Creating DLL-compatible plugins
 
-<!-- Those are stripped-down editors with Essentials plugins loaded from a DLL, exposed on CKEditor global -->
-<script src="./node_modules/@ckeditor/ckeditor5-dll-classic/build/dll-classic.js"></script>
+## Runtime plugins
 
-<!-- Editor features as DLL consumer builds exposed as CKEditor5[FeatureName] -->
-<script src="./node_modules/@ckeditor/ckeditor5-basic-styles/build/basic-styles.js"></script>
-
-<!-- Finally, this is a end-user plugin that uses DLL -->
-<script src="./build/dll-consumer-plugin.js"></script>
-
-<script>
-	// Import Bold, Italic from the CKEditor 5 global.
-	const { ClassicEditor, basicStyles, core, ui } = CKEditor5;
-	const { Bold, Italic } = basicStyles;
-
-	const { Plugin, Command } = core;
-	const { ButtonView } = ui;
-
-	class ExampleCommand extends Command {
-		execute() {
-			const model = this.editor.model;
-
-			model.change( writer => {
-				model.insertContent( writer.createText( 'The cake is a lie!' ) );
-			} );
-		}
-	}
-
-	class DLLConsumerPlugin extends Plugin {
-		constructor( editor ) {
-			super( editor );
-
-			editor.commands.add( 'example-command', new ExampleCommand( editor ) );
-
-			editor.ui.componentFactory.add( 'example-button', locale => {
-				const button = new ButtonView( locale );
-
-				const command = editor.commands.get( 'example-command' );
-
-				button.set( {
-					withText: true,
-					icon: false,
-					label: 'Click me!'
-				} );
-
-				button.bind( 'isEnabled' ).to( command );
-
-				button.on( 'execute', () => editor.execute( 'example-command' ) );
-
-				return button;
-			} );
-		}
-	}
-
-	const config = {
-		extraPlugins: [
-			Bold,
-			Italic,
-			DLLConsumerPlugin
-		],
-		toolbar: [
-			'bold',
-			'italic',
-			'|',
-			'htmlEmbed',
-			'|',
-			'example-button',
-			'|',
-			'undo',
-			'redo'
-		]
-	};
-
-	// ClassicEditor is exposed by the ckeditor5-dll-classic:
-	ClassicEditor.create( document.querySelector( '#editor-classic' ), config )
-		.then( editor => {
-			window.editor = editor;
-		} );
-
-</script>
-```
-
-## Building DLL and writing for DLLs
-
-### Code guidelines
-
-To allow simultaneous development of standard and DLL builds you need to follow the below rules:
-
-1. You are allowed to import only from base DLL packages listed in [Base DLL bundle](#base-dll-bundle) using `ckeditor5` package.
-   For instance, import public API from the `ckeditor5` package:
-   ```js
-   import { Plugin } from 'ckeditor5/core';
-   ```
-   Do not import by a full path:
-   ```js
-   import Plugin from '@ckeditor5-core/src/plugin';
-   ```
-2. Do not import anything from other packages.
-   Imports from other packages are disallowed. Their API should be provided on the editor plugin:
-   Do not:
-   ```js
-   import { doBar } from '@ckeditor/ckeditor5-foo-bar/src/utils/bar';
-
-   doBar();
-   ```
-   Do instead:
-   ```js
-   editor.plugins.get( 'Foo' ).doBar();
-   ```
-
-### Building the DLL builds
-
-In the main repo you can run `build:dll` task which will build the base DLL build and all DLL-enabled builds:
-
-```shell
-yarn run build:dll
-```
-
-This script will look for `build:dll` script inside any packages from `./packages` folder.
-
-The full rebuild is not necessary for the DLL consumer plugins if the main DLL bundle has not changed. You can run `yarn run build:dll` in the DLL consumer plugin after changes.
-
-Additionally, if the main bundle has been changed but its exports remain the same (ie bugfix in `ckeditor5-core`), the rebuild of DLL consumer plugins is not needed.
+-->

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "release:publish": "node ./scripts/release/publish.js",
     "switch-to-dev-dev": "sh ./scripts/switch-to-dev-dev.sh",
     "clean-up-svg-icons": "sh ./scripts/clean-up-svg-icons.sh",
-    "build:dll": "node ./scripts/dll/build-dlls.js",
+    "dll:build": "node ./scripts/dll/build-dlls.js",
     "check-dependencies": "ckeditor5-dev-tests-check-dependencies"
   },
   "lint-staged": {

--- a/packages/ckeditor5-adapter-ckfinder/package.json
+++ b/packages/ckeditor5-adapter-ckfinder/package.json
@@ -51,6 +51,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-alignment/package.json
+++ b/packages/ckeditor5-alignment/package.json
@@ -49,6 +49,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-autoformat/package.json
+++ b/packages/ckeditor5-autoformat/package.json
@@ -55,6 +55,6 @@
     "eslint-plugin-ckeditor5-rules"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-autosave/package.json
+++ b/packages/ckeditor5-autosave/package.json
@@ -43,6 +43,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-basic-styles/package.json
+++ b/packages/ckeditor5-basic-styles/package.json
@@ -46,6 +46,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-block-quote/package.json
+++ b/packages/ckeditor5-block-quote/package.json
@@ -50,6 +50,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-ckfinder/package.json
+++ b/packages/ckeditor5-ckfinder/package.json
@@ -49,6 +49,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-cloud-services/package.json
+++ b/packages/ckeditor5-cloud-services/package.json
@@ -41,6 +41,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-code-block/package.json
+++ b/packages/ckeditor5-code-block/package.json
@@ -52,6 +52,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-easy-image/package.json
+++ b/packages/ckeditor5-easy-image/package.json
@@ -47,6 +47,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-editor-balloon/package.json
+++ b/packages/ckeditor5-editor-balloon/package.json
@@ -49,6 +49,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-editor-classic/package.json
+++ b/packages/ckeditor5-editor-classic/package.json
@@ -49,6 +49,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-editor-decoupled/package.json
+++ b/packages/ckeditor5-editor-decoupled/package.json
@@ -49,6 +49,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-editor-inline/package.json
+++ b/packages/ckeditor5-editor-inline/package.json
@@ -49,6 +49,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-essentials/package.json
+++ b/packages/ckeditor5-essentials/package.json
@@ -47,6 +47,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-font/package.json
+++ b/packages/ckeditor5-font/package.json
@@ -47,6 +47,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-heading/package.json
+++ b/packages/ckeditor5-heading/package.json
@@ -54,6 +54,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-highlight/package.json
+++ b/packages/ckeditor5-highlight/package.json
@@ -50,6 +50,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-horizontal-line/package.json
+++ b/packages/ckeditor5-horizontal-line/package.json
@@ -48,6 +48,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-html-embed/package.json
+++ b/packages/ckeditor5-html-embed/package.json
@@ -51,6 +51,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-image/package.json
+++ b/packages/ckeditor5-image/package.json
@@ -62,6 +62,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-indent/package.json
+++ b/packages/ckeditor5-indent/package.json
@@ -45,6 +45,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-link/package.json
+++ b/packages/ckeditor5-link/package.json
@@ -54,6 +54,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-list/package.json
+++ b/packages/ckeditor5-list/package.json
@@ -59,6 +59,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-markdown-gfm/package.json
+++ b/packages/ckeditor5-markdown-gfm/package.json
@@ -55,6 +55,6 @@
     "block-elements"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-media-embed/package.json
+++ b/packages/ckeditor5-media-embed/package.json
@@ -54,6 +54,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-mention/package.json
+++ b/packages/ckeditor5-mention/package.json
@@ -56,6 +56,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-page-break/package.json
+++ b/packages/ckeditor5-page-break/package.json
@@ -48,6 +48,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-paste-from-office/package.json
+++ b/packages/ckeditor5-paste-from-office/package.json
@@ -56,6 +56,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-remove-format/package.json
+++ b/packages/ckeditor5-remove-format/package.json
@@ -52,6 +52,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-restricted-editing/package.json
+++ b/packages/ckeditor5-restricted-editing/package.json
@@ -51,6 +51,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-special-characters/package.json
+++ b/packages/ckeditor5-special-characters/package.json
@@ -47,6 +47,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-table/package.json
+++ b/packages/ckeditor5-table/package.json
@@ -58,6 +58,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-watchdog/package.json
+++ b/packages/ckeditor5-watchdog/package.json
@@ -43,6 +43,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/packages/ckeditor5-word-count/package.json
+++ b/packages/ckeditor5-word-count/package.json
@@ -52,6 +52,6 @@
     "build"
   ],
   "scripts": {
-    "build:dll": "webpack"
+    "dll:build": "webpack"
   }
 }

--- a/scripts/dll/build-dlls.js
+++ b/scripts/dll/build-dlls.js
@@ -17,13 +17,13 @@ const IS_DEVELOPMENT_MODE = process.argv.includes( '--dev' );
 if ( IS_DEVELOPMENT_MODE ) {
 	console.log( '🛠️️  ' + chalk.yellow( 'Development mode is active.' ) );
 } else {
-	console.log( '⚠️  ' + chalk.magenta( 'Production mode is active.' ) );
+	console.log( '⚠️  ' + chalk.magenta( 'Production mode is active. Use --dev to build in the development mode.' ) );
 }
 
-// --------------------------------------------------------
-// -------------------------------------- Main package DLL.
+// -------------------------------------------------------------
+// ------------------------------------------- Base DLL build --
 
-console.log( '\n📍 ' + chalk.cyan.underline( 'Building DLL for the main package...\n' ) );
+console.log( '\n📍 ' + chalk.cyan.underline( 'Creating the base DLL build...\n' ) );
 
 const webpackArguments = [ '--config=./scripts/dll/webpack.config.dll.js' ];
 
@@ -39,10 +39,10 @@ childProcess.spawnSync( 'webpack', webpackArguments, {
 	stderr: 'inherit'
 } );
 
-// --------------------------------------------------------
-// ------------------------------ ckeditor5-* packages DLL.
+// -------------------------------------------------------------
+// ---------------------------- DLL-compatible package builds --
 
-console.log( '\n📍 ' + chalk.underline( 'Building DLLs for ckeditor5-* packages...\n' ) );
+console.log( '\n📍 ' + chalk.underline( 'Creating DLL-compatible package builds...\n' ) );
 
 const nodeArguments = [ './scripts/dll/build-packages-dlls.js' ];
 

--- a/scripts/dll/build-packages-dlls.js
+++ b/scripts/dll/build-packages-dlls.js
@@ -17,13 +17,13 @@ const notBaseDLL = name => name !== 'ckeditor5-dll';
 const hasDLLBuild = name => {
 	const scripts = require( path.join( process.cwd(), 'packages', name, 'package.json' ) ).scripts;
 
-	return scripts && scripts[ 'build:dll' ];
+	return scripts && scripts[ 'dll:build' ];
 };
 
 const buildDll = fullPackageName => {
 	console.log( `Running "${ fullPackageName }" build...` );
 
-	const yarnArguments = [ 'run', 'build:dll' ];
+	const yarnArguments = [ 'run', 'dll:build' ];
 
 	if ( IS_DEVELOPMENT_MODE ) {
 		yarnArguments.push( '--dev' );
@@ -45,10 +45,6 @@ const packages = childProcess.execSync( 'ls -1 packages', {
 	encoding: 'utf8',
 	cwd: ROOT_DIRECTORY
 } ).toString().trim().split( '\n' );
-
-console.log( '----------------------' );
-console.log( 'Running full DLL build' );
-console.log( '----------------------' );
 
 packages
 	.filter( notBaseDLL )

--- a/tests/manual/all-features-dll.md
+++ b/tests/manual/all-features-dll.md
@@ -2,7 +2,7 @@
 
 **This DLL sample test requires that the DLL core and DLL packages are built.**
 
-To build the DLL core and packages, run `yarn run build:dll` and then refresh this page.
+To build the DLL core and packages, run `yarn run dll:build` and then refresh this page.
 
 Expected results:
 * There should be no errors in the console.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Rewrote the DLL builds guide. Closes #9094. Closes #8905.

---

### Additional information

*   I didn't read the content once after writing it as I need to leave today. **I didn't even build this guide**.
*   It needs a followup to re-add the missing parts (implementing DLL-compat plugins and similar). I stripped it down now as it's not essential yet.
*   I reported #9146 as I think it's odd it's not there.
*   There's also a PR in cke5-internal.