### PR TITLE
Editor will not crash when restircted area marker is removed

### DIFF
--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmode/converters.js
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmode/converters.js
@@ -79,7 +79,7 @@ export function resurrectCollapsedMarkerPostFixer( editor ) {
 		let changeApplied = false;
 
 		for ( const { name, data } of editor.model.document.differ.getChangedMarkers() ) {
-			if ( name.startsWith( 'restrictedEditingException' ) && data.newRange.root.rootName == '$graveyard' ) {
+			if ( name.startsWith( 'restrictedEditingException' ) && data.newRange && data.newRange.root.rootName == '$graveyard' ) {
 				writer.updateMarker( name, {
 					range: writer.createRange( writer.createPositionAt( data.oldRange.start ) )
 				} );

--- a/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting.js
+++ b/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting.js
@@ -536,6 +536,31 @@ describe( 'RestrictedEditingModeEditing', () => {
 			expect( markerRange.isEqual( expectedRange ) ).to.be.true;
 		} );
 
+		// https://github.com/ckeditor/ckeditor5/issues/9650
+		it( 'should not try to fix the marker if it was removed from markers collection', () => {
+			setModelData( model, '<paragraph>[]foo bar baz</paragraph>' );
+			const firstParagraph = model.document.getRoot().getChild( 0 );
+
+			model.change( writer => {
+				writer.addMarker( 'restrictedEditingException:1', {
+					range: writer.createRange(
+						writer.createPositionAt( firstParagraph, 4 ),
+						writer.createPositionAt( firstParagraph, 5 )
+					),
+					usingOperation: true,
+					affectsData: true
+				} );
+			} );
+
+			expect( () => {
+				model.change( writer => {
+					writer.removeMarker( 'restrictedEditingException:1' );
+				} );
+			} ).not.to.throw();
+
+			assertEqualMarkup( getModelData( model ), '<paragraph>[]foo bar baz</paragraph>' );
+		} );
+
 		it( 'should not move collapsed marker to $graveyard if it was removed by dragging', () => {
 			setModelData( model, '<paragraph>foo bar b[]az</paragraph>' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (restricted-editing): Editor will not crash when restircted area marker is removed. Closes #9650.