### PR TITLE
stylesmap.js Remove duplicate jsdoc getReducedForm

### DIFF
--- a/packages/ckeditor5-engine/src/view/stylesmap.js
+++ b/packages/ckeditor5-engine/src/view/stylesmap.js
@@ -540,7 +540,6 @@ export class StylesProcessor {
 	 *
 	 * **Note**: To define reducer callbacks use {@link #setReducer}.
 	 *
-	 * @param {String} name
 	 * @param {String} name Name of style property.
 	 * @param {Object} styles Object holding normalized styles.
 	 * @returns {Array.<module:engine/view/stylesmap~PropertyDescriptor>}


### PR DESCRIPTION
This error is triggering a duplicate value in docs.
https://ckeditor.com/docs/ckeditor5/latest/api/module_engine_view_stylesmap-StylesProcessor.html