### PR TITLE
Page break: make upcast converter less strict

### DIFF
--- a/packages/ckeditor5-page-break/src/pagebreakediting.js
+++ b/packages/ckeditor5-page-break/src/pagebreakediting.js
@@ -99,7 +99,7 @@ export default class PageBreakEditing extends Plugin {
 					if ( element.childCount == 1 ) {
 						const viewSpan = element.getChild( 0 );
 
-						// The child must be the "span" element that is not displayed and has a space inside.
+						// The child must be the "span" element that is not displayed.
 						if ( !viewSpan.is( 'element', 'span' ) || viewSpan.getStyle( 'display' ) != 'none' ) {
 							return;
 						}

--- a/packages/ckeditor5-page-break/src/pagebreakediting.js
+++ b/packages/ckeditor5-page-break/src/pagebreakediting.js
@@ -100,13 +100,7 @@ export default class PageBreakEditing extends Plugin {
 						const viewSpan = element.getChild( 0 );
 
 						// The child must be the "span" element that is not displayed and has a space inside.
-						if ( !viewSpan.is( 'element', 'span' ) || viewSpan.getStyle( 'display' ) != 'none' || viewSpan.childCount != 1 ) {
-							return;
-						}
-
-						const text = viewSpan.getChild( 0 );
-
-						if ( !text.is( '$text' ) || text.data !== ' ' ) {
+						if ( !viewSpan.is( 'element', 'span' ) || viewSpan.getStyle( 'display' ) != 'none' ) {
 							return;
 						}
 					} else if ( element.childCount > 1 ) {

--- a/packages/ckeditor5-page-break/tests/pagebreakediting.js
+++ b/packages/ckeditor5-page-break/tests/pagebreakediting.js
@@ -172,34 +172,21 @@ describe( 'PageBreakEditing', () => {
 					.to.equal( '' );
 			} );
 
+			it( 'should convert if inner span is empty', () => {
+				editor.setData(
+					'<div class="page-break" style="page-break-after:always;">' +
+						'<span style="display:none;"></span>' +
+					'</div>'
+				);
+
+				expect( getModelData( model, { withoutSelection: true } ) )
+					.to.equal( '<pageBreak></pageBreak>' );
+			} );
+
 			it( 'should not convert if inner span has wrong styles', () => {
 				editor.setData(
 					'<div class="page-break" style="page-break-after:always;">' +
 						'<span style="display:inline-block;">&nbsp;</span>' +
-					'</div>'
-				);
-
-				expect( getModelData( model, { withoutSelection: true } ) )
-					.to.equal( '' );
-			} );
-
-			it( 'should not convert if inner span has any children', () => {
-				editor.setData(
-					'<div class="page-break" style="page-break-after:always;">' +
-						'<span style="display:none;">' +
-							'<span>Foo</span>' +
-						'</span>' +
-					'</div>'
-				);
-
-				expect( getModelData( model, { withoutSelection: true } ) )
-					.to.equal( '' );
-			} );
-
-			it( 'should not convert if inner span has text', () => {
-				editor.setData(
-					'<div class="page-break" style="page-break-after:always;">' +
-						'<span style="display:none;">Foo</span>' +
 					'</div>'
 				);
 
@@ -235,26 +222,6 @@ describe( 'PageBreakEditing', () => {
 
 				expect( getModelData( model, { withoutSelection: true } ) )
 					.to.equal( '<pageBreak></pageBreak><section><$text foo="true">Foo</$text></section>' );
-			} );
-
-			it( 'should not convert if inner span has no children', () => {
-				editor.setData( '<div class="page-break" style="page-break-after:always;"><span style="display:none;"></span></div>' );
-
-				expect( getModelData( model, { withoutSelection: true } ) )
-					.to.equal( '' );
-			} );
-
-			it( 'should not convert if inner span has other element as a child', () => {
-				editor.setData(
-					'<div class="page-break" style="page-break-after:always;">' +
-						'<span style="display:none;">' +
-							'<span></span>' +
-						'</span>' +
-					'</div>'
-				);
-
-				expect( getModelData( model, { withoutSelection: true } ) )
-					.to.equal( '' );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (page-break): Upcast converter will be less strict when checking if a view element should be converted to the model. Closes #9385.