### PR TITLE
MediaEmbed: Set custom element name (alt)

### DIFF
--- a/packages/ckeditor5-media-embed/docs/features/media-embed.md
+++ b/packages/ckeditor5-media-embed/docs/features/media-embed.md
@@ -101,7 +101,7 @@ By default, the media embed feature outputs semantic `<oembed url="...">` tags f
 </figure>
 ```
 
-Further customization of semantic data output can be done through the {@link module:media-embed/mediaembed~MediaEmbedConfig#preferredElementName `config.mediaEmbed.preferredElementName`}. As an example, if `preferredElementName` is set to `o-embed`:
+Further customization of semantic data output can be done through the {@link module:media-embed/mediaembed~MediaEmbedConfig#elementName `config.mediaEmbed.elementName`}. As an example, if `elementName` is set to `o-embed`:
 
 ```html
 <figure class="media">
@@ -109,7 +109,7 @@ Further customization of semantic data output can be done through the {@link mod
 </figure>
 ```
 
-To be backward compatible with legacy semantic elements, `<oembed>` tags are still supported when `preferredElementName` is set.
+To be backward compatible with legacy semantic elements, `<oembed>` tags are still supported when `elementName` is set.
 
 #### Including previews in data
 

--- a/packages/ckeditor5-media-embed/docs/features/media-embed.md
+++ b/packages/ckeditor5-media-embed/docs/features/media-embed.md
@@ -101,7 +101,7 @@ By default, the media embed feature outputs semantic `<oembed url="...">` tags f
 </figure>
 ```
 
-Further customization of semantic data output can be done through the {@link module:media-embed/mediaembed~MediaEmbedConfig#preferredElementName `config.mediaEmbed.preferredElementName`} and {@link module:media-embed/mediaembed~MediaEmbedConfig#elementNames `config.mediaEmbed.elementNames`} options. As an example, if `preferredElementName` is set to `o-embed`:
+Further customization of semantic data output can be done through the {@link module:media-embed/mediaembed~MediaEmbedConfig#preferredElementName `config.mediaEmbed.preferredElementName`}. As an example, if `preferredElementName` is set to `o-embed`:
 
 ```html
 <figure class="media">
@@ -109,21 +109,7 @@ Further customization of semantic data output can be done through the {@link mod
 </figure>
 ```
 
-And further, to be backward compatible with legacy semantic elements (any element using the `url` attribute, these can be passed via `elementNames`: `['oembed', 'o-embed']`. If there is a semantic tag for `<mytag url="..."></mytag>`, you can set `['oembed', 'o-embed', 'mytag']`. To remove support for tags, omit the tag name. To skip handling of `<oembed>` tags, `['oembed']`:
-
-```js
-ClassicEditor
-	.create( document.querySelector( '#editor' ), {
-		plugins: [ MediaEmbed, ... ],,
-		toolbar: [ 'mediaEmbed', ... ]
-		mediaEmbed: {
-			elementNames: ['oembed']
-		}
-	} )
-	.then( ... )
-	.catch( ... );
-```
-
+To be backward compatible with legacy semantic elements, `<oembed>` tags are still supported when `preferredElementName` is set.
 
 #### Including previews in data
 

--- a/packages/ckeditor5-media-embed/docs/features/media-embed.md
+++ b/packages/ckeditor5-media-embed/docs/features/media-embed.md
@@ -101,6 +101,30 @@ By default, the media embed feature outputs semantic `<oembed url="...">` tags f
 </figure>
 ```
 
+Further customization of semantic data output can be done through the {@link module:media-embed/mediaembed~MediaEmbedConfig#preferredElementName `config.mediaEmbed.preferredElementName`} and {@link module:media-embed/mediaembed~MediaEmbedConfig#elementNames `config.mediaEmbed.elementNames`} options. As an example, if `preferredElementName` is set to `o-embed`:
+
+```html
+<figure class="media">
+	<o-embed url="https://media-url"></oembed>
+</figure>
+```
+
+And further, to be backward compatible with legacy semantic elements (any element using the `url` attribute, these can be passed via `elementNames`: `['oembed', 'o-embed']`. If there is a semantic tag for `<mytag url="..."></mytag>`, you can set `['oembed', 'o-embed', 'mytag']`. To remove support for tags, omit the tag name. To skip handling of `<oembed>` tags, `['oembed']`:
+
+```js
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ MediaEmbed, ... ],,
+		toolbar: [ 'mediaEmbed', ... ]
+		mediaEmbed: {
+			elementNames: ['oembed']
+		}
+	} )
+	.then( ... )
+	.catch( ... );
+```
+
+
 #### Including previews in data
 
 Optionally, by setting `mediaEmbed.previewsInData` to `true` you can configure the media embed feature to output media in the same way they look in the editor. So if the media element is "previewable", the media preview (HTML) is saved to the database:

--- a/packages/ckeditor5-media-embed/docs/features/media-embed.md
+++ b/packages/ckeditor5-media-embed/docs/features/media-embed.md
@@ -105,7 +105,7 @@ Further customization of semantic data output can be done through the {@link mod
 
 ```html
 <figure class="media">
-	<o-embed url="https://media-url"></oembed>
+	<o-embed url="https://media-url"></o-embed>
 </figure>
 ```
 

--- a/packages/ckeditor5-media-embed/docs/features/media-embed.md
+++ b/packages/ckeditor5-media-embed/docs/features/media-embed.md
@@ -109,7 +109,7 @@ Further customization of semantic data output can be done through the {@link mod
 </figure>
 ```
 
-To be backward compatible with legacy semantic elements, `<oembed>` tags are still supported when `elementName` is set.
+If `elementName` is overridden to something beside the default value, existing `<oembed>` elements will still be shown when for backward compatibility purposes.
 
 #### Including previews in data
 

--- a/packages/ckeditor5-media-embed/src/converters.js
+++ b/packages/ckeditor5-media-embed/src/converters.js
@@ -28,6 +28,7 @@
  * @param {module:media-embed/mediaregistry~MediaRegistry} registry The registry providing
  * the media and their content.
  * @param {Object} options
+ * @param {String} [options.elementName] When set, overrides the default element name for semantic media embeds.
  * @param {String} [options.renderMediaPreview] When `true`, the converter will create the view in the non-semantic form.
  * @param {String} [options.renderForEditingView] When `true`, the converter will create a view specific for the
  * editing pipeline (e.g. including CSS classes, content placeholders).

--- a/packages/ckeditor5-media-embed/src/mediaembed.js
+++ b/packages/ckeditor5-media-embed/src/mediaembed.js
@@ -255,26 +255,6 @@ export default class MediaEmbed extends Plugin {
  */
 
 /**
- * Supporting legacy semantic element names.
- *
- * When `['oembed', 'o-embed']` (default), the feature renders "semantic" data for content with
- * `<oembed>` an `<o-embed>` tags:
- *
- *		<figure class="media">
- *			<oembed url="https://url"></oembed>
- *		</figure>
- *
- *		<figure class="media">
- *			<o-embed url="https://url"></oembed>
- *		</figure>
- *
- * By default, the feature will render new media embeds via the option
- * {@link module:media-embed/mediaembed~MediaEmbedConfig#preferredElementName `config.mediaEmbed.preferredElementName`}
- *
- * @member {Array} [module:media-embed/mediaembed~MediaEmbedConfig#elementNames]
- */
-
-/**
  * Controls the data format produced by the feature.
  *
  * When `false` (default), the feature produces "semantic" data, i.e. it does not include the preview of

--- a/packages/ckeditor5-media-embed/src/mediaembed.js
+++ b/packages/ckeditor5-media-embed/src/mediaembed.js
@@ -237,20 +237,30 @@ export default class MediaEmbed extends Plugin {
  */
 
 /**
- * Customizing semantic element name.
+ * Override the element name used for "semantic" data.
  *
- * When `oembed` (default), the feature produces "semantic" data with tag `<oembed>`:
+ * This is not relevant if {@link module:media-embed/mediaembed~MediaEmbedConfig#previewsInData `config.mediaEmbed.previewsInData`}
+ * is set to `true`.
+ *
+ * When unset, the feature produces tag `<oembed>`:
  *
  *		<figure class="media">
  *			<oembed url="https://url"></oembed>
  *		</figure>
  *
- * It can also be set to other element names, for instance, `o-embed` will produce:
+ * To override the element name used, for instance, to use `<o-embed>`:
+ *
+ *		mediaEmbed: {
+ *			elementName: 'o-embed'
+ *		}
+ *
+ * This will produce semantic data like such:
  *
  *		<figure class="media">
  *			<o-embed url="https://url"></o-embed>
  *		</figure>
  *
+ * @default 'o-embed'
  * @member {String} [module:media-embed/mediaembed~MediaEmbedConfig#elementName]
  */
 

--- a/packages/ckeditor5-media-embed/src/mediaembed.js
+++ b/packages/ckeditor5-media-embed/src/mediaembed.js
@@ -251,7 +251,7 @@ export default class MediaEmbed extends Plugin {
  *			<o-embed url="https://url"></o-embed>
  *		</figure>
  *
- * @member {String} [module:media-embed/mediaembed~MediaEmbedConfig#preferredElementName]
+ * @member {String} [module:media-embed/mediaembed~MediaEmbedConfig#elementName]
  */
 
 /**

--- a/packages/ckeditor5-media-embed/src/mediaembed.js
+++ b/packages/ckeditor5-media-embed/src/mediaembed.js
@@ -248,7 +248,7 @@ export default class MediaEmbed extends Plugin {
  * It can also be set to other element names, for instance, `o-embed` will produce:
  *
  *		<figure class="media">
- *			<o-embed url="https://url"></oembed>
+ *			<o-embed url="https://url"></o-embed>
  *		</figure>
  *
  * @member {String} [module:media-embed/mediaembed~MediaEmbedConfig#preferredElementName]

--- a/packages/ckeditor5-media-embed/src/mediaembed.js
+++ b/packages/ckeditor5-media-embed/src/mediaembed.js
@@ -237,6 +237,44 @@ export default class MediaEmbed extends Plugin {
  */
 
 /**
+ * Customizing semantic element name.
+ *
+ * When `oembed` (default), the feature produces "semantic" data with tag `<oembed>`:
+ *
+ *		<figure class="media">
+ *			<oembed url="https://url"></oembed>
+ *		</figure>
+ *
+ * It can also be set to other element names, for instance, `o-embed` will produce:
+ *
+ *		<figure class="media">
+ *			<o-embed url="https://url"></oembed>
+ *		</figure>
+ *
+ * @member {String} [module:media-embed/mediaembed~MediaEmbedConfig#preferredElementName]
+ */
+
+/**
+ * Supporting legacy semantic element names.
+ *
+ * When `['oembed', 'o-embed']` (default), the feature renders "semantic" data for content with
+ * `<oembed>` an `<o-embed>` tags:
+ *
+ *		<figure class="media">
+ *			<oembed url="https://url"></oembed>
+ *		</figure>
+ *
+ *		<figure class="media">
+ *			<o-embed url="https://url"></oembed>
+ *		</figure>
+ *
+ * By default, the feature will render new media embeds via the option
+ * {@link module:media-embed/mediaembed~MediaEmbedConfig#preferredElementName `config.mediaEmbed.preferredElementName`}
+ *
+ * @member {Array} [module:media-embed/mediaembed~MediaEmbedConfig#elementNames]
+ */
+
+/**
  * Controls the data format produced by the feature.
  *
  * When `false` (default), the feature produces "semantic" data, i.e. it does not include the preview of

--- a/packages/ckeditor5-media-embed/src/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/src/mediaembedediting.js
@@ -36,7 +36,7 @@ export default class MediaEmbedEditing extends Plugin {
 		super( editor );
 
 		editor.config.define( 'mediaEmbed', {
-			preferredElementName: 'oembed',
+			elementName: 'oembed',
 			providers: [
 				{
 					name: 'dailymotion',
@@ -163,8 +163,8 @@ export default class MediaEmbedEditing extends Plugin {
 		const t = editor.t;
 		const conversion = editor.conversion;
 		const renderMediaPreview = editor.config.get( 'mediaEmbed.previewsInData' );
-		const preferredElementName = editor.config.get( 'mediaEmbed.preferredElementName' );
-		const elementNames = preferredElementName ? [ preferredElementName ] : [];
+		const elementName = editor.config.get( 'mediaEmbed.elementName' );
+		const elementNames = elementName ? [ elementName ] : [];
 		if ( elementNames.includes( 'oembed' ) ) {
 			elementNames.push( 'oembed' );
 		}
@@ -188,7 +188,7 @@ export default class MediaEmbedEditing extends Plugin {
 				const url = modelElement.getAttribute( 'url' );
 
 				return createMediaFigureElement( writer, registry, url, {
-					preferredElementName,
+					elementName,
 					renderMediaPreview: url && renderMediaPreview
 				} );
 			}
@@ -197,7 +197,7 @@ export default class MediaEmbedEditing extends Plugin {
 		// Model -> Data (url -> data-oembed-url)
 		conversion.for( 'dataDowncast' ).add(
 			modelToViewUrlAttributeConverter( registry, {
-				preferredElementName,
+				elementName,
 				renderMediaPreview
 			} ) );
 
@@ -207,7 +207,7 @@ export default class MediaEmbedEditing extends Plugin {
 			view: ( modelElement, { writer } ) => {
 				const url = modelElement.getAttribute( 'url' );
 				const figure = createMediaFigureElement( writer, registry, url, {
-					preferredElementName,
+					elementName,
 					renderForEditingView: true
 				} );
 
@@ -218,7 +218,7 @@ export default class MediaEmbedEditing extends Plugin {
 		// Model -> View (url -> data-oembed-url)
 		conversion.for( 'editingDowncast' ).add(
 			modelToViewUrlAttributeConverter( registry, {
-				preferredElementName,
+				elementName,
 				renderForEditingView: true
 			} ) );
 

--- a/packages/ckeditor5-media-embed/src/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/src/mediaembedediting.js
@@ -36,7 +36,6 @@ export default class MediaEmbedEditing extends Plugin {
 		super( editor );
 
 		editor.config.define( 'mediaEmbed', {
-			elementNames: [ 'oembed', 'o-embed' ],
 			preferredElementName: 'oembed',
 			providers: [
 				{
@@ -164,8 +163,12 @@ export default class MediaEmbedEditing extends Plugin {
 		const t = editor.t;
 		const conversion = editor.conversion;
 		const renderMediaPreview = editor.config.get( 'mediaEmbed.previewsInData' );
-		const elementNames = editor.config.get( 'mediaEmbed.elementNames' );
 		const preferredElementName = editor.config.get( 'mediaEmbed.preferredElementName' );
+		const elementNames = preferredElementName ? [ preferredElementName ] : [];
+		if ( elementNames.includes( 'oembed' ) ) {
+			elementNames.push( 'oembed' );
+		}
+
 		const registry = this.registry;
 
 		editor.commands.add( 'mediaEmbed', new MediaEmbedCommand( editor ) );

--- a/packages/ckeditor5-media-embed/src/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/src/mediaembedediting.js
@@ -164,10 +164,6 @@ export default class MediaEmbedEditing extends Plugin {
 		const conversion = editor.conversion;
 		const renderMediaPreview = editor.config.get( 'mediaEmbed.previewsInData' );
 		const elementName = editor.config.get( 'mediaEmbed.elementName' );
-		const elementNames = [ elementName ];
-		if ( elementNames.includes( 'oembed' ) ) {
-			elementNames.push( 'oembed' );
-		}
 
 		const registry = this.registry;
 
@@ -226,12 +222,10 @@ export default class MediaEmbedEditing extends Plugin {
 		conversion.for( 'upcast' )
 			// Upcast semantic media.
 			.elementToElement( {
-				view: {
-					name: new RegExp( `^(${ elementNames.join( '|' ) })$` ),
-					attributes: {
-						url: true
-					}
-				},
+				view: element => [ 'oembed', elementName ].includes( element.name ) && element.getAttribute( 'url' ) ?
+					{ name: true } :
+					null,
+
 				model: ( viewMedia, { writer } ) => {
 					const url = viewMedia.getAttribute( 'url' );
 

--- a/packages/ckeditor5-media-embed/src/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/src/mediaembedediting.js
@@ -225,7 +225,6 @@ export default class MediaEmbedEditing extends Plugin {
 				view: element => [ 'oembed', elementName ].includes( element.name ) && element.getAttribute( 'url' ) ?
 					{ name: true } :
 					null,
-
 				model: ( viewMedia, { writer } ) => {
 					const url = viewMedia.getAttribute( 'url' );
 

--- a/packages/ckeditor5-media-embed/src/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/src/mediaembedediting.js
@@ -36,6 +36,8 @@ export default class MediaEmbedEditing extends Plugin {
 		super( editor );
 
 		editor.config.define( 'mediaEmbed', {
+			elementNames: [ 'oembed', 'o-embed' ],
+			preferredElementName: 'oembed',
 			providers: [
 				{
 					name: 'dailymotion',
@@ -162,6 +164,8 @@ export default class MediaEmbedEditing extends Plugin {
 		const t = editor.t;
 		const conversion = editor.conversion;
 		const renderMediaPreview = editor.config.get( 'mediaEmbed.previewsInData' );
+		const elementNames = editor.config.get( 'mediaEmbed.elementNames' );
+		const preferredElementName = editor.config.get( 'mediaEmbed.preferredElementName' );
 		const registry = this.registry;
 
 		editor.commands.add( 'mediaEmbed', new MediaEmbedCommand( editor ) );
@@ -181,6 +185,7 @@ export default class MediaEmbedEditing extends Plugin {
 				const url = modelElement.getAttribute( 'url' );
 
 				return createMediaFigureElement( writer, registry, url, {
+					preferredElementName,
 					renderMediaPreview: url && renderMediaPreview
 				} );
 			}
@@ -189,6 +194,7 @@ export default class MediaEmbedEditing extends Plugin {
 		// Model -> Data (url -> data-oembed-url)
 		conversion.for( 'dataDowncast' ).add(
 			modelToViewUrlAttributeConverter( registry, {
+				preferredElementName,
 				renderMediaPreview
 			} ) );
 
@@ -198,6 +204,7 @@ export default class MediaEmbedEditing extends Plugin {
 			view: ( modelElement, { writer } ) => {
 				const url = modelElement.getAttribute( 'url' );
 				const figure = createMediaFigureElement( writer, registry, url, {
+					preferredElementName,
 					renderForEditingView: true
 				} );
 
@@ -208,6 +215,7 @@ export default class MediaEmbedEditing extends Plugin {
 		// Model -> View (url -> data-oembed-url)
 		conversion.for( 'editingDowncast' ).add(
 			modelToViewUrlAttributeConverter( registry, {
+				preferredElementName,
 				renderForEditingView: true
 			} ) );
 
@@ -216,7 +224,7 @@ export default class MediaEmbedEditing extends Plugin {
 			// Upcast semantic media.
 			.elementToElement( {
 				view: {
-					name: 'oembed',
+					name: new RegExp( `^(${ elementNames.join( '|' ) })$` ),
 					attributes: {
 						url: true
 					}

--- a/packages/ckeditor5-media-embed/src/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/src/mediaembedediting.js
@@ -164,7 +164,7 @@ export default class MediaEmbedEditing extends Plugin {
 		const conversion = editor.conversion;
 		const renderMediaPreview = editor.config.get( 'mediaEmbed.previewsInData' );
 		const elementName = editor.config.get( 'mediaEmbed.elementName' );
-		const elementNames = elementName ? [ elementName ] : [];
+		const elementNames = [ elementName ];
 		if ( elementNames.includes( 'oembed' ) ) {
 			elementNames.push( 'oembed' );
 		}

--- a/packages/ckeditor5-media-embed/src/mediaregistry.js
+++ b/packages/ckeditor5-media-embed/src/mediaregistry.js
@@ -67,6 +67,13 @@ export default class MediaRegistry {
 		 * @member {Array}
 		 */
 		this.providerDefinitions = providerDefinitions;
+
+		/**
+		 * The preferred element names for newly added media embed.
+		 *
+		 * @member {String}
+		 */
+		this.preferredElementName = config.preferredElementName;
 	}
 
 	/**
@@ -206,6 +213,7 @@ class Media {
 	 *
 	 * @param {module:engine/view/downcastwriter~DowncastWriter} writer The view writer used to produce a view element.
 	 * @param {Object} options
+	 * @param {String} [options.preferredElementName]
 	 * @param {String} [options.renderMediaPreview]
 	 * @param {String} [options.renderForEditingView]
 	 * @returns {module:engine/view/element~Element}
@@ -233,7 +241,7 @@ class Media {
 				attributes.url = this.url;
 			}
 
-			viewElement = writer.createEmptyElement( 'oembed', attributes );
+			viewElement = writer.createEmptyElement( options.preferredElementName, attributes );
 		}
 
 		writer.setCustomProperty( 'media-content', true, viewElement );

--- a/packages/ckeditor5-media-embed/src/mediaregistry.js
+++ b/packages/ckeditor5-media-embed/src/mediaregistry.js
@@ -69,7 +69,7 @@ export default class MediaRegistry {
 		this.providerDefinitions = providerDefinitions;
 
 		/**
-		 * The preferred element names for newly added media embed.
+		 * The view element name for newly added media embed.
 		 *
 		 * @member {String}
 		 */

--- a/packages/ckeditor5-media-embed/src/mediaregistry.js
+++ b/packages/ckeditor5-media-embed/src/mediaregistry.js
@@ -73,7 +73,7 @@ export default class MediaRegistry {
 		 *
 		 * @member {String}
 		 */
-		this.preferredElementName = config.preferredElementName;
+		this.elementName = config.elementName;
 	}
 
 	/**
@@ -213,7 +213,7 @@ class Media {
 	 *
 	 * @param {module:engine/view/downcastwriter~DowncastWriter} writer The view writer used to produce a view element.
 	 * @param {Object} options
-	 * @param {String} [options.preferredElementName]
+	 * @param {String} [options.elementName]
 	 * @param {String} [options.renderMediaPreview]
 	 * @param {String} [options.renderForEditingView]
 	 * @returns {module:engine/view/element~Element}
@@ -241,7 +241,7 @@ class Media {
 				attributes.url = this.url;
 			}
 
-			viewElement = writer.createEmptyElement( options.preferredElementName, attributes );
+			viewElement = writer.createEmptyElement( options.elementName, attributes );
 		}
 
 		writer.setCustomProperty( 'media-content', true, viewElement );

--- a/packages/ckeditor5-media-embed/src/mediaregistry.js
+++ b/packages/ckeditor5-media-embed/src/mediaregistry.js
@@ -67,13 +67,6 @@ export default class MediaRegistry {
 		 * @member {Array}
 		 */
 		this.providerDefinitions = providerDefinitions;
-
-		/**
-		 * The view element name for newly added media embed.
-		 *
-		 * @member {String}
-		 */
-		this.elementName = config.elementName;
 	}
 
 	/**

--- a/packages/ckeditor5-media-embed/src/mediaregistry.js
+++ b/packages/ckeditor5-media-embed/src/mediaregistry.js
@@ -95,6 +95,7 @@ export default class MediaRegistry {
 	 * @param {module:engine/view/downcastwriter~DowncastWriter} writer The view writer used to produce a view element.
 	 * @param {String} url The URL to be translated into a view element.
 	 * @param {Object} options
+	 * @param {String} [options.elementName]
 	 * @param {String} [options.renderMediaPreview]
 	 * @param {String} [options.renderForEditingView]
 	 * @returns {module:engine/view/element~Element}

--- a/packages/ckeditor5-media-embed/src/utils.js
+++ b/packages/ckeditor5-media-embed/src/utils.js
@@ -68,6 +68,7 @@ export function isMediaWidget( viewElement ) {
  * @param {module:media-embed/mediaregistry~MediaRegistry} registry
  * @param {String} url
  * @param {Object} options
+ * @param {String} [options.elementName]
  * @param {String} [options.useSemanticWrapper]
  * @param {String} [options.renderForEditingView]
  * @returns {module:engine/view/containerelement~ContainerElement}

--- a/packages/ckeditor5-media-embed/tests/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedediting.js
@@ -477,10 +477,10 @@ describe( 'MediaEmbedEditing', () => {
 		} );
 
 		describe( 'conversion in the data pipeline', () => {
-			describe( 'preferredElementName#o-embed', () => {
+			describe( 'elementName#o-embed', () => {
 				beforeEach( () => {
 					return createTestEditor( {
-						preferredElementName: 'o-embed',
+						elementName: 'o-embed',
 						providers: providerDefinitions
 					} )
 						.then( newEditor => {

--- a/packages/ckeditor5-media-embed/tests/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedediting.js
@@ -611,8 +611,12 @@ describe( 'MediaEmbedEditing', () => {
 						} )
 							.then( newEditor => {
 								newEditor.setData(
-									'<figure class="media"><o-embed url="unknown.media"></o-embed></figure>' +
-									'<figure class="media"><o-embed url="foo.com/123"></o-embed></figure>' );
+									'<figure class="media">' +
+										'<div data-oembed-url="foo.com/123"></div>' +
+									'</figure>' +
+									'<figure class="media">' +
+										'<div data-oembed-url="unknown.media/123"></div>' +
+									'</figure>' );
 
 								expect( getModelData( newEditor.model, { withoutSelection: true } ) )
 									.to.equal( '<media url="foo.com/123"></media>' );


### PR DESCRIPTION
Alternative to #9373

1. `elementNames` removed from public API
2. `oembed` works implicitly, even when `preferredElementName` is custom

See https://github.com/ckeditor/ckeditor5/pull/9375#issuecomment-812871471