### PR TITLE
Fix (ui) buttonview error when withKeystroke is true but keystroke is undefined

### DIFF
--- a/packages/ckeditor5-ui/src/button/buttonview.js
+++ b/packages/ckeditor5-ui/src/button/buttonview.js
@@ -184,7 +184,7 @@ export default class ButtonView extends View {
 		this.children.add( this.tooltipView );
 		this.children.add( this.labelView );
 
-		if ( this.withKeystroke ) {
+		if ( this.withKeystroke && this.keystroke ) {
 			this.children.add( this.keystrokeView );
 		}
 	}

--- a/packages/ckeditor5-utils/src/keyboard.js
+++ b/packages/ckeditor5-utils/src/keyboard.js
@@ -101,10 +101,11 @@ export function getCode( key ) {
  * @returns {Number} Keystroke code.
  */
 export function parseKeystroke( keystroke ) {
-	if ( typeof keystroke == 'string' ) {
-		keystroke = splitKeystrokeText( keystroke );
-	}
-
+	if ( typeof keystroke != 'string' ) 
+		return
+		
+	keystroke = splitKeystrokeText( keystroke );
+	
 	return keystroke
 		.map( key => ( typeof key == 'string' ) ? getEnvKeyCode( key ) : key )
 		.reduce( ( key, sum ) => sum + key, 0 );


### PR DESCRIPTION
I experienced an error with CKEditor with my custom plugin initialized after updating CKEditor to v 26.0.0 

```
TypeError: Cannot read property 'map' of undefined
    at parseKeystroke (keyboard.js:109)
    at getEnvKeystrokeText (keyboard.js:121)
    at TemplateToBinding.callback (buttonview.js:270)
    at TemplateToBinding.getValue (template.js:908)
    at template.js:1038
    at Array.map (<anonymous>)
    at getValueSchemaValue (template.js:1035)
    at syncValueSchemaValue (template.js:1053)
    at Template._bindToObservable (template.js:783)
    at Template._renderText (template.js:477)
(anonymous) @ app.js:19
Promise.catch (async)
./app.js @ app.js:18
__webpack_require__ @ bootstrap:19
(anonymous) @ bootstrap:83
(anonymous) @ bootstrap:83
```


This happened because I unconsciously created a button view with arg `withKeystroke=true` and forget to define `keystroke`. 

```
editor.ui.componentFactory.add( 'customPlugin', locale => {
            const view = new ButtonView( locale );
            view.set( {
                label: 'Custom Plugin',
                icon: someIcon,
                tooltip: true,
                withKeystroke : true
            } );

            return view;
        } );
```

On CKEditor 25.0.0 this works fine but in CKEditor 26.0.0+ this causes the error.

My proposed fix to prevent this error is by giving additional conditional checking in `buttonview.js` when creating keystrokeView and check `parseKeystroke`'s argument in keyboard.js.
