### PR TITLE
Improve engine view matcher with new pattern syntax

### DIFF
--- a/packages/ckeditor5-engine/src/view/element.js
+++ b/packages/ckeditor5-engine/src/view/element.js
@@ -468,11 +468,11 @@ export default class Element extends Node {
 	/**
 	 * Returns iterator that contains all style names.
 	 *
-	 * @param {Boolean} [deep=false] Expand shorthand style properties and return all equivalent style representations.
+	 * @param {Boolean} [expand=false] Expand shorthand style properties and return all equivalent style representations.
 	 * @returns {Iterable.<String>}
 	 */
-	getStyleNames( deep = false ) {
-		return this._styles.getStyleNames( deep );
+	getStyleNames( expand = false ) {
+		return this._styles.getStyleNames( expand );
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/view/element.js
+++ b/packages/ckeditor5-engine/src/view/element.js
@@ -468,7 +468,7 @@ export default class Element extends Node {
 	/**
 	 * Returns iterator that contains all style names.
 	 *
-	 * TODO param
+	 * @param {Boolean} [deep=false] Expand shorthand style properties and all return equivalent style representations.
 	 * @returns {Iterable.<String>}
 	 */
 	getStyleNames( deep = false ) {

--- a/packages/ckeditor5-engine/src/view/element.js
+++ b/packages/ckeditor5-engine/src/view/element.js
@@ -468,10 +468,11 @@ export default class Element extends Node {
 	/**
 	 * Returns iterator that contains all style names.
 	 *
+	 * TODO param
 	 * @returns {Iterable.<String>}
 	 */
-	getStyleNames() {
-		return this._styles.getStyleNames();
+	getStyleNames( deep = false ) {
+		return this._styles.getStyleNames( deep );
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/view/element.js
+++ b/packages/ckeditor5-engine/src/view/element.js
@@ -468,7 +468,7 @@ export default class Element extends Node {
 	/**
 	 * Returns iterator that contains all style names.
 	 *
-	 * @param {Boolean} [deep=false] Expand shorthand style properties and all return equivalent style representations.
+	 * @param {Boolean} [deep=false] Expand shorthand style properties and return all equivalent style representations.
 	 * @returns {Iterable.<String>}
 	 */
 	getStyleNames( deep = false ) {

--- a/packages/ckeditor5-engine/src/view/matcher.js
+++ b/packages/ckeditor5-engine/src/view/matcher.js
@@ -462,7 +462,8 @@ function matchStyles( patterns, element ) {
  *		const pattern = /^p/;
  *
  * If `MatcherPattern` is given as an `Object`, all the object's properties will be matched with view element properties.
- * Let's examine available pattern options:
+ * If the view element won't meet all of the object's pattern properties, the match won't happen.
+ * Available `Object` matching properties:
  *
  * Matching view element:
  *
@@ -515,7 +516,7 @@ function matchStyles( patterns, element ) {
  *			attributes: [
  *				'title',    // Match `title` attribute (can be empty).
  *				/^data-*$/, // Match attributes starting with `data-` e.g. `data-foo` with any value (can be empty).
-*			]
+ *			]
  *		};
  *
  *		// Match view element which has matching attributes (key-value pairs).
@@ -528,10 +529,10 @@ function matchStyles( patterns, element ) {
  *				{
  *					key: /^data-.*$/,                // Match attributes starting with `data-` e.g. `data-foo`.
  *					value: true                      // Match any value (can be empty).
-*				}
-*			]
+ *				}
+ *			]
  *		};
-*
+ *
  * Matching view element styles:
  *
  *		// Match view element with any style.
@@ -539,7 +540,7 @@ function matchStyles( patterns, element ) {
  *			name: 'p',
  *			styles: true
  *		};
-*
+ *
  *		// Match view element which has matching styles (String).
  *		const pattern = {
  *			name: 'p',
@@ -568,7 +569,7 @@ function matchStyles( patterns, element ) {
  *			attributes: [
  *				'color',      // Match `color` with any value.
  *				/^border.*$/, // Match all border properties.
-*			]
+ *			]
  *		};
  *
  *		// Match view element which has matching styles (key-value pairs).
@@ -581,8 +582,8 @@ function matchStyles( patterns, element ) {
  *				{
  *					key: /^border.*$/, // Match any border style.
  *					value: true        // Match any value.
-*				}
-*			]
+ *				}
+ *			]
  *		};
  *
  * Matching view element classes:
@@ -592,7 +593,7 @@ function matchStyles( patterns, element ) {
  *			name: 'p',
  *			classes: true
  *		};
-*
+ *
  *		// Match view element which has matching class (String).
  *		const pattern = {
  *			name: 'p',
@@ -633,8 +634,8 @@ function matchStyles( patterns, element ) {
  *				{
  *					key: /^image-side-(left|right)$/, // Match `image-side-left` or `image-side-right` class.
  *					value: true
-*				}
-*			]
+ *				}
+ *			]
  *		};
  *
  * Pattern can combine multiple properties allowing for more complex view element matching:

--- a/packages/ckeditor5-engine/src/view/matcher.js
+++ b/packages/ckeditor5-engine/src/view/matcher.js
@@ -335,7 +335,8 @@ function matchPatterns( patterns, attributes ) {
 		} );
 	} );
 
-	if ( !match.length ) {
+	// Return null when there was no matches or we didn't match all patterns.
+	if ( !match.length || match.length != patterns.length ) {
 		return null;
 	}
 

--- a/packages/ckeditor5-engine/src/view/matcher.js
+++ b/packages/ckeditor5-engine/src/view/matcher.js
@@ -322,29 +322,27 @@ function matchPatterns( patterns, attributes ) {
 		}
 	}
 
-	patterns = normalizePatterns( patterns );
+	patterns = normalizePatterns( patterns ) || [];
 
