### PR TITLE
 Extra space was added after a soft-break when data was loaded if the soft-break was the last element in its parent

### DIFF
--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -1322,7 +1322,19 @@ function forEachDomNodeAncestor( node, callback ) {
 function isNbspBlockFiller( domNode, blockElements ) {
 	const isNBSP = isText( domNode ) && domNode.data == '\u00A0';
 
-	return isNBSP && hasBlockParent( domNode, blockElements ) && domNode.parentNode.childNodes.length === 1;
+	if ( !isNBSP || !hasBlockParent( domNode, blockElements ) ) {
+		return false;
+	}
+
+	if ( domNode.parentNode.childNodes.length === 1 ) {
+		return true;
+	}
+
+	if ( domNode.previousSibling && domNode.previousSibling.tagName == 'BR' && !domNode.nextSibling ) {
+		return true;
+	}
+
+	return false;
 }
 
 // Checks if domNode has block parent.

--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -1322,19 +1322,11 @@ function forEachDomNodeAncestor( node, callback ) {
 function isNbspBlockFiller( domNode, blockElements ) {
 	const isNBSP = isText( domNode ) && domNode.data == '\u00A0';
 
-	if ( !isNBSP || !hasBlockParent( domNode, blockElements ) ) {
-		return false;
-	}
+	// `!!` to make sure that boolean is returned by this function, instead `null` could be returned.
+	const isOnlyChild = !!domNode.parentNode && domNode.parentNode.childNodes.length === 1;
+	const isLastAfterBr = !!domNode.previousSibling && domNode.previousSibling.tagName == 'BR' && !domNode.nextSibling;
 
-	if ( domNode.parentNode.childNodes.length === 1 ) {
-		return true;
-	}
-
-	if ( domNode.previousSibling && domNode.previousSibling.tagName == 'BR' && !domNode.nextSibling ) {
-		return true;
-	}
-
-	return false;
+	return isNBSP && hasBlockParent( domNode, blockElements ) && ( isOnlyChild || isLastAfterBr );
 }
 
 // Checks if domNode has block parent.

--- a/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
@@ -329,7 +329,7 @@ describe( 'DomConverter', () => {
 				expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.false;
 			} );
 
-			it( 'should return false filler is placed in a non-block element', () => {
+			it( 'should return false if filler is placed in a non-block element', () => {
 				const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
 
 				const context = document.createElement( 'span' );
@@ -375,6 +375,13 @@ describe( 'DomConverter', () => {
 				context.innerHTML = '<br>&nbsp;';
 
 				expect( converter.isBlockFiller( context.firstChild ) ).to.be.false;
+			} );
+
+			it( 'should return true for nbsp after <br>', () => {
+				const context = document.createElement( 'span' );
+				context.innerHTML = '<br>&nbsp;';
+
+				expect( converter.isBlockFiller( context.lastChild ) ).to.be.false;
 			} );
 		} );
 


### PR DESCRIPTION
### :warning: Do not merge - see comment!

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fixed (engine): Extra space was added after a soft-break when data was loaded if the soft-break was the last element in its parent. Closes #9346.

---

### Additional information

I decided to go with commit message that explains the benefit to the end-user. However, I am not sure if it should be "soft-break", "softbreak" or "soft break" :D.