### PR TITLE
Internal (engine): Fixed new marker-to-data conversion inside code blocks.

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
@@ -966,12 +966,18 @@ function handleMarkerBoundary( range, isStart, conversionApi, data, viewMarkerDa
 
 		const viewElement = conversionApi.mapper.toViewElement( modelElement );
 
-		insertMarkerAsAttribute( viewElement, isStart, isBefore, conversionApi, data, viewMarkerData );
-	} else {
-		const viewPosition = conversionApi.mapper.toViewPosition( modelPosition );
+		// On rare circumstances, the model element could be not mapped to any view element and that would cause an error.
+		// One of those situations is a soft break inside code block.
+		if ( viewElement ) {
+			insertMarkerAsAttribute( viewElement, isStart, isBefore, conversionApi, data, viewMarkerData );
 
-		insertMarkerAsElement( viewPosition, isStart, conversionApi, data, viewMarkerData );
+			return;
+		}
 	}
+
+	const viewPosition = conversionApi.mapper.toViewPosition( modelPosition );
+
+	insertMarkerAsElement( viewPosition, isStart, conversionApi, data, viewMarkerData );
 }
 
 // Helper function for `insertMarkerData()` that marks a marker boundary in the view as an attribute on a view element.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (engine): Fixed new marker-to-data conversion inside code blocks.

---

### Additional information

This is internal because it fixes changes that were introduced in this iteration when working on #9622.