### PR TITLE
Removed the unnecessary resetting of the last element's bottom margin.

### DIFF
--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -28,11 +28,6 @@
 	margin-top: 0;
 }
 
-/*
-.ck.ck-content > :not(.ck-fake-selection-container):last-of-type {
-	margin-bottom: 0;
-}
-*/
 
 /* Override default Umberto's styles because they apply margins to media embed widgets with iframe
 previews breaking their structure. */

--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -28,6 +28,18 @@
 	margin-top: 0;
 }
 
+/*
+ * Override Umberto styles to avoid content jumping when the fake selection container shows up.
+ * To work properly, this must match 1:1 the styles brought by Umberto.
+ * https://github.com/ckeditor/ckeditor5/issues/9825
+ */
+.ck.ck-content > p,
+.ck.ck-content > ul,
+.ck.ck-content > ol,
+.ck.ck-content > blockquote,
+.ck.ck-content > pre {
+	margin-bottom: var(--ck-spacing-large);
+}
 
 /* Override default Umberto's styles because they apply margins to media embed widgets with iframe
 previews breaking their structure. */
@@ -102,6 +114,7 @@ It breaks CKEditor 5 (see how <p><code>[]</code></p> looks). */
 	margin: 0;
 }
 
+/* stylelint-disable-next-line */
 .demo-row p {
 	margin-bottom: 0;
 }
@@ -135,6 +148,7 @@ It breaks CKEditor 5 (see how <p><code>[]</code></p> looks). */
 	margin-top: 10px;
 }
 
+/* stylelint-disable-next-line */
 .main__notification-body p {
 	margin-bottom: 0.3em;
 }

--- a/packages/ckeditor5-html-embed/theme/htmlembed.css
+++ b/packages/ckeditor5-html-embed/theme/htmlembed.css
@@ -6,7 +6,7 @@
 /* The feature container. */
 .ck-widget.raw-html-embed {
 	/* Give the embed some air. */
-	margin: var(--ck-spacing-large) auto;
+	margin: 0.9em auto;
 	position: relative;
 	display: flow-root;
 

--- a/packages/ckeditor5-html-embed/theme/htmlembed.css
+++ b/packages/ckeditor5-html-embed/theme/htmlembed.css
@@ -6,9 +6,16 @@
 /* The feature container. */
 .ck-widget.raw-html-embed {
 	/* Give the embed some air. */
-	margin: 1em auto;
+	margin: var(--ck-spacing-large) auto;
 	position: relative;
 	display: flow-root;
+
+	/* Give the html embed some minimal width in the content to prevent them
+	from being "squashed" in tight spaces, e.g. in table cells (https://github.com/ckeditor/ckeditor5/issues/8331) */
+	min-width: 15em;
+
+	/* Don't inherit the style, e.g. when in a block quote. */
+	font-style: normal;
 
 	/* ----- Emebed label in the upper left corner ----------------------------------------------- */
 
@@ -56,16 +63,4 @@
 		align-items: center;
 		justify-content: center;
 	}
-}
-
-.ck-content .raw-html-embed {
-	/* Give the embed some air. */
-	margin: 1em auto;
-
-	/* Give the html embed some minimal width in the content to prevent them
-	from being "squashed" in tight spaces, e.g. in table cells (https://github.com/ckeditor/ckeditor5/issues/8331) */
-	min-width: 15em;
-
-	/* Don't inherit the style, e.g. when in a block quote. */
-	font-style: normal;
 }

