### PR TITLE
Link UI should be shown when clicking a linked inline widget

### DIFF
--- a/packages/ckeditor5-link/src/linkimageui.js
+++ b/packages/ckeditor5-link/src/linkimageui.js
@@ -46,17 +46,15 @@ export default class LinkImageUI extends Plugin {
 	init() {
 		const editor = this.editor;
 		const viewDocument = editor.editing.view.document;
-		const linkUI = editor.plugins.get( 'LinkUI' );
 
-		// Prevent browser navigation when clicking a linked image.
 		this.listenTo( viewDocument, 'click', ( evt, data ) => {
-			// Block the `LinkUI` plugin when an image was clicked. In such a case, we'd like to display the image toolbar.
-			// See: #9607.
 			if ( this._isSelectedLinkedImage( editor.model.document.selection ) ) {
-				linkUI.forceDisabled( 'LinkImageUI:link' );
+				// Prevent browser navigation when clicking a linked image.
 				data.preventDefault();
-			} else {
-				linkUI.clearForceDisabled( 'LinkImageUI:link' );
+
+				// Block the `LinkUI` plugin when an image was clicked.
+				// In such a case, we'd like to display the image toolbar.
+				evt.stop();
 			}
 		}, { priority: 'high' } );
 

--- a/packages/ckeditor5-link/src/linkimageui.js
+++ b/packages/ckeditor5-link/src/linkimageui.js
@@ -46,13 +46,19 @@ export default class LinkImageUI extends Plugin {
 	init() {
 		const editor = this.editor;
 		const viewDocument = editor.editing.view.document;
+		const linkUI = editor.plugins.get( 'LinkUI' );
 
 		// Prevent browser navigation when clicking a linked image.
 		this.listenTo( viewDocument, 'click', ( evt, data ) => {
+			// Block the `LinkUI` plugin when an image was clicked. In such a case, we'd like to display the image toolbar.
+			// See: #9607.
 			if ( this._isSelectedLinkedImage( editor.model.document.selection ) ) {
+				linkUI.forceDisabled( 'LinkImageUI:link' );
 				data.preventDefault();
+			} else {
+				linkUI.clearForceDisabled( 'LinkImageUI:link' );
 			}
-		} );
+		}, { priority: 'high' } );
 
 		this._createToolbarLinkImageButton();
 	}

--- a/packages/ckeditor5-link/src/linkui.js
+++ b/packages/ckeditor5-link/src/linkui.js
@@ -10,8 +10,6 @@
 import { Plugin } from 'ckeditor5/src/core';
 import { ClickObserver } from 'ckeditor5/src/engine';
 import { ButtonView, ContextualBalloon, clickOutsideHandler } from 'ckeditor5/src/ui';
-import { isWidget } from 'ckeditor5/src/widget';
-
 import LinkFormView from './ui/linkformview';
 import LinkActionsView from './ui/linkactionsview';
 import { addLinkProtocolIfApplicable, isLinkElement, LINK_KEYSTROKE } from './utils';
@@ -245,6 +243,10 @@ export default class LinkUI extends Plugin {
 		// Keep panel open until selection will be inside the same link element.
 		this.listenTo( viewDocument, 'click', () => {
 			const parentLink = this._getSelectedLinkElement();
+
+			if ( !this.isEnabled ) {
+				return;
+			}
 
 			if ( parentLink ) {
 				// Then show panel but keep focus inside editor editable.
@@ -642,13 +644,6 @@ export default class LinkUI extends Plugin {
 
 			// Check if the link element is fully selected.
 			if ( view.createRangeIn( startLink ).getTrimmed().isEqual( range ) ) {
-				// The link element is not fully selected when, for instance, there's an inline image widget directly inside.
-				// This should be interpreted as a selected inline image and the image UI should be displayed instead
-				// (LinkUI should not interact).
-				if ( startLink.childCount === 1 && isWidget( startLink.getChild( 0 ) ) ) {
-					return null;
-				}
-
 				return startLink;
 			} else {
 				return null;

--- a/packages/ckeditor5-link/src/linkui.js
+++ b/packages/ckeditor5-link/src/linkui.js
@@ -10,6 +10,7 @@
 import { Plugin } from 'ckeditor5/src/core';
 import { ClickObserver } from 'ckeditor5/src/engine';
 import { ButtonView, ContextualBalloon, clickOutsideHandler } from 'ckeditor5/src/ui';
+import { isWidget } from 'ckeditor5/src/widget';
 import LinkFormView from './ui/linkformview';
 import LinkActionsView from './ui/linkactionsview';
 import { addLinkProtocolIfApplicable, isLinkElement, LINK_KEYSTROKE } from './utils';
@@ -243,10 +244,6 @@ export default class LinkUI extends Plugin {
 		// Keep panel open until selection will be inside the same link element.
 		this.listenTo( viewDocument, 'click', () => {
 			const parentLink = this._getSelectedLinkElement();
-
-			if ( !this.isEnabled ) {
-				return;
-			}
 
 			if ( parentLink ) {
 				// Then show panel but keep focus inside editor editable.
@@ -619,8 +616,9 @@ export default class LinkUI extends Plugin {
 	 * the {@link module:engine/view/document~Document editing view's} selection or `null`
 	 * if there is none.
 	 *
-	 * **Note**: For a non–collapsed selection, the link element is only returned when **fully**
-	 * selected and the **only** element within the selection boundaries.
+	 * **Note**: For a non–collapsed selection, the link element is returned when **fully**
+	 * selected and the **only** element within the selection boundaries, or when
+	 * a linked widget is selected.
 	 *
 	 * @private
 	 * @returns {module:engine/view/attributeelement~AttributeElement|null}
@@ -628,8 +626,10 @@ export default class LinkUI extends Plugin {
 	_getSelectedLinkElement() {
 		const view = this.editor.editing.view;
 		const selection = view.document.selection;
+		const selectedElement = selection.getSelectedElement();
 
-		if ( selection.isCollapsed ) {
+		// The selection is collapsed or some widget is selected (especially inline widget).
+		if ( selection.isCollapsed || selectedElement && isWidget( selectedElement ) ) {
 			return findLinkElementAncestor( selection.getFirstPosition() );
 		} else {
 			// The range for fully selected link is usually anchored in adjacent text nodes.

--- a/packages/ckeditor5-link/tests/linkimageui.js
+++ b/packages/ckeditor5-link/tests/linkimageui.js
@@ -145,7 +145,9 @@ describe( 'LinkImageUI', () => {
 				linkUI = editor.plugins.get( 'LinkUI' );
 			} );
 
-			it( 'should disable the LinkUI plugin when clicked the linked image', () => {
+			it( 'should not show the LinkUI when clicked the linked image', () => {
+				const spy = sinon.stub( linkUI, '_showUI' ).returns( {} );
+
 				editor.setData( '<figure class="image"><a href="https://example.com"><img src="" /></a></figure>' );
 
 				editor.model.change( writer => {
@@ -159,10 +161,13 @@ describe( 'LinkImageUI', () => {
 
 				viewDocument.fire( 'click', domEventDataMock );
 
-				expect( linkUI.isEnabled ).to.equal( false );
+				expect( editor.model.document.getRoot().getChild( 0 ).is( 'element', 'image' ) ).to.be.true;
+				expect( spy.notCalled ).to.be.true;
 			} );
 
-			it( 'should disable the LinkUI plugin when clicked the linked inline image', () => {
+			it( 'should not show the LinkUI when clicked the linked inline image', () => {
+				const spy = sinon.stub( linkUI, '_showUI' ).returns( {} );
+
 				editor.setData( '<p><a href="https://example.com"><img src="" /></a></p>' );
 
 				editor.model.change( writer => {
@@ -176,39 +181,8 @@ describe( 'LinkImageUI', () => {
 
 				viewDocument.fire( 'click', domEventDataMock );
 
-				expect( linkUI.isEnabled ).to.equal( false );
-			} );
-
-			it( 'should enable the LinkUI plugin when clicked other element', () => {
-				editor.setData( '<figure class="image"><a href="https://example.com"><img src="" /></a></figure><p>Foo.</p>' );
-
-				editor.model.change( writer => {
-					writer.setSelection( editor.model.document.getRoot().getChild( 0 ), 'on' );
-				} );
-
-				const imageWidget = viewDocument.selection.getSelectedElement();
-				const imageData = fakeEventData();
-				const imageEventInfo = new EventInfo( imageWidget, 'click' );
-				const imageDomEventDataMock = new DomEventData( viewDocument, imageEventInfo, imageData );
-
-				// Click the image first.
-				viewDocument.fire( 'click', imageDomEventDataMock );
-
-				expect( linkUI.isEnabled ).to.equal( false );
-
-				editor.model.change( writer => {
-					writer.setSelection( editor.model.document.getRoot().getChild( 1 ), 'in' );
-				} );
-
-				const paragraphElement = viewDocument.selection.getSelectedElement();
-				const paragraphData = fakeEventData();
-				const paragraphEventInfo = new EventInfo( paragraphElement, 'click' );
-				const paragraphDomEventDataMock = new DomEventData( viewDocument, paragraphEventInfo, paragraphData );
-
-				// Then, click the paragraph.
-				viewDocument.fire( 'click', paragraphDomEventDataMock );
-
-				expect( linkUI.isEnabled ).to.equal( true );
+				expect( editor.model.document.getRoot().getChild( 0 ).getChild( 0 ).is( 'element', 'imageInline' ) ).to.be.true;
+				expect( spy.notCalled ).to.be.true;
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -1037,6 +1037,33 @@ describe( 'LinkUI', () => {
 				sinon.assert.calledWithExactly( spy );
 			} );
 
+			it( 'should show the UI when the selection spans over a link which only child is a widget', () => {
+				editor.model.schema.register( 'inlineWidget', {
+					allowWhere: '$text',
+					isObject: true,
+					isInline: true,
+					allowAttributesOf: '$text'
+				} );
+
+				// The view element has no children.
+				editor.conversion.for( 'downcast' )
+					.elementToElement( {
+						model: 'inlineWidget',
+						view: ( modelItem, { writer } ) => toWidget(
+							writer.createContainerElement( 'inlineWidget', {}, {
+								isAllowedInsideAttributeElement: true
+							} ),
+							writer,
+							{ label: 'inline widget' }
+						)
+					} );
+
+				setModelData( editor.model, '<paragraph>[<inlineWidget linkHref="url"></inlineWidget>]</paragraph>' );
+
+				observer.fire( 'click', { target: {} } );
+				sinon.assert.calledWithExactly( spy );
+			} );
+
 			it( 'should do nothing when selection is not inside link element', () => {
 				setModelData( editor.model, '[]' );
 
@@ -1079,31 +1106,6 @@ describe( 'LinkUI', () => {
 				sinon.assert.notCalled( spy );
 			} );
 
-			it( 'should do nothing when the selection spans over a link which only child is a widget', () => {
-				editor.model.schema.register( 'inlineWidget', {
-					allowWhere: '$text',
-					isObject: true,
-					isInline: true,
-					allowAttributesOf: '$text'
-				} );
-
-				// The view element has no children.
-				editor.conversion.for( 'downcast' )
-					.elementToElement( {
-						model: 'inlineWidget',
-						view: ( modelItem, { writer } ) => toWidget(
-							writer.createContainerElement( 'inlineWidget' ),
-							writer,
-							{ label: 'inline widget' }
-						)
-					} );
-
-				setModelData( editor.model, '<paragraph>[<inlineWidget linkHref="url"></inlineWidget>]</paragraph>' );
-
-				observer.fire( 'click', { target: {} } );
-				sinon.assert.notCalled( spy );
-			} );
-
 			// See: #9607.
 			it( 'should show the UI when clicking on the linked inline widget', () => {
 				editor.model.schema.register( 'inlineWidget', {
@@ -1131,17 +1133,6 @@ describe( 'LinkUI', () => {
 
 				observer.fire( 'click', { target: document.body } );
 				sinon.assert.calledWithExactly( spy );
-			} );
-
-			it( 'should do nothing if the plugin is disabled', () => {
-				setModelData( editor.model, '<$text linkHref="url">fo[]o</$text>' );
-
-				linkUIFeature.forceDisabled( 'foo' );
-
-				observer.fire( 'click', { target: {} } );
-				sinon.assert.notCalled( spy );
-
-				linkUIFeature.clearForceDisabled( 'foo' );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-widget/tests/manual/inline-widget.js
+++ b/packages/ckeditor5-widget/tests/manual/inline-widget.js
@@ -22,6 +22,7 @@ import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
 import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import ShiftEnter from '@ckeditor/ckeditor5-enter/src/shiftenter';
 import Table from '@ckeditor/ckeditor5-table/src/table';
+import Link from '@ckeditor/ckeditor5-link/src/link';
 
 class InlineWidget extends Plugin {
 	constructor( editor ) {
@@ -119,8 +120,8 @@ class InlineWidget extends Plugin {
 
 ClassicEditor
 	.create( global.document.querySelector( '#editor' ), {
-		plugins: [ Enter, Typing, Paragraph, Heading, Bold, Undo, Clipboard, Widget, ShiftEnter, InlineWidget, Table ],
-		toolbar: [ 'heading', '|', 'bold', '|', 'placeholder', '|', 'insertTable', '|', 'undo', 'redo' ]
+		plugins: [ Enter, Typing, Paragraph, Heading, Bold, Undo, Clipboard, Widget, ShiftEnter, InlineWidget, Table, Link ],
+		toolbar: [ 'heading', '|', 'bold', 'link', '|', 'placeholder', '|', 'insertTable', '|', 'undo', 'redo' ]
 	} )
 	.then( editor => {
 		window.editor = editor;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (link): The link UI should be shown when clicking a linked inline widget. Closes #9607.
