### PR TITLE
Add support for the `config.forceValue` option in `ListCommand`

### DIFF
--- a/packages/ckeditor5-list/src/listcommand.js
+++ b/packages/ckeditor5-list/src/listcommand.js
@@ -57,7 +57,7 @@ export default class ListCommand extends Command {
 	 * @param {Object} [options] Command options.
 	 * @param {Boolean} [options.forceValue] If set, it will force the command behavior. If `true`, the command will try to convert the
 	 * selected items and potentially the neighbor elements to the proper list items.
-	 * If not set, the command will look for its current value to decide what it should do.
+	 * If not set, the command will toggle selected elements to list items or paragraphs, depending on the selection.
 	 */
 	execute( options = {} ) {
 		const model = this.editor.model;

--- a/packages/ckeditor5-list/src/listcommand.js
+++ b/packages/ckeditor5-list/src/listcommand.js
@@ -51,18 +51,23 @@ export default class ListCommand extends Command {
 	}
 
 	/**
-	 * Executes the command.
+	 * Executes the list command.
 	 *
-	 * @protected
+	 * @fires execute
+	 * @param {Object} [options] Command options.
+	 * @param {Boolean} [options.forceValue] If set, it will force the command behavior. If `true`, the command will try to convert the
+	 * selected items and potentially the neighbor elements to the proper list items.
+	 * If not set, the command will look for its current value to decide what it should do.
 	 */
-	execute() {
+	execute( options = {} ) {
 		const model = this.editor.model;
 		const document = model.document;
 		const blocks = Array.from( document.selection.getSelectedBlocks() )
 			.filter( block => checkCanBecomeListItem( block, model.schema ) );
+		const value = options.forceValue === undefined ? this.value : !options.forceValue;
 
 		// Whether we are turning off some items.
-		const turnOff = this.value === true;
+		const turnOff = value === true;
 		// If we are turning off items, we are going to rename them to paragraphs.
 
 		model.change( writer => {

--- a/packages/ckeditor5-list/src/listcommand.js
+++ b/packages/ckeditor5-list/src/listcommand.js
@@ -64,10 +64,10 @@ export default class ListCommand extends Command {
 		const document = model.document;
 		const blocks = Array.from( document.selection.getSelectedBlocks() )
 			.filter( block => checkCanBecomeListItem( block, model.schema ) );
-		const value = options.forceValue === undefined ? this.value : !options.forceValue;
 
 		// Whether we are turning off some items.
-		const turnOff = value === true;
+		const turnOff = options.forceValue !== undefined ? !options.forceValue : this.value;
+
 		// If we are turning off items, we are going to rename them to paragraphs.
 
 		model.change( writer => {

--- a/packages/ckeditor5-list/src/listcommand.js
+++ b/packages/ckeditor5-list/src/listcommand.js
@@ -56,8 +56,8 @@ export default class ListCommand extends Command {
 	 * @fires execute
 	 * @param {Object} [options] Command options.
 	 * @param {Boolean} [options.forceValue] If set, it will force the command behavior. If `true`, the command will try to convert the
-	 * selected items and potentially the neighbor elements to the proper list items.
-	 * If not set, the command will toggle selected elements to list items or paragraphs, depending on the selection.
+	 * selected items and potentially the neighbor elements to the proper list items. If set to `false` it will convert selected elements
+	 * to paragraphs. If not set, the command will toggle selected elements to list items or paragraphs, depending on the selection.
 	 */
 	execute( options = {} ) {
 		const model = this.editor.model;

--- a/packages/ckeditor5-list/tests/listcommand.js
+++ b/packages/ckeditor5-list/tests/listcommand.js
@@ -133,6 +133,33 @@ describe( 'ListCommand', () => {
 				} );
 			} );
 
+			describe( 'options.forceValue', () => {
+				it( 'should force converting into the list if the `options.forceValue` is set to `true`', () => {
+					setData( model, '<paragraph>fo[]o</paragraph>' );
+
+					command.execute( { forceValue: true } );
+
+					expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="bulleted">fo[]o</listItem>' );
+
+					command.execute( { forceValue: true } );
+
+					expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="bulleted">fo[]o</listItem>' );
+				} );
+
+				it( 'should force converting into the paragraph if the `options.forceValue` is set to `false`', () => {
+					setData( model, '<listItem listIndent="0" listType="bulleted">fo[]o</listItem>' );
+
+					command.execute( { forceValue: false } );
+
+					// Attributes will be removed by post fixer.
+					expect( getData( model ) ).to.equal( '<paragraph listIndent="0" listType="bulleted">fo[]o</paragraph>' );
+
+					command.execute( { forceValue: false } );
+
+					expect( getData( model ) ).to.equal( '<paragraph listIndent="0" listType="bulleted">fo[]o</paragraph>' );
+				} );
+			} );
+
 			describe( 'collapsed selection', () => {
 				it( 'should rename closest block to listItem and set correct attributes', () => {
 					setData( model, '<paragraph>fo[]o</paragraph>' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Introduced the `config.forceValue` option to `ListCommand` that allows overriding the default toggle-like behavior to allow more predictable state changes during applying track changes suggestions.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._