### PR TITLE
Border properties will be merged into the single group if possible

### DIFF
--- a/packages/ckeditor5-engine/src/view/styles/border.js
+++ b/packages/ckeditor5-engine/src/view/styles/border.js
@@ -77,10 +77,6 @@ export function addBorderRules( stylesProcessor ) {
 	stylesProcessor.setExtractor( 'border-bottom', getBorderPositionExtractor( 'bottom' ) );
 	stylesProcessor.setExtractor( 'border-left', getBorderPositionExtractor( 'left' ) );
 
-	stylesProcessor.setExtractor( 'border-color', getBorderTypeExtractor( 'color' ) );
-	stylesProcessor.setExtractor( 'border-width', getBorderTypeExtractor( 'width' ) );
-	stylesProcessor.setExtractor( 'border-style', getBorderTypeExtractor( 'style' ) );
-
 	stylesProcessor.setExtractor( 'border-top-color', 'border.color.top' );
 	stylesProcessor.setExtractor( 'border-right-color', 'border.color.right' );
 	stylesProcessor.setExtractor( 'border-bottom-color', 'border.color.bottom' );
@@ -219,30 +215,6 @@ function extractBorderPosition( border, which ) {
 	}
 
 	return value;
-}
-
-// Returns a single style value for a given type if all 4 sides are equal.
-function getBorderTypeExtractor( type ) {
-	return ( name, styles ) => {
-		if ( !styles.border ) {
-			return;
-		}
-
-		const value = styles.border[ type ];
-
-		if ( !value ) {
-			return;
-		}
-
-		const values = Object.values( value );
-
-		if ( values.length != 4 ) {
-			return value;
-		}
-
-		// Return a single value if all 4 are equal.
-		return values.reduce( ( result, style ) => result == style ? result : null ) || value;
-	};
 }
 
 function normalizeBorderShorthand( string ) {

--- a/packages/ckeditor5-engine/src/view/styles/border.js
+++ b/packages/ckeditor5-engine/src/view/styles/border.js
@@ -99,7 +99,7 @@ export function addBorderRules( stylesProcessor ) {
 	stylesProcessor.setReducer( 'border-right', getBorderPositionReducer( 'right' ) );
 	stylesProcessor.setReducer( 'border-bottom', getBorderPositionReducer( 'bottom' ) );
 	stylesProcessor.setReducer( 'border-left', getBorderPositionReducer( 'left' ) );
-	stylesProcessor.setReducer( 'border', borderReducer() );
+	stylesProcessor.setReducer( 'border', getBorderReducer() );
 
 	stylesProcessor.setStyleRelation( 'border', [
 		'border-color', 'border-style', 'border-width',
@@ -235,7 +235,7 @@ function normalizeBorderShorthand( string ) {
 	return result;
 }
 
-// The border reducer.
+// The border reducer factory.
 //
 // It tries to produce the most optimal output for the specified styles.
 //
@@ -261,112 +261,56 @@ function normalizeBorderShorthand( string ) {
 // Definitions are merged only if all border selectors have the same values.
 //
 // @returns {Function}
-function borderReducer() {
+function getBorderReducer() {
 	return value => {
-		const topReducer = reduceBorderPosition( extractBorderPosition( value, 'top' ), 'top' );
-		const rightReducer = reduceBorderPosition( extractBorderPosition( value, 'right' ), 'right' );
-		const bottomReducer = reduceBorderPosition( extractBorderPosition( value, 'bottom' ), 'bottom' );
-		const leftReducer = reduceBorderPosition( extractBorderPosition( value, 'left' ), 'left' );
+		const topStyles = extractBorderPosition( value, 'top' );
+		const rightStyles = extractBorderPosition( value, 'right' );
+		const bottomStyles = extractBorderPosition( value, 'bottom' );
+		const leftStyles = extractBorderPosition( value, 'left' );
 
-		if ( shouldMergeAllBordersDefinitions( topReducer, rightReducer, bottomReducer, leftReducer ) ) {
-			return [
-				// All `border-*` reducers define the same value.
-				[ 'border', `${ topReducer[ 0 ][ 1 ] }` ]
-			];
+		const borderStyles = [ topStyles, rightStyles, bottomStyles, leftStyles ];
+
+		const borderStylesByType = {
+			width: getReducedStyleValueForType( borderStyles, 'width' ),
+			style: getReducedStyleValueForType( borderStyles, 'style' ),
+			color: getReducedStyleValueForType( borderStyles, 'color' )
+		};
+
+		// Try reducing to a single `border:` property.
+		const reducedBorderStyle = reduceBorderPosition( borderStylesByType, 'all' );
+
+		if ( reducedBorderStyle.length == 1 ) {
+			return reducedBorderStyle;
 		}
 
-		const results = [];
-		const borderReducers = [ topReducer, rightReducer, bottomReducer, leftReducer ];
+		// Try reducing to `border-style:`, `border-width:`, `border-color:` properties.
+		const reducedStyleTypes = Object.entries( borderStylesByType ).reduce( ( reducedStyleTypes, [ type, value ] ) => {
+			if ( value ) {
+				reducedStyleTypes.push( [ `border-${ type }`, value ] );
 
-		mergeBorderDefinitions( results, /border-[^-]+-style/, 'border-style', borderReducers );
-		mergeBorderDefinitions( results, /border-[^-]+-width/, 'border-width', borderReducers );
-		mergeBorderDefinitions( results, /border-[^-]+-color/, 'border-color', borderReducers );
+				// Remove it from the full set to not include it in the most specific properties later.
+				borderStyles.forEach( style => ( style[ type ] = null ) );
+			}
 
+			return reducedStyleTypes;
+		}, [] );
+
+		// The reduced properties (by type) and all the rest that could not be reduced.
 		return [
-			...results,
-			...topReducer,
-			...rightReducer,
-			...bottomReducer,
-			...leftReducer
+			...reducedStyleTypes,
+			...reduceBorderPosition( topStyles, 'top' ),
+			...reduceBorderPosition( rightStyles, 'right' ),
+			...reduceBorderPosition( bottomStyles, 'bottom' ),
+			...reduceBorderPosition( leftStyles, 'left' )
 		];
 	};
 
-	// Checks whether border properties should be merged into the single `border` property.
-	//
-	// The merge can happen if each `border-*` property returns exactly the same value.
-	//
-	// @param {Array} topReducer `border-top-*` definitions.
-	// @param {Array} rightReducer `border-right-*` definitions.
-	// @param {Array} bottomReducer `border-bottom-*` definitions.
-	// @param {Array} leftReducer `border-left-*` definitions.
-	// @returns {Boolean}
-	function shouldMergeAllBordersDefinitions( topReducer, rightReducer, bottomReducer, leftReducer ) {
-		return topReducer.length === 1 &&
-			rightReducer.length === 1 &&
-			bottomReducer.length === 1 &&
-			leftReducer.length === 1 &&
-			topReducer[ 0 ][ 0 ] === 'border-top' &&
-			rightReducer[ 0 ][ 0 ] === 'border-right' &&
-			bottomReducer[ 0 ][ 0 ] === 'border-bottom' &&
-			leftReducer[ 0 ][ 0 ] === 'border-left' &&
-			areEquals( [
-				topReducer[ 0 ][ 1 ],
-				bottomReducer[ 0 ][ 1 ],
-				bottomReducer[ 0 ][ 1 ],
-				leftReducer[ 0 ][ 1 ]
-			] );
-	}
-
-	// Tries to merge the same values definitions for all borders (top, right, bottom, left) into the single one (border-*).
-	//
-	// The merge is possible if all values for `border-*-(style|color|width)` are identical.
-	//
-	// After merging, the checked CSS definitions are removed from the initial data.
-	//
-	// @param {Array} resultsReducers The resulting array where all reducers are being added.
-	// @param {RegExp} pattern Definitions returned by reducers must match to this pattern.
-	// @param {String} definition The output definition that will be created.
-	// @param {Array} reducers All `border-*-(style|color|width` combinations (the initial data).
-	function mergeBorderDefinitions( resultsReducers, pattern, definition, reducers ) {
-		// The array should contain 4 items that describes the same property (color, width, or style) for each border.
-		const patternReducers = [];
-
-		// The initial data contains definitions for all directions (top, right, bottom, left).
-		for ( const borderReducers of reducers ) {
-			// Find the rule that match to the output `definition`.
-			const item = borderReducers.find( item => item[ 0 ].match( pattern ) );
-
-			if ( item ) {
-				patternReducers.push( item );
-			}
-		}
-
-		// Merge can happen only if we have values for all borders...
-		if ( patternReducers.length !== 4 ) {
-			return;
-		}
-
-		// ...and these values must be identical.
-		if ( !areEquals( patternReducers.map( item => item[ 1 ] ) ) ) {
-			return;
-		}
-
-		// Create the new definition...
-		resultsReducers.push( [ definition, patternReducers[ 0 ][ 1 ] ] );
-
-		// ...and remove parsed entries from the initial array because they
-		// should not be returned to avoid creating improper output.
-		patternReducers.forEach( ( item, index ) => {
-			reducers[ index ].splice( reducers[ index ].indexOf( item ), 1 );
-		} );
-	}
-
-	// Returns true if all specified items are identical. Otherwise, returns false.
-	//
-	// @param {Array.<String>} items
-	// @returns {Boolean}
-	function areEquals( items ) {
-		return new Set( items ).size === 1;
+	// @param {Array.<Object>} styles The array of objects with `style`, `color`, `width` properties.
+	// @param {'width'|'style'|'color'} type
+	function getReducedStyleValueForType( styles, type ) {
+		return styles
+			.map( style => style[ type ] )
+			.reduce( ( result, style ) => result == style ? result : null );
 	}
 }
 
@@ -382,27 +326,34 @@ function getBorderPositionReducer( which ) {
 // Otherwise, the specific definitions will be returned: `border-(width|style|color)-*: [value]`.
 //
 // @param {Object|null} value Styles if defined.
-// @param {'top'|'right'|'bottom'|left|} which The border position.
+// @param {'top'|'right'|'bottom'|'left'|'all'} which The border position.
 // @returns {Array}
 function reduceBorderPosition( value, which ) {
 	const borderTypes = [];
 
-	if ( value && value.width !== undefined ) {
+	if ( value && value.width ) {
 		borderTypes.push( 'width' );
 	}
 
-	if ( value && value.style !== undefined ) {
+	if ( value && value.style ) {
 		borderTypes.push( 'style' );
 	}
 
-	if ( value && value.color !== undefined ) {
+	if ( value && value.color ) {
 		borderTypes.push( 'color' );
 	}
 
-	if ( borderTypes.length === 3 ) {
+	if ( borderTypes.length == 3 ) {
+		const borderValue = borderTypes.map( item => value[ item ] ).join( ' ' );
+
 		return [
-			[ `border-${ which }`, borderTypes.map( item => value[ item ] ).join( ' ' ) ]
+			which == 'all' ? [ 'border', borderValue ] : [ `border-${ which }`, borderValue ]
 		];
+	}
+
+	// We are unable to reduce to a single `border:` property.
+	if ( which == 'all' ) {
+		return [];
 	}
 
 	return borderTypes.map( type => {

--- a/packages/ckeditor5-engine/src/view/styles/border.js
+++ b/packages/ckeditor5-engine/src/view/styles/border.js
@@ -39,9 +39,6 @@ import { getShorthandValues, getBoxSidesValueReducer, getBoxSidesValues, isLengt
  *			}
  *		};
  *
- * The `border` value is reduced to a 4 values for each box edge (even if they could be further reduces to a single
- * `border:<width> <style> <color>` style.
- *
  * @param {module:engine/view/stylesmap~StylesProcessor} stylesProcessor
  */
 export function addBorderRules( stylesProcessor ) {
@@ -102,7 +99,7 @@ export function addBorderRules( stylesProcessor ) {
 	stylesProcessor.setReducer( 'border-right', getBorderPositionReducer( 'right' ) );
 	stylesProcessor.setReducer( 'border-bottom', getBorderPositionReducer( 'bottom' ) );
 	stylesProcessor.setReducer( 'border-left', getBorderPositionReducer( 'left' ) );
-	stylesProcessor.setReducer( 'border', borderReducer );
+	stylesProcessor.setReducer( 'border', borderReducer() );
 
 	stylesProcessor.setStyleRelation( 'border', [
 		'border-color', 'border-style', 'border-width',
@@ -238,15 +235,135 @@ function normalizeBorderShorthand( string ) {
 	return result;
 }
 
-function borderReducer( value ) {
-	const reduced = [];
+// The border reducer.
+//
+// It tries to produce the most optimal output for the specified styles.
+//
+// For border style:
+//
+//      style: {top: "solid", bottom: "solid", right: "solid", left: "solid"}
+//
+// It will produce: `border-style: top` output.
+// For border style and color:
+//
+//      color: {top: "#ff0", bottom: "#ff0", right: "#ff0", left: "#ff0"}
+//      style: {top: "solid", bottom: "solid", right: "solid", left: "solid"}
+//
+// It will produce: `border-color: #ff0; border-style: solid`
+// If all border parameters are specified:
+//
+//      color: {top: "#ff0", bottom: "#ff0", right: "#ff0", left: "#ff0"}
+//      style: {top: "solid", bottom: "solid", right: "solid", left: "solid"}
+//      width: {top: "2px", bottom: "2px", right: "2px", left: "2px"}
+//
+// It will combine everything into the single property: `border: 2px solid #ff0`.
+//
+// Definitions are merged only if all border selectors have the same values.
+//
+// @returns {Function}
+function borderReducer() {
+	return value => {
+		const topReducer = reduceBorderPosition( extractBorderPosition( value, 'top' ), 'top' );
+		const rightReducer = reduceBorderPosition( extractBorderPosition( value, 'right' ), 'right' );
+		const bottomReducer = reduceBorderPosition( extractBorderPosition( value, 'bottom' ), 'bottom' );
+		const leftReducer = reduceBorderPosition( extractBorderPosition( value, 'left' ), 'left' );
 
-	reduced.push( ...reduceBorderPosition( extractBorderPosition( value, 'top' ), 'top' ) );
-	reduced.push( ...reduceBorderPosition( extractBorderPosition( value, 'right' ), 'right' ) );
-	reduced.push( ...reduceBorderPosition( extractBorderPosition( value, 'bottom' ), 'bottom' ) );
-	reduced.push( ...reduceBorderPosition( extractBorderPosition( value, 'left' ), 'left' ) );
+		if ( shouldMergeAllBordersDefinitions( topReducer, rightReducer, bottomReducer, leftReducer ) ) {
+			return [
+				// All `border-*` reducers define the same value.
+				[ 'border', `${ topReducer[ 0 ][ 1 ] }` ]
+			];
+		}
 
-	return reduced;
+		const results = [];
+		const borderReducers = [ topReducer, rightReducer, bottomReducer, leftReducer ];
+
+		mergeBorderDefinitions( results, /border-[^-]+-style/, 'border-style', borderReducers );
+		mergeBorderDefinitions( results, /border-[^-]+-width/, 'border-width', borderReducers );
+		mergeBorderDefinitions( results, /border-[^-]+-color/, 'border-color', borderReducers );
+
+		return [
+			...results,
+			...topReducer,
+			...rightReducer,
+			...bottomReducer,
+			...leftReducer
+		];
+	};
+
+	// Checks whether border properties should be merged into the single `border` property.
+	//
+	// The merge can happen if each `border-*` property returns exactly the same value.
+	//
+	// @param {Array} topReducer `border-top-*` definitions.
+	// @param {Array} rightReducer `border-right-*` definitions.
+	// @param {Array} bottomReducer `border-bottom-*` definitions.
+	// @param {Array} leftReducer `border-left-*` definitions.
+	// @returns {Boolean}
+	function shouldMergeAllBordersDefinitions( topReducer, rightReducer, bottomReducer, leftReducer ) {
+		return topReducer[ 0 ][ 0 ] === 'border-top' &&
+			rightReducer[ 0 ][ 0 ] === 'border-right' &&
+			bottomReducer[ 0 ][ 0 ] === 'border-bottom' &&
+			leftReducer[ 0 ][ 0 ] === 'border-left' &&
+			areEquals( [
+				topReducer[ 0 ][ 1 ],
+				bottomReducer[ 0 ][ 1 ],
+				bottomReducer[ 0 ][ 1 ],
+				leftReducer[ 0 ][ 1 ]
+			] );
+	}
+
+	// Tries to merge the same values definitions for all borders (top, right, bottom, left) into the single one (border-*).
+	//
+	// The merge is possible if all values for `border-*-(style|color|width)` are identical.
+	//
+	// After merging, the checked CSS definitions are removed from the initial data.
+	//
+	// @param {Array} resultsReducers The resulting array where all reducers are being added.
+	// @param {RegExp} pattern Definitions returned by reducers must match to this pattern.
+	// @param {String} definition The output definition that will be created.
+	// @param {Array} reducers All `border-*-(style|color|width` combinations (the initial data).
+	function mergeBorderDefinitions( resultsReducers, pattern, definition, reducers ) {
+		// The array should contain 4 items that describes the same property (color, width, or style) for each border.
+		const patternReducers = [];
+
+		// The initial data contains definitions for all directions (top, right, bottom, left).
+		for ( const borderReducers of reducers ) {
+			// Find the rule that match to the output `definition`.
+			const item = borderReducers.find( item => item[ 0 ].match( pattern ) );
+
+			if ( item ) {
+				patternReducers.push( item );
+			}
+		}
+
+		// Merge can happen only if we have values for all borders...
+		if ( patternReducers.length !== 4 ) {
+			return;
+		}
+
+		// ...and these values must be identical.
+		if ( !areEquals( patternReducers.map( item => item[ 1 ] ) ) ) {
+			return;
+		}
+
+		// Create the new definition...
+		resultsReducers.push( [ definition, patternReducers[ 0 ][ 1 ] ] );
+
+		// ...and remove parsed entries from the initial array because they
+		// should not be returned to avoid creating improper output.
+		patternReducers.forEach( ( item, index ) => {
+			reducers[ index ].splice( reducers[ index ].indexOf( item ), 1 );
+		} );
+	}
+
+	// Returns true if all specified items are identical. Otherwise, returns false.
+	//
+	// @param {Array.<String>} items
+	// @returns {Boolean}
+	function areEquals( items ) {
+		return new Set( items ).size === 1;
+	}
 }
 
 function getBorderPositionReducer( which ) {
@@ -254,23 +371,39 @@ function getBorderPositionReducer( which ) {
 }
 
 function reduceBorderPosition( value, which ) {
-	const reduced = [];
+	const borderToSet = [];
 
 	if ( value && value.width !== undefined ) {
-		reduced.push( value.width );
+		borderToSet.push( 'width' );
 	}
 
 	if ( value && value.style !== undefined ) {
-		reduced.push( value.style );
+		borderToSet.push( 'style' );
 	}
 
 	if ( value && value.color !== undefined ) {
-		reduced.push( value.color );
+		borderToSet.push( 'color' );
 	}
 
-	if ( reduced.length ) {
-		return [ [ `border-${ which }`, reduced.join( ' ' ) ] ];
+	if ( borderToSet.length === 3 ) {
+		return [
+			[ `border-${ which }`, borderToSet.map( item => value[ item ] ).join( ' ' ) ]
+		];
 	}
 
-	return [];
+	const result = [];
+
+	if ( borderToSet.includes( 'width' ) ) {
+		result.push( [ `border-${ which }-width`, value.width ] );
+	}
+
+	if ( borderToSet.includes( 'style' ) ) {
+		result.push( [ `border-${ which }-style`, value.style ] );
+	}
+
+	if ( borderToSet.includes( 'color' ) ) {
+		result.push( [ `border-${ which }-color`, value.color ] );
+	}
+
+	return result;
 }

--- a/packages/ckeditor5-engine/src/view/styles/border.js
+++ b/packages/ckeditor5-engine/src/view/styles/border.js
@@ -77,6 +77,10 @@ export function addBorderRules( stylesProcessor ) {
 	stylesProcessor.setExtractor( 'border-bottom', getBorderPositionExtractor( 'bottom' ) );
 	stylesProcessor.setExtractor( 'border-left', getBorderPositionExtractor( 'left' ) );
 
+	stylesProcessor.setExtractor( 'border-color', getBorderTypeExtractor( 'color' ) );
+	stylesProcessor.setExtractor( 'border-width', getBorderTypeExtractor( 'width' ) );
+	stylesProcessor.setExtractor( 'border-style', getBorderTypeExtractor( 'style' ) );
+
 	stylesProcessor.setExtractor( 'border-top-color', 'border.color.top' );
 	stylesProcessor.setExtractor( 'border-right-color', 'border.color.right' );
 	stylesProcessor.setExtractor( 'border-bottom-color', 'border.color.bottom' );
@@ -217,6 +221,30 @@ function extractBorderPosition( border, which ) {
 	return value;
 }
 
+// Returns a single style value for a given type if all 4 sides are equal.
+function getBorderTypeExtractor( type ) {
+	return ( name, styles ) => {
+		if ( !styles.border ) {
+			return;
+		}
+
+		const value = styles.border[ type ];
+
+		if ( !value ) {
+			return;
+		}
+
+		const values = Object.values( value );
+
+		if ( values.length != 4 ) {
+			return value;
+		}
+
+		// Return a single value if all 4 are equal.
+		return values.reduce( ( result, style ) => result == style ? result : null ) || value;
+	};
+}
+
 function normalizeBorderShorthand( string ) {
 	const result = {};
 
@@ -279,7 +307,7 @@ function getBorderReducer() {
 		// Try reducing to a single `border:` property.
 		const reducedBorderStyle = reduceBorderPosition( borderStylesByType, 'all' );
 
-		if ( reducedBorderStyle.length == 1 ) {
+		if ( reducedBorderStyle.length ) {
 			return reducedBorderStyle;
 		}
 

--- a/packages/ckeditor5-engine/src/view/styles/border.js
+++ b/packages/ckeditor5-engine/src/view/styles/border.js
@@ -374,40 +374,38 @@ function getBorderPositionReducer( which ) {
 	return value => reduceBorderPosition( value, which );
 }
 
+// Returns an array with reduced border styles depending on specified values.
+//
+// If all (width, style, color) border properties are specified, the returned selector will be
+// merged into the group: `border-*: [width] [style] [color]`.
+//
+// Otherwise, the specific definitions will be returned: `border-(width|style|color)-*: [value]`.
+//
+// @param {Object|null} value Styles if defined.
+// @param {'top'|'right'|'bottom'|left|} which The border position.
+// @returns {Array}
 function reduceBorderPosition( value, which ) {
-	const borderToSet = [];
+	const borderTypes = [];
 
 	if ( value && value.width !== undefined ) {
-		borderToSet.push( 'width' );
+		borderTypes.push( 'width' );
 	}
 
 	if ( value && value.style !== undefined ) {
-		borderToSet.push( 'style' );
+		borderTypes.push( 'style' );
 	}
 
 	if ( value && value.color !== undefined ) {
-		borderToSet.push( 'color' );
+		borderTypes.push( 'color' );
 	}
 
-	if ( borderToSet.length === 3 ) {
+	if ( borderTypes.length === 3 ) {
 		return [
-			[ `border-${ which }`, borderToSet.map( item => value[ item ] ).join( ' ' ) ]
+			[ `border-${ which }`, borderTypes.map( item => value[ item ] ).join( ' ' ) ]
 		];
 	}
 
-	const result = [];
-
-	if ( borderToSet.includes( 'width' ) ) {
-		result.push( [ `border-${ which }-width`, value.width ] );
-	}
-
-	if ( borderToSet.includes( 'style' ) ) {
-		result.push( [ `border-${ which }-style`, value.style ] );
-	}
-
-	if ( borderToSet.includes( 'color' ) ) {
-		result.push( [ `border-${ which }-color`, value.color ] );
-	}
-
-	return result;
+	return borderTypes.map( type => {
+		return [ `border-${ which }-${ type }`, value[ type ] ];
+	} );
 }

--- a/packages/ckeditor5-engine/src/view/styles/border.js
+++ b/packages/ckeditor5-engine/src/view/styles/border.js
@@ -301,7 +301,11 @@ function borderReducer() {
 	// @param {Array} leftReducer `border-left-*` definitions.
 	// @returns {Boolean}
 	function shouldMergeAllBordersDefinitions( topReducer, rightReducer, bottomReducer, leftReducer ) {
-		return topReducer[ 0 ][ 0 ] === 'border-top' &&
+		return topReducer.length === 1 &&
+			rightReducer.length === 1 &&
+			bottomReducer.length === 1 &&
+			leftReducer.length === 1 &&
+			topReducer[ 0 ][ 0 ] === 'border-top' &&
 			rightReducer[ 0 ][ 0 ] === 'border-right' &&
 			bottomReducer[ 0 ][ 0 ] === 'border-bottom' &&
 			leftReducer[ 0 ][ 0 ] === 'border-left' &&

--- a/packages/ckeditor5-engine/src/view/styles/utils.js
+++ b/packages/ckeditor5-engine/src/view/styles/utils.js
@@ -184,12 +184,6 @@ export function getBoxSidesValues( value = '' ) {
  */
 export function getBoxSidesValueReducer( styleShorthand ) {
 	return value => {
-		if ( typeof value == 'string' ) {
-			return [
-				[ styleShorthand, value ]
-			];
-		}
-
 		const { top, right, bottom, left } = value;
 
 		const reduced = [];

--- a/packages/ckeditor5-engine/src/view/styles/utils.js
+++ b/packages/ckeditor5-engine/src/view/styles/utils.js
@@ -184,6 +184,12 @@ export function getBoxSidesValues( value = '' ) {
  */
 export function getBoxSidesValueReducer( styleShorthand ) {
 	return value => {
+		if ( typeof value == 'string' ) {
+			return [
+				[ styleShorthand, value ]
+			];
+		}
+
 		const { top, right, bottom, left } = value;
 
 		const reduced = [];

--- a/packages/ckeditor5-engine/tests/view/styles/border.js
+++ b/packages/ckeditor5-engine/tests/view/styles/border.js
@@ -63,10 +63,7 @@ describe( 'Border styles normalization', () => {
 		styles.setTo( 'border:1px solid blue;' );
 
 		expect( styles.toString() ).to.equal(
-			'border-bottom:1px solid blue;' +
-			'border-left:1px solid blue;' +
-			'border-right:1px solid blue;' +
-			'border-top:1px solid blue;'
+			'border:1px solid blue;'
 		);
 		expect( styles.getAsString( 'border-color' ) ).to.equal( 'blue' );
 		expect( styles.getAsString( 'border-style' ) ).to.equal( 'solid' );
@@ -80,7 +77,7 @@ describe( 'Border styles normalization', () => {
 			color: { top: 'blue' }
 		} );
 
-		expect( styles.toString( 'border' ) ).to.equal( 'border-top:blue;' );
+		expect( styles.toString( 'border' ) ).to.equal( 'border-top-color:blue;' );
 		expect( styles.has( 'border-top-color' ) ).to.be.true;
 		expect( styles.getAsString( 'border-top-color' ) ).to.equal( 'blue' );
 	} );
@@ -153,105 +150,95 @@ describe( 'Border styles normalization', () => {
 		styles.remove( 'border-color' );
 
 		expect( styles.toString() ).to.equal(
-			'border-bottom:1px solid;' +
-			'border-left:1px solid;' +
-			'border-right:1px solid;' +
-			'border-top:1px solid;'
+			'border-style:solid;' +
+			'border-width:1px;'
 		);
 
 		expect( styles.getAsString( 'border' ) ).to.be.undefined;
 		expect( styles.getAsString( 'border-color' ) ).to.be.undefined;
 		expect( styles.getAsString( 'border-style' ) ).to.equal( 'solid' );
 		expect( styles.getAsString( 'border-width' ) ).to.equal( '1px' );
-		expect( styles.getAsString( 'border-top' ) ).to.equal( '1px solid' );
-		expect( styles.getAsString( 'border-right' ) ).to.equal( '1px solid' );
-		expect( styles.getAsString( 'border-bottom' ) ).to.equal( '1px solid' );
-		expect( styles.getAsString( 'border-left' ) ).to.equal( '1px solid' );
+		expect( styles.getAsString( 'border-top-style' ) ).to.equal( 'solid' );
+		expect( styles.getAsString( 'border-top-width' ) ).to.equal( '1px' );
+		expect( styles.getAsString( 'border-right-style' ) ).to.equal( 'solid' );
+		expect( styles.getAsString( 'border-right-width' ) ).to.equal( '1px' );
+		expect( styles.getAsString( 'border-bottom-style' ) ).to.equal( 'solid' );
+		expect( styles.getAsString( 'border-bottom-width' ) ).to.equal( '1px' );
+		expect( styles.getAsString( 'border-left-style' ) ).to.equal( 'solid' );
+		expect( styles.getAsString( 'border-left-width' ) ).to.equal( '1px' );
+
+		// Merge into the single property is possible only if all (style, width, and color) values are specified.
+		expect( styles.getAsString( 'border-top' ) ).to.equal( undefined );
+		expect( styles.getAsString( 'border-right' ) ).to.equal( undefined );
+		expect( styles.getAsString( 'border-bottom' ) ).to.equal( undefined );
+		expect( styles.getAsString( 'border-left' ) ).to.equal( undefined );
 	} );
 
 	it( 'should output border with only style shorthand (style)', () => {
 		styles.setTo( 'border:solid;' );
 
-		expect( styles.toString() ).to.equal(
-			'border-bottom:solid;' +
-			'border-left:solid;' +
-			'border-right:solid;' +
-			'border-top:solid;'
-		);
+		expect( styles.toString() ).to.equal( 'border-style:solid;' );
 		expect( styles.getAsString( 'border' ) ).to.be.undefined;
 		expect( styles.getAsString( 'border-color' ) ).to.be.undefined;
-		expect( styles.getAsString( 'border-style' ) ).to.equal( 'solid' );
 		expect( styles.getAsString( 'border-width' ) ).to.be.undefined;
-		expect( styles.getAsString( 'border-top' ) ).to.equal( 'solid' );
-		expect( styles.getAsString( 'border-right' ) ).to.equal( 'solid' );
-		expect( styles.getAsString( 'border-bottom' ) ).to.equal( 'solid' );
-		expect( styles.getAsString( 'border-left' ) ).to.equal( 'solid' );
+		expect( styles.getAsString( 'border-style' ) ).to.equal( 'solid' );
+
+		// The "group" definition can be used only if all (style, width, and color) values are specified.
+		expect( styles.getAsString( 'border-top' ) ).to.equal( undefined );
+		expect( styles.getAsString( 'border-right' ) ).to.equal( undefined );
+		expect( styles.getAsString( 'border-bottom' ) ).to.equal( undefined );
+		expect( styles.getAsString( 'border-left' ) ).to.equal( undefined );
 	} );
 
 	it( 'should output border with only style shorthand (color)', () => {
 		styles.setTo( 'border:#f00;' );
 
-		expect( styles.toString() ).to.equal(
-			'border-bottom:#f00;' +
-			'border-left:#f00;' +
-			'border-right:#f00;' +
-			'border-top:#f00;'
-		);
+		expect( styles.toString() ).to.equal( 'border-color:#f00;' );
 		expect( styles.getAsString( 'border' ) ).to.be.undefined;
 		expect( styles.getAsString( 'border-color' ) ).to.equal( '#f00' );
 		expect( styles.getAsString( 'border-style' ) ).to.be.undefined;
 		expect( styles.getAsString( 'border-width' ) ).to.be.undefined;
-		expect( styles.getAsString( 'border-top' ) ).to.equal( '#f00' );
-		expect( styles.getAsString( 'border-right' ) ).to.equal( '#f00' );
-		expect( styles.getAsString( 'border-bottom' ) ).to.equal( '#f00' );
-		expect( styles.getAsString( 'border-left' ) ).to.equal( '#f00' );
+
+		// The "group" definition can be used only if all (style, width, and color) values are specified.
+		expect( styles.getAsString( 'border-top' ) ).to.equal( undefined );
+		expect( styles.getAsString( 'border-right' ) ).to.equal( undefined );
+		expect( styles.getAsString( 'border-bottom' ) ).to.equal( undefined );
+		expect( styles.getAsString( 'border-left' ) ).to.equal( undefined );
 	} );
 
 	it( 'should output border with only style shorthand (width)', () => {
 		styles.setTo( 'border:1px;' );
 
-		expect( styles.toString() ).to.equal(
-			'border-bottom:1px;' +
-			'border-left:1px;' +
-			'border-right:1px;' +
-			'border-top:1px;'
-		);
+		expect( styles.toString() ).to.equal( 'border-width:1px;' );
 		expect( styles.getAsString( 'border' ) ).to.be.undefined;
 		expect( styles.getAsString( 'border-color' ) ).to.be.undefined;
 		expect( styles.getAsString( 'border-style' ) ).to.be.undefined;
 		expect( styles.getAsString( 'border-width' ) ).to.equal( '1px' );
-		expect( styles.getAsString( 'border-top' ) ).to.equal( '1px' );
-		expect( styles.getAsString( 'border-right' ) ).to.equal( '1px' );
-		expect( styles.getAsString( 'border-bottom' ) ).to.equal( '1px' );
-		expect( styles.getAsString( 'border-left' ) ).to.equal( '1px' );
+
+		// The "group" definition can be used only if all (style, width, and color) values are specified.
+		expect( styles.getAsString( 'border-top' ) ).to.equal( undefined );
+		expect( styles.getAsString( 'border-right' ) ).to.equal( undefined );
+		expect( styles.getAsString( 'border-bottom' ) ).to.equal( undefined );
+		expect( styles.getAsString( 'border-left' ) ).to.equal( undefined );
 	} );
 
 	it( 'should properly remove border properties one by one', () => {
 		styles.setTo( 'border:1px solid blue;' );
 
-		expect( styles.toString() ).to.equal(
-			'border-bottom:1px solid blue;' +
-			'border-left:1px solid blue;' +
-			'border-right:1px solid blue;' +
-			'border-top:1px solid blue;'
-		);
+		// All properties are identical so they will be merged into the `border` definition.
+		expect( styles.toString() ).to.equal( 'border:1px solid blue;' );
 
 		styles.remove( 'border-color' );
 
 		expect( styles.toString() ).to.equal(
-			'border-bottom:1px solid;' +
-			'border-left:1px solid;' +
-			'border-right:1px solid;' +
-			'border-top:1px solid;'
+			'border-style:solid;' +
+			'border-width:1px;'
 		);
 
 		styles.remove( 'border-style' );
 
 		expect( styles.toString() ).to.equal(
-			'border-bottom:1px;' +
-			'border-left:1px;' +
-			'border-right:1px;' +
-			'border-top:1px;'
+			'border-width:1px;'
 		);
 
 		styles.remove( 'border-width' );
@@ -309,6 +296,69 @@ describe( 'Border styles normalization', () => {
 			styles.setTo( 'border:1px solid #f00' );
 
 			expect( styles.getAsString( 'border-left' ) ).to.equal( '1px solid #f00' );
+		} );
+
+		it( 'should output merged "border-style" property and the rest for particular borders', () => {
+			styles.setTo(
+				'border-top: 1px solid #aaa;' +
+				'border-right:2px solid #bbb;' +
+				'border-bottom:3px solid #ccc;' +
+				'border-left:4px solid #ddd;'
+			);
+
+			// Assuming that `border-color` will be applied from outside (external CSS).
+			styles.remove( 'border-color' );
+
+			expect( styles.toString() ).to.equal(
+				'border-bottom-width:3px;' +
+				'border-left-width:4px;' +
+				'border-right-width:2px;' +
+				// All borders use the same border-style, so it's merged into the single property.
+				'border-style:solid;' +
+				'border-top-width:1px;'
+			);
+		} );
+
+		it( 'should output merged "border-style" property and the rest for particular borders', () => {
+			styles.setTo(
+				'border-top: 1px solid #aaa;' +
+				'border-right:2px dotted #aaa;' +
+				'border-bottom:3px dashed #aaa;' +
+				'border-left:4px double #aaa;'
+			);
+
+			// Assuming that `border-width` will be applied from outside (external CSS).
+			styles.remove( 'border-width' );
+
+			expect( styles.toString() ).to.equal(
+				'border-bottom-style:dashed;' +
+				// All borders use the same border-color, so it's merged into the single property.
+				'border-color:#aaa;' +
+				'border-left-style:double;' +
+				'border-right-style:dotted;' +
+				'border-top-style:solid;'
+			);
+		} );
+
+		it( 'should output merged "border-width" property and the rest for particular borders', () => {
+			styles.setTo(
+				'border-top: 1px solid #aaa;' +
+				'border-right:1px dotted #bbb;' +
+				'border-bottom:1px dashed #ccc;' +
+				'border-left:1px double #ddd;'
+			);
+
+			// Assuming that `border-style` will be applied from outside (external CSS).
+			styles.remove( 'border-style' );
+
+			expect( styles.toString() ).to.equal(
+				'border-bottom-color:#ccc;' +
+				'border-left-color:#ddd;' +
+				'border-right-color:#bbb;' +
+				'border-top-color:#aaa;' +
+				// All borders use the same border-width, so it's merged into the single property.
+				'border-width:1px;'
+			);
 		} );
 	} );
 
@@ -627,14 +677,14 @@ describe( 'Border styles normalization', () => {
 
 			expect( styles.toString() ).to.equal(
 				'border-bottom:3.0pt dotted #FFC000;' +
-				'border-left:none;' +
+				'border-left-style:none;' +
 				'border-right:3.0pt dotted #FFC000;' +
-				'border-top:none;'
+				'border-top-style:none;'
 			);
-			expect( styles.getAsString( 'border-top' ) ).to.equal( 'none' );
+			expect( styles.getAsString( 'border-top-style' ) ).to.equal( 'none' );
 			expect( styles.getAsString( 'border-right' ) ).to.equal( '3.0pt dotted #FFC000' );
 			expect( styles.getAsString( 'border-bottom' ) ).to.equal( '3.0pt dotted #FFC000' );
-			expect( styles.getAsString( 'border-left' ) ).to.equal( 'none' );
+			expect( styles.getAsString( 'border-left-style' ) ).to.equal( 'none' );
 		} );
 
 		it( 'should output nothing if no border style defined', () => {

--- a/packages/ckeditor5-engine/tests/view/styles/border.js
+++ b/packages/ckeditor5-engine/tests/view/styles/border.js
@@ -428,90 +428,45 @@ describe( 'Border styles normalization', () => {
 		it( 'should parse #RGB color value', () => {
 			styles.setTo( 'border:#f00;' );
 
-			expect( styles.getNormalized( 'border-color' ) ).to.equal( '#f00' );
+			expect( styles.getNormalized( 'border-color' ) ).to.deep.equal( {
+				top: '#f00',
+				right: '#f00',
+				bottom: '#f00',
+				left: '#f00'
+			} );
 		} );
 
 		it( 'should parse #RGBA color value', () => {
 			styles.setTo( 'border:#f00A;' );
 
-			expect( styles.getNormalized( 'border-color' ) ).to.equal( '#f00A' );
+			expect( styles.getNormalized( 'border-color' ) ).to.deep.equal( {
+				top: '#f00A',
+				right: '#f00A',
+				bottom: '#f00A',
+				left: '#f00A'
+			} );
 		} );
 
 		it( 'should parse rgb() color value', () => {
 			styles.setTo( 'border:rgb(0, 30%,35);' );
 
-			expect( styles.getNormalized( 'border-color' ) ).to.equal( 'rgb(0, 30%, 35)' );
+			expect( styles.getNormalized( 'border-color' ) ).to.deep.equal( {
+				top: 'rgb(0, 30%, 35)',
+				right: 'rgb(0, 30%, 35)',
+				bottom: 'rgb(0, 30%, 35)',
+				left: 'rgb(0, 30%, 35)'
+			} );
 		} );
 
 		it( 'should parse hsl() color value', () => {
 			styles.setTo( 'border:hsl(0, 100%, 50%);' );
 
-			expect( styles.getNormalized( 'border-color' ) ).to.equal( 'hsl(0, 100%, 50%)' );
-		} );
-
-		it( 'should return object for a single border side set', () => {
-			styles.setTo( 'border-top:hsl(0, 100%, 50%);' );
-
-			expect( styles.getNormalized( 'border-color' ) ).to.deep.equal( {
-				top: 'hsl(0, 100%, 50%)'
-			} );
-		} );
-
-		it( 'should return object for two border sides set', () => {
-			styles.setTo(
-				'border-top:hsl(0, 100%, 50%);' +
-				'border-left:#f00;'
-			);
-
 			expect( styles.getNormalized( 'border-color' ) ).to.deep.equal( {
 				top: 'hsl(0, 100%, 50%)',
-				left: '#f00'
+				right: 'hsl(0, 100%, 50%)',
+				bottom: 'hsl(0, 100%, 50%)',
+				left: 'hsl(0, 100%, 50%)'
 			} );
-		} );
-
-		it( 'should return object for three border sides set', () => {
-			styles.setTo(
-				'border-top:hsl(0, 100%, 50%);' +
-				'border-left:#f00;' +
-				'border-bottom:#ff0;'
-			);
-
-			expect( styles.getNormalized( 'border-color' ) ).to.deep.equal( {
-				top: 'hsl(0, 100%, 50%)',
-				bottom: '#ff0',
-				left: '#f00'
-			} );
-		} );
-
-		it( 'should return object for all border side set (different values)', () => {
-			styles.setTo(
-				'border-top:hsl(0, 100%, 50%);' +
-				'border-left:#f00;' +
-				'border-bottom:#ff0;' +
-				'border-right:rgb(0, 30%, 35);'
-			);
-
-			expect( styles.getNormalized( 'border-color' ) ).to.deep.equal( {
-				top: 'hsl(0, 100%, 50%)',
-				bottom: '#ff0',
-				left: '#f00',
-				right: 'rgb(0, 30%, 35)'
-			} );
-		} );
-
-		it( 'should return string for all border side set (same values)', () => {
-			styles.setTo(
-				'border-top:#f00;' +
-				'border-left:#f00;' +
-				'border-bottom:#f00;' +
-				'border-right:#f00;'
-			);
-
-			expect( styles.getNormalized( 'border-color' ) ).to.equal( '#f00' );
-		} );
-
-		it( 'should return undefined for border not set', () => {
-			expect( styles.getNormalized( 'border-color' ) ).to.be.undefined;
 		} );
 	} );
 
@@ -571,13 +526,23 @@ describe( 'Border styles normalization', () => {
 		it( 'should parse none value', () => {
 			styles.setTo( 'border:none;' );
 
-			expect( styles.getNormalized( 'border-style' ) ).to.equal( 'none' );
+			expect( styles.getNormalized( 'border-style' ) ).to.deep.equal( {
+				top: 'none',
+				right: 'none',
+				bottom: 'none',
+				left: 'none'
+			} );
 		} );
 
 		it( 'should parse line-style value', () => {
 			styles.setTo( 'border:solid;' );
 
-			expect( styles.getNormalized( 'border-style' ) ).to.equal( 'solid' );
+			expect( styles.getNormalized( 'border-style' ) ).to.deep.equal( {
+				top: 'solid',
+				right: 'solid',
+				bottom: 'solid',
+				left: 'solid'
+			} );
 		} );
 
 		it( 'should not parse non line-style value', () => {
@@ -589,71 +554,6 @@ describe( 'Border styles normalization', () => {
 				bottom: undefined,
 				left: undefined
 			} );
-		} );
-
-		it( 'should return object for a single border side set', () => {
-			styles.setTo( 'border-top:dashed;' );
-
-			expect( styles.getNormalized( 'border-style' ) ).to.deep.equal( {
-				top: 'dashed'
-			} );
-		} );
-
-		it( 'should return object for two border sides set', () => {
-			styles.setTo(
-				'border-top:dashed;' +
-				'border-left:dotted;'
-			);
-
-			expect( styles.getNormalized( 'border-style' ) ).to.deep.equal( {
-				top: 'dashed',
-				left: 'dotted'
-			} );
-		} );
-
-		it( 'should return object for three border sides set', () => {
-			styles.setTo(
-				'border-top:dashed;' +
-				'border-left:dotted;' +
-				'border-bottom:solid;'
-			);
-
-			expect( styles.getNormalized( 'border-style' ) ).to.deep.equal( {
-				top: 'dashed',
-				left: 'dotted',
-				bottom: 'solid'
-			} );
-		} );
-
-		it( 'should return object for all border sides set (different values)', () => {
-			styles.setTo(
-				'border-top:dashed;' +
-				'border-left:dotted;' +
-				'border-bottom:solid;' +
-				'border-right:solid;'
-			);
-
-			expect( styles.getNormalized( 'border-style' ) ).to.deep.equal( {
-				top: 'dashed',
-				left: 'dotted',
-				bottom: 'solid',
-				right: 'solid'
-			} );
-		} );
-
-		it( 'should return string for all border sides set (same values)', () => {
-			styles.setTo(
-				'border-top:dotted;' +
-				'border-left:dotted;' +
-				'border-bottom:dotted;' +
-				'border-right:dotted;'
-			);
-
-			expect( styles.getNormalized( 'border-style' ) ).to.equal( 'dotted' );
-		} );
-
-		it( 'should return undefined for border not set', () => {
-			expect( styles.getNormalized( 'border-style' ) ).to.be.undefined;
 		} );
 	} );
 
@@ -713,96 +613,56 @@ describe( 'Border styles normalization', () => {
 		it( 'should parse px value', () => {
 			styles.setTo( 'border:1px;' );
 
-			expect( styles.getNormalized( 'border-width' ) ).to.equal( '1px' );
+			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
+				top: '1px',
+				right: '1px',
+				bottom: '1px',
+				left: '1px'
+			} );
 		} );
 
 		it( 'should parse em value', () => {
 			styles.setTo( 'border:1em;' );
 
-			expect( styles.getNormalized( 'border-width' ) ).to.equal( '1em' );
+			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
+				top: '1em',
+				right: '1em',
+				bottom: '1em',
+				left: '1em'
+			} );
 		} );
 
 		it( 'should parse thin value', () => {
 			styles.setTo( 'border:thin' );
 
-			expect( styles.getNormalized( 'border-width' ) ).to.equal( 'thin' );
+			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
+				top: 'thin',
+				right: 'thin',
+				bottom: 'thin',
+				left: 'thin'
+			} );
 		} );
 
 		it( 'should parse medium value', () => {
 			styles.setTo( 'border:medium' );
 
-			expect( styles.getNormalized( 'border-width' ) ).to.equal( 'medium' );
+			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
+				top: 'medium',
+				right: 'medium',
+				bottom: 'medium',
+				left: 'medium'
+			} );
 		} );
 
 		it( 'should parse thick value', () => {
 			styles.setTo( 'border:thick' );
 
-			expect( styles.getNormalized( 'border-width' ) ).to.equal( 'thick' );
-		} );
-
-		it( 'should return object for a single border side set', () => {
-			styles.setTo( 'border-top:2px;' );
-
 			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
-				top: '2px'
+				top: 'thick',
+				right: 'thick',
+				bottom: 'thick',
+				left: 'thick'
 			} );
-		} );
-
-		it( 'should return object for two border sides set', () => {
-			styles.setTo(
-				'border-top:1px;' +
-				'border-left:2px;'
-			);
-
-			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
-				top: '1px',
-				left: '2px'
-			} );
-		} );
-
-		it( 'should return object for three border sides set', () => {
-			styles.setTo(
-				'border-top:1px;' +
-				'border-left:2px;' +
-				'border-bottom:3px;'
-			);
-
-			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
-				top: '1px',
-				left: '2px',
-				bottom: '3px'
-			} );
-		} );
-
-		it( 'should return object for all border sides set (different values)', () => {
-			styles.setTo(
-				'border-top:1px;' +
-				'border-left:2px;' +
-				'border-bottom:3px;' +
-				'border-right:4px;'
-			);
-
-			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
-				top: '1px',
-				left: '2px',
-				bottom: '3px',
-				right: '4px'
-			} );
-		} );
-
-		it( 'should return string for all border sides set (same values)', () => {
-			styles.setTo(
-				'border-top:2px;' +
-				'border-left:2px;' +
-				'border-bottom:2px;' +
-				'border-right:2px;'
-			);
-
-			expect( styles.getNormalized( 'border-width' ) ).to.equal( '2px' );
-		} );
-
-		it( 'should return undefined for border not set', () => {
-			expect( styles.getNormalized( 'border-width' ) ).to.be.undefined;
 		} );
 	} );
 

--- a/packages/ckeditor5-engine/tests/view/styles/border.js
+++ b/packages/ckeditor5-engine/tests/view/styles/border.js
@@ -428,45 +428,90 @@ describe( 'Border styles normalization', () => {
 		it( 'should parse #RGB color value', () => {
 			styles.setTo( 'border:#f00;' );
 
-			expect( styles.getNormalized( 'border-color' ) ).to.deep.equal( {
-				top: '#f00',
-				right: '#f00',
-				bottom: '#f00',
-				left: '#f00'
-			} );
+			expect( styles.getNormalized( 'border-color' ) ).to.equal( '#f00' );
 		} );
 
 		it( 'should parse #RGBA color value', () => {
 			styles.setTo( 'border:#f00A;' );
 
-			expect( styles.getNormalized( 'border-color' ) ).to.deep.equal( {
-				top: '#f00A',
-				right: '#f00A',
-				bottom: '#f00A',
-				left: '#f00A'
-			} );
+			expect( styles.getNormalized( 'border-color' ) ).to.equal( '#f00A' );
 		} );
 
 		it( 'should parse rgb() color value', () => {
 			styles.setTo( 'border:rgb(0, 30%,35);' );
 
-			expect( styles.getNormalized( 'border-color' ) ).to.deep.equal( {
-				top: 'rgb(0, 30%, 35)',
-				right: 'rgb(0, 30%, 35)',
-				bottom: 'rgb(0, 30%, 35)',
-				left: 'rgb(0, 30%, 35)'
-			} );
+			expect( styles.getNormalized( 'border-color' ) ).to.equal( 'rgb(0, 30%, 35)' );
 		} );
 
 		it( 'should parse hsl() color value', () => {
 			styles.setTo( 'border:hsl(0, 100%, 50%);' );
 
+			expect( styles.getNormalized( 'border-color' ) ).to.equal( 'hsl(0, 100%, 50%)' );
+		} );
+
+		it( 'should return object for a single border side set', () => {
+			styles.setTo( 'border-top:hsl(0, 100%, 50%);' );
+
+			expect( styles.getNormalized( 'border-color' ) ).to.deep.equal( {
+				top: 'hsl(0, 100%, 50%)'
+			} );
+		} );
+
+		it( 'should return object for two border sides set', () => {
+			styles.setTo(
+				'border-top:hsl(0, 100%, 50%);' +
+				'border-left:#f00;'
+			);
+
 			expect( styles.getNormalized( 'border-color' ) ).to.deep.equal( {
 				top: 'hsl(0, 100%, 50%)',
-				right: 'hsl(0, 100%, 50%)',
-				bottom: 'hsl(0, 100%, 50%)',
-				left: 'hsl(0, 100%, 50%)'
+				left: '#f00'
 			} );
+		} );
+
+		it( 'should return object for three border sides set', () => {
+			styles.setTo(
+				'border-top:hsl(0, 100%, 50%);' +
+				'border-left:#f00;' +
+				'border-bottom:#ff0;'
+			);
+
+			expect( styles.getNormalized( 'border-color' ) ).to.deep.equal( {
+				top: 'hsl(0, 100%, 50%)',
+				bottom: '#ff0',
+				left: '#f00'
+			} );
+		} );
+
+		it( 'should return object for all border side set (different values)', () => {
+			styles.setTo(
+				'border-top:hsl(0, 100%, 50%);' +
+				'border-left:#f00;' +
+				'border-bottom:#ff0;' +
+				'border-right:rgb(0, 30%, 35);'
+			);
+
+			expect( styles.getNormalized( 'border-color' ) ).to.deep.equal( {
+				top: 'hsl(0, 100%, 50%)',
+				bottom: '#ff0',
+				left: '#f00',
+				right: 'rgb(0, 30%, 35)'
+			} );
+		} );
+
+		it( 'should return string for all border side set (same values)', () => {
+			styles.setTo(
+				'border-top:#f00;' +
+				'border-left:#f00;' +
+				'border-bottom:#f00;' +
+				'border-right:#f00;'
+			);
+
+			expect( styles.getNormalized( 'border-color' ) ).to.equal( '#f00' );
+		} );
+
+		it( 'should return undefined for border not set', () => {
+			expect( styles.getNormalized( 'border-color' ) ).to.be.undefined;
 		} );
 	} );
 
@@ -526,23 +571,13 @@ describe( 'Border styles normalization', () => {
 		it( 'should parse none value', () => {
 			styles.setTo( 'border:none;' );
 
-			expect( styles.getNormalized( 'border-style' ) ).to.deep.equal( {
-				top: 'none',
-				right: 'none',
-				bottom: 'none',
-				left: 'none'
-			} );
+			expect( styles.getNormalized( 'border-style' ) ).to.equal( 'none' );
 		} );
 
 		it( 'should parse line-style value', () => {
 			styles.setTo( 'border:solid;' );
 
-			expect( styles.getNormalized( 'border-style' ) ).to.deep.equal( {
-				top: 'solid',
-				right: 'solid',
-				bottom: 'solid',
-				left: 'solid'
-			} );
+			expect( styles.getNormalized( 'border-style' ) ).to.equal( 'solid' );
 		} );
 
 		it( 'should not parse non line-style value', () => {
@@ -554,6 +589,71 @@ describe( 'Border styles normalization', () => {
 				bottom: undefined,
 				left: undefined
 			} );
+		} );
+
+		it( 'should return object for a single border side set', () => {
+			styles.setTo( 'border-top:dashed;' );
+
+			expect( styles.getNormalized( 'border-style' ) ).to.deep.equal( {
+				top: 'dashed'
+			} );
+		} );
+
+		it( 'should return object for two border sides set', () => {
+			styles.setTo(
+				'border-top:dashed;' +
+				'border-left:dotted;'
+			);
+
+			expect( styles.getNormalized( 'border-style' ) ).to.deep.equal( {
+				top: 'dashed',
+				left: 'dotted'
+			} );
+		} );
+
+		it( 'should return object for three border sides set', () => {
+			styles.setTo(
+				'border-top:dashed;' +
+				'border-left:dotted;' +
+				'border-bottom:solid;'
+			);
+
+			expect( styles.getNormalized( 'border-style' ) ).to.deep.equal( {
+				top: 'dashed',
+				left: 'dotted',
+				bottom: 'solid'
+			} );
+		} );
+
+		it( 'should return object for all border sides set (different values)', () => {
+			styles.setTo(
+				'border-top:dashed;' +
+				'border-left:dotted;' +
+				'border-bottom:solid;' +
+				'border-right:solid;'
+			);
+
+			expect( styles.getNormalized( 'border-style' ) ).to.deep.equal( {
+				top: 'dashed',
+				left: 'dotted',
+				bottom: 'solid',
+				right: 'solid'
+			} );
+		} );
+
+		it( 'should return string for all border sides set (same values)', () => {
+			styles.setTo(
+				'border-top:dotted;' +
+				'border-left:dotted;' +
+				'border-bottom:dotted;' +
+				'border-right:dotted;'
+			);
+
+			expect( styles.getNormalized( 'border-style' ) ).to.equal( 'dotted' );
+		} );
+
+		it( 'should return undefined for border not set', () => {
+			expect( styles.getNormalized( 'border-style' ) ).to.be.undefined;
 		} );
 	} );
 
@@ -613,56 +713,96 @@ describe( 'Border styles normalization', () => {
 		it( 'should parse px value', () => {
 			styles.setTo( 'border:1px;' );
 
-			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
-				top: '1px',
-				right: '1px',
-				bottom: '1px',
-				left: '1px'
-			} );
+			expect( styles.getNormalized( 'border-width' ) ).to.equal( '1px' );
 		} );
 
 		it( 'should parse em value', () => {
 			styles.setTo( 'border:1em;' );
 
-			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
-				top: '1em',
-				right: '1em',
-				bottom: '1em',
-				left: '1em'
-			} );
+			expect( styles.getNormalized( 'border-width' ) ).to.equal( '1em' );
 		} );
 
 		it( 'should parse thin value', () => {
 			styles.setTo( 'border:thin' );
 
-			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
-				top: 'thin',
-				right: 'thin',
-				bottom: 'thin',
-				left: 'thin'
-			} );
+			expect( styles.getNormalized( 'border-width' ) ).to.equal( 'thin' );
 		} );
 
 		it( 'should parse medium value', () => {
 			styles.setTo( 'border:medium' );
 
-			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
-				top: 'medium',
-				right: 'medium',
-				bottom: 'medium',
-				left: 'medium'
-			} );
+			expect( styles.getNormalized( 'border-width' ) ).to.equal( 'medium' );
 		} );
 
 		it( 'should parse thick value', () => {
 			styles.setTo( 'border:thick' );
 
+			expect( styles.getNormalized( 'border-width' ) ).to.equal( 'thick' );
+		} );
+
+		it( 'should return object for a single border side set', () => {
+			styles.setTo( 'border-top:2px;' );
+
 			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
-				top: 'thick',
-				right: 'thick',
-				bottom: 'thick',
-				left: 'thick'
+				top: '2px'
 			} );
+		} );
+
+		it( 'should return object for two border sides set', () => {
+			styles.setTo(
+				'border-top:1px;' +
+				'border-left:2px;'
+			);
+
+			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
+				top: '1px',
+				left: '2px'
+			} );
+		} );
+
+		it( 'should return object for three border sides set', () => {
+			styles.setTo(
+				'border-top:1px;' +
+				'border-left:2px;' +
+				'border-bottom:3px;'
+			);
+
+			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
+				top: '1px',
+				left: '2px',
+				bottom: '3px'
+			} );
+		} );
+
+		it( 'should return object for all border sides set (different values)', () => {
+			styles.setTo(
+				'border-top:1px;' +
+				'border-left:2px;' +
+				'border-bottom:3px;' +
+				'border-right:4px;'
+			);
+
+			expect( styles.getNormalized( 'border-width' ) ).to.deep.equal( {
+				top: '1px',
+				left: '2px',
+				bottom: '3px',
+				right: '4px'
+			} );
+		} );
+
+		it( 'should return string for all border sides set (same values)', () => {
+			styles.setTo(
+				'border-top:2px;' +
+				'border-left:2px;' +
+				'border-bottom:2px;' +
+				'border-right:2px;'
+			);
+
+			expect( styles.getNormalized( 'border-width' ) ).to.equal( '2px' );
+		} );
+
+		it( 'should return undefined for border not set', () => {
+			expect( styles.getNormalized( 'border-width' ) ).to.be.undefined;
 		} );
 	} );
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/table/tablecellproperties/model.html
+++ b/packages/ckeditor5-paste-from-office/tests/_data/table/tablecellproperties/model.html
@@ -1,17 +1,17 @@
-<table borderColor="{}" borderStyle="{"top":"none","bottom":"none","right":"none","left":"none"}" borderWidth="{}">
+<table borderColor="{}" borderStyle="none" borderWidth="{}">
 	<tableRow>
-		<tableCell backgroundColor="#CCCCCC" borderColor="{"top":"windowtext","bottom":"windowtext","right":"windowtext","left":"windowtext"}" borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"solid"}" borderWidth="{"top":"1.0pt","bottom":"1.0pt","right":"1.0pt","left":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="59.0%">
+		<tableCell backgroundColor="#CCCCCC" borderColor="windowtext" borderStyle="solid" borderWidth="1.0pt" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="59.0%">
 			<paragraph><$text bold="true">Project Phase</$text></paragraph>
 		</tableCell>
-		<tableCell backgroundColor="#CCCCCC" borderColor="{"top":"windowtext","bottom":"windowtext","right":"windowtext","left":"windowtext"}" borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"none"}" borderWidth="{"top":"1.0pt","bottom":"1.0pt","right":"1.0pt","left":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="24.0%">
+		<tableCell backgroundColor="#CCCCCC" borderColor="windowtext" borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"none"}" borderWidth="1.0pt" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="24.0%">
 			<paragraph><$text bold="true">Deadline</$text></paragraph>
 		</tableCell>
-		<tableCell backgroundColor="#CCCCCC" borderColor="{"top":"windowtext","bottom":"windowtext","right":"windowtext","left":"windowtext"}" borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"none"}" borderWidth="{"top":"1.0pt","bottom":"1.0pt","right":"1.0pt","left":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="17.0%">
+		<tableCell backgroundColor="#CCCCCC" borderColor="windowtext" borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"none"}" borderWidth="1.0pt" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="17.0%">
 			<paragraph><$text bold="true">Status</$text></paragraph>
 		</tableCell>
 	</tableRow>
 	<tableRow>
-		<tableCell borderColor="{"top":"windowtext","bottom":"windowtext","right":"windowtext","left":"windowtext"}" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="{"top":"1.0pt","bottom":"1.0pt","right":"1.0pt","left":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="59.0%">
+		<tableCell borderColor="windowtext" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="1.0pt" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="59.0%">
 			<paragraph>Phase 1: Market research</paragraph>
 		</tableCell>
 		<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="24.0%">
@@ -22,7 +22,7 @@
 		</tableCell>
 		</tableRow>
 	<tableRow>
-		<tableCell backgroundColor="#EEEEEE" borderColor="{"top":"windowtext","bottom":"windowtext","right":"windowtext","left":"windowtext"}" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="{"top":"1.0pt","bottom":"1.0pt","right":"1.0pt","left":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="59.0%">
+		<tableCell backgroundColor="#EEEEEE" borderColor="windowtext" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="1.0pt" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="59.0%">
 			<paragraph>Phase 2: Editor features implementation</paragraph>
 		</tableCell>
 		<tableCell backgroundColor="#EEEEEE" borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="24.0%">
@@ -33,7 +33,7 @@
 		</tableCell>
 	</tableRow>
 	<tableRow>
-		<tableCell borderColor="{"top":"windowtext","bottom":"windowtext","right":"windowtext","left":"windowtext"}" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="{"top":"1.0pt","bottom":"1.0pt","right":"1.0pt","left":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="59.0%">
+		<tableCell borderColor="windowtext" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="1.0pt" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="59.0%">
 			<paragraph>Phase 3: Rollout to Production</paragraph>
 		</tableCell>
 		<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="24.0%">

--- a/packages/ckeditor5-table/src/converters/tableproperties.js
+++ b/packages/ckeditor5-table/src/converters/tableproperties.js
@@ -11,12 +11,13 @@
  * Conversion helper for upcasting attributes using normalized styles.
  *
  * @param {module:engine/conversion/conversion~Conversion} conversion
- * @param {String} modelElement
- * @param {String} modelAttribute
- * @param {String} styleName
- * @param {Boolean} [reduceBoxSides=false]
+ * @param {Object} options
+ * @param {String} options.modelElement
+ * @param {String} options.modelAttribute
+ * @param {String} options.styleName
+ * @param {Boolean} [options.reduceBoxSides=false]
  */
-export function upcastStyleToAttribute( conversion, modelElement, modelAttribute, styleName, reduceBoxSides = false ) {
+export function upcastStyleToAttribute( conversion, { modelElement, modelAttribute, styleName, reduceBoxSides = false } ) {
 	conversion.for( 'upcast' ).attributeToAttribute( {
 		view: {
 			styles: {
@@ -97,11 +98,12 @@ export function upcastBorderStyles( conversion, viewElementName ) {
  * Conversion helper for downcasting an attribute to a style.
  *
  * @param {module:engine/conversion/conversion~Conversion} conversion
- * @param {String} modelElement
- * @param {String} modelAttribute
- * @param {String} styleName
+ * @param {Object} options
+ * @param {String} options.modelElement
+ * @param {String} options.modelAttribute
+ * @param {String} options.styleName
  */
-export function downcastAttributeToStyle( conversion, modelElement, modelAttribute, styleName ) {
+export function downcastAttributeToStyle( conversion, { modelElement, modelAttribute, styleName } ) {
 	conversion.for( 'downcast' ).attributeToAttribute( {
 		model: {
 			name: modelElement,
@@ -120,10 +122,11 @@ export function downcastAttributeToStyle( conversion, modelElement, modelAttribu
  * Conversion helper for downcasting attributes from the model table to a view table (not to `<figure>`).
  *
  * @param {module:engine/conversion/conversion~Conversion} conversion
- * @param {String} modelAttribute
- * @param {String} styleName
+ * @param {Object} options
+ * @param {String} options.modelAttribute
+ * @param {String} options.styleName
  */
-export function downcastTableAttribute( conversion, modelAttribute, styleName ) {
+export function downcastTableAttribute( conversion, { modelAttribute, styleName } ) {
 	conversion.for( 'downcast' ).add( dispatcher => dispatcher.on( `attribute:${ modelAttribute }:table`, ( evt, data, conversionApi ) => {
 		const { item, attributeNewValue } = data;
 		const { mapper, writer } = conversionApi;

--- a/packages/ckeditor5-table/src/converters/tableproperties.js
+++ b/packages/ckeditor5-table/src/converters/tableproperties.js
@@ -44,13 +44,21 @@ export function upcastBorderStyles( conversion, viewElementName ) {
 			return;
 		}
 
-		// TODO: this is counter-intuitive: ie.: if only `border-top` is defined then `hasStyle( 'border' )` also returns true.
-		// TODO: this might needs to be fixed in styles normalizer.
+		// Check the most detailed properties. These will be always set directly or
+		// when using the "group" properties like: `border-(top|right|bottom|left)` or `border`.
 		const stylesToConsume = [
-			'border-top',
-			'border-right',
-			'border-bottom',
-			'border-left'
+			'border-top-width',
+			'border-top-color',
+			'border-top-style',
+			'border-bottom-width',
+			'border-bottom-color',
+			'border-bottom-style',
+			'border-right-width',
+			'border-right-color',
+			'border-right-style',
+			'border-left-width',
+			'border-left-color',
+			'border-left-style'
 		].filter( styleName => data.viewItem.hasStyle( styleName ) );
 
 		if ( !stylesToConsume.length ) {

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.js
@@ -85,7 +85,7 @@ export default class TableCellPropertiesEditing extends Plugin {
 		editor.commands.add( 'tableCellHeight', new TableCellHeightCommand( editor ) );
 
 		editor.data.addStyleProcessorRules( addPaddingRules );
-		enableProperty( schema, conversion, 'padding', 'padding' );
+		enableProperty( schema, conversion, 'padding', 'padding', true );
 		editor.commands.add( 'tableCellPadding', new TableCellPaddingCommand( editor ) );
 
 		editor.data.addStyleProcessorRules( addBackgroundRules );
@@ -195,10 +195,11 @@ function enableVerticalAlignmentProperty( schema, conversion ) {
 // @param {String} styleName
 // @param {module:engine/model/schema~Schema} schema
 // @param {module:engine/conversion/conversion~Conversion} conversion
-function enableProperty( schema, conversion, modelAttribute, styleName ) {
+// @param {Boolean} [reduceBoxSides=false]
+function enableProperty( schema, conversion, modelAttribute, styleName, reduceBoxSides = false ) {
 	schema.extend( 'tableCell', {
 		allowAttributes: [ modelAttribute ]
 	} );
-	upcastStyleToAttribute( conversion, 'tableCell', modelAttribute, styleName );
+	upcastStyleToAttribute( conversion, 'tableCell', modelAttribute, styleName, reduceBoxSides );
 	downcastAttributeToStyle( conversion, 'tableCell', modelAttribute, styleName );
 }

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.js
@@ -78,18 +78,18 @@ export default class TableCellPropertiesEditing extends Plugin {
 		enableHorizontalAlignmentProperty( schema, conversion, locale );
 		editor.commands.add( 'tableCellHorizontalAlignment', new TableCellHorizontalAlignmentCommand( editor ) );
 
-		enableProperty( schema, conversion, 'width', 'width' );
+		enableProperty( schema, conversion, { modelAttribute: 'width', styleName: 'width' } );
 		editor.commands.add( 'tableCellWidth', new TableCellWidthCommand( editor ) );
 
-		enableProperty( schema, conversion, 'height', 'height' );
+		enableProperty( schema, conversion, { modelAttribute: 'height', styleName: 'height' } );
 		editor.commands.add( 'tableCellHeight', new TableCellHeightCommand( editor ) );
 
 		editor.data.addStyleProcessorRules( addPaddingRules );
-		enableProperty( schema, conversion, 'padding', 'padding', true );
+		enableProperty( schema, conversion, { modelAttribute: 'padding', styleName: 'padding', reduceBoxSides: true } );
 		editor.commands.add( 'tableCellPadding', new TableCellPaddingCommand( editor ) );
 
 		editor.data.addStyleProcessorRules( addBackgroundRules );
-		enableProperty( schema, conversion, 'backgroundColor', 'background-color' );
+		enableProperty( schema, conversion, { modelAttribute: 'backgroundColor', styleName: 'background-color' } );
 		editor.commands.add( 'tableCellBackgroundColor', new TableCellBackgroundColorCommand( editor ) );
 
 		enableVerticalAlignmentProperty( schema, conversion );
@@ -107,9 +107,9 @@ function enableBorderProperties( schema, conversion ) {
 	} );
 	upcastBorderStyles( conversion, 'td' );
 	upcastBorderStyles( conversion, 'th' );
-	downcastAttributeToStyle( conversion, 'tableCell', 'borderStyle', 'border-style' );
-	downcastAttributeToStyle( conversion, 'tableCell', 'borderColor', 'border-color' );
-	downcastAttributeToStyle( conversion, 'tableCell', 'borderWidth', 'border-width' );
+	downcastAttributeToStyle( conversion, { modelElement: 'tableCell', modelAttribute: 'borderStyle', styleName: 'border-style' } );
+	downcastAttributeToStyle( conversion, { modelElement: 'tableCell', modelAttribute: 'borderColor', styleName: 'border-color' } );
+	downcastAttributeToStyle( conversion, { modelElement: 'tableCell', modelAttribute: 'borderWidth', styleName: 'border-width' } );
 }
 
 // Enables the `'horizontalAlignment'` attribute for table cells.
@@ -191,15 +191,19 @@ function enableVerticalAlignmentProperty( schema, conversion ) {
 
 // Enables conversion for an attribute for simple view-model mappings.
 //
-// @param {String} modelAttribute
-// @param {String} styleName
 // @param {module:engine/model/schema~Schema} schema
 // @param {module:engine/conversion/conversion~Conversion} conversion
-// @param {Boolean} [reduceBoxSides=false]
-function enableProperty( schema, conversion, modelAttribute, styleName, reduceBoxSides = false ) {
+// @param {Object} options
+// @param {String} options.modelAttribute
+// @param {String} options.styleName
+// @param {Boolean} [options.reduceBoxSides=false]
+function enableProperty( schema, conversion, options ) {
+	const { modelAttribute } = options;
+
 	schema.extend( 'tableCell', {
 		allowAttributes: [ modelAttribute ]
 	} );
-	upcastStyleToAttribute( conversion, 'tableCell', modelAttribute, styleName, reduceBoxSides );
-	downcastAttributeToStyle( conversion, 'tableCell', modelAttribute, styleName );
+
+	upcastStyleToAttribute( conversion, { modelElement: 'tableCell', ...options } );
+	downcastAttributeToStyle( conversion, { modelElement: 'tableCell', ...options } );
 }

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.js
@@ -78,14 +78,14 @@ export default class TablePropertiesEditing extends Plugin {
 		enableAlignmentProperty( schema, conversion );
 		editor.commands.add( 'tableAlignment', new TableAlignmentCommand( editor ) );
 
-		enableTableToFigureProperty( schema, conversion, 'width', 'width' );
+		enableTableToFigureProperty( schema, conversion, { modelAttribute: 'width', styleName: 'width' } );
 		editor.commands.add( 'tableWidth', new TableWidthCommand( editor ) );
 
-		enableTableToFigureProperty( schema, conversion, 'height', 'height' );
+		enableTableToFigureProperty( schema, conversion, { modelAttribute: 'height', styleName: 'height' } );
 		editor.commands.add( 'tableHeight', new TableHeightCommand( editor ) );
 
 		editor.data.addStyleProcessorRules( addBackgroundRules );
-		enableProperty( schema, conversion, 'backgroundColor', 'background-color' );
+		enableProperty( schema, conversion, { modelAttribute: 'backgroundColor', styleName: 'background-color' } );
 		editor.commands.add( 'tableBackgroundColor', new TableBackgroundColorCommand( editor ) );
 	}
 }
@@ -99,9 +99,9 @@ function enableBorderProperties( schema, conversion ) {
 		allowAttributes: [ 'borderWidth', 'borderColor', 'borderStyle' ]
 	} );
 	upcastBorderStyles( conversion, 'table' );
-	downcastTableAttribute( conversion, 'borderColor', 'border-color' );
-	downcastTableAttribute( conversion, 'borderStyle', 'border-style' );
-	downcastTableAttribute( conversion, 'borderWidth', 'border-width' );
+	downcastTableAttribute( conversion, { modelAttribute: 'borderColor', styleName: 'border-color' } );
+	downcastTableAttribute( conversion, { modelAttribute: 'borderStyle', styleName: 'border-style' } );
+	downcastTableAttribute( conversion, { modelAttribute: 'borderWidth', styleName: 'border-width' } );
 }
 
 // Enables the `'alignment'` attribute for table.
@@ -155,28 +155,34 @@ function enableAlignmentProperty( schema, conversion ) {
 
 // Enables conversion for an attribute for simple view-model mappings.
 //
-// @param {String} modelAttribute
-// @param {String} styleName
 // @param {module:engine/model/schema~Schema} schema
 // @param {module:engine/conversion/conversion~Conversion} conversion
-function enableProperty( schema, conversion, modelAttribute, styleName ) {
+// @param {Object} options
+// @param {String} options.modelAttribute
+// @param {String} options.styleName
+function enableProperty( schema, conversion, options ) {
+	const { modelAttribute } = options;
+
 	schema.extend( 'table', {
 		allowAttributes: [ modelAttribute ]
 	} );
-	upcastStyleToAttribute( conversion, 'table', modelAttribute, styleName );
-	downcastTableAttribute( conversion, modelAttribute, styleName );
+	upcastStyleToAttribute( conversion, { modelElement: 'table', ...options } );
+	downcastTableAttribute( conversion, options );
 }
 
 // Enables conversion for an attribute for simple view (figure) to model (table) mappings.
 //
-// @param {String} modelAttribute
-// @param {String} styleName
 // @param {module:engine/model/schema~Schema} schema
 // @param {module:engine/conversion/conversion~Conversion} conversion
-function enableTableToFigureProperty( schema, conversion, modelAttribute, styleName ) {
+// @param {Object} options
+// @param {String} options.modelAttribute
+// @param {String} options.styleName
+function enableTableToFigureProperty( schema, conversion, options ) {
+	const { modelAttribute } = options;
+
 	schema.extend( 'table', {
 		allowAttributes: [ modelAttribute ]
 	} );
-	upcastStyleToAttribute( conversion, 'table', modelAttribute, styleName );
-	downcastAttributeToStyle( conversion, 'table', modelAttribute, styleName );
+	upcastStyleToAttribute( conversion, { modelElement: 'table', ...options } );
+	downcastAttributeToStyle( conversion, { modelElement: 'table', ...options } );
 }

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
@@ -201,7 +201,7 @@ describe( 'table cell properties', () => {
 
 						command.execute( { value: '#f00' } );
 
-						assertTableCellStyle( editor, 'border-bottom:#f00;border-left:#f00;border-right:#f00;border-top:#f00;' );
+						assertTableCellStyle( editor, 'border-color:#f00;' );
 					} );
 
 					it( 'should change selected table cell borderColor to a passed value', () => {
@@ -209,7 +209,7 @@ describe( 'table cell properties', () => {
 
 						command.execute( { value: '#f00' } );
 
-						assertTableCellStyle( editor, 'border-bottom:#f00;border-left:#f00;border-right:#f00;border-top:#f00;' );
+						assertTableCellStyle( editor, 'border-color:#f00;' );
 					} );
 
 					it( 'should remove borderColor from a selected table cell if no value is passed', () => {
@@ -227,7 +227,7 @@ describe( 'table cell properties', () => {
 
 						command.execute( { value: '#f00' } );
 
-						assertTableCellStyle( editor, 'border-bottom:#f00;border-left:#f00;border-right:#f00;border-top:#f00;' );
+						assertTableCellStyle( editor, 'border-color:#f00;' );
 					} );
 
 					it( 'should change selected table cell borderColor to a passed value', () => {
@@ -235,7 +235,7 @@ describe( 'table cell properties', () => {
 
 						command.execute( { value: '#f00' } );
 
-						assertTableCellStyle( editor, 'border-bottom:#f00;border-left:#f00;border-right:#f00;border-top:#f00;' );
+						assertTableCellStyle( editor, 'border-color:#f00;' );
 					} );
 
 					it( 'should remove borderColor from a selected table cell if no value is passed', () => {
@@ -259,8 +259,8 @@ describe( 'table cell properties', () => {
 						command.execute( { value: '#f00' } );
 
 						assertEqualMarkup( editor.getData(), viewTable( [
-							[ { contents: '00', style: 'border-bottom:#f00;border-left:#f00;border-right:#f00;border-top:#f00;' }, '01' ],
-							[ '10', { contents: '11', style: 'border-bottom:#f00;border-left:#f00;border-right:#f00;border-top:#f00;' } ]
+							[ { contents: '00', style: 'border-color:#f00;' }, '01' ],
+							[ '10', { contents: '11', style: 'border-color:#f00;' } ]
 						] ) );
 					} );
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellborderstylecommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellborderstylecommand.js
@@ -201,7 +201,7 @@ describe( 'table cell properties', () => {
 
 						command.execute( { value: 'solid' } );
 
-						assertTableCellStyle( editor, 'border-bottom:solid;border-left:solid;border-right:solid;border-top:solid;' );
+						assertTableCellStyle( editor, 'border-style:solid;' );
 					} );
 
 					it( 'should change selected table cell borderStyle to a passed value', () => {
@@ -209,7 +209,7 @@ describe( 'table cell properties', () => {
 
 						command.execute( { value: 'solid' } );
 
-						assertTableCellStyle( editor, 'border-bottom:solid;border-left:solid;border-right:solid;border-top:solid;' );
+						assertTableCellStyle( editor, 'border-style:solid;' );
 					} );
 
 					it( 'should remove borderStyle from a selected table cell if no value is passed', () => {
@@ -227,7 +227,7 @@ describe( 'table cell properties', () => {
 
 						command.execute( { value: 'solid' } );
 
-						assertTableCellStyle( editor, 'border-bottom:solid;border-left:solid;border-right:solid;border-top:solid;' );
+						assertTableCellStyle( editor, 'border-style:solid;' );
 					} );
 
 					it( 'should change selected table cell borderStyle to a passed value', () => {
@@ -235,7 +235,7 @@ describe( 'table cell properties', () => {
 
 						command.execute( { value: 'solid' } );
 
-						assertTableCellStyle( editor, 'border-bottom:solid;border-left:solid;border-right:solid;border-top:solid;' );
+						assertTableCellStyle( editor, 'border-style:solid;' );
 					} );
 
 					it( 'should remove borderStyle from a selected table cell if no value is passed', () => {
@@ -260,12 +260,12 @@ describe( 'table cell properties', () => {
 
 						assertEqualMarkup( editor.getData(), viewTable( [
 							[
-								{ contents: '00', style: 'border-bottom:solid;border-left:solid;border-right:solid;border-top:solid;' },
+								{ contents: '00', style: 'border-style:solid;' },
 								'01'
 							],
 							[
 								'10',
-								{ contents: '11', style: 'border-bottom:solid;border-left:solid;border-right:solid;border-top:solid;' }
+								{ contents: '11', style: 'border-style:solid;' }
 							]
 						] ) );
 					} );

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
@@ -200,7 +200,7 @@ describe( 'table cell properties', () => {
 
 					command.execute( { value: 25 } );
 
-					assertTableCellStyle( editor, 'border-bottom:25px;border-left:25px;border-right:25px;border-top:25px;' );
+					assertTableCellStyle( editor, 'border-width:25px;' );
 				} );
 
 				it( 'should add default unit for numeric values (string passed)', () => {
@@ -208,7 +208,7 @@ describe( 'table cell properties', () => {
 
 					command.execute( { value: 25 } );
 
-					assertTableCellStyle( editor, 'border-bottom:25px;border-left:25px;border-right:25px;border-top:25px;' );
+					assertTableCellStyle( editor, 'border-width:25px;' );
 				} );
 
 				it( 'should not add default unit for numeric values with unit', () => {
@@ -216,7 +216,7 @@ describe( 'table cell properties', () => {
 
 					command.execute( { value: '25pt' } );
 
-					assertTableCellStyle( editor, 'border-bottom:25pt;border-left:25pt;border-right:25pt;border-top:25pt;' );
+					assertTableCellStyle( editor, 'border-width:25pt;' );
 				} );
 
 				it( 'should add default unit to floats (number passed)', () => {
@@ -224,7 +224,7 @@ describe( 'table cell properties', () => {
 
 					command.execute( { value: 25.1 } );
 
-					assertTableCellStyle( editor, 'border-bottom:25.1px;border-left:25.1px;border-right:25.1px;border-top:25.1px;' );
+					assertTableCellStyle( editor, 'border-width:25.1px;' );
 				} );
 
 				it( 'should add default unit to floats (string passed)', () => {
@@ -232,7 +232,7 @@ describe( 'table cell properties', () => {
 
 					command.execute( { value: '0.1' } );
 
-					assertTableCellStyle( editor, 'border-bottom:0.1px;border-left:0.1px;border-right:0.1px;border-top:0.1px;' );
+					assertTableCellStyle( editor, 'border-width:0.1px;' );
 				} );
 
 				it( 'should pass invalid values', () => {
@@ -240,7 +240,7 @@ describe( 'table cell properties', () => {
 
 					command.execute( { value: 'bar' } );
 
-					assertTableCellStyle( editor, 'border-bottom:bar;border-left:bar;border-right:bar;border-top:bar;' );
+					assertTableCellStyle( editor, 'border-width:bar;' );
 				} );
 
 				it( 'should pass invalid value (string passed, CSS float without leading 0)', () => {
@@ -248,7 +248,7 @@ describe( 'table cell properties', () => {
 
 					command.execute( { value: '.2' } );
 
-					assertTableCellStyle( editor, 'border-bottom:.2;border-left:.2;border-right:.2;border-top:.2;' );
+					assertTableCellStyle( editor, 'border-width:.2;' );
 				} );
 
 				describe( 'collapsed selection', () => {
@@ -257,7 +257,7 @@ describe( 'table cell properties', () => {
 
 						command.execute( { value: '1px' } );
 
-						assertTableCellStyle( editor, 'border-bottom:1px;border-left:1px;border-right:1px;border-top:1px;' );
+						assertTableCellStyle( editor, 'border-width:1px;' );
 					} );
 
 					it( 'should change selected table cell borderWidth to a passed value', () => {
@@ -265,7 +265,7 @@ describe( 'table cell properties', () => {
 
 						command.execute( { value: '1px' } );
 
-						assertTableCellStyle( editor, 'border-bottom:1px;border-left:1px;border-right:1px;border-top:1px;' );
+						assertTableCellStyle( editor, 'border-width:1px;' );
 					} );
 
 					it( 'should remove borderWidth from a selected table cell if no value is passed', () => {
@@ -283,7 +283,7 @@ describe( 'table cell properties', () => {
 
 						command.execute( { value: '1px' } );
 
-						assertTableCellStyle( editor, 'border-bottom:1px;border-left:1px;border-right:1px;border-top:1px;' );
+						assertTableCellStyle( editor, 'border-width:1px;' );
 					} );
 
 					it( 'should change selected table cell borderWidth to a passed value', () => {
@@ -291,7 +291,7 @@ describe( 'table cell properties', () => {
 
 						command.execute( { value: '1px' } );
 
-						assertTableCellStyle( editor, 'border-bottom:1px;border-left:1px;border-right:1px;border-top:1px;' );
+						assertTableCellStyle( editor, 'border-width:1px;' );
 					} );
 
 					it( 'should remove borderWidth from a selected table cell if no value is passed', () => {
@@ -316,12 +316,12 @@ describe( 'table cell properties', () => {
 
 						assertEqualMarkup( editor.getData(), viewTable( [
 							[
-								{ contents: '00', style: 'border-bottom:1px;border-left:1px;border-right:1px;border-top:1px;' },
+								{ contents: '00', style: 'border-width:1px;' },
 								'01'
 							],
 							[
 								'10',
-								{ contents: '11', style: 'border-bottom:1px;border-left:1px;border-right:1px;border-top:1px;' }
+								{ contents: '11', style: 'border-width:1px;' }
 							]
 						] ) );
 					} );

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -295,7 +295,7 @@ describe( 'table cell properties', () => {
 						left: '#f00'
 					}, tableCell ) );
 
-					assertTableCellStyle( editor, 'border-bottom:#f00;border-left:#f00;border-right:#f00;border-top:#f00;' );
+					assertTableCellStyle( editor, 'border-color:#f00;' );
 				} );
 
 				it( 'should downcast borderColor attribute (different top, right, bottom, left)', () => {
@@ -307,10 +307,10 @@ describe( 'table cell properties', () => {
 					}, tableCell ) );
 
 					assertTableCellStyle( editor,
-						'border-bottom:deeppink;' +
-						'border-left:rgb(255, 0, 0);' +
-						'border-right:hsla(0, 100%, 50%, 0.5);' +
-						'border-top:#f00;'
+						'border-bottom-color:deeppink;' +
+						'border-left-color:rgb(255, 0, 0);' +
+						'border-right-color:hsla(0, 100%, 50%, 0.5);' +
+						'border-top-color:#f00;'
 					);
 				} );
 
@@ -342,7 +342,7 @@ describe( 'table cell properties', () => {
 						left: 'solid'
 					}, tableCell ) );
 
-					assertTableCellStyle( editor, 'border-bottom:solid;border-left:solid;border-right:solid;border-top:solid;' );
+					assertTableCellStyle( editor, 'border-style:solid;' );
 				} );
 
 				it( 'should downcast borderStyle attribute (different top, right, bottom, left)', () => {
@@ -353,7 +353,12 @@ describe( 'table cell properties', () => {
 						left: 'dashed'
 					}, tableCell ) );
 
-					assertTableCellStyle( editor, 'border-bottom:dotted;border-left:dashed;border-right:ridge;border-top:solid;' );
+					assertTableCellStyle( editor,
+						'border-bottom-style:dotted;' +
+						'border-left-style:dashed;' +
+						'border-right-style:ridge;' +
+						'border-top-style:solid;'
+					);
 				} );
 
 				it( 'should consume converted item borderWidth attribute', () => {
@@ -384,7 +389,12 @@ describe( 'table cell properties', () => {
 						left: 'thick'
 					}, tableCell ) );
 
-					assertTableCellStyle( editor, 'border-bottom:1337rem;border-left:thick;border-right:.1em;border-top:42px;' );
+					assertTableCellStyle( editor,
+						'border-bottom-width:1337rem;' +
+						'border-left-width:thick;' +
+						'border-right-width:.1em;' +
+						'border-top-width:42px;'
+					);
 				} );
 
 				it( 'should downcast borderWidth attribute (different top, right, bottom, left)', () => {
@@ -395,7 +405,7 @@ describe( 'table cell properties', () => {
 						left: '42px'
 					}, tableCell ) );
 
-					assertTableCellStyle( editor, 'border-bottom:42px;border-left:42px;border-right:42px;border-top:42px;' );
+					assertTableCellStyle( editor, 'border-width:42px;' );
 				} );
 
 				it( 'should downcast borderColor, borderStyle and borderWidth attributes together (same top, right, bottom, left)', () => {
@@ -422,12 +432,7 @@ describe( 'table cell properties', () => {
 						}, tableCell );
 					} );
 
-					assertTableCellStyle( editor,
-						'border-bottom:42px solid #f00;' +
-						'border-left:42px solid #f00;' +
-						'border-right:42px solid #f00;' +
-						'border-top:42px solid #f00;'
-					);
+					assertTableCellStyle( editor, 'border:42px solid #f00;' );
 				} );
 
 				it(
@@ -499,12 +504,7 @@ describe( 'table cell properties', () => {
 							left: 'deeppink'
 						}, tableCell ) );
 
-						assertTableCellStyle( editor,
-							'border-bottom:42px solid deeppink;' +
-							'border-left:42px solid deeppink;' +
-							'border-right:42px solid deeppink;' +
-							'border-top:42px solid deeppink;'
-						);
+						assertTableCellStyle( editor, 'border:42px solid deeppink;' );
 					} );
 
 					it( 'should downcast borderStyle attribute change', () => {
@@ -515,12 +515,7 @@ describe( 'table cell properties', () => {
 							left: 'ridge'
 						}, tableCell ) );
 
-						assertTableCellStyle( editor,
-							'border-bottom:42px ridge #f00;' +
-							'border-left:42px ridge #f00;' +
-							'border-right:42px ridge #f00;' +
-							'border-top:42px ridge #f00;'
-						);
+						assertTableCellStyle( editor, 'border:42px ridge #f00;' );
 					} );
 
 					it( 'should downcast borderWidth attribute change', () => {
@@ -531,22 +526,15 @@ describe( 'table cell properties', () => {
 							left: 'thick'
 						}, tableCell ) );
 
-						assertTableCellStyle( editor,
-							'border-bottom:thick solid #f00;' +
-							'border-left:thick solid #f00;' +
-							'border-right:thick solid #f00;' +
-							'border-top:thick solid #f00;'
-						);
+						assertTableCellStyle( editor, 'border:thick solid #f00;' );
 					} );
 
 					it( 'should downcast borderColor attribute removal', () => {
 						model.change( writer => writer.removeAttribute( 'borderColor', tableCell ) );
 
 						assertTableCellStyle( editor,
-							'border-bottom:42px solid;' +
-							'border-left:42px solid;' +
-							'border-right:42px solid;' +
-							'border-top:42px solid;'
+							'border-style:solid;' +
+							'border-width:42px;'
 						);
 					} );
 
@@ -554,10 +542,8 @@ describe( 'table cell properties', () => {
 						model.change( writer => writer.removeAttribute( 'borderStyle', tableCell ) );
 
 						assertTableCellStyle( editor,
-							'border-bottom:42px #f00;' +
-							'border-left:42px #f00;' +
-							'border-right:42px #f00;' +
-							'border-top:42px #f00;'
+							'border-color:#f00;' +
+							'border-width:42px;'
 						);
 					} );
 
@@ -565,10 +551,8 @@ describe( 'table cell properties', () => {
 						model.change( writer => writer.removeAttribute( 'borderWidth', tableCell ) );
 
 						assertTableCellStyle( editor,
-							'border-bottom:solid #f00;' +
-							'border-left:solid #f00;' +
-							'border-right:solid #f00;' +
-							'border-top:solid #f00;'
+							'border-color:#f00;' +
+							'border-style:solid;'
 						);
 					} );
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -92,9 +92,9 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					assertTRBLAttribute( tableCell, 'borderColor', '#f00' );
-					assertTRBLAttribute( tableCell, 'borderStyle', 'solid' );
-					assertTRBLAttribute( tableCell, 'borderWidth', '1px' );
+					expect( tableCell.getAttribute( 'borderColor' ) ).to.equal( '#f00' );
+					expect( tableCell.getAttribute( 'borderStyle' ) ).to.equal( 'solid' );
+					expect( tableCell.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
 				} );
 
 				it( 'should upcast border-color shorthand', () => {
@@ -102,7 +102,7 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					assertTRBLAttribute( tableCell, 'borderColor', '#f00' );
+					expect( tableCell.getAttribute( 'borderColor' ) ).to.equal( '#f00' );
 				} );
 
 				it( 'should upcast border-style shorthand', () => {
@@ -110,7 +110,7 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					assertTRBLAttribute( tableCell, 'borderStyle', 'ridge' );
+					expect( tableCell.getAttribute( 'borderStyle' ) ).to.equal( 'ridge' );
 				} );
 
 				it( 'should upcast border-width shorthand', () => {
@@ -118,7 +118,7 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					assertTRBLAttribute( tableCell, 'borderWidth', '1px' );
+					expect( tableCell.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
 				} );
 
 				it( 'should upcast border-top shorthand', () => {

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -3877,24 +3877,9 @@ describe( 'table clipboard', () => {
 
 			const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-			expect( tableCell.getAttribute( 'borderColor' ) ).to.deep.equal( {
-				top: '#f00',
-				right: '#f00',
-				bottom: '#f00',
-				left: '#f00'
-			} );
-			expect( tableCell.getAttribute( 'borderStyle' ) ).to.deep.equal( {
-				top: 'solid',
-				right: 'solid',
-				bottom: 'solid',
-				left: 'solid'
-			} );
-			expect( tableCell.getAttribute( 'borderWidth' ) ).to.deep.equal( {
-				top: '1px',
-				right: '1px',
-				bottom: '1px',
-				left: '1px'
-			} );
+			expect( tableCell.getAttribute( 'borderColor' ) ).to.equal( '#f00' );
+			expect( tableCell.getAttribute( 'borderStyle' ) ).to.equal( 'solid' );
+			expect( tableCell.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
 			expect( tableCell.getAttribute( 'backgroundColor' ) ).to.equal( '#ba7' );
 			expect( tableCell.getAttribute( 'width' ) ).to.equal( '1337px' );
 		} );
@@ -3988,9 +3973,9 @@ describe( 'table clipboard', () => {
 			const tableModelData = modelTable( [
 				[ {
 					contents: '<paragraph>Test</paragraph>',
-					borderColor: `{"top":"${ color }","bottom":"${ color }","right":"${ color }","left":"${ color }"}`,
-					borderStyle: `{"top":"${ style }","bottom":"${ style }","right":"${ style }","left":"${ style }"}`,
-					borderWidth: `{"top":"${ width }","bottom":"${ width }","right":"${ width }","left":"${ width }"}`
+					borderColor: color,
+					borderStyle: style,
+					borderWidth: width
 				} ]
 			] );
 

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tablebordercolorcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tablebordercolorcommand.js
@@ -127,7 +127,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: '#f00' } );
 
-						assertTableStyle( editor, 'border-bottom:#f00;border-left:#f00;border-right:#f00;border-top:#f00;' );
+						assertTableStyle( editor, 'border-color:#f00;' );
 					} );
 
 					it( 'should change selected table borderColor to a passed value', () => {
@@ -135,7 +135,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: '#f00' } );
 
-						assertTableStyle( editor, 'border-bottom:#f00;border-left:#f00;border-right:#f00;border-top:#f00;' );
+						assertTableStyle( editor, 'border-color:#f00;' );
 					} );
 
 					it( 'should remove borderColor from a selected table if no value is passed', () => {
@@ -153,7 +153,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: '#f00' } );
 
-						assertTableStyle( editor, 'border-bottom:#f00;border-left:#f00;border-right:#f00;border-top:#f00;' );
+						assertTableStyle( editor, 'border-color:#f00;' );
 					} );
 
 					it( 'should change selected table borderColor to a passed value', () => {
@@ -161,7 +161,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: '#f00' } );
 
-						assertTableStyle( editor, 'border-bottom:#f00;border-left:#f00;border-right:#f00;border-top:#f00;' );
+						assertTableStyle( editor, 'border-color:#f00;' );
 					} );
 
 					it( 'should remove borderColor from a selected table if no value is passed', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tableborderstylecommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tableborderstylecommand.js
@@ -127,7 +127,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: 'solid' } );
 
-						assertTableStyle( editor, 'border-bottom:solid;border-left:solid;border-right:solid;border-top:solid;' );
+						assertTableStyle( editor, 'border-style:solid;' );
 					} );
 
 					it( 'should change selected table borderStyle to a passed value', () => {
@@ -135,7 +135,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: 'solid' } );
 
-						assertTableStyle( editor, 'border-bottom:solid;border-left:solid;border-right:solid;border-top:solid;' );
+						assertTableStyle( editor, 'border-style:solid;' );
 					} );
 
 					it( 'should remove borderStyle from a selected table if no value is passed', () => {
@@ -153,7 +153,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: 'solid' } );
 
-						assertTableStyle( editor, 'border-bottom:solid;border-left:solid;border-right:solid;border-top:solid;' );
+						assertTableStyle( editor, 'border-style:solid;' );
 					} );
 
 					it( 'should change selected table borderStyle to a passed value', () => {
@@ -161,7 +161,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: 'solid' } );
 
-						assertTableStyle( editor, 'border-bottom:solid;border-left:solid;border-right:solid;border-top:solid;' );
+						assertTableStyle( editor, 'border-style:solid;' );
 					} );
 
 					it( 'should remove borderStyle from a selected table if no value is passed', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tableborderwidthcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tableborderwidthcommand.js
@@ -126,7 +126,7 @@ describe( 'table properties', () => {
 
 					command.execute( { value: 25 } );
 
-					assertTableStyle( editor, 'border-bottom:25px;border-left:25px;border-right:25px;border-top:25px;' );
+					assertTableStyle( editor, 'border-width:25px;' );
 				} );
 
 				it( 'should add default unit for numeric values (string passed)', () => {
@@ -134,7 +134,7 @@ describe( 'table properties', () => {
 
 					command.execute( { value: 25 } );
 
-					assertTableStyle( editor, 'border-bottom:25px;border-left:25px;border-right:25px;border-top:25px;' );
+					assertTableStyle( editor, 'border-width:25px;' );
 				} );
 
 				it( 'should not add default unit for numeric values with unit', () => {
@@ -142,7 +142,7 @@ describe( 'table properties', () => {
 
 					command.execute( { value: '25pt' } );
 
-					assertTableStyle( editor, 'border-bottom:25pt;border-left:25pt;border-right:25pt;border-top:25pt;' );
+					assertTableStyle( editor, 'border-width:25pt;' );
 				} );
 
 				it( 'should add default unit to floats (number passed)', () => {
@@ -150,7 +150,7 @@ describe( 'table properties', () => {
 
 					command.execute( { value: 25.1 } );
 
-					assertTableStyle( editor, 'border-bottom:25.1px;border-left:25.1px;border-right:25.1px;border-top:25.1px;' );
+					assertTableStyle( editor, 'border-width:25.1px;' );
 				} );
 
 				it( 'should add default unit to floats (string passed)', () => {
@@ -158,7 +158,7 @@ describe( 'table properties', () => {
 
 					command.execute( { value: '0.1' } );
 
-					assertTableStyle( editor, 'border-bottom:0.1px;border-left:0.1px;border-right:0.1px;border-top:0.1px;' );
+					assertTableStyle( editor, 'border-width:0.1px;' );
 				} );
 
 				it( 'should pass invalid values', () => {
@@ -166,7 +166,7 @@ describe( 'table properties', () => {
 
 					command.execute( { value: 'bar' } );
 
-					assertTableStyle( editor, 'border-bottom:bar;border-left:bar;border-right:bar;border-top:bar;' );
+					assertTableStyle( editor, 'border-width:bar;' );
 				} );
 
 				it( 'should pass invalid value (string passed, CSS float without leading 0)', () => {
@@ -174,7 +174,7 @@ describe( 'table properties', () => {
 
 					command.execute( { value: '.2' } );
 
-					assertTableStyle( editor, 'border-bottom:.2;border-left:.2;border-right:.2;border-top:.2;' );
+					assertTableStyle( editor, 'border-width:.2;' );
 				} );
 
 				describe( 'collapsed selection', () => {
@@ -183,7 +183,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: '1px' } );
 
-						assertTableStyle( editor, 'border-bottom:1px;border-left:1px;border-right:1px;border-top:1px;' );
+						assertTableStyle( editor, 'border-width:1px;' );
 					} );
 
 					it( 'should change selected table borderWidth to a passed value', () => {
@@ -191,7 +191,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: '1px' } );
 
-						assertTableStyle( editor, 'border-bottom:1px;border-left:1px;border-right:1px;border-top:1px;' );
+						assertTableStyle( editor, 'border-width:1px;' );
 					} );
 
 					it( 'should remove borderWidth from a selected table if no value is passed', () => {
@@ -209,7 +209,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: '1px' } );
 
-						assertTableStyle( editor, 'border-bottom:1px;border-left:1px;border-right:1px;border-top:1px;' );
+						assertTableStyle( editor, 'border-width:1px;' );
 					} );
 
 					it( 'should change selected table borderWidth to a passed value', () => {
@@ -217,7 +217,7 @@ describe( 'table properties', () => {
 
 						command.execute( { value: '1px' } );
 
-						assertTableStyle( editor, 'border-bottom:1px;border-left:1px;border-right:1px;border-top:1px;' );
+						assertTableStyle( editor, 'border-width:1px;' );
 					} );
 
 					it( 'should remove borderWidth from a selected table if no value is passed', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -86,9 +86,9 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					assertTRBLAttribute( table, 'borderColor', '#f00' );
-					assertTRBLAttribute( table, 'borderStyle', 'solid' );
-					assertTRBLAttribute( table, 'borderWidth', '1px' );
+					expect( table.getAttribute( 'borderColor' ) ).to.equal( '#f00' );
+					expect( table.getAttribute( 'borderStyle' ) ).to.equal( 'solid' );
+					expect( table.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
 				} );
 
 				it( 'should upcast border-color shorthand', () => {
@@ -96,7 +96,7 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					assertTRBLAttribute( table, 'borderColor', '#f00' );
+					expect( table.getAttribute( 'borderColor' ) ).to.equal( '#f00' );
 				} );
 
 				it( 'should upcast border-style shorthand', () => {
@@ -104,7 +104,7 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					assertTRBLAttribute( table, 'borderStyle', 'ridge' );
+					expect( table.getAttribute( 'borderStyle' ) ).to.equal( 'ridge' );
 				} );
 
 				it( 'should upcast border-width shorthand', () => {
@@ -112,7 +112,7 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					assertTRBLAttribute( table, 'borderWidth', '1px' );
+					expect( table.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
 				} );
 
 				it( 'should upcast border-top shorthand', () => {
@@ -227,17 +227,14 @@ describe( 'table properties', () => {
 
 						const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-						assertTRBLAttribute( table, 'borderColor', 'red' );
-						assertTRBLAttribute( table, 'borderStyle', 'solid' );
-						assertTRBLAttribute( table, 'borderWidth', '1px' );
+						expect( table.getAttribute( 'borderColor' ) ).to.equal( 'red' );
+						expect( table.getAttribute( 'borderStyle' ) ).to.equal( 'solid' );
+						expect( table.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
 
 						// Also check the entire structure of the model.
 						// Previously the test was too loose in that regard.
 						expect( getModelData( editor.model ) ).to.equal(
-							'[<table ' +
-								'borderColor="{"top":"red","bottom":"red","right":"red","left":"red"}" ' +
-								'borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"solid"}" ' +
-								'borderWidth="{"top":"1px","bottom":"1px","right":"1px","left":"1px"}">' +
+							'[<table borderColor="red" borderStyle="solid" borderWidth="1px">' +
 								'<tableRow>' +
 									'<tableCell>' +
 										'<paragraph>' +
@@ -245,11 +242,7 @@ describe( 'table properties', () => {
 										'</paragraph>' +
 									'</tableCell>' +
 									'<tableCell>' +
-										'<table ' +
-											'borderColor="{"top":"green","bottom":"green","right":"green","left":"green"}" ' +
-											'borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"solid"}" ' +
-											'borderWidth="{"top":"1px","bottom":"1px","right":"1px","left":"1px"}"' +
-										'>' +
+										'<table borderColor="green" borderStyle="solid" borderWidth="1px">' +
 											'<tableRow>' +
 												'<tableCell>' +
 													'<paragraph>' +
@@ -374,11 +367,7 @@ describe( 'table properties', () => {
 										'<paragraph>parent:00</paragraph>' +
 									'</tableCell>' +
 									'<tableCell>' +
-										'<table ' +
-											'borderColor="{"top":"green","bottom":"green","right":"green","left":"green"}" ' +
-											'borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"solid"}" ' +
-											'borderWidth="{"top":"1px","bottom":"1px","right":"1px","left":"1px"}"' +
-										'>' +
+										'<table borderColor="green" borderStyle="solid" borderWidth="1px">' +
 											'<tableRow>' +
 												'<tableCell>' +
 													'<paragraph>child:00</paragraph>' +
@@ -416,15 +405,12 @@ describe( 'table properties', () => {
 
 							const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-							assertTRBLAttribute( table, 'borderColor', 'red' );
-							assertTRBLAttribute( table, 'borderStyle', 'solid' );
-							assertTRBLAttribute( table, 'borderWidth', '1px' );
+							expect( table.getAttribute( 'borderColor' ) ).to.equal( 'red' );
+							expect( table.getAttribute( 'borderStyle' ) ).to.equal( 'solid' );
+							expect( table.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
 
 							expect( getModelData( editor.model ) ).to.equal(
-								'[<table ' +
-									'borderColor="{"top":"red","bottom":"red","right":"red","left":"red"}" ' +
-									'borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"solid"}" ' +
-									'borderWidth="{"top":"1px","bottom":"1px","right":"1px","left":"1px"}">' +
+								'[<table borderColor="red" borderStyle="solid" borderWidth="1px">' +
 									'<tableRow>' +
 										'<tableCell>' +
 											'<paragraph>' +

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -580,7 +580,7 @@ describe( 'table properties', () => {
 						left: '#f00'
 					}, table ) );
 
-					assertTableStyle( editor, 'border-bottom:#f00;border-left:#f00;border-right:#f00;border-top:#f00;' );
+					assertTableStyle( editor, 'border-color:#f00;' );
 				} );
 
 				it( 'should downcast borderColor attribute (different top, right, bottom, left)', () => {
@@ -592,10 +592,10 @@ describe( 'table properties', () => {
 					}, table ) );
 
 					assertTableStyle( editor,
-						'border-bottom:deeppink;' +
-						'border-left:rgb(255, 0, 0);' +
-						'border-right:hsla(0, 100%, 50%, 0.5);' +
-						'border-top:#f00;'
+						'border-bottom-color:deeppink;' +
+						'border-left-color:rgb(255, 0, 0);' +
+						'border-right-color:hsla(0, 100%, 50%, 0.5);' +
+						'border-top-color:#f00;'
 					);
 				} );
 
@@ -627,7 +627,7 @@ describe( 'table properties', () => {
 						left: 'solid'
 					}, table ) );
 
-					assertTableStyle( editor, 'border-bottom:solid;border-left:solid;border-right:solid;border-top:solid;' );
+					assertTableStyle( editor, 'border-style:solid;' );
 				} );
 
 				it( 'should downcast borderStyle attribute (different top, right, bottom, left)', () => {
@@ -638,7 +638,12 @@ describe( 'table properties', () => {
 						left: 'dashed'
 					}, table ) );
 
-					assertTableStyle( editor, 'border-bottom:dotted;border-left:dashed;border-right:ridge;border-top:solid;' );
+					assertTableStyle( editor,
+						'border-bottom-style:dotted;' +
+						'border-left-style:dashed;' +
+						'border-right-style:ridge;' +
+						'border-top-style:solid;'
+					);
 				} );
 
 				it( 'should consume converted item borderWidth attribute', () => {
@@ -669,7 +674,10 @@ describe( 'table properties', () => {
 						left: 'thick'
 					}, table ) );
 
-					assertTableStyle( editor, 'border-bottom:1337rem;border-left:thick;border-right:.1em;border-top:42px;' );
+					assertTableStyle(
+						editor,
+						'border-bottom-width:1337rem;border-left-width:thick;border-right-width:.1em;border-top-width:42px;'
+					);
 				} );
 
 				it( 'should downcast borderWidth attribute (different top, right, bottom, left)', () => {
@@ -680,7 +688,7 @@ describe( 'table properties', () => {
 						left: '42px'
 					}, table ) );
 
-					assertTableStyle( editor, 'border-bottom:42px;border-left:42px;border-right:42px;border-top:42px;' );
+					assertTableStyle( editor, 'border-width:42px;' );
 				} );
 
 				it( 'should downcast borderColor, borderStyle and borderWidth attributes together (same top, right, bottom, left)', () => {
@@ -707,12 +715,7 @@ describe( 'table properties', () => {
 						}, table );
 					} );
 
-					assertTableStyle( editor,
-						'border-bottom:42px solid #f00;' +
-						'border-left:42px solid #f00;' +
-						'border-right:42px solid #f00;' +
-						'border-top:42px solid #f00;'
-					);
+					assertTableStyle( editor, 'border:42px solid #f00;' );
 				} );
 
 				it(
@@ -784,12 +787,7 @@ describe( 'table properties', () => {
 							left: 'deeppink'
 						}, table ) );
 
-						assertTableStyle( editor,
-							'border-bottom:42px solid deeppink;' +
-							'border-left:42px solid deeppink;' +
-							'border-right:42px solid deeppink;' +
-							'border-top:42px solid deeppink;'
-						);
+						assertTableStyle( editor, 'border:42px solid deeppink;' );
 					} );
 
 					it( 'should downcast borderStyle attribute change', () => {
@@ -800,12 +798,7 @@ describe( 'table properties', () => {
 							left: 'ridge'
 						}, table ) );
 
-						assertTableStyle( editor,
-							'border-bottom:42px ridge #f00;' +
-							'border-left:42px ridge #f00;' +
-							'border-right:42px ridge #f00;' +
-							'border-top:42px ridge #f00;'
-						);
+						assertTableStyle( editor, 'border:42px ridge #f00;' );
 					} );
 
 					it( 'should downcast borderWidth attribute change', () => {
@@ -816,22 +809,15 @@ describe( 'table properties', () => {
 							left: 'thick'
 						}, table ) );
 
-						assertTableStyle( editor,
-							'border-bottom:thick solid #f00;' +
-							'border-left:thick solid #f00;' +
-							'border-right:thick solid #f00;' +
-							'border-top:thick solid #f00;'
-						);
+						assertTableStyle( editor, 'border:thick solid #f00;' );
 					} );
 
 					it( 'should downcast borderColor attribute removal', () => {
 						model.change( writer => writer.removeAttribute( 'borderColor', table ) );
 
 						assertTableStyle( editor,
-							'border-bottom:42px solid;' +
-							'border-left:42px solid;' +
-							'border-right:42px solid;' +
-							'border-top:42px solid;'
+							'border-style:solid;' +
+							'border-width:42px;'
 						);
 					} );
 
@@ -839,10 +825,9 @@ describe( 'table properties', () => {
 						model.change( writer => writer.removeAttribute( 'borderStyle', table ) );
 
 						assertTableStyle( editor,
-							'border-bottom:42px #f00;' +
-							'border-left:42px #f00;' +
-							'border-right:42px #f00;' +
-							'border-top:42px #f00;'
+							'border-color:#f00;' +
+							'border-width:42px;'
+
 						);
 					} );
 
@@ -850,10 +835,8 @@ describe( 'table properties', () => {
 						model.change( writer => writer.removeAttribute( 'borderWidth', table ) );
 
 						assertTableStyle( editor,
-							'border-bottom:solid #f00;' +
-							'border-left:solid #f00;' +
-							'border-right:solid #f00;' +
-							'border-top:solid #f00;'
+							'border-color:#f00;' +
+							'border-style:solid;'
 						);
 					} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (table): Border definitions produced by the `TableProperties` and `TableCellProperties` features will be merged into a group if possible. Instead of producing `border-(top|right|bottom|left):*` selectors, the `border:*` definition will be returned. See #9490.

Fix (engine): The `view.Element#getNormalizedStyle()` will return the merged `border` definition produced if all its properties (width, style, and color) are specified. Otherwise, `border-(width|style|color)` definition should be returned. Closes #9490.

MINOR BREAKING CHANGE (table): Values for the `borderColor`, `borderStyle`, and `borderWidth` attributes are unified (to values produced by the editor itself) while upcasting the table or table cells if all borders (top, right, bottom, and left) have the same values. Previously, the `<table style="border: 1px solid #ff0">` element was upcasted to `<table borderStyle="{"top":"solid","right":"solid","bottom":"solid","left":"solid"}" borderColor="{...}" borderWidth="{...}">`. Now the object will be replaced with the string value: `<table borderStyle="solid" borderColor="#ff0" borderWidth="1px">`. The same structure is created when using the editor's toolbar. If border values are not identical, the object notation will be inserted into the model (as it is now).

MINOR BREAKING CHANGE (table): Conversion helpers: `upcastStyleToAttribute()`, `downcastAttributeToStyle()`, `downcastTableAttribute()` accept two arguments now (the conversion instance and the options object). The previous usage: `conversionHelper( conversion, /* ... */ )` should be replaced with `conversionHelper( conversion, { /* ... */ } )`.

---

### Additional information

Do not forget about merging a PR in CF.
