### PR TITLE
Docs: markdown update.

### DIFF
--- a/packages/ckeditor5-autoformat/docs/features/autoformat.md
+++ b/packages/ckeditor5-autoformat/docs/features/autoformat.md
@@ -17,7 +17,7 @@ The following block formatting options are available:
 
 * {@link features/lists Bulleted list} &ndash; Start a line with `*` or `-` followed by a space.
 * {@link features/lists Numbered list} &ndash; Start a line with `1.` or `1)` followed by a space.
-* {@link features/todo-lists To-do list} &ndash; Start a line with `[ ]` or `[x]` followed by a space for an unchecked or checked item respectively.
+* {@link features/todo-lists To-do list} &ndash; Start a line with `[ ]` or `[x]` followed by a space to insert an unchecked or checked list item, respectively.
 * {@link features/headings Headings} &ndash; Start a line with `#` or `##` or `###` followed by a space to create a heading 1, heading 2 or heading 3 (up to heading 6 if {@link module:heading/heading~HeadingConfig#options} defines more headings).
 * {@link features/block-quote Block quote} &ndash; Start a line with `>` followed by a space.
 * {@link features/code-blocks Code block} &ndash; Start a line with `` ``` ``.

--- a/packages/ckeditor5-autoformat/docs/features/autoformat.md
+++ b/packages/ckeditor5-autoformat/docs/features/autoformat.md
@@ -17,7 +17,7 @@ The following block formatting options are available:
 
 * {@link features/lists Bulleted list} &ndash; Start a line with `*` or `-` followed by a space.
 * {@link features/lists Numbered list} &ndash; Start a line with `1.` or `1)` followed by a space.
-* {@link features/todo-lists To-do list} &ndash; Start a line with `[ ]` followed by a space.
+* {@link features/todo-lists To-do list} &ndash; Start a line with `[ ]` or `[x]` followed by a space for an unchecked or checked item respectively.
 * {@link features/headings Headings} &ndash; Start a line with `#` or `##` or `###` followed by a space to create a heading 1, heading 2 or heading 3 (up to heading 6 if {@link module:heading/heading~HeadingConfig#options} defines more headings).
 * {@link features/block-quote Block quote} &ndash; Start a line with `>` followed by a space.
 * {@link features/code-blocks Code block} &ndash; Start a line with `` ``` ``.

--- a/packages/ckeditor5-list/docs/features/todo-lists.md
+++ b/packages/ckeditor5-list/docs/features/todo-lists.md
@@ -8,7 +8,7 @@ order: 20
 
 The {@link module:list/todolist~TodoList to-do list} feature lets you create a list of interactive checkboxes with labels. It supports all features of regular lists so you can nest a to-do list together with {@link features/lists bulleted and numbered lists} in any combination.
 
-To-do lists can be introduced using the dedicated toolbar button. Thanks to the integration with the {@link features/autoformat autoformatting feature}, they can also be added with Markdown code &mdash; simply start a line with `[ ]` followed by a space.
+To-do lists can be introduced using the dedicated toolbar button. Thanks to the integration with the {@link features/autoformat autoformatting feature}, they can also be added with Markdown code &mdash; simply start a line with `[ ]` or `[x]` followed by a space to insert an unchecked or checked item respectively.
 
 ## Demo
 

--- a/packages/ckeditor5-list/docs/features/todo-lists.md
+++ b/packages/ckeditor5-list/docs/features/todo-lists.md
@@ -8,7 +8,7 @@ order: 20
 
 The {@link module:list/todolist~TodoList to-do list} feature lets you create a list of interactive checkboxes with labels. It supports all features of regular lists so you can nest a to-do list together with {@link features/lists bulleted and numbered lists} in any combination.
 
-To-do lists can be introduced using the dedicated toolbar button. Thanks to the integration with the {@link features/autoformat autoformatting feature}, they can also be added with Markdown code &mdash; simply start a line with `[ ]` or `[x]` followed by a space to insert an unchecked or checked item respectively.
+To-do lists can be introduced using the dedicated toolbar button. Thanks to the integration with the {@link features/autoformat autoformatting feature}, they can also be added with Markdown code. Simply start a line with `[ ]` or `[x]` followed by a space to insert an unchecked or checked list item, respectively.
 
 ## Demo
 

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -91,10 +91,7 @@ ClassicEditor
 	This means that advanced formatting like list styles, table styles or page break markers will be stripped in the effecting data. These are not supported by Markdown and therefore cannot be converted from HTML to Markdown.
 </info-box>
 
-While the Markdown plugin is stable and ready to use, some issues were reported for it. Feel free to upvote 👍&nbsp; them on GitHub if they are important for you:
-
-* The horizontal rule is not yet supported by the {@link features/autoformat autoformatting} feature but it gets output to Markdown nevertheless if inserted using the toolbar button. GitHub issue: [#5720](https://github.com/ckeditor/ckeditor5/issues/5720).
-* Pasting Markdown-formatted content does not automatically convert the pasted syntax markers into properly formatted content. GitHub issues: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322).
+While the Markdown plugin is stable and ready to use, pasting Markdown-formatted content does not automatically convert the pasted syntax markers into properly formatted content. GitHub issues: [#2321](https://github.com/ckeditor/ckeditor5/issues/2321), [#2322](https://github.com/ckeditor/ckeditor5/issues/2322). Feel free to upvote 👍&nbsp; this on GitHub if you would like to see this introduced.
 
 ## Contribute
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (list). Adding Markdown marker information. Closes #9281 

Docs (autoformat).  Adding Markdown marker information.

Docs (markdown-gfm). Removing known issues information. Closes #9283

---

### Additional information

New marker `[x]` information added to the guides. Removed outdated horizontal line information from guide.