### PR TITLE
Docs: fixed broken fake consoles in demos

### DIFF
--- a/docs/_snippets/builds/saving-data/autosave.html
+++ b/docs/_snippets/builds/saving-data/autosave.html
@@ -19,7 +19,7 @@
 
 <p>Server data:</p>
 
-<pre class="highlight language-json" id="snippet-autosave-console">Type some text to test the &#x3C;a href=&#x22;#autosave-feature&#x22;&#x3E;autosave&#x3C;/a&#x3E; feature.</pre>
+<pre class="highlight language-html" id="snippet-autosave-console">Type some text to test the &#x3C;a href=&#x22;#autosave-feature&#x22;&#x3E;autosave&#x3C;/a&#x3E; feature.</pre>
 
 <style>
 	#snippet-autosave-header {

--- a/docs/_snippets/builds/saving-data/autosave.html
+++ b/docs/_snippets/builds/saving-data/autosave.html
@@ -19,7 +19,7 @@
 
 <p>Server data:</p>
 
-<pre><code id="snippet-autosave-console">Type some text to test the &#x3C;a href=&#x22;#autosave-feature&#x22;&#x3E;autosave&#x3C;/a&#x3E; feature.</code></pre>
+<pre class="highlight language-json" id="snippet-autosave-console">Type some text to test the &#x3C;a href=&#x22;#autosave-feature&#x22;&#x3E;autosave&#x3C;/a&#x3E; feature.</pre>
 
 <style>
 	#snippet-autosave-header {

--- a/docs/_snippets/builds/saving-data/manualsave.html
+++ b/docs/_snippets/builds/saving-data/manualsave.html
@@ -15,7 +15,7 @@
 
 <p>Server data:</p>
 
-<pre class="highlight language-json" id="snippet-manualsave-console">&#x3C;p&#x3E;Change the content of this editor, then save it on the server.&#x3C;/p&#x3E;</pre>
+<pre class="highlight language-html" id="snippet-manualsave-console">&#x3C;p&#x3E;Change the content of this editor, then save it on the server.&#x3C;/p&#x3E;</pre>
 
 <style>
 	#snippet-manualsave-header {

--- a/docs/_snippets/builds/saving-data/manualsave.html
+++ b/docs/_snippets/builds/saving-data/manualsave.html
@@ -15,7 +15,7 @@
 
 <p>Server data:</p>
 
-<pre><code id="snippet-manualsave-console">&#x3C;p&#x3E;Change the content of this editor, then save it on the server.&#x3C;/p&#x3E;</code></pre>
+<pre class="highlight language-json" id="snippet-manualsave-console">&#x3C;p&#x3E;Change the content of this editor, then save it on the server.&#x3C;/p&#x3E;</pre>
 
 <style>
 	#snippet-manualsave-header {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: fixed broken fake consoles in 'Getting and saving data' demos.

Closes https://github.com/ckeditor/ckeditor5/issues/9938.

