### PR TITLE
Pasting an image without the source attribute will not break the editor

### DIFF
--- a/packages/ckeditor5-image/src/imagestyle/converters.js
+++ b/packages/ckeditor5-image/src/imagestyle/converters.js
@@ -61,9 +61,13 @@ export function viewToModelStyleAttribute( styles ) {
 		const viewElement = data.viewItem;
 		const modelImageElement = first( data.modelRange.getItems() );
 
-		// Check if `modelImageElement` exists (see: https://github.com/ckeditor/ckeditor5/issues/8270)
-		// and `imageStyle` attribute is allowed for that element, otherwise stop conversion early.
-		if ( modelImageElement && !conversionApi.schema.checkAttribute( modelImageElement, 'imageStyle' ) ) {
+		// Check if `modelImageElement` exists (see: #8270, and #9563)...
+		if ( !modelImageElement ) {
+			return;
+		}
+
+		// ...and the `imageStyle` attribute is allowed for that element, otherwise stop conversion early.
+		if ( !conversionApi.schema.checkAttribute( modelImageElement, 'imageStyle' ) ) {
 			return;
 		}
 

--- a/packages/ckeditor5-image/tests/imagestyle/imagestyleediting.js
+++ b/packages/ckeditor5-image/tests/imagestyle/imagestyleediting.js
@@ -329,6 +329,18 @@ describe( 'ImageStyleEditing', () => {
 						'<p><span class="ck-widget image-inline" contenteditable="false"><img src="/assets/sample.png"></img></span></p>'
 					);
 				} );
+
+				// See: #9563.
+				describe( 'with non-existing resource', () => {
+					it( 'inserts an empty paragraph when the "src" attribute is missing', () => {
+						editor.setData(
+							'<p><span><img class="image-style-align-left" /></span></p>'
+						);
+
+						expect( getModelData( model, { withoutSelection: true } ) )
+							.to.equal( '<paragraph></paragraph>' );
+					} );
+				} );
 			} );
 
 			describe( 'of the block image', () => {
@@ -401,6 +413,44 @@ describe( 'ImageStyleEditing', () => {
 					);
 
 					await customEditor.destroy();
+				} );
+
+				// See: #9563.
+				describe( 'with non-existing resource', () => {
+					it( 'inserts an empty paragraph when the "src" attribute is missing', () => {
+						editor.setData(
+							'<figure class="image image-style-align-center">' +
+								'<img alt="Foo." />' +
+							'</figure>'
+						);
+
+						expect( getModelData( model, { withoutSelection: true } ) )
+							.to.equal( '<paragraph></paragraph>' );
+					} );
+
+					it( 'inserts a paragraph with the "figcaption" content when the "src" attribute is missing (img + figcaption)', () => {
+						editor.setData(
+							'<figure class="image image-style-align-center">' +
+								'<img alt="Foo." />' +
+								'<figcaption>Bar.</figcaption>' +
+							'</figure>'
+						);
+
+						expect( getModelData( model, { withoutSelection: true } ) )
+							.to.equal( '<paragraph>Bar.</paragraph>' );
+					} );
+
+					it( 'inserts a paragraph with the "figcaption" content when the "src" attribute is missing (figcaption + img)', () => {
+						editor.setData(
+							'<figure class="image image-style-align-center">' +
+								'<figcaption>Bar.</figcaption>' +
+								'<img alt="Foo." />' +
+							'</figure>'
+						);
+
+						expect( getModelData( model, { withoutSelection: true } ) )
+							.to.equal( '<paragraph>Bar.</paragraph>' );
+					} );
 				} );
 			} );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (image): Pasting an image without the source attribute will not break the editor. Closes #9563.
