### PR TITLE
Pass icon color as stroke via .ck-icon__stroke

### DIFF
--- a/packages/ckeditor5-ui/src/icon/iconview.js
+++ b/packages/ckeditor5-ui/src/icon/iconview.js
@@ -121,6 +121,9 @@ export default class IconView extends View {
 			this.element.querySelectorAll( '.ck-icon__fill' ).forEach( path => {
 				path.style.fill = this.fillColor;
 			} );
+			this.element.querySelectorAll( '.ck-icon__stroke' ).forEach( path => {
+				path.style.stroke = this.fillColor;
+			} );
 		}
 	}
 }

--- a/packages/ckeditor5-ui/tests/icon/iconview.js
+++ b/packages/ckeditor5-ui/tests/icon/iconview.js
@@ -127,6 +127,61 @@ describe( 'IconView', () => {
 				expect( view.element.children[ 1 ].style.fill ).to.equal( 'red' );
 			} );
 		} );
+
+		describe( 'stroke color', () => {
+			it( 'should be set intially based on view#fillColor', () => {
+				view.fillColor = 'red';
+				view.content = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg">' +
+						'<path class="ck-icon__stroke"/>' +
+						'<path/>' +
+						'<path class="ck-icon__stroke"/>' +
+					'</svg>';
+
+				expect( view.element.children[ 0 ].style.stroke ).to.equal( 'red' );
+				expect( view.element.children[ 1 ].style.stroke ).to.equal( '' );
+				expect( view.element.children[ 2 ].style.stroke ).to.equal( 'red' );
+			} );
+
+			it( 'should react to changes in view#fillColor', () => {
+				view.content = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg">' +
+						'<path class="ck-icon__stroke"/>' +
+						'<path/>' +
+						'<path class="ck-icon__stroke"/>' +
+					'</svg>';
+
+				expect( view.element.children[ 0 ].style.stroke ).to.equal( '' );
+				expect( view.element.children[ 1 ].style.stroke ).to.equal( '' );
+				expect( view.element.children[ 2 ].style.stroke ).to.equal( '' );
+
+				view.fillColor = 'red';
+
+				expect( view.element.children[ 0 ].style.stroke ).to.equal( 'red' );
+				expect( view.element.children[ 1 ].style.stroke ).to.equal( '' );
+				expect( view.element.children[ 2 ].style.stroke ).to.equal( 'red' );
+			} );
+
+			it( 'should react to changes in view#content', () => {
+				view.content = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg">' +
+						'<path class="ck-icon__stroke"/>' +
+						'<path/>' +
+						'<path class="ck-icon__stroke"/>' +
+					'</svg>';
+
+				view.fillColor = 'red';
+
+				expect( view.element.children[ 0 ].style.stroke ).to.equal( 'red' );
+				expect( view.element.children[ 1 ].style.stroke ).to.equal( '' );
+				expect( view.element.children[ 2 ].style.stroke ).to.equal( 'red' );
+
+				view.content = '<svg version="1.1" xmlns="http://www.w3.org/2000/svg">' +
+						'<path/>' +
+						'<path class="ck-icon__stroke"/>' +
+					'</svg>';
+
+				expect( view.element.children[ 0 ].style.stroke ).to.equal( '' );
+				expect( view.element.children[ 1 ].style.stroke ).to.equal( 'red' );
+			} );
+		} );
 	} );
 } );
 


### PR DESCRIPTION
Internal. Closes #9310.

Passthrough for highlight colors to apply [`stroke`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/Presentation#attr-stroke) in [`<path>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/path) via `.ck-icon__stroke`.

[Custom icons](https://ckeditor.com/docs/ckeditor5/latest/builds/guides/faq.html#how-to-customize-the-ckeditor-5-icons) for [`Highlight`](https://ckeditor.com/docs/ckeditor5/latest/features/highlight.html) using `stroke` can now be colored.

---

### Additional information

For later (when/if we refactor):

Internally we still use the "fillColor" class property variable. I think this is fine, as long as the highlight colors passthrough to the icon.  Later, It may be a good idea to refactor the `fillColor` name to avoid confusion.