### PR TITLE
Conversion:elementToAttribute: do not overwrite an attribute that is already specified

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
@@ -940,7 +940,7 @@ function setAttributeOn( modelRange, modelAttribute, shallow, conversionApi ) {
 			continue;
 		}
 
-		// Do not overwrite the attribute if a node has already specified it. See #8921.
+		// Do not override the attribute if it's already present. See #8921.
 		if ( node.hasAttribute( modelAttribute.key ) ) {
 			continue;
 		}

--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
@@ -940,13 +940,16 @@ function setAttributeOn( modelRange, modelAttribute, shallow, conversionApi ) {
 			continue;
 		}
 
-		// Do not override the attribute if it's already present. See #8921.
+		// Mark the node as consumed even if the attribute will not be updated because it's in a valid context (schema)
+		// and would be converted if the attribute wouldn't be present. See #8921.
+		result = true;
+
+		// Do not override the attribute if it's already present.
 		if ( node.hasAttribute( modelAttribute.key ) ) {
 			continue;
 		}
 
 		conversionApi.writer.setAttribute( modelAttribute.key, modelAttribute.value, node );
-		result = true;
 	}
 
 	return result;

--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
@@ -872,7 +872,7 @@ function prepareToAttributeConverter( config, shallow ) {
 		const modelValue = typeof config.model.value == 'function' ?
 			config.model.value( data.viewItem, conversionApi ) : config.model.value;
 
-		// Do not convert if attribute building function returned falsy value.
+		// Do not convert if the attribute building function returned a falsy value.
 		if ( modelValue === null ) {
 			return;
 		}
@@ -889,18 +889,18 @@ function prepareToAttributeConverter( config, shallow ) {
 			return;
 		}
 
-		// Since we are converting to attribute we need an range on which we will set the attribute.
-		// If the range is not created yet, we will create it.
+		// Since we are converting to attribute we need a range on which we will set the attribute.
+		// If the range is not created yet, let's create it by converting children of the current node first.
 		if ( !data.modelRange ) {
 			// Convert children and set conversion result as a current data.
 			data = Object.assign( data, conversionApi.convertChildren( data.viewItem, data.modelCursor ) );
 		}
 
-		// Set attribute on current `output`.
+		// Set the attribute (on nodes that allow it).
 		setAttributeOn( data.modelRange, { key: modelKey, value: modelValue }, shallow, conversionApi );
 
-		// Mark the node as consumed even if the attribute will not be updated because it's in a valid context (schema)
-		// and would be converted if the attribute wouldn't be present. See #9249.
+		// Consume the thing being converted regardless of whether setAttributeOn() was actually able
+		// to set the attribute. See #9249.
 		conversionApi.consumable.consume( data.viewItem, match.match );
 	};
 }
