### PR TITLE
Updated docs for web crawler and better navigation detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "popper": "^1.0.1",
     "postcss-loader": "^3.0.0",
     "progress-bar-webpack-plugin": "^2.1.0",
-    "puppeteer": "^5.5.0",
+    "puppeteer": "^8.0.0",
     "raw-loader": "^4.0.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "raw-loader": "^4.0.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "strip-ansi": "^6.0.0",
     "style-loader": "^1.2.1",
     "stylelint": "^13.5.0",
     "stylelint-config-ckeditor5": "^2.0.0",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Updated docs for web crawler. Closes #9171.

Internal: Better navigation detection in web crawler.

Internal: Bumped `puppeteer` version to `^8.0.0`.
