### PR TITLE
Split Travis jobs into two machines (parallel tasks)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
-sudo: required
 dist: xenial
 addons:
   chrome: stable
 language: node_js
 services:
 - xvfb
-cache:
-  yarn: true
 node_js:
 - "12"
-cache:
-- node_modules
+cache: yarn
 before_install:
 - export START_TIME=$( date +%s )
 - export COVERALLS_SERVICE_JOB_ID=$( TRAVIS_JOB_ID )
@@ -18,20 +14,14 @@ before_install:
 - npm i -g yarn
 install:
 - yarn install
-# The "./manual/all-features-dll.js" test requires building DLL.
-- yarn run dll:build
 script:
-- node ./scripts/continuous-integration-script.js
-- yarn run lint
-- yarn run stylelint
-- ./scripts/check-manual-tests.sh -r ckeditor5 -f ckeditor5
-- yarn run docs --strict
-- 'if [ $TRAVIS_TEST_RESULT -eq 0 ]; then
-    travis_wait 30 yarn run docs:build-and-publish-nightly;
-  fi'
+- ./scripts/ci/travis-check.js
+# "travis_wait" does not work in child processes. Hence, it must be called from the configuration file.
+- if [[ $TRAVIS_JOB_TYPE == "Validate" && $TRAVIS_TEST_RESULT -eq 0 ]]; then travis_wait 30 yarn run docs:build-and-publish-nightly; fi
 after_script:
 - export END_TIME=$( date +%s )
 - ckeditor5-dev-tests-notify-travis-status
 env:
-  global:
-  - secure: RO140EQDHmEOPJPikk8eCY5IdHpnEKGm41p5U1ewAbeZv1DpCG+rSumR2JdYl75kFAaZvCSm1NuVMM+kmYd+/z+LQbKj7QH5G/UHNho3H89blIU6WlJhT0YR5vclm9rvnEvOtxnfODca1Qrw+CaCoJks2o4VYbJB7mOBVNsh7Bc=
+  jobs:
+  - TRAVIS_JOB_TYPE=Coverage
+  - TRAVIS_JOB_TYPE=Validate

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ install:
 script:
 - ./scripts/ci/travis-check.js
 # "travis_wait" does not work in child processes. Hence, it must be called from the configuration file.
-- if [[ $TRAVIS_JOB_TYPE == "Validate" && $TRAVIS_TEST_RESULT -eq 0 ]]; then travis_wait 30 yarn run docs:build-and-publish-nightly; fi
+- if [[ $TRAVIS_JOB_TYPE == "Validation" && $TRAVIS_TEST_RESULT -eq 0 ]]; then travis_wait 30 yarn run docs:build-and-publish-nightly; fi
 after_script:
 - export END_TIME=$( date +%s )
 - ckeditor5-dev-tests-notify-travis-status
 env:
   jobs:
-  - TRAVIS_JOB_TYPE=Coverage
-  - TRAVIS_JOB_TYPE=Validate
+  - TRAVIS_JOB_TYPE=Tests
+  - TRAVIS_JOB_TYPE=Validation

--- a/scripts/ci/check-packages-code-coverage.js
+++ b/scripts/ci/check-packages-code-coverage.js
@@ -9,6 +9,12 @@
 
 'use strict';
 
+/**
+ * This script should be used on Travis CI. It executes tests and prepares the code coverage report
+ * for each package found in the `packages/` directory. Then, all reports are merged into a single
+ * file that will be sent to Coveralls.
+ */
+
 const childProcess = require( 'child_process' );
 const crypto = require( 'crypto' );
 const fs = require( 'fs' );
@@ -64,7 +70,7 @@ childProcess.execSync( 'mkdir .nyc_output' );
 childProcess.execSync( 'rm -r -f .out' );
 childProcess.execSync( 'mkdir .out' );
 
