### PR TITLE
Docs: linking blog post to docs.

### DIFF
--- a/packages/ckeditor5-restricted-editing/docs/features/restricted-editing.md
+++ b/packages/ckeditor5-restricted-editing/docs/features/restricted-editing.md
@@ -13,7 +13,7 @@ In order to do that, this feature introduces two editing modes:
 
 You can imagine a workflow in which a certain group of users is responsible for creating templates of documents while a second group of users can only fill the gaps (for example, fill the missing data, like names, dates, product names, etc.).
 
-By using this feature, the users of your application will be able to create template documents. In a certain way, this feature could be used to generate forms with rich-text capabilities.
+By using this feature, the users of your application will be able to create template documents. In a certain way, this feature could be used to generate forms with rich-text capabilities. This kind of practical application is shown in the [How to create ready-to-print documents with CKEditor 5 pagination feature](https://ckeditor.com/blog/How-to-create-ready-to-print-documents-with-page-structure-in-WYSIWYG-editor---CKEditor-5-pagination-feature/) blog post.
 
 <info-box>
 	See also the {@link features/read-only read-only feature} that lets you turn the entire WYSIWYG editor into read-only mode.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: linking blog post in the documentation.

---

### **Additional information**

Part of the feature discoverability improvement epic. Linking the Pagination blogpost showcasing usage of restricted editing to create user-interactive tmeplates.