### PR TITLE
The widget type around feature should work in the "Custom element conversion guide"

### DIFF
--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-custom-element-converter.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-custom-element-converter.js
@@ -142,17 +142,24 @@ function createModelToViewPositionMapper( view ) {
 		const modelPosition = data.modelPosition;
 		const parent = modelPosition.parent;
 
+		// Only mapping of positions that are directly in
+		// the <infoBox> model element should be modified.
 		if ( !parent.is( 'element', 'infoBox' ) ) {
 			return;
 		}
 
+		// Get the mapped view element <div class="info-box">.
 		const viewElement = data.mapper.toViewElement( parent );
+
+		// Find the <div class="info-box-content"> in it.
 		const viewContentElement = findContentViewElement( view, viewElement );
 
+		// Translate the model position offset to the view position offset.
 		data.viewPosition = data.mapper.findPositionIn( viewContentElement, modelPosition.offset );
 	};
 }
 
+// Returns the <div class="info-box-content"> nested in the info box view structure.
 function findContentViewElement( editingView, viewElement ) {
 	for ( const value of editingView.createRangeIn( viewElement ) ) {
 		if ( value.item.is( 'element', 'div' ) && value.item.hasClass( 'info-box-content' ) ) {

--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
@@ -372,7 +372,7 @@ class InfoBox {
 		editor.conversion.for( 'dataDowncast' )
 			.add( dispatcher => dispatcher.on( 'insert:infoBox', dataDowncastConverter ) );
 
-        // Model to view position mapper is needed since the model <infoBox> content needs to end up in the inner
+        // Model-to-view position mapper is needed since the model <infoBox> content needs to end up in the inner
         // <div class="info-box-content">.
         editor.editing.mapper.on( 'modelToViewPosition', createModelToViewPositionMapper( editor.editing.view ) );
         editor.data.mapper.on( 'modelToViewPosition', createModelToViewPositionMapper( editor.editing.view ) );

--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
@@ -272,7 +272,7 @@ editor.conversion.for( 'dataDowncast' )
 
 Due to the fact that the info box's view structure is more complex than its model structure, you need to take care of one additional aspect to make the converters work &mdash; position mapping.
 
-### The model to view position mapping
+### The model-to-view position mapping
 
 The downcast converters shown in the previous section will not yet work correctly. This is how a given model would look like, after being downcasted:
 

--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
@@ -278,11 +278,11 @@ The downcast converters shown in the previous section will not work correctly ye
 
 ```
 <infoBox infoBoxType="Info">    ->    <div class="info-box info-box-info">
-    <paragraph>                 ->        <p>
-        Foobar                  ->            Foobar
-    </paragraph>                ->        </p>
-                                          <div class="info-box-title">Info</div>
-                                          <div class="info-box-content"></div>
+	<paragraph>                 ->        <p>
+		Foobar                  ->            Foobar
+	</paragraph>                ->        </p>
+										  <div class="info-box-title">Info</div>
+										  <div class="info-box-content"></div>
 </infoBox>                      ->    </div>
 ```
 
@@ -292,12 +292,12 @@ You defined downcast conversion for `<infoBox>` itself, but you need to specify 
 
 ```
 <infoBox infoBoxType="Info">    ->    <div class="info-box info-box-info">
-                                          <div class="info-box-title">Info</div>
-                                          <div class="info-box-content">
-    <paragraph>                 ->            <p>
-        Foobar                  ->                Foobar
-    </paragraph>                ->            </p>
-                                          </div>
+										  <div class="info-box-title">Info</div>
+										  <div class="info-box-content">
+	<paragraph>                 ->            <p>
+		Foobar                  ->                Foobar
+	</paragraph>                ->            </p>
+										  </div>
 </infoBox>                      ->    </div>
 ```
 
@@ -305,34 +305,34 @@ Such a mapping can be achieved by registering this callback to the {@link module
 
 ```js
 function createModelToViewPositionMapper( view ) {
-    return ( evt, data ) => {
-        const modelPosition = data.modelPosition;
-        const parent = modelPosition.parent;
+	return ( evt, data ) => {
+		const modelPosition = data.modelPosition;
+		const parent = modelPosition.parent;
 
-        // Only mapping of positions that are directly in
-        // the <infoBox> model element should be modified.
-        if ( !parent.is( 'element', 'infoBox' ) ) {
-            return;
-        }
+		// Only mapping of positions that are directly in
+		// the <infoBox> model element should be modified.
+		if ( !parent.is( 'element', 'infoBox' ) ) {
+			return;
+		}
 
-        // Get the mapped view element <div class="info-box">.
-        const viewElement = data.mapper.toViewElement( parent );
+		// Get the mapped view element <div class="info-box">.
+		const viewElement = data.mapper.toViewElement( parent );
 
-        // Find the <div class="info-box-content"> in it.
-        const viewContentElement = findContentViewElement( view, viewElement );
+		// Find the <div class="info-box-content"> in it.
+		const viewContentElement = findContentViewElement( view, viewElement );
 
-        // Translate the model position offset to the view position offset.
-        data.viewPosition = data.mapper.findPositionIn( viewContentElement, modelPosition.offset );
-    };
+		// Translate the model position offset to the view position offset.
+		data.viewPosition = data.mapper.findPositionIn( viewContentElement, modelPosition.offset );
+	};
 }
 
 // Returns the <div class="info-box-content"> nested in the info box view structure.
 function findContentViewElement( editingView, viewElement ) {
-    for ( const value of editingView.createRangeIn( viewElement ) ) {
-        if ( value.item.is( 'element', 'div' ) && value.item.hasClass( 'info-box-content' ) ) {
-            return value.item;
-        }
-    }
+	for ( const value of editingView.createRangeIn( viewElement ) ) {
+		if ( value.item.is( 'element', 'div' ) && value.item.hasClass( 'info-box-content' ) ) {
+			return value.item;
+		}
+	}
 }
 ```
 
@@ -344,7 +344,7 @@ editor.data.mapper.on( 'modelToViewPosition', createModelToViewPositionMapper( e
 ```
 
 <info-box>
-    **Note**: You do not need the reverse position mapping ({@link module:engine/conversion/mapper~Mapper#event:viewToModelPosition from the view to the model}) because the default view-to-model position mapping looks for the {@link module:engine/conversion/mapper~Mapper#findMappedViewAncestor mapped view ancestor} and maps the offset in respect to the model element.
+	**Note**: You do not need the reverse position mapping ({@link module:engine/conversion/mapper~Mapper#event:viewToModelPosition from the view to the model}) because the default view-to-model position mapping looks for the {@link module:engine/conversion/mapper~Mapper#findMappedViewAncestor mapped view ancestor} and maps the offset in respect to the model element.
 </info-box>
 
 ### Updated plugin code
@@ -372,11 +372,11 @@ class InfoBox {
 		editor.conversion.for( 'dataDowncast' )
 			.add( dispatcher => dispatcher.on( 'insert:infoBox', dataDowncastConverter ) );
 
-        // Model-to-view position mapper is needed since the model <infoBox> content needs to end up in the inner
-        // <div class="info-box-content">.
-        editor.editing.mapper.on( 'modelToViewPosition', createModelToViewPositionMapper( editor.editing.view ) );
-        editor.data.mapper.on( 'modelToViewPosition', createModelToViewPositionMapper( editor.editing.view ) );
-    }
+		// Model-to-view position mapper is needed since the model <infoBox> content needs to end up in the inner
+		// <div class="info-box-content">.
+		editor.editing.mapper.on( 'modelToViewPosition', createModelToViewPositionMapper( editor.editing.view ) );
+		editor.data.mapper.on( 'modelToViewPosition', createModelToViewPositionMapper( editor.editing.view ) );
+	}
 }
 
 function upcastConverter() {
@@ -392,6 +392,6 @@ function dataDowncastConverter() {
 }
 
 function createModelToViewPositionMapper() {
-    // ...
+	// ...
 }
 ```

--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
@@ -270,9 +270,11 @@ editor.conversion.for( 'dataDowncast' )
 	.add( dispatcher => dispatcher.on( 'insert:infoBox', dataDowncastConverter ) );
 ```
 
+Due to the fact that the info box's view structure is more complex than its model structure we need to take care of one additional aspect to make the converters work &mdash; position mapping.
+
 ### The model to view position mapping
 
-After adding the above downcast converters we would end up with the following view structure:
+The downcast converters shown in the previous section will not yet work correctly. This is how a given model would look after being downcasted:
 
 ```
 <div class="info-box info-box-info">
@@ -284,7 +286,9 @@ After adding the above downcast converters we would end up with the following vi
 </div>
 ```
 
-This is not what we need. We expect the content of the `<infoBox>` to be inside the `<div class="info-box-content">`. We have the downcast conversion for the `<infoBox>` and its own structure, but we need to specify where its content should land in the view. By the default it would be converted as a direct child of `<div class="info-box">` (as you can see in the above snippet) but it should go into the `<div class="info-box-content">`. To achieve this, we need to register a callback for the {@link module:engine/conversion/mapper~Mapper#event:modelToViewPosition `Mapper#modelToViewPosition` event}, so the positions inside the model `<infoBox>` element would map to the positions inside the `<div class="info-box-content">` view element.
+As you can see, this is not a correct view structure. The content of the model's `<infoBox>` element ended up directly inside the outer `<div>`. We expect the the `<infoBox>`'s content to be inside the `<div class="info-box-content">`.
+
+We defined downcast conversion for `<infoBox>` itself, but we need to specify where its content should land in its view structure. By default, it is converted as direct children of `<div class="info-box">` (as you can see in the above snippet) but it should go into the `<div class="info-box-content">`. To achieve this, we need to register a callback for the {@link module:engine/conversion/mapper~Mapper#event:modelToViewPosition `Mapper#modelToViewPosition` event}, so positions inside the model `<infoBox>` element would map to positions inside the `<div class="info-box-content">` view element.
 
 ```
 <infoBox infoBoxType="Info">    ->    <div class="info-box info-box-info">
@@ -297,7 +301,7 @@ This is not what we need. We expect the content of the `<infoBox>` to be inside 
 </infoBox>                      ->    </div>
 ```
 
-The callback that we need:
+Such mapping can be achieved by registering this callback to {@link XYZ} event:
 
 ```js
 function createModelToViewPositionMapper( view ) {

--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
@@ -277,31 +277,31 @@ Due to the fact that the info box's view structure is more complex than its mode
 The downcast converters shown in the previous section will not yet work correctly. This is how a given model would look after being downcasted:
 
 ```
-<div class="info-box info-box-info">
-    []<p>
-        Foobar
-    </p>
-    <div class="info-box-title">Info</div>
-    <div class="info-box-content"></div>
-</div>
+<infoBox infoBoxType="Info">    ->    <div class="info-box info-box-info">
+    <paragraph>                 ->        <p>
+        Foobar                  ->            Foobar
+    </paragraph>                ->        </p>                                          
+                                          <div class="info-box-title">Info</div>
+                                          <div class="info-box-content"></div>
+</infoBox>                      ->    </div>
 ```
 
-As you can see, this is not a correct view structure. The content of the model's `<infoBox>` element ended up directly inside the outer `<div>`. We expect the the `<infoBox>`'s content to be inside the `<div class="info-box-content">`.
+As you can see, this is not a correct view structure. The content of the model's `<infoBox>` element ended up directly inside the outer `<div>`. We expect the `<infoBox>`'s content to be inside the `<div class="info-box-content">`.
 
-We defined downcast conversion for `<infoBox>` itself, but we need to specify where its content should land in its view structure. By default, it is converted as direct children of `<div class="info-box">` (as you can see in the above snippet) but it should go into the `<div class="info-box-content">`. To achieve this, we need to register a callback for the {@link module:engine/conversion/mapper~Mapper#event:modelToViewPosition `Mapper#modelToViewPosition` event}, so positions inside the model `<infoBox>` element would map to positions inside the `<div class="info-box-content">` view element.
+We defined downcast conversion for `<infoBox>` itself, but we need to specify where its content should land in its view structure. By default, it is converted as direct children of `<div class="info-box">` (as you can see in the above snippet) but it should go into the `<div class="info-box-content">`. To achieve this, we need to register a callback for the {@link module:engine/conversion/mapper~Mapper#event:modelToViewPosition `Mapper#modelToViewPosition`} event, so positions inside the model `<infoBox>` element would map to positions inside the `<div class="info-box-content">` view element.
 
 ```
 <infoBox infoBoxType="Info">    ->    <div class="info-box info-box-info">
                                           <div class="info-box-title">Info</div>
                                           <div class="info-box-content">
-    []<paragraph>               ->            []<p>
+    <paragraph>                 ->            <p>
         Foobar                  ->                Foobar
     </paragraph>                ->            </p>
                                           </div>
 </infoBox>                      ->    </div>
 ```
 
-Such mapping can be achieved by registering this callback to {@link XYZ} event:
+Such mapping can be achieved by registering this callback to the {@link module:engine/conversion/mapper~Mapper#event:modelToViewPosition `Mapper#modelToViewPosition`} event:
 
 ```js
 function createModelToViewPositionMapper( view ) {
@@ -336,12 +336,16 @@ function findContentViewElement( editingView, viewElement ) {
 }
 ```
 
-It needs to be plugged into the {@link module:engine/conversion/mapper~Mapper#event:modelToViewPosition `Mapper#modelToViewPosition` event} for both downcast pipelines:
+It needs to be plugged into the {@link module:engine/conversion/mapper~Mapper#event:modelToViewPosition `Mapper#modelToViewPosition`} event for both downcast pipelines:
 
 ```js
 editor.editing.mapper.on( 'modelToViewPosition', createModelToViewPositionMapper( editor.editing.view ) );
 editor.data.mapper.on( 'modelToViewPosition', createModelToViewPositionMapper( editor.editing.view ) );
 ```
+
+<info-box>
+    **Note**: We do not need the reverse position mapping ({@link module:engine/conversion/mapper~Mapper#event:viewToModelPosition from view to model}) because the default view to model position mapping is looking for the {@link module:engine/conversion/mapper~Mapper#findMappedViewAncestor mapped view ancestor} and maps offset in respect to that model element.
+</info-box>
 
 ### Updated plugin code
 

--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
@@ -344,7 +344,7 @@ editor.data.mapper.on( 'modelToViewPosition', createModelToViewPositionMapper( e
 ```
 
 <info-box>
-    **Note**: You do not need the reverse position mapping ({@link module:engine/conversion/mapper~Mapper#event:viewToModelPosition from view to model}) because the default view to model position mapping looks for the {@link module:engine/conversion/mapper~Mapper#findMappedViewAncestor mapped view ancestor} and maps offset in respect to that model element.
+    **Note**: You do not need the reverse position mapping ({@link module:engine/conversion/mapper~Mapper#event:viewToModelPosition from the view to the model}) because the default view-to-model position mapping looks for the {@link module:engine/conversion/mapper~Mapper#findMappedViewAncestor mapped view ancestor} and maps the offset in respect to the model element.
 </info-box>
 
 ### Updated plugin code

--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
@@ -251,8 +251,8 @@ function insertViewElements( data, conversionApi, infoBox, infoBoxTitle, infoBox
 		infoBoxContent
 	);
 
-    // The mapping between the model <infoBox> and its view representation.
-    conversionApi.mapper.bindElements( data.item, infoBox );
+	// The mapping between the model <infoBox> and its view representation.
+	conversionApi.mapper.bindElements( data.item, infoBox );
 
 	conversionApi.writer.insert(
 		conversionApi.mapper.toViewPosition( data.range.start ),

--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
@@ -274,7 +274,7 @@ Due to the fact that the info box's view structure is more complex than its mode
 
 ### The model-to-view position mapping
 
-The downcast converters shown in the previous section will not yet work correctly. This is how a given model would look like, after being downcasted:
+The downcast converters shown in the previous section will not work correctly yet. This is what the given model would look like, after being downcasted:
 
 ```
 <infoBox infoBoxType="Info">    ->    <div class="info-box info-box-info">

--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/custom-element-conversion.md
@@ -253,7 +253,7 @@ function insertViewElements( data, conversionApi, infoBox, infoBoxTitle, infoBox
 
     // The mapping between the model <infoBox> and its view representation.
     conversionApi.mapper.bindElements( data.item, infoBox );
-  
+
 	conversionApi.writer.insert(
 		conversionApi.mapper.toViewPosition( data.range.start ),
 		infoBox
@@ -261,7 +261,7 @@ function insertViewElements( data, conversionApi, infoBox, infoBoxTitle, infoBox
 }
 ```
 
-These two converters need to be plugged as listeners to the {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher#insert `DowncastDispatcher#insert` event}:
+These two converters need to be plugged as listeners into the {@link module:engine/conversion/downcastdispatcher~DowncastDispatcher#insert `DowncastDispatcher#insert` event}:
 
 ```js
 editor.conversion.for( 'editingDowncast' )
@@ -270,25 +270,25 @@ editor.conversion.for( 'dataDowncast' )
 	.add( dispatcher => dispatcher.on( 'insert:infoBox', dataDowncastConverter ) );
 ```
 
-Due to the fact that the info box's view structure is more complex than its model structure we need to take care of one additional aspect to make the converters work &mdash; position mapping.
+Due to the fact that the info box's view structure is more complex than its model structure, you need to take care of one additional aspect to make the converters work &mdash; position mapping.
 
 ### The model to view position mapping
 
-The downcast converters shown in the previous section will not yet work correctly. This is how a given model would look after being downcasted:
+The downcast converters shown in the previous section will not yet work correctly. This is how a given model would look like, after being downcasted:
 
 ```
 <infoBox infoBoxType="Info">    ->    <div class="info-box info-box-info">
     <paragraph>                 ->        <p>
         Foobar                  ->            Foobar
-    </paragraph>                ->        </p>                                          
+    </paragraph>                ->        </p>
                                           <div class="info-box-title">Info</div>
                                           <div class="info-box-content"></div>
 </infoBox>                      ->    </div>
 ```
 
-As you can see, this is not a correct view structure. The content of the model's `<infoBox>` element ended up directly inside the outer `<div>`. We expect the `<infoBox>`'s content to be inside the `<div class="info-box-content">`.
+This is not a correct view structure. The content of the model's `<infoBox>` element ended up directly inside the outer `<div>`. The `<infoBox>`'s content should be inside the `<div class="info-box-content">`.
 
-We defined downcast conversion for `<infoBox>` itself, but we need to specify where its content should land in its view structure. By default, it is converted as direct children of `<div class="info-box">` (as you can see in the above snippet) but it should go into the `<div class="info-box-content">`. To achieve this, we need to register a callback for the {@link module:engine/conversion/mapper~Mapper#event:modelToViewPosition `Mapper#modelToViewPosition`} event, so positions inside the model `<infoBox>` element would map to positions inside the `<div class="info-box-content">` view element.
+You defined downcast conversion for `<infoBox>` itself, but you need to specify where its content should land in its view structure. By default, it is converted as direct children of `<div class="info-box">` (as shown in the above snippet) but it should go into `<div class="info-box-content">`. To achieve this, you need to register a callback for the {@link module:engine/conversion/mapper~Mapper#event:modelToViewPosition `Mapper#modelToViewPosition`} event, so positions inside the model `<infoBox>` element would map to positions inside the `<div class="info-box-content">` view element.
 
 ```
 <infoBox infoBoxType="Info">    ->    <div class="info-box info-box-info">
@@ -301,32 +301,32 @@ We defined downcast conversion for `<infoBox>` itself, but we need to specify wh
 </infoBox>                      ->    </div>
 ```
 
-Such mapping can be achieved by registering this callback to the {@link module:engine/conversion/mapper~Mapper#event:modelToViewPosition `Mapper#modelToViewPosition`} event:
+Such a mapping can be achieved by registering this callback to the {@link module:engine/conversion/mapper~Mapper#event:modelToViewPosition `Mapper#modelToViewPosition`} event:
 
 ```js
 function createModelToViewPositionMapper( view ) {
     return ( evt, data ) => {
         const modelPosition = data.modelPosition;
         const parent = modelPosition.parent;
-    
-        // Only mapping of positions that are directly in 
+
+        // Only mapping of positions that are directly in
         // the <infoBox> model element should be modified.
         if ( !parent.is( 'element', 'infoBox' ) ) {
             return;
         }
-    
+
         // Get the mapped view element <div class="info-box">.
         const viewElement = data.mapper.toViewElement( parent );
-        
-        // Find the <div class="info-box-content"> in it. 
+
+        // Find the <div class="info-box-content"> in it.
         const viewContentElement = findContentViewElement( view, viewElement );
-    
+
         // Translate the model position offset to the view position offset.
         data.viewPosition = data.mapper.findPositionIn( viewContentElement, modelPosition.offset );
     };
 }
 
-// Returns the <div class="info-box-content"> nested in the info box view structure. 
+// Returns the <div class="info-box-content"> nested in the info box view structure.
 function findContentViewElement( editingView, viewElement ) {
     for ( const value of editingView.createRangeIn( viewElement ) ) {
         if ( value.item.is( 'element', 'div' ) && value.item.hasClass( 'info-box-content' ) ) {
@@ -344,7 +344,7 @@ editor.data.mapper.on( 'modelToViewPosition', createModelToViewPositionMapper( e
 ```
 
 <info-box>
-    **Note**: We do not need the reverse position mapping ({@link module:engine/conversion/mapper~Mapper#event:viewToModelPosition from view to model}) because the default view to model position mapping is looking for the {@link module:engine/conversion/mapper~Mapper#findMappedViewAncestor mapped view ancestor} and maps offset in respect to that model element.
+    **Note**: You do not need the reverse position mapping ({@link module:engine/conversion/mapper~Mapper#event:viewToModelPosition from view to model}) because the default view to model position mapping looks for the {@link module:engine/conversion/mapper~Mapper#findMappedViewAncestor mapped view ancestor} and maps offset in respect to that model element.
 </info-box>
 
 ### Updated plugin code


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (engine): The widget type around feature should work in the "Custom element conversion guide". Closes [#9444](https://github.com/ckeditor/ckeditor5/issues/9444).

---

### Additional information

Extracted from #9445 to be merged directly to `stable`.