### PR TITLE
Change marker-to-data logic to improve conversion inside document fragment

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
@@ -405,9 +405,8 @@ export default class DowncastHelpers extends ConversionHelpers {
 	 *
 	 * This conversion creates a representation for model marker boundaries in the view:
 	 *
-	 * * If the marker boundary is at a position where text nodes are allowed, then a view element with the specified tag name
-	 * and `name` attribute is added at this position.
-	 * * In other cases, a specified attribute is set on a view element that is before or after the marker boundary.
+	 * * If the marker boundary is before or after a model element, a view attribute is set on a corresponding view element.
+	 * * In other cases, a view element with the specified tag name is inserted at corresponding view position.
 	 *
 	 * Typically, marker names use the `group:uniqueId:otherData` convention. For example: `comment:e34zfk9k2n459df53sjl34:zx32c`.
 	 * The default configuration for this conversion is that the first part is the `group` part and the rest of
@@ -945,32 +944,31 @@ function insertMarkerData( viewCreator ) {
 // Helper function for `insertMarkerData()` that marks a marker boundary at the beginning or end of given `range`.
 function handleMarkerBoundary( range, isStart, conversionApi, data, viewMarkerData ) {
 	const modelPosition = isStart ? range.start : range.end;
-	const canInsertElement = conversionApi.schema.checkChild( modelPosition, '$text' );
+	const elementAfter = modelPosition.nodeAfter && modelPosition.nodeAfter.is( 'element' ) ? modelPosition.nodeAfter : null;
+	const elementBefore = modelPosition.nodeBefore && modelPosition.nodeBefore.is( 'element' ) ? modelPosition.nodeBefore : null;
 
-	if ( canInsertElement ) {
-		const viewPosition = conversionApi.mapper.toViewPosition( modelPosition );
-
-		insertMarkerAsElement( viewPosition, isStart, conversionApi, data, viewMarkerData );
-	} else {
+	if ( elementAfter || elementBefore ) {
 		let modelElement;
 		let isBefore;
 
 		// If possible, we want to add `data-group-start-before` and `data-group-end-after` attributes.
-		// Below `if` is constructed in a way that will favor adding these attributes.
-		//
-		// Also, I assume that there will be always an element either after or before the position.
-		// If not, then it is a case when we are not in a position where text is allowed and also there are no elements around...
-		if ( isStart && modelPosition.nodeAfter || !isStart && !modelPosition.nodeBefore ) {
-			modelElement = modelPosition.nodeAfter;
+		if ( isStart && elementAfter || !isStart && !elementBefore ) {
+			// `data-group-start-before`, `data-group-end-after`.
+			modelElement = elementAfter;
 			isBefore = true;
 		} else {
-			modelElement = modelPosition.nodeBefore;
+			// `data-group-end-before`, `data-group-start-after`.
+			modelElement = elementBefore;
 			isBefore = false;
 		}
 
 		const viewElement = conversionApi.mapper.toViewElement( modelElement );
 
 		insertMarkerAsAttribute( viewElement, isStart, isBefore, conversionApi, data, viewMarkerData );
+	} else {
+		const viewPosition = conversionApi.mapper.toViewPosition( modelPosition );
+
+		insertMarkerAsElement( viewPosition, isStart, conversionApi, data, viewMarkerData );
 	}
 }
 

--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
@@ -953,11 +953,13 @@ function handleMarkerBoundary( range, isStart, conversionApi, data, viewMarkerDa
 
 		// If possible, we want to add `data-group-start-before` and `data-group-end-after` attributes.
 		if ( isStart && elementAfter || !isStart && !elementBefore ) {
-			// `data-group-start-before`, `data-group-end-after`.
+			// <elementBefore/>[<elementAfter/> -> data-group-start-before elementAfter
+			// <$text/>]<elementAfter/> -> data-group-end-before elementAfter
 			modelElement = elementAfter;
 			isBefore = true;
 		} else {
-			// `data-group-end-before`, `data-group-start-after`.
+			// <elementBefore>[<$text/> -> data-group-start-after elementBefore
+			// <elementBefore/>]<elementAfter/> -> data-group-end-after elementBefore
 			modelElement = elementBefore;
 			isBefore = false;
 		}

--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
@@ -953,13 +953,13 @@ function handleMarkerBoundary( range, isStart, conversionApi, data, viewMarkerDa
 
 		// If possible, we want to add `data-group-start-before` and `data-group-end-after` attributes.
 		if ( isStart && elementAfter || !isStart && !elementBefore ) {
-			// <elementBefore/>[<elementAfter/> -> data-group-start-before elementAfter
-			// <$text/>]<elementAfter/> -> data-group-end-before elementAfter
+			// [<elementAfter>...</elementAfter> -> <elementAfter data-group-start-before="...">...</elementAfter>
+			// <parent>]<elementAfter> -> <parent><elementAfter data-group-end-before="...">
 			modelElement = elementAfter;
 			isBefore = true;
 		} else {
-			// <elementBefore>[<$text/> -> data-group-start-after elementBefore
-			// <elementBefore/>]<elementAfter/> -> data-group-end-after elementBefore
+			// <elementBefore>...</elementBefore>] -> <elementBefore data-group-end-after="...">...</elementBefore>
+			// </elementBefore>[</parent> -> </elementBefore data-group-start-after="..."></parent>
 			modelElement = elementBefore;
 			isBefore = false;
 		}

--- a/packages/ckeditor5-engine/src/model/treewalker.js
+++ b/packages/ckeditor5-engine/src/model/treewalker.js
@@ -382,10 +382,9 @@ function formatReturnValue( type, item, previousPosition, nextPosition, length )
 /**
  * Type of the step made by {@link module:engine/model/treewalker~TreeWalker}.
  * Possible values: `'elementStart'` if walker is at the beginning of a node, `'elementEnd'` if walker is at the end of node,
- * `'character'` if walker traversed over a character, or `'text'` if walker traversed over multiple characters (available in
- * character merging mode, see {@link module:engine/model/treewalker~TreeWalker#constructor}).
+ * or `'text'` if walker traversed over text.
  *
- * @typedef {'elementStart'|'elementEnd'|'character'|'text'} module:engine/model/treewalker~TreeWalkerValueType
+ * @typedef {'elementStart'|'elementEnd'|'text'} module:engine/model/treewalker~TreeWalkerValueType
  */
 
 /**
@@ -404,7 +403,7 @@ function formatReturnValue( type, item, previousPosition, nextPosition, length )
  * the position after the item.
  * * Backward iteration: For `'elementEnd'` it is last position inside element. For all other types it is the position
  * before the item.
- * @property {Number} [length] Length of the item. For `'elementStart'` and `'character'` it is 1. For `'text'` it is
+ * @property {Number} [length] Length of the item. For `'elementStart'` it is 1. For `'text'` it is
  * the length of the text. For `'elementEnd'` it is `undefined`.
  */
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (engine): In marker-to-data conversion, attributes for marker boundaries will be used every time the marker starts or ends before or after a model element, instead only where text is not allowed by model schema. Closes #9622.