### PR TITLE
Docs: fixed code block in Markdown output demo.

### DIFF
--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
@@ -28,6 +28,7 @@
 		<ul>
 			<li>Numbered lists</li>
 			<li>Bulleted lists</li>
+			<li>To-do lists</li>
 		</ul>
 	</li>
 </ul>

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.html
@@ -1,4 +1,4 @@
-<div id="snippet-markdown">
+<textarea id="snippet-markdown">
 
 <h2>The Markdown language</h2>
 <p>Markdown is a lightweight markup language that you can use to add formatting elements to plain text documents. Created by <a href="https://daringfireball.net/projects/markdown/" target="_blank">John Gruber</a> in <s>2003</s>2004, Markdown is now one of the world&rsquo;s most popular markup languages.</p>
@@ -8,12 +8,10 @@
 <h2>Editing with Markdown output</h2>
 <p>The <a href="https://ckeditor.com/">CKEditor 5 WYSIWYG</a> editor lets you use this flexible yet simple markup language in the GitHub flavor. The editor-produced Markdown output supports the most important features, like <a href="https://ckeditor.com/">links</a>, <strong>different</strong> kinds of <em>emphasis</em>, <code>inline code formatting</code> or code blocks:</p>
 
-<pre>
-&lt;code class="language-css">p {
-  text-align: center;
-  color: red;
-}&lt;/code>
-</pre>
+&lt;pre>&lt;code class="language-css">p {
+	text-align: center;
+	color: red;
+  }&lt;/code>&lt;/pre>
 
 <h2>Formatting blocks with Markdown</h2>
 <p>Markdown can be used to create various block-level features, such as:</p>
@@ -64,7 +62,7 @@
 	</tbody>
 </table>
 
-</div>
+</textarea>
 
 <p>Output:</p>
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (markdown-gfm): Fixed demo display error. Closes #9487.