### PR TITLE
Developer loop sample: yarn start

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
   "workspaces": {
     "packages": [
       "packages/*",
+      "packages/sample/*",
       "external/*",
       "external/*/packages/*",
       "external/*/external/*",

--- a/packages/ckeditor5-media-embed/sample/app.js
+++ b/packages/ckeditor5-media-embed/sample/app.js
@@ -1,0 +1,39 @@
+/* eslint-disable no-undef */
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
+import { Paragraph } from 'ckeditor5/src/paragraph';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
+
+import { genericUrlRegex } from '@social-embed/lib';
+
+import MediaEmbed from '../src/mediaembed';
+
+import '@social-embed/wc';
+
+ClassicEditor.create( document.querySelector( '#editor' ), {
+	plugins: [ Essentials, Paragraph, Bold, Italic, MediaEmbed ],
+	toolbar: [ 'bold', 'italic', 'mediaEmbed' ],
+	mediaEmbed: {
+		elementName: 'o-embed',
+		extraProviders: [
+			{
+				name: 'genericProvider',
+				url: genericUrlRegex,
+				html: match => {
+					return `<o-embed url="${ match[ 0 ] }"></o-embed>`;
+				}
+			}
+		]
+	}
+} )
+	.then( editor => {
+		console.log( 'Editor was initialized', editor );
+		window.editor = editor;
+		CKEditorInspector.attach( editor );
+	} )
+	.catch( error => {
+		console.error( error );
+		console.error( error.stack );
+	} );

--- a/packages/ckeditor5-media-embed/sample/index.html
+++ b/packages/ckeditor5-media-embed/sample/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>CKEditor5 w/ Media Embed</title>
+    <style>
+      html {
+        text-align: center;
+      }
+      body {
+        max-width: 768px;
+        margin: 0 auto;
+        font-feature-settings: "kern" 1;
+        font-kerning: normal;
+        -webkit-font-smoothing: antialiased; /* Chrome, Safari */
+        -moz-osx-font-smoothing: grayscale; /* Firefox */
+        font-family: BlinkMacSystemFont, -apple-system, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+        letter-spacing: 0.015em;
+        word-spacing: 0.001em;
+      }
+
+      o-embed {
+        --social-embed-iframe-height: 100%;
+        --social-embed-iframe-width: 100%;
+        height: 30rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h2>
+      CKEditor 5 with
+      <a
+        href="https://ckeditor.com/docs/ckeditor5/latest/features/media-embed.html"
+        rel="noopener noreferrer"
+        target="_blank"
+        >ckeditor5-media-embed</a
+      >
+    </h2>
+    <figure id="editor">
+      <p />
+      <figure class="media">
+        <o-embed url="https://www.bing.com"></o-embed>
+      </figure>
+      <figure class="media">
+        <o-embed url="https://www.ibm.com"></o-embed>
+      </figure>
+    </figure>
+  </body>
+</html>

--- a/packages/ckeditor5-media-embed/sample/package.json
+++ b/packages/ckeditor5-media-embed/sample/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@ckeditor/ckeditor5-media-embed-sample",
+  "private": true,
+  "description": "Dev loop for CKEditor 5's Media Embed",
+  "keywords": [
+    "ckeditor",
+    "ckeditor5",
+    "ckeditor 5",
+    "ckeditor5-feature",
+    "ckeditor5-plugin"
+  ],
+  "dependencies": {
+    "@social-embed/lib": "^0.0.1-next.12",
+    "@social-embed/wc": "^0.0.3-next.3"
+  },
+  "devDependencies": {
+    "css-loader": "^5.2.4",
+    "html-webpack-plugin": "4",
+    "mini-css-extract-plugin": "^1.6.0",
+    "raw-loader": "^4.0.2",
+    "webpack-cli": "^3.3.11",
+    "webpack-dev-server": "^3.11.2"
+  },
+  "engines": {
+    "node": ">=12.0.0",
+    "npm": ">=5.7.1"
+  },
+  "author": "Tony Narlock",
+  "license": "MIT",
+  "scripts": {
+    "start": "webpack-dev-server --mode development"
+  }
+}

--- a/packages/ckeditor5-media-embed/sample/webpack.config.js
+++ b/packages/ckeditor5-media-embed/sample/webpack.config.js
@@ -1,0 +1,67 @@
+/* eslint-disable no-undef */
+const path = require( 'path' );
+const { styles } = require( '@ckeditor/ckeditor5-dev-utils' );
+const HtmlWebpackPlugin = require( 'html-webpack-plugin' );
+const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
+
+module.exports = {
+	// https://webpack.js.org/configuration/entry-context/
+	entry: './app.js',
+
+	// https://webpack.js.org/configuration/output/
+	output: {
+		path: path.resolve( __dirname, 'dist' ),
+		filename: 'bundle.js'
+	},
+
+	devServer: {
+		disableHostCheck: true,
+		headers: {
+			'Access-Control-Allow-Origin': '*'
+		},
+		historyApiFallback: true,
+		hot: true,
+		inline: true,
+		index: './index.html'
+	},
+
+	plugins: [
+		new MiniCssExtractPlugin(),
+		new HtmlWebpackPlugin( {
+			template: './index.html'
+		} )
+	],
+
+	module: {
+		rules: [
+			{
+				test: /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
+				use: [ 'raw-loader' ]
+			},
+			{
+				test: /ckeditor5-[^/\\]+[/\\]theme[/\\].+\.css$/,
+				use: [
+					MiniCssExtractPlugin.loader,
+					'css-loader',
+					{
+						loader: 'postcss-loader',
+						options: styles.getPostCssConfig( {
+							themeImporter: {
+								themePath: require.resolve(
+									'@ckeditor/ckeditor5-theme-lark'
+								)
+							},
+							minify: true
+						} )
+					}
+				]
+			}
+		]
+	},
+
+	// Useful for debugging.
+	devtool: 'source-map',
+
+	// By default webpack logs warnings if the bundle is bigger than 200kb.
+	performance: { hints: false }
+};


### PR DESCRIPTION
This is a concept / prototype of a `yarn start` similar to other frontend js projects

### Instructions

- `cd packages/ckeditor5-media-embed/sample`
- `yarn`
- `yarn start`
- http://localhost:8080
- Edit / reload files from:
  - `ckeditor5-media-embed/src/**/*.js`
  - `sample/{app.js,index.html}`
- Access [`window.editor`](https://ckeditor.com/docs/ckeditor5/latest/api/module_editor-classic_classiceditor-ClassicEditor.html) (e.g. [`window.editor.getData()`](https://ckeditor.com/docs/ckeditor5/latest/api/module_editor-classic_classiceditor-ClassicEditor.html#function-getData), [CKEditor inspector](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/development-tools.html#ckeditor-5-inspector))

Discussion: #9611

---

### Additional information

This provides a fast dev loop where source code changes are immediately viewable in the browser.

It also supports having a local copy of [`ClassicEditor`](https://ckeditor.com/docs/ckeditor5/latest/api/module_editor-classic_classiceditor-ClassicEditor.html) on the window global and [CKEditor 5 inspector](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/development-tools.html#ckeditor-5-inspector)

### Screenshots

![image](https://user-images.githubusercontent.com/26336/120544709-57879e00-c3b3-11eb-8070-dd5e20ff03b4.png)

![image](https://user-images.githubusercontent.com/26336/120544801-6ec68b80-c3b3-11eb-9103-fd01089df856.png)