### PR TITLE
Fix crash in renderer

### DIFF
--- a/packages/ckeditor5-engine/src/view/renderer.js
+++ b/packages/ckeditor5-engine/src/view/renderer.js
@@ -268,6 +268,12 @@ export default class Renderer {
 
 		if ( actions.indexOf( 'replace' ) !== -1 ) {
 			const counter = { equal: 0, insert: 0, delete: 0 };
+			// Removing nodes from the DOM as we iterate can cause `actualDomChildren`
+			// (which is a live-updating `NodeList`) to get out of sync with the
+			// indices that we compute as we iterate over `actions`, producing
+			// incorrect element mappings. So collect all the DOM nodes that need to
+			// be removed and remove them after the iteration is complete.
+			const toRemove = [];
 
 			for ( const action of actions ) {
 				if ( action === 'replace' ) {
@@ -282,12 +288,14 @@ export default class Renderer {
 						this._updateElementMappings( viewChild, actualDomChildren[ deleteIndex ] );
 					}
 
-					remove( expectedDomChildren[ insertIndex ] );
+					toRemove.push( expectedDomChildren[ insertIndex ] );
 					counter.equal++;
 				} else {
 					counter[ action ]++;
 				}
 			}
+
+			toRemove.forEach( remove );
 		}
 	}
 

--- a/packages/ckeditor5-engine/tests/view/renderer.js
+++ b/packages/ckeditor5-engine/tests/view/renderer.js
@@ -3435,6 +3435,30 @@ describe( 'Renderer', () => {
 
 				expect( domRoot.innerHTML ).to.equal( '<span>2</span><strong>6</strong><span>5</span>1<span>3</span><strong>7</strong>4' );
 			} );
+
+			it( 'should correctly handle multiple changes when using fastDiff', () => {
+				let str = '';
+				for ( let i = 0; i < 100; i++ ) {
+					str = `${ str }${ i }<attribute:span>${ i }</attribute:span>`;
+				}
+
+				viewRoot._insertChild( 0,
+					parse( str )
+				);
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				viewRoot._removeChildren( 0, 1 );
+				viewRoot._removeChildren( 4, 1 );
+
+				renderer.markToSync( 'children', viewRoot );
+
+				// This would throw without a fix.
+				renderer.render();
+
+				expect( domRoot.innerHTML ).to.equal(
+					str.slice( 1 ).replaceAll( 'attribute:span', 'span' ).replace( '<span>2</span>', '' ) );
+			} );
 		} );
 
 		describe( 'optimal (minimal) rendering – minimal children changes', () => {


### PR DESCRIPTION
This loop was doing unsafe removals of DOM nodes while iterating over indices that point into a live `NodeList`, and was causing a crash in certain cases.

The error is:

```
TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at Function.from (<anonymous>)
    at Renderer._updateAttrs (webpack:///./packages/ckeditor5-engine/src/view/renderer.js?:19:11593)
    at Renderer.render (webpack:///./packages/ckeditor5-engine/src/view/renderer.js?:19:2390)
```

and it can happen when this loop ends up setting up an incorrect mapping from a view element to a text node, and then `_updateAttrs()` is called on that text node.

The factors that I've identified that will cause this to reproduce are:
* Enough nodes to make `_diffNodeLists()` use the fastDiff implementation
* A render involving at least two changes (e.g. removals) separated other nodes