### PR TITLE
Bugfix for mention plugin, trivial, mentionId input validation

### DIFF
--- a/packages/ckeditor5-mention/src/mentioncommand.js
+++ b/packages/ckeditor5-mention/src/mentioncommand.js
@@ -104,7 +104,7 @@ export default class MentionCommand extends Command {
 			);
 		}
 
-		if ( mentionID.charAt( 0 ) != options.marker ) {
+		if ( typeof mentionID !== 'string' || mentionID.charAt( 0 ) != options.marker ) {
 			/**
 			 * The feed item ID must start with the marker character.
 			 *


### PR DESCRIPTION
Type (ckeditor5-mention): Added missing validation check, so non-string input won't trigger **typeError**, but let the proper exception be thrown.

---

### Additional information

As per: https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/contributing.html
I skipped creating a separate GH issue for such a trivial change. 

