### PR TITLE
Added retries in crawler in case of an error

### DIFF
--- a/docs/_snippets/builds/frameworks/framework-integration.js
+++ b/docs/_snippets/builds/frameworks/framework-integration.js
@@ -1,0 +1,16 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals document */
+
+// Sometimes the request to `badge.fury.io` fails for unknown reason, so ignore it.
+const metaElement = document.createElement( 'meta' );
+
+metaElement.name = 'x-cke-crawler-ignore-patterns';
+metaElement.content = JSON.stringify( {
+	'request-failure': 'badge.fury.io'
+} );
+
+document.head.appendChild( metaElement );

--- a/docs/builds/guides/frameworks/angular.md
+++ b/docs/builds/guides/frameworks/angular.md
@@ -4,9 +4,15 @@ category: builds-integration-frameworks
 order: 20
 ---
 
+{@snippet builds/frameworks/framework-integration}
+
 # Rich text editor component for Angular
 
-[![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-angular.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-angular)
+<p>
+	<a href="https://www.npmjs.com/package/@ckeditor/ckeditor5-angular" target="_blank" rel="noopener">
+		<img src="https://badge.fury.io/js/%40ckeditor%2Fckeditor5-angular.svg" alt="npm version" loading="lazy">
+	</a>
+</p>
 
 CKEditor 5 consists of {@link builds/guides/overview ready-to-use editor builds} and {@link framework/guides/overview CKEditor 5 Framework} upon which the builds are based.
 

--- a/docs/builds/guides/frameworks/react.md
+++ b/docs/builds/guides/frameworks/react.md
@@ -4,9 +4,15 @@ category: builds-integration-frameworks
 order: 30
 ---
 
+{@snippet builds/frameworks/framework-integration}
+
 # Rich text editor component for React
 
-[![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-react.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-react)
+<p>
+	<a href="https://www.npmjs.com/package/@ckeditor/ckeditor5-react" target="_blank" rel="noopener">
+		<img src="https://badge.fury.io/js/%40ckeditor%2Fckeditor5-react.svg" alt="npm version" loading="lazy">
+	</a>
+</p>
 
 CKEditor 5 consists of {@link builds/guides/overview ready-to-use editor builds} and {@link framework/guides/overview CKEditor 5 Framework} upon which the builds are based.
 

--- a/docs/builds/guides/frameworks/vuejs-v2.md
+++ b/docs/builds/guides/frameworks/vuejs-v2.md
@@ -4,9 +4,15 @@ category: builds-integration-frameworks
 order: 40
 ---
 
+{@snippet builds/frameworks/framework-integration}
+
 # Rich text editor component for Vue.js 2.x
 
-[![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-vue2.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-vue2)
+<p>
+	<a href="https://www.npmjs.com/package/@ckeditor/ckeditor5-vue2" target="_blank" rel="noopener">
+		<img src="https://badge.fury.io/js/%40ckeditor%2Fckeditor5-vue2.svg" alt="npm version" loading="lazy">
+	</a>
+</p>
 
 <info-box>
 	**Important**: This guide is about the CKEditor 5 integration with Vue.js 2.x. To learn more about the integration with Vue.js 3+, check out the {@link builds/guides/frameworks/vuejs-v3 "Rich text editor component for Vue.js 3+"} guide.

--- a/docs/builds/guides/frameworks/vuejs-v3.md
+++ b/docs/builds/guides/frameworks/vuejs-v3.md
@@ -4,9 +4,15 @@ category: builds-integration-frameworks
 order: 50
 ---
 
+{@snippet builds/frameworks/framework-integration}
+
 # Rich text editor component for Vue.js 3+
 
-[![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-vue.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-vue)
+<p>
+	<a href="https://www.npmjs.com/package/@ckeditor/ckeditor5-vue" target="_blank" rel="noopener">
+		<img src="https://badge.fury.io/js/%40ckeditor%2Fckeditor5-vue.svg" alt="npm version" loading="lazy">
+	</a>
+</p>
 
 <info-box>
 	**Important**: This guide is about the CKEditor 5 integration with Vue.js 3+. To learn more about the integration with Vue.js 2.x, check out the {@link builds/guides/frameworks/vuejs-v2 "Rich text editor component for Vue.js 2.x"} guide.

--- a/scripts/web-crawler/constants.js
+++ b/scripts/web-crawler/constants.js
@@ -11,6 +11,8 @@ const DEFAULT_CONCURRENCY = require( 'os' ).cpus().length / 2;
 
 const DEFAULT_TIMEOUT = 15 * 1000;
 
+const DEFAULT_REMAINING_ATTEMPTS = 3;
+
 const ERROR_TYPES = {
 	PAGE_CRASH: {
 		event: 'error',
@@ -57,6 +59,7 @@ const DATA_ATTRIBUTE_NAME = 'data-cke-crawler-skip';
 module.exports = {
 	DEFAULT_CONCURRENCY,
 	DEFAULT_TIMEOUT,
+	DEFAULT_REMAINING_ATTEMPTS,
 	ERROR_TYPES,
 	PATTERN_TYPE_TO_ERROR_TYPE_MAP,
 	IGNORE_ALL_ERRORS_WILDCARD,

--- a/scripts/web-crawler/spinner.js
+++ b/scripts/web-crawler/spinner.js
@@ -32,11 +32,11 @@ function getProgressHandler( spinner ) {
 	let current = 0;
 
 	return ( { total } ) => {
+		current++;
+
 		const progress = Math.round( current / total * 100 );
 
 		spinner.text = `Checking pages… ${ chalk.bold( `${ progress }% (${ current } of ${ total })` ) }`;
-
-		current++;
 	};
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Added retries in crawler in case of an error. Closes https://github.com/cksource/ckeditor5-internal/issues/687.

---

### Additional information

From now on, the crawler will try to open the page up to 3 times when it encounters an error to eliminate various random causes of these errors.

All NPM badges in the documentation (except the API, which is not scanned by default by the crawler) have been converted to `<img src="..." alt="..." loading="lazy">` tags. The `loading="lazy"` attribute has been added, so these resources do not delay the `load` event anymore.

Additionally, request failures from `badge.fury.io` domain are now ignored.