### PR TITLE
Expand DomConverter.blockElements with missing elements

### DIFF
--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -1135,10 +1135,8 @@ describe( 'CodeBlockEditing', () => {
 			editor.setData( `<pre><code>foo</code></pre>
 				<pre><code>bar</code></pre>` );
 
-			// Note: The empty <paragraph> in between should not be here. It's a conversion/auto–paragraphing bug.
 			expect( getModelData( model ) ).to.equal(
 				'<codeBlock language="plaintext">[]foo</codeBlock>' +
-				'<paragraph> </paragraph>' +
 				'<codeBlock language="plaintext">bar</codeBlock>' );
 		} );
 

--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -1304,7 +1304,7 @@ export default class DomConverter {
 // Used to check if given native `Element` or `Text` node has parent with tag name from `types` array.
 //
 // @param {Node} node
-// @param {Iterable.<String>} types
+// @param {Array.<String>} types
 // @param {Boolean} [boundaryParent] Can be given if parents should be checked up to a given element (excluding that element).
 // @returns {Boolean} `true` if such parent exists or `false` if it does not.
 function _hasDomParentOfType( node, types, boundaryParent ) {

--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -85,9 +85,14 @@ export default class DomConverter {
 		 * You can extend this array if you introduce support for block elements which are not yet recognized here.
 		 *
 		 * @readonly
-		 * @member {Array.<String>} module:engine/view/domconverter~DomConverter#blockElements
+		 * @member {Set.<String>} module:engine/view/domconverter~DomConverter#blockElements
 		 */
-		this.blockElements = [ 'p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'dd', 'dt', 'figcaption', 'td', 'th' ];
+		this.blockElements = new Set( [
+			'address', 'article', 'aside', 'blockquote', 'caption', 'center', 'dd', 'details', 'dir', 'div',
+			'dl', 'dt', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header',
+			'hgroup', 'legend', 'li', 'main', 'menu', 'nav', 'ol', 'p', 'pre', 'section', 'summary', 'table', 'tbody',
+			'td', 'tfoot', 'th', 'thead', 'tr', 'ul'
+		] );
 
 		/**
 		 * The DOM-to-view mapping.
@@ -1299,11 +1304,13 @@ export default class DomConverter {
 // Used to check if given native `Element` or `Text` node has parent with tag name from `types` array.
 //
 // @param {Node} node
-// @param {Array.<String>} types
+// @param {Iterable.<String>} types
 // @param {Boolean} [boundaryParent] Can be given if parents should be checked up to a given element (excluding that element).
 // @returns {Boolean} `true` if such parent exists or `false` if it does not.
 function _hasDomParentOfType( node, types, boundaryParent ) {
 	let parents = getAncestors( node );
+
+	types = Array.from( types );
 
 	if ( boundaryParent ) {
 		parents = parents.slice( parents.indexOf( boundaryParent ) + 1 );
@@ -1329,6 +1336,7 @@ function forEachDomNodeAncestor( node, callback ) {
 // A &nbsp; is a block filler only if it is a single child of a block element.
 //
 // @param {Node} domNode DOM node.
+// @param {Iterable.<String>} blockElements
 // @returns {Boolean}
 function isNbspBlockFiller( domNode, blockElements ) {
 	const isNBSP = domNode.isEqualNode( NBSP_FILLER_REF );
@@ -1339,9 +1347,12 @@ function isNbspBlockFiller( domNode, blockElements ) {
 // Checks if domNode has block parent.
 //
 // @param {Node} domNode DOM node.
+// @param {Iterable.<String>} blockElements
 // @returns {Boolean}
 function hasBlockParent( domNode, blockElements ) {
 	const parent = domNode.parentNode;
+
+	blockElements = Array.from( blockElements );
 
 	return parent && parent.tagName && blockElements.includes( parent.tagName.toLowerCase() );
 }

--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -85,14 +85,14 @@ export default class DomConverter {
 		 * You can extend this array if you introduce support for block elements which are not yet recognized here.
 		 *
 		 * @readonly
-		 * @member {Set.<String>} module:engine/view/domconverter~DomConverter#blockElements
+		 * @member {Array.<String>} module:engine/view/domconverter~DomConverter#blockElements
 		 */
-		this.blockElements = new Set( [
+		this.blockElements = [
 			'address', 'article', 'aside', 'blockquote', 'caption', 'center', 'dd', 'details', 'dir', 'div',
 			'dl', 'dt', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header',
 			'hgroup', 'legend', 'li', 'main', 'menu', 'nav', 'ol', 'p', 'pre', 'section', 'summary', 'table', 'tbody',
 			'td', 'tfoot', 'th', 'thead', 'tr', 'ul'
-		] );
+		];
 
 		/**
 		 * The DOM-to-view mapping.
@@ -1310,8 +1310,6 @@ export default class DomConverter {
 function _hasDomParentOfType( node, types, boundaryParent ) {
 	let parents = getAncestors( node );
 
-	types = Array.from( types );
-
 	if ( boundaryParent ) {
 		parents = parents.slice( parents.indexOf( boundaryParent ) + 1 );
 	}
@@ -1336,7 +1334,7 @@ function forEachDomNodeAncestor( node, callback ) {
 // A &nbsp; is a block filler only if it is a single child of a block element.
 //
 // @param {Node} domNode DOM node.
-// @param {Iterable.<String>} blockElements
+// @param {Array.<String>} blockElements
 // @returns {Boolean}
 function isNbspBlockFiller( domNode, blockElements ) {
 	const isNBSP = domNode.isEqualNode( NBSP_FILLER_REF );
@@ -1347,12 +1345,10 @@ function isNbspBlockFiller( domNode, blockElements ) {
 // Checks if domNode has block parent.
 //
 // @param {Node} domNode DOM node.
-// @param {Iterable.<String>} blockElements
+// @param {Array.<String>} blockElements
 // @returns {Boolean}
 function hasBlockParent( domNode, blockElements ) {
 	const parent = domNode.parentNode;
-
-	blockElements = Array.from( blockElements );
 
 	return parent && parent.tagName && blockElements.includes( parent.tagName.toLowerCase() );
 }

--- a/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
@@ -295,40 +295,66 @@ describe( 'DomConverter', () => {
 	} );
 
 	describe( 'isBlockFiller()', () => {
+		const blockElements = new Set( [
+			'address', 'article', 'aside', 'blockquote', 'caption', 'center', 'dd', 'details', 'dir', 'div',
+			'dl', 'dt', 'fieldset', 'figcaption', 'figure', 'footer', 'form', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'header',
+			'hgroup', 'legend', 'li', 'main', 'menu', 'nav', 'ol', 'p', 'pre', 'section', 'summary', 'table', 'tbody',
+			'td', 'tfoot', 'th', 'thead', 'tr', 'ul'
+		] );
+
 		for ( const mode of [ 'nbsp', 'markedNbsp' ] ) {
 			describe( 'mode "' + mode + '"', () => {
 				beforeEach( () => {
 					converter = new DomConverter( viewDocument, { blockFillerMode: mode } );
 				} );
 
-				it( 'should return true if the node is an nbsp filler and is a single child of a block level element', () => {
-					const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
+				for ( const elementName of blockElements ) {
+					describe( `<${ elementName }> context`, () => {
+						it( 'should return true if the node is an nbsp filler and is a single child of a block level element', () => {
+							const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
 
-					const context = document.createElement( 'div' );
-					context.appendChild( nbspFillerInstance );
+							const context = document.createElement( elementName );
+							context.appendChild( nbspFillerInstance );
 
-					expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.true;
-				} );
+							expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.true;
+						} );
 
-				it( 'should return false if the node is an nbsp filler and is not a single child of a block level element', () => {
-					const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
+						it( 'should return false if the node is an nbsp filler and is not a single child of a block level element', () => {
+							const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
 
-					const context = document.createElement( 'div' );
-					context.appendChild( nbspFillerInstance );
-					context.appendChild( document.createTextNode( 'a' ) );
+							const context = document.createElement( elementName );
+							context.appendChild( nbspFillerInstance );
+							context.appendChild( document.createTextNode( 'a' ) );
 
-					expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.false;
-				} );
+							expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.false;
+						} );
 
-				it( 'should return false if there are two nbsp fillers in a block element', () => {
-					const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
+						it( 'should return false if there are two nbsp fillers in a block element', () => {
+							const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
 
-					const context = document.createElement( 'div' );
-					context.appendChild( nbspFillerInstance );
-					context.appendChild( NBSP_FILLER( document ) ); // eslint-disable-line new-cap
+							const context = document.createElement( elementName );
+							context.appendChild( nbspFillerInstance );
+							context.appendChild( NBSP_FILLER( document ) ); // eslint-disable-line new-cap
 
-					expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.false;
-				} );
+							expect( converter.isBlockFiller( nbspFillerInstance ) ).to.be.false;
+						} );
+
+						it( 'should return false for a normal <br> element', () => {
+							const context = document.createElement( elementName );
+							context.innerHTML = 'x<br>x';
+
+							expect( converter.isBlockFiller( context.childNodes[ 1 ] ) ).to.be.false;
+						} );
+
+						// SPECIAL CASE (see ckeditor5#5564).
+						it( 'should return true for a <br> element which is the only child of its block parent', () => {
+							const context = document.createElement( elementName );
+							context.innerHTML = '<br>';
+
+							expect( converter.isBlockFiller( context.firstChild ) ).to.be.true;
+						} );
+					} );
+				}
 
 				it( 'should return false filler is placed in a non-block element', () => {
 					const nbspFillerInstance = NBSP_FILLER( document ); // eslint-disable-line new-cap
@@ -347,21 +373,6 @@ describe( 'DomConverter', () => {
 
 				it( 'should return false for inline filler', () => {
 					expect( converter.isBlockFiller( document.createTextNode( INLINE_FILLER ) ) ).to.be.false;
-				} );
-
-				it( 'should return false for a normal <br> element', () => {
-					const context = document.createElement( 'div' );
-					context.innerHTML = 'x<br>x';
-
-					expect( converter.isBlockFiller( context.childNodes[ 1 ] ) ).to.be.false;
-				} );
-
-				// SPECIAL CASE (see ckeditor5#5564).
-				it( 'should return true for a <br> element which is the only child of its block parent', () => {
-					const context = document.createElement( 'div' );
-					context.innerHTML = '<br>';
-
-					expect( converter.isBlockFiller( context.firstChild ) ).to.be.true;
 				} );
 
 				it( 'should return false for a <br> element which is the only child of its non-block parent', () => {

--- a/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/blockquotes.js
+++ b/packages/ckeditor5-markdown-gfm/tests/gfmdataprocessor/blockquotes.js
@@ -115,8 +115,7 @@ describe( 'GFMDataProcessor', () => {
 						'<code>' +
 							'code 2' +
 						'</code>' +
-					// Space after `</pre>` might be due to bug in engine. See: https://github.com/ckeditor/ckeditor5/issues/7863.
-					'</pre> ' +
+					'</pre>' +
 				'</blockquote>',
 
 				'> Example 1:\n' +
@@ -129,9 +128,7 @@ describe( 'GFMDataProcessor', () => {
 				'>\n' +
 				'> ```\n' +
 				'> code 2\n' +
-				'> ```' +
-				// The below is an artefact of space after `</pre>`. See comment above & https://github.com/ckeditor/ckeditor5/issues/7863.
-				'\n>\n>'
+				'> ```'
 			);
 		} );
 
@@ -169,8 +166,7 @@ describe( 'GFMDataProcessor', () => {
 						'<code>' +
 							'code 2' +
 						'</code>' +
-					// Space after `</pre>` might be due to bug in engine. See: https://github.com/ckeditor/ckeditor5/issues/7863.
-					'</pre> ' +
+					'</pre>' +
 				'</blockquote>',
 
 				// When converting back to data, DataProcessor will normalize tabs to ```.
@@ -184,9 +180,7 @@ describe( 'GFMDataProcessor', () => {
 				'>\n' +
 				'> ```\n' +
 				'> code 2\n' +
-				'> ```' +
-				// The below is an artefact of space after `</pre>`. See comment above & https://github.com/ckeditor/ckeditor5/issues/7863.
-				'\n>\n>'
+				'> ```'
 			);
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): `DomConverter.blockElements` is missing some of the HTML block element names. Closes #9801. Closes #7863.