@@ -933,6 +933,7 @@ function onlyViewNameIsDefined( viewConfig, viewItem ) {
 function setAttributeOn( modelRange, modelAttribute, shallow, conversionApi ) {
 	// Set attribute on each item in range according to Schema.
 	for ( const node of Array.from( modelRange.getItems( { shallow } ) ) ) {
+		// Skip if not allowed.
 		if ( !conversionApi.schema.checkAttribute( node, modelAttribute.key ) ) {
 			continue;
 		}

--- a/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
@@ -474,6 +474,7 @@ describe( 'UpcastHelpers', () => {
 				);
 			} );
 
+			// See https://github.com/ckeditor/ckeditor5/pull/9249#issuecomment-813935851
 			it( 'should consume both elements even if the attribute from the most inner element will be used', () => {
 				upcastDispatcher.on( 'element:span', ( evt, data, conversionApi ) => {
 					const viewItem = data.viewItem;

--- a/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
@@ -473,6 +473,26 @@ describe( 'UpcastHelpers', () => {
 					'<$text fontColor="#0000ff" fontSize="11">Bar</$text>'
 				);
 			} );
+
+			it( 'should consume both elements even if the attribute from the most inner element will be used', () => {
+				upcastDispatcher.on( 'element:span', ( evt, data, conversionApi ) => {
+					const viewItem = data.viewItem;
+					const wasConsumed = conversionApi.consumable.consume( viewItem, {
+						styles: [ 'font-size' ]
+					} );
+
+					expect( wasConsumed, `span[fontSize=${ viewItem.getStyle( 'font-size' ) }]` ).to.equal( false );
+				}, { priority: 'lowest' } );
+
+				const viewElement = viewParse(
+					'<span style="font-size:9px;"><span style="font-size:11px;">Bar</span></span>'
+				);
+
+				expectResult(
+					viewElement,
+					'<$text fontSize="11">Bar</$text>'
+				);
+			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
+++ b/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
@@ -343,5 +343,60 @@ describe( 'FontColorEditing', () => {
 				'<p>foo<span style="color:rgb(10,20,30);">bar</span>o</p>'
 			);
 		} );
+
+		// #8921
+		describe( 'nested elements that will be converted into the fontColor attribute', () => {
+			it( 'should use the most inner value while converting nested font elements', () => {
+				const data = '<p><font color="#00ffff"><font color="#ff0000">foo</font></font></p>';
+
+				editor.setData( data );
+
+				expect( getModelData( doc ) ).to.equal(
+					'<paragraph><$text fontColor="#ff0000">[]foo</$text></paragraph>'
+				);
+				expect( editor.getData() ).to.equal(
+					'<p><span style="color:#ff0000;">foo</span></p>'
+				);
+			} );
+
+			it( 'should use the most inner value while converting a span with defined the color styles', () => {
+				const data = '<p><font color="#00ffff"><span style="color:#ff0000">foo</span></font></p>';
+
+				editor.setData( data );
+
+				expect( getModelData( doc ) ).to.equal(
+					'<paragraph><$text fontColor="#ff0000">[]foo</$text></paragraph>'
+				);
+				expect( editor.getData() ).to.equal(
+					'<p><span style="color:#ff0000;">foo</span></p>'
+				);
+			} );
+
+			it( 'should use the most inner value while converting the font element inside a span', () => {
+				const data = '<p><span style="color:#ff0000"><font color="#00ffff">foo</font></span></p>';
+
+				editor.setData( data );
+
+				expect( getModelData( doc ) ).to.equal(
+					'<paragraph><$text fontColor="#00ffff">[]foo</$text></paragraph>'
+				);
+				expect( editor.getData() ).to.equal(
+					'<p><span style="color:#00ffff;">foo</span></p>'
+				);
+			} );
+
+			it( 'should use the most inner value while converting nested spans with the color styles', () => {
+				const data = '<p><span style="color:#00ffff"><span style="color:#ff0000">foo</span></span></p>';
+
+				editor.setData( data );
+
+				expect( getModelData( doc ) ).to.equal(
+					'<paragraph><$text fontColor="#ff0000">[]foo</$text></paragraph>'
+				);
+				expect( editor.getData() ).to.equal(
+					'<p><span style="color:#ff0000;">foo</span></p>'
+				);
+			} );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-highlight/tests/highlightediting.js
+++ b/packages/ckeditor5-highlight/tests/highlightediting.js
@@ -54,11 +54,12 @@ describe( 'HighlightEditing', () => {
 			expect( editor.getData() ).to.equal( data );
 		} );
 
-		it( 'should convert only one defined marker classes', () => {
-			editor.setData( '<p>f<mark class="marker-green marker-yellow">o</mark>o</p>' );
+		// After closing #8921, converted will be the last class in the alphabetical order that matches the configuration options.
+		it( 'should convert only one class even if the marker has a few of them', () => {
+			editor.setData( '<p>f<mark class="marker-yellow marker-green">o</mark>o</p>' );
 
-			expect( getModelData( model ) ).to.equal( '<paragraph>[]f<$text highlight="greenMarker">o</$text>o</paragraph>' );
-			expect( editor.getData() ).to.equal( '<p>f<mark class="marker-green">o</mark>o</p>' );
+			expect( getModelData( model ) ).to.equal( '<paragraph>[]f<$text highlight="yellowMarker">o</$text>o</paragraph>' );
+			expect( editor.getData() ).to.equal( '<p>f<mark class="marker-yellow">o</mark>o</p>' );
 		} );
 
 		it( 'should not convert undefined marker classes', () => {

--- a/packages/ckeditor5-language/tests/textpartlanguageediting.js
+++ b/packages/ckeditor5-language/tests/textpartlanguageediting.js
@@ -82,6 +82,21 @@ describe( 'TextPartLanguageEditing', () => {
 
 			expect( editor.getData() ).to.equal( '<p><span lang="fr" dir="ltr">foo</span>bar</p>' );
 		} );
+
+		it( 'should respect nested element language ', () => {
+			editor.setData( '<p><span dir="rtl" lang="he">hebrew<span dir="ltr" lang="fr">french</span>hebrew</span></p>' );
+
+			expect( getModelData( model, { withoutSelection: true } ) )
+				.to.equal( '<paragraph>' +
+					'<$text language="he:rtl">hebrew</$text>' +
+					'<$text language="fr:ltr">french</$text>' +
+					'<$text language="he:rtl">hebrew</$text></paragraph>' );
+
+			expect( editor.getData() ).to.equal( '<p>' +
+				'<span lang="he" dir="rtl">hebrew</span>' +
+				'<span lang="fr" dir="ltr">french</span>' +
+				'<span lang="he" dir="rtl">hebrew</span></p>' );
+		} );
 	} );
 
 	describe( 'editing pipeline conversion', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): While setting attributes upon upcast conversion, don't override attributes that were already set. The correct behavior is to keep the "information" applied by the deepest nodes in the view tree as, in most cases, the deepest node will have precedence (e.g. inline style applied by the deepest node). Closes #8921.

---

Calling:

```js
editor.setData(`<span style="font-family:'helvetica';"> <span style="color:#0000ff;"> <span style="font-size:16px;font-family:'arial';color:#000000;"> aaa </span> </span> </span>`)
```

in the [all features manual test](http://localhost:8125/ckeditor5/tests/manual/all-features.html) with the following changes:

```diff
diff --git a/tests/manual/all-features.js b/tests/manual/all-features.js
index d40a704ce3..c1b8a76565 100644
--- a/tests/manual/all-features.js
+++ b/tests/manual/all-features.js
@@ -57,6 +57,13 @@ ClassicEditor
             SpecialCharacters, SpecialCharactersEssentials, WordCount,
             ImageUpload, CloudServices
         ],
+        fontSize: {
+            supportAllValues: true,
+            options: [ 10, 12, 14]
+        },
+        fontFamily: {
+            supportAllValues: true
+        },
         toolbar: [
             'heading',
             '|',
```

ends with:

![image](https://user-images.githubusercontent.com/2270764/111316741-cf231800-8663-11eb-9b07-19020cfb8df4.png)

So it looks like the PR fixes the issue.