### PR TITLE
Docs: fixing toolbar tooltip for restricted editing.

### DIFF
--- a/packages/ckeditor5-restricted-editing/docs/_snippets/features/restricted-editing.js
+++ b/packages/ckeditor5-restricted-editing/docs/_snippets/features/restricted-editing.js
@@ -39,9 +39,9 @@ async function startStandardEditingMode() {
 	await reloadEditor( {
 		removePlugins: [ 'RestrictedEditingMode' ],
 		toolbar: [
-			'heading', '|', 'bold', 'italic', 'link', '|',
+			'restrictedEditingException', '|', 'heading', '|', 'bold', 'italic', 'link', '|',
 			'bulletedList', 'numberedList', 'blockQuote', 'insertTable', '|',
-			'restrictedEditingException', '|', 'undo', 'redo'
+			'undo', 'redo'
 		],
 		image: {
 			toolbar: [ 'imageStyle:full', 'imageStyle:side', '|', 'imageTextAlternative' ]
@@ -59,7 +59,7 @@ async function startStandardEditingMode() {
 async function startRestrictedEditingMode() {
 	await reloadEditor( {
 		removePlugins: [ 'StandardEditingMode' ],
-		toolbar: [ 'bold', 'italic', 'link', '|', 'restrictedEditing', '|', 'undo', 'redo' ]
+		toolbar: [ 'restrictedEditing', '|', 'bold', 'italic', 'link', '|', 'undo', 'redo' ]
 	} );
 }
 
@@ -76,6 +76,9 @@ async function reloadEditor( config ) {
 			item => item.label && [ 'Enable editing', 'Disable editing' ].includes( item.label )
 		),
 		text: 'Click to add or remove editable regions.',
-		editor: window.editor
+		editor: window.editor,
+		tippyOptions: {
+			placement: 'bottom-start'
+		}
 	} );
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs. Closes #9280.

---

### Additional information

Moving the toolbar tooltip to stay in place when switching between modes in restricted editing demo.