### PR TITLE
Fixed dragging text in read-only mode. Fixed dragging nested editable.

### DIFF
--- a/packages/ckeditor5-clipboard/src/dragdrop.js
+++ b/packages/ckeditor5-clipboard/src/dragdrop.js
@@ -242,7 +242,7 @@ export default class DragDrop extends Plugin {
 			const selection = modelDocument.selection;
 
 			// Don't drag the editable element itself.
-			if ( data.target && data.target.is( 'rootElement' ) ) {
+			if ( data.target && data.target.is( 'editableElement' ) ) {
 				data.preventDefault();
 
 				return;
@@ -470,7 +470,7 @@ export default class DragDrop extends Plugin {
 			// If this was not a widget then we should check if we need to drag some text content.
 			// In Chrome set a 'draggable' attribute on closest editable to allow immediate dragging of the selected text range.
 			// In Firefox this is not needed. In Safari it makes the whole editable draggable (not just textual content).
-			if ( env.isBlink && !draggableElement && !viewDocument.selection.isCollapsed ) {
+			if ( env.isBlink && !editor.isReadOnly && !draggableElement && !viewDocument.selection.isCollapsed ) {
 				const selectedElement = viewDocument.selection.getSelectedElement();
 
 				if ( !selectedElement || !isWidget( selectedElement ) ) {

--- a/packages/ckeditor5-clipboard/src/dragdrop.js
+++ b/packages/ckeditor5-clipboard/src/dragdrop.js
@@ -470,6 +470,8 @@ export default class DragDrop extends Plugin {
 			// If this was not a widget then we should check if we need to drag some text content.
 			// In Chrome set a 'draggable' attribute on closest editable to allow immediate dragging of the selected text range.
 			// In Firefox this is not needed. In Safari it makes the whole editable draggable (not just textual content).
+			// Disabled in read-only mode because draggable="true" + contenteditable="false" results
+			// in not firing selectionchange event ever, which makes the selection stuck in read-only mode.
 			if ( env.isBlink && !editor.isReadOnly && !draggableElement && !viewDocument.selection.isCollapsed ) {
 				const selectedElement = viewDocument.selection.getSelectedElement();
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (clipboard): Fixed changing selection in read-only mode. Closes #9372.

Fix (clipboard): Nested editable should not be dragged. Closes #9370.

---

### Additional information