### PR TITLE
Added the option to remember the language when creating a new code block.

### DIFF
--- a/packages/ckeditor5-code-block/src/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/src/codeblockcommand.js
@@ -55,10 +55,11 @@ export default class CodeBlockCommand extends Command {
 	 *
 	 * @fires execute
 	 * @param {Object} [options] Command options.
-	 * @param {String|null} [options.language] TODO.
+	 * @param {String|null} [options.language] Language picked from dropdown.
 	 * @param {Boolean} [options.forceValue] If set, it will force the command behavior. If `true`, the command will apply a code block,
 	 * otherwise the command will remove the code block. If not set, the command will act basing on its current value.
-	 * @param {Boolean} [options.usePreviousLanguageChoice=false] TODO.
+	 * @param {Boolean} [options.usePreviousLanguageChoice=true] Defines whether or not button will create code block with the same
+	 * language as the previous code block.
 	 */
 	execute( options = {} ) {
 		const editor = this.editor;

--- a/packages/ckeditor5-code-block/src/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/src/codeblockcommand.js
@@ -53,7 +53,10 @@ export default class CodeBlockCommand extends Command {
 
 		const blocks = Array.from( selection.getSelectedBlocks() );
 		const value = ( options.forceValue === undefined ) ? !this.value : options.forceValue;
-		const language = options.language || firstLanguageInConfig.language;
+		let language = options.language || firstLanguageInConfig.language;
+		if ( options.usePreviousLanguageChoice && options.lastLanguage ) {
+			language = options.lastLanguage;
+		}
 
 		model.change( writer => {
 			if ( value ) {

--- a/packages/ckeditor5-code-block/src/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/src/codeblockcommand.js
@@ -25,7 +25,8 @@ export default class CodeBlockCommand extends Command {
 		super( editor );
 
 		/**
-		 * Remebers what language the last code block was created in.
+		 * Contains the last used language.
+
 		 * @protected
 		 * @type {String|null}
 		 */
@@ -55,10 +56,10 @@ export default class CodeBlockCommand extends Command {
 	 *
 	 * @fires execute
 	 * @param {Object} [options] Command options.
-	 * @param {String|null} [options.language] Language picked from dropdown.
+	 * @param {String} [options.language] The code block language.
 	 * @param {Boolean} [options.forceValue] If set, it will force the command behavior. If `true`, the command will apply a code block,
 	 * otherwise the command will remove the code block. If not set, the command will act basing on its current value.
-	 * @param {Boolean} [options.usePreviousLanguageChoice=true] Defines whether or not button will create code block with the same
+	 * @param {Boolean} [options.usePreviousLanguageChoice] If set on `true` and the `options.language` is not specified, the command will apply the previous language (if the command was already executed) when inserting the `codeBlock` element.
 	 * language as the previous code block.
 	 */
 	execute( options = {} ) {
@@ -198,12 +199,12 @@ function canBeCodeBlock( schema, element ) {
 // @param {String} defaultLanguage
 // @return {String}
 function getLanguage( options, lastLanguage, defaultLanguage ) {
-	if ( options.usePreviousLanguageChoice && lastLanguage ) {
-		return lastLanguage;
-	}
-
 	if ( options.language ) {
 		return options.language;
+	}
+
+	if ( options.usePreviousLanguageChoice && lastLanguage ) {
+		return lastLanguage;
 	}
 
 	return defaultLanguage;

--- a/packages/ckeditor5-code-block/src/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/src/codeblockcommand.js
@@ -25,7 +25,7 @@ export default class CodeBlockCommand extends Command {
 		super( editor );
 
 		/**
-		 * TODO
+		 * Remebers what language the last code block was created in.
 		 * @protected
 		 * @type {String|null}
 		 */
@@ -124,7 +124,6 @@ export default class CodeBlockCommand extends Command {
 	 * @param {String} [language]
 	 */
 	_applyCodeBlock( writer, blocks, language ) {
-		// TODO: Make sure it's proper place.
 		this._lastLanguage = language;
 
 		const schema = this.editor.model.schema;
@@ -186,7 +185,10 @@ function canBeCodeBlock( schema, element ) {
 	return schema.checkChild( element.parent, 'codeBlock' );
 }
 
-// TODO: Docs
+// Picks the language for the new code block. If option usePreviousLanguageChoice
+// is true and some code block was already created (lastLanguage is not null) then previously
+// used language will be returned. Else, it will see if any language is passed as an option
+// and return that. If not, it will return default language.
 //
 // @param {Object} options
 // @param {Boolean} [options.usePreviousLanguageChoice]

--- a/packages/ckeditor5-code-block/src/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/src/codeblockcommand.js
@@ -61,7 +61,6 @@ export default class CodeBlockCommand extends Command {
 	 * otherwise the command will remove the code block. If not set, the command will act basing on its current value.
 	 * @param {Boolean} [options.usePreviousLanguageChoice] If set on `true` and the `options.language` is not specified, the command
 	 * will apply the previous language (if the command was already executed) when inserting the `codeBlock` element.
-	 * language as the previous code block.
 	 */
 	execute( options = {} ) {
 		const editor = this.editor;

--- a/packages/ckeditor5-code-block/src/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/src/codeblockcommand.js
@@ -53,10 +53,8 @@ export default class CodeBlockCommand extends Command {
 
 		const blocks = Array.from( selection.getSelectedBlocks() );
 		const value = ( options.forceValue === undefined ) ? !this.value : options.forceValue;
-		let language = options.language || firstLanguageInConfig.language;
-		if ( options.usePreviousLanguageChoice && options.lastLanguage ) {
-			language = options.lastLanguage;
-		}
+		const lastLanguageEnabled = options.usePreviousLanguageChoice && options.lastLanguage;
+		const language = lastLanguageEnabled ? options.lastLanguage : options.language || firstLanguageInConfig.language;
 
 		model.change( writer => {
 			if ( value ) {

--- a/packages/ckeditor5-code-block/src/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/src/codeblockcommand.js
@@ -59,7 +59,8 @@ export default class CodeBlockCommand extends Command {
 	 * @param {String} [options.language] The code block language.
 	 * @param {Boolean} [options.forceValue] If set, it will force the command behavior. If `true`, the command will apply a code block,
 	 * otherwise the command will remove the code block. If not set, the command will act basing on its current value.
-	 * @param {Boolean} [options.usePreviousLanguageChoice] If set on `true` and the `options.language` is not specified, the command will apply the previous language (if the command was already executed) when inserting the `codeBlock` element.
+	 * @param {Boolean} [options.usePreviousLanguageChoice] If set on `true` and the `options.language` is not specified, the command
+	 * will apply the previous language (if the command was already executed) when inserting the `codeBlock` element.
 	 * language as the previous code block.
 	 */
 	execute( options = {} ) {
@@ -187,10 +188,10 @@ function canBeCodeBlock( schema, element ) {
 	return schema.checkChild( element.parent, 'codeBlock' );
 }
 
-// Picks the language for the new code block. If option usePreviousLanguageChoice
-// is true and some code block was already created (lastLanguage is not null) then previously
-// used language will be returned. Else, it will see if any language is passed as an option
-// and return that. If not, it will return default language.
+// Picks the language for the new code block. If any language is passed as an option,
+// it will be returned. Else, if option usePreviousLanguageChoice is true and some
+// code block was already created (lastLanguage is not null) then previously used
+// language will be returned. If not, it will return default language.
 //
 // @param {Object} options
 // @param {Boolean} [options.usePreviousLanguageChoice]

--- a/packages/ckeditor5-code-block/src/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/src/codeblockcommand.js
@@ -19,6 +19,20 @@ import { getNormalizedAndLocalizedLanguageDefinitions } from './utils';
  */
 export default class CodeBlockCommand extends Command {
 	/**
+	 * @inheritDoc
+	 */
+	constructor( editor ) {
+		super( editor );
+
+		/**
+		 * TODO
+		 * @protected
+		 * @type {String|null}
+		 */
+		this._lastLanguage = null;
+	}
+
+	/**
 	 * Whether the selection starts in a code block.
 	 *
 	 * @observable
@@ -41,8 +55,10 @@ export default class CodeBlockCommand extends Command {
 	 *
 	 * @fires execute
 	 * @param {Object} [options] Command options.
+	 * @param {String|null} [options.language] TODO.
 	 * @param {Boolean} [options.forceValue] If set, it will force the command behavior. If `true`, the command will apply a code block,
 	 * otherwise the command will remove the code block. If not set, the command will act basing on its current value.
+	 * @param {Boolean} [options.usePreviousLanguageChoice=false] TODO.
 	 */
 	execute( options = {} ) {
 		const editor = this.editor;
@@ -53,8 +69,7 @@ export default class CodeBlockCommand extends Command {
 
 		const blocks = Array.from( selection.getSelectedBlocks() );
 		const value = ( options.forceValue === undefined ) ? !this.value : options.forceValue;
-		const lastLanguageEnabled = options.usePreviousLanguageChoice && options.lastLanguage;
-		const language = lastLanguageEnabled ? options.lastLanguage : options.language || firstLanguageInConfig.language;
+		const language = getLanguage( options, this._lastLanguage, firstLanguageInConfig.language );
 
 		model.change( writer => {
 			if ( value ) {
@@ -109,6 +124,9 @@ export default class CodeBlockCommand extends Command {
 	 * @param {String} [language]
 	 */
 	_applyCodeBlock( writer, blocks, language ) {
+		// TODO: Make sure it's proper place.
+		this._lastLanguage = language;
+
 		const schema = this.editor.model.schema;
 		const allowedBlocks = blocks.filter( block => canBeCodeBlock( schema, block ) );
 
@@ -166,4 +184,24 @@ function canBeCodeBlock( schema, element ) {
 	}
 
 	return schema.checkChild( element.parent, 'codeBlock' );
+}
+
+// TODO: Docs
+//
+// @param {Object} options
+// @param {Boolean} [options.usePreviousLanguageChoice]
+// @param {String} [options.language]
+// @param {String|null} lastLanguage
+// @param {String} defaultLanguage
+// @return {String}
+function getLanguage( options, lastLanguage, defaultLanguage ) {
+	if ( options.usePreviousLanguageChoice && lastLanguage ) {
+		return lastLanguage;
+	}
+
+	if ( options.language ) {
+		return options.language;
+	}
+
+	return defaultLanguage;
 }

--- a/packages/ckeditor5-code-block/src/codeblockui.js
+++ b/packages/ckeditor5-code-block/src/codeblockui.js
@@ -58,7 +58,7 @@ export default class CodeBlockUI extends Plugin {
 			splitButtonView.on( 'execute', () => {
 				editor.execute( 'codeBlock', {
 					language: defaultLanguageDefinition.language,
-					usePreviousLanguageChoice: false
+					usePreviousLanguageChoice: true
 				} );
 
 				editor.editing.view.focus();

--- a/packages/ckeditor5-code-block/src/codeblockui.js
+++ b/packages/ckeditor5-code-block/src/codeblockui.js
@@ -40,6 +40,7 @@ export default class CodeBlockUI extends Plugin {
 		const componentFactory = editor.ui.componentFactory;
 		const normalizedLanguageDefs = getNormalizedAndLocalizedLanguageDefinitions( editor );
 		const defaultLanguageDefinition = normalizedLanguageDefs[ 0 ];
+		let lastLanguage = '';
 
 		componentFactory.add( 'codeBlock', locale => {
 			const command = editor.commands.get( 'codeBlock' );
@@ -57,7 +58,9 @@ export default class CodeBlockUI extends Plugin {
 
 			splitButtonView.on( 'execute', () => {
 				editor.execute( 'codeBlock', {
-					language: defaultLanguageDefinition.language
+					language: defaultLanguageDefinition.language,
+					lastLanguage,
+					usePreviousLanguageChoice: true
 				} );
 
 				editor.editing.view.focus();
@@ -68,6 +71,8 @@ export default class CodeBlockUI extends Plugin {
 					language: evt.source._codeBlockLanguage,
 					forceValue: true
 				} );
+
+				lastLanguage = evt.source._codeBlockLanguage;
 
 				editor.editing.view.focus();
 			} );

--- a/packages/ckeditor5-code-block/src/codeblockui.js
+++ b/packages/ckeditor5-code-block/src/codeblockui.js
@@ -39,7 +39,6 @@ export default class CodeBlockUI extends Plugin {
 		const t = editor.t;
 		const componentFactory = editor.ui.componentFactory;
 		const normalizedLanguageDefs = getNormalizedAndLocalizedLanguageDefinitions( editor );
-		const defaultLanguageDefinition = normalizedLanguageDefs[ 0 ];
 
 		componentFactory.add( 'codeBlock', locale => {
 			const command = editor.commands.get( 'codeBlock' );
@@ -57,7 +56,6 @@ export default class CodeBlockUI extends Plugin {
 
 			splitButtonView.on( 'execute', () => {
 				editor.execute( 'codeBlock', {
-					language: defaultLanguageDefinition.language,
 					usePreviousLanguageChoice: true
 				} );
 

--- a/packages/ckeditor5-code-block/src/codeblockui.js
+++ b/packages/ckeditor5-code-block/src/codeblockui.js
@@ -40,7 +40,6 @@ export default class CodeBlockUI extends Plugin {
 		const componentFactory = editor.ui.componentFactory;
 		const normalizedLanguageDefs = getNormalizedAndLocalizedLanguageDefinitions( editor );
 		const defaultLanguageDefinition = normalizedLanguageDefs[ 0 ];
-		let lastLanguage = '';
 
 		componentFactory.add( 'codeBlock', locale => {
 			const command = editor.commands.get( 'codeBlock' );
@@ -59,7 +58,6 @@ export default class CodeBlockUI extends Plugin {
 			splitButtonView.on( 'execute', () => {
 				editor.execute( 'codeBlock', {
 					language: defaultLanguageDefinition.language,
-					lastLanguage,
 					usePreviousLanguageChoice: true
 				} );
 
@@ -71,8 +69,6 @@ export default class CodeBlockUI extends Plugin {
 					language: evt.source._codeBlockLanguage,
 					forceValue: true
 				} );
-
-				lastLanguage = evt.source._codeBlockLanguage;
 
 				editor.editing.view.focus();
 			} );

--- a/packages/ckeditor5-code-block/src/codeblockui.js
+++ b/packages/ckeditor5-code-block/src/codeblockui.js
@@ -58,7 +58,7 @@ export default class CodeBlockUI extends Plugin {
 			splitButtonView.on( 'execute', () => {
 				editor.execute( 'codeBlock', {
 					language: defaultLanguageDefinition.language,
-					usePreviousLanguageChoice: true
+					usePreviousLanguageChoice: false
 				} );
 
 				editor.editing.view.focus();

--- a/packages/ckeditor5-code-block/tests/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/tests/codeblockcommand.js
@@ -276,6 +276,44 @@ describe( 'CodeBlockCommand', () => {
 				'<codeBlock language="plaintext">[FooBar<softBreak></softBreak>Baz]</codeBlock>'
 			);
 		} );
+
+		describe( 'options.usePreviousLanguageChoice=true', () => {
+			it( 'it should remember the selected language', () => {
+				setModelData( model, '<paragraph>fo[]o</paragraph>' );
+
+				command.execute( { language: 'php' } );
+
+				expect( command._lastLanguage ).to.equal( 'php' );
+			} );
+
+			it( 'it should apply the previous language if specified', () => {
+				setModelData( model, '<paragraph>fo[]o</paragraph>' );
+
+				command._lastLanguage = 'css';
+
+				command.execute( { usePreviousLanguageChoice: true } );
+
+				expect( getModelData( model ) ).to.equal( '<codeBlock language="css">fo[]o</codeBlock>' );
+			} );
+
+			it( 'it should not apply the previous language if specified but usePreviousLanguageChoice=false', () => {
+				setModelData( model, '<paragraph>fo[]o</paragraph>' );
+
+				command._lastLanguage = 'css';
+
+				command.execute();
+
+				expect( getModelData( model ) ).to.equal( '<codeBlock language="plaintext">fo[]o</codeBlock>' );
+			} );
+
+			it( 'it should apply the default language when the last language is not set yet', () => {
+				setModelData( model, '<paragraph>fo[]o</paragraph>' );
+
+				command.execute( { usePreviousLanguageChoice: true } );
+
+				expect( getModelData( model ) ).to.equal( '<codeBlock language="plaintext">fo[]o</codeBlock>' );
+			} );
+		} );
 	} );
 
 	describe( 'BlockQuote integration', () => {

--- a/packages/ckeditor5-code-block/tests/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/tests/codeblockcommand.js
@@ -313,6 +313,16 @@ describe( 'CodeBlockCommand', () => {
 
 				expect( getModelData( model ) ).to.equal( '<codeBlock language="plaintext">fo[]o</codeBlock>' );
 			} );
+
+			it( 'it should prioritize using language passed as an option over previous language', () => {
+				setModelData( model, '<paragraph>fo[]o</paragraph>' );
+
+				command._lastLanguage = 'css';
+
+				command.execute( { language: 'php', usePreviousLanguageChoice: true } );
+
+				expect( getModelData( model ) ).to.equal( '<codeBlock language="php">fo[]o</codeBlock>' );
+			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-code-block/tests/codeblockui.js
+++ b/packages/ckeditor5-code-block/tests/codeblockui.js
@@ -208,7 +208,7 @@ describe( 'CodeBlockUI', () => {
 				expect( button ).to.have.property( 'isOn', true );
 			} );
 
-			it( 'should execute the command with the first configured language', () => {
+			it( 'should execute the command with the "usePreviousLanguageChoice" option set to "true"', () => {
 				const dropdown = editor.ui.componentFactory.create( 'codeBlock' );
 				const button = dropdown.buttonView;
 				const executeSpy = sinon.stub( editor, 'execute' );
@@ -219,35 +219,7 @@ describe( 'CodeBlockUI', () => {
 				sinon.assert.calledOnce( executeSpy );
 				sinon.assert.calledOnce( focusSpy );
 				sinon.assert.calledWithExactly( executeSpy.firstCall, 'codeBlock', {
-					language: 'plaintext',
 					usePreviousLanguageChoice: true
-				} );
-			} );
-
-			describe( 'integration with "usePreviousLanguageChoice=true"', () => {
-				it( 'should create second code block with the same language as the first one', () => {
-					const dropdown = editor.ui.componentFactory.create( 'codeBlock' );
-					const button = dropdown.buttonView;
-					const executeSpy = sinon.stub( editor, 'execute' );
-					const listView = dropdown.panelView.children.first;
-					const cSharpButton = listView.items.get( 2 ).children.first;
-
-					expect( cSharpButton.label ).to.equal( 'C#' );
-
-					// Dropdown call - using the dropdown to select language and create code block.
-					cSharpButton.fire( 'execute' );
-
-					// Executing the `codeBlock` command when selection is inside the `<codeBlock>`, removes it.
-					button.fire( 'execute' );
-
-					// Executing it once again should create the code block the C# language instead of the default (plaintext).
-					button.fire( 'execute' );
-
-					sinon.expect( executeSpy.callCount ).to.equal( 3 );
-					sinon.assert.calledWithExactly( executeSpy.thirdCall, 'codeBlock', {
-						language: 'C#',
-						usePreviousLanguageChoice: true
-					} );
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-code-block/tests/codeblockui.js
+++ b/packages/ckeditor5-code-block/tests/codeblockui.js
@@ -223,6 +223,33 @@ describe( 'CodeBlockUI', () => {
 					usePreviousLanguageChoice: true
 				} );
 			} );
+
+			describe( 'integration with "usePreviousLanguageChoice=true"', () => {
+				it( 'should create second code block with the same language as the first one', () => {
+					const dropdown = editor.ui.componentFactory.create( 'codeBlock' );
+					const button = dropdown.buttonView;
+					const executeSpy = sinon.stub( editor, 'execute' );
+					const listView = dropdown.panelView.children.first;
+					const cSharpButton = listView.items.get( 2 ).children.first;
+
+					expect( cSharpButton.label ).to.equal( 'C#' );
+
+					// Dropdown call - using the dropdown to select language and create code block.
+					cSharpButton.fire( 'execute' );
+
+					// Executing the `codeBlock` command when selection is inside the `<codeBlock>`, removes it.
+					button.fire( 'execute' );
+
+					// Executing it once again should create the code block the C# language instead of the default (plaintext).
+					button.fire( 'execute' );
+
+					sinon.expect( executeSpy.callCount ).to.equal( 3 );
+					sinon.assert.calledWithExactly( executeSpy.thirdCall, 'codeBlock', {
+						language: 'C#',
+						usePreviousLanguageChoice: true
+					} );
+				} );
+			} );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-code-block/tests/codeblockui.js
+++ b/packages/ckeditor5-code-block/tests/codeblockui.js
@@ -219,7 +219,8 @@ describe( 'CodeBlockUI', () => {
 				sinon.assert.calledOnce( executeSpy );
 				sinon.assert.calledOnce( focusSpy );
 				sinon.assert.calledWithExactly( executeSpy.firstCall, 'codeBlock', {
-					language: 'plaintext'
+					language: 'plaintext',
+					usePreviousLanguageChoice: true
 				} );
 			} );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (code-block): When inserting a new code block, instead of applying the default language (the first in the dropdown view), the feature re-use the previously inserted language. Closes #8722.