### PR TITLE
Docs: migration guides order

### DIFF
--- a/docs/builds/guides/migration/migration-from-ckeditor-4.md
+++ b/docs/builds/guides/migration/migration-from-ckeditor-4.md
@@ -5,7 +5,7 @@
 # * List and clarify the things that need attention when migrating.
 
 category: builds-migration
-order: 10
+order: 100
 ---
 
 # Migration from CKEditor 4

--- a/docs/builds/guides/migration/migration-to-25.md
+++ b/docs/builds/guides/migration/migration-to-25.md
@@ -1,7 +1,7 @@
 ---
 category: builds-migration
 menu-title: Migration to v25.x
-order: 95
+order: 99
 ---
 
 # Migration to CKEditor 5 v25.0.0

--- a/docs/builds/guides/migration/migration-to-25.md
+++ b/docs/builds/guides/migration/migration-to-25.md
@@ -1,7 +1,7 @@
 ---
 category: builds-migration
 menu-title: Migration to v25.x
-order: 10
+order: 95
 ---
 
 # Migration to CKEditor 5 v25.0.0

--- a/docs/builds/guides/migration/migration-to-26.md
+++ b/docs/builds/guides/migration/migration-to-26.md
@@ -1,7 +1,7 @@
 ---
 category: builds-migration
 menu-title: Migration to v26.x
-order: 10
+order: 90
 ---
 
 # Migration to CKEditor 5 v26.0.0

--- a/docs/builds/guides/migration/migration-to-26.md
+++ b/docs/builds/guides/migration/migration-to-26.md
@@ -1,7 +1,7 @@
 ---
 category: builds-migration
 menu-title: Migration to v26.x
-order: 90
+order: 98
 ---
 
 # Migration to CKEditor 5 v26.0.0

--- a/docs/builds/guides/migration/migration-to-27.md
+++ b/docs/builds/guides/migration/migration-to-27.md
@@ -1,10 +1,10 @@
 ---
 category: builds-migration
 menu-title: Migration to v27.x
-order: 10
+order: 85
 ---
 
-# Migration to CKEditor 5 v27.0.0
+# Migration to CKEditor 5 v27.x
 
 ## Migration to CKEditor 5 v27.0.0
 

--- a/docs/builds/guides/migration/migration-to-27.md
+++ b/docs/builds/guides/migration/migration-to-27.md
@@ -1,7 +1,7 @@
 ---
 category: builds-migration
 menu-title: Migration to v27.x
-order: 85
+order: 99
 ---
 
 # Migration to CKEditor 5 v27.x

--- a/docs/builds/guides/migration/migration-to-27.md
+++ b/docs/builds/guides/migration/migration-to-27.md
@@ -1,7 +1,7 @@
 ---
 category: builds-migration
 menu-title: Migration to v27.x
-order: 99
+order: 97
 ---
 
 # Migration to CKEditor 5 v27.x

--- a/docs/builds/index.md
+++ b/docs/builds/index.md
@@ -15,6 +15,12 @@ CKEditor 5 Builds are the fastest and easiest way to use CKEditor 5 in your appl
 	Use the <span class="navigation-hint_desktop">**navigation tree on the left**</span><span class="navigation-hint_mobile">**main menu button in the upper-left corner**</span> to navigate through CKEditor 5 Builds documentation.
 </info-box>
 
+Learn more about the {@link builds/guides/overview available pre-configured builds} or {@link builds/guides/development/custom-builds creating custom builds} and updating them on the go with the {@link builds/guides/development/dll-builds DLL webpack} solution.
+
+Get to now more about the {@link builds/guides/development/plugins plugins} and the supported {@link builds/guides/frameworks/overview frameworks integrations}.
+
+Refer to the {@link builds/guides/migration/migration-from-ckeditor-4 CKEditor 4 migration guide} or other migration guides if you are updating your integration.
+
 ## Related links
 
  * {@link examples/index Examples} &ndash; Try live demos of all available builds.

--- a/docs/builds/index.md
+++ b/docs/builds/index.md
@@ -19,7 +19,7 @@ Learn more about the {@link builds/guides/overview available pre-configured buil
 
 Get to know more about the {@link builds/guides/development/plugins plugin development} and the supported {@link builds/guides/frameworks/overview integrations with popular JavaScript frameworks}.
 
-Refer to the {@link builds/guides/migration/migration-from-ckeditor-4 CKEditor 4 migration guide} or other migration guides if you are updating your integration.
+Refer to the {@link builds/guides/migration/migration-from-ckeditor-4 CKEditor 4 migration guide} or other migration guides if you are updating your CKEditor 5 installation.
 
 ## Related links
 

--- a/docs/builds/index.md
+++ b/docs/builds/index.md
@@ -17,7 +17,7 @@ CKEditor 5 Builds are the fastest and easiest way to use CKEditor 5 in your appl
 
 Learn more about the {@link builds/guides/overview available pre-configured builds} or {@link builds/guides/development/custom-builds creating custom builds} and updating them on the go with the {@link builds/guides/development/dll-builds DLL webpack} solution.
 
-Get to now more about the {@link builds/guides/development/plugins plugins} and the supported {@link builds/guides/frameworks/overview frameworks integrations}.
+Get to know more about the {@link builds/guides/development/plugins plugins development} and the supported {@link builds/guides/frameworks/overview frameworks integrations}.
 
 Refer to the {@link builds/guides/migration/migration-from-ckeditor-4 CKEditor 4 migration guide} or other migration guides if you are updating your integration.
 

--- a/docs/builds/index.md
+++ b/docs/builds/index.md
@@ -17,7 +17,7 @@ CKEditor 5 Builds are the fastest and easiest way to use CKEditor 5 in your appl
 
 Learn more about the {@link builds/guides/overview available pre-configured builds} or {@link builds/guides/development/custom-builds creating custom builds} and updating them on the go with the {@link builds/guides/development/dll-builds DLL webpack} solution.
 
-Get to know more about the {@link builds/guides/development/plugins plugins development} and the supported {@link builds/guides/frameworks/overview frameworks integrations}.
+Get to know more about the {@link builds/guides/development/plugins plugin development} and the supported {@link builds/guides/frameworks/overview integrations with popular JavaScript frameworks}.
 
 Refer to the {@link builds/guides/migration/migration-from-ckeditor-4 CKEditor 4 migration guide} or other migration guides if you are updating your integration.
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Reversing migration guides order in TOC. Closes #9550.

Docs: Extending the build landing page just a tiny little bit. Partially addresses cksource/docs#368