### PR TITLE
`DataController#toView()` should have a default value for the `options` parameter

### DIFF
--- a/packages/ckeditor5-engine/src/controller/datacontroller.js
+++ b/packages/ckeditor5-engine/src/controller/datacontroller.js
@@ -205,7 +205,7 @@ export default class DataController {
 	 *
 	 * @param {module:engine/model/element~Element|module:engine/model/documentfragment~DocumentFragment} modelElementOrFragment
 	 * Element whose content will be stringified.
-	 * @param {Object} [options] Additional configuration passed to the conversion process.
+	 * @param {Object} [options={}] Additional configuration passed to the conversion process.
 	 * @returns {String} Output data.
 	 */
 	stringify( modelElementOrFragment, options = {} ) {

--- a/packages/ckeditor5-engine/src/controller/datacontroller.js
+++ b/packages/ckeditor5-engine/src/controller/datacontroller.js
@@ -208,7 +208,7 @@ export default class DataController {
 	 * @param {Object} [options] Additional configuration passed to the conversion process.
 	 * @returns {String} Output data.
 	 */
-	stringify( modelElementOrFragment, options ) {
+	stringify( modelElementOrFragment, options = {} ) {
 		// Model -> view.
 		const viewDocumentFragment = this.toView( modelElementOrFragment, options );
 
@@ -228,7 +228,7 @@ export default class DataController {
 	 * {@link module:engine/conversion/downcastdispatcher~DowncastConversionApi#options} during the conversion process.
 	 * @returns {module:engine/view/documentfragment~DocumentFragment} Output view DocumentFragment.
 	 */
-	toView( modelElementOrFragment, options ) {
+	toView( modelElementOrFragment, options = {} ) {
 		const viewDocument = this.viewDocument;
 		const viewWriter = this._viewWriter;
 

--- a/packages/ckeditor5-engine/src/controller/datacontroller.js
+++ b/packages/ckeditor5-engine/src/controller/datacontroller.js
@@ -205,7 +205,7 @@ export default class DataController {
 	 *
 	 * @param {module:engine/model/element~Element|module:engine/model/documentfragment~DocumentFragment} modelElementOrFragment
 	 * Element whose content will be stringified.
-	 * @param {Object} [options={}] Additional configuration passed to the conversion process.
+	 * @param {Object} [options] Additional configuration passed to the conversion process.
 	 * @returns {String} Output data.
 	 */
 	stringify( modelElementOrFragment, options = {} ) {
@@ -224,7 +224,7 @@ export default class DataController {
 	 *
 	 * @param {module:engine/model/element~Element|module:engine/model/documentfragment~DocumentFragment} modelElementOrFragment
 	 * Element or document fragment whose content will be converted.
-	 * @param {Object} [options] Additional configuration that will be available through
+	 * @param {Object} [options={}] Additional configuration that will be available through
 	 * {@link module:engine/conversion/downcastdispatcher~DowncastConversionApi#options} during the conversion process.
 	 * @returns {module:engine/view/documentfragment~DocumentFragment} Output view DocumentFragment.
 	 */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): `DataController#toView()` should have a default value for the `options` parameter. Closes #9293.