### PR TITLE
MediaEmbed: Set custom element name

### DIFF
--- a/packages/ckeditor5-media-embed/docs/features/media-embed.md
+++ b/packages/ckeditor5-media-embed/docs/features/media-embed.md
@@ -101,6 +101,30 @@ By default, the media embed feature outputs semantic `<oembed url="...">` tags f
 </figure>
 ```
 
+Further customization of semantic data output can be done through the {@link module:media-embed/mediaembed~MediaEmbedConfig#preferredElementName `config.mediaEmbed.preferredElementName`} and {@link module:media-embed/mediaembed~MediaEmbedConfig#elementNames `config.mediaEmbed.elementNames`} options. As an example, if `preferredElementName` is set to `o-embed`:
+
+```html
+<figure class="media">
+	<o-embed url="https://media-url"></oembed>
+</figure>
+```
+
+And further, to be backward compatible with legacy semantic elements (any element using the `url` attribute, these can be passed via `elementNames`: `['oembed', 'o-embed']`. If there is a semantic tag for `<mytag url="..."></mytag>`, you can set `['oembed', 'o-embed', 'mytag']`. To remove support for tags, omit the tag name. To skip handling of `<oembed>` tags, `['oembed']`:
+
+```js
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ MediaEmbed, ... ],,
+		toolbar: [ 'mediaEmbed', ... ]
+		mediaEmbed: {
+			elementNames: ['oembed']
+		}
+	} )
+	.then( ... )
+	.catch( ... );
+```
+
+
 #### Including previews in data
 
 Optionally, by setting `mediaEmbed.previewsInData` to `true` you can configure the media embed feature to output media in the same way they look in the editor. So if the media element is "previewable", the media preview (HTML) is saved to the database:

--- a/packages/ckeditor5-media-embed/src/mediaembed.js
+++ b/packages/ckeditor5-media-embed/src/mediaembed.js
@@ -237,6 +237,44 @@ export default class MediaEmbed extends Plugin {
  */
 
 /**
+ * Customizing semantic element name.
+ *
+ * When `oembed` (default), the feature produces "semantic" data with tag `<oembed>`:
+ *
+ *		<figure class="media">
+ *			<oembed url="https://url"></oembed>
+ *		</figure>
+ *
+ * It can also be set to other element names, for instance, `o-embed` will produce:
+ *
+ *		<figure class="media">
+ *			<o-embed url="https://url"></oembed>
+ *		</figure>
+ *
+ * @member {String} [module:media-embed/mediaembed~MediaEmbedConfig#preferredElementName]
+ */
+
+/**
+ * Supporting legacy semantic element names.
+ *
+ * When `['oembed', 'o-embed']` (default), the feature renders "semantic" data for content with
+ * `<oembed>` an `<o-embed>` tags:
+ *
+ *		<figure class="media">
+ *			<oembed url="https://url"></oembed>
+ *		</figure>
+ *
+ *		<figure class="media">
+ *			<o-embed url="https://url"></oembed>
+ *		</figure>
+ *
+ * By default, the feature will render new media embeds via the option
+ * {@link module:media-embed/mediaembed~MediaEmbedConfig#preferredElementName `config.mediaEmbed.preferredElementName`}
+ *
+ * @member {Array} [module:media-embed/mediaembed~MediaEmbedConfig#elementNames]
+ */
+
+/**
  * Controls the data format produced by the feature.
  *
  * When `false` (default), the feature produces "semantic" data, i.e. it does not include the preview of

--- a/packages/ckeditor5-media-embed/src/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/src/mediaembedediting.js
@@ -36,6 +36,8 @@ export default class MediaEmbedEditing extends Plugin {
 		super( editor );
 
 		editor.config.define( 'mediaEmbed', {
+			elementNames: [ 'oembed', 'o-embed' ],
+			preferredElementName: 'oembed',
 			providers: [
 				{
 					name: 'dailymotion',
@@ -162,6 +164,8 @@ export default class MediaEmbedEditing extends Plugin {
 		const t = editor.t;
 		const conversion = editor.conversion;
 		const renderMediaPreview = editor.config.get( 'mediaEmbed.previewsInData' );
+		const elementNames = editor.config.get( 'mediaEmbed.elementNames' );
+		const preferredElementName = editor.config.get( 'mediaEmbed.preferredElementName' );
 		const registry = this.registry;
 
 		editor.commands.add( 'mediaEmbed', new MediaEmbedCommand( editor ) );
@@ -181,6 +185,7 @@ export default class MediaEmbedEditing extends Plugin {
 				const url = modelElement.getAttribute( 'url' );
 
 				return createMediaFigureElement( writer, registry, url, {
+					preferredElementName,
 					renderMediaPreview: url && renderMediaPreview
 				} );
 			}
@@ -189,6 +194,7 @@ export default class MediaEmbedEditing extends Plugin {
 		// Model -> Data (url -> data-oembed-url)
 		conversion.for( 'dataDowncast' ).add(
 			modelToViewUrlAttributeConverter( registry, {
+				preferredElementName,
 				renderMediaPreview
 			} ) );
 
@@ -198,6 +204,7 @@ export default class MediaEmbedEditing extends Plugin {
 			view: ( modelElement, { writer } ) => {
 				const url = modelElement.getAttribute( 'url' );
 				const figure = createMediaFigureElement( writer, registry, url, {
+					preferredElementName,
 					renderForEditingView: true
 				} );
 
@@ -208,6 +215,7 @@ export default class MediaEmbedEditing extends Plugin {
 		// Model -> View (url -> data-oembed-url)
 		conversion.for( 'editingDowncast' ).add(
 			modelToViewUrlAttributeConverter( registry, {
+				preferredElementName,
 				renderForEditingView: true
 			} ) );
 
@@ -216,7 +224,7 @@ export default class MediaEmbedEditing extends Plugin {
 			// Upcast semantic media.
 			.elementToElement( {
 				view: {
-					name: 'oembed',
+					name: new RegExp( `^(${ elementNames.join( '|' ) })$` ),
 					attributes: {
 						url: true
 					}

--- a/packages/ckeditor5-media-embed/src/mediaregistry.js
+++ b/packages/ckeditor5-media-embed/src/mediaregistry.js
@@ -67,6 +67,13 @@ export default class MediaRegistry {
 		 * @member {Array}
 		 */
 		this.providerDefinitions = providerDefinitions;
+
+		/**
+		 * The preferred element names for newly added media embed.
+		 *
+		 * @member {String}
+		 */
+		this.preferredElementName = config.preferredElementName;
 	}
 
 	/**
@@ -206,6 +213,7 @@ class Media {
 	 *
 	 * @param {module:engine/view/downcastwriter~DowncastWriter} writer The view writer used to produce a view element.
 	 * @param {Object} options
+	 * @param {String} [options.preferredElementName]
 	 * @param {String} [options.renderMediaPreview]
 	 * @param {String} [options.renderForEditingView]
 	 * @returns {module:engine/view/element~Element}
@@ -233,7 +241,7 @@ class Media {
 				attributes.url = this.url;
 			}
 
-			viewElement = writer.createEmptyElement( 'oembed', attributes );
+			viewElement = writer.createEmptyElement( options.preferredElementName, attributes );
 		}
 
 		writer.setCustomProperty( 'media-content', true, viewElement );

--- a/packages/ckeditor5-media-embed/tests/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedediting.js
@@ -611,8 +611,12 @@ describe( 'MediaEmbedEditing', () => {
 						} )
 							.then( newEditor => {
 								newEditor.setData(
-									'<figure class="media"><o-embed url="unknown.media"></o-embed></figure>' +
-									'<figure class="media"><o-embed url="foo.com/123"></o-embed></figure>' );
+									'<figure class="media">' +
+										'<div data-oembed-url="foo.com/123"></div>' +
+									'</figure>' +
+									'<figure class="media">' +
+										'<div data-oembed-url="unknown.media/123"></div>' +
+									'</figure>' );
 
 								expect( getModelData( newEditor.model, { withoutSelection: true } ) )
 									.to.equal( '<media url="foo.com/123"></media>' );


### PR DESCRIPTION
See #9373 for details.

`<oembed>`  is an invalid name for custom elements ([WhatWG](https://html.spec.whatwg.org/#valid-custom-element-name), [MDN](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#high-level_view)).

Allow setting element name (especially to `<o-embed>`). Retain compatibility with existing tags.

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Type: Message. Closes #9373


### Checklist

`MediaEmbed`
- [x] Add `preferredElementName` option (default: `'oembed'`)
- [x] Add `elementNames` option (default: `['oembed', 'o-embed']`)
- [x] Preserves existing behavior
  - [x] `elementNames` option: Default includes `'oembed'`: `['oembed', 'o-embed']`
  - [x] `preferredElementName` option: Default is `'oembed'`
- [x] Basic docs (Internal API)
- [x] Basic docs (Markdown docs) 
- [x] Tests

---

### Additional information

Also related: #2737 (Implement a web component to handle `<oembed url="...">`)

I have an `<o-embed>` custom element polyfill here: [Github](https://github.com/social-embed/social-embed
), [NPM](https://www.npmjs.com/package/@social-embed/wc) [CodeSandbox](https://codepen.io/attachment/pen/poRRwdy)