### PR TITLE
Table caption handling

### DIFF
--- a/packages/ckeditor5-table/src/converters/downcast.js
+++ b/packages/ckeditor5-table/src/converters/downcast.js
@@ -59,9 +59,7 @@ export function downcastInsertTable( options = {} ) {
 
 			const tableRow = table.getChild( row );
 
-			// Ignore caption models.
-			// FIXME: This shouldn't be hardcoded.
-			if ( tableRow.name === 'caption' ) {
+			if ( !tableRow.is( 'element', 'tableRow' ) ) {
 				continue;
 			}
 
@@ -81,8 +79,7 @@ export function downcastInsertTable( options = {} ) {
 		for ( const tableRow of table.getChildren() ) {
 			const rowIndex = tableRow.index;
 
-			// FIXME: This shouldn't be hardcoded.
-			if ( tableRow.name == 'caption' ) {
+			if ( !tableRow.is( 'element', 'tableRow' ) ) {
 				continue;
 			}
 

--- a/packages/ckeditor5-table/src/converters/downcast.js
+++ b/packages/ckeditor5-table/src/converters/downcast.js
@@ -58,6 +58,13 @@ export function downcastInsertTable( options = {} ) {
 			const { row, cell } = tableSlot;
 
 			const tableRow = table.getChild( row );
+
+			// Ignore caption models.
+			// FIXME: This shouldn't be hardcoded.
+			if ( tableRow.name === 'caption' ) {
+				continue;
+			}
+
 			const trElement = viewRows.get( row ) || createTr( tableElement, tableRow, row, tableAttributes, conversionApi );
 			viewRows.set( row, trElement );
 
@@ -73,6 +80,11 @@ export function downcastInsertTable( options = {} ) {
 		// this can happen only in the document fragment that only part of the table is down-casted.
 		for ( const tableRow of table.getChildren() ) {
 			const rowIndex = tableRow.index;
+
+			// FIXME: This shouldn't be hardcoded.
+			if ( tableRow.name == 'caption' ) {
+				continue;
+			}
 
 			if ( !viewRows.has( rowIndex ) ) {
 				viewRows.set( rowIndex, createTr( tableElement, tableRow, rowIndex, tableAttributes, conversionApi ) );

--- a/packages/ckeditor5-table/src/converters/table-cell-paragraph-post-fixer.js
+++ b/packages/ckeditor5-table/src/converters/table-cell-paragraph-post-fixer.js
@@ -70,10 +70,10 @@ function fixTable( table, writer ) {
 	let wasFixed = false;
 
 	for ( const row of table.getChildren() ) {
-		// Ignore caption model.
-		if ( row.name === 'caption' ) {
+		if ( !row.is( 'element', 'tableRow' ) ) {
 			continue;
 		}
+
 		wasFixed = fixTableRow( row, writer ) || wasFixed;
 	}
 
@@ -86,6 +86,10 @@ function fixTable( table, writer ) {
 // @param {module:engine/model/writer~Writer} writer
 function fixTableRow( tableRow, writer ) {
 	let wasFixed = false;
+
+	if ( !tableRow.is( 'element', 'tableRow' ) ) {
+		return false;
+	}
 
 	for ( const tableCell of tableRow.getChildren() ) {
 		wasFixed = fixTableCellContent( tableCell, writer ) || wasFixed;

--- a/packages/ckeditor5-table/src/converters/table-cell-paragraph-post-fixer.js
+++ b/packages/ckeditor5-table/src/converters/table-cell-paragraph-post-fixer.js
@@ -70,6 +70,10 @@ function fixTable( table, writer ) {
 	let wasFixed = false;
 
 	for ( const row of table.getChildren() ) {
+		// Ignore caption model.
+		if ( row.name === 'caption' ) {
+			continue;
+		}
 		wasFixed = fixTableRow( row, writer ) || wasFixed;
 	}
 

--- a/packages/ckeditor5-table/src/converters/table-layout-post-fixer.js
+++ b/packages/ckeditor5-table/src/converters/table-layout-post-fixer.js
@@ -325,8 +325,10 @@ function fixTableRowsSizes( table, writer ) {
 
 		for ( const [ rowIndex, size ] of rowsLengths.entries() ) {
 			const columnsToInsert = maxColumns - size;
+			const isTableRow = table.getChild( rowIndex ).is( 'element', 'tableRow' );
 
-			if ( columnsToInsert ) {
+			// Table can hold models other than rows - we shouldn't fix them.
+			if ( isTableRow && columnsToInsert ) {
 				for ( let i = 0; i < columnsToInsert; i++ ) {
 					createEmptyTableCell( writer, writer.createPositionAt( table.getChild( rowIndex ), 'end' ) );
 				}

--- a/packages/ckeditor5-table/src/converters/table-layout-post-fixer.js
+++ b/packages/ckeditor5-table/src/converters/table-layout-post-fixer.js
@@ -325,10 +325,9 @@ function fixTableRowsSizes( table, writer ) {
 
 		for ( const [ rowIndex, size ] of rowsLengths.entries() ) {
 			const columnsToInsert = maxColumns - size;
-			const isTableRow = table.getChild( rowIndex ).is( 'element', 'tableRow' );
 
 			// Table can hold models other than rows - we shouldn't fix them.
-			if ( isTableRow && columnsToInsert ) {
+			if ( columnsToInsert ) {
 				for ( let i = 0; i < columnsToInsert; i++ ) {
 					createEmptyTableCell( writer, writer.createPositionAt( table.getChild( rowIndex ), 'end' ) );
 				}
@@ -380,7 +379,11 @@ function findCellsToTrim( table ) {
 // @returns {Array.<Number>}
 function getRowsLengths( table ) {
 	// TableWalker will not provide items for the empty rows, we need to pre-fill this array.
-	const lengths = new Array( table.childCount ).fill( 0 );
+	const count = Array.from( table.getChildren() ).reduce(
+		( count, row ) => row.is( 'element', 'tableRow' ) ? count + 1 : count,
+		0
+	);
+	const lengths = new Array( count ).fill( 0 );
 
 	for ( const { row } of new TableWalker( table, { includeAllSlots: true } ) ) {
 		lengths[ row ]++;

--- a/packages/ckeditor5-table/src/converters/upcasttable.js
+++ b/packages/ckeditor5-table/src/converters/upcasttable.js
@@ -26,7 +26,7 @@ export default function upcastTable() {
 				return;
 			}
 
-			const { rows, headingRows, headingColumns } = scanTable( viewTable );
+			const { caption, rows, headingRows, headingColumns } = scanTable( viewTable );
 
 			// Only set attributes if values is greater then 0.
 			const attributes = {};
@@ -43,6 +43,10 @@ export default function upcastTable() {
 
 			if ( !conversionApi.safeInsert( table, data.modelCursor ) ) {
 				return;
+			}
+
+			if ( caption ) {
+				conversionApi.convertItem( caption, conversionApi.writer.createPositionAt( table, 0 ) );
 			}
 
 			conversionApi.consumable.consume( viewTable, { name: true } );
@@ -119,6 +123,7 @@ export function ensureParagraphInTableCell( elementName ) {
 // @returns {{headingRows, headingColumns, rows}}
 function scanTable( viewTable ) {
 	const tableMeta = {
+		caption: undefined,
 		headingRows: 0,
 		headingColumns: 0
 	};
@@ -171,6 +176,10 @@ function scanTable( viewTable ) {
 					}
 				}
 			}
+		}
+		// Separate caption from other table elements.
+		else if ( tableChild.name === 'caption' ) {
+			tableMeta.caption = tableChild;
 		}
 	}
 

--- a/packages/ckeditor5-table/src/converters/upcasttable.js
+++ b/packages/ckeditor5-table/src/converters/upcasttable.js
@@ -45,14 +45,15 @@ export default function upcastTable() {
 				return;
 			}
 
-			if ( caption ) {
-				conversionApi.convertItem( caption, conversionApi.writer.createPositionAt( table, 0 ) );
-			}
-
 			conversionApi.consumable.consume( viewTable, { name: true } );
 
 			// Upcast table rows in proper order (heading rows first).
 			rows.forEach( row => conversionApi.convertItem( row, conversionApi.writer.createPositionAt( table, 'end' ) ) );
+
+			if ( caption ) {
+				// Convert table > caption.
+				conversionApi.convertItem( caption, conversionApi.writer.createPositionAt( table, 'end' ) );
+			}
 
 			// Create one row and one table cell for empty table.
 			if ( table.isEmpty ) {

--- a/packages/ckeditor5-table/src/tablecaption.js
+++ b/packages/ckeditor5-table/src/tablecaption.js
@@ -1,0 +1,30 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module table/tablecaption
+ */
+
+import { Plugin } from 'ckeditor5/src/core';
+import TableCaptionEditing from './tablecaption/tablecaptionediting';
+
+/**
+ * @extends module:core/plugin~Plugin
+ */
+export default class TableCaption extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
+	static get pluginName() {
+		return 'TableCaption';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	static get requires() {
+		return [ TableCaptionEditing ];
+	}
+}

--- a/packages/ckeditor5-table/src/tablecaption/tablecaptionediting.js
+++ b/packages/ckeditor5-table/src/tablecaption/tablecaptionediting.js
@@ -1,0 +1,211 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module table/tablecaption/tablecaptionediting
+ */
+
+import { Plugin } from 'ckeditor5/src/core';
+import { enablePlaceholder } from 'ckeditor5/src/engine';
+import { toWidgetEditable } from 'ckeditor5/src/widget';
+import { first } from 'ckeditor5/src/utils';
+
+/**
+ * The table caption engine plugin.
+ *
+ * It registers proper converters. It takes care of adding a caption element if the table without it is inserted
+ * to the model document.
+ *
+ * @extends module:core/plugin~Plugin
+ */
+export default class TableCaptionEditing extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
+	static get pluginName() {
+		return 'TableCaptionEditing';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	init() {
+		const editor = this.editor;
+		const schema = editor.model.schema;
+		const view = editor.editing.view;
+		const t = editor.t;
+
+		schema.register( 'caption', {
+			allowIn: 'table',
+			allowContentOf: '$block',
+			isLimit: true
+		} );
+
+		// View -> model converter for the data pipeline.
+		editor.conversion.for( 'upcast' )
+			.elementToElement( {
+				view: matchTableCaptionViewElement,
+				model: 'caption'
+			} )
+			.add( viewFigureToModel() );
+
+		// Model -> view converter for the data pipeline.
+		editor.conversion.for( 'dataDowncast' ).elementToElement( {
+			model: 'caption',
+			view: ( modelElement, { writer } ) => {
+				if ( !isTable( modelElement.parent ) ) {
+					return null;
+				}
+
+				return writer.createContainerElement( 'figcaption' );
+			}
+		} );
+
+		// Model -> view converter for the editing pipeline.
+		editor.conversion.for( 'editingDowncast' ).elementToElement( {
+			model: 'caption',
+			view: ( modelElement, { writer } ) => {
+				if ( !isTable( modelElement.parent ) ) {
+					return null;
+				}
+
+				const figcaptionElement = writer.createEditableElement( 'figcaption' );
+				writer.setCustomProperty( 'imageCaption', true, figcaptionElement );
+
+				enablePlaceholder( {
+					view,
+					element: figcaptionElement,
+					text: t( 'Enter image caption' )
+				} );
+
+				return toWidgetEditable( figcaptionElement, writer );
+			}
+		} );
+
+		editor.data.mapper.on( 'modelToViewPosition', mapModelPositionToView( view ) );
+		editor.editing.mapper.on( 'modelToViewPosition', mapModelPositionToView( view ) );
+
+		editor.editing.mapper.on( 'modelToViewPosition',
+			( evt, data ) => {
+				const modelPosition = data.modelPosition;
+				const parent = modelPosition.parent;
+
+				if ( !parent.is( 'element', 'caption' ) ) {
+					return;
+				}
+
+				// Place the caption's content next to the table.
+				const viewContainer = data.mapper.toViewElement( parent.parent );
+
+				data.viewPosition = data.mapper.findPositionIn( viewContainer, modelPosition.offset );
+			}
+		);
+	}
+}
+
+// @private
+// @param {module:engine/view/view~View} editingView
+// @returns {Function}
+function mapModelPositionToView( editingView ) {
+	return ( evt, data ) => {
+		const modelPosition = data.modelPosition;
+		const parent = modelPosition.parent;
+
+		if ( !parent.is( 'element', 'table' ) ) {
+			return;
+		}
+
+		const viewElement = data.mapper.toViewElement( parent );
+
+		data.viewPosition = editingView.createPositionAt( viewElement, modelPosition.offset + 1 );
+	};
+}
+
+/**
+ * {@link module:engine/view/matcher~Matcher} pattern. Checks if a given element is a `<figcaption>` element that is placed
+ * inside the image `<figure>` element.
+ *
+ * @param {module:engine/view/element~Element} element
+ * @returns {Object|null} Returns the object accepted by {@link module:engine/view/matcher~Matcher} or `null` if the element
+ * cannot be matched.
+ */
+export function matchTableCaptionViewElement( element ) {
+	const parent = element.parent;
+
+	if ( element.name == 'figcaption' && parent && parent.name == 'figure' && parent.hasClass( 'table' ) ) {
+		return { name: true };
+	}
+
+	if ( element.name == 'caption' && parent && parent.name == 'table' ) {
+		return { name: true };
+	}
+
+	return null;
+}
+
+/**
+ * Checks if the provided model element is a `table`.
+ *
+ * @param {module:engine/model/element~Element} modelElement
+ * @returns {Boolean}
+ */
+export function isTable( modelElement ) {
+	return !!modelElement && modelElement.is( 'element', 'table' );
+}
+
+export function viewFigureToModel() {
+	return dispatcher => {
+		dispatcher.on( 'element:figure', converter );
+	};
+
+	function converter( evt, data, conversionApi ) {
+		// Do not convert if this is not an "table figure".
+		if ( !conversionApi.consumable.test( data.viewItem, { name: true, classes: 'table' } ) ) {
+			return;
+		}
+
+		// Find an table element inside the figure element.
+		const viewTable = getViewTableFromFigure( data.viewItem );
+
+		// Do not convert if table element is absent, is missing src attribute or was already converted.
+		if ( !viewTable || !conversionApi.consumable.test( viewTable, { name: true } ) ) {
+			return;
+		}
+
+		// Convert view table to model table.
+		const conversionResult = conversionApi.convertItem( viewTable, data.modelCursor );
+
+		// Get table element from conversion result.
+		const modelTable = first( conversionResult.modelRange.getItems() );
+
+		// When table wasn't successfully converted then finish conversion.
+		if ( !modelTable ) {
+			return;
+		}
+
+		// Convert rest of the figure element's children as an table children.
+		conversionApi.convertChildren( data.viewItem, modelTable );
+
+		conversionApi.updateConversionResult( modelTable, data );
+	}
+}
+
+export function getViewTableFromFigure( figureView ) {
+	if ( figureView.is( 'element', 'table' ) ) {
+		return figureView;
+	}
+
+	const figureChildren = [];
+
+	for ( const figureChild of figureView.getChildren() ) {
+		figureChildren.push( figureChild );
+
+		if ( figureChild.is( 'element' ) ) {
+			figureChildren.push( ...figureChild.getChildren() );
+		}
+	}
+
+	return figureChildren.find( viewChild => viewChild.is( 'element', 'table' ) );
+}

--- a/packages/ckeditor5-table/src/tablecaption/tablecaptionediting.js
+++ b/packages/ckeditor5-table/src/tablecaption/tablecaptionediting.js
@@ -58,20 +58,18 @@ export default class TableCaptionEditing extends Plugin {
 			.add( viewFigureToModel() );
 
 		// Model -> view converter for the data pipeline.
+		editor.conversion.for( 'dataDowncast' ).elementToElement( {
+			model: 'caption',
+			view: ( modelElement, { writer } ) => {
+				if ( !isTable( modelElement.parent ) ) {
+					return null;
+				}
 
-		// editor.conversion.for( 'dataDowncast' ).elementToElement( {
-		// 	model: 'caption',
-		// 	view: ( modelElement, { writer } ) => {
-		// 		if ( !isTable( modelElement.parent ) ) {
-		// 			return null;
-		// 		}
-
-		// 		return writer.createContainerElement( 'figcaption' );
-		// 	}
-		// } );
+				return writer.createContainerElement( 'figcaption' );
+			}
+		} );
 
 		// Model -> view converter for the editing pipeline.
-
 		editor.conversion.for( 'editingDowncast' ).elementToElement( {
 			model: 'caption',
 			view: ( modelElement, { writer } ) => {

--- a/packages/ckeditor5-table/src/tableediting.js
+++ b/packages/ckeditor5-table/src/tableediting.js
@@ -152,6 +152,7 @@ export default class TableEditing extends Plugin {
 		editor.commands.add( 'selectTableRow', new SelectRowCommand( editor ) );
 		editor.commands.add( 'selectTableColumn', new SelectColumnCommand( editor ) );
 
+		// FIXME: Fix postfixers :D
 		injectTableHeadingRowsRefreshPostFixer( model );
 		injectTableLayoutPostFixer( model );
 		injectTableCellRefreshPostFixer( model, editor.editing.mapper );

--- a/packages/ckeditor5-table/src/tableediting.js
+++ b/packages/ckeditor5-table/src/tableediting.js
@@ -9,7 +9,7 @@
 
 import { Plugin } from 'ckeditor5/src/core';
 
-import upcastTable, { ensureParagraphInTableCell, skipEmptyTableRow } from './converters/upcasttable';
+import upcastTable, { ensureParagraphInTableCell, skipEmptyTableRow, upcastFigureWithTable } from './converters/upcasttable';
 import {
 	convertParagraphInTableCell,
 	downcastInsertCell,
@@ -91,6 +91,9 @@ export default class TableEditing extends Plugin {
 			}
 		} );
 
+		// Figure conversion.
+		conversion.for( 'upcast' ).add( upcastFigureWithTable() );
+
 		// Table conversion.
 		conversion.for( 'upcast' ).add( upcastTable() );
 
@@ -113,7 +116,7 @@ export default class TableEditing extends Plugin {
 		conversion.for( 'editingDowncast' ).add( downcastInsertCell() );
 
 		// Duplicates code - needed to properly refresh paragraph inside a table cell.
-		editor.conversion.for( 'editingDowncast' ).elementToElement( {
+		conversion.for( 'editingDowncast' ).elementToElement( {
 			model: 'paragraph',
 			view: convertParagraphInTableCell,
 			converterPriority: 'high'
@@ -152,7 +155,6 @@ export default class TableEditing extends Plugin {
 		editor.commands.add( 'selectTableRow', new SelectRowCommand( editor ) );
 		editor.commands.add( 'selectTableColumn', new SelectColumnCommand( editor ) );
 
-		// FIXME: Fix postfixers :D
 		injectTableHeadingRowsRefreshPostFixer( model );
 		injectTableLayoutPostFixer( model );
 		injectTableCellRefreshPostFixer( model, editor.editing.mapper );

--- a/packages/ckeditor5-table/src/tablewalker.js
+++ b/packages/ckeditor5-table/src/tablewalker.js
@@ -212,7 +212,8 @@ export default class TableWalker {
 		const row = this._table.getChild( this._row );
 
 		// Iterator is done when there's no row (table ended) or the row is after `endRow` limit.
-		if ( !row || this._isOverEndRow() ) {
+		// We assume here that any non-row element might happen at the end of the table.
+		if ( !row || !row.is( 'element', 'tableRow' ) || this._isOverEndRow() ) {
 			return { done: true };
 		}
 

--- a/packages/ckeditor5-table/tests/tablecaption/tablecaptionediting.js
+++ b/packages/ckeditor5-table/tests/tablecaption/tablecaptionediting.js
@@ -10,7 +10,7 @@ import { getData as getModelData, setData as setModelData } from '@ckeditor/cked
 import TableCaptionEditing from '../../src/tablecaption/tablecaptionediting';
 import TableEditing from '../../src/tableediting';
 
-describe.only( 'TableCaptionEditing', () => {
+describe( 'TableCaptionEditing', () => {
 	let editor, model;
 
 	beforeEach( () => {
@@ -54,9 +54,7 @@ describe.only( 'TableCaptionEditing', () => {
 								'<paragraph>foobar</paragraph>' +
 							'</tableCell>' +
 						'</tableRow>' +
-						'<caption>' +
-							'Foo caption' +
-						'</caption>' +
+						'<caption>Foo caption</caption>' +
 					'</table>'
 				);
 
@@ -69,9 +67,7 @@ describe.only( 'TableCaptionEditing', () => {
 								'</tr>' +
 							'</tbody>' +
 						'</table>' +
-						'<figcaption>' +
-							'Foo caption' +
-						'</figcaption>' +
+						'<figcaption>Foo caption</figcaption>' +
 					'</figure>'
 				);
 			} );
@@ -136,8 +132,7 @@ describe.only( 'TableCaptionEditing', () => {
 					) );
 			} );
 
-			// eslint-disable-next-line max-len
-			it( 'should convert a table inside <figure> with <figcaption> preceding the table - <figcaption> has higher priority', () => {
+			it( 'should convert a doubled captions', () => {
 				editor.setData(
 					'<figure class="table">' +
 						'<table>' +
@@ -156,14 +151,14 @@ describe.only( 'TableCaptionEditing', () => {
 
 				expect( getModelData( model, { withoutSelection: true } ) )
 					.to.equal( String(
-						'<paragraph>Foo caption</paragraph>' +
 						'<table>' +
 							'<tableRow>' +
 								'<tableCell>' +
-									'foobar' +
+									'<paragraph>foobar</paragraph>' +
 								'</tableCell>' +
 							'</tableRow>' +
 							'<caption>Bar caption</caption>' +
+							'<caption>Foo caption</caption>' +
 						'</table>'
 					) );
 			} );

--- a/packages/ckeditor5-table/tests/tablecaption/tablecaptionediting.js
+++ b/packages/ckeditor5-table/tests/tablecaption/tablecaptionediting.js
@@ -1,0 +1,172 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
+import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+
+import TableCaptionEditing from '../../src/tablecaption/tablecaptionediting';
+import TableEditing from '../../src/tableediting';
+
+describe.only( 'TableCaptionEditing', () => {
+	let editor, model;
+
+	beforeEach( () => {
+		return VirtualTestEditor
+			.create( {
+				plugins: [ TableEditing, TableCaptionEditing, Paragraph, TableCaptionEditing ]
+			} )
+			.then( newEditor => {
+				editor = newEditor;
+
+				model = editor.model;
+			} );
+	} );
+
+	afterEach( () => {
+		editor.destroy();
+	} );
+
+	it( 'should have pluginName', () => {
+		expect( TableCaptionEditing.pluginName ).to.equal( 'TableCaptionEditing' );
+	} );
+
+	it( 'should set proper schema rules', () => {
+		// Table:
+		expect( model.schema.isRegistered( 'table' ) ).to.be.true;
+		expect( model.schema.isObject( 'table' ) ).to.be.true;
+		expect( model.schema.isBlock( 'table' ) ).to.be.true;
+
+		expect( model.schema.checkChild( [ '$root' ], 'table' ) ).to.be.true;
+		expect( model.schema.checkAttribute( [ '$root', 'table' ], 'headingRows' ) ).to.be.true;
+		expect( model.schema.checkAttribute( [ '$root', 'table' ], 'headingColumns' ) ).to.be.true;
+	} );
+
+	describe( 'conversion in data pipeline', () => {
+		describe( 'model to view', () => {
+			it( 'should convert to figure > figcaption + table', () => {
+				setModelData( model,
+					'<table>' +
+						'<caption>' +
+							'Foo caption' +
+						'</caption>' +
+						'<tableRow>' +
+							'<tableCell>' +
+								'<paragraph>foobar</paragraph>' +
+							'</tableCell>' +
+						'</tableRow>' +
+					'</table>'
+				);
+
+				expect( editor.getData() ).to.equal(
+					'<figure class="table">' +
+						'<table>' +
+							'<tbody>' +
+								'<tr>' +
+									'<td>foobar</td>' +
+								'</tr>' +
+							'</tbody>' +
+						'</table>' +
+						'<figcaption>' +
+							'Foo caption' +
+						'</figcaption>' +
+					'</figure>'
+				);
+			} );
+		} );
+
+		describe( 'view to model', () => {
+			it( 'should convert a table with <caption>', () => {
+				editor.setData(
+					'<table>' +
+						'<caption>Foo caption</caption>' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>' +
+									'foobar' +
+								'</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>'
+				);
+
+				expect( getModelData( model, { withoutSelection: true } ) )
+					.to.equal( String(
+						'<table>' +
+							'<caption>Foo caption</caption>' +
+							'<tableRow>' +
+								'<tableCell>' +
+									'<paragraph>foobar</paragraph>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>'
+					)	);
+			} );
+
+			it( 'should convert a table inside <figure> with <figcaption> preceding the table', () => {
+				editor.setData(
+					'<figure class="table">' +
+						'<figcaption>Foo caption</figcaption>' +
+						'<table>' +
+							'<tbody>' +
+								'<tr>' +
+									'<td>' +
+										'foobar' +
+									'</td>' +
+								'</tr>' +
+							'</tbody>' +
+						'</table>' +
+					'</figure>'
+				);
+
+				expect( getModelData( model, { withoutSelection: true } ) )
+					.to.equal( String(
+						'<table>' +
+							'<caption>' +
+								'Foo caption' +
+							'</caption>' +
+							'<tableRow>' +
+								'<tableCell>' +
+									'<paragraph>foobar</paragraph>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>'
+					) );
+			} );
+
+			// eslint-disable-next-line max-len
+			it( 'should convert a table inside <figure> with <figcaption> preceding the table - <figcaption> has higher priority', () => {
+				editor.setData(
+					'<figure class="table">' +
+						'<figcaption>Foo caption</figcaption>' +
+						'<table>' +
+							'<caption>Bar caption</caption>' +
+							'<tbody>' +
+								'<tr>' +
+									'<td>' +
+										'foobar' +
+									'</td>' +
+								'</tr>' +
+							'</tbody>' +
+						'</table>' +
+					'</figure>'
+				);
+
+				expect( getModelData( model, { withoutSelection: true } ) )
+					.to.equal( String(
+						'<paragraph>Foo caption</paragraph>' +
+						'<table>' +
+							'<caption>Bar caption</caption>' +
+							'<tableRow>' +
+								'<tableCell>' +
+									'foobar' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>'
+					) );
+			} );
+		} );
+	} );
+} );

--- a/packages/ckeditor5-table/tests/tablecaption/tablecaptionediting.js
+++ b/packages/ckeditor5-table/tests/tablecaption/tablecaptionediting.js
@@ -46,17 +46,17 @@ describe.only( 'TableCaptionEditing', () => {
 
 	describe( 'conversion in data pipeline', () => {
 		describe( 'model to view', () => {
-			it( 'should convert to figure > figcaption + table', () => {
+			it( 'should convert to figure > table + figcaption', () => {
 				setModelData( model,
 					'<table>' +
-						'<caption>' +
-							'Foo caption' +
-						'</caption>' +
 						'<tableRow>' +
 							'<tableCell>' +
 								'<paragraph>foobar</paragraph>' +
 							'</tableCell>' +
 						'</tableRow>' +
+						'<caption>' +
+							'Foo caption' +
+						'</caption>' +
 					'</table>'
 				);
 
@@ -95,12 +95,12 @@ describe.only( 'TableCaptionEditing', () => {
 				expect( getModelData( model, { withoutSelection: true } ) )
 					.to.equal( String(
 						'<table>' +
-							'<caption>Foo caption</caption>' +
 							'<tableRow>' +
 								'<tableCell>' +
 									'<paragraph>foobar</paragraph>' +
 								'</tableCell>' +
 							'</tableRow>' +
+							'<caption>Foo caption</caption>' +
 						'</table>'
 					)	);
 			} );
@@ -108,7 +108,6 @@ describe.only( 'TableCaptionEditing', () => {
 			it( 'should convert a table inside <figure> with <figcaption> preceding the table', () => {
 				editor.setData(
 					'<figure class="table">' +
-						'<figcaption>Foo caption</figcaption>' +
 						'<table>' +
 							'<tbody>' +
 								'<tr>' +
@@ -118,20 +117,21 @@ describe.only( 'TableCaptionEditing', () => {
 								'</tr>' +
 							'</tbody>' +
 						'</table>' +
+						'<figcaption>Foo caption</figcaption>' +
 					'</figure>'
 				);
 
 				expect( getModelData( model, { withoutSelection: true } ) )
 					.to.equal( String(
 						'<table>' +
-							'<caption>' +
-								'Foo caption' +
-							'</caption>' +
 							'<tableRow>' +
 								'<tableCell>' +
 									'<paragraph>foobar</paragraph>' +
 								'</tableCell>' +
 							'</tableRow>' +
+							'<caption>' +
+								'Foo caption' +
+							'</caption>' +
 						'</table>'
 					) );
 			} );
@@ -140,7 +140,6 @@ describe.only( 'TableCaptionEditing', () => {
 			it( 'should convert a table inside <figure> with <figcaption> preceding the table - <figcaption> has higher priority', () => {
 				editor.setData(
 					'<figure class="table">' +
-						'<figcaption>Foo caption</figcaption>' +
 						'<table>' +
 							'<caption>Bar caption</caption>' +
 							'<tbody>' +
@@ -151,6 +150,7 @@ describe.only( 'TableCaptionEditing', () => {
 								'</tr>' +
 							'</tbody>' +
 						'</table>' +
+						'<figcaption>Foo caption</figcaption>' +
 					'</figure>'
 				);
 
@@ -158,12 +158,12 @@ describe.only( 'TableCaptionEditing', () => {
 					.to.equal( String(
 						'<paragraph>Foo caption</paragraph>' +
 						'<table>' +
-							'<caption>Bar caption</caption>' +
 							'<tableRow>' +
 								'<tableCell>' +
 									'foobar' +
 								'</tableCell>' +
 							'</tableRow>' +
+							'<caption>Bar caption</caption>' +
 						'</table>'
 					) );
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (table): Added support for captions (`figure > figcaption + table` and `table > caption`). Closes #9084.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
