### PR TITLE
Fix (ckeditor5-core): check that command exists in multicommand execute

### DIFF
--- a/packages/ckeditor5-core/src/multicommand.js
+++ b/packages/ckeditor5-core/src/multicommand.js
@@ -63,7 +63,7 @@ export default class MultiCommand extends Command {
 	execute( ...args ) {
 		const command = this._getFirstEnabledCommand();
 
-		return command.execute( args );
+		return command != null && command.execute( args );
 	}
 
 	/**


### PR DESCRIPTION
`_getFirstEnabledCommand` may return `undefined`, but `execute` does not check if returned value is defined.

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._

Not encountered as a bug, but found will creating Typescript typings.