### PR TITLE
Move hard coded colors from components to global _colors.css

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/splitbutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/splitbutton.css
@@ -5,11 +5,6 @@
 
 @import "../../../mixins/_rounded.css";
 
-:root {
-	--ck-color-split-button-hover-background: hsl(0, 0%, 92%);
-	--ck-color-split-button-hover-border: hsl(0, 0%, 70%);
-}
-
 .ck.ck-splitbutton {
 	/*
 	 * Note: ck-rounded and ck-dir mixins don't go together (because they both use @nest).

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/editorui/editorui.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/editorui/editorui.css
@@ -9,10 +9,6 @@
 @import "../../../mixins/_focus.css";
 @import "../../mixins/_button.css";
 
-:root {
-	--ck-color-editable-blur-selection: hsl(0, 0%, 85%);
-}
-
 .ck.ck-editor__editable:not(.ck-editor__nested-editable) {
 	@mixin ck-rounded-corners;
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_colors.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_colors.css
@@ -57,6 +57,9 @@
 	--ck-color-switch-button-inner-background:					var(--ck-color-base-background);
 	--ck-color-switch-button-inner-shadow:						hsla(0, 0%, 0%, 0.1);
 
+	--ck-color-split-button-hover-background:                   hsl(0, 0%, 92%);
+	--ck-color-split-button-hover-border:                       hsl(0, 0%, 70%);
+	
 	/* -- Dropdown ------------------------------------------------------------------------------ */
 
 	--ck-color-dropdown-panel-background: 						var(--ck-color-base-background);
@@ -103,9 +106,14 @@
 
 	--ck-color-upload-bar-background:		 					hsl(209, 92%, 70%);
 
-	/* -- Link -------------------------------------------------------------------------------- */
+	/* -- Link ---------------------------------------------------------------------------------- */
 
 	--ck-color-link-default:									hsl(240, 100%, 47%);
 	--ck-color-link-selected-background:						hsla(201, 100%, 56%, 0.1);
 	--ck-color-link-fake-selection:								hsla(201, 100%, 56%, 0.3);
+
+	/* Editor ------------------------------------------------------------------------------------ */
+	
+	--ck-color-editable-blur-selection:                         hsl(0, 0%, 85%);
+
 }


### PR DESCRIPTION
This posed a problem for me while I was trying to implement my own dark theme by overriding colors in _colors.css as described by the documentation. I had this light background on unfocussed selected text and had to go through the components css files to find where this was defined and override it myself.

![image](https://user-images.githubusercontent.com/10884874/119040037-eee7fc80-b982-11eb-842d-55159dce1457.png)

