### PR TITLE
Fixed 'widget-toolbar-no-item' errors.

### DIFF
--- a/packages/ckeditor5-adapter-ckfinder/tests/manual/uploadadapter.js
+++ b/packages/ckeditor5-adapter-ckfinder/tests/manual/uploadadapter.js
@@ -24,6 +24,7 @@ import CKFinderUploadAdapter from '../../src/uploadadapter';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [
 			Enter, Typing, Paragraph, Heading, Undo, Bold, Italic, Heading, List, Image, ImageToolbar, Clipboard,
 			ImageCaption, ImageStyle, ImageUpload, CKFinderUploadAdapter

--- a/packages/ckeditor5-alignment/tests/manual/alignment.js
+++ b/packages/ckeditor5-alignment/tests/manual/alignment.js
@@ -11,6 +11,7 @@ import Alignment from '../../src/alignment';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, Alignment ],
 		toolbar: [
 			'heading', '|', 'alignment', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'

--- a/packages/ckeditor5-alignment/tests/manual/alignmentbuttons.js
+++ b/packages/ckeditor5-alignment/tests/manual/alignmentbuttons.js
@@ -11,6 +11,7 @@ import Alignment from '../../src/alignment';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, Alignment ],
 		toolbar: [
 			'heading', '|', 'alignment:left', 'alignment:right', 'alignment:center', 'alignment:justify', '|',

--- a/packages/ckeditor5-alignment/tests/manual/alignmentconfig.js
+++ b/packages/ckeditor5-alignment/tests/manual/alignmentconfig.js
@@ -11,6 +11,7 @@ import Alignment from '../../src/alignment';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, Alignment ],
 		toolbar: [
 			'heading', '|', 'alignment', '|', 'alignment:left', 'alignment:right', 'alignment:center', 'alignment:justify', '|',

--- a/packages/ckeditor5-alignment/tests/manual/rtl.js
+++ b/packages/ckeditor5-alignment/tests/manual/rtl.js
@@ -11,6 +11,7 @@ import Alignment from '../../src/alignment';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		language: 'ar',
 		plugins: [ ArticlePluginSet, Alignment ],
 		toolbar: [

--- a/packages/ckeditor5-block-quote/tests/manual/blockquote.js
+++ b/packages/ckeditor5-block-quote/tests/manual/blockquote.js
@@ -10,6 +10,7 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [
 			ArticlePluginSet
 		],

--- a/packages/ckeditor5-block-quote/tests/manual/blockquotenonesting.js
+++ b/packages/ckeditor5-block-quote/tests/manual/blockquotenonesting.js
@@ -18,6 +18,7 @@ function DisallowNestingBlockQuotes( editor ) {
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, DisallowNestingBlockQuotes ],
 		toolbar: [
 			'heading', '|', 'insertTable', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'

--- a/packages/ckeditor5-clipboard/tests/manual/copycut.js
+++ b/packages/ckeditor5-clipboard/tests/manual/copycut.js
@@ -12,6 +12,7 @@ import { stringify as stringifyView } from '@ckeditor/ckeditor5-engine/src/dev-u
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [ 'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'undo', 'redo' ]
 	} )

--- a/packages/ckeditor5-clipboard/tests/manual/pasting.js
+++ b/packages/ckeditor5-clipboard/tests/manual/pasting.js
@@ -12,6 +12,7 @@ import { stringify as stringifyView } from '@ckeditor/ckeditor5-engine/src/dev-u
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [ 'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'undo', 'redo' ]
 	} )

--- a/packages/ckeditor5-cloud-services/tests/manual/token.js
+++ b/packages/ckeditor5-cloud-services/tests/manual/token.js
@@ -17,6 +17,7 @@ const requestOutput = document.getElementById( 'request' );
 
 ClassicEditor
 	.create( document.getElementById( 'editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		cloudServices: {
 			tokenUrl: getToken,
 			uploadUrl: UPLOAD_URL

--- a/packages/ckeditor5-code-block/tests/manual/codeblock.js
+++ b/packages/ckeditor5-code-block/tests/manual/codeblock.js
@@ -14,6 +14,7 @@ import Indent from '@ckeditor/ckeditor5-indent/src/indent';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ Code, CodeBlock, Autoformat, Indent, ArticlePluginSet ],
 		toolbar: [
 			'heading', '|',

--- a/packages/ckeditor5-code-block/tests/manual/rtl.js
+++ b/packages/ckeditor5-code-block/tests/manual/rtl.js
@@ -12,6 +12,7 @@ import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		language: 'ar',
 		plugins: [ Code, CodeBlock, ArticlePluginSet ],
 		toolbar: [ 'heading', '|', 'bold', 'italic', 'code', 'blockQuote', 'codeBlock', 'undo', 'redo', 'insertTable' ]

--- a/packages/ckeditor5-core/tests/manual/formsubmit.js
+++ b/packages/ckeditor5-core/tests/manual/formsubmit.js
@@ -13,6 +13,7 @@ document.getElementById( 'form' ).submit = () => {};
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [ 'bold', 'italic', 'undo', 'redo' ]
 	} )

--- a/packages/ckeditor5-editor-inline/tests/manual/inlineeditor-data.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/inlineeditor-data.js
@@ -15,6 +15,7 @@ let counter = 1;
 function initEditor() {
 	InlineEditor
 		.create( `<h2>Editor ${ counter }</h2><p>This is an editor instance.</p>`, {
+			image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 			plugins: [ ArticlePluginSet ],
 			toolbar: [ 'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo' ]
 		} )

--- a/packages/ckeditor5-editor-inline/tests/manual/inlineeditor.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/inlineeditor.js
@@ -20,6 +20,7 @@ function initEditors() {
 	function init( selector ) {
 		InlineEditor
 			.create( document.querySelector( selector ), {
+				image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 				plugins: [ ArticlePluginSet ],
 				toolbar: [ 'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo' ]
 			} )

--- a/packages/ckeditor5-editor-inline/tests/manual/rtl.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/rtl.js
@@ -10,6 +10,7 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 
 InlineEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [ 'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo' ],
 		language: 'ar'

--- a/packages/ckeditor5-editor-inline/tests/manual/tickets/4/1.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/tickets/4/1.js
@@ -10,6 +10,7 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 
 InlineEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [ 'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo' ]
 	} )

--- a/packages/ckeditor5-engine/tests/manual/tickets/1439/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/1439/1.js
@@ -10,6 +10,7 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: {
 			items: [

--- a/packages/ckeditor5-engine/tests/manual/tickets/7892/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/7892/1.js
@@ -9,6 +9,7 @@ import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor'
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 
 const config = {
+	image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 	plugins: [ ArticlePluginSet ],
 	toolbar: [
 		'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'

--- a/packages/ckeditor5-font/tests/manual/font-color.js
+++ b/packages/ckeditor5-font/tests/manual/font-color.js
@@ -12,6 +12,7 @@ import FontBackgroundColor from '../../src/fontbackgroundcolor';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [
 			ArticlePluginSet,
 			FontColor,

--- a/packages/ckeditor5-font/tests/manual/font-family.js
+++ b/packages/ckeditor5-font/tests/manual/font-family.js
@@ -38,6 +38,7 @@ async function reloadEditor( options = {} ) {
 	}
 
 	const config = {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, FontFamily ],
 		toolbar: [
 			'heading', '|', 'fontFamily', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'

--- a/packages/ckeditor5-font/tests/manual/font-size-numeric.js
+++ b/packages/ckeditor5-font/tests/manual/font-size-numeric.js
@@ -38,6 +38,7 @@ async function reloadEditor( options = {} ) {
 	}
 
 	const config = {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, FontSize ],
 		toolbar: [
 			'heading', '|', 'fontSize', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'

--- a/packages/ckeditor5-font/tests/manual/font-size-presets.js
+++ b/packages/ckeditor5-font/tests/manual/font-size-presets.js
@@ -11,6 +11,7 @@ import FontSize from '../../src/fontsize';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, FontSize ],
 		toolbar: [
 			'heading', '|', 'fontSize', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'

--- a/packages/ckeditor5-font/tests/manual/tickets/8233/1.js
+++ b/packages/ckeditor5-font/tests/manual/tickets/8233/1.js
@@ -11,6 +11,7 @@ import FontSize from '../../../../src/fontsize';
 import FontFamily from '../../../../src/fontfamily';
 
 const config = {
+	image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 	plugins: [ ArticlePluginSet, FontSize, FontFamily ],
 	toolbar: [
 		'heading', '|', 'fontFamily', 'fontSize', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'

--- a/packages/ckeditor5-highlight/tests/manual/highlight-buttons.js
+++ b/packages/ckeditor5-highlight/tests/manual/highlight-buttons.js
@@ -11,6 +11,7 @@ import Highlight from '../../src/highlight';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, Highlight ],
 		toolbar: [
 			'highlight:yellowMarker', 'highlight:greenMarker', 'highlight:pinkMarker', 'highlight:blueMarker',

--- a/packages/ckeditor5-highlight/tests/manual/highlight.js
+++ b/packages/ckeditor5-highlight/tests/manual/highlight.js
@@ -11,6 +11,7 @@ import Highlight from '../../src/highlight';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, Highlight ],
 		toolbar: [
 			'heading', '|', 'highlight', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'

--- a/packages/ckeditor5-html-embed/tests/manual/tickets/8328/1.js
+++ b/packages/ckeditor5-html-embed/tests/manual/tickets/8328/1.js
@@ -11,6 +11,7 @@ import HtmlEmbed from '../../../../src/htmlembed';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, HtmlEmbed ],
 		toolbar: [
 			'heading', '|', 'bold', 'italic', 'link', '|',

--- a/packages/ckeditor5-image/tests/manual/tickets/127/1.js
+++ b/packages/ckeditor5-image/tests/manual/tickets/127/1.js
@@ -19,6 +19,7 @@ import ImageToolbar from '../../../../src/imagetoolbar';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ Enter, Typing, Paragraph, Link, Bold, Image, Undo, ImageToolbar, BalloonToolbar, ImageCaption ],
 		toolbar: [ 'bold', 'undo', 'redo' ]
 	} )

--- a/packages/ckeditor5-image/tests/manual/tickets/8433/1.js
+++ b/packages/ckeditor5-image/tests/manual/tickets/8433/1.js
@@ -15,6 +15,7 @@ import { UploadAdapterMock } from '@ckeditor/ckeditor5-upload/tests/_utils/mocks
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, HtmlEmbed, ImageInsert, ImageResize ],
 		toolbar: [ 'insertImage', '|', 'htmlEmbed' ],
 		htmlEmbed: {

--- a/packages/ckeditor5-language/tests/manual/textpartlanguage.js
+++ b/packages/ckeditor5-language/tests/manual/textpartlanguage.js
@@ -11,6 +11,7 @@ import TextPartLanguage from '../../src/textpartlanguage';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [
 			ArticlePluginSet,
 			TextPartLanguage

--- a/packages/ckeditor5-link/tests/manual/tickets/113/1.js
+++ b/packages/ckeditor5-link/tests/manual/tickets/113/1.js
@@ -11,6 +11,7 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 // Editor for the external insert.
 ClassicEditor
 	.create( document.querySelector( '#editor-insert' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [ 'undo', 'redo', 'link' ]
 	} )
@@ -27,6 +28,7 @@ ClassicEditor
 // Editor for the external delete.
 ClassicEditor
 	.create( document.querySelector( '#editor-delete' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [ 'undo', 'redo', 'link' ]
 	} )

--- a/packages/ckeditor5-link/tests/manual/tickets/6053/1.js
+++ b/packages/ckeditor5-link/tests/manual/tickets/6053/1.js
@@ -10,6 +10,7 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [ 'undo', 'redo', 'link' ],
 		link: {

--- a/packages/ckeditor5-media-embed/tests/manual/mediaembed.js
+++ b/packages/ckeditor5-media-embed/tests/manual/mediaembed.js
@@ -12,6 +12,7 @@ import MediaEmbedToolbar from '../../src/mediaembedtoolbar';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, MediaEmbed, MediaEmbedToolbar ],
 		toolbar: [
 			'heading', '|', 'mediaEmbed', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'link', 'undo', 'redo'

--- a/packages/ckeditor5-media-embed/tests/manual/semanticmediaembed.js
+++ b/packages/ckeditor5-media-embed/tests/manual/semanticmediaembed.js
@@ -11,6 +11,7 @@ import MediaEmbed from '../../src/mediaembed';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, MediaEmbed ],
 		toolbar: [
 			'heading', '|', 'mediaEmbed', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'link', 'undo', 'redo'

--- a/packages/ckeditor5-mention/tests/manual/mention-custom-renderer.js
+++ b/packages/ckeditor5-mention/tests/manual/mention-custom-renderer.js
@@ -13,6 +13,7 @@ import Font from '@ckeditor/ckeditor5-font/src/font';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, Underline, Font, Mention ],
 		toolbar: [
 			'heading',

--- a/packages/ckeditor5-mention/tests/manual/mention-custom-view.js
+++ b/packages/ckeditor5-mention/tests/manual/mention-custom-view.js
@@ -62,6 +62,7 @@ class CustomMentionAttributeView extends Plugin {
 
 ClassicEditor
 	.create( global.document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, Underline, Font, Mention, CustomMentionAttributeView ],
 		toolbar: [
 			'heading',

--- a/packages/ckeditor5-paste-from-office/tests/manual/integration.js
+++ b/packages/ckeditor5-paste-from-office/tests/manual/integration.js
@@ -33,6 +33,7 @@ const dataDiv = document.querySelector( '#data' );
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [
 			ArticlePluginSet,
 			Strikethrough,

--- a/packages/ckeditor5-paste-from-office/tests/manual/tickets/7957/1.js
+++ b/packages/ckeditor5-paste-from-office/tests/manual/tickets/7957/1.js
@@ -27,6 +27,7 @@ import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices'
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, Strikethrough, Underline, Table, TableToolbar, PageBreak, CloudServices,
 			TableProperties, TableCellProperties, EasyImage, PasteFromOffice, FontColor, FontBackgroundColor, ImageUpload ],
 		toolbar: [ 'heading', '|', 'bold', 'italic', 'strikethrough', 'underline', 'link',

--- a/packages/ckeditor5-remove-format/tests/manual/removeformat.js
+++ b/packages/ckeditor5-remove-format/tests/manual/removeformat.js
@@ -26,6 +26,7 @@ import ImageResize from '@ckeditor/ckeditor5-image/src/imageresize';
 
 ClassicEditor
 	.create( global.document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [
 			Bold, Clipboard, Enter, Italic, Link, Paragraph, RemoveFormat, ShiftEnter, Typing,
 			Underline, Undo, Image, ImageCaption, ImageToolbar, ImageResize

--- a/packages/ckeditor5-table/tests/manual/rtl.js
+++ b/packages/ckeditor5-table/tests/manual/rtl.js
@@ -13,6 +13,7 @@ import TableCellProperties from '../../src/tablecellproperties';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, TableProperties, TableCellProperties ],
 		language: {
 			ui: 'ar',

--- a/packages/ckeditor5-table/tests/manual/table.js
+++ b/packages/ckeditor5-table/tests/manual/table.js
@@ -10,6 +10,7 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [
 			'heading', '|', 'insertTable', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'

--- a/packages/ckeditor5-table/tests/manual/tablecaption.js
+++ b/packages/ckeditor5-table/tests/manual/tablecaption.js
@@ -17,6 +17,7 @@ import TableCaption from '../../src/tablecaption';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [
 			ArticlePluginSet, Table, TableToolbar, TableSelection, TableClipboard, TableProperties, TableCellProperties, TableCaption
 		],

--- a/packages/ckeditor5-table/tests/manual/tableclipboard.js
+++ b/packages/ckeditor5-table/tests/manual/tableclipboard.js
@@ -22,6 +22,7 @@ createEditor( '#editor-geometry', 'geometry' );
 function createEditor( target, inspectorName ) {
 	ClassicEditor
 		.create( document.querySelector( target ), {
+			image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 			plugins: [ ArticlePluginSet, Table, TableToolbar, TableSelection, TableClipboard, TableProperties, TableCellProperties ],
 			toolbar: [
 				'heading', '|',

--- a/packages/ckeditor5-table/tests/manual/tabledefaultproperties.js
+++ b/packages/ckeditor5-table/tests/manual/tabledefaultproperties.js
@@ -24,6 +24,7 @@ document.querySelector( '#table-properties-styles-preview' ).innerText = styleAs
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, Alignment, Indent, IndentBlock, TableProperties, TableCellProperties ],
 		toolbar: [
 			'heading', '|', 'insertTable', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'

--- a/packages/ckeditor5-table/tests/manual/tablemocking.js
+++ b/packages/ckeditor5-table/tests/manual/tablemocking.js
@@ -18,6 +18,7 @@ import { getSelectionAffectedTableCells } from '../../src/utils/selection';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [
 			'insertTable', 'undo', 'redo'

--- a/packages/ckeditor5-table/tests/manual/tablenonesting.js
+++ b/packages/ckeditor5-table/tests/manual/tablenonesting.js
@@ -18,6 +18,7 @@ function DisallowNestingTables( editor ) {
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, DisallowNestingTables ],
 		toolbar: [
 			'heading', '|', 'insertTable', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'

--- a/packages/ckeditor5-table/tests/manual/tableproperties.js
+++ b/packages/ckeditor5-table/tests/manual/tableproperties.js
@@ -21,6 +21,7 @@ document.querySelector( '#cloned-source' ).append( ...clonedSource.childNodes );
 
 ClassicEditor
 	.create( sourceElement, {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, Alignment, Indent, IndentBlock, TableProperties, TableCellProperties ],
 		toolbar: [
 			'heading', '|', 'insertTable', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'

--- a/packages/ckeditor5-table/tests/manual/tickets/6062.js
+++ b/packages/ckeditor5-table/tests/manual/tickets/6062.js
@@ -10,6 +10,7 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [
 			'heading', '|', 'insertTable', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'

--- a/packages/ckeditor5-theme-lark/tests/manual/inverted.js
+++ b/packages/ckeditor5-theme-lark/tests/manual/inverted.js
@@ -14,6 +14,7 @@ import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
 import Highlight from '@ckeditor/ckeditor5-highlight/src/highlight';
 
 const config = {
+	image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 	plugins: [ ArticlePluginSet, Strikethrough, Code, Highlight ],
 	toolbar: [ 'heading', '|', 'bold', 'italic', 'strikethrough', 'code', 'link', '|', 'highlight', '|', 'undo', 'redo' ]
 };

--- a/packages/ckeditor5-theme-lark/tests/manual/tickets/113/1.js
+++ b/packages/ckeditor5-theme-lark/tests/manual/tickets/113/1.js
@@ -10,6 +10,7 @@ import BalloonEditor from '@ckeditor/ckeditor5-editor-balloon/src/ballooneditor'
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 
 const config = {
+	image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 	plugins: [ ArticlePluginSet ]
 };
 

--- a/packages/ckeditor5-theme-lark/tests/manual/tickets/189/1.js
+++ b/packages/ckeditor5-theme-lark/tests/manual/tickets/189/1.js
@@ -10,6 +10,7 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 
 BalloonEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [ 'bold', 'link' ]
 	} )

--- a/packages/ckeditor5-theme-lark/tests/manual/tickets/189/assets/iframe-content.js
+++ b/packages/ckeditor5-theme-lark/tests/manual/tickets/189/assets/iframe-content.js
@@ -14,6 +14,7 @@ if ( window.top === window ) {
 } else {
 	BalloonEditor
 		.create( document.querySelector( '#editor' ), {
+			image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 			plugins: [ ArticlePluginSet ],
 			toolbar: [ 'bold', 'link' ]
 		} )

--- a/packages/ckeditor5-ui/tests/manual/balloontoolbar/balloontoolbar.js
+++ b/packages/ckeditor5-ui/tests/manual/balloontoolbar/balloontoolbar.js
@@ -11,6 +11,7 @@ import BalloonToolbar from '../../../src/toolbar/balloon/balloontoolbar';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, BalloonToolbar ],
 		toolbar: [ 'bold', 'italic', 'link', 'undo', 'redo' ],
 		balloonToolbar: [ 'bold', 'italic', 'link' ]

--- a/packages/ckeditor5-ui/tests/manual/contextualballoon/contextualballoon.js
+++ b/packages/ckeditor5-ui/tests/manual/contextualballoon/contextualballoon.js
@@ -76,6 +76,7 @@ class CustomStackHighlight {
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, BalloonToolbar, CustomStackHighlight, Mention ],
 		toolbar: [ 'bold', 'link' ],
 		balloonToolbar: [ 'bold', 'link' ],

--- a/packages/ckeditor5-ui/tests/manual/contextualballoon/externalchanges.js
+++ b/packages/ckeditor5-ui/tests/manual/contextualballoon/externalchanges.js
@@ -12,6 +12,7 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 // Editor for the external insert.
 ClassicEditor
 	.create( document.querySelector( '#editor-insert' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, BalloonToolbar ],
 		toolbar: [ 'bold', 'link' ],
 		balloonToolbar: [ 'bold', 'link' ]
@@ -29,6 +30,7 @@ ClassicEditor
 // Editor for the external delete.
 ClassicEditor
 	.create( document.querySelector( '#editor-delete' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, BalloonToolbar ],
 		toolbar: [ 'bold', 'link' ],
 		balloonToolbar: [ 'bold', 'link' ]

--- a/packages/ckeditor5-ui/tests/manual/tickets/170/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/170/1.js
@@ -15,6 +15,7 @@ document.querySelector( '.container-outer' ).scrollTop = 450;
 // Init editor with balloon attached to the target element.
 ClassicEditor
 	.create( document.querySelector( '#editor-attach' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [ 'bold', 'italic', 'undo', 'redo' ]
 	} )
@@ -40,6 +41,7 @@ ClassicEditor
 // Init editor with balloon sticked to the target element.
 ClassicEditor
 	.create( document.querySelector( '#editor-stick' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [ 'bold', 'italic', 'undo', 'redo' ]
 	} )

--- a/packages/ckeditor5-ui/tests/manual/tickets/198/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/198/1.js
@@ -12,6 +12,7 @@ import BalloonToolbar from '../../../../src/toolbar/balloon/balloontoolbar';
 // Editor for the external insert.
 ClassicEditor
 	.create( document.querySelector( '#editor-insert' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, BalloonToolbar ],
 		toolbar: [ 'undo', 'redo' ],
 		balloonToolbar: [ 'bold', 'italic' ]
@@ -29,6 +30,7 @@ ClassicEditor
 // Editor for the external delete.
 ClassicEditor
 	.create( document.querySelector( '#editor-delete' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, BalloonToolbar ],
 		toolbar: [ 'undo', 'redo' ],
 		balloonToolbar: [ 'bold', 'italic' ]

--- a/packages/ckeditor5-ui/tests/manual/tickets/228/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/228/1.js
@@ -10,6 +10,7 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet ],
 		toolbar: [ 'heading' ]
 	} )

--- a/packages/ckeditor5-ui/tests/manual/tickets/385/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/385/1.js
@@ -11,6 +11,7 @@ import BalloonToolbar from '../../../../src/toolbar/balloon/balloontoolbar';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, BalloonToolbar ],
 		toolbar: [ 'bold', 'italic', 'link', 'undo', 'redo' ],
 		balloonToolbar: [ 'bold', 'italic', 'link' ]

--- a/packages/ckeditor5-watchdog/tests/manual/watchdog.js
+++ b/packages/ckeditor5-watchdog/tests/manual/watchdog.js
@@ -30,6 +30,7 @@ class TypingError {
 }
 
 const editorConfig = {
+	image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 	plugins: [
 		ArticlePluginSet, TypingError
 	],

--- a/packages/ckeditor5-word-count/tests/manual/wordcount.js
+++ b/packages/ckeditor5-word-count/tests/manual/wordcount.js
@@ -11,6 +11,7 @@ import WordCount from '../../src/wordcount';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
 		plugins: [ ArticlePluginSet, WordCount ],
 		toolbar: [
 			'heading', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'link', 'undo', 'redo'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Tests: Fixed most 'widget-toolbar-no-item' errors. Closes #8695.

---

### Additional information

`ckeditor5\packages\ckeditor5-theme-lark\tests\manual\tickets\189\1.js` still seems to have this issue despite making same change as in all other files.