### PR TITLE
config.initialData was skipped when set to an empty string and DOM data was used instead

### DIFF
--- a/packages/ckeditor5-editor-balloon/src/ballooneditor.js
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditor.js
@@ -213,7 +213,7 @@ export default class BalloonEditor extends Editor {
 							throw new CKEditorError( 'editor-create-initial-data', null );
 						}
 
-						const initialData = config.initialData || getInitialData( sourceElementOrData );
+						const initialData = config.initialData !== undefined ? config.initialData : getInitialData( sourceElementOrData );
 
 						return editor.data.init( initialData );
 					} )

--- a/packages/ckeditor5-editor-balloon/tests/ballooneditor.js
+++ b/packages/ckeditor5-editor-balloon/tests/ballooneditor.js
@@ -187,6 +187,23 @@ describe( 'BalloonEditor', () => {
 			} );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5/issues/8974
+		it( 'initializes with empty content if config.initialData is set to an empty string', () => {
+			const editorElement = document.createElement( 'div' );
+			editorElement.innerHTML = '<p><strong>foo</strong> bar</p>';
+
+			return BalloonEditor.create( editorElement, {
+				initialData: '',
+				plugins: [ Paragraph ]
+			} ).then( editor => {
+				expect( editor.getData() ).to.equal( '' );
+
+				return editor.destroy();
+			} ).then( () => {
+				editorElement.remove();
+			} );
+		} );
+
 		it( 'throws if initial data is passed in Editor#create and config.initialData is also used', done => {
 			BalloonEditor.create( '<p>Hello world!</p>', {
 				initialData: '<p>I am evil!</p>',

--- a/packages/ckeditor5-editor-classic/src/classiceditor.js
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.js
@@ -198,7 +198,7 @@ export default class ClassicEditor extends Editor {
 							throw new CKEditorError( 'editor-create-initial-data', null );
 						}
 
-						const initialData = config.initialData || getInitialData( sourceElementOrData );
+						const initialData = config.initialData !== undefined ? config.initialData : getInitialData( sourceElementOrData );
 
 						return editor.data.init( initialData );
 					} )

--- a/packages/ckeditor5-editor-classic/tests/classiceditor.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditor.js
@@ -205,6 +205,18 @@ describe( 'ClassicEditor', () => {
 			} );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5/issues/8974
+		it( 'initializes with empty content if config.initialData is set to an empty string', () => {
+			return ClassicEditor.create( editorElement, {
+				initialData: '',
+				plugins: [ Paragraph ]
+			} ).then( editor => {
+				expect( editor.getData() ).to.equal( '' );
+
+				editor.destroy();
+			} );
+		} );
+
 		it( 'throws if initial data is passed in Editor#create and config.initialData is also used', done => {
 			ClassicEditor.create( '<p>Hello world!</p>', {
 				initialData: '<p>I am evil!</p>',

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitor.js
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitor.js
@@ -238,7 +238,7 @@ export default class DecoupledEditor extends Editor {
 							throw new CKEditorError( 'editor-create-initial-data', null );
 						}
 
-						const initialData = config.initialData || getInitialData( sourceElementOrData );
+						const initialData = config.initialData !== undefined ? config.initialData : getInitialData( sourceElementOrData );
 
 						return editor.data.init( initialData );
 					} )

--- a/packages/ckeditor5-editor-decoupled/tests/decouplededitor.js
+++ b/packages/ckeditor5-editor-decoupled/tests/decouplededitor.js
@@ -150,6 +150,18 @@ describe( 'DecoupledEditor', () => {
 			} );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5/issues/8974
+		it( 'initializes with empty content if config.initialData is set to an empty string', () => {
+			return DecoupledEditor.create( document.createElement( 'div' ), {
+				initialData: '',
+				plugins: [ Paragraph ]
+			} ).then( editor => {
+				expect( editor.getData() ).to.equal( '' );
+
+				editor.destroy();
+			} );
+		} );
+
 		// See: https://github.com/ckeditor/ckeditor5/issues/746
 		it( 'should throw when trying to create the editor using the same source element more than once', done => {
 			const sourceElement = document.createElement( 'div' );

--- a/packages/ckeditor5-editor-inline/src/inlineeditor.js
+++ b/packages/ckeditor5-editor-inline/src/inlineeditor.js
@@ -209,7 +209,7 @@ export default class InlineEditor extends Editor {
 							throw new CKEditorError( 'editor-create-initial-data', null );
 						}
 
-						const initialData = config.initialData || getInitialData( sourceElementOrData );
+						const initialData = config.initialData !== undefined ? config.initialData : getInitialData( sourceElementOrData );
 
 						return editor.data.init( initialData );
 					} )

--- a/packages/ckeditor5-editor-inline/tests/inlineeditor.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditor.js
@@ -181,6 +181,23 @@ describe( 'InlineEditor', () => {
 			} );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5/issues/8974
+		it( 'initializes with empty content if config.initialData is set to an empty string', () => {
+			const editorElement = document.createElement( 'div' );
+			editorElement.innerHTML = '<p>Hello world!</p>';
+
+			return InlineEditor.create( editorElement, {
+				initialData: '',
+				plugins: [ Paragraph ]
+			} ).then( editor => {
+				expect( editor.getData() ).to.equal( '' );
+
+				return editor.destroy();
+			} ).then( () => {
+				editorElement.remove();
+			} );
+		} );
+
 		it( 'should pass the config.toolbar.shouldNotGroupWhenFull configuration to the view', () => {
 			const editorElement = document.createElement( 'div' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fixed: `config.initialData` was skipped when set to an empty string and DOM data was used instead. Closes #8974.

---

### Additional information

Alternative commit message:

Fixed: Editor was not initialized with empty data for `config.initialData` set to an empty string.