### PR TITLE
Remove all link* attributes when interacting with link boundaries

### DIFF
--- a/packages/ckeditor5-link/tests/linkediting.js
+++ b/packages/ckeditor5-link/tests/linkediting.js
@@ -1093,8 +1093,13 @@ describe( 'LinkEditing', () => {
 			expect( getModelData( model ) ).to.equal( '<paragraph><$text bold="true">Bar[]</$text></paragraph>' );
 		} );
 
-		it( 'should remove manual decorators', () => {
-			setModelData( model, '<paragraph><$text linkIsFoo="true" linkIsBar="true" linkHref="url">Bar[]</$text></paragraph>' );
+		it( 'should remove all `link*` attributes', () => {
+			allowLinkTarget( editor );
+
+			setModelData(
+				model,
+				'<paragraph><$text linkIsFoo="true" linkTarget="_blank" linkHref="https://ckeditor.com">Bar[]</$text></paragraph>'
+			);
 
 			editor.editing.view.document.fire( 'mousedown' );
 			editor.editing.view.document.fire( 'selectionChange', {
@@ -1102,15 +1107,29 @@ describe( 'LinkEditing', () => {
 			} );
 
 			expect( getModelData( model ) ).to.equal(
-				'<paragraph><$text linkHref="url" linkIsBar="true" linkIsFoo="true">Bar</$text>[]</paragraph>'
+				'<paragraph><$text linkHref="https://ckeditor.com" linkIsFoo="true" linkTarget="_blank">Bar</$text>[]</paragraph>'
 			);
 
 			editor.execute( 'input', { text: 'Foo' } );
 
 			expect( getModelData( model ) ).to.equal(
-				'<paragraph><$text linkHref="url" linkIsBar="true" linkIsFoo="true">Bar</$text>Foo[]</paragraph>'
+				'<paragraph><$text linkHref="https://ckeditor.com" linkIsFoo="true" linkTarget="_blank">Bar</$text>Foo[]</paragraph>'
 			);
 		} );
+
+		// Based on `packages/ckeditor5-engine/docs/_snippets/framework/extending-content-allow-link-target.js`.
+		// And covers #8462.
+		function allowLinkTarget( editor ) {
+			editor.model.schema.extend( '$text', { allowAttributes: 'linkTarget' } );
+
+			editor.conversion.for( 'downcast' ).attributeToElement( {
+				model: 'linkTarget',
+				view: ( attributeValue, { writer } ) => {
+					return writer.createAttributeElement( 'a', { target: attributeValue }, { priority: 5 } );
+				},
+				converterPriority: 'low'
+			} );
+		}
 	} );
 
 	// https://github.com/ckeditor/ckeditor5/issues/4762


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (link): All text attributes starting their names with `link` will be removed when typing over a link or clicking at the end of the link. Closes #8462.
