### PR TITLE
Docs: linking list blog post to docs.

### DIFF
--- a/packages/ckeditor5-list/docs/features/lists.md
+++ b/packages/ckeditor5-list/docs/features/lists.md
@@ -8,6 +8,10 @@ order: 10
 
 The {@link module:list/list~List list} feature allows creating ordered (numbered) and unordered (bulleted) lists. This allows for better structuring and presenting specific content such as enumerating elements, creating tables of content or {@link features/todo-lists to-do lists}.
 
+Lists are useful when you want to emphasize selected information, highlight a series of steps, enumerate items of a collection. They draw the reader's attention and, just like {@link features/block-quote block quotes} or {@link features/indent indentation}, give the text a structure and breathing room. They help visually separate passages for a better reading experience and make skimming for information easier.
+
+You may find additional interesting details and examples in the [Lists in CKEditor 5](https://ckeditor.com/blog/Feature-of-the-month-Lists-in-CKEditor-5/) blog post after reading this guide.
+
 <info-box info>
 	The feature is enabled by default in all CKEditor 5 WYSIWYG editor builds.
 </info-box>

--- a/packages/ckeditor5-list/docs/features/todo-lists.md
+++ b/packages/ckeditor5-list/docs/features/todo-lists.md
@@ -10,6 +10,8 @@ The {@link module:list/todolist~TodoList to-do list} feature lets you create a l
 
 To-do lists can be introduced using the dedicated toolbar button. Thanks to the integration with the {@link features/autoformat autoformatting feature}, they can also be added with Markdown code. Simply start a line with `[ ]` or `[x]` followed by a space to insert an unchecked or checked list item, respectively.
 
+After reading this guide, you may find additional interesting details and examples in the [Lists in CKEditor 5](https://ckeditor.com/blog/Feature-of-the-month-Lists-in-CKEditor-5/) blog post.
+
 ## Demo
 
 {@snippet features/todo-list}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: linking lists blog post in the documentation.

---

### Additional information

Part of the feature discoverability improvement epic. Includes expanded introduction and links to the dedicated blog post.