### PR TITLE
CF/3390: The image should not resize to 100% if the resize command was overridden

### DIFF
--- a/packages/ckeditor5-image/src/imageresize/imageresizehandles.js
+++ b/packages/ckeditor5-image/src/imageresize/imageresizehandles.js
@@ -18,6 +18,8 @@ const RESIZABLE_IMAGES_CSS_SELECTOR = 'figure.image.ck-widget > img,' +
 
 const IMAGE_WIDGETS_CLASSES_MATCH_REGEXP = /(image|image-inline)/;
 
+const RESIZED_IMAGE_CLASS = 'image_resized';
+
 /**
  * The image resize by handles feature.
  *
@@ -108,14 +110,20 @@ export default class ImageResizeHandles extends Plugin {
 					},
 
 					onCommit( newValue ) {
+						// Get rid of the CSS class in case the command execution that follows is unsuccessful
+						// (e.g. Track Changes can override it and the new dimensions will not apply).
+						editingView.change( writer => {
+							writer.removeClass( RESIZED_IMAGE_CLASS, widgetView );
+						} );
+
 						editor.execute( 'resizeImage', { width: newValue } );
 					}
 				} );
 
 			resizer.on( 'updateSize', () => {
-				if ( !widgetView.hasClass( 'image_resized' ) ) {
+				if ( !widgetView.hasClass( RESIZED_IMAGE_CLASS ) ) {
 					editingView.change( writer => {
-						writer.addClass( 'image_resized', widgetView );
+						writer.addClass( RESIZED_IMAGE_CLASS, widgetView );
 					} );
 				}
 			} );

--- a/packages/ckeditor5-image/src/imageresize/imageresizehandles.js
+++ b/packages/ckeditor5-image/src/imageresize/imageresizehandles.js
@@ -111,7 +111,9 @@ export default class ImageResizeHandles extends Plugin {
 
 					onCommit( newValue ) {
 						// Get rid of the CSS class in case the command execution that follows is unsuccessful
-						// (e.g. Track Changes can override it and the new dimensions will not apply).
+						// (e.g. Track Changes can override it and the new dimensions will not apply). Otherwise,
+						// the presence of the class and the absence of the width style will cause it to take 100%
+						// of the horizontal space.
 						editingView.change( writer => {
 							writer.removeClass( RESIZED_IMAGE_CLASS, widgetView );
 						} );

--- a/packages/ckeditor5-image/tests/imageresize/imageresizehandles.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizehandles.js
@@ -129,6 +129,27 @@ describe( 'ImageResizeHandles', () => {
 				expect( resizer.isEnabled ).to.be.false;
 				expect( resizerWrapper.style.display ).to.equal( 'none' );
 			} );
+
+			it( 'removes the image_resized class if the command was overriden and canceled', async () => {
+				// Stub "execute" to override the command like, for instance, Track Changes would.
+				const stub = sinon.stub( editor.commands.get( 'resizeImage' ), 'execute' );
+
+				await setModelAndWaitForImages( editor,
+					`<paragraph>foo</paragraph>[<imageBlock src="${ IMAGE_SRC_FIXTURE }"></imageBlock>]` );
+
+				widget = viewDocument.getRoot().getChild( 1 );
+
+				const domParts = getWidgetDomParts( editor, widget, 'bottom-left' );
+				const finalPointerPosition = getHandleCenterPoint( domParts.widget, 'bottom-left' ).moveBy( 10, -10 );
+
+				resizerMouseSimulator.dragTo( editor, domParts.resizeHandle, finalPointerPosition );
+
+				expect( stub.calledOnce ).to.be.true;
+				expect( stub.args[ 0 ][ 0 ] ).to.deep.equal( { width: '80px' } );
+
+				expect( widget.hasClass( 'image_resized' ), 'CSS class' ).to.be.false;
+				expect( widget.hasStyle( 'width' ), 'width style' ).to.be.false;
+			} );
 		} );
 
 		describe( 'side image resizing', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (image): The image should not resize to 100% if the resize command was overridden (canceled). 

---

### Additional information