### PR TITLE
Do not insert inline images inside code blocks

### DIFF
--- a/packages/ckeditor5-code-block/package.json
+++ b/packages/ckeditor5-code-block/package.json
@@ -24,6 +24,7 @@
     "@ckeditor/ckeditor5-engine": "^27.1.0",
     "@ckeditor/ckeditor5-enter": "^27.1.0",
     "@ckeditor/ckeditor5-editor-classic": "^27.1.0",
+    "@ckeditor/ckeditor5-image": "^27.1.0",
     "@ckeditor/ckeditor5-indent": "^27.1.0",
     "@ckeditor/ckeditor5-markdown-gfm": "^27.1.0",
     "@ckeditor/ckeditor5-paragraph": "^27.1.0",

--- a/packages/ckeditor5-code-block/src/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/src/codeblockcommand.js
@@ -115,6 +115,11 @@ export default class CodeBlockCommand extends Command {
 			writer.rename( block, 'codeBlock' );
 			writer.setAttribute( 'language', language, block );
 			schema.removeDisallowedAttributes( [ block ], writer );
+
+			// The `codeBlock` should contain only $text nodes as its children. See #9567.
+			Array.from( block.getChildren() )
+				.filter( child => !child.is( '$text' ) )
+				.forEach( writer.remove.bind( writer ) );
 		}
 
 		allowedBlocks.reverse().forEach( ( currentBlock, i ) => {

--- a/packages/ckeditor5-code-block/src/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/src/codeblockcommand.js
@@ -119,9 +119,7 @@ export default class CodeBlockCommand extends Command {
 			// Remove children of the  `codeBlock` element that are not allowed. See #9567.
 			Array.from( block.getChildren() )
 				.filter( child => !schema.checkChild( block, child ) )
-				.forEach( child => {
-					writer.remove( child );
-				} );
+				.forEach( child => writer.remove( child ) );
 		}
 
 		allowedBlocks.reverse().forEach( ( currentBlock, i ) => {

--- a/packages/ckeditor5-code-block/src/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/src/codeblockcommand.js
@@ -116,7 +116,7 @@ export default class CodeBlockCommand extends Command {
 			writer.setAttribute( 'language', language, block );
 			schema.removeDisallowedAttributes( [ block ], writer );
 
-			// The `codeBlock` should contain only $text nodes as its children. See #9567.
+			// The `codeBlock` element should contain only $text nodes as its children. See #9567.
 			Array.from( block.getChildren() )
 				.filter( child => !child.is( '$text' ) )
 				.forEach( writer.remove.bind( writer ) );

--- a/packages/ckeditor5-code-block/src/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/src/codeblockcommand.js
@@ -116,10 +116,12 @@ export default class CodeBlockCommand extends Command {
 			writer.setAttribute( 'language', language, block );
 			schema.removeDisallowedAttributes( [ block ], writer );
 
-			// The `codeBlock` element should contain only $text nodes as its children. See #9567.
+			// Remove children of the  `codeBlock` element that are not allowed. See #9567.
 			Array.from( block.getChildren() )
-				.filter( child => !child.is( '$text' ) )
-				.forEach( writer.remove.bind( writer ) );
+				.filter( child => !schema.checkChild( block, child ) )
+				.forEach( child => {
+					writer.remove( child );
+				} );
 		}
 
 		allowedBlocks.reverse().forEach( ( currentBlock, i ) => {

--- a/packages/ckeditor5-code-block/src/codeblockediting.js
+++ b/packages/ckeditor5-code-block/src/codeblockediting.js
@@ -125,6 +125,13 @@ export default class CodeBlockEditing extends Plugin {
 			}
 		} );
 
+		// Disallow object elements inside `codeBlock`. See #9567.
+		editor.model.schema.addChildCheck( ( context, childDefinition ) => {
+			if ( context.endsWith( 'codeBlock' ) && childDefinition.isObject ) {
+				return false;
+			}
+		} );
+
 		// Conversion.
 		editor.editing.downcastDispatcher.on( 'insert:codeBlock', modelToViewCodeBlockInsertion( model, normalizedLanguagesDefs, true ) );
 		editor.data.downcastDispatcher.on( 'insert:codeBlock', modelToViewCodeBlockInsertion( model, normalizedLanguagesDefs ) );
@@ -228,15 +235,6 @@ export default class CodeBlockEditing extends Plugin {
 			data.preventDefault();
 			evt.stop();
 		}, { context: 'pre' } );
-
-		// Disallow `imageInline` inside `codeBlock`. See #9567.
-		if ( editor.plugins.has( 'ImageInlineEditing' ) ) {
-			editor.model.schema.addChildCheck( ( context, childDefinition ) => {
-				if ( context.endsWith( 'codeBlock' ) && childDefinition.name == 'imageInline' ) {
-					return false;
-				}
-			} );
-		}
 	}
 }
 

--- a/packages/ckeditor5-code-block/src/codeblockediting.js
+++ b/packages/ckeditor5-code-block/src/codeblockediting.js
@@ -228,6 +228,15 @@ export default class CodeBlockEditing extends Plugin {
 			data.preventDefault();
 			evt.stop();
 		}, { context: 'pre' } );
+
+		// Disallow `imageInline` inside `codeBlock`. See #9567.
+		if ( editor.plugins.has( 'ImageInlineEditing' ) ) {
+			editor.model.schema.addChildCheck( ( context, childDefinition ) => {
+				if ( context.endsWith( 'codeBlock' ) && childDefinition.name == 'imageInline' ) {
+					return false;
+				}
+			} );
+		}
 	}
 }
 

