### PR TITLE
Docs: Added section about allowing all elements and attributes in GHS feature guide

### DIFF
--- a/packages/ckeditor5-html-support/docs/features/general-html-support.md
+++ b/packages/ckeditor5-html-support/docs/features/general-html-support.md
@@ -214,6 +214,21 @@ The General HTML Support feature distinguishes several content types, each treat
 
 The enabled elements will not just be available "anywhere" in the content, as they still need to adhere to certain rules derived from the HTML schema and from common sense. Also, the behavior of specific types of elements in the editing area will be different. For instance, the object elements will only be selectable as a whole, and the inline elements will work the same as other formatting features supported by CKEditor 5 (e.g. bold, italic) do.
 
+### Enabling all elements and attributes
+
+In some cases, it might be desired to disable content filtering, so all elements and attributes will be allowed. It could be done with a special configuration:
+
+```js
+{
+	name: /.*/,
+	attributes: true,
+	classes: true,
+	styles: true
+}
+```
+
+The above configuration will work similarly to `allowedContent: true` option from CKEditor 4.
+
 ## Known issues
 
 It is possible to add support for arbitrary styles, classes and other attributes to existing CKEditor 5 features (such as paragraphs, headings, list items, etc.).


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Added section about allowing all elements and attributes in GHS feature guide. Closes #9976.