-const packages = childProcess.execSync( 'ls packages -1', {
+const packages = childProcess.execSync( 'ls -1 packages', {
 	encoding: 'utf8'
 } ).toString().trim().split( '\n' );
 
@@ -115,12 +121,12 @@ if ( Object.values( failedChecks ).some( checksSet => checksSet.size > 0 ) ) {
 	process.exit( 1 ); // Exit code 1 will break the CI build.
 }
 
-/*
- * @param {String} binaryName - Name of a CLI binary to be called.
- * @param {String[]} cliArguments - An array of arguments to be passed to the `binaryName`.
- * @param {String} packageName - Checked package name.
- * @param {String} checkName - A key associated with the problem in the `failedChecks` dictionary.
- * @param {String} failMessage - Message to be shown if check failed.
+/**
+ * @param {String} binaryName Name of a CLI binary to be called.
+ * @param {Array.<String>} cliArguments An array of arguments to be passed to the `binaryName`.
+ * @param {String} packageName Checked package name.
+ * @param {String} checkName A key associated with the problem in the `failedChecks` dictionary.
+ * @param {String} failMessage Message to be shown if check failed.
  */
 function runSubprocess( binaryName, cliArguments, packageName, checkName, failMessage ) {
 	const subprocess = childProcess.spawnSync( binaryName, cliArguments, {
@@ -155,10 +161,9 @@ function appendCoverageReport() {
 
 	matches.forEach( filePath => {
 		const buffer = fs.readFileSync( filePath );
+		const reportPath = [ '.out', 'combined_lcov.info' ].join( path.sep );
 
-		fs.writeFileSync( [ '.out', 'combined_lcov.info' ].join( path.sep ), buffer, {
-			flag: 'as'
-		} );
+		fs.writeFileSync( reportPath, buffer, { flag: 'as' } );
 	} );
 }
 

--- a/scripts/ci/travis-check.js
+++ b/scripts/ci/travis-check.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* eslint-env node */
+
+'use strict';
+
+const childProcess = require( 'child_process' );
+const crypto = require( 'crypto' );
+const path = require( 'path' );
+
+const ROOT_DIRECTORY = path.join( __dirname, '..', '..' );
+const { TRAVIS_JOB_TYPE } = process.env;
+
+const RED = '\x1B[0;31m';
+const GREEN = '\x1B[32m';
+const CYAN = '\x1B[36;1m';
+const MAGENTA = '\x1B[35;1m';
+const NO_COLOR = '\x1B[0m';
+
+// Tests + Code coverage.
+if ( TRAVIS_JOB_TYPE === 'Coverage' ) {
+	console.log( `\n${ CYAN }Running the "Coverage" build.${ NO_COLOR }\n` );
+
+	exec( 'node', './scripts/ci/check-packages-code-coverage.js' );
+}
+
+// Verifying the code style.
+if ( TRAVIS_JOB_TYPE === 'Validate' ) {
+	console.log( `\n${ CYAN }Running the "Validate" build.${ NO_COLOR }\n` );
+
+	// Linters.
+	exec( 'yarn', 'run', 'lint' );
+	exec( 'yarn', 'run', 'stylelint' );
+
+	// Verifying manual tests.
+	exec( 'yarn', 'run', 'dll:build' );
+	exec( 'sh', './scripts/check-manual-tests.sh', '-r', 'ckeditor5', '-f', 'ckeditor5' );
+
+	// Build the docs.
+	exec( 'yarn', 'run', 'docs', '--strict' );
+}
+
+/**
+ * Executes the specified command. E.g. for displaying the Node's version, use:
+ *
+ *		exec( 'node', '-v' );
+ *
+ * The output will be formatted using Travis's structure that increases readability.
+ *
+ * @param {..String} command
+ */
+function exec( ...command ) {
+	const travis = {
+		_lastTimerId: null,
+		_lastStartTime: null,
+
+		foldStart() {
+			console.log( `travis_fold:start:script${ MAGENTA }$ ${ command.join( ' ' ) }${ NO_COLOR }` );
+			this._timeStart();
+		},
+
+		foldEnd() {
+			this._timeFinish();
+			console.log( '\ntravis_fold:end:script\n' );
+		},
+
+		_timeStart() {
+			const nanoSeconds = process.hrtime.bigint();
+
+			this._lastTimerId = crypto.createHash( 'md5' ).update( nanoSeconds.toString() ).digest( 'hex' );
+			this._lastStartTime = nanoSeconds;
+
+			// Intentional direct write to stdout, to manually control EOL.
+			process.stdout.write( `travis_time:start:${ this._lastTimerId }\r\n` );
+		},
+
+		_timeFinish() {
+			const travisEndTime = process.hrtime.bigint();
+			const duration = travisEndTime - this._lastStartTime;
+
+			// Intentional direct write to stdout, to manually control EOL.
+			process.stdout.write(
+				`\ntravis_time:end:${ this._lastTimerId }:start=${ this._lastStartTime },` +
+				`finish=${ travisEndTime },duration=${ duration }\r\n`
+			);
+		}
+	};
+
+	travis.foldStart();
+
+	const childProcessStatus = childProcess.spawnSync( command[ 0 ], command.slice( 1 ), {
+		encoding: 'utf8',
+		shell: true,
+		cwd: ROOT_DIRECTORY,
+		stdio: 'inherit',
+		stderr: 'inherit'
+	} );
+
+	const EXIT_CODE = childProcessStatus.status;
+	const COLOR = EXIT_CODE ? RED : GREEN;
+
+	travis.foldEnd();
+
+	console.log( `${ COLOR }The command "${ command.join( ' ' ) }" exited with ${ EXIT_CODE }.${ NO_COLOR }\n` );
+
+	if ( childProcessStatus.status ) {
+		// An error occurred. Break the entire script.
+		process.exit( EXIT_CODE );
+	}
+}

--- a/scripts/ci/travis-check.js
+++ b/scripts/ci/travis-check.js
@@ -23,15 +23,15 @@ const MAGENTA = '\x1B[35;1m';
 const NO_COLOR = '\x1B[0m';
 
 // Tests + Code coverage.
-if ( TRAVIS_JOB_TYPE === 'Coverage' ) {
-	console.log( `\n${ CYAN }Running the "Coverage" build.${ NO_COLOR }\n` );
+if ( TRAVIS_JOB_TYPE === 'Tests' ) {
+	console.log( `\n${ CYAN }Running the "Tests" build.${ NO_COLOR }\n` );
 
 	exec( 'node', './scripts/ci/check-packages-code-coverage.js' );
 }
 
 // Verifying the code style.
-if ( TRAVIS_JOB_TYPE === 'Validate' ) {
-	console.log( `\n${ CYAN }Running the "Validate" build.${ NO_COLOR }\n` );
+if ( TRAVIS_JOB_TYPE === 'Validation' ) {
+	console.log( `\n${ CYAN }Running the "Validation" build.${ NO_COLOR }\n` );
 
 	// Linters.
 	exec( 'yarn', 'run', 'lint' );

--- a/scripts/docs/build-and-publish-nightly.js
+++ b/scripts/docs/build-and-publish-nightly.js
@@ -15,13 +15,18 @@ This script is to be used on CI to automatically update https://ckeditor5.github
 
 */
 
+const buildBranch = process.env.TRAVIS_BRANCH;
+
 // Build the documentation only when master branch is updated.
-if ( process.env.TRAVIS_BRANCH !== 'master' ) {
+if ( buildBranch !== 'master' ) {
+	printDebugLog( `Aborting due to an invalid branch (${ buildBranch }).` );
 	process.exit();
 }
 
 // Build the documentation only when a cron task triggered the CI.
 if ( process.env.TRAVIS_EVENT_TYPE !== 'cron' ) {
+	printDebugLog( `Aborting due to an invalid event type (${ process.env.TRAVIS_EVENT_TYPE }).` );
+
 	process.exit();
 }
 
@@ -108,5 +113,11 @@ function exec( command ) {
 		console.error( error );
 
 		process.exit( 1 );
+	}
+}
+
+function printDebugLog( message ) {
+	if ( process.env.DEBUG == 'true' ) {
+		console.log( '[Nightly Docs]', message );
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Split Travis jobs into two machines (parallel tasks). Closes cksource/ckeditor5-internal#706.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
