### PR TITLE
#9794: Disallow inline images in captions

### DIFF
--- a/packages/ckeditor5-engine/src/model/utils/insertcontent.js
+++ b/packages/ckeditor5-engine/src/model/utils/insertcontent.js
@@ -759,11 +759,6 @@ class Insertion {
 		}
 
 		while ( allowedIn != this.position.parent ) {
-			// If a parent which we'd need to leave is a limit element, break.
-			if ( this.schema.isLimit( this.position.parent ) ) {
-				return false;
-			}
-
 			if ( this.position.isAtStart ) {
 				// If insertion position is at the beginning of the parent, move it out instead of splitting.
 				// <p>^Foo</p> -> ^<p>Foo</p>
@@ -824,10 +819,6 @@ class Insertion {
 			return null;
 		}
 
-		if ( contextElement.parent ) {
-			return this._getAllowedIn( contextElement.parent, childNode );
-		}
-
-		return null;
+		return this._getAllowedIn( contextElement.parent, childNode );
 	}
 }

--- a/packages/ckeditor5-engine/src/model/utils/insertcontent.js
+++ b/packages/ckeditor5-engine/src/model/utils/insertcontent.js
@@ -698,7 +698,7 @@ class Insertion {
 		// Do not autoparagraph if the paragraph won't be allowed there,
 		// cause that would lead to an infinite loop. The paragraph would be rejected in
 		// the next _handleNode() call and we'd be here again.
-		if ( this._getAllowedIn( paragraph, this.position.parent ) && this.schema.checkChild( paragraph, node ) ) {
+		if ( this._getAllowedIn( this.position.parent, paragraph ) && this.schema.checkChild( paragraph, node ) ) {
 			paragraph._appendChild( node );
 			this._handleNode( paragraph );
 		}
@@ -747,7 +747,7 @@ class Insertion {
 	 * `false` is returned if the node isn't allowed at any position up in the tree, `true` if was.
 	 */
 	_checkAndSplitToAllowedPosition( node ) {
-		const allowedIn = this._getAllowedIn( node, this.position.parent );
+		const allowedIn = this._getAllowedIn( this.position.parent, node );
 
 		if ( !allowedIn ) {
 			return false;
@@ -806,17 +806,26 @@ class Insertion {
 	 * Gets the element in which the given node is allowed. It checks the passed element and all its ancestors.
 	 *
 	 * @private
-	 * @param {module:engine/model/node~Node} node The node to check.
-	 * @param {module:engine/model/element~Element} element The element in which the node's correctness should be checked.
+	 * @param {module:engine/model/element~Element} contextElement The element in which context the node should be checked.
+	 * @param {module:engine/model/node~Node} childNode The node to check.
 	 * @returns {module:engine/model/element~Element|null}
 	 */
-	_getAllowedIn( node, element ) {
-		if ( this.schema.checkChild( element, node ) ) {
-			return element;
+	_getAllowedIn( contextElement, childNode ) {
+		if ( this.schema.checkChild( contextElement, childNode ) ) {
+			return contextElement;
 		}
 
-		if ( element.parent ) {
-			return this._getAllowedIn( node, element.parent );
+		// If the child wasn't allowed in the context element and the element is a limit there's no point in
+		// checking any further towards the root. This is it: the limit is unsplittable and there's nothing
+		// we can do about it. Without this check, the algorithm will analyze parent of the limit and may create
+		// an illusion of the child being allowed. There's no way to insert it down there, though. It results in
+		// infinite loops.
+		if ( this.schema.isLimit( contextElement ) ) {
+			return null;
+		}
+
+		if ( contextElement.parent ) {
+			return this._getAllowedIn( contextElement.parent, childNode );
 		}
 
 		return null;

--- a/packages/ckeditor5-engine/tests/model/utils/insertcontent.js
+++ b/packages/ckeditor5-engine/tests/model/utils/insertcontent.js
@@ -538,6 +538,29 @@ describe( 'DataController utils', () => {
 				expect( stringify( root, affectedRange ) ).to.equal( '[<heading1>bar</heading1>]' );
 			} );
 
+			// https://github.com/ckeditor/ckeditor5/issues/9794
+			it( 'should not insert a disallowed inline widget into a limit element', () => {
+				const schema = model.schema;
+
+				schema.register( 'limit', {
+					isLimit: true,
+					allowIn: '$root'
+				} );
+
+				schema.extend( '$text', {
+					allowIn: 'limit'
+				} );
+
+				const content = new DocumentFragment( [ new Element( 'inlineWidget' ) ] );
+
+				setData( model, '<limit>[]</limit>' );
+
+				const affectedRange = insertContent( model, content );
+
+				expect( getData( model ) ).to.equal( '<limit>[]</limit>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<limit>[]</limit>' );
+			} );
+
 			describe( 'block to block handling', () => {
 				it( 'inserts one paragraph', () => {
 					setData( model, '<paragraph>f[]oo</paragraph>' );
@@ -1372,8 +1395,8 @@ describe( 'DataController utils', () => {
 				// Pasted content is forbidden in current selection.
 				const affectedRange = insertHelper( '<wrapper><limit><paragraph>foo</paragraph></limit></wrapper>' );
 
-				expect( getData( model ) ).to.equal( '<wrapper><limit>[]<paragraph></paragraph></limit></wrapper>' );
-				expect( stringify( root, affectedRange ) ).to.equal( '<wrapper><limit>[]<paragraph></paragraph></limit></wrapper>' );
+				expect( getData( model ) ).to.equal( '<wrapper><limit><paragraph>[]</paragraph></limit></wrapper>' );
+				expect( stringify( root, affectedRange ) ).to.equal( '<wrapper><limit><paragraph>[]</paragraph></limit></wrapper>' );
 			} );
 
 			it( 'should correctly paste allowed nodes', () => {

--- a/packages/ckeditor5-image/src/image/imageinlineediting.js
+++ b/packages/ckeditor5-image/src/image/imageinlineediting.js
@@ -64,6 +64,15 @@ export default class ImageInlineEditing extends Plugin {
 			allowAttributes: [ 'alt', 'src', 'srcset' ]
 		} );
 
+		// Disallow inline images in captions (for now). This is the best spot to do that because
+		// independent packages can introduce captions (ImageCaption, TableCaption, etc.) so better this
+		// be future-proof.
+		schema.addChildCheck( ( context, childDefinition ) => {
+			if ( context.endsWith( 'caption' ) && childDefinition.name === 'imageInline' ) {
+				return false;
+			}
+		} );
+
 		this._setupConversion();
 
 		if ( editor.plugins.has( 'ImageBlockEditing' ) ) {

--- a/packages/ckeditor5-image/tests/image/imageinlineediting.js
+++ b/packages/ckeditor5-image/tests/image/imageinlineediting.js
@@ -76,7 +76,7 @@ describe( 'ImageInlineEditing', () => {
 				isLimit: true
 			} );
 
-			expect( model.schema.checkChild( [ '$root', 'codeBlock' ], 'imageInline' ) ).to.be.false;
+			expect( model.schema.checkChild( [ '$root', 'caption' ], 'imageInline' ) ).to.be.false;
 		} );
 	} );
 

--- a/packages/ckeditor5-image/tests/image/imageinlineediting.js
+++ b/packages/ckeditor5-image/tests/image/imageinlineediting.js
@@ -869,4 +869,90 @@ describe( 'ImageInlineEditing', () => {
 			);
 		} );
 	} );
+
+	describe( 'integration with the caption element', () => {
+		let editorElement, editor, model, view;
+
+		beforeEach( async () => {
+			editorElement = document.createElement( 'div' );
+			document.body.appendChild( editorElement );
+
+			editor = await ClassicTestEditor.create( editorElement, {
+				plugins: [
+					ImageInlineEditing,
+					ImageBlockEditing,
+					ImageCaption,
+					ImageResizeEditing,
+					Clipboard,
+					LinkImage,
+					Paragraph,
+					ListEditing
+				]
+			} );
+
+			model = editor.model;
+			doc = model.document;
+			view = editor.editing.view;
+			viewDocument = view.document;
+		} );
+
+		afterEach( async () => {
+			await editor.destroy();
+			editorElement.remove();
+		} );
+
+		it( 'should disallow (nested) inline images inside the caption', () => {
+			editor.setData(
+				'<figure class="image">' +
+					'<img src="/assets/sample.png" />' +
+					'<figcaption>foo<img src="/assets/sample.png" />bar</figcaption>' +
+				'</figure>'
+			);
+
+			expect( getModelData( model, { withoutSelection: true } ) )
+				.to.equal( '<imageBlock src="/assets/sample.png"><caption>foobar</caption></imageBlock>' );
+		} );
+
+		it( 'should disallow (nested) linked inline images inside the caption', () => {
+			editor.setData(
+				'<figure class="image">' +
+					'<img src="/assets/sample.png" />' +
+					'<figcaption>foo<a href="https://cksource.com"><img src="/assets/sample.png" /></a>bar</figcaption>' +
+				'</figure>'
+			);
+
+			expect( getModelData( model, { withoutSelection: true } ) )
+				.to.equal( '<imageBlock src="/assets/sample.png"><caption>foobar</caption></imageBlock>' );
+		} );
+
+		it( 'should disallow pasting inline images into the caption', () => {
+			const dataTransfer = new DataTransfer( {
+				types: [ 'text/html' ],
+				getData: () => '<img src="/assets/sample.png" />'
+			} );
+
+			setModelData( model, '<imageBlock src="/assets/sample.png"><caption>foo[]bar</caption></imageBlock>' );
+
+			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+
+			expect( getModelData( model ) ).to.equal(
+				'<imageBlock src="/assets/sample.png"><caption>foo[]bar</caption></imageBlock>'
+			);
+		} );
+
+		it( 'should disallow pasting linked inline images into the caption', () => {
+			const dataTransfer = new DataTransfer( {
+				types: [ 'text/html' ],
+				getData: () => '<a href="https://cksource.com"><img src="/assets/sample.png" /></a>'
+			} );
+
+			setModelData( model, '<imageBlock src="/assets/sample.png"><caption>foo[]bar</caption></imageBlock>' );
+
+			viewDocument.fire( 'clipboardInput', { dataTransfer } );
+
+			expect( getModelData( model ) ).to.equal(
+				'<imageBlock src="/assets/sample.png"><caption>foo[]bar</caption></imageBlock>'
+			);
+		} );
+	} );
 } );

--- a/packages/ckeditor5-image/tests/image/imageinlineediting.js
+++ b/packages/ckeditor5-image/tests/image/imageinlineediting.js
@@ -54,18 +54,30 @@ describe( 'ImageInlineEditing', () => {
 		expect( editor.plugins.get( ImageInlineEditing ) ).to.be.instanceOf( ImageInlineEditing );
 	} );
 
-	it( 'should set proper schema rules', () => {
-		expect( model.schema.isRegistered( 'imageInline' ) ).to.be.true;
-		expect( model.schema.isInline( 'imageInline' ) ).to.be.true;
-		expect( model.schema.isObject( 'imageInline' ) ).to.be.true;
+	describe( 'schema rules', () => {
+		it( 'should be set', () => {
+			expect( model.schema.isRegistered( 'imageInline' ) ).to.be.true;
+			expect( model.schema.isInline( 'imageInline' ) ).to.be.true;
+			expect( model.schema.isObject( 'imageInline' ) ).to.be.true;
 
-		expect( model.schema.checkChild( [ '$root', '$block' ], 'imageInline' ) ).to.be.true;
-		expect( model.schema.checkAttribute( [ '$root', '$block', 'imageInline' ], 'src' ) ).to.be.true;
-		expect( model.schema.checkAttribute( [ '$root', '$block', 'imageInline' ], 'alt' ) ).to.be.true;
+			expect( model.schema.checkChild( [ '$root', '$block' ], 'imageInline' ) ).to.be.true;
+			expect( model.schema.checkAttribute( [ '$root', '$block', 'imageInline' ], 'src' ) ).to.be.true;
+			expect( model.schema.checkAttribute( [ '$root', '$block', 'imageInline' ], 'alt' ) ).to.be.true;
 
-		expect( model.schema.checkChild( [ '$root' ], 'imageInline' ) ).to.be.false;
-		expect( model.schema.checkChild( [ '$root', '$block', 'imageInline' ], 'imageBlock' ) ).to.be.false;
-		expect( model.schema.checkChild( [ '$root', '$block', 'imageInline' ], '$text' ) ).to.be.false;
+			expect( model.schema.checkChild( [ '$root' ], 'imageInline' ) ).to.be.false;
+			expect( model.schema.checkChild( [ '$root', '$block', 'imageInline' ], 'imageBlock' ) ).to.be.false;
+			expect( model.schema.checkChild( [ '$root', '$block', 'imageInline' ], '$text' ) ).to.be.false;
+		} );
+
+		it( 'should disallow imageInline in the caption element', () => {
+			model.schema.register( 'caption', {
+				allowIn: '$root',
+				allowContentOf: '$block',
+				isLimit: true
+			} );
+
+			expect( model.schema.checkChild( [ '$root', 'codeBlock' ], 'imageInline' ) ).to.be.false;
+		} );
 	} );
 
 	it( 'should register ImageLoadObserver', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine,image): Disallowed inline images in `caption` elements. Closes #9794.

---

### Additional information

Adding the schema check in `ImageInlineEditing` revealed a bug in `insertContent` resulting in infinite loops. When an inline image was disallowed in the caption (a limit), the algorithm attempted to autoparagraph it in that caption on a (wrong) assumption that the paragraph is allowed there. Then, since that failed, the algorithm decomposed that paragraph, reached the inline image inside, and autoparagraphed it again on a wrong assumption... This PR also addresses this issue.