### PR TITLE
Decreased the size of output log from web crawler

### DIFF
--- a/scripts/web-crawler/spinner.js
+++ b/scripts/web-crawler/spinner.js
@@ -16,7 +16,6 @@ const ora = require( 'ora' );
  */
 function createSpinner() {
 	return ora( {
-		indent: 2,
 		spinner: {
 			frames: [ '⣾', '⣷', '⣯', '⣟', '⡿', '⢿', '⣻', '⣽' ]
 		}

--- a/scripts/web-crawler/utils.js
+++ b/scripts/web-crawler/utils.js
@@ -25,6 +25,30 @@ function getBaseUrl( url ) {
 }
 
 /**
+ * Extracts first line from error message.
+ *
+ * @param {String} message Error message.
+ * @returns {String}
+ */
+function getFirstLineFromErrorMessage( message ) {
+	return message.split( '\n' ).shift();
+}
+
+/**
+ * Checks, if provided string is a valid URL utilizing the HTTP or HTTPS protocols.
+ *
+ * @param {String} url The URL to validate.
+ * @returns {Boolean}
+ */
+function isUrlValid( url ) {
+	try {
+		return [ 'http:', 'https:' ].includes( new URL( url ).protocol );
+	} catch ( error ) {
+		return false;
+	}
+}
+
+/**
  * Parses CLI arguments and prepares configuration for the crawler.
  *
  * @param {Array.<String>} args CLI arguments and options.
@@ -35,6 +59,7 @@ function getBaseUrl( url ) {
  * to not exclude anything.
  * @returns {Number} options.concurrency Number of concurrent pages (browser tabs) to be used during crawling. By default all
  * links are opened one by one, sequentially (concurrency is 1).
+ * @returns {Boolean} options.quit Terminates the scan as soon as an error is found. False (off) by default.
  */
 function parseArguments( args ) {
 	const config = {
@@ -47,14 +72,16 @@ function parseArguments( args ) {
 
 		boolean: [
 			'docs',
-			'manual'
+			'manual',
+			'quit'
 		],
 
 		alias: {
 			u: 'url',
 			d: 'depth',
 			e: 'exclusions',
-			c: 'concurrency'
+			c: 'concurrency',
+			q: 'quit'
 		}
 	};
 
@@ -91,6 +118,10 @@ function parseArguments( args ) {
 		throw new Error( 'Missing required --url argument.' );
 	}
 
+	if ( !isUrlValid( options.url ) ) {
+		throw new Error( 'Provided --url argument is not a valid URL.' );
+	}
+
 	return {
 		url: options.url,
 		depth: options.depth ?
@@ -101,7 +132,8 @@ function parseArguments( args ) {
 			[],
 		concurrency: options.concurrency ?
 			Number( options.concurrency ) :
-			1
+			1,
+		quit: Boolean( options.quit )
 	};
 }
 
@@ -117,6 +149,8 @@ function toArray( data ) {
 
 module.exports = {
 	getBaseUrl,
+	getFirstLineFromErrorMessage,
+	isUrlValid,
 	parseArguments,
 	toArray
 };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other: Decreased the size of output log from web crawler. Closes #9062.

Feature: New CLI switch `--quit` (`-q`) to terminate the web crawler scan as soon as the first error is found.

---

### Additional information

From now on, only the first line of the error message will be displayed. My observations shows, that it is completely sufficient and it helps to quickly find out the cause of the error, especially if the log contains a lot of entries.

I chose **not to add** a "verbose" CLI switch, which would display the entire call stack with an error, as I found it of little use. It is certainly not needed to integrate the web crawler with CI, which we are focusing on now.

Instead, I added a new switch `--quit` (`-q`) so that we can finish scanning as soon as the first error is detected. This CLI switch will shorten the _check → correct → check_ cycle when fixing errors.

Other than that, there are also a few minor visual tweaks in the output log presentation. Some errors are now merged together to take up less space. Only the `host` part from the URL is shown in case of an error related to resource download.

Example:

![merged-log-entries](https://user-images.githubusercontent.com/56868128/110468722-f6646d00-80d8-11eb-8b97-8d4bd3d7ec38.png)
