### PR TITLE
Executing the imageType command from the model.change callback.

### DIFF
--- a/packages/ckeditor5-image/src/imagestyle/imagestylecommand.js
+++ b/packages/ckeditor5-image/src/imagestyle/imagestylecommand.js
@@ -93,21 +93,22 @@ export default class ImageStyleCommand extends Command {
 	 * @fires execute
 	 */
 	execute( options ) {
-		const requestedArrangement = options.value;
 		const model = this.editor.model;
 
-		let imageElement = model.document.selection.getSelectedElement();
-		const supportedTypes = this._arrangements.get( requestedArrangement ).modelElements;
-
-		// Change the image type if a style requires it.
-		if ( !supportedTypes.includes( imageElement.name ) ) {
-			this.editor.execute( !supportedTypes.includes( 'image' ) ? 'imageTypeInline' : 'imageTypeBlock' );
-
-			// Update the imageElement to the newly created image.
-			imageElement = model.document.selection.getSelectedElement();
-		}
-
 		model.change( writer => {
+			const requestedArrangement = options.value;
+			const supportedTypes = this._arrangements.get( requestedArrangement ).modelElements;
+
+			let imageElement = model.document.selection.getSelectedElement();
+
+			// Change the image type if a style requires it.
+			if ( !supportedTypes.includes( imageElement.name ) ) {
+				this.editor.execute( !supportedTypes.includes( 'image' ) ? 'imageTypeInline' : 'imageTypeBlock' );
+
+				// Update the imageElement to the newly created image.
+				imageElement = model.document.selection.getSelectedElement();
+			}
+
 			// Default style means that there is no `imageStyle` attribute in the model.
 			// https://github.com/ckeditor/ckeditor5-image/issues/147
 			if ( this._arrangements.get( requestedArrangement ).isDefault ) {

--- a/packages/ckeditor5-image/tests/imagestyle/imagestylecommand.js
+++ b/packages/ckeditor5-image/tests/imagestyle/imagestylecommand.js
@@ -57,6 +57,20 @@ describe( 'ImageStyleCommand', () => {
 		} );
 	} );
 
+	it( 'should undo the whole command action if the image type has changed', () => {
+		const initialData = '[<image src="assets/sample.png"></image>]';
+
+		setData( model, initialData );
+
+		command.execute( { value: onlyInline.name } );
+
+		expect( getData( model ) ).to.equal( '<paragraph>[<imageInline src="assets/sample.png"></imageInline>]</paragraph>' );
+
+		editor.execute( 'undo' );
+
+		expect( getData( model ) ).to.equal( initialData );
+	} );
+
 	describe( 'constructor()', () => {
 		it( 'should set default arrangement names properly if both of them are defined in the config', () => {
 			expect( command._defaultArrangements ).to.deep.equal( {


### PR DESCRIPTION
Fix (image): The whole action of the `imageStyle` command (changing the image type and its style) should be undone in one step. Closes #9322.