--- a/packages/ckeditor5-html-embed/theme/htmlembed.css
+++ b/packages/ckeditor5-html-embed/theme/htmlembed.css
@@ -6,6 +6,8 @@
 /* The feature container. */
 .ck-widget.raw-html-embed {
 	/* Give the embed some air. */
+	/* The first value should be equal to --ck-spacing-large variable if used in the editor context
+	to avoid the content jumping (See https://github.com/ckeditor/ckeditor5/issues/9825). */
 	margin: 0.9em auto;
 	position: relative;
 	display: flow-root;

--- a/packages/ckeditor5-image/theme/image.css
+++ b/packages/ckeditor5-image/theme/image.css
@@ -10,7 +10,7 @@
 		text-align: center;
 
 		/* Make sure there is some space between the content and the image. Center image by default. */
-		margin: 1em auto;
+		margin: var(--ck-spacing-large) auto;
 
 		/* Make sure the caption will be displayed properly (See: https://github.com/ckeditor/ckeditor5/issues/1870). */
 		min-width: 50px;

--- a/packages/ckeditor5-image/theme/image.css
+++ b/packages/ckeditor5-image/theme/image.css
@@ -10,7 +10,7 @@
 		text-align: center;
 
 		/* Make sure there is some space between the content and the image. Center image by default. */
-		margin: var(--ck-spacing-large) auto;
+		margin: 0.9em auto;
 
 		/* Make sure the caption will be displayed properly (See: https://github.com/ckeditor/ckeditor5/issues/1870). */
 		min-width: 50px;

--- a/packages/ckeditor5-image/theme/image.css
+++ b/packages/ckeditor5-image/theme/image.css
@@ -10,6 +10,8 @@
 		text-align: center;
 
 		/* Make sure there is some space between the content and the image. Center image by default. */
+		/* The first value should be equal to --ck-spacing-large variable if used in the editor context
+	 	to avoid the content jumping (See https://github.com/ckeditor/ckeditor5/issues/9825). */
 		margin: 0.9em auto;
 
 		/* Make sure the caption will be displayed properly (See: https://github.com/ckeditor/ckeditor5/issues/1870). */

--- a/packages/ckeditor5-media-embed/theme/mediaembed.css
+++ b/packages/ckeditor5-media-embed/theme/mediaembed.css
@@ -9,7 +9,7 @@
 	clear: both;
 
 	/* Make sure there is some space between the content and the media. */
-	margin: 1em 0;
+	margin: var(--ck-spacing-large) 0;
 
 	/* Make sure media is not overriden with Bootstrap default `flex` value.
 	See: https://github.com/ckeditor/ckeditor5/issues/1373. */

--- a/packages/ckeditor5-media-embed/theme/mediaembed.css
+++ b/packages/ckeditor5-media-embed/theme/mediaembed.css
@@ -9,7 +9,9 @@
 	clear: both;
 
 	/* Make sure there is some space between the content and the media. */
-	margin: var(--ck-spacing-large) 0;
+	/* The first value should be equal to --ck-spacing-large variable if used in the editor context
+	to avoid the content jumping (See https://github.com/ckeditor/ckeditor5/issues/9825). */
+	margin: 0.9em 0;
 
 	/* Make sure media is not overriden with Bootstrap default `flex` value.
 	See: https://github.com/ckeditor/ckeditor5/issues/1373. */

--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -5,6 +5,8 @@
 
 .ck-content .table {
 	/* Give the table widget some air and center it horizontally */
+	/* The first value should be equal to --ck-spacing-large variable if used in the editor context
+	to avoid the content jumping (See https://github.com/ckeditor/ckeditor5/issues/9825). */
 	margin: 0.9em auto;
 	display: table;
 

--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -5,7 +5,7 @@
 
 .ck-content .table {
 	/* Give the table widget some air and center it horizontally */
-	margin: var(--ck-spacing-large) auto;
+	margin: 0.9em auto;
 	display: table;
 
 	& table {

--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -5,7 +5,7 @@
 
 .ck-content .table {
 	/* Give the table widget some air and center it horizontally */
-	margin: 1em auto;
+	margin: var(--ck-spacing-large) auto;
 	display: table;
 
 	& table {

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/editorui/editorui.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/editorui/editorui.css
@@ -42,6 +42,10 @@
 
 	/* https://github.com/ckeditor/ckeditor5/issues/847 */
 	& > *:last-child {
+		/*
+		 * This value should match with the default margins of the block elements (like .media or .image)
+		 * to avoid a content jumping when the fake selection container shows up (See https://github.com/ckeditor/ckeditor5/issues/9825).
+		 */
 		margin-bottom: var(--ck-spacing-large);
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (image): The last element of the editor content should not have the forced `margin: 0` CSS rule. Closes #9825.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
