### PR TITLE
Delete content should not exclude block widget at the end of the deletion range

### DIFF
--- a/packages/ckeditor5-engine/src/model/utils/deletecontent.js
+++ b/packages/ckeditor5-engine/src/model/utils/deletecontent.js
@@ -148,7 +148,13 @@ function getLivePositionsForSelectedBlocks( range ) {
 			// This is how modifySelection works and here we are making use of it.
 			model.modifySelection( selection, { direction: 'backward' } );
 
-			endPosition = selection.getLastPosition();
+			const newEndPosition = selection.getLastPosition();
+			const nodeAfter = newEndPosition.nodeAfter;
+
+			// Use the shifted end position only if it did not jump over some object.
+			if ( !nodeAfter || !model.schema.isObject( nodeAfter ) ) {
+				endPosition = newEndPosition;
+			}
 		}
 	}
 

--- a/packages/ckeditor5-engine/tests/model/utils/deletecontent.js
+++ b/packages/ckeditor5-engine/tests/model/utils/deletecontent.js
@@ -677,6 +677,12 @@ describe( 'DataController utils', () => {
 					'<paragraph>ba[r</paragraph><blockWidget><nestedEditable>f]oo</nestedEditable></blockWidget>',
 					'<paragraph>ba[]</paragraph><blockWidget><nestedEditable>oo</nestedEditable></blockWidget>'
 				);
+
+				test(
+					'does not shrink deletion range if selection ends at start position of block following an object',
+					'<paragraph>x</paragraph><paragraph>[foo</paragraph><blockWidget></blockWidget><paragraph>]bar</paragraph>',
+					'<paragraph>x</paragraph><paragraph>[]bar</paragraph>'
+				);
 			} );
 
 			describe( 'with markers', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): The `model.deleteContent()` should not exclude a block widget at the end of the deletion range.

---

### Additional information