### PR TITLE
Docs: Enable language auto-detection in the WProofreader demo

### DIFF
--- a/docs/_snippets/features/wproofreader.js
+++ b/docs/_snippets/features/wproofreader.js
@@ -19,7 +19,7 @@ ClassicEditor
 		plugins: [ ArticlePluginSet, EasyImage, ImageUpload, CloudServices, WProofreader ],
 		wproofreader: {
 			serviceId: '1:Eebp63-lWHbt2-ASpHy4-AYUpy2-fo3mk4-sKrza1-NsuXy4-I1XZC2-0u2F54-aqYWd1-l3Qf14-umd',
-			lang: 'en_AI',
+			lang: 'auto',
 			srcUrl: 'https://svc.webspellchecker.net/spellcheck31/wscbundle/wscbundle.js'
 		},
 		cloudServices: CS_CONFIG,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Enable language auto-detection in the WProofreader demo. Closes #9364.

---

### Additional information

This PR enables language auto-detection in the WProofreader demo, however, it would be nice to show this feature in the content, i.e. some sentences with typos in multiple languages. @godai78, can I ask for your help in preparing such content?