### PR TITLE
Saving empty caption content.

### DIFF
--- a/packages/ckeditor5-image/src/imagecaption/toggleimagecaptioncommand.js
+++ b/packages/ckeditor5-image/src/imagecaption/toggleimagecaptioncommand.js
@@ -157,9 +157,7 @@ export default class ToggleImageCaptionCommand extends Command {
 		}
 
 		// Store the caption content so it can be restored quickly if the user changes their mind even if they toggle image<->imageInline.
-		if ( captionElement.childCount ) {
-			imageCaptionEditing._saveCaption( selectedImage, captionElement );
-		}
+		imageCaptionEditing._saveCaption( selectedImage, captionElement );
 
 		writer.setSelection( selectedImage, 'on' );
 		writer.remove( captionElement );

--- a/packages/ckeditor5-image/tests/imagecaption/toggleimagecaptioncommand.js
+++ b/packages/ckeditor5-image/tests/imagecaption/toggleimagecaptioncommand.js
@@ -249,16 +249,24 @@ describe( 'ToggleImageCaptionCommand', () => {
 				);
 			} );
 
-			it( 'should not save the caption content if empty', () => {
-				setModelData( model, '[<image src="test.png"><caption></caption></image>]' );
+			it( 'should save the empty caption content', () => {
+				const imgSrc = 'foo/bar.jpg';
+
+				setModelData( model, `[<image src="${ imgSrc }"><caption>foo</caption></image>]` );
 
 				editor.execute( 'toggleImageCaption' );
-
-				expect( getModelData( model ) ).to.equal( '[<image src="test.png"></image>]' );
-
 				editor.execute( 'toggleImageCaption' );
 
-				expect( getModelData( model ) ).to.equal( '[<image src="test.png"><caption></caption></image>]' );
+				const caption = model.document.getRoot().getChild( 0 ).getChild( 0 );
+
+				model.change( writer => {
+					writer.remove( writer.createRangeIn( caption ) );
+				} );
+
+				editor.execute( 'toggleImageCaption' );
+				editor.execute( 'toggleImageCaption' );
+
+				expect( getModelData( model ) ).to.equal( `[<image src="${ imgSrc }"><caption></caption></image>]` );
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (image): The emptied caption content should be preserved when hiding and showing the caption. Closes #9592.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
