### PR TITLE
Inserting the inline image in the empty list item

### DIFF
--- a/packages/ckeditor5-image/src/image/utils.js
+++ b/packages/ckeditor5-image/src/image/utils.js
@@ -94,18 +94,17 @@ export function getImageTypeMatcher( editor, matchImageType ) {
 export function determineImageTypeForInsertionAtSelection( schema, selection ) {
 	const firstBlock = first( selection.getSelectedBlocks() );
 
-	if ( !firstBlock ) {
+	// Insert a block image if the selection is not in/on block elements or it's on a block widget.
+	if ( !firstBlock || schema.isObject( firstBlock ) ) {
 		return 'image';
 	}
 
-	if ( firstBlock.isEmpty ) {
-		// When inserting the image into the lists, use inline image. See #9391.
-		if ( firstBlock.name === 'listItem' ) {
-			return 'imageInline';
-		}
-
+	// A block image should also be inserted into an empty block element
+	// (that is not an empty list item so the list won't get split).
+	if ( firstBlock.isEmpty && firstBlock.name != 'listItem' ) {
 		return 'image';
 	}
 
-	return schema.isObject( firstBlock ) ? 'image' : 'imageInline';
+	// Otherwise insert an inline image.
+	return 'imageInline';
 }

--- a/packages/ckeditor5-image/src/image/utils.js
+++ b/packages/ckeditor5-image/src/image/utils.js
@@ -94,5 +94,18 @@ export function getImageTypeMatcher( editor, matchImageType ) {
 export function determineImageTypeForInsertionAtSelection( schema, selection ) {
 	const firstBlock = first( selection.getSelectedBlocks() );
 
-	return ( !firstBlock || firstBlock.isEmpty || schema.isObject( firstBlock ) ) ? 'image' : 'imageInline';
+	if ( !firstBlock ) {
+		return 'image';
+	}
+
+	if ( firstBlock.isEmpty ) {
+		// When inserting the image into the lists, use inline image. See #9391.
+		if ( firstBlock.name === 'listItem' ) {
+			return 'imageInline';
+		}
+
+		return 'image';
+	}
+
+	return schema.isObject( firstBlock ) ? 'image' : 'imageInline';
 }

--- a/packages/ckeditor5-image/tests/image/imageinlineediting.js
+++ b/packages/ckeditor5-image/tests/image/imageinlineediting.js
@@ -11,6 +11,7 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import DataTransfer from '@ckeditor/ckeditor5-clipboard/src/datatransfer';
 import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import LinkImage from '@ckeditor/ckeditor5-link/src/linkimage';
+import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
 
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import normalizeHtml from '@ckeditor/ckeditor5-utils/tests/_utils/normalizehtml';
@@ -642,7 +643,16 @@ describe( 'ImageInlineEditing', () => {
 			document.body.appendChild( editorElement );
 
 			editor = await ClassicTestEditor.create( editorElement, {
-				plugins: [ ImageInlineEditing, ImageBlockEditing, ImageCaption, ImageResizeEditing, Clipboard, LinkImage, Paragraph ]
+				plugins: [
+					ImageInlineEditing,
+					ImageBlockEditing,
+					ImageCaption,
+					ImageResizeEditing,
+					Clipboard,
+					LinkImage,
+					Paragraph,
+					ListEditing
+				]
 			} );
 
 			model = editor.model;
@@ -668,6 +678,23 @@ describe( 'ImageInlineEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>f<imageInline src="/assets/sample.png"></imageInline>[]oo</paragraph>'
+			);
+		} );
+
+		it( 'should paste or drop a block image as inline in the empty list item', () => {
+			const dataTransfer = new DataTransfer( {
+				types: [ 'text/html' ],
+				getData: () => '<figure class="image"><img src="/assets/sample.png" /></figure>'
+			} );
+
+			setModelData( model, '<listItem listType="bulleted" listIndent="0"></listItem>' );
+
+			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+
+			expect( getModelData( model ) ).to.equal(
+				'<listItem listIndent="0" listType="bulleted">' +
+					'<imageInline src="/assets/sample.png"></imageInline>[]' +
+				'</listItem>'
 			);
 		} );
 

--- a/packages/ckeditor5-image/tests/image/utils.js
+++ b/packages/ckeditor5-image/tests/image/utils.js
@@ -73,10 +73,14 @@ describe( 'image utils', () => {
 				isObject: true,
 				allowIn: [ '$block' ]
 			} );
+			schema.register( 'listItem', {
+				inheritAllFrom: '$block'
+			} );
 
 			schema.extend( '$text', { allowIn: [ 'block', '$root' ] } );
 
 			editor.conversion.for( 'downcast' ).elementToElement( { model: 'block', view: 'block' } );
+			editor.conversion.for( 'downcast' ).elementToElement( { model: 'listItem', view: 'li' } );
 			editor.conversion.for( 'downcast' ).elementToElement( { model: 'blockWidget', view: 'blockWidget' } );
 			editor.conversion.for( 'downcast' ).elementToElement( { model: 'inlineWidget', view: 'inlineWidget' } );
 		} );
@@ -95,6 +99,12 @@ describe( 'image utils', () => {
 			setModelData( model, '<block>[]</block>' );
 
 			expect( determineImageTypeForInsertionAtSelection( schema, model.document.selection ) ).to.equal( 'image' );
+		} );
+
+		it( 'should return "imageInline" when the selected listItem in the selection is empty', () => {
+			setModelData( model, '<listItem>[]</listItem>' );
+
+			expect( determineImageTypeForInsertionAtSelection( schema, model.document.selection ) ).to.equal( 'imageInline' );
 		} );
 
 		it( 'should return "image" when the selected block is an object (a widget)', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (image): When inserting an image in an empty list item, the `inlineImage` element will be used as the default type of image. Closes #9391.

