### PR TITLE
Fixing target=_blank duplicates after clicking on it in the documenta…

### DIFF
--- a/packages/ckeditor5-link/src/linkediting.js
+++ b/packages/ckeditor5-link/src/linkediting.js
@@ -516,6 +516,7 @@ export default class LinkEditing extends Plugin {
 // @param {module:utils/collection~Collection} manualDecorators
 function removeLinkAttributesFromSelection( writer, manualDecorators ) {
 	writer.removeSelectionAttribute( 'linkHref' );
+	writer.removeSelectionAttribute( 'linkTarget' );
 
 	for ( const decorator of manualDecorators ) {
 		writer.removeSelectionAttribute( decorator.id );

--- a/packages/ckeditor5-link/tests/linkediting.js
+++ b/packages/ckeditor5-link/tests/linkediting.js
@@ -158,6 +158,22 @@ describe( 'LinkEditing', () => {
 			expect( [ ...model.document.selection.getAttributeKeys() ] ).to.be.empty;
 		} );
 
+		it( 'should remove linkTarget attribute when pasting a link', () => {
+			editor.model.schema.extend( '$text', { allowAttributes: 'linkTarget' } );
+
+			setModelData( model, '<paragraph>foo[]</paragraph>' );
+
+			model.change( writer => {
+				model.insertContent( writer.createText( 'INSERTED', { linkHref: 'ckeditor.com', linkTarget: '_blank' } ) );
+			} );
+
+			expect( getModelData( model ) ).to.equal(
+				'<paragraph>foo<$text linkHref="ckeditor.com" linkTarget="_blank">INSERTED</$text>[]</paragraph>'
+			);
+
+			expect( [ ...model.document.selection.getAttributeKeys() ] ).to.be.empty;
+		} );
+
 		it( 'should remove all attributes starting with "link" (e.g. decorator attributes) when pasting a link', () => {
 			setModelData( model, '<paragraph>foo[]</paragraph>' );
 


### PR DESCRIPTION
…tion example.

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (link): Fixing target=_blank duplicates after clicking on it in the documentation. Closes #8462.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
