### PR TITLE
Fix jsdoc isEmpty getter

### DIFF
--- a/packages/ckeditor5-engine/src/view/stylesmap.js
+++ b/packages/ckeditor5-engine/src/view/stylesmap.js
@@ -44,7 +44,7 @@ export default class StylesMap {
 	/**
 	 * Returns true if style map has no styles set.
 	 *
-	 * @returns {Boolean}
+	 * @type {Boolean}
 	 */
 	get isEmpty() {
 		const entries = Object.entries( this._styles );


### PR DESCRIPTION
This error is triggering an empty value in docs.
https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_view_stylesmap-StylesMap.html