### PR TITLE
#9524: Selected inline widgets wrapped in an attribute in the view should create a fake selection

### DIFF
--- a/packages/ckeditor5-image/src/imageutils.js
+++ b/packages/ckeditor5-image/src/imageutils.js
@@ -124,21 +124,8 @@ export default class ImageUtils extends Plugin {
 	getClosestSelectedImageWidget( selection ) {
 		const viewElement = selection.getSelectedElement();
 
-		if ( viewElement ) {
-			if ( this.isImageWidget( viewElement ) ) {
-				return viewElement;
-			}
-
-			// If a selected inline image widget is the only child of a link, the selection will encompass
-			// that link. But this still counts as a selected image widget. This is what it looks like:
-			// [<a href="..."><span class="image-inline ck-widget ck-widget_selected"><img ... /></span></a>]
-			if ( viewElement.is( 'element', 'a' ) && viewElement.childCount === 1 ) {
-				const firstChild = viewElement.getChild( 0 );
-
-				if ( firstChild.is( 'element' ) && this.isImageWidget( firstChild ) ) {
-					return firstChild;
-				}
-			}
+		if ( viewElement && this.isImageWidget( viewElement ) ) {
+			return viewElement;
 		}
 
 		let parent = selection.getFirstPosition().parent;

--- a/packages/ckeditor5-image/tests/imageutils.js
+++ b/packages/ckeditor5-image/tests/imageutils.js
@@ -20,7 +20,6 @@ import ImageInlineEditing from '../src/image/imageinlineediting';
 import ImageCaptionEditing from '../src/imagecaption/imagecaptionediting';
 
 import ImageUtils from '../src/imageutils';
-import { createImageViewElement } from '../src/image/utils';
 
 describe( 'ImageUtils plugin', () => {
 	let editor, imageUtils, element, image, writer, viewDocument;
@@ -158,56 +157,6 @@ describe( 'ImageUtils plugin', () => {
 			frag = writer.createDocumentFragment( element );
 
 			const selection = writer.createSelection( innerContainer, 'in' );
-
-			expect( imageUtils.getClosestSelectedImageWidget( selection ) ).to.be.null;
-		} );
-
-		it( 'should return true when an inline image widget is encompassed by a link', () => {
-			const paragraph = writer.createContainerElement( 'p' );
-			const inlineImageView = createImageViewElement( writer, 'imageInline' );
-			imageUtils.toImageWidget( inlineImageView, writer, 'image widget' );
-
-			writer.insert( writer.createPositionAt( paragraph, 0 ), inlineImageView );
-
-			writer.wrap( writer.createRangeOn( inlineImageView ), writer.createAttributeElement( 'a', {
-				href: 'https://ckeditor.com'
-			} ) );
-
-			// <p>[<a href="..."><span class="image-inline ...">...</span></a>]</p>
-			const selection = writer.createSelection( writer.createRangeOn( inlineImageView.parent ) );
-
-			expect( imageUtils.getClosestSelectedImageWidget( selection ) ).to.equal( inlineImageView );
-		} );
-
-		it( 'should return false when an inline image widget is encompassed by a link that has some additional content', () => {
-			const paragraph = writer.createContainerElement( 'p' );
-			const inlineImageView = createImageViewElement( writer, 'imageInline' );
-			imageUtils.toImageWidget( inlineImageView, writer, 'image widget' );
-
-			writer.insert( writer.createPositionAt( paragraph, 0 ), inlineImageView );
-			writer.insert( writer.createPositionAt( paragraph, 1 ), writer.createText( 'foo' ) );
-
-			writer.wrap( writer.createRangeIn( paragraph ), writer.createAttributeElement( 'a', {
-				href: 'https://ckeditor.com'
-			} ) );
-
-			// <p>[<a href="..."><span class="image-inline ...">...</span>foo</a>]</p>
-			const selection = writer.createSelection( writer.createRangeOn( inlineImageView.parent ) );
-
-			expect( imageUtils.getClosestSelectedImageWidget( selection ) ).to.be.null;
-		} );
-
-		it( 'should return false when a link that does not have an image but something else is selected', () => {
-			const paragraph = writer.createContainerElement( 'p' );
-
-			writer.insert( writer.createPositionAt( paragraph, 0 ), writer.createText( 'foo' ) );
-
-			writer.wrap( writer.createRangeIn( paragraph ), writer.createAttributeElement( 'a', {
-				href: 'https://ckeditor.com'
-			} ) );
-
-			// <p>[<a href="...">foo</a>]</p>
-			const selection = writer.createSelection( writer.createRangeOn( paragraph.getChild( 0 ) ) );
 
 			expect( imageUtils.getClosestSelectedImageWidget( selection ) ).to.be.null;
 		} );

--- a/packages/ckeditor5-link/tests/linkimageui.js
+++ b/packages/ckeditor5-link/tests/linkimageui.js
@@ -126,7 +126,7 @@ describe( 'LinkImageUI', () => {
 				writer.setSelection( editor.model.document.getRoot().getChild( 0 ), 'in' );
 			} );
 
-			const imageWidget = viewDocument.selection.getSelectedElement().getChild( 0 );
+			const imageWidget = viewDocument.selection.getSelectedElement();
 			const data = fakeEventData();
 			const eventInfo = new EventInfo( imageWidget, 'click' );
 			const domEventDataMock = new DomEventData( viewDocument, eventInfo, data );

--- a/packages/ckeditor5-widget/src/widget.js
+++ b/packages/ckeditor5-widget/src/widget.js
@@ -78,7 +78,7 @@ export default class Widget extends Plugin {
 			// child is an inline widget. This prevents creating a correct fake selection when this inline widget is selected.
 			// Normalize the selection in this case
 			//
-			//		[<attributeElement><inlineWidget /><attributeElement>] -> <attributeElement>[<inlineWidget />]<attributeElement>
+			//		[<attributeElement><inlineWidget /></attributeElement>] -> <attributeElement>[<inlineWidget />]</attributeElement>
 			//
 			// Thanks to this:
 			//
@@ -87,6 +87,8 @@ export default class Widget extends Plugin {
 			//
 			// See https://github.com/ckeditor/ckeditor5/issues/9524.
 			if ( selectedElement ) {
+				// Trim the range first because the selection could be on a couple of nested attributes enclosing the widget:
+				// [<attributeElementA><attributeElementB><inlineWidget /></attributeElementB></attributeElementA>]
 				selectedElement = viewWriter.createRangeOn( selectedElement ).getTrimmed().getContainedElement();
 
 				if ( selectedElement && isWidget( selectedElement ) ) {

--- a/packages/ckeditor5-widget/src/widget.js
+++ b/packages/ckeditor5-widget/src/widget.js
@@ -86,12 +86,14 @@ export default class Widget extends Plugin {
 			// * any logic depending on (View)Selection#getSelectedElement() also works OK.
 			//
 			// See https://github.com/ckeditor/ckeditor5/issues/9524.
-			if ( selectedElement && selectedElement.is( 'attributeElement' ) && selectedElement.childCount === 1 ) {
-				const firstElement = selectedElement.getChild( 0 );
+			if ( selectedElement ) {
+				selectedElement = viewWriter.createRangeOn( selectedElement ).getTrimmed().getContainedElement();
 
-				if ( isWidget( firstElement ) ) {
-					selectedElement = firstElement;
-					viewWriter.setSelection( viewWriter.createRangeOn( firstElement ) );
+				if ( selectedElement && isWidget( selectedElement ) ) {
+					viewWriter.setSelection( viewWriter.createRangeOn( selectedElement ), {
+						fake: true,
+						label: getLabel( selectedElement )
+					} );
 				}
 			}
 
@@ -105,11 +107,6 @@ export default class Widget extends Plugin {
 
 						this._previouslySelected.add( node );
 						lastMarked = node;
-
-						// Check if widget is a single element selected.
-						if ( node == selectedElement ) {
-							viewWriter.setSelection( viewSelection.getRanges(), { fake: true, label: getLabel( selectedElement ) } );
-						}
 					}
 				}
 			}

--- a/packages/ckeditor5-widget/tests/widget-integration.js
+++ b/packages/ckeditor5-widget/tests/widget-integration.js
@@ -289,8 +289,9 @@ describe( 'Widget - integration', () => {
 
 		viewDocument.fire( 'mousedown', domEventDataMock );
 
+		expect( viewDocument.selection.isFake ).to.be.true;
 		expect( getViewData( view ) ).to.equal(
-			'<p>Foo{<span class="ck-widget ck-widget_selected" contenteditable="false">foo bar</span>}Bar</p>'
+			'<p>Foo[<span class="ck-widget ck-widget_selected" contenteditable="false">foo bar</span>]Bar</p>'
 		);
 
 		expect( getModelData( model ) ).to.equal( '<paragraph>Foo[<inline-widget>foo bar</inline-widget>]Bar</paragraph>' );

--- a/packages/ckeditor5-widget/tests/widget.js
+++ b/packages/ckeditor5-widget/tests/widget.js
@@ -59,7 +59,7 @@ describe( 'Widget', () => {
 				} );
 				model.schema.extend( '$text', {
 					allowIn: [ 'nested', 'editable' ],
-					allowAttributes: [ 'attr' ]
+					allowAttributes: [ 'attr', 'bttr' ]
 				} );
 				model.schema.register( 'editable', {
 					allowIn: [ 'widget', '$root' ]
@@ -68,7 +68,7 @@ describe( 'Widget', () => {
 					allowWhere: '$text',
 					isObject: true,
 					isInline: true,
-					allowAttributes: [ 'attr' ]
+					allowAttributes: [ 'attr', 'bttr' ]
 				} );
 
 				// Image feature.
@@ -124,6 +124,9 @@ describe( 'Widget', () => {
 					} )
 					.attributeToElement( { model: 'attr', view: ( modelAttributeValue, conversionApi ) => {
 						return conversionApi.writer.createAttributeElement( 'attr', { value: modelAttributeValue } );
+					} } )
+					.attributeToElement( { model: 'bttr', view: ( modelAttributeValue, conversionApi ) => {
+						return conversionApi.writer.createAttributeElement( 'bttr', { value: modelAttributeValue } );
 					} } );
 			} );
 	} );
@@ -243,6 +246,22 @@ describe( 'Widget', () => {
 			'<p>foo ' +
 				'<attr value="foo">' +
 					'[<span class="ck-widget ck-widget_selected" contenteditable="false"></span>]' +
+				'</attr>' +
+			' bar</p>'
+		);
+
+		expect( viewDocument.selection.isFake ).to.be.true;
+	} );
+
+	it( 'should apply fake view selection when an inline widget is surrounded by a couple of nested attribute elements', () => {
+		setModelData( model, '<paragraph>foo [<inline-widget attr="foo" bttr="bar"></inline-widget>] bar</paragraph>' );
+
+		expect( getViewData( view ) ).to.equal(
+			'<p>foo ' +
+				'<attr value="foo">' +
+					'<bttr value="bar">' +
+						'[<span class="ck-widget ck-widget_selected" contenteditable="false"></span>]' +
+					'</bttr>' +
 				'</attr>' +
 			' bar</p>'
 		);

--- a/packages/ckeditor5-widget/tests/widgetresize.js
+++ b/packages/ckeditor5-widget/tests/widgetresize.js
@@ -13,6 +13,7 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 
 import { toWidget } from '../src/utils';
 import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 
 import { resizerMouseSimulator, focusEditor, getHandleCenterPoint, getWidgetDomParts } from './widgetresize/_utils/utils';
 
@@ -474,8 +475,11 @@ describe( 'WidgetResize', () => {
 			localEditorElement = createEditorElement();
 			localEditor = await ClassicEditor.create( localEditorElement, {
 				plugins: [
-					WidgetResize, simpleWidgetPlugin
-				]
+					ArticlePluginSet, WidgetResize, simpleWidgetPlugin
+				],
+				image: {
+					toolbar: [ 'imageStyle:full', 'imageStyle:side' ]
+				}
 			} );
 		} );
 
@@ -491,11 +495,65 @@ describe( 'WidgetResize', () => {
 			// Nothing should be thrown.
 		} );
 
-		it( 'sets the visible resizer if associated widget is already focused', async () => {
+		it( 'sets the visible resizer if associated widget is already selected', async () => {
 			setModelData( localEditor.model, '[<widget></widget>]' );
 
 			const widgetResizePlugin = localEditor.plugins.get( WidgetResize );
 			const resizer = widgetResizePlugin.attachTo( gerResizerOptions( localEditor ) );
+
+			expect( widgetResizePlugin.visibleResizer ).to.eql( resizer );
+		} );
+
+		it( 'sets the visible resizer if the associated inline widget surrounded by an attribute is already selected', async () => {
+			localEditor.model.schema.register( 'inline-widget', {
+				allowWhere: '$text',
+				isObject: true,
+				isInline: true,
+				allowAttributes: [ 'attr' ]
+			} );
+
+			localEditor.model.schema.extend( '$text', {
+				allowAttributes: [ 'attr' ]
+			} );
+
+			localEditor.conversion.for( 'downcast' )
+				.elementToElement( {
+					model: 'inline-widget',
+					view: ( modelItem, { writer } ) => {
+						const span = writer.createContainerElement( 'span', null, { isAllowedInsideAttributeElement: true } );
+
+						return toWidget( span, writer );
+					}
+				} )
+				.attributeToElement( {
+					model: 'attr',
+					view: ( attributeValue, { writer } ) => {
+						return writer.createAttributeElement( 'attr' );
+					}
+				} );
+
+			setModelData( localEditor.model, '<paragraph>foo [<inline-widget attr="foo"></inline-widget>] bar</paragraph>' );
+
+			expect( getViewData( localEditor.editing.view ) ).to.equal(
+				'<p>' +
+					'foo ' +
+					'<attr>[<span class="ck-widget ck-widget_selected" contenteditable="false"></span>]</attr>' +
+					' bar' +
+				'</p>'
+			);
+
+			const widgetResizePlugin = localEditor.plugins.get( WidgetResize );
+			const resizer = widgetResizePlugin.attachTo( {
+				modelElement: localEditor.model.document.getRoot().getChild( 0 ).getChild( 1 ),
+				viewElement: localEditor.editing.view.document.getRoot().getChild( 0 ).getChild( 1 ).getChild( 0 ),
+				editor: localEditor,
+
+				isCentered: () => false,
+				getHandleHost: domWidgetElement => domWidgetElement,
+				getResizeHost: domWidgetElement => domWidgetElement,
+
+				onCommit: commitStub
+			} );
 
 			expect( widgetResizePlugin.visibleResizer ).to.eql( resizer );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (widget): Selected inline widgets wrapped in an attribute in the view should create a fake selection. Closes #9524. Closes #9521.