### PR TITLE
Introduce the uploadComplete event in ImageUploadEditing

### DIFF
--- a/packages/ckeditor5-image/docs/framework/guides/deep-dive/upload-adapter.md
+++ b/packages/ckeditor5-image/docs/framework/guides/deep-dive/upload-adapter.md
@@ -376,7 +376,7 @@ xhr.addEventListener( 'load', () => {
 
 There is a chance you might need to pass additional data from the server to provide additional data to some features. In order to do that you need to wrap all URLs in the `urls` property and pass additional data in the top level of the object.
 
-For image uploading, you can later retrieve the data in {@link module:image/imageupload/imageuploadediting~ImageUploadEditing#event:uploadComplete the `uploadComplete` event}, which allows setting new attributes and overriding the existing ones on the model image based on the data just after the image is uploaded.
+For image uploading, you can later retrieve the data in the {@link module:image/imageupload/imageuploadediting~ImageUploadEditing#event:uploadComplete `uploadComplete`} event, which allows setting new attributes and overriding the existing ones on the model image based on the data just after the image is uploaded.
 
 ```js
 {

--- a/packages/ckeditor5-image/docs/framework/guides/deep-dive/upload-adapter.md
+++ b/packages/ckeditor5-image/docs/framework/guides/deep-dive/upload-adapter.md
@@ -372,6 +372,22 @@ xhr.addEventListener( 'load', () => {
 } );
 ```
 
+### Passing additional data to the response
+
+There is a chance you might need to pass additional data from the server to provide additional data to some features. In order to do that you need to wrap all URLs in the `urls` property and pass additional data in the top level of the object.
+
+For image uploading, you can later retrieve the data in {@link module:image/imageupload/imageuploadediting~ImageUploadEditing#event:uploadComplete the `uploadComplete` event}, which allows setting new attributes and overriding the existing ones on the model image based on the data just after the image is uploaded.
+
+```js
+{
+	urls: {
+		default: 'http://example.com/images/image–default-size.png',
+		// Optional different sizes of images.
+	},
+	customProperty: 'foo'
+}
+```
+
 ### Activating a custom upload adapter
 
 Having implemented the adapter, you must figure out how to enable it in the WYSIWYG editor. The good news is that it is pretty easy, and you do not need to {@link builds/guides/development/custom-builds rebuild the editor} to do that!

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.js
@@ -282,7 +282,7 @@ export default class ImageUploadEditing extends Plugin {
 					 *
 					 * 		const imageUploadEditing = editor.plugins.get( 'ImageUploadEditing );
 					 *
-					 * 		imageUploadEditing.on( 'uploadComplete', evt, { data, imageElement } => {
+					 * 		imageUploadEditing.on( 'uploadComplete', ( evt, { data, imageElement } ) => {
 					 * 			editor.model.change( writer => {
 					 * 				writer.setAttribute( 'someAttribute', 'foo', imageElement );
 					 * 			} );
@@ -291,15 +291,17 @@ export default class ImageUploadEditing extends Plugin {
 					 * You can also stop the default handler that sets the `src` and `srcset` attributes
 					 * if you want to provide custom values for these attributes.
 					 *
-					 * 		imageUploadEditing.on( 'uploadComplete', evt, { data, imageElement } => {
+					 * 		imageUploadEditing.on( 'uploadComplete', ( evt, { data, imageElement } ) => {
 					 * 			evt.stop();
 					 * 		} );
 					 *
+					 * **Note**: This event is fired by the {@link module:image/imageupload/imageuploadediting~ImageUploadEditing} plugin.
+					 *
 					 * @event uploadComplete
-					 * @param {Object} options The `uploadComplete` event options.
-					 * @param {Object} options.data The data coming from the upload adapter.
-					 * @param {module:engine/model/element~Element} options.imageElement The
-					 * {@link module:engine/model/element~Element image element} that can be customized.
+					 * @param {Object} data The `uploadComplete` event data.
+					 * @param {Object} data.data The data coming from the upload adapter.
+					 * @param {module:engine/model/element~Element} data.imageElement The
+					 * model {@link module:engine/model/element~Element image element} that can be customized.
 					 */
 					this.fire( 'uploadComplete', { data, imageElement } );
 				} );

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.js
@@ -199,7 +199,6 @@ export default class ImageUploadEditing extends Plugin {
 		// Set the default handler for feeding the image element with `src` and `srcset` attributes.
 		this.on( 'uploadComplete', ( evt, { imageElement, writer, data } ) => {
 			writer.setAttribute( 'src', data.default, imageElement );
-
 			this._parseAndSetSrcsetAttributeOnImage( data, imageElement, writer );
 		}, { priority: 'low' } );
 	}

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.js
@@ -197,9 +197,13 @@ export default class ImageUploadEditing extends Plugin {
 		} );
 
 		// Set the default handler for feeding the image element with `src` and `srcset` attributes.
-		this.on( 'uploadComplete', ( evt, { imageElement, writer, data } ) => {
-			writer.setAttribute( 'src', data.default, imageElement );
-			this._parseAndSetSrcsetAttributeOnImage( data, imageElement, writer );
+		this.on( 'uploadComplete', ( evt, { imageElement, data } ) => {
+			const urls = data.urls ? data.urls : data;
+
+			this.editor.model.change( writer => {
+				writer.setAttribute( 'src', urls.default, imageElement );
+				this._parseAndSetSrcsetAttributeOnImage( urls, imageElement, writer );
+			} );
 		}, { priority: 'low' } );
 	}
 
@@ -278,25 +282,26 @@ export default class ImageUploadEditing extends Plugin {
 					 *
 					 * 		const imageUploadEditing = editor.plugins.get( 'ImageUploadEditing );
 					 *
-					 * 		imageUploadEditing.on( 'uploadComplete', evt, { writer, data, imageElement } => {
-					 * 			writer.setAttribute( 'someAttribute', 'foo', imageElement );
+					 * 		imageUploadEditing.on( 'uploadComplete', evt, { data, imageElement } => {
+					 * 			editor.model.change( writer => {
+					 * 				writer.setAttribute( 'someAttribute', 'foo', imageElement );
+					 * 			} );
 					 * 		} );
 					 *
 					 * You can also stop the default handler that sets the `src` and `srcset` attributes
 					 * if you want to provide custom values for these attributes.
 					 *
-					 * 		imageUploadEditing.on( 'uploadComplete', evt, { writer, data, imageElement } => {
+					 * 		imageUploadEditing.on( 'uploadComplete', evt, { data, imageElement } => {
 					 * 			evt.stop();
 					 * 		} );
 					 *
 					 * @event uploadComplete
 					 * @param {Object} options The `uploadComplete` event options.
 					 * @param {Object} options.data The data coming from the upload adapter.
-					 * @param {module:engine/model/element~Element} options.image The
-					 * {@link module:engine/model/element~Element image element}.
-					 * @param {module:engine/model/writer~Writer} options.writer A writer that can operate on the image element.
+					 * @param {module:engine/model/element~Element} options.imageElement The
+					 * {@link module:engine/model/element~Element image element} that can be customized.
 					 */
-					this.fire( 'uploadComplete', { writer, data, imageElement } );
+					this.fire( 'uploadComplete', { data, imageElement } );
 				} );
 
 				clean();

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
@@ -653,10 +653,9 @@ describe( 'ImageUploadEditing', () => {
 	describe( 'uploadComplete event', () => {
 		it( 'should be fired when the upload adapter resolves with the image data', async () => {
 			const file = createNativeFileMock();
-			setModelData( model, '<paragraph>{}foo bar</paragraph>' );
+			setModelData( model, '<paragraph>[]foo bar</paragraph>' );
 
 			const imageUploadEditing = editor.plugins.get( 'ImageUploadEditing' );
-
 			const uploadCompleteSpy = sinon.spy();
 
 			imageUploadEditing.on( 'uploadComplete', uploadCompleteSpy );
@@ -680,16 +679,13 @@ describe( 'ImageUploadEditing', () => {
 			const eventArgs = uploadCompleteSpy.firstCall.args[ 1 ];
 
 			expect( eventArgs ).to.be.an( 'object' );
-
-			expect( eventArgs.imageElement ).to.be.an( 'object' );
-			expect( eventArgs.imageElement.name ).to.equal( 'image' );
-
+			expect( eventArgs.imageElement.is( 'model:element', 'image' ) ).to.be.true;
 			expect( eventArgs.data ).to.deep.equal( { default: 'image.png' } );
 		} );
 
 		it( 'should allow modifying the image element once the original image is uploaded', async () => {
 			const file = createNativeFileMock();
-			setModelData( model, '<paragraph>{}foo bar</paragraph>' );
+			setModelData( model, '<paragraph>[]foo bar</paragraph>' );
 
 			editor.model.schema.extend( 'image', { allowAttributes: 'data-original' } );
 
@@ -706,10 +702,12 @@ describe( 'ImageUploadEditing', () => {
 				} );
 
 			const imageUploadEditing = editor.plugins.get( 'ImageUploadEditing' );
+			let batch;
 
 			imageUploadEditing.on( 'uploadComplete', ( evt, { imageElement, data } ) => {
 				editor.model.change( writer => {
 					writer.setAttribute( 'data-original', data.originalUrl, imageElement );
+					batch = writer.batch;
 				} );
 			} );
 
@@ -725,24 +723,47 @@ describe( 'ImageUploadEditing', () => {
 				loader.file.then( () => adapterMocks[ 0 ].mockSuccess( { originalUrl: 'original.jpg', default: 'image.jpg' } ) );
 			} );
 
+			// Make sure the custom attribute was set in the same transparent batch as the default handling (setting src and status).
+			expect( batch.type ).to.equal( 'transparent' );
+			expect( batch.operations.length ).to.equal( 3 );
+
+			expect( batch.operations[ 0 ].type ).to.equal( 'changeAttribute' );
+			expect( batch.operations[ 0 ].key ).to.equal( 'uploadStatus' );
+			expect( batch.operations[ 0 ].newValue ).to.equal( 'complete' );
+
+			expect( batch.operations[ 1 ].type ).to.equal( 'addAttribute' );
+			expect( batch.operations[ 1 ].key ).to.equal( 'data-original' );
+			expect( batch.operations[ 1 ].newValue ).to.equal( 'original.jpg' );
+
+			expect( batch.operations[ 2 ].type ).to.equal( 'addAttribute' );
+			expect( batch.operations[ 2 ].key ).to.equal( 'src' );
+			expect( batch.operations[ 2 ].newValue ).to.equal( 'image.jpg' );
+
+			expect( getModelData( model ) ).to.equal(
+				'[<image data-original="original.jpg" src="image.jpg"></image>]<paragraph>foo bar</paragraph>'
+			);
+
 			expect( getViewData( view ) ).to.equal(
 				'[<figure class="ck-widget image" contenteditable="false">' +
-				'<img data-original="original.jpg" src="image.jpg"></img>' +
-				'</figure>]<p>foo bar</p>'
+					'<img data-original="original.jpg" src="image.jpg"></img>' +
+				'</figure>]' +
+				'<p>foo bar</p>'
 			);
 		} );
 
 		it( 'should allow stopping the original listener that sets image attributes based on the data', async () => {
 			const file = createNativeFileMock();
-			setModelData( model, '<paragraph>{}foo bar</paragraph>' );
+			setModelData( model, '<paragraph>[]foo bar</paragraph>' );
 
 			const imageUploadEditing = editor.plugins.get( 'ImageUploadEditing' );
+			let batch;
 
 			imageUploadEditing.on( 'uploadComplete', ( evt, { imageElement } ) => {
 				evt.stop();
 
 				model.change( writer => {
 					writer.setAttribute( 'src', 'foo.jpg', imageElement );
+					batch = writer.batch;
 				} );
 			} );
 
@@ -760,10 +781,27 @@ describe( 'ImageUploadEditing', () => {
 				) );
 			} );
 
+			// Make sure the custom attribute was set in the same transparent batch as the default handling (setting src and status).
+			expect( batch.type ).to.equal( 'transparent' );
+			expect( batch.operations.length ).to.equal( 2 );
+
+			expect( batch.operations[ 0 ].type ).to.equal( 'changeAttribute' );
+			expect( batch.operations[ 0 ].key ).to.equal( 'uploadStatus' );
+			expect( batch.operations[ 0 ].newValue ).to.equal( 'complete' );
+
+			expect( batch.operations[ 1 ].type ).to.equal( 'addAttribute' );
+			expect( batch.operations[ 1 ].key ).to.equal( 'src' );
+			expect( batch.operations[ 1 ].newValue ).to.equal( 'foo.jpg' );
+
+			expect( getModelData( model ) ).to.equal(
+				'[<image src="foo.jpg"></image>]<paragraph>foo bar</paragraph>'
+			);
+
 			expect( getViewData( view ) ).to.equal(
 				'[<figure class="ck-widget image" contenteditable="false">' +
-				'<img src="foo.jpg"></img>' +
-				'</figure>]<p>foo bar</p>'
+					'<img src="foo.jpg"></img>' +
+				'</figure>]' +
+				'<p>foo bar</p>'
 			);
 		} );
 	} );

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
@@ -69,7 +69,7 @@ describe( 'ImageUploadEditing', () => {
 				viewDocument = view.document;
 
 				// Stub `view.scrollToTheSelection` as it will fail on VirtualTestEditor without DOM.
-				sinon.stub( view, 'scrollToTheSelection' ).callsFake( () => { } );
+				sinon.stub( view, 'scrollToTheSelection' ).callsFake( () => {} );
 			} );
 	} );
 

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
@@ -25,7 +25,7 @@ import { setData as setModelData, getData as getModelData } from '@ckeditor/cked
 import { getData as getViewData, stringify as stringifyView } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 
 import Notification from '@ckeditor/ckeditor5-ui/src/notification/notification';
-import Writer from '@ckeditor/ckeditor5-engine/src/model/writer';
+import { modelToViewAttributeConverter } from '../../src/image/converters';
 
 describe( 'ImageUploadEditing', () => {
 	// eslint-disable-next-line max-len
@@ -629,42 +629,122 @@ describe( 'ImageUploadEditing', () => {
 		loader.file.then( () => nativeReaderMock.mockSuccess( base64Sample ) );
 	} );
 
-	it( 'should allow hooking into the `uploadComplete` event', done => {
-		const file = createNativeFileMock();
-		setModelData( model, '<paragraph>{}foo bar</paragraph>' );
+	describe( 'uploadComplete event', () => {
+		it( 'should be fired when the upload adapter resolves with the image data', async () => {
+			const file = createNativeFileMock();
+			setModelData( model, '<paragraph>{}foo bar</paragraph>' );
 
-		const imageUploadEditing = editor.plugins.get( 'ImageUploadEditing' );
+			const imageUploadEditing = editor.plugins.get( 'ImageUploadEditing' );
 
-		const uploadCompleteSpy = sinon.spy();
+			const uploadCompleteSpy = sinon.spy();
 
-		imageUploadEditing.on( 'uploadComplete', uploadCompleteSpy );
+			imageUploadEditing.on( 'uploadComplete', uploadCompleteSpy );
 
-		editor.execute( 'uploadImage', { file } );
+			editor.execute( 'uploadImage', { file } );
 
-		model.document.once( 'change', () => {
+			await new Promise( res => {
+				model.document.once( 'change', res );
+				loader.file.then( () => nativeReaderMock.mockSuccess( base64Sample ) );
+			} );
+
 			sinon.assert.notCalled( uploadCompleteSpy );
 
-			model.document.once( 'change', () => {
-				tryExpect( done, () => {
-					sinon.assert.calledOnce( uploadCompleteSpy );
+			await new Promise( res => {
+				model.document.once( 'change', res, { priority: 'lowest' } );
+				loader.file.then( () => adapterMocks[ 0 ].mockSuccess( { default: 'image.png' } ) );
+			} );
 
-					const eventArgs = uploadCompleteSpy.firstCall.args[ 1 ];
+			sinon.assert.calledOnce( uploadCompleteSpy );
 
-					expect( eventArgs ).to.be.an( 'object' );
+			const eventArgs = uploadCompleteSpy.firstCall.args[ 1 ];
 
-					expect( eventArgs.writer ).to.be.instanceOf( Writer );
+			expect( eventArgs ).to.be.an( 'object' );
 
-					expect( eventArgs.imageElement ).to.be.an( 'object' );
-					expect( eventArgs.imageElement.name ).to.equal( 'image' );
+			expect( eventArgs.imageElement ).to.be.an( 'object' );
+			expect( eventArgs.imageElement.name ).to.equal( 'image' );
 
-					expect( eventArgs.data ).to.deep.equal( { default: 'image.png' } );
-				} );
-			}, { priority: 'lowest' } );
-
-			loader.file.then( () => adapterMocks[ 0 ].mockSuccess( { default: 'image.png' } ) );
+			expect( eventArgs.data ).to.deep.equal( { default: 'image.png' } );
 		} );
 
-		loader.file.then( () => nativeReaderMock.mockSuccess( base64Sample ) );
+		it( 'should allow modifying the image element once the original image is uploaded', async () => {
+			const file = createNativeFileMock();
+			setModelData( model, '<paragraph>{}foo bar</paragraph>' );
+
+			editor.model.schema.extend( 'image', { allowAttributes: 'data-original' } );
+
+			editor.conversion.for( 'downcast' )
+				.add( modelToViewAttributeConverter( 'data-original' ) );
+
+			editor.conversion.for( 'upcast' )
+				.attributeToAttribute( {
+					view: {
+						name: 'img',
+						key: 'data-original'
+					},
+					model: 'data-original'
+				} );
+
+			const imageUploadEditing = editor.plugins.get( 'ImageUploadEditing' );
+
+			imageUploadEditing.on( 'uploadComplete', ( evt, { imageElement, data } ) => {
+				editor.model.change( writer => {
+					writer.setAttribute( 'data-original', data.originalUrl, imageElement );
+				} );
+			} );
+
+			editor.execute( 'uploadImage', { file } );
+
+			await new Promise( res => {
+				model.document.once( 'change', res );
+				loader.file.then( () => nativeReaderMock.mockSuccess( base64Sample ) );
+			} );
+
+			await new Promise( res => {
+				model.document.once( 'change', res, { priority: 'lowest' } );
+				loader.file.then( () => adapterMocks[ 0 ].mockSuccess( { originalUrl: 'original.jpg', default: 'image.jpg' } ) );
+			} );
+
+			expect( getViewData( view ) ).to.equal(
+				'[<figure class="ck-widget image" contenteditable="false">' +
+				'<img data-original="original.jpg" src="image.jpg"></img>' +
+				'</figure>]<p>foo bar</p>'
+			);
+		} );
+
+		it( 'should allow stopping the original listener that sets image attributes based on the data', async () => {
+			const file = createNativeFileMock();
+			setModelData( model, '<paragraph>{}foo bar</paragraph>' );
+
+			const imageUploadEditing = editor.plugins.get( 'ImageUploadEditing' );
+
+			imageUploadEditing.on( 'uploadComplete', ( evt, { imageElement } ) => {
+				evt.stop();
+
+				model.change( writer => {
+					writer.setAttribute( 'src', 'foo.jpg', imageElement );
+				} );
+			} );
+
+			editor.execute( 'uploadImage', { file } );
+
+			await new Promise( res => {
+				model.document.once( 'change', res );
+				loader.file.then( () => nativeReaderMock.mockSuccess( base64Sample ) );
+			} );
+
+			await new Promise( res => {
+				model.document.once( 'change', res, { priority: 'lowest' } );
+				loader.file.then( () => adapterMocks[ 0 ].mockSuccess(
+					{ default: 'image.png', 500: 'image-500.png', 800: 'image-800.png' }
+				) );
+			} );
+
+			expect( getViewData( view ) ).to.equal(
+				'[<figure class="ck-widget image" contenteditable="false">' +
+				'<img src="foo.jpg"></img>' +
+				'</figure>]<p>foo bar</p>'
+			);
+		} );
 	} );
 
 	it( 'should prevent from browser redirecting when an image is dropped on another image', () => {

--- a/packages/ckeditor5-upload/src/adapters/simpleuploadadapter.js
+++ b/packages/ckeditor5-upload/src/adapters/simpleuploadadapter.js
@@ -174,7 +174,14 @@ class Adapter {
 				return reject( response && response.error && response.error.message ? response.error.message : genericErrorText );
 			}
 
-			resolve( response.url ? { default: response.url } : response.urls );
+			const urls = response.url ? { default: response.url } : response.urls;
+
+			// Resolve with the normalized `urls` property and pass the rest of the response
+			// to allow customizing the behavior of features relying on the upload adapters.
+			resolve( {
+				...response,
+				urls
+			} );
 		} );
 
 		// Upload progress when it is supported.

--- a/packages/ckeditor5-upload/src/filerepository.js
+++ b/packages/ckeditor5-upload/src/filerepository.js
@@ -609,6 +609,20 @@ mix( FileLoader, ObservableMixin );
  *			'1052': 'http://server/default-size.image.png'
  *		}
  *
+ * You can also pass additional properties from the server. In this case you need to wrap URLs
+ * in the `urls` object and pass additional properties along the `urls` property.
+ *
+ * 		{
+ * 			myCustomProperty: 'foo',
+ * 			urls: {
+ *				default: 'http://server/default-size.image.png',
+ *				'160': 'http://server/size-160.image.png',
+ *				'500': 'http://server/size-500.image.png',
+ *				'1000': 'http://server/size-1000.image.png',
+ *				'1052': 'http://server/default-size.image.png'
+ *			}
+ *		}
+ *
  * NOTE: When returning multiple images, the widest returned one should equal the default one. It is essential to
  * correctly set `width` attribute of the image. See this discussion:
  * https://github.com/ckeditor/ckeditor5-easy-image/issues/4 for more information.

--- a/packages/ckeditor5-upload/tests/adapters/simpleuploadadapter.js
+++ b/packages/ckeditor5-upload/tests/adapters/simpleuploadadapter.js
@@ -158,8 +158,12 @@ describe( 'SimpleUploadAdapter', () => {
 							return uploadPromise;
 						} )
 						.then( uploadResponse => {
-							expect( uploadResponse ).to.be.a( 'object' );
-							expect( uploadResponse ).to.have.property( 'default', 'http://example.com/images/image.jpeg' );
+							expect( uploadResponse ).to.deep.equal( {
+								url: 'http://example.com/images/image.jpeg',
+								urls: {
+									default: 'http://example.com/images/image.jpeg'
+								}
+							} );
 						} );
 				} );
 
@@ -200,8 +204,12 @@ describe( 'SimpleUploadAdapter', () => {
 									return uploadPromise;
 								} )
 								.then( uploadResponse => {
-									expect( uploadResponse ).to.be.a( 'object' );
-									expect( uploadResponse ).to.have.property( 'default', 'http://example.com/images/image.jpeg' );
+									expect( uploadResponse ).to.deep.equal( {
+										url: 'http://example.com/images/image.jpeg',
+										urls: {
+											default: 'http://example.com/images/image.jpeg'
+										}
+									} );
 
 									editorElement.remove();
 								} )
@@ -241,8 +249,12 @@ describe( 'SimpleUploadAdapter', () => {
 									return uploadPromise;
 								} )
 								.then( uploadResponse => {
-									expect( uploadResponse ).to.be.a( 'object' );
-									expect( uploadResponse ).to.have.property( 'default', 'http://example.com/images/image.jpeg' );
+									expect( uploadResponse ).to.deep.equal( {
+										url: 'http://example.com/images/image.jpeg',
+										urls: {
+											default: 'http://example.com/images/image.jpeg'
+										}
+									} );
 
 									editorElement.remove();
 								} )
@@ -280,8 +292,12 @@ describe( 'SimpleUploadAdapter', () => {
 									return uploadPromise;
 								} )
 								.then( uploadResponse => {
-									expect( uploadResponse ).to.be.a( 'object' );
-									expect( uploadResponse ).to.have.property( 'default', 'http://example.com/images/image.jpeg' );
+									expect( uploadResponse ).to.deep.equal( {
+										url: 'http://example.com/images/image.jpeg',
+										urls: {
+											default: 'http://example.com/images/image.jpeg'
+										}
+									} );
 
 									editorElement.remove();
 								} )
@@ -318,8 +334,12 @@ describe( 'SimpleUploadAdapter', () => {
 									return uploadPromise;
 								} )
 								.then( uploadResponse => {
-									expect( uploadResponse ).to.be.a( 'object' );
-									expect( uploadResponse ).to.have.property( 'default', 'http://example.com/images/image.jpeg' );
+									expect( uploadResponse ).to.deep.equal( {
+										url: 'http://example.com/images/image.jpeg',
+										urls: {
+											default: 'http://example.com/images/image.jpeg'
+										}
+									} );
 
 									editorElement.remove();
 								} )
@@ -348,7 +368,45 @@ describe( 'SimpleUploadAdapter', () => {
 						return uploadPromise;
 					} )
 					.then( uploadResponse => {
-						expect( uploadResponse ).to.deep.equal( validResponse.urls );
+						expect( uploadResponse ).to.deep.equal( {
+							urls: {
+								default: 'http://example.com/images/image.jpeg',
+								'120': 'http://example.com/images/image-120.jpeg',
+								'240': 'http://example.com/images/image-240.jpeg'
+							}
+						} );
+					} );
+			} );
+
+			it( 'should pass additional properties to the response', () => {
+				const validResponse = {
+					urls: {
+						default: 'http://example.com/images/image.jpeg',
+						'120': 'http://example.com/images/image-120.jpeg',
+						'240': 'http://example.com/images/image-240.jpeg'
+					},
+					customProperty: 'foo'
+				};
+
+				const uploadPromise = adapter.upload();
+
+				return loader.file
+					.then( () => {
+						sinonXHR.requests[ 0 ].respond( 200, {
+							'Content-Type': 'application/json'
+						}, JSON.stringify( validResponse ) );
+
+						return uploadPromise;
+					} )
+					.then( uploadResponse => {
+						expect( uploadResponse ).to.deep.equal( {
+							urls: {
+								default: 'http://example.com/images/image.jpeg',
+								'120': 'http://example.com/images/image-120.jpeg',
+								'240': 'http://example.com/images/image-240.jpeg'
+							},
+							customProperty: 'foo'
+						} );
 					} );
 			} );
 

--- a/packages/ckeditor5-upload/tests/adapters/simpleuploadadapter.js
+++ b/packages/ckeditor5-upload/tests/adapters/simpleuploadadapter.js
@@ -368,13 +368,7 @@ describe( 'SimpleUploadAdapter', () => {
 						return uploadPromise;
 					} )
 					.then( uploadResponse => {
-						expect( uploadResponse ).to.deep.equal( {
-							urls: {
-								default: 'http://example.com/images/image.jpeg',
-								'120': 'http://example.com/images/image-120.jpeg',
-								'240': 'http://example.com/images/image-240.jpeg'
-							}
-						} );
+						expect( uploadResponse ).to.deep.equal( validResponse );
 					} );
 			} );
 
@@ -399,14 +393,7 @@ describe( 'SimpleUploadAdapter', () => {
 						return uploadPromise;
 					} )
 					.then( uploadResponse => {
-						expect( uploadResponse ).to.deep.equal( {
-							urls: {
-								default: 'http://example.com/images/image.jpeg',
-								'120': 'http://example.com/images/image-120.jpeg',
-								'240': 'http://example.com/images/image-240.jpeg'
-							},
-							customProperty: 'foo'
-						} );
+						expect( uploadResponse ).to.deep.equal( validResponse );
 					} );
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (image): Introduced the `uploadComplete` event in `ImageUploadEditing` that allows customizing the image element (e.g. setting custom attributes) based on data retrieved from the upload adapter. Closes #5204.

Feature (upload): Upload adapters' `upload` method can now return a promise that resolves to an object with additional properties along with the `urls` array. See more in #5204.

MINOR BREAKING CHANGE (upload): The `SimpleUploadAdapter#upload()` returns now a promise that resolves to an object with normalized data including the `urls` array, which was only returned before. This may affect all integrations depending on the `SimpleUploadAdapter` uploading mechanism.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._