### PR TITLE
Add optional editorClass config (proof of concept)

### DIFF
--- a/packages/ckeditor5-core/src/editor/editorconfig.jsdoc
+++ b/packages/ckeditor5-core/src/editor/editorconfig.jsdoc
@@ -271,6 +271,21 @@
  */
 
 /**
+ * Specifies an additional editor class name to apply in the outermost editor element.
+ *
+ *		const config = {
+ *			editorClass: 'my-editor-instance'
+ *		};
+ *
+ * - {@link module:editor-classic/classiceditorui~ClassicEditorUI#element `ClassicEditor#element`})
+ * - {@link module:editor-balloon/ballooneditorui~BalloonEditorUI#element `editor.ui.element`}
+ *
+ * This is useful when instantiating editors styled against special class names. This way you can avoid having to use your own `<div>` wrapper.
+ *
+ * @member {String} module:core/editor/editorconfig~EditorConfig#editorClass
+ */
+
+/**
  * Specifies the text displayed in the editor when there is no content (editor is empty). It is intended to
  * help users locate the editor in the application (form) and prompt them to input the content. Work similarly
  * as to the native DOM

--- a/packages/ckeditor5-editor-classic/src/classiceditor.js
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.js
@@ -65,8 +65,10 @@ export default class ClassicEditor extends Editor {
 		this.model.document.createRoot();
 
 		const shouldToolbarGroupWhenFull = !this.config.get( 'toolbar.shouldNotGroupWhenFull' );
+		const editorClass = this.config.get( 'editorClass' );
 		const view = new ClassicEditorUIView( this.locale, this.editing.view, {
-			shouldToolbarGroupWhenFull
+			shouldToolbarGroupWhenFull,
+			editorClass
 		} );
 
 		this.ui = new ClassicEditorUI( this, view );

--- a/packages/ckeditor5-editor-classic/src/classiceditoruiview.js
+++ b/packages/ckeditor5-editor-classic/src/classiceditoruiview.js
@@ -27,9 +27,10 @@ export default class ClassicEditorUIView extends BoxedEditorUIView {
 	 * @param {Boolean} [options.shouldToolbarGroupWhenFull] When set `true` enables automatic items grouping
 	 * in the main {@link module:editor-classic/classiceditoruiview~ClassicEditorUIView#toolbar toolbar}.
 	 * See {@link module:ui/toolbar/toolbarview~ToolbarOptions#shouldGroupWhenFull} to learn more.
+	 * @param {String} [options.editorClass] When set to string adds custom class name to view instance.
 	 */
 	constructor( locale, editingView, options = {} ) {
-		super( locale );
+		super( locale, options );
 
 		/**
 		 * Sticky panel view instance. This is a parent view of a {@link #toolbar}

--- a/packages/ckeditor5-ui/src/editorui/boxed/boxededitoruiview.js
+++ b/packages/ckeditor5-ui/src/editorui/boxed/boxededitoruiview.js
@@ -21,9 +21,13 @@ export default class BoxedEditorUIView extends EditorUIView {
 	 * Creates an instance of the boxed editor UI view class.
 	 *
 	 * @param {module:utils/locale~Locale} locale The locale instance..
+	 * @param {Object} [options={}] Configuration options for the BoxedEditorUIView instance.
+	 * @param {String} [options.elementClass] When set to string adds custom class name to view instance.
 	 */
-	constructor( locale ) {
+	constructor( locale, options = {} ) {
 		super( locale );
+
+		this.editorClass = options.editorClass || '';
 
 		/**
 		 * Collection of the child views located in the top (`.ck-editor__top`)
@@ -60,7 +64,8 @@ export default class BoxedEditorUIView extends EditorUIView {
 					'ck',
 					'ck-reset',
 					'ck-editor',
-					'ck-rounded-corners'
+					'ck-rounded-corners',
+					this.editorClass
 				],
 				role: 'application',
 				dir: locale.uiLanguageDirection,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Type: Add editorClass. Closes #9539

---

### Additional information

This adds `editorClass` and helps us automatically wrap the editor in a CSS Namespace based on the build.  
