### PR TITLE
Fixed missing links in the migration guide.

### DIFF
--- a/docs/builds/guides/migration/migration-to-29.md
+++ b/docs/builds/guides/migration/migration-to-29.md
@@ -9,11 +9,11 @@ order: 95
 
 This migration guide enumerates the most important changes that require your attention when upgrading to CKEditor 5 v29.0.0 due to changes introduced in the {@link module:image/image~Image} plugin and some other image-related features.
 
-For the entire list of the changes introduced in version 29.0.0 of the CKEditor 5 see the changelog (TODO:link).
+<!-- For the entire list of the changes introduced in version 29.0.0 of the CKEditor 5 see the changelog (TODO:link). -->
 
 To see the new editor UI for the images visit the {@link features/images-overview image feature guide}, especially:
-* Images in the structured content, (TODO:link)
-* Images in the document-like content (TODO:link)
+* {@link features/images-styles#semantical-styles Images in the structured content }
+* {@link features/images-styles#presentational-styles Images in the document-like content}
 
 ## Inline images
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: The migration guide should link properly to the image feature page. Closes #9915.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
