### PR TITLE
Update htmlembed.css

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-html-embed/htmlembed.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-html-embed/htmlembed.css
@@ -142,7 +142,6 @@
 
 	& .raw-html-embed__preview-content {
 		box-sizing: border-box;
-		text-align: center;
 		background-color: var(--ck-color-base-foreground);
 
 		& > * {


### PR DESCRIPTION
Other (html-embed): The preview content for the HTML Embed plugin should not be centered. Closes #9486.

MINOR BREAKING CHANGE (html-embed): The preview content will not be centered anymore.