### PR TITLE
Fixed Drag & Drop issues

### DIFF
--- a/packages/ckeditor5-clipboard/src/dragdrop.js
+++ b/packages/ckeditor5-clipboard/src/dragdrop.js
@@ -150,10 +150,10 @@ export default class DragDrop extends Plugin {
 		this._draggingUid = '';
 
 		/**
-		 * The reference to the view element that currently has a 'draggable' attribute set (it's set while dragging).
+		 * The reference to the model element that currently has a 'draggable' attribute set (it's set while dragging).
 		 *
 		 * @private
-		 * @type {module:engine/view/element~Element}
+		 * @type {module:engine/model/element~Element}
 		 */
 		this._draggableElement = null;
 
@@ -182,11 +182,21 @@ export default class DragDrop extends Plugin {
 		this._setupDropMarker();
 		this._setupDraggableAttributeHandling();
 
-		this.listenTo( editor, 'change:isReadOnly', ( evt, name, value ) => {
-			if ( value ) {
+		this.listenTo( editor, 'change:isReadOnly', ( evt, name, isReadOnly ) => {
+			if ( isReadOnly ) {
 				this._finalizeDragging( false );
 			}
 		} );
+
+		this.on( 'change:isEnabled', ( evt, name, isEnabled ) => {
+			if ( !isEnabled ) {
+				this._finalizeDragging( false );
+			}
+		} );
+
+		if ( env.isAndroid ) {
+			this.forceDisabled( 'noAndroidSupport' );
+		}
 	}
 
 	/**
@@ -218,10 +228,6 @@ export default class DragDrop extends Plugin {
 
 		// The handler for the drag start, it's responsible for setting data transfer object.
 		this.listenTo( viewDocument, 'dragstart', ( evt, data ) => {
-			if ( editor.isReadOnly ) {
-				return;
-			}
-
 			const selection = modelDocument.selection;
 
 			// Don't drag the editable element itself.
@@ -261,13 +267,19 @@ export default class DragDrop extends Plugin {
 
 			this._draggingUid = uid();
 
-			data.dataTransfer.effectAllowed = 'copyMove';
+			data.dataTransfer.effectAllowed = editor.isReadOnly || !this.isEnabled ? 'copy' : 'copyMove';
 			data.dataTransfer.setData( 'application/ckeditor5-dragging-uid', this._draggingUid );
 
 			const draggedSelection = model.createSelection( this._draggedRange.toRange() );
 			const content = editor.data.toView( model.getSelectedContent( draggedSelection ) );
 
 			viewDocument.fire( 'clipboardOutput', { dataTransfer: data.dataTransfer, content, method: evt.name } );
+
+			if ( editor.isReadOnly || !this.isEnabled ) {
+				this._draggedRange.detach();
+				this._draggedRange = null;
+				this._draggingUid = '';
+			}
 		}, { priority: 'low' } );
 
 		// The handler for finalizing drag & drop. It should be triggered always after dragging completed
@@ -278,9 +290,15 @@ export default class DragDrop extends Plugin {
 		}, { priority: 'low' } );
 
 		// Dragging over the editable.
-		this.listenTo( viewDocument, 'dragenter', () => {
-			if ( editor.isReadOnly ) {
+		this.listenTo( viewDocument, 'dragenter', ( evt, data ) => {
+			if ( editor.isReadOnly || !this.isEnabled ) {
 				return;
+			}
+
+			if ( data.target ) {
+				view.change( writer => {
+					writer.setAttribute( 'spellcheck', 'false', data.target.root );
+				} );
 			}
 
 			view.focus();
@@ -295,7 +313,7 @@ export default class DragDrop extends Plugin {
 
 		// Handler for moving dragged content over the target area.
 		this.listenTo( viewDocument, 'dragging', ( evt, data ) => {
-			if ( editor.isReadOnly ) {
+			if ( editor.isReadOnly || !this.isEnabled ) {
 				data.dataTransfer.dropEffect = 'none';
 
 				return;
@@ -305,10 +323,19 @@ export default class DragDrop extends Plugin {
 
 			const targetRange = findDropTargetRange( editor, data.targetRanges, data.target );
 
-			// This is content being dragged from other editor or content.
-			// Moving out of current editor instance is not possible until 'dragend' event case will be fixed.
+			// If this is content being dragged from other editor moving out of current editor instance
+			// is not possible until 'dragend' event case will be fixed.
 			if ( !this._draggedRange ) {
 				data.dataTransfer.dropEffect = 'copy';
+			}
+
+			// In Firefox it's already set and effectAllowed remains the same as originally set.
+			if ( !env.isGecko ) {
+				if ( data.dataTransfer.effectAllowed == 'copy' ) {
+					data.dataTransfer.dropEffect = 'copy';
+				} else if ( [ 'all', 'copyMove' ].includes( data.dataTransfer.effectAllowed ) ) {
+					data.dataTransfer.dropEffect = 'move';
+				}
 			}
 
 			/* istanbul ignore else */
@@ -380,7 +407,7 @@ export default class DragDrop extends Plugin {
 		const clipboardPipeline = this.editor.plugins.get( ClipboardPipeline );
 
 		clipboardPipeline.on( 'contentInsertion', ( evt, data ) => {
-			if ( this.editor.isReadOnly || data.method !== 'drop' ) {
+			if ( this.editor.isReadOnly || !this.isEnabled || data.method !== 'drop' ) {
 				return;
 			}
 
@@ -392,7 +419,7 @@ export default class DragDrop extends Plugin {
 		}, { priority: 'high' } );
 
 		clipboardPipeline.on( 'contentInsertion', ( evt, data ) => {
-			if ( this.editor.isReadOnly || data.method !== 'drop' ) {
+			if ( this.editor.isReadOnly || !this.isEnabled || data.method !== 'drop' ) {
 				return;
 			}
 
@@ -423,12 +450,12 @@ export default class DragDrop extends Plugin {
 		this.listenTo( viewDocument, 'mousedown', ( evt, data ) => {
 			// The lack of data can be caused by editor tests firing fake mouse events. This should not occur
 			// in real-life scenarios but this greatly simplifies editor tests that would otherwise fail a lot.
-			if ( editor.isReadOnly || !data ) {
+			if ( env.isAndroid || !data ) {
 				return;
 			}
 
 			// Check if this is mousedown over the widget (but not nested editable).
-			this._draggableElement = findDraggableWidget( data.target );
+			let draggableElement = findDraggableWidget( data.target );
 
 			// Note: There is a limitation that if there is more than a widget selected (widget and some text)
 			// and dragging starts on widget, then only a widget is dragged.
@@ -436,19 +463,22 @@ export default class DragDrop extends Plugin {
 			// If this was not a widget so we should check if we need to drag some text content.
 			// In Chrome set a 'draggable' attribute on closest editable to allow immediate dragging of the selected text range.
 			// In Firefox this is not needed. In Safari it makes the whole editable draggable (not just textual content).
-			if ( env.isBlink && !this._draggableElement && !viewDocument.selection.isCollapsed ) {
+			if ( env.isBlink && !draggableElement && !viewDocument.selection.isCollapsed ) {
 				const selectedElement = viewDocument.selection.getSelectedElement();
 
 				if ( !selectedElement || !isWidget( selectedElement ) ) {
-					this._draggableElement = viewDocument.selection.editableElement;
+					draggableElement = viewDocument.selection.editableElement;
 				}
 			}
 
-			if ( this._draggableElement ) {
+			if ( draggableElement ) {
 				view.change( writer => {
-					writer.setAttribute( 'draggable', 'true', this._draggableElement );
-					writer.setAttribute( 'spellcheck', 'false', this._draggableElement.root );
+					writer.setAttribute( 'draggable', 'true', draggableElement );
+					writer.setAttribute( 'spellcheck', 'false', draggableElement.root );
 				} );
+
+				// Keep the reference to the model element in case view element got removed while dragging.
+				this._draggableElement = editor.editing.mapper.toModelElement( draggableElement );
 			}
 		} );
 
@@ -464,17 +494,21 @@ export default class DragDrop extends Plugin {
 	 * @private
 	 */
 	_clearDraggableAttributes() {
-		if ( !this._draggableElement ) {
-			return;
-		}
+		const editing = this.editor.editing;
 
-		// Remove 'draggable' and 'spellcheck' attributes.
-		this.editor.editing.view.change( writer => {
-			writer.removeAttribute( 'draggable', this._draggableElement );
-			writer.removeAttribute( 'spellcheck', this._draggableElement.root );
+		editing.view.change( writer => {
+			// Remove 'draggable' attribute.
+			if ( this._draggableElement && this._draggableElement.root.rootName != '$graveyard' ) {
+				writer.removeAttribute( 'draggable', editing.mapper.toViewElement( this._draggableElement ) );
+			}
+
+			this._draggableElement = null;
+
+			// Remove 'spellcheck' attributes.
+			for ( const root of editing.view.document.roots ) {
+				writer.removeAttribute( 'spellcheck', root );
+			}
 		} );
-
-		this._draggableElement = null;
 	}
 
 	/**
@@ -578,7 +612,7 @@ export default class DragDrop extends Plugin {
 		}
 
 		// Delete moved content.
-		if ( moved ) {
+		if ( moved && !editor.isReadOnly && this.isEnabled ) {
 			model.deleteContent( model.createSelection( this._draggedRange ), { doNotAutoparagraph: true } );
 		}
 
@@ -769,7 +803,7 @@ function getFinalDropEffect( dataTransfer ) {
 		return dataTransfer.dropEffect;
 	}
 
-	return dataTransfer.effectAllowed == 'copyMove' ? 'move' : 'copy';
+	return [ 'all', 'copyMove' ].includes( dataTransfer.effectAllowed ) ? 'move' : 'copy';
 }
 
 // Returns a function wrapper that will trigger a function after a specified wait time.

--- a/packages/ckeditor5-clipboard/src/dragdrop.js
+++ b/packages/ckeditor5-clipboard/src/dragdrop.js
@@ -192,7 +192,9 @@ export default class DragDrop extends Plugin {
 
 		this.listenTo( editor, 'change:isReadOnly', ( evt, name, isReadOnly ) => {
 			if ( isReadOnly ) {
-				this._finalizeDragging( false );
+				this.forceDisabled( 'readOnlyMode' );
+			} else {
+				this.clearForceDisabled( 'readOnlyMode' );
 			}
 		} );
 
@@ -276,7 +278,7 @@ export default class DragDrop extends Plugin {
 
 			this._draggingUid = uid();
 
-			data.dataTransfer.effectAllowed = editor.isReadOnly || !this.isEnabled ? 'copy' : 'copyMove';
+			data.dataTransfer.effectAllowed = this.isEnabled ? 'copyMove' : 'copy';
 			data.dataTransfer.setData( 'application/ckeditor5-dragging-uid', this._draggingUid );
 
 			const draggedSelection = model.createSelection( this._draggedRange.toRange() );
@@ -284,7 +286,7 @@ export default class DragDrop extends Plugin {
 
 			viewDocument.fire( 'clipboardOutput', { dataTransfer: data.dataTransfer, content, method: evt.name } );
 
-			if ( editor.isReadOnly || !this.isEnabled ) {
+			if ( !this.isEnabled ) {
 				this._draggedRange.detach();
 				this._draggedRange = null;
 				this._draggingUid = '';
@@ -300,7 +302,7 @@ export default class DragDrop extends Plugin {
 
 		// Dragging over the editable.
 		this.listenTo( viewDocument, 'dragenter', () => {
-			if ( editor.isReadOnly || !this.isEnabled ) {
+			if ( !this.isEnabled ) {
 				return;
 			}
 
@@ -316,7 +318,7 @@ export default class DragDrop extends Plugin {
 
 		// Handler for moving dragged content over the target area.
 		this.listenTo( viewDocument, 'dragging', ( evt, data ) => {
-			if ( editor.isReadOnly || !this.isEnabled ) {
+			if ( !this.isEnabled ) {
 				data.dataTransfer.dropEffect = 'none';
 
 				return;
@@ -410,7 +412,7 @@ export default class DragDrop extends Plugin {
 		const clipboardPipeline = this.editor.plugins.get( ClipboardPipeline );
 
 		clipboardPipeline.on( 'contentInsertion', ( evt, data ) => {
-			if ( this.editor.isReadOnly || !this.isEnabled || data.method !== 'drop' ) {
+			if ( !this.isEnabled || data.method !== 'drop' ) {
 				return;
 			}
 
@@ -422,7 +424,7 @@ export default class DragDrop extends Plugin {
 		}, { priority: 'high' } );
 
 		clipboardPipeline.on( 'contentInsertion', ( evt, data ) => {
-			if ( this.editor.isReadOnly || !this.isEnabled || data.method !== 'drop' ) {
+			if ( !this.isEnabled || data.method !== 'drop' ) {
 				return;
 			}
 
@@ -613,7 +615,7 @@ export default class DragDrop extends Plugin {
 		}
 
 		// Delete moved content.
-		if ( moved && !editor.isReadOnly && this.isEnabled ) {
+		if ( moved && this.isEnabled ) {
 			model.deleteContent( model.createSelection( this._draggedRange ), { doNotAutoparagraph: true } );
 		}
 

--- a/packages/ckeditor5-clipboard/tests/dragdrop.js
+++ b/packages/ckeditor5-clipboard/tests/dragdrop.js
@@ -17,11 +17,11 @@ import HorizontalLine from '@ckeditor/ckeditor5-horizontal-line/src/horizontalli
 import ShiftEnter from '@ckeditor/ckeditor5-enter/src/shiftenter';
 import BlockQuote from '@ckeditor/ckeditor5-block-quote/src/blockquote';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { getData as getViewData, stringify as stringifyView } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
-import { env } from '@ckeditor/ckeditor5-utils';
 
 describe( 'Drag and Drop', () => {
 	let editorElement, editor, model, view, viewDocument, root, mapper, domConverter;
@@ -34,6 +34,26 @@ describe( 'Drag and Drop', () => {
 
 	it( 'has proper name', () => {
 		expect( DragDrop.pluginName ).to.equal( 'DragDrop' );
+	} );
+
+	it( 'should be disabled on Android', async () => {
+		env.isAndroid = true;
+
+		const editorElement = document.createElement( 'div' );
+		document.body.appendChild( editorElement );
+
+		const editor = await ClassicTestEditor.create( editorElement, {
+			plugins: [ DragDrop ]
+		} );
+
+		const plugin = editor.plugins.get( 'DragDrop' );
+
+		expect( plugin.isEnabled ).to.be.false;
+
+		await editor.destroy();
+		await editorElement.remove();
+
+		env.isAndroid = false;
 	} );
 
 	describe( 'dragging', () => {
@@ -80,6 +100,7 @@ describe( 'Drag and Drop', () => {
 			// Dragging.
 
 			targetPosition = model.createPositionAt( root.getChild( 0 ), 3 );
+			dataTransferMock.effectAllowed = 'copyMove';
 			fireDragging( dataTransferMock, targetPosition );
 			clock.tick( 100 );
 
@@ -91,6 +112,7 @@ describe( 'Drag and Drop', () => {
 			// Dragging.
 
 			targetPosition = model.createPositionAt( root.getChild( 0 ), 5 );
+			dataTransferMock.effectAllowed = 'copy';
 			fireDragging( dataTransferMock, targetPosition );
 			clock.tick( 100 );
 
@@ -101,6 +123,7 @@ describe( 'Drag and Drop', () => {
 
 			// Dropping.
 
+			dataTransferMock.effectAllowed = 'copyMove';
 			dataTransferMock.dropEffect = 'move';
 			targetPosition = model.createPositionAt( root.getChild( 0 ), 6 );
 			fireDrop( dataTransferMock, targetPosition );
@@ -202,6 +225,7 @@ describe( 'Drag and Drop', () => {
 			// Dragging.
 
 			targetPosition = model.createPositionAt( root.getChild( 0 ), 3 );
+			dataTransferMock.effectAllowed = 'copy';
 			fireDragging( dataTransferMock, targetPosition );
 			clock.tick( 100 );
 
@@ -622,6 +646,84 @@ describe( 'Drag and Drop', () => {
 			expect( getViewData( view ) ).to.equal( '<p>foobarfoo{}</p>' );
 		} );
 
+		it( 'should not allow dropping if the plugin is disabled', () => {
+			setModelData( model, '<paragraph>[foo]bar</paragraph>' );
+
+			const plugin = editor.plugins.get( 'DragDrop' );
+			const clock = sinon.useFakeTimers();
+			const dataTransferMock = createDataTransfer();
+			const spyClipboardOutput = sinon.spy();
+			const spyClipboardInput = sinon.spy();
+			let targetPosition;
+
+			viewDocument.on( 'clipboardOutput', ( event, data ) => spyClipboardOutput( data ) );
+			viewDocument.on( 'clipboardInput', ( event, data ) => spyClipboardInput( data ) );
+
+			fireDragStart( dataTransferMock );
+			expectDragStarted( dataTransferMock, 'foo', spyClipboardOutput );
+
+			// Dragging.
+
+			targetPosition = model.createPositionAt( root.getChild( 0 ), 3 );
+			fireDragging( dataTransferMock, targetPosition );
+			clock.tick( 100 );
+
+			expectDraggingMarker( targetPosition );
+			expect( getViewData( view, { renderUIElements: true } ) ).to.equal(
+				'<p>{foo}<span class="ck ck-clipboard-drop-target-position">\u2060<span></span>\u2060</span>bar</p>'
+			);
+
+			plugin.forceDisabled( 'test' );
+
+			// Dragging.
+
+			targetPosition = model.createPositionAt( root.getChild( 0 ), 5 );
+			fireDragging( dataTransferMock, targetPosition );
+			clock.tick( 100 );
+
+			expect( dataTransferMock.dropEffect ).to.equal( 'none' );
+			expect( model.markers.has( 'drop-target' ) ).to.be.false;
+			expect( getViewData( view, { renderUIElements: true } ) ).to.equal( '<p>{foo}bar</p>' );
+
+			plugin.clearForceDisabled( 'test' );
+			// Dropping.
+
+			dataTransferMock.dropEffect = 'move';
+			targetPosition = model.createPositionAt( root.getChild( 0 ), 6 );
+			fireDrop( dataTransferMock, targetPosition );
+			clock.tick( 100 );
+
+			expect( spyClipboardInput.called ).to.be.true;
+			expect( spyClipboardInput.firstCall.firstArg.method ).to.equal( 'drop' );
+			expect( spyClipboardInput.firstCall.firstArg.dataTransfer ).to.equal( dataTransferMock );
+
+			fireDragEnd( dataTransferMock );
+			expectFinalized();
+
+			expect( getModelData( model ) ).to.equal( '<paragraph>foobarfoo[]</paragraph>' );
+			expect( getViewData( view ) ).to.equal( '<p>foobarfoo{}</p>' );
+		} );
+
+		it( 'should do nothing if dragging on Android', () => {
+			env.isAndroid = true;
+
+			setModelData( model, '<paragraph>[foo]bar</paragraph>' );
+
+			const dataTransferMock = createDataTransfer();
+			const spyClipboardInput = sinon.spy();
+
+			viewDocument.on( 'clipboardInput', ( event, data ) => spyClipboardInput( data ) );
+
+			fireDragStart( dataTransferMock );
+
+			expect( dataTransferMock.getData( 'text/html' ) ).to.equal( 'foo' );
+			expect( dataTransferMock.effectAllowed ).to.equal( 'copyMove' );
+
+			expect( viewDocument.getRoot().hasAttribute( 'draggable' ) ).to.be.false;
+
+			env.isAndroid = false;
+		} );
+
 		describe( 'dragstart', () => {
 			it( 'should not start dragging if the selection is collapsed', () => {
 				setModelData( model, '<paragraph>foo[]bar</paragraph>' );
@@ -667,7 +769,7 @@ describe( 'Drag and Drop', () => {
 				expect( spyClipboardOutput.notCalled ).to.be.true;
 			} );
 
-			it( 'should not start dragging if the editor is read-only', () => {
+			it( 'should mark allowed effect as "copy" if the editor is read-only', () => {
 				setModelData( model, '<paragraph>[foo]bar</paragraph>' );
 
 				const dataTransferMock = createDataTransfer();
@@ -679,9 +781,9 @@ describe( 'Drag and Drop', () => {
 
 				fireDragStart( dataTransferMock );
 
-				expect( viewDocument.getRoot().hasAttribute( 'draggable' ) ).to.be.false;
-				expect( viewDocument.getRoot().hasAttribute( 'spellcheck' ) ).to.be.false;
-				expect( spyClipboardOutput.notCalled ).to.be.true;
+				expect( viewDocument.getRoot().hasAttribute( 'draggable' ) ).to.be.true;
+				expect( viewDocument.getRoot().hasAttribute( 'spellcheck' ) ).to.be.true;
+				expect( dataTransferMock.effectAllowed ).to.equal( 'copy' );
 			} );
 
 			it( 'should start dragging by grabbing the widget selection handle', () => {
@@ -1146,7 +1248,7 @@ describe( 'Drag and Drop', () => {
 			it( 'should focus the editor while dragging over the editable', () => {
 				const stubFocus = sinon.stub( view, 'focus' );
 
-				viewDocument.fire( 'dragenter' );
+				viewDocument.fire( 'dragenter', {} );
 
 				expect( stubFocus.calledOnce ).to.be.true;
 			} );
@@ -1159,6 +1261,15 @@ describe( 'Drag and Drop', () => {
 				viewDocument.fire( 'dragenter' );
 
 				expect( stubFocus.calledOnce ).to.be.false;
+			} );
+
+			it( 'should set "spellcheck" attribute on the entered root element', () => {
+				viewDocument.fire( 'dragenter', {
+					target: viewDocument.getRoot().getChild( 0 )
+				} );
+
+				expect( viewDocument.getRoot().hasAttribute( 'spellcheck' ) ).to.be.true;
+				expect( viewDocument.getRoot().getAttribute( 'spellcheck' ) ).to.equal( 'false' );
 			} );
 		} );
 

--- a/packages/ckeditor5-clipboard/tests/dragdrop.js
+++ b/packages/ckeditor5-clipboard/tests/dragdrop.js
@@ -782,7 +782,6 @@ describe( 'Drag and Drop', () => {
 				fireDragStart( dataTransferMock );
 
 				expect( viewDocument.getRoot().hasAttribute( 'draggable' ) ).to.be.true;
-				expect( viewDocument.getRoot().hasAttribute( 'spellcheck' ) ).to.be.true;
 				expect( dataTransferMock.effectAllowed ).to.equal( 'copy' );
 			} );
 
@@ -1165,6 +1164,7 @@ describe( 'Drag and Drop', () => {
 					'<table><tableRow><tableCell><paragraph>abc</paragraph></tableCell></tableRow></table>'
 				);
 
+				const clock = sinon.useFakeTimers();
 				const domNode = view.getDomRoot().querySelector( '.ck-widget__selection-handle' );
 				const widgetViewElement = viewDocument.getRoot().getChild( 1 );
 				const selectionHandleElement = widgetViewElement.getChild( 0 );
@@ -1184,6 +1184,7 @@ describe( 'Drag and Drop', () => {
 				expect( widgetViewElement.getAttribute( 'draggable' ) ).to.equal( 'true' );
 
 				viewDocument.fire( 'mouseup' );
+				clock.tick( 50 );
 
 				expect( widgetViewElement.hasAttribute( 'draggable' ) ).to.be.false;
 			} );
@@ -1194,6 +1195,7 @@ describe( 'Drag and Drop', () => {
 					'<horizontalLine></horizontalLine>'
 				);
 
+				const clock = sinon.useFakeTimers();
 				const widgetViewElement = viewDocument.getRoot().getChild( 1 );
 				const viewElement = widgetViewElement.getChild( 0 );
 				const domNode = domConverter.mapViewToDom( viewElement );
@@ -1213,13 +1215,51 @@ describe( 'Drag and Drop', () => {
 				expect( widgetViewElement.getAttribute( 'draggable' ) ).to.equal( 'true' );
 
 				viewDocument.fire( 'mouseup' );
+				clock.tick( 50 );
 
 				expect( widgetViewElement.hasAttribute( 'draggable' ) ).to.be.false;
+			} );
+
+			it( 'should do nothing on mouseup on android', () => {
+				env.isAndroid = true;
+
+				setModelData( model,
+					'<paragraph>[]foobar</paragraph>' +
+					'<horizontalLine></horizontalLine>'
+				);
+
+				const clock = sinon.useFakeTimers();
+				const widgetViewElement = viewDocument.getRoot().getChild( 1 );
+				const viewElement = widgetViewElement.getChild( 0 );
+				const domNode = domConverter.mapViewToDom( viewElement );
+
+				expect( viewElement.is( 'element', 'hr' ) ).to.be.true;
+
+				const eventData = {
+					domTarget: domNode,
+					target: viewElement,
+					domEvent: {},
+					preventDefault() {}
+				};
+
+				viewDocument.fire( 'mousedown', {
+					...eventData
+				} );
+
+				expect( widgetViewElement.hasAttribute( 'draggable' ) ).to.be.false;
+
+				viewDocument.fire( 'mouseup' );
+				clock.tick( 50 );
+
+				expect( widgetViewElement.hasAttribute( 'draggable' ) ).to.be.false;
+
+				env.isAndroid = false;
 			} );
 
 			it( 'should remove "draggable" attribute from editable element', () => {
 				setModelData( model, '<paragraph>[foo]bar</paragraph>' );
 
+				const clock = sinon.useFakeTimers();
 				const editableElement = viewDocument.getRoot();
 				const viewElement = editableElement.getChild( 0 );
 				const domNode = domConverter.mapViewToDom( viewElement );
@@ -1239,6 +1279,7 @@ describe( 'Drag and Drop', () => {
 				expect( editableElement.getAttribute( 'draggable' ) ).to.equal( 'true' );
 
 				viewDocument.fire( 'mouseup' );
+				clock.tick( 50 );
 
 				expect( editableElement.hasAttribute( 'draggable' ) ).to.be.false;
 			} );
@@ -1261,15 +1302,6 @@ describe( 'Drag and Drop', () => {
 				viewDocument.fire( 'dragenter' );
 
 				expect( stubFocus.calledOnce ).to.be.false;
-			} );
-
-			it( 'should set "spellcheck" attribute on the entered root element', () => {
-				viewDocument.fire( 'dragenter', {
-					target: viewDocument.getRoot().getChild( 0 )
-				} );
-
-				expect( viewDocument.getRoot().hasAttribute( 'spellcheck' ) ).to.be.true;
-				expect( viewDocument.getRoot().getAttribute( 'spellcheck' ) ).to.equal( 'false' );
 			} );
 		} );
 
@@ -1720,7 +1752,6 @@ describe( 'Drag and Drop', () => {
 		expect( dataTransferMock.effectAllowed ).to.equal( effectAllowed );
 
 		expect( viewDocument.getRoot().getAttribute( 'draggable' ) ).to.equal( 'true' );
-		expect( viewDocument.getRoot().getAttribute( 'spellcheck' ) ).to.equal( 'false' );
 
 		if ( spyClipboardOutput ) {
 			expect( spyClipboardOutput.called ).to.be.true;
@@ -1743,7 +1774,6 @@ describe( 'Drag and Drop', () => {
 
 	function expectFinalized() {
 		expect( viewDocument.getRoot().hasAttribute( 'draggable' ) ).to.be.false;
-		expect( viewDocument.getRoot().hasAttribute( 'spellcheck' ) ).to.be.false;
 
 		expect( model.markers.has( 'drop-target' ) ).to.be.false;
 	}

--- a/packages/ckeditor5-widget/src/widget.js
+++ b/packages/ckeditor5-widget/src/widget.js
@@ -171,6 +171,12 @@ export default class Widget extends Plugin {
 			}
 		}
 
+		// On Android selection would jump to the first table cell, on other devices
+		// we can't block it (and don't need to) because of drag and drop support.
+		if ( env.isAndroid ) {
+			domEventData.preventDefault();
+		}
+
 		// Focus editor if is not focused already.
 		if ( !viewDocument.isFocused ) {
 			view.focus();

--- a/packages/ckeditor5-widget/tests/widget.js
+++ b/packages/ckeditor5-widget/tests/widget.js
@@ -20,6 +20,7 @@ import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import toArray from '@ckeditor/ckeditor5-utils/src/toarray';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 describe( 'Widget', () => {
 	let element, editor, model, view, viewDocument;
@@ -148,6 +149,24 @@ describe( 'Widget', () => {
 		viewDocument.fire( 'mousedown', domEventDataMock );
 
 		expect( getModelData( model ) ).to.equal( '[<widget></widget>]' );
+	} );
+
+	it( 'should create selection over clicked widget (Android)', () => {
+		env.isAndroid = true;
+
+		setModelData( model, '[]<widget></widget>' );
+		const viewDiv = viewDocument.getRoot().getChild( 0 );
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( viewDiv ),
+			preventDefault: sinon.spy()
+		} );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		sinon.assert.calledOnce( domEventDataMock.domEvent.preventDefault );
+		expect( getModelData( model ) ).to.equal( '[<widget></widget>]' );
+
+		env.isAndroid = false;
 	} );
 
 	it( 'should create selection when clicked in nested element', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (clipboard): Drag and drop is disabled on Android. Closes #9287.

Internal (clipboard): Fixed setting drop effect while dragging in non-Gecko browsers. Closes #9270.

Internal (clipboard): Fixed crash while dragging removed element.

Internal (widget): Fixed selection jumping to the first table cell on selection handle click on Android.

---

### Additional information