### PR TITLE
fix: autosave plugin not ignoring `transparent` type events

### DIFF
--- a/packages/ckeditor5-autosave/src/autosave.js
+++ b/packages/ckeditor5-autosave/src/autosave.js
@@ -150,8 +150,14 @@ export default class Autosave extends Plugin {
 
 		this._pendingActions = editor.plugins.get( PendingActions );
 
-		this.listenTo( doc, 'change:data', () => {
+		this.listenTo( doc, 'change:data', (_e, batch) => {
 			if ( !this._saveCallbacks.length ) {
+				return;
+			}
+			
+			// If the change is from another collaborative session from another user
+			// don't autosave.
+			if ( batch.type === 'transparent') {
 				return;
 			}
 

--- a/packages/ckeditor5-autosave/src/autosave.js
+++ b/packages/ckeditor5-autosave/src/autosave.js
@@ -154,7 +154,7 @@ export default class Autosave extends Plugin {
 			if ( !this._saveCallbacks.length ) {
 				return;
 			}
-			
+
 			// If the change is from another collaborative session from another user
 			// don't autosave.
 			if ( batch.type === 'transparent') {

--- a/packages/ckeditor5-autosave/src/autosave.js
+++ b/packages/ckeditor5-autosave/src/autosave.js
@@ -150,14 +150,14 @@ export default class Autosave extends Plugin {
 
 		this._pendingActions = editor.plugins.get( PendingActions );
 
-		this.listenTo( doc, 'change:data', (_e, batch) => {
+		this.listenTo( doc, 'change:data', ( _e, batch ) => {
 			if ( !this._saveCallbacks.length ) {
 				return;
 			}
 
 			// If the change is from another collaborative session from another user
 			// don't autosave.
-			if ( batch.type === 'transparent') {
+			if ( batch.type === 'transparent' ) {
 				return;
 			}
 


### PR DESCRIPTION
Fix: autosave plugin not ignoring `transparent` type events. Closes #9233.

---

### Additional information

Considering all transparent events can be safely ignored by autosave feature as mentioned in  https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_model_batch-Batch.html#member-type