-	for ( const pattern in patterns ) {
-		const { key: patternKey, value: patternVal } = patterns[ pattern ];
-
+	patterns.forEach( ( { key: patternKey, value: patternVal } ) => {
 		attributes.forEach( ( [ attributeKey, attributeValue ] ) => {
 			if (
-				( patternKey instanceof RegExp && patternKey.test( attributeKey ) ) ||
-				patternKey === attributeKey
+				patternKey === attributeKey ||
+				( patternKey instanceof RegExp && patternKey.test( attributeKey ) )
 			) {
-				if ( patternVal === true ) {
-					match.push( attributeKey );
-				} else if ( patternVal === attributeValue ) {
-					match.push( attributeKey );
-				} else if ( patternVal instanceof RegExp && patternVal.test( attributeValue ) ) {
+				if (
+					patternVal === true ||
+					patternVal === attributeValue ||
+					( patternVal instanceof RegExp && patternVal.test( attributeValue ) )
+				) {
 					match.push( attributeKey );
 				}
 			}
 		} );
+	} );
 
-		if ( !match.length ) {
-			return null;
-		}
+	if ( !match.length ) {
+		return null;
 	}
 
 	return match;
@@ -364,7 +362,7 @@ function matchPatterns( patterns, attributes ) {
 //		value: /https:.*/
 //	}
 // @param {Object|Array} patterns
-// @returns {Array|null} Returns an array of objects or null if patterns were not in a form of expected input.
+// @returns {Array|null} Returns an array of objects or null if provided patterns were not in an expected form.
 function normalizePatterns( patterns ) {
 	if ( Array.isArray( patterns ) ) {
 		return patterns.map(
@@ -382,9 +380,9 @@ function normalizePatterns( patterns ) {
 		return Object.entries( patterns ).map(
 			( [ patternKey, patternValue ] ) => ( { key: patternKey, value: patternValue } )
 		);
-	} else {
-		return null;
 	}
+
+	return null;
 }
 
 // Checks if attributes of provided element can be matched against provided patterns.
@@ -406,10 +404,10 @@ function matchAttributes( patterns, element ) {
 // @param {module:engine/view/element~Element} element Element which classes will be tested.
 // @returns {Array|null} Returns array with matched class names or `null` if no classes were matched.
 function matchClasses( patterns, element ) {
-	const classNames = Array.from( element.getClassNames() );
-	const attributes = classNames.map( className => [ className ] );
+	const classes = Array.from( element.getClassNames() )
+		.map( className => [ className ] );
 
-	return matchPatterns( patterns, attributes );
+	return matchPatterns( patterns, classes );
 }
 
 // Checks if styles of provided element can be matched against provided patterns.
@@ -419,10 +417,10 @@ function matchClasses( patterns, element ) {
 // @param {module:engine/view/element~Element} element Element which styles will be tested.
 // @returns {Array|null} Returns array with matched style names or `null` if no styles were matched.
 function matchStyles( patterns, element ) {
-	const styleNames = element.getStyleNames();
-	const attributes = styleNames.map( style => [ style, element.getStyle( style ) ] );
+	const styles = element.getStyleNames()
+		.map( style => [ style, element.getStyle( style ) ] );
 
-	return matchPatterns( patterns, attributes );
+	return matchPatterns( patterns, styles );
 }
 
 /**

--- a/packages/ckeditor5-engine/src/view/matcher.js
+++ b/packages/ckeditor5-engine/src/view/matcher.js
@@ -7,8 +7,8 @@
  * @module engine/view/matcher
  */
 
-import { logWarning } from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import { isPlainObject } from 'lodash-es';
+import { logWarning } from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 /**
  * View matcher class.

--- a/packages/ckeditor5-engine/src/view/matcher.js
+++ b/packages/ckeditor5-engine/src/view/matcher.js
@@ -382,7 +382,13 @@ function isValueMatched( patternValue, itemKey, getter ) {
 // @param {module:engine/view/element~Element} element Element which attributes will be tested.
 // @returns {Array|null} Returns array with matched attribute names or `null` if no attributes were matched.
 function matchAttributes( patterns, element ) {
-	return matchPatterns( patterns, element.getAttributeKeys(), key => element.getAttribute( key ) );
+	// Both `class` and `style` attributes are handled in `matchClasses()` and `matchStyles()` respectively.
+	const attributesToExclude = new Set( [ 'class', 'style' ] );
+	const attributeKeys = [ ...element.getAttributeKeys() ].filter(
+		key => !attributesToExclude.has( key )
+	);
+
+	return matchPatterns( patterns, attributeKeys, key => element.getAttribute( key ) );
 }
 
 // Checks if classes of provided element can be matched against provided patterns.

--- a/packages/ckeditor5-engine/src/view/matcher.js
+++ b/packages/ckeditor5-engine/src/view/matcher.js
@@ -462,62 +462,186 @@ function matchStyles( patterns, element ) {
  *		const pattern = /^p/;
  *
  * If `MatcherPattern` is given as an `Object`, all the object's properties will be matched with view element properties.
+ * Let's examine available pattern options:
  *
- *		// Match view element's name.
- *		const pattern = { name: /^p/ };
+ * Matching view element:
+ *
+ *		// Match view element's name using String:
+ *		const pattern = { name: 'p' };
+ *
+ *		// or by providing RegExp:
+ *		const pattern = { name: /^(ul|ol)$/ };
+ *
+ *		// The name can also be skipped to match any view element with matching attributes:
+ *		const pattern = {
+ *			attributes: {
+ *				'title': true
+ *			}
+ *		};
+ *
+ * Matching view element attributes:
  *
  *		// Match view element with any attribute value.
  *		const pattern = {
+ *			name: 'p',
  *			attributes: true
- *		}
+ *		};
  *
- *		// Match view element which has matching attributes.
+ *		// Match view element which has matching attributes (String).
  *		const pattern = {
+ *			name: 'figure',
+ *			attributes: 'title' // Match title attribute (can be empty).
+ *		};
+ *
+ *		// Match view element which has matching attributes (RegExp).
+ *		const pattern = {
+ *			name: 'figure',
+ *			attributes: /^data-.*$/ // Match attributes starting with `data-` e.g. `data-foo` with any value (can be empty).
+ *		};
+ *
+ *		// Match view element which has matching attributes (Object).
+ *		const pattern = {
+ *			name: 'figure',
  *			attributes: {
- *				title: 'foobar',	// Attribute title should equal 'foobar'.
- *				foo: /^\w+/,		// Attribute foo should match /^\w+/ regexp.
- *				bar: true			// Attribute bar should be set (can be empty).
+ *				title: 'foobar',           // Match `title` attribute with 'foobar' value.
+ *				alt: true,                 // Match `alt` attribute with any value (can be empty).
+ *				'data-type': /^(jpg|png)$/ // Match `data-type` attribute with `jpg` or `png` value.
  *			}
  *		};
  *
- *		// Match view element which has given class.
+ *		// Match view element which has matching attributes (Array).
  *		const pattern = {
- *			classes: 'foobar'
- *		};
- *
- *		// Match view element class using regular expression.
- *		const pattern = {
- *			classes: /foo.../
- *		};
- *
- *		// Multiple classes to match.
- *		const pattern = {
- *			classes: [ 'baz', 'bar', /foo.../ ]
- *		};
- *
- *		// Multiple attributes to match, value does not matter.
- *		const pattern = {
- *			attributes: [ 'title', 'href', /^data-foo.*$/ ]
- *		};
- *
- *		// Match view element which has given styles.
- *		const pattern = {
- *			styles: {
- *				position: 'absolute',
- *				color: /^\w*blue$/
- *			}
- *		};
- *
- *		// Match view element which has many custom data attributes.
- *		const pattern = {
+ *			name: 'figure',
  *			attributes: [
- *				{ key: /data-.+/, value: true }
- *			]
- *		}
+ *				'title',    // Match `title` attribute (can be empty).
+ *				/^data-*$/, // Match attributes starting with `data-` e.g. `data-foo` with any value (can be empty).
+*			]
+ *		};
  *
- *		// Pattern with multiple properties.
+ *		// Match view element which has matching attributes (key-value-pairs).
+ *		const pattern = {
+ *			name: 'input',
+ *			attributes: [
+ *				{
+ *					key: 'type',                     // Match `type` as an attribute key.
+ *					value: /^(text|number|date)$/ }, // Match `text`, `number` or `date` values.
+ *				{
+ *					key: /^data-.*$/,                // Match attributes starting with `data-` e.g. `data-foo`.
+ *					value: true                      // Match any value (can be empty).
+*				}
+*			]
+ *		};
+*
+ * Matching view element styles:
+ *
+ *		// Match view element with any style.
+ *		const pattern = {
+ *			name: 'p',
+ *			styles: true
+ *		};
+*
+ *		// Match view element which has matching styles (String).
+ *		const pattern = {
+ *			name: 'p',
+ *			styles: 'color' // Match attributes with `color` style.
+ *		};
+ *
+ *		// Match view element which has matching styles (RegExp).
+ *		const pattern = {
+ *			name: 'p',
+ *			styles: /^border.*$/ // Match view element with any border style.
+ *		};
+ *
+ *		// Match view element which has matching styles (Object).
+ *		const pattern = {
+ *			name: 'p',
+ *			attributes: {
+ *				color: /rgb\((\d{1,3}), (\d{1,3}), (\d{1,3})\)/, // Match `color` in RGB format only.
+ *				'font-weight': 600,                              // Match `font-weight` only if it's `600`.
+ *				'text-decoration': true                          // Match any text decoration.
+ *			}
+ *		};
+ *
+ *		// Match view element which has matching styles (Array).
+ *		const pattern = {
+ *			name: 'p',
+ *			attributes: [
+ *				'color',      // Match `color` with any value.
+ *				/^border.*$/, // Match all border properties.
+*			]
+ *		};
+ *
+ *		// Match view element which has matching styles (key-value-pairs).
+ *		const pattern = {
+ *			name: 'p',
+ *			attributes: [
+ *				{
+ *					key: 'color',                                    // Match `color` as an property key.
+ *					value: /rgb\((\d{1,3}), (\d{1,3}), (\d{1,3})\)/, // Match RGB format only.
+ *				{
+ *					key: /^border.*$/, // Match any border style.
+ *					value: true        // Match any value.
+*				}
+*			]
+ *		};
+ *
+ * Matching view element classes:
+ *
+ *		// Match view element with any class.
+ *		const pattern = {
+ *			name: 'p',
+ *			classes: true
+ *		};
+*
+ *		// Match view element which has matching class (String).
+ *		const pattern = {
+ *			name: 'p',
+ *			classes: 'highlighted' // Match `highlighted` class.
+ *		};
+ *
+ *		// Match view element which has matching classes (RegExp).
+ *		const pattern = {
+ *			name: 'figure',
+ *			classes: /^image-side-(left|right)$/ // Match `image-side-left` or `image-side-right` class.
+ *		};
+ *
+ *		// Match view element which has matching classes (Object).
+ *		const pattern = {
+ *			name: 'p',
+ *			classes: {
+ *				highlighted: true, // Match `highlighted` class.
+ *				marker: true       // Match `marker` class.
+ *			}
+ *		};
+ *
+ *		// Match view element which has matching classes (Array).
+ *		const pattern = {
+ *			name: 'figure',
+ *			classes: [
+ *				'image',                    // Match `image` class.
+ *				/^image-side-(left|right)$/ // Match `image-side-left` or `image-side-right` class.
+ *			]
+ *		};
+ *
+ *		// Match view element which has matching classes (key-value-pairs).
+ *		const pattern = {
+ *			name: 'figure',
+ *			classes: [
+ *				{
+ *					key: 'image', // Match `image` class.
+ *					value: true
+ *				{
+ *					key: /^image-side-(left|right)$/, // Match `image-side-left` or `image-side-right` class.
+ *					value: true
+*				}
+*			]
+ *		};
+ *
+ * Pattern can combine multiple properties allowing for more complex view element matching:
+ *
  *		const pattern = {
  *			name: 'span',
+ *			attributes: [ 'title' ],
  *			styles: {
  *				'font-weight': 'bold'
  *			},

--- a/packages/ckeditor5-engine/src/view/matcher.js
+++ b/packages/ckeditor5-engine/src/view/matcher.js
@@ -7,6 +7,7 @@
  * @module engine/view/matcher
  */
 
+import { logWarning } from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import { isPlainObject } from 'lodash-es';
 
 /**
@@ -338,7 +339,12 @@ function matchPatterns( patterns, items, valueGetter ) {
 function normalizePatterns( patterns ) {
 	if ( Array.isArray( patterns ) ) {
 		return patterns.map( pattern => {
-			if ( isPlainObject( pattern ) && pattern.key && pattern.value ) {
+			if ( isPlainObject( pattern ) ) {
+				if ( pattern.key === undefined || pattern.value === undefined ) {
+					// Documented at the end of matcher.js.
+					logWarning( 'matcher-patterns-pattern-missing-key-or-value', pattern );
+				}
+
 				return [ pattern.key, pattern.value ];
 			}
 
@@ -523,4 +529,12 @@ function matchStyles( patterns, element ) {
  * Each object key represents style name. Value can be given as `String` or `RegExp`.
  * @property {Object} [attributes] Object with key-value pairs representing attributes to match.
  * Each object key represents attribute name. Value can be given as `String` or `RegExp`.
+ */
+
+/**
+ * The key-value matcher pattern is missing key or value. Both must be present.
+ * Refer the documentation: {@link module:engine/view/matcher~MatcherPattern}.
+ *
+ * @param {Object} pattern Pattern with missing properties.
+ * @error matcher-patterns-pattern-missing-key-or-value
  */

--- a/packages/ckeditor5-engine/src/view/matcher.js
+++ b/packages/ckeditor5-engine/src/view/matcher.js
@@ -242,47 +242,48 @@ function matchName( pattern, name ) {
 // Checks if an array of key/value pairs can be matched against provided patterns.
 //
 // Patterns can be provided in a following ways:
-// 	- a boolean value matches any attribute with any value (or no value),
-//	- a RegExp expression or object matches any attribute name,
-//	- an object matches any attribute that has the same name as the object item's key, where object item's value is:
-//		- equal to `true`, which matches any attribute value,
-//		- a string that is equal to attribute value,
-//		- a regular expression that matches attribute value,
-//	- an array with items, where the item is:
-//		- a string that is equal to attribute value,
-//		- an object with `key` and `value` property, where `key` is a regular expression matching attribute name and
-//		  `value` is either regular expression matching attribute value or a string equal to attribute value.
+// 	- a boolean value matches any attribute with any value (or no value):
 //
-//			pattern: true,
+//			pattern: true
 //
-//			// or
+//	- a RegExp expression or object matches any attribute name:
 //
 //			pattern: /h[1-6]/
 //
-//			// or
+//	- an object matches any attribute that has the same name as the object item's key, where object item's value is:
+//		- equal to `true`, which matches any attribute value:
 //
 //			pattern: {
-//				required: true,
-//				src: /https.*/,
+//				required: true
+//			}
+//
+//		- a string that is equal to attribute value:
+//
+//			pattern: {
 //				rel: 'nofollow'
 //			}
 //
-//			// or
+//		- a regular expression that matches attribute value,
+//
+//			pattern: {
+//				src: /https.*/
+//			}
+//
+//	- an array with items, where the item is:
+//		- a string that is equal to attribute value:
 //
 //			pattern: [ 'data-property-1', 'data-property-2' ],
 //
-//			// or
-//
-//			pattern: [ 'data-test', 'data-foo' ],
-//
-//			// or
+//		- an object with `key` and `value` property, where `key` is a regular expression matching attribute name and
+//		  `value` is either regular expression matching attribute value or a string equal to attribute value:
 //
 //			pattern: [
+//				{ key: /data-property-.*/, value: true },
+//				// or:
 //				{ key: /data-property-.*/, value: 'foobar' },
-//				// or
+//				// or:
 //				{ key: /data-property-.*/, value: /foo.*/ }
 //			]
-//		}
 //
 // @param {Object} patterns Object with information about attributes to match.
 // @param {Array} items An array of key/value pairs, e.g.:

--- a/packages/ckeditor5-engine/src/view/matcher.js
+++ b/packages/ckeditor5-engine/src/view/matcher.js
@@ -8,6 +8,7 @@
  */
 
 import { isPlainObject } from 'lodash-es';
+
 import { logWarning } from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 /**
@@ -321,19 +322,51 @@ function matchPatterns( patterns, items, valueGetter ) {
 	return match;
 }
 
-// Bring all the possible pattern forms to an array of objects with `key` and `value` property.
-// For example:
+// Bring all the possible pattern forms to an array of arrays where first item is a key and second is a value.
 //
-//	{
-//		src: /https:.*/
-//	}
+// Examples:
+//
+// Boolean pattern value:
+//
+//		true
+//
+// to
+//
+//		[ [ true, true ] ]
+//
+// Textual pattern value:
+//
+//		'attribute-name-or-class-or-style'
+//
+// to
+//
+//		[ [ 'attribute-name-or-class-or-style', true ] ]
+//
+// Regular expression:
+//
+//		/^data-.*$/
+//
+// to
+//
+//		[ [ /^data-.*$/, true ] ]
+//
+// Objects (plain or with `key` and `value` specified explicitly):
+//
+//		{
+//			src: /^https:.*$/
+//		}
+//
+// or
+//
+//		[ {
+//			key: 'src',
+//			value: /^https:.*$/
+//		} ]
 //
 // to:
 //
-//	{
-//		key: 'src',
-//		value: /https:.*/
-//	}
+//		[ [ 'src', /^https:.*$/ ] ]
+//
 // @param {Object|Array} patterns
 // @returns {Array|null} Returns an array of objects or null if provided patterns were not in an expected form.
 function normalizePatterns( patterns ) {
@@ -342,7 +375,7 @@ function normalizePatterns( patterns ) {
 			if ( isPlainObject( pattern ) ) {
 				if ( pattern.key === undefined || pattern.value === undefined ) {
 					// Documented at the end of matcher.js.
-					logWarning( 'matcher-patterns-pattern-missing-key-or-value', pattern );
+					logWarning( 'matcher-pattern-missing-key-or-value', pattern );
 				}
 
 				return [ pattern.key, pattern.value ];
@@ -351,7 +384,9 @@ function normalizePatterns( patterns ) {
 			// Assume the pattern is either String or RegExp.
 			return [ pattern, true ];
 		} );
-	} else if ( isPlainObject( patterns ) ) {
+	}
+
+	if ( isPlainObject( patterns ) ) {
 		return Object.entries( patterns );
 	}
 
@@ -536,5 +571,5 @@ function matchStyles( patterns, element ) {
  * Refer the documentation: {@link module:engine/view/matcher~MatcherPattern}.
  *
  * @param {Object} pattern Pattern with missing properties.
- * @error matcher-patterns-pattern-missing-key-or-value
+ * @error matcher-pattern-missing-key-or-value
  */

--- a/packages/ckeditor5-engine/src/view/matcher.js
+++ b/packages/ckeditor5-engine/src/view/matcher.js
@@ -429,10 +429,29 @@ function matchClasses( patterns, element ) {
 // @param {module:engine/view/element~Element} element Element which styles will be tested.
 // @returns {Array|null} Returns array with matched style names or `null` if no styles were matched.
 function matchStyles( patterns, element ) {
+	const mapToDenormalized = ( style => {
+		const styles = element.getNormalizedStyle( style );
+
+		if ( typeof styles == 'object' ) {
+			return Object.entries( styles ).map(
+				( [ st, val ] ) => {
+					return [ `${ style }-${ st }`, val ];
+				}
+			);
+		}
+
+		return [];
+	} );
 	const styles = element.getStyleNames()
 		.map( style => [ style, element.getStyle( style ) ] );
 
-	return matchPatterns( patterns, styles );
+	const denorm = [];
+	styles.forEach( ( [ style ] ) => {
+		const d = mapToDenormalized( style );
+		denorm.push( ...d );
+	} );
+
+	return matchPatterns( patterns, styles.concat( denorm ) );
 }
 
 /**

--- a/packages/ckeditor5-engine/src/view/matcher.js
+++ b/packages/ckeditor5-engine/src/view/matcher.js
@@ -342,17 +342,6 @@ function matchPatterns( patterns, attributes ) {
 	return match;
 }
 
-function isAttributeKeyMatched( patternKey, attributeKey ) {
-	return patternKey === attributeKey ||
-		( patternKey instanceof RegExp && patternKey.test( attributeKey ) );
-}
-
-function isAttributeValueMatched( patternValue, attributeValue ) {
-	return patternValue === true ||
-		patternValue === attributeValue ||
-		( patternValue instanceof RegExp && patternValue.test( attributeValue ) );
-}
-
 // Bring all the possible pattern forms to an array of objects with `key` and `value` property.
 // For example:
 //
@@ -390,6 +379,23 @@ function normalizePatterns( patterns ) {
 	return null;
 }
 
+// @param {String|RegExp} patternKey A pattern representing attribute key we want to match.
+// @param {String} attributeKey An actual attribute key (e.g. `'src'`, `'background-color'`, `'ck-widget'`) we're testing against pattern.
+// @returns {Boolean}
+function isAttributeKeyMatched( patternKey, attributeKey ) {
+	return patternKey === attributeKey ||
+		( patternKey instanceof RegExp && patternKey.test( attributeKey ) );
+}
+
+// @param {String|RegExp} patternValue A pattern representing attribute value we want to match.
+// @param {String} attributeValue An actual attribute value (e.g. `'http://example.com/'`, `'red'`) we're testing against pattern.
+// @returns {Boolean}
+function isAttributeValueMatched( patternValue, attributeValue ) {
+	return patternValue === true ||
+		patternValue === attributeValue ||
+		( patternValue instanceof RegExp && patternValue.test( attributeValue ) );
+}
+
 // Checks if attributes of provided element can be matched against provided patterns.
 //
 // @param {Object} patterns Object with information about attributes to match. Each key of the object will be
@@ -409,6 +415,7 @@ function matchAttributes( patterns, element ) {
 // @param {module:engine/view/element~Element} element Element which classes will be tested.
 // @returns {Array|null} Returns array with matched class names or `null` if no classes were matched.
 function matchClasses( patterns, element ) {
+	// TODO: No special case for classes. We assume the config to be reasonable (i.e. just an array of classes, not an object).
 	const classes = Array.from( element.getClassNames() )
 		.map( className => [ className ] );
 
@@ -478,6 +485,13 @@ function matchStyles( patterns, element ) {
  *				color: /^\w*blue$/
  *			}
  *		};
+ *
+ *		// Match view element which has many custom data attributes.
+ *		const pattern = {
+ *			attributes: [
+ *				{ key: /data-.+/, value: true }
+ *			]
+ *		}
  *
  *		// Pattern with multiple properties.
  *		const pattern = {

--- a/packages/ckeditor5-engine/src/view/matcher.js
+++ b/packages/ckeditor5-engine/src/view/matcher.js
@@ -462,7 +462,7 @@ function matchStyles( patterns, element ) {
  *		const pattern = /^p/;
  *
  * If `MatcherPattern` is given as an `Object`, all the object's properties will be matched with view element properties.
- * If the view element won't meet all of the object's pattern properties, the match won't happen.
+ * If the view element does not meet all of the object's pattern properties, the match will not happen.
  * Available `Object` matching properties:
  *
  * Matching view element:

--- a/packages/ckeditor5-engine/src/view/matcher.js
+++ b/packages/ckeditor5-engine/src/view/matcher.js
@@ -518,7 +518,7 @@ function matchStyles( patterns, element ) {
 *			]
  *		};
  *
- *		// Match view element which has matching attributes (key-value-pairs).
+ *		// Match view element which has matching attributes (key-value pairs).
  *		const pattern = {
  *			name: 'input',
  *			attributes: [
@@ -571,7 +571,7 @@ function matchStyles( patterns, element ) {
 *			]
  *		};
  *
- *		// Match view element which has matching styles (key-value-pairs).
+ *		// Match view element which has matching styles (key-value pairs).
  *		const pattern = {
  *			name: 'p',
  *			attributes: [
@@ -623,7 +623,7 @@ function matchStyles( patterns, element ) {
  *			]
  *		};
  *
- *		// Match view element which has matching classes (key-value-pairs).
+ *		// Match view element which has matching classes (key-value pairs).
  *		const pattern = {
  *			name: 'figure',
  *			classes: [

--- a/packages/ckeditor5-engine/src/view/matcher.js
+++ b/packages/ckeditor5-engine/src/view/matcher.js
@@ -324,19 +324,13 @@ function matchPatterns( patterns, attributes ) {
 
 	patterns = normalizePatterns( patterns ) || [];
 
-	patterns.forEach( ( { key: patternKey, value: patternVal } ) => {
+	patterns.forEach( ( { key: patternKey, value: patternValue } ) => {
 		attributes.forEach( ( [ attributeKey, attributeValue ] ) => {
 			if (
-				patternKey === attributeKey ||
-				( patternKey instanceof RegExp && patternKey.test( attributeKey ) )
+				isAttributeKeyMatched( patternKey, attributeKey ) &&
+				isAttributeValueMatched( patternValue, attributeValue )
 			) {
-				if (
-					patternVal === true ||
-					patternVal === attributeValue ||
-					( patternVal instanceof RegExp && patternVal.test( attributeValue ) )
-				) {
-					match.push( attributeKey );
-				}
+				match.push( attributeKey );
 			}
 		} );
 	} );
@@ -346,6 +340,17 @@ function matchPatterns( patterns, attributes ) {
 	}
 
 	return match;
+}
+
+function isAttributeKeyMatched( patternKey, attributeKey ) {
+	return patternKey === attributeKey ||
+		( patternKey instanceof RegExp && patternKey.test( attributeKey ) );
+}
+
+function isAttributeValueMatched( patternValue, attributeValue ) {
+	return patternValue === true ||
+		patternValue === attributeValue ||
+		( patternValue instanceof RegExp && patternValue.test( attributeValue ) );
 }
 
 // Bring all the possible pattern forms to an array of objects with `key` and `value` property.

--- a/packages/ckeditor5-engine/src/view/styles/background.js
+++ b/packages/ckeditor5-engine/src/view/styles/background.js
@@ -41,6 +41,8 @@ export function addBackgroundRules( stylesProcessor ) {
 
 		return ret;
 	} );
+
+	stylesProcessor.setStyleRelation( 'background', [ 'background-color' ] );
 }
 
 function normalizeBackground( value ) {

--- a/packages/ckeditor5-engine/src/view/stylesmap.js
+++ b/packages/ckeditor5-engine/src/view/stylesmap.js
@@ -25,7 +25,7 @@ export default class StylesMap {
 		 * Keeps an internal representation of styles map. Normalized styles are kept as object tree to allow unified modification and
 		 * value access model using lodash's get, set, unset, etc methods.
 		 *
-		 * When no style processor rules are defined the it acts as simple key-value storage.
+		 * When no style processor rules are defined it acts as simple key-value storage.
 		 *
 		 * @private
 		 * @type {Object}
@@ -350,9 +350,20 @@ export default class StylesMap {
 	}
 
 	/**
-	 * Returns style property names as they would appear when using {@link #toString `#toString()`}.
+	 * Returns all style properties names as they would appear when using {@link #toString `#toString()`}.
 	 *
-	 * TODO param
+	 * When `deep` is set to true and there's a shorthand style property set, it will also return all equivalent styles:
+	 *
+	 * 		// margin: 1em
+	 *
+	 * will be expanded to:
+	 *
+	 * 		// margin-left: 1em
+	 * 		// margin-right: 1em
+	 * 		// margin-top: 1em
+	 * 		// margin-bottom: 1em
+	 *
+	 * @param {Boolean} [deep=false] Expand shorthand style properties and all return equivalent style representations.
 	 * @returns {Array.<String>}
 	 */
 	getStyleNames( deep = false ) {
@@ -567,7 +578,7 @@ export class StylesProcessor {
 	}
 
 	/**
-	 * TODO
+	 * Return all style properties. Expand shorthand properties (e.g. `margin`, `background`).
 	 *
 	 * @param {Object} styles Object holding normalized styles.
 	 * @returns {Array.<String>}

--- a/packages/ckeditor5-engine/src/view/stylesmap.js
+++ b/packages/ckeditor5-engine/src/view/stylesmap.js
@@ -352,7 +352,7 @@ export default class StylesMap {
 	/**
 	 * Returns all style properties names as they would appear when using {@link #toString `#toString()`}.
 	 *
-	 * When `deep` is set to true and there's a shorthand style property set, it will also return all equivalent styles:
+	 * When `expand` is set to true and there's a shorthand style property set, it will also return all equivalent styles:
 	 *
 	 * 		stylesMap.setTo( 'margin: 1em' )
 	 *
@@ -360,15 +360,15 @@ export default class StylesMap {
 	 *
 	 * 		[ 'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left' ]
 	 *
-	 * @param {Boolean} [deep=false] Expand shorthand style properties and all return equivalent style representations.
+	 * @param {Boolean} [expand=false] Expand shorthand style properties and all return equivalent style representations.
 	 * @returns {Array.<String>}
 	 */
-	getStyleNames( deep = false ) {
+	getStyleNames( expand = false ) {
 		if ( this.isEmpty ) {
 			return [];
 		}
 
-		if ( deep ) {
+		if ( expand ) {
 			return this._styleProcessor.getStyleNames( this._styles );
 		}
 

--- a/packages/ckeditor5-engine/src/view/stylesmap.js
+++ b/packages/ckeditor5-engine/src/view/stylesmap.js
@@ -354,14 +354,11 @@ export default class StylesMap {
 	 *
 	 * When `deep` is set to true and there's a shorthand style property set, it will also return all equivalent styles:
 	 *
-	 * 		// margin: 1em
+	 * 		stylesMap.setTo( 'margin: 1em' )
 	 *
 	 * will be expanded to:
 	 *
-	 * 		// margin-left: 1em
-	 * 		// margin-right: 1em
-	 * 		// margin-top: 1em
-	 * 		// margin-bottom: 1em
+	 * 		[ 'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left' ]
 	 *
 	 * @param {Boolean} [deep=false] Expand shorthand style properties and all return equivalent style representations.
 	 * @returns {Array.<String>}
@@ -578,7 +575,7 @@ export class StylesProcessor {
 	}
 
 	/**
-	 * Return all style properties. Expand shorthand properties (e.g. `margin`, `background`).
+	 * Return all style properties. Also expand shorthand properties (e.g. `margin`, `background`) if
 	 *
 	 * @param {Object} styles Object holding normalized styles.
 	 * @returns {Array.<String>}

--- a/packages/ckeditor5-engine/src/view/stylesmap.js
+++ b/packages/ckeditor5-engine/src/view/stylesmap.js
@@ -582,7 +582,7 @@ export class StylesProcessor {
 	 */
 	getStyleNames( styles ) {
 		// Find all extractable styles that have a value.
-		const deepStyleNames = Array.from( this._consumables.keys() ).filter( name => {
+		const expandedStyleNames = Array.from( this._consumables.keys() ).filter( name => {
 			const style = this.getNormalized( name, styles );
 
 			if ( style && typeof style == 'object' ) {
@@ -595,7 +595,7 @@ export class StylesProcessor {
 		// For simple styles (for example `color`) we don't have a map of those styles
 		// but they are 1 to 1 with normalized object keys.
 		const styleNamesKeysSet = new Set( [
-			...deepStyleNames,
+			...expandedStyleNames,
 			...Object.keys( styles )
 		] );
 

--- a/packages/ckeditor5-engine/src/view/stylesmap.js
+++ b/packages/ckeditor5-engine/src/view/stylesmap.js
@@ -575,7 +575,7 @@ export class StylesProcessor {
 	}
 
 	/**
-	 * Return all style properties. Also expand shorthand properties (e.g. `margin`, `background`) if
+	 * Return all style properties. Also expand shorthand properties (e.g. `margin`, `background`) if respective extractor is available.
 	 *
 	 * @param {Object} styles Object holding normalized styles.
 	 * @returns {Array.<String>}

--- a/packages/ckeditor5-engine/src/view/stylesmap.js
+++ b/packages/ckeditor5-engine/src/view/stylesmap.js
@@ -352,11 +352,16 @@ export default class StylesMap {
 	/**
 	 * Returns style property names as they would appear when using {@link #toString `#toString()`}.
 	 *
+	 * TODO param
 	 * @returns {Array.<String>}
 	 */
-	getStyleNames() {
+	getStyleNames( deep = false ) {
 		if ( this.isEmpty ) {
 			return [];
+		}
+
+		if ( deep ) {
+			return this._styleProcessor.getStyleNames( this._styles );
 		}
 
 		const entries = this._getStylesEntries();
@@ -559,6 +564,34 @@ export class StylesProcessor {
 		}
 
 		return [ [ name, normalizedValue ] ];
+	}
+
+	/**
+	 * TODO
+	 *
+	 * @param {Object} styles Object holding normalized styles.
+	 * @returns {Array.<String>}
+	 */
+	getStyleNames( styles ) {
+		// Find all extractable styles that have a value.
+		const deepStyleNames = Array.from( this._consumables.keys() ).filter( name => {
+			const style = this.getNormalized( name, styles );
+
+			if ( style && typeof style == 'object' ) {
+				return Object.keys( style ).length;
+			}
+
+			return style;
+		} );
+
+		// For simple styles (for example `color`) we don't have a map of those styles
+		// but they are 1 to 1 with normalized object keys.
+		const styleNamesKeysSet = new Set( [
+			...deepStyleNames,
+			...Object.keys( styles )
+		] );
+
+		return Array.from( styleNamesKeysSet.values() );
 	}
 
 	/**

--- a/packages/ckeditor5-engine/tests/view/element.js
+++ b/packages/ckeditor5-engine/tests/view/element.js
@@ -892,6 +892,7 @@ describe( 'Element', () => {
 			} );
 		} );
 
+		// TODO add tests for getStyleNames( true )
 		describe( 'getStyleNames', () => {
 			it( 'should return iterator with all style names', () => {
 				const names = [ 'color', 'position' ];

--- a/packages/ckeditor5-engine/tests/view/element.js
+++ b/packages/ckeditor5-engine/tests/view/element.js
@@ -9,6 +9,8 @@ import Element from '../../src/view/element';
 import Text from '../../src/view/text';
 import TextProxy from '../../src/view/textproxy';
 import Document from '../../src/view/document';
+import { addBorderRules } from '../../src/view/styles/border';
+import { addMarginRules } from '../../src/view/styles/margin';
 import { StylesProcessor } from '../../src/view/stylesmap';
 
 describe( 'Element', () => {
@@ -892,7 +894,6 @@ describe( 'Element', () => {
 			} );
 		} );
 
-		// TODO add tests for getStyleNames( true )
 		describe( 'getStyleNames', () => {
 			it( 'should return iterator with all style names', () => {
 				const names = [ 'color', 'position' ];
@@ -908,6 +909,48 @@ describe( 'Element', () => {
 				for ( const name of iterator ) {
 					expect( name ).to.equal( names[ i++ ] );
 				}
+			} );
+		} );
+
+		describe( 'getStyleNames - deep = true', () => {
+			it( 'should return all styles in an expanded form', () => {
+				addBorderRules( el.document.stylesProcessor );
+				addMarginRules( el.document.stylesProcessor );
+
+				el._setStyle( {
+					margin: '1 em',
+					border: '2px dotted silver'
+				} );
+
+				const styles = Array.from( el.getStyleNames( true ) );
+
+				expect( styles ).to.deep.equal( [
+					'border',
+					'border-color',
+					'border-style',
+					'border-width',
+					'border-top',
+					'border-right',
+					'border-bottom',
+					'border-left',
+					'border-top-color',
+					'border-right-color',
+					'border-bottom-color',
+					'border-left-color',
+					'border-top-style',
+					'border-right-style',
+					'border-bottom-style',
+					'border-left-style',
+					'border-top-width',
+					'border-right-width',
+					'border-bottom-width',
+					'border-left-width',
+					'margin',
+					'margin-top',
+					'margin-right',
+					'margin-bottom',
+					'margin-left'
+				] );
 			} );
 		} );
 

--- a/packages/ckeditor5-engine/tests/view/element.js
+++ b/packages/ckeditor5-engine/tests/view/element.js
@@ -912,7 +912,7 @@ describe( 'Element', () => {
 			} );
 		} );
 
-		describe( 'getStyleNames - deep = true', () => {
+		describe( 'getStyleNames - expand = true', () => {
 			it( 'should return all styles in an expanded form', () => {
 				addBorderRules( el.document.stylesProcessor );
 				addMarginRules( el.document.stylesProcessor );

--- a/packages/ckeditor5-engine/tests/view/matcher.js
+++ b/packages/ckeditor5-engine/tests/view/matcher.js
@@ -337,6 +337,56 @@ describe( 'Matcher', () => {
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
+		it( 'should match element class names using an object', () => {
+			const pattern = {
+				classes: {
+					foo: true,
+					bar: true
+				}
+			};
+
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( document, 'p', { class: 'foo bar' } );
+			const el2 = new Element( document, 'p', { class: 'bar'	} );
+			const el3 = new Element( document, 'p', { class: 'qux'	} );
+
+			const result = matcher.match( el1 );
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).that.equal( el1 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
+			expect( result.match.classes.length ).equal( 2 );
+			expect( result.match.classes ).to.deep.equal( [ 'foo', 'bar' ] );
+
+			expect( matcher.match( el2 ) ).to.be.null;
+			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
+		it( 'should match element class names using key->value pairs', () => {
+			const pattern = {
+				classes: [
+					{ key: 'foo', value: true },
+					{ key: /^b.*$/, value: true }
+				]
+			};
+
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( document, 'p', { class: 'foo bar' } );
+			const el2 = new Element( document, 'p', { class: 'bar'	} );
+			const el3 = new Element( document, 'p', { class: 'qux'	} );
+
+			const result = matcher.match( el1 );
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).that.equal( el1 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
+			expect( result.match.classes.length ).equal( 2 );
+			expect( result.match.classes ).to.deep.equal( [ 'foo', 'bar' ] );
+
+			expect( matcher.match( el2 ) ).to.be.null;
+			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
 		it( 'should match element class names using RegExp', () => {
 			const pattern = { classes: /fooba./ };
 			const matcher = new Matcher( pattern );
@@ -437,7 +487,7 @@ describe( 'Matcher', () => {
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
-		it( 'should match element deep styles', () => {
+		it( 'should match element expanded styles', () => {
 			const pattern = {
 				styles: {
 					'border-left-style': /.*/
@@ -466,7 +516,7 @@ describe( 'Matcher', () => {
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
-		it( 'should match element deep styles when CSS shorthand is used', () => {
+		it( 'should match element expanded styles when CSS shorthand is used', () => {
 			const pattern = {
 				styles: {
 					'border-left': /.*/

--- a/packages/ckeditor5-engine/tests/view/matcher.js
+++ b/packages/ckeditor5-engine/tests/view/matcher.js
@@ -134,6 +134,54 @@ describe( 'Matcher', () => {
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
+		it( 'should match all element attributes using key->value, where key is a RegExp object and value is a boolean', () => {
+			const pattern = {
+				attributes: [
+					{ key: /data-b.*/, value: true }
+				]
+			};
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( document, 'p', { 'data-foo': 'foo', 'data-bar': 'bar', title: 'other' } );
+			const el2 = new Element( document, 'p', { title: 'foobar' } );
+			const el3 = new Element( document, 'p' );
+
+			const result = matcher.match( el1 );
+
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).and.equal( el1 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
+			expect( result.match.attributes.length ).equal( 1 );
+			expect( result.match.attributes[ 0 ] ).equal( 'data-bar' );
+
+			expect( matcher.match( el2 ) ).to.be.null;
+			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
+		it( 'should match all element attributes using key->value, where key is a RegExp object and value is a string', () => {
+			const pattern = {
+				attributes: [
+					{ key: /data-.*/, value: 'bar' }
+				]
+			};
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( document, 'p', { 'data-foo': 'foo', 'data-bar': 'bar', title: 'other' } );
+			const el2 = new Element( document, 'p', { title: 'foobar' } );
+			const el3 = new Element( document, 'p' );
+
+			const result = matcher.match( el1 );
+
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).and.equal( el1 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
+			expect( result.match.attributes.length ).equal( 1 );
+			expect( result.match.attributes[ 0 ] ).equal( 'data-bar' );
+
+			expect( matcher.match( el2 ) ).to.be.null;
+			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
 		it( 'should match all element attributes using key->value, where both are RegExp objects', () => {
 			const pattern = {
 				attributes: [
@@ -158,31 +206,18 @@ describe( 'Matcher', () => {
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
-		it( 'should match all element attributes using key->value, where key is a RegExp object', () => {
+		it( 'should match nothing if pattern is incorrect', () => {
 			const pattern = {
-				attributes: [
-					{ key: /data-.*/, value: 'bar' }
-				]
+				// A stub for a non-plain object.
+				attributes: 1
 			};
 			const matcher = new Matcher( pattern );
 			const el1 = new Element( document, 'p', { 'data-foo': 'foo', 'data-bar': 'bar', title: 'other' } );
-			const el2 = new Element( document, 'p', { title: 'foobar' } );
-			const el3 = new Element( document, 'p' );
 
-			const result = matcher.match( el1 );
-
-			expect( result ).to.be.an( 'object' );
-			expect( result ).to.have.property( 'element' ).and.equal( el1 );
-			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
-			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
-			expect( result.match.attributes.length ).equal( 1 );
-			expect( result.match.attributes[ 0 ] ).equal( 'data-bar' );
-
-			expect( matcher.match( el2 ) ).to.be.null;
-			expect( matcher.match( el3 ) ).to.be.null;
+			expect( matcher.match( el1 ) ).to.be.null;
 		} );
 
-		it( 'should match element attributes', () => {
+		it( 'should match element attributes using String', () => {
 			const pattern = {
 				attributes: {
 					title: 'foobar'

--- a/packages/ckeditor5-engine/tests/view/matcher.js
+++ b/packages/ckeditor5-engine/tests/view/matcher.js
@@ -90,8 +90,6 @@ describe( 'Matcher', () => {
 			expect( matcher.match( el2 ) ).to.be.null;
 		} );
 
-		// TODO: Add test for making sure all attributes has to be matched (AND operator instead of OR).
-
 		it( 'should match all element attributes', () => {
 			const pattern = {
 				attributes: true
@@ -409,7 +407,6 @@ describe( 'Matcher', () => {
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
-		// TODO: Should I `addStyleProcessorRules()` by myself in Matcher?
 		it( 'should match element styles when CSS shorthand is used', () => {
 			const pattern = {
 				styles: {

--- a/packages/ckeditor5-engine/tests/view/matcher.js
+++ b/packages/ckeditor5-engine/tests/view/matcher.js
@@ -83,6 +83,8 @@ describe( 'Matcher', () => {
 			expect( matcher.match( el2 ) ).to.be.null;
 		} );
 
+		// TODO: Add test for making sure all attributes has to be matched (AND operator instead of OR).
+
 		it( 'should match all element attributes', () => {
 			const pattern = {
 				attributes: true
@@ -313,25 +315,28 @@ describe( 'Matcher', () => {
 		it( 'should match element class names using an array', () => {
 			const pattern = { classes: [ 'foobar', 'foobaz' ] };
 			const matcher = new Matcher( pattern );
-			const el1 = new Element( document, 'p', { class: 'foobar'	} );
-			const el2 = new Element( document, 'p', { class: 'foobaz'	} );
-			const el3 = new Element( document, 'p', { class: 'qux'	} );
+			const el1 = new Element( document, 'p', { class: 'foobar foobaz' } );
 
-			let result = matcher.match( el1 );
+			// TODO: Uncomment after deciding whether we want AND or OR operand for array of patterns.
+			// const el2 = new Element( document, 'p', { class: 'foobaz'	} );
+			// const el3 = new Element( document, 'p', { class: 'qux'	} );
+
+			const result = matcher.match( el1 );
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
 			expect( result.match.classes[ 0 ] ).equal( 'foobar' );
 
-			result = matcher.match( el2 );
-			expect( result ).to.be.an( 'object' );
-			expect( result ).to.have.property( 'element' ).that.equal( el2 );
-			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
-			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
-			expect( result.match.classes[ 0 ] ).equal( 'foobaz' );
+			// TODO: Uncomment after deciding whether we want AND or OR operand for array of patterns.
+			// result = matcher.match( el2 );
+			// expect( result ).to.be.an( 'object' );
+			// expect( result ).to.have.property( 'element' ).that.equal( el2 );
+			// expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			// expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
+			// expect( result.match.classes[ 0 ] ).equal( 'foobaz' );
 
-			expect( matcher.match( el3 ) ).to.be.null;
+			// expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
 		it( 'should match element class names using RegExp', () => {

--- a/packages/ckeditor5-engine/tests/view/matcher.js
+++ b/packages/ckeditor5-engine/tests/view/matcher.js
@@ -7,6 +7,7 @@ import Matcher from '../../src/view/matcher';
 import Element from '../../src/view/element';
 import Document from '../../src/view/document';
 import { StylesProcessor } from '../../src/view/stylesmap';
+import { addMarginRules } from '../../src/view/styles/margin';
 
 describe( 'Matcher', () => {
 	let document;
@@ -406,6 +407,38 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
 			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
+
+			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
+		// TODO: Should I `addStyleProcessorRules()` by myself in Matcher?
+		it( 'should match element styles when CSS shorthand is used', () => {
+			const pattern = {
+				styles: {
+					'margin-left': /.*/
+				}
+			};
+			const matcher = new Matcher( pattern );
+
+			addMarginRules( document.stylesProcessor );
+
+			const el1 = new Element( document, 'p', { style: 'margin: 1px' } );
+			const el2 = new Element( document, 'p', { style: 'margin-left: darkblue' } );
+			const el3 = new Element( document, 'p', { style: 'border: 1px solid' } );
+
+			let result = matcher.match( el1 );
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).that.equal( el1 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
+			expect( result.match.styles[ 0 ] ).to.equal( 'margin-left' );
+
+			result = matcher.match( el2 );
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).that.equal( el2 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
+			expect( result.match.styles[ 0 ] ).to.equal( 'margin-left' );
 
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );

--- a/packages/ckeditor5-engine/tests/view/matcher.js
+++ b/packages/ckeditor5-engine/tests/view/matcher.js
@@ -83,6 +83,105 @@ describe( 'Matcher', () => {
 			expect( matcher.match( el2 ) ).to.be.null;
 		} );
 
+		it( 'should match all element attributes', () => {
+			const pattern = {
+				attributes: true
+			};
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( document, 'p', { title: 'foobar' } );
+			const el2 = new Element( document, 'p', { title: ''	} );
+			const el3 = new Element( document, 'p' );
+
+			let result = matcher.match( el1 );
+
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).and.equal( el1 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
+			expect( result.match.attributes[ 0 ] ).equal( 'title' );
+
+			result = matcher.match( el2 );
+
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).and.equal( el2 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
+			expect( result.match.attributes[ 0 ] ).equal( 'title' );
+
+			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
+		it( 'should match all element attributes using RegExp', () => {
+			const pattern = {
+				attributes: /data-.*/
+			};
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( document, 'p', { 'data-foo': 'foo', 'data-bar': 'bar', title: 'other' } );
+			const el2 = new Element( document, 'p', { title: 'foobar' } );
+			const el3 = new Element( document, 'p' );
+
+			const result = matcher.match( el1 );
+
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).and.equal( el1 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
+			expect( result.match.attributes.length ).equal( 2 );
+			expect( result.match.attributes[ 0 ] ).equal( 'data-foo' );
+			expect( result.match.attributes[ 1 ] ).equal( 'data-bar' );
+
+			expect( matcher.match( el2 ) ).to.be.null;
+			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
+		it( 'should match all element attributes using key->value, where both are RegExp objects', () => {
+			const pattern = {
+				attributes: [
+					{ key: /data-.*/, value: /b.*?r/ }
+				]
+			};
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( document, 'p', { 'data-foo': 'foo', 'data-bar': 'bar', title: 'other' } );
+			const el2 = new Element( document, 'p', { title: 'foobar' } );
+			const el3 = new Element( document, 'p' );
+
+			const result = matcher.match( el1 );
+
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).and.equal( el1 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
+			expect( result.match.attributes.length ).equal( 1 );
+			expect( result.match.attributes[ 0 ] ).equal( 'data-bar' );
+
+			expect( matcher.match( el2 ) ).to.be.null;
+			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
+		it( 'should match all element attributes using key->value, where key is a RegExp object', () => {
+			const pattern = {
+				attributes: [
+					{ key: /data-.*/, value: 'bar' }
+				]
+			};
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( document, 'p', { 'data-foo': 'foo', 'data-bar': 'bar', title: 'other' } );
+			const el2 = new Element( document, 'p', { title: 'foobar' } );
+			const el3 = new Element( document, 'p' );
+
+			const result = matcher.match( el1 );
+
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).and.equal( el1 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
+			expect( result.match.attributes.length ).equal( 1 );
+			expect( result.match.attributes[ 0 ] ).equal( 'data-bar' );
+
+			expect( matcher.match( el2 ) ).to.be.null;
+			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
 		it( 'should match element attributes', () => {
 			const pattern = {
 				attributes: {

--- a/packages/ckeditor5-engine/tests/view/matcher.js
+++ b/packages/ckeditor5-engine/tests/view/matcher.js
@@ -318,9 +318,8 @@ describe( 'Matcher', () => {
 			const matcher = new Matcher( pattern );
 			const el1 = new Element( document, 'p', { class: 'foobar foobaz' } );
 
-			// TODO: Uncomment after deciding whether we want AND or OR operand for array of patterns.
-			// const el2 = new Element( document, 'p', { class: 'foobaz'	} );
-			// const el3 = new Element( document, 'p', { class: 'qux'	} );
+			const el2 = new Element( document, 'p', { class: 'foobaz'	} );
+			const el3 = new Element( document, 'p', { class: 'qux'	} );
 
 			const result = matcher.match( el1 );
 			expect( result ).to.be.an( 'object' );
@@ -329,15 +328,8 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
 			expect( result.match.classes[ 0 ] ).equal( 'foobar' );
 
-			// TODO: Uncomment after deciding whether we want AND or OR operand for array of patterns.
-			// result = matcher.match( el2 );
-			// expect( result ).to.be.an( 'object' );
-			// expect( result ).to.have.property( 'element' ).that.equal( el2 );
-			// expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
-			// expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
-			// expect( result.match.classes[ 0 ] ).equal( 'foobaz' );
-
-			// expect( matcher.match( el3 ) ).to.be.null;
+			expect( matcher.match( el2 ) ).to.be.null;
+			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
 		it( 'should match element class names using RegExp', () => {

--- a/packages/ckeditor5-engine/tests/view/matcher.js
+++ b/packages/ckeditor5-engine/tests/view/matcher.js
@@ -310,6 +310,30 @@ describe( 'Matcher', () => {
 			expect( new Matcher( { classes: 'baz' } ).match( el1 ) ).to.be.null;
 		} );
 
+		it( 'should match element class names using an array', () => {
+			const pattern = { classes: [ 'foobar', 'foobaz' ] };
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( document, 'p', { class: 'foobar'	} );
+			const el2 = new Element( document, 'p', { class: 'foobaz'	} );
+			const el3 = new Element( document, 'p', { class: 'qux'	} );
+
+			let result = matcher.match( el1 );
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).that.equal( el1 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
+			expect( result.match.classes[ 0 ] ).equal( 'foobar' );
+
+			result = matcher.match( el2 );
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).that.equal( el2 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
+			expect( result.match.classes[ 0 ] ).equal( 'foobaz' );
+
+			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
 		it( 'should match element class names using RegExp', () => {
 			const pattern = { classes: /fooba./ };
 			const matcher = new Matcher( pattern );
@@ -353,6 +377,60 @@ describe( 'Matcher', () => {
 			expect( new Matcher( { styles: { color: 'blue' } } ).match( el1 ) ).to.be.null;
 		} );
 
+		it( 'should match element styles using boolean', () => {
+			const pattern = {
+				styles: {
+					color: true
+				}
+			};
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( document, 'p', { style: 'color: blue' } );
+			const el2 = new Element( document, 'p', { style: 'color: darkblue' } );
+			const el3 = new Element( document, 'p', { style: 'border: 1px solid' } );
+
+			let result = matcher.match( el1 );
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).that.equal( el1 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
+			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
+
+			result = matcher.match( el2 );
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).that.equal( el2 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
+			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
+
+			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
+		it( 'should match element styles using an array', () => {
+			const pattern = {
+				styles: [ 'color' ]
+			};
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( document, 'p', { style: 'color: blue' } );
+			const el2 = new Element( document, 'p', { style: 'color: darkblue' } );
+			const el3 = new Element( document, 'p', { style: 'border: 1px solid' } );
+
+			let result = matcher.match( el1 );
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).that.equal( el1 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
+			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
+
+			result = matcher.match( el2 );
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).that.equal( el2 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
+			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
+
+			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
 		it( 'should match element styles using RegExp', () => {
 			const pattern = {
 				styles: {
@@ -377,6 +455,28 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
 			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
+			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
+		it( 'should match element styles using key->value, where both are RegExp objects', () => {
+			const pattern = {
+				styles: [
+					{ key: /border-.*/, value: /.*/ }
+				]
+			};
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( document, 'p', { style: 'border-top: 1px solid blue' } );
+			const el2 = new Element( document, 'p', { style: 'border: 1px solid red' } );
+			const el3 = new Element( document, 'p', { style: 'color: red' } );
+
+			const result = matcher.match( el1 );
+			expect( result ).to.be.an( 'object' );
+			expect( result ).to.have.property( 'element' ).that.equal( el1 );
+			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
+			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
+			expect( result.match.styles[ 0 ] ).to.equal( 'border-top' );
+
+			expect( matcher.match( el2 ) ).to.be.null;
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 

--- a/packages/ckeditor5-engine/tests/view/matcher.js
+++ b/packages/ckeditor5-engine/tests/view/matcher.js
@@ -98,7 +98,7 @@ describe( 'Matcher', () => {
 			};
 			const matcher = new Matcher( pattern );
 			const el1 = new Element( document, 'p', { title: 'foobar' } );
-			const el2 = new Element( document, 'p', { title: ''	} );
+			const el2 = new Element( document, 'p', { title: '', alt: 'alternative'	} );
 			const el3 = new Element( document, 'p' );
 
 			let result = matcher.match( el1 );
@@ -107,7 +107,7 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).and.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
-			expect( result.match.attributes[ 0 ] ).equal( 'title' );
+			expect( result.match.attributes ).to.deep.equal( [ 'title' ] );
 
 			result = matcher.match( el2 );
 
@@ -115,7 +115,7 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).and.equal( el2 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
-			expect( result.match.attributes[ 0 ] ).equal( 'title' );
+			expect( result.match.attributes ).to.deep.equal( [ 'title', 'alt' ] );
 
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
@@ -136,8 +136,7 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
 			expect( result.match.attributes.length ).equal( 2 );
-			expect( result.match.attributes[ 0 ] ).equal( 'data-foo' );
-			expect( result.match.attributes[ 1 ] ).equal( 'data-bar' );
+			expect( result.match.attributes ).to.deep.equal( [ 'data-foo', 'data-bar' ] );
 
 			expect( matcher.match( el2 ) ).to.be.null;
 			expect( matcher.match( el3 ) ).to.be.null;
@@ -161,7 +160,7 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
 			expect( result.match.attributes.length ).equal( 1 );
-			expect( result.match.attributes[ 0 ] ).equal( 'data-bar' );
+			expect( result.match.attributes ).to.deep.equal( [ 'data-bar' ] );
 
 			expect( matcher.match( el2 ) ).to.be.null;
 			expect( matcher.match( el3 ) ).to.be.null;
@@ -185,7 +184,7 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
 			expect( result.match.attributes.length ).equal( 1 );
-			expect( result.match.attributes[ 0 ] ).equal( 'data-bar' );
+			expect( result.match.attributes ).to.deep.equal( [ 'data-bar' ] );
 
 			expect( matcher.match( el2 ) ).to.be.null;
 			expect( matcher.match( el3 ) ).to.be.null;
@@ -209,7 +208,7 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
 			expect( result.match.attributes.length ).equal( 1 );
-			expect( result.match.attributes[ 0 ] ).equal( 'data-bar' );
+			expect( result.match.attributes ).to.deep.equal( [ 'data-bar' ] );
 
 			expect( matcher.match( el2 ) ).to.be.null;
 			expect( matcher.match( el3 ) ).to.be.null;
@@ -245,7 +244,7 @@ describe( 'Matcher', () => {
 
 			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
 
-			expect( result.match.attributes[ 0 ] ).equal( 'title' );
+			expect( result.match.attributes ).to.deep.equal( [ 'title' ] );
 			expect( matcher.match( el2 ) ).to.be.null;
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
@@ -266,14 +265,14 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
-			expect( result.match.attributes[ 0 ] ).equal( 'title' );
+			expect( result.match.attributes ).to.deep.equal( [ 'title' ] );
 
 			result = matcher.match( el2 );
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el2 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
-			expect( result.match.attributes[ 0 ] ).equal( 'title' );
+			expect( result.match.attributes ).to.deep.equal( [ 'title' ] );
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
@@ -293,14 +292,14 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
-			expect( result.match.attributes[ 0 ] ).equal( 'title' );
+			expect( result.match.attributes ).to.deep.equal( [ 'title' ] );
 
 			result = matcher.match( el2 );
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el2 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'attributes' ).that.is.an( 'array' );
-			expect( result.match.attributes[ 0 ] ).equal( 'title' );
+			expect( result.match.attributes ).to.deep.equal( [ 'title' ] );
 
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
@@ -315,7 +314,7 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
-			expect( result.match.classes[ 0 ] ).equal( 'foobar' );
+			expect( result.match.classes ).to.deep.equal( [ 'foobar' ] );
 			expect( new Matcher( { classes: 'baz' } ).match( el1 ) ).to.be.null;
 		} );
 
@@ -332,8 +331,7 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
 			expect( result.match.classes.length ).equal( 2 );
-			expect( result.match.classes[ 0 ] ).equal( 'foo' );
-			expect( result.match.classes[ 1 ] ).equal( 'bar' );
+			expect( result.match.classes ).to.deep.equal( [ 'foo', 'bar' ] );
 
 			expect( matcher.match( el2 ) ).to.be.null;
 			expect( matcher.match( el3 ) ).to.be.null;
@@ -351,14 +349,14 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
-			expect( result.match.classes[ 0 ] ).equal( 'foobar' );
+			expect( result.match.classes ).to.deep.equal( [ 'foobar' ] );
 
 			result = matcher.match( el2 );
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el2 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
-			expect( result.match.classes[ 0 ] ).equal( 'foobaz' );
+			expect( result.match.classes ).to.deep.equal( [ 'foobaz' ] );
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
@@ -377,7 +375,7 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
-			expect( result.match.styles[ 0 ] ).equal( 'color' );
+			expect( result.match.styles ).to.deep.equal( [ 'color' ] );
 			expect( matcher.match( el2 ) ).to.be.null;
 			expect( new Matcher( { styles: { color: 'blue' } } ).match( el1 ) ).to.be.null;
 		} );
@@ -398,14 +396,14 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
-			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
+			expect( result.match.styles ).to.deep.equal( [ 'color' ] );
 
 			result = matcher.match( el2 );
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el2 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
-			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
+			expect( result.match.styles ).to.deep.equal( [ 'color' ] );
 
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
@@ -427,14 +425,14 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
-			expect( result.match.styles[ 0 ] ).to.equal( 'margin-left' );
+			expect( result.match.styles ).to.deep.equal( [ 'margin-left' ] );
 
 			result = matcher.match( el2 );
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el2 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
-			expect( result.match.styles[ 0 ] ).to.equal( 'margin-left' );
+			expect( result.match.styles ).to.deep.equal( [ 'margin-left' ] );
 
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
@@ -456,14 +454,14 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
-			expect( result.match.styles[ 0 ] ).to.equal( 'border-left-style' );
+			expect( result.match.styles ).to.deep.equal( [ 'border-left-style' ] );
 
 			result = matcher.match( el2 );
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el2 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
-			expect( result.match.styles[ 0 ] ).to.equal( 'border-left-style' );
+			expect( result.match.styles ).to.deep.equal( [ 'border-left-style' ] );
 
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
@@ -485,14 +483,14 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
-			expect( result.match.styles[ 0 ] ).to.equal( 'border-left' );
+			expect( result.match.styles ).to.deep.equal( [ 'border-left' ] );
 
 			result = matcher.match( el2 );
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el2 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
-			expect( result.match.styles[ 0 ] ).to.equal( 'border-left' );
+			expect( result.match.styles ).to.deep.equal( [ 'border-left' ] );
 
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
@@ -511,14 +509,14 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
-			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
+			expect( result.match.styles ).to.deep.equal( [ 'color' ] );
 
 			result = matcher.match( el2 );
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el2 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
-			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
+			expect( result.match.styles ).to.deep.equal( [ 'color' ] );
 
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
@@ -539,14 +537,14 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
-			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
+			expect( result.match.styles ).to.deep.equal( [ 'color' ] );
 
 			result = matcher.match( el2 );
 			expect( result ).to.be.an( 'object' );
 			expect( result ).to.have.property( 'element' ).that.equal( el2 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'styles' ).that.is.an( 'array' );
-			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
+			expect( result.match.styles ).to.deep.equal( [ 'color' ] );
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
@@ -590,7 +588,7 @@ describe( 'Matcher', () => {
 			expect( matcher.match( el3 ) ).to.be.null;
 		} );
 
-		it( 'should display warning when key->value pattern is missing either key or value', () => {
+		it( 'should display warning when key->value pattern is missing key', () => {
 			const pattern = {
 				styles: [
 					{ key: /border-.*/ }
@@ -604,9 +602,32 @@ describe( 'Matcher', () => {
 
 			sinon.assert.calledOnceWithMatch(
 				warnStub,
-				'matcher-patterns-pattern-missing-key-or-value',
+				'matcher-pattern-missing-key-or-value',
 				pattern.styles[ 0 ]
 			);
+
+			sinon.restore();
+		} );
+
+		it( 'should display warning when key->value pattern is missing value', () => {
+			const pattern = {
+				styles: [
+					{ value: 'red' }
+				]
+			};
+			const warnStub = sinon.stub( console, 'warn' );
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( document, 'p', { style: 'border-top: 1px solid blue' } );
+
+			matcher.match( el1 );
+
+			sinon.assert.calledOnceWithMatch(
+				warnStub,
+				'matcher-pattern-missing-key-or-value',
+				pattern.styles[ 0 ]
+			);
+
+			sinon.restore();
 		} );
 
 		it( 'should allow to use function as a pattern', () => {
@@ -666,8 +687,7 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.is.an( 'object' );
 			expect( result.match ).to.have.property( 'attributes' ).that.is.an( 'array' );
-			expect( result.match.attributes[ 0 ] ).to.equal( 'name' );
-			expect( result.match.attributes[ 1 ] ).to.equal( 'title' );
+			expect( result.match.attributes ).to.deep.equal( [ 'name', 'title' ] );
 		} );
 
 		it( 'should match multiple classes', () => {
@@ -685,8 +705,7 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.is.an( 'object' );
 			expect( result.match ).to.have.property( 'classes' ).that.is.an( 'array' );
-			expect( result.match.classes[ 0 ] ).to.equal( 'foo' );
-			expect( result.match.classes[ 1 ] ).to.equal( 'bar' );
+			expect( result.match.classes ).to.deep.equal( [ 'foo', 'bar' ] );
 		} );
 
 		it( 'should match multiple styles', () => {
@@ -710,8 +729,7 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.is.an( 'object' );
 			expect( result.match ).to.have.property( 'styles' ).that.is.an( 'array' );
-			expect( result.match.styles[ 0 ] ).to.equal( 'color' );
-			expect( result.match.styles[ 1 ] ).to.equal( 'position' );
+			expect( result.match.styles ).to.deep.equal( [ 'color', 'position' ] );
 		} );
 	} );
 

--- a/packages/ckeditor5-engine/tests/view/matcher.js
+++ b/packages/ckeditor5-engine/tests/view/matcher.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+/* global console */
+
 import Matcher from '../../src/view/matcher';
 import Element from '../../src/view/element';
 import Document from '../../src/view/document';
@@ -318,11 +320,10 @@ describe( 'Matcher', () => {
 		} );
 
 		it( 'should match element class names using an array', () => {
-			const pattern = { classes: [ 'foobar', 'foobaz' ] };
+			const pattern = { classes: [ 'foo', 'bar' ] };
 			const matcher = new Matcher( pattern );
-			const el1 = new Element( document, 'p', { class: 'foobar foobaz' } );
-
-			const el2 = new Element( document, 'p', { class: 'foobaz'	} );
+			const el1 = new Element( document, 'p', { class: 'foo bar' } );
+			const el2 = new Element( document, 'p', { class: 'bar'	} );
 			const el3 = new Element( document, 'p', { class: 'qux'	} );
 
 			const result = matcher.match( el1 );
@@ -330,7 +331,9 @@ describe( 'Matcher', () => {
 			expect( result ).to.have.property( 'element' ).that.equal( el1 );
 			expect( result ).to.have.property( 'pattern' ).that.equal( pattern );
 			expect( result ).to.have.property( 'match' ).that.has.property( 'classes' ).that.is.an( 'array' );
-			expect( result.match.classes[ 0 ] ).equal( 'foobar' );
+			expect( result.match.classes.length ).equal( 2 );
+			expect( result.match.classes[ 0 ] ).equal( 'foo' );
+			expect( result.match.classes[ 1 ] ).equal( 'bar' );
 
 			expect( matcher.match( el2 ) ).to.be.null;
 			expect( matcher.match( el3 ) ).to.be.null;
@@ -585,6 +588,25 @@ describe( 'Matcher', () => {
 			] );
 
 			expect( matcher.match( el3 ) ).to.be.null;
+		} );
+
+		it( 'should display warning when key->value pattern is missing either key or value', () => {
+			const pattern = {
+				styles: [
+					{ key: /border-.*/ }
+				]
+			};
+			const warnStub = sinon.stub( console, 'warn' );
+			const matcher = new Matcher( pattern );
+			const el1 = new Element( document, 'p', { style: 'border-top: 1px solid blue' } );
+
+			matcher.match( el1 );
+
+			sinon.assert.calledOnceWithMatch(
+				warnStub,
+				'matcher-patterns-pattern-missing-key-or-value',
+				pattern.styles[ 0 ]
+			);
 		} );
 
 		it( 'should allow to use function as a pattern', () => {

--- a/packages/ckeditor5-engine/tests/view/stylesmap.js
+++ b/packages/ckeditor5-engine/tests/view/stylesmap.js
@@ -272,7 +272,7 @@ describe( 'StylesMap', () => {
 			expect( stylesMap.getStyleNames() ).to.deep.equal( [ 'foo' ] );
 		} );
 
-		it( 'should output full names for known style names - deep = true', () => {
+		it( 'should output full names for known style names - expand = true', () => {
 			stylesMap.setTo( 'margin: 1px' );
 
 			expect( stylesMap.getStyleNames( true ) ).to.deep.equal( [
@@ -284,7 +284,7 @@ describe( 'StylesMap', () => {
 			expect( stylesMap.getStyleNames( true ) ).to.deep.equal( [ 'margin', 'margin-top' ] );
 		} );
 
-		it( 'should output full names for known style names - deep = true - other extractors must not affect the output', () => {
+		it( 'should output full names for known style names - expand = true - other extractors must not affect the output', () => {
 			// Let's add this line to ensure that only matching extractors are used to expand style names.
 			addBorderRules( stylesProcessor );
 

--- a/packages/ckeditor5-engine/tests/view/stylesmap.js
+++ b/packages/ckeditor5-engine/tests/view/stylesmap.js
@@ -6,13 +6,14 @@
 import StylesMap, { StylesProcessor } from '../../src/view/stylesmap';
 import encodedImage from './_utils/encodedimage.txt';
 import { addMarginRules } from '../../src/view/styles/margin';
+import { addBorderRules } from '../../src/view/styles/border';
 import { getBoxSidesValueReducer } from '../../src/view/styles/utils';
 
 describe( 'StylesMap', () => {
-	let stylesMap;
+	let stylesMap, stylesProcessor;
 
 	beforeEach( () => {
-		const stylesProcessor = new StylesProcessor();
+		stylesProcessor = new StylesProcessor();
 
 		// Define simple "foo" shorthand normalizers, similar to the "margin" shorthand normalizers, for testing purposes.
 		stylesProcessor.setNormalizer( 'foo', value => ( {
@@ -272,6 +273,21 @@ describe( 'StylesMap', () => {
 		} );
 
 		it( 'should output full names for known style names - deep = true', () => {
+			stylesMap.setTo( 'margin: 1px' );
+
+			expect( stylesMap.getStyleNames( true ) ).to.deep.equal( [
+				'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left'
+			] );
+
+			stylesMap.setTo( 'margin-top: 1px' );
+
+			expect( stylesMap.getStyleNames( true ) ).to.deep.equal( [ 'margin', 'margin-top' ] );
+		} );
+
+		it( 'should output full names for known style names - deep = true - other extractors must not affect the output', () => {
+			// Let's add this line to ensure that only matching extractors are used to expand style names.
+			addBorderRules( stylesProcessor );
+
 			stylesMap.setTo( 'margin: 1px' );
 
 			expect( stylesMap.getStyleNames( true ) ).to.deep.equal( [

--- a/packages/ckeditor5-engine/tests/view/stylesmap.js
+++ b/packages/ckeditor5-engine/tests/view/stylesmap.js
@@ -254,7 +254,6 @@ describe( 'StylesMap', () => {
 		} );
 	} );
 
-	// TODO tests for getStyleNames( true )
 	describe( 'getStyleNames()', () => {
 		it( 'should output empty array for empty styles', () => {
 			expect( stylesMap.getStyleNames() ).to.deep.equal( [] );
@@ -270,6 +269,18 @@ describe( 'StylesMap', () => {
 			stylesMap.setTo( 'foo: 1px;foo-top: 2em;' );
 
 			expect( stylesMap.getStyleNames() ).to.deep.equal( [ 'foo' ] );
+		} );
+
+		it( 'should output full names for known style names - deep = true', () => {
+			stylesMap.setTo( 'margin: 1px' );
+
+			expect( stylesMap.getStyleNames( true ) ).to.deep.equal( [
+				'margin', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left'
+			] );
+
+			stylesMap.setTo( 'margin-top: 1px' );
+
+			expect( stylesMap.getStyleNames( true ) ).to.deep.equal( [ 'margin', 'margin-top' ] );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-engine/tests/view/stylesmap.js
+++ b/packages/ckeditor5-engine/tests/view/stylesmap.js
@@ -254,6 +254,7 @@ describe( 'StylesMap', () => {
 		} );
 	} );
 
+	// TODO tests for getStyleNames( true )
 	describe( 'getStyleNames()', () => {
 		it( 'should output empty array for empty styles', () => {
 			expect( stylesMap.getStyleNames() ).to.deep.equal( [] );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (engine): Improved engine view matcher with new pattern syntax allowing to match attribute keys using regular expressions. Unified pattern syntax between attributes, styles, and classes. Closes #9872.

Feature (engine): Added special `expand` option to `StylesMap.getStyleNames()` and view `Element.getStyleNames()` methods allowing to expand shorthand style properties.

---

### Additional information

* Adding missing test suite to `StylesProcessor` will be handled in the follow-up: https://github.com/ckeditor/ckeditor5/issues/9811.
* Exclusion of `style` and `class` attributes is reverted back to original form. There is a follow-up, where we'll decide how to approach this: https://github.com/ckeditor/ckeditor5/issues/9813.
