### PR TITLE
Add metadata and HTML output for the TableCaption

### DIFF
--- a/docs/builds/guides/integration/features-html-output-overview.md
+++ b/docs/builds/guides/integration/features-html-output-overview.md
@@ -1915,6 +1915,19 @@ The data used to generate the following tables comes from the package metadata. 
 				</p>
 			</td>
 		</tr>
+		<tr>
+			<td class="plugin">
+				<p>
+					<a href="../../../features/table.html#table-caption">Table caption</a>
+				</p>
+				<p>
+					<a href="../../../api/module_table_tablecaption-TableCaption.html"><code>TableCaption</code></a>
+				</p>
+			</td>
+			<td class="html-output">
+				<code>&lt;<strong>figcaption</strong> <strong>data-placeholder</strong>="*"&gt;</code>
+			</td>
+		</tr>
 	</tbody>
 </table>
 <h3 id="ckeditor5-track-changes"><code>ckeditor5-track-changes</code></h3>

--- a/packages/ckeditor5-table/ckeditor5-metadata.json
+++ b/packages/ckeditor5-table/ckeditor5-metadata.json
@@ -153,6 +153,22 @@
 				"table.contentToolbar",
 				"table.tableToolbar"
 			]
+		},
+		{
+			"name": "Table caption",
+			"className": "TableCaption",
+			"description": "Adds support for table captions, which inform the reader about the content of the table. Using captions is also beneficial from the accessibility point of view.",
+			"docs": "features/table.html#table-caption",
+			"path": "src/tablecaption.js",
+			"requires": [
+				"Table"
+			],
+			"htmlOutput": [
+				{
+					"elements": "figcaption",
+					"attributes": "data-placeholder"
+				}
+			]
 		}
 	]
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Added metadata and HTML output for the TableCaption. Closes #9806.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._