### PR TITLE
Block filler was not removed if placed after a <br> or marker tag

### DIFF
--- a/packages/ckeditor5-block-quote/tests/blockquoteediting.js
+++ b/packages/ckeditor5-block-quote/tests/blockquoteediting.js
@@ -99,7 +99,7 @@ describe( 'BlockQuoteEditing', () => {
 			writer.remove( writer.createRangeIn( bq ) );
 		} );
 
-		expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p>&nbsp;</p>' ); // Autoparagraphed.
+		expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p><span data-cke-filler="true">&nbsp;</span></p>' ); // Autoparagraphed.
 	} );
 
 	it( 'should unwrap a blockQuote if it was inserted into another blockQuote', () => {

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -740,7 +740,9 @@ describe( 'CodeBlockEditing', () => {
 		it( 'should convert empty codeBlock to empty pre tag', () => {
 			setModelData( model, '<codeBlock language="plaintext"></codeBlock>' );
 
-			expect( editor.getData( { trim: 'none' } ) ).to.equal( '<pre><code class="language-plaintext">&nbsp;</code></pre>' );
+			expect( editor.getData( { trim: 'none' } ) ).to.equal(
+				'<pre><code class="language-plaintext"><span data-cke-filler="true">&nbsp;</span></code></pre>'
+			);
 		} );
 
 		it( 'should convert non-empty codeBlock to pre tag', () => {

--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -26,8 +26,8 @@ import getCommonAncestor from '@ckeditor/ckeditor5-utils/src/dom/getcommonancest
 import isText from '@ckeditor/ckeditor5-utils/src/dom/istext';
 import { isElement } from 'lodash-es';
 
-// eslint-disable-next-line new-cap
-const BR_FILLER_REF = BR_FILLER( document );
+const BR_FILLER_REF = BR_FILLER( document ); // eslint-disable-line new-cap
+const NBSP_FILLER_REF = NBSP_FILLER( document ); // eslint-disable-line new-cap
 
 /**
  * `DomConverter` is a set of tools to do transformations between DOM nodes and view nodes. It also handles
@@ -1320,6 +1320,10 @@ function forEachDomNodeAncestor( node, callback ) {
 // @param {Node} domNode DOM node.
 // @returns {Boolean}
 function isNbspBlockFiller( domNode, blockElements ) {
+	return domNode.isEqualNode( NBSP_FILLER_REF ) || isUnmarkedNbspBlockFiller( domNode, blockElements );
+}
+
+function isUnmarkedNbspBlockFiller( domNode, blockElements ) {
 	const isNBSP = isText( domNode ) && domNode.data == '\u00A0';
 
 	return isNBSP && hasBlockParent( domNode, blockElements ) && domNode.parentNode.childNodes.length === 1;

--- a/packages/ckeditor5-engine/src/view/filler.js
+++ b/packages/ckeditor5-engine/src/view/filler.js
@@ -41,7 +41,13 @@ import isText from '@ckeditor/ckeditor5-utils/src/dom/istext';
  * @see module:engine/view/filler~BR_FILLER
  * @function
  */
-export const NBSP_FILLER = domDocument => domDocument.createTextNode( '\u00A0' );
+export const NBSP_FILLER = domDocument => {
+	const span = domDocument.createElement( 'span' );
+	span.dataset.ckeFiller = true;
+	span.innerHTML = '\u00A0';
+
+	return span;
+};
 
 /**
  * `<br>` filler creator. This is a function which creates `<br data-cke-filler="true">` element.

--- a/packages/ckeditor5-engine/tests/controller/datacontroller.js
+++ b/packages/ckeditor5-engine/tests/controller/datacontroller.js
@@ -398,7 +398,7 @@ describe( 'DataController', () => {
 		it( 'should get empty paragraph (with trim=none)', () => {
 			setData( model, '<paragraph></paragraph>' );
 
-			expect( data.get( { trim: 'none' } ) ).to.equal( '<p>&nbsp;</p>' );
+			expect( data.get( { trim: 'none' } ) ).to.equal( '<p><span data-cke-filler="true">&nbsp;</span></p>' );
 		} );
 
 		it( 'should get two paragraphs', () => {

--- a/packages/ckeditor5-engine/tests/tickets/5564.js
+++ b/packages/ckeditor5-engine/tests/tickets/5564.js
@@ -35,7 +35,7 @@ describe( 'Bug ckeditor5#5564', () => {
 	it( 'preserves a soft break in an empty paragraph', () => {
 		setModelData( editor.model, '<paragraph>x</paragraph><paragraph><softBreak /></paragraph><paragraph>x</paragraph>' );
 
-		const expectedData = '<p>x</p><p><br>&nbsp;</p><p>x</p>';
+		const expectedData = '<p>x</p><p><br><span data-cke-filler="true">&nbsp;</span></p><p>x</p>';
 		const actualData = editor.getData();
 
 		expect( actualData ).to.equal( expectedData );

--- a/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
@@ -300,7 +300,7 @@ describe( 'DomConverter', () => {
 				converter = new DomConverter( viewDocument, { blockFillerMode: 'nbsp' } );
 			} );
 
-			it( 'should return true if the node is an nbsp filler and is a single child of a block level element', () => {
+			it( 'should return true if the node is an nbsp filler', () => {
 				const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
 
 				const context = document.createElement( 'div' );
@@ -309,33 +309,54 @@ describe( 'DomConverter', () => {
 				expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.true;
 			} );
 
-			it( 'should return false if the node is an nbsp filler and is not a single child of a block level element', () => {
+			it( 'should return true for nbsp filler after <br>', () => {
 				const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
 
 				const context = document.createElement( 'div' );
+				context.innerHTML = '<br>';
 				context.appendChild( nbspFillerInstance );
-				context.appendChild( document.createTextNode( 'a' ) );
 
-				expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.false;
+				expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.true;
 			} );
 
-			it( 'should return false if there are two nbsp fillers in a block element', () => {
-				const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
+			describe( 'backward compatibility tests (using nbsp text node as a filler)', () => {
+				it( 'should return true if the node is an nbsp filler and is a single child of a block level element', () => {
+					const nbspFillerInstance = document.createTextNode( '\u00A0' );
 
-				const context = document.createElement( 'div' );
-				context.appendChild( nbspFillerInstance );
-				context.appendChild( NBSP_FILLER( document ) ); // eslint-disable-line new-cap
+					const context = document.createElement( 'div' );
+					context.appendChild( nbspFillerInstance );
 
-				expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.false;
-			} );
+					expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.true;
+				} );
 
-			it( 'should return false filler is placed in a non-block element', () => {
-				const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
+				it( 'should return false if the node is an nbsp filler and is not a single child of a block level element', () => {
+					const nbspFillerInstance = document.createTextNode( '\u00A0' );
 
-				const context = document.createElement( 'span' );
-				context.appendChild( nbspFillerInstance );
+					const context = document.createElement( 'div' );
+					context.appendChild( nbspFillerInstance );
+					context.appendChild( document.createTextNode( 'a' ) );
 
-				expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.false;
+					expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.false;
+				} );
+
+				it( 'should return false if there are two nbsp fillers in a block element', () => {
+					const nbspFillerInstance = document.createTextNode( '\u00A0' );
+
+					const context = document.createElement( 'div' );
+					context.appendChild( nbspFillerInstance );
+					context.appendChild( document.createTextNode( '\u00A0' ) );
+
+					expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.false;
+				} );
+
+				it( 'should return false if filler is placed in a non-block element', () => {
+					const nbspFillerInstance = document.createTextNode( '\u00A0' );
+
+					const context = document.createElement( 'span' );
+					context.appendChild( nbspFillerInstance );
+
+					expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.false;
+				} );
 			} );
 
 			it( 'should return false if the node is an instance of the BR block filler', () => {

--- a/packages/ckeditor5-enter/tests/shiftenter-integration.js
+++ b/packages/ckeditor5-enter/tests/shiftenter-integration.js
@@ -50,7 +50,7 @@ describe( 'ShiftEnter integration', () => {
 
 		editor.execute( 'shiftEnter' );
 
-		expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p><br>&nbsp;</p>' );
+		expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p><br><span data-cke-filler="true">&nbsp;</span></p>' );
 		expect( editor.ui.view.editable.element.innerHTML ).to.equal( '<p><br><br data-cke-filler="true"></p>' );
 	} );
 

--- a/packages/ckeditor5-heading/tests/title.js
+++ b/packages/ckeditor5-heading/tests/title.js
@@ -467,7 +467,7 @@ describe( 'Title', () => {
 		it( 'should return empty paragraph when body is empty', () => {
 			setData( model, '<title><title-content>Foo</title-content></title>' );
 
-			expect( editor.plugins.get( 'Title' ).getBody() ).to.equal( '<p>&nbsp;</p>' );
+			expect( editor.plugins.get( 'Title' ).getBody() ).to.equal( '<p><span data-cke-filler="true">&nbsp;</span></p>' );
 		} );
 
 		it( 'should return marker - starts and ends inside a body', () => {

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -522,7 +522,7 @@ describe( 'LinkUI', () => {
 						'<p>[</p>' +
 						'<p><span class="ck-fake-link-selection">foo</span>]</p>'
 					);
-					expect( editor.getData() ).to.equal( '<p>&nbsp;</p><p>foo</p>' );
+					expect( editor.getData() ).to.equal( '<p><span data-cke-filler="true">&nbsp;</span></p><p>foo</p>' );
 				} );
 
 				it( 'should display a fake visual selection on the next non-empty text node when selection starts at the end ' +
@@ -585,9 +585,9 @@ describe( 'LinkUI', () => {
 					expect( getViewData( editor.editing.view ) ).to.equal( expectedViewData );
 					expect( editor.getData() ).to.equal(
 						'<p>foo</p>' +
-						'<p>&nbsp;</p><p>&nbsp;</p>' +
+						'<p><span data-cke-filler="true">&nbsp;</span></p><p><span data-cke-filler="true">&nbsp;</span></p>' +
 						'<p>bar</p>' +
-						'<p>&nbsp;</p><p>&nbsp;</p>' +
+						'<p><span data-cke-filler="true">&nbsp;</span></p><p><span data-cke-filler="true">&nbsp;</span></p>' +
 						'<p>baz</p>'
 					);
 				} );
@@ -640,7 +640,7 @@ describe( 'LinkUI', () => {
 						'<p>]<span class="ck-fake-link-selection ck-fake-link-selection_collapsed"></span>bar</p>';
 
 					expect( getViewData( editor.editing.view ) ).to.equal( expectedViewData );
-					expect( editor.getData() ).to.equal( '<p>foo</p><p>&nbsp;</p><p>bar</p>' );
+					expect( editor.getData() ).to.equal( '<p>foo</p><p><span data-cke-filler="true">&nbsp;</span></p><p>bar</p>' );
 				} );
 
 				it( 'should be displayed on selection focus when selection contains few empty elements ' +
@@ -669,7 +669,12 @@ describe( 'LinkUI', () => {
 						'<p>]<span class="ck-fake-link-selection ck-fake-link-selection_collapsed"></span>bar</p>';
 
 					expect( getViewData( editor.editing.view ) ).to.equal( expectedViewData );
-					expect( editor.getData() ).to.equal( '<p>foo</p><p>&nbsp;</p><p>&nbsp;</p><p>bar</p>' );
+					expect( editor.getData() ).to.equal(
+						'<p>foo</p>' +
+						'<p><span data-cke-filler="true">&nbsp;</span></p>' +
+						'<p><span data-cke-filler="true">&nbsp;</span></p>' +
+						'<p>bar</p>'
+					);
 				} );
 
 				it( 'should be displayed on selection focus when selection contains few empty elements ' +
@@ -698,7 +703,12 @@ describe( 'LinkUI', () => {
 						'<p>bar</p>';
 
 					expect( getViewData( editor.editing.view ) ).to.equal( expectedViewData );
-					expect( editor.getData() ).to.equal( '<p>foo</p><p>&nbsp;</p><p>&nbsp;</p><p>bar</p>' );
+					expect( editor.getData() ).to.equal(
+						'<p>foo</p>' +
+						'<p><span data-cke-filler="true">&nbsp;</span></p>' +
+						'<p><span data-cke-filler="true">&nbsp;</span></p>' +
+						'<p>bar</p>'
+					);
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-list/tests/listediting.js
+++ b/packages/ckeditor5-list/tests/listediting.js
@@ -1883,23 +1883,23 @@ describe( 'ListEditing', () => {
 						'1' +
 						'<ul>' +
 							'<li>' +
-								'&nbsp;' +
+								'<span data-cke-filler="true">&nbsp;</span>' +
 								'<ul>' +
-									'<li>&nbsp;</li>' +
+									'<li><span data-cke-filler="true">&nbsp;</span></li>' +
 									'<li>1.1.2</li>' +
 									'<li>1.1.3</li>' +
 									'<li>1.1.4</li>' +
 								'</ul>' +
 							'</li>' +
 							'<li>' +
-								'&nbsp;' +
+								'<span data-cke-filler="true">&nbsp;</span>' +
 								'<ul><li>1.2.1</li></ul>' +
 							'</li>' +
 						'</ul>' +
 					'</li>' +
 					'<li>2</li>' +
 					'<li>' +
-						'&nbsp;' +
+						'<span data-cke-filler="true">&nbsp;</span>' +
 						'<ol>' +
 							'<li>' +
 								'3<strong>.</strong>1' +

--- a/packages/ckeditor5-page-break/tests/pagebreakediting.js
+++ b/packages/ckeditor5-page-break/tests/pagebreakediting.js
@@ -68,7 +68,9 @@ describe( 'PageBreakEditing', () => {
 				setModelData( model, '<pageBreak></pageBreak>' );
 
 				expect( editor.getData() ).to.equal(
-					'<div class="page-break" style="page-break-after:always;"><span style="display:none;">&nbsp;</span></div>'
+					'<div class="page-break" style="page-break-after:always;">' +
+						'<span style="display:none;"><span data-cke-filler="true">&nbsp;</span></span>' +
+					'</div>'
 				);
 			} );
 		} );

--- a/packages/ckeditor5-paragraph/tests/paragraph-intergration.js
+++ b/packages/ckeditor5-paragraph/tests/paragraph-intergration.js
@@ -148,7 +148,7 @@ describe( 'Paragraph feature – integration', () => {
 					const doc = editor.model.document;
 					const root = doc.getRoot();
 
-					expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p>&nbsp;</p>' );
+					expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p><span data-cke-filler="true">&nbsp;</span></p>' );
 					expect( editor.commands.get( 'undo' ).isEnabled ).to.be.false;
 
 					editor.setData( '<p>Foobar.</p>' );
@@ -157,7 +157,7 @@ describe( 'Paragraph feature – integration', () => {
 						writer.remove( root.getChild( 0 ) );
 					} );
 
-					expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p>&nbsp;</p>' );
+					expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p><span data-cke-filler="true">&nbsp;</span></p>' );
 
 					editor.execute( 'undo' );
 
@@ -165,7 +165,7 @@ describe( 'Paragraph feature – integration', () => {
 
 					editor.execute( 'redo' );
 
-					expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p>&nbsp;</p>' );
+					expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p><span data-cke-filler="true">&nbsp;</span></p>' );
 
 					editor.execute( 'undo' );
 
@@ -193,12 +193,20 @@ describe( 'Paragraph feature – integration', () => {
 						writer.remove( otherRoot.getChild( 0 ) );
 					} );
 
-					expect( editor.data.get( { rootName: 'main', trim: 'none' } ) ).to.equal( '<p>&nbsp;</p>' );
-					expect( editor.data.get( { rootName: 'otherRoot', trim: 'none' } ) ).to.equal( '<p>&nbsp;</p>' );
+					expect( editor.data.get( { rootName: 'main', trim: 'none' } ) ).to.equal(
+						'<p><span data-cke-filler="true">&nbsp;</span></p>'
+					);
+
+					expect( editor.data.get( { rootName: 'otherRoot', trim: 'none' } ) ).to.equal(
+						'<p><span data-cke-filler="true">&nbsp;</span></p>'
+					);
 
 					editor.execute( 'undo' );
 
-					expect( editor.data.get( { rootName: 'main', trim: 'none' } ) ).to.equal( '<p>&nbsp;</p>' );
+					expect( editor.data.get( { rootName: 'main', trim: 'none' } ) ).to.equal(
+						'<p><span data-cke-filler="true">&nbsp;</span></p>'
+					);
+
 					expect( editor.data.get( { rootName: 'otherRoot', trim: 'none' } ) ).to.equal( '<p>Foobar.</p>' );
 
 					editor.execute( 'undo' );

--- a/packages/ckeditor5-table/tests/_utils/utils.js
+++ b/packages/ckeditor5-table/tests/_utils/utils.js
@@ -388,6 +388,10 @@ function makeRows( tableData, options ) {
 						`</${ wrappingElement }>`;
 				}
 
+				if ( contents == '&nbsp;' ) {
+					contents = '<span data-cke-filler="true">&nbsp;</span>';
+				}
+
 				const formattedAttributes = formatAttributes( attributes );
 				const tableCell = `<${ resultingCellElement }${ formattedAttributes }>${ contents }</${ resultingCellElement }>`;
 

--- a/packages/ckeditor5-table/tests/converters/downcast.js
+++ b/packages/ckeditor5-table/tests/converters/downcast.js
@@ -185,7 +185,7 @@ describe( 'downcast converters', () => {
 							'<table>' +
 								'<tbody>' +
 									'<tr>' +
-										'<td>&nbsp;</td>' +
+										'<td><span data-cke-filler="true">&nbsp;</span></td>' +
 									'</tr>' +
 								'</tbody>' +
 							'</table>' +
@@ -213,7 +213,7 @@ describe( 'downcast converters', () => {
 
 				assertEqualMarkup( editor.getData(),
 					'<table foo="bar">' +
-						'<tr><td><p>&nbsp;</p></td></tr>' +
+						'<tr><td><p><span data-cke-filler="true">&nbsp;</span></p></td></tr>' +
 					'</table>'
 				);
 			} );
@@ -231,7 +231,7 @@ describe( 'downcast converters', () => {
 					'<figure class="table">' +
 						'<table>' +
 							'<tbody>' +
-								'<tr><td>&nbsp;</td></tr>' +
+								'<tr><td><span data-cke-filler="true">&nbsp;</span></td></tr>' +
 							'</tbody>' +
 						'</table>' +
 					'</figure>'
@@ -250,7 +250,7 @@ describe( 'downcast converters', () => {
 						'<figure class="table">' +
 							'<table>' +
 								'<tbody>' +
-									'<tr><td>&nbsp;</td></tr>' +
+									'<tr><td><span data-cke-filler="true">&nbsp;</span></td></tr>' +
 								'</tbody>' +
 							'</table>' +
 						'</figure>' +
@@ -338,7 +338,7 @@ describe( 'downcast converters', () => {
 					'<figure class="table">' +
 						'<table>' +
 							'<tbody>' +
-								'<tr><td>&nbsp;</td></tr>' +
+								'<tr><td><span data-cke-filler="true">&nbsp;</span></td></tr>' +
 							'</tbody>' +
 						'</table>' +
 					'</figure>'

--- a/packages/ckeditor5-table/tests/table-integration.js
+++ b/packages/ckeditor5-table/tests/table-integration.js
@@ -104,7 +104,7 @@ describe( 'Table feature – integration', () => {
 		} );
 
 		it( 'fixing empty roots should be transparent to undo', () => {
-			expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p>&nbsp;</p>' );
+			expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p><span data-cke-filler="true">&nbsp;</span></p>' );
 			expect( editor.commands.get( 'undo' ).isEnabled ).to.be.false;
 
 			editor.data.set( viewTable( [ [ 'foo' ] ] ) );
@@ -115,7 +115,7 @@ describe( 'Table feature – integration', () => {
 				writer.remove( root.getChild( 0 ) );
 			} );
 
-			expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p>&nbsp;</p>' );
+			expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p><span data-cke-filler="true">&nbsp;</span></p>' );
 
 			editor.execute( 'undo' );
 
@@ -123,7 +123,7 @@ describe( 'Table feature – integration', () => {
 
 			editor.execute( 'redo' );
 
-			expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p>&nbsp;</p>' );
+			expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p><span data-cke-filler="true">&nbsp;</span></p>' );
 
 			editor.execute( 'undo' );
 
@@ -144,12 +144,20 @@ describe( 'Table feature – integration', () => {
 				writer.remove( otherRoot.getChild( 0 ) );
 			} );
 
-			expect( editor.data.get( { trim: 'none', rootName: 'main' } ) ).to.equal( '<p>&nbsp;</p>' );
-			expect( editor.data.get( { trim: 'none', rootName: 'otherRoot' } ) ).to.equal( '<p>&nbsp;</p>' );
+			expect( editor.data.get( { trim: 'none', rootName: 'main' } ) ).to.equal(
+				'<p><span data-cke-filler="true">&nbsp;</span></p>'
+			);
+
+			expect( editor.data.get( { trim: 'none', rootName: 'otherRoot' } ) ).to.equal(
+				'<p><span data-cke-filler="true">&nbsp;</span></p>'
+			);
 
 			editor.execute( 'undo' );
 
-			expect( editor.data.get( { trim: 'none', rootName: 'main' } ) ).to.equal( '<p>&nbsp;</p>' );
+			expect( editor.data.get( { trim: 'none', rootName: 'main' } ) ).to.equal(
+				'<p><span data-cke-filler="true">&nbsp;</span></p>'
+			);
+
 			expect( editor.data.get( { trim: 'none', rootName: 'otherRoot' } ) ).to.equal( viewTable( [ [ 'foo' ] ] ) );
 
 			editor.execute( 'undo' );

--- a/packages/ckeditor5-typing/tests/tickets/59.js
+++ b/packages/ckeditor5-typing/tests/tickets/59.js
@@ -44,7 +44,7 @@ describe( 'Bug ckeditor5-typing#59', () => {
 			editor.execute( 'delete' );
 		}
 
-		expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p>&nbsp;</p>' );
+		expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p><span data-cke-filler="true">&nbsp;</span></p>' );
 	} );
 
 	// This is something that came to my mind after I worked on ckeditor/ckeditor5-engine#659.
@@ -60,6 +60,6 @@ describe( 'Bug ckeditor5-typing#59', () => {
 			editor.execute( 'bold' );
 		}
 
-		expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p>&nbsp;</p>' );
+		expect( editor.getData( { trim: 'none' } ) ).to.equal( '<p><span data-cke-filler="true">&nbsp;</span></p>' );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): Block filler was not removed when loading editor data if it was placed after a `<br>` or marker tag, what resulted in extra space character. Closes #9345.

Other (engine): From now on, nbsp block fillers will be wrapped with an additional span: `<span data-cke-filler="true">&nbsp;</span>`.