--- a/packages/ckeditor5-code-block/tests/codeblock-integration.js
+++ b/packages/ckeditor5-code-block/tests/codeblock-integration.js
@@ -8,26 +8,27 @@ import Enter from '@ckeditor/ckeditor5-enter/src/enter';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import GFMDataProcessor from '@ckeditor/ckeditor5-markdown-gfm/src/gfmdataprocessor';
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import ImageInlineEditing from '@ckeditor/ckeditor5-image/src/image/imageinlineediting';
 
 import CodeBlockEditing from '../src/codeblockediting';
 
-// A simple plugin that enables the GFM data processor.
-class CodeBlockIntegration extends Plugin {
-	constructor( editor ) {
-		super( editor );
-		editor.data.processor = new GFMDataProcessor( editor.data.viewDocument );
-	}
-}
-
-function getEditor( initialData = '' ) {
-	return ClassicTestEditor
-		.create( initialData, {
-			plugins: [ CodeBlockIntegration, CodeBlockEditing, Enter, Paragraph ]
-		} );
-}
-
 describe( 'CodeBlock - integration', () => {
 	describe( 'with Markdown GFM', () => {
+		function getEditor( initialData = '' ) {
+			return ClassicTestEditor
+				.create( initialData, {
+					plugins: [ CodeBlockIntegration, CodeBlockEditing, Enter, Paragraph ]
+				} );
+		}
+
+		// A simple plugin that enables the GFM data processor.
+		class CodeBlockIntegration extends Plugin {
+			constructor( editor ) {
+				super( editor );
+				editor.data.processor = new GFMDataProcessor( editor.data.viewDocument );
+			}
+		}
+
 		it( 'should be loaded and returned from the editor (for plain text)', async () => {
 			const editor = await getEditor(
 				'```\n' +
@@ -57,6 +58,55 @@ describe( 'CodeBlock - integration', () => {
 			);
 
 			await editor.destroy();
+		} );
+	} );
+
+	describe( 'with ImageInline', () => {
+		let editor;
+
+		beforeEach( () => {
+			return ClassicTestEditor
+				.create( '', {
+					plugins: [ ImageInlineEditing, CodeBlockEditing, Enter, Paragraph ]
+				} )
+				.then( newEditor => {
+					editor = newEditor;
+				} );
+		} );
+
+		afterEach( () => {
+			return editor.destroy();
+		} );
+
+		it( 'should remove inline images when executing the "codeBlock" command', () => {
+			editor.setData( '<p>Foo<img src="/assets/sample.png">Bar.</p>' );
+			editor.execute( 'codeBlock' );
+
+			expect( editor.getData() ).to.equal(
+				'<pre>' +
+					'<code class="language-plaintext">FooBar.</code>' +
+				'</pre>'
+			);
+		} );
+
+		it( 'should remove inline images when upcasting the "codeBlock" element (the paragraph inside the code)', () => {
+			editor.setData( '<pre><code><p>Foo<img src="/assets/sample.png">Bar.</p></code></pre>' );
+
+			expect( editor.getData() ).to.equal(
+				'<pre>' +
+					'<code class="language-plaintext">FooBar.</code>' +
+				'</pre>'
+			);
+		} );
+
+		it( 'should remove inline images when upcasting the "codeBlock" element (without the paragraph)', () => {
+			editor.setData( '<pre><code>Foo<img src="/assets/sample.png">Bar.</code></pre>' );
+
+			expect( editor.getData() ).to.equal(
+				'<pre>' +
+					'<code class="language-plaintext">FooBar.</code>' +
+				'</pre>'
+			);
 		} );
 	} );
 } );

--- a/packages/ckeditor5-code-block/tests/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/tests/codeblockcommand.js
@@ -250,6 +250,19 @@ describe( 'CodeBlockCommand', () => {
 
 			expect( getModelData( model ) ).to.equal( '<codeBlock language="css">f[o]o</codeBlock>' );
 		} );
+
+		it( 'should remove all non-text nodes when inserting the "codeBlock" element', () => {
+			model.schema.register( 'div', { inheritAllFrom: '$block', allowIn: 'paragraph' } );
+			editor.conversion.elementToElement( { model: 'div', view: 'div' } );
+
+			setModelData( model, '[<paragraph>Foo<div></div>Bar</paragraph>]' );
+
+			command.execute();
+
+			expect( getModelData( model ) ).to.equal(
+				'<codeBlock language="plaintext">[FooBar]</codeBlock>'
+			);
+		} );
 	} );
 
 	describe( 'BlockQuote integration', () => {

--- a/packages/ckeditor5-code-block/tests/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/tests/codeblockcommand.js
@@ -251,7 +251,7 @@ describe( 'CodeBlockCommand', () => {
 			expect( getModelData( model ) ).to.equal( '<codeBlock language="css">f[o]o</codeBlock>' );
 		} );
 
-		it( 'should remove all non-text nodes when inserting the "codeBlock" element', () => {
+		it( 'should remove all non-allowed nodes when inserting the "codeBlock" element', () => {
 			model.schema.register( 'div', { inheritAllFrom: '$block', allowIn: 'paragraph' } );
 			editor.conversion.elementToElement( { model: 'div', view: 'div' } );
 
@@ -261,6 +261,19 @@ describe( 'CodeBlockCommand', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<codeBlock language="plaintext">[FooBar]</codeBlock>'
+			);
+		} );
+
+		it( 'should remove all non-allowed nodes when inserting the "codeBlock" element (the softBreak check)', () => {
+			model.schema.register( 'div', { inheritAllFrom: '$block', allowIn: 'paragraph' } );
+			editor.conversion.elementToElement( { model: 'div', view: 'div' } );
+
+			setModelData( model, '[<paragraph>Foo<div></div>Bar<softBreak></softBreak>Baz</paragraph>]' );
+
+			command.execute();
+
+			expect( getModelData( model ) ).to.equal(
+				'<codeBlock language="plaintext">[FooBar<softBreak></softBreak>Baz]</codeBlock>'
 			);
 		} );
 	} );

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -128,6 +128,19 @@ describe( 'CodeBlockEditing', () => {
 		expect( model.schema.checkChild( [ '$root', 'codeBlock' ], 'codeBlock' ) ).to.be.false;
 	} );
 
+	it( 'disallows for object elements in codeBlock', () => {
+		// Fake "inline-widget".
+		model.schema.register( 'inline-widget', {
+			inheritAllFrom: '$block',
+			// Allow to be a child of the `codeBlock` element.
+			allowIn: 'codeBlock',
+			// And mark as an object.
+			isObject: true
+		} );
+
+		expect( model.schema.checkChild( [ '$root', 'codeBlock' ], 'inline-widget' ) ).to.be.false;
+	} );
+
 	it( 'allows only for $text in codeBlock', () => {
 		expect( model.schema.checkChild( [ '$root', 'codeBlock' ], '$text' ) ).to.equal( true );
 		expect( model.schema.checkChild( [ '$root', 'codeBlock' ], '$block' ) ).to.equal( false );

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -124,11 +124,11 @@ describe( 'CodeBlockEditing', () => {
 		expect( model.schema.checkChild( [ '$root' ], 'codeBlock' ) ).to.be.true;
 	} );
 
-	it( 'disallows for codeBlock in the other codeBlock', () => {
+	it( 'disallows codeBlock in the other codeBlock', () => {
 		expect( model.schema.checkChild( [ '$root', 'codeBlock' ], 'codeBlock' ) ).to.be.false;
 	} );
 
-	it( 'disallows for object elements in codeBlock', () => {
+	it( 'disallows object elements in codeBlock', () => {
 		// Fake "inline-widget".
 		model.schema.register( 'inline-widget', {
 			inheritAllFrom: '$block',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (code-block): The code block feature will not allow for inserting inline images as its content. Closes #9567.

