### PR TITLE
i/9981: CSS for RTL editor in find and replace feature added

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.js
+++ b/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.js
@@ -430,6 +430,11 @@ export default class FindAndReplaceFormView extends View {
 				this.replaceInputView,
 				{
 					tag: 'div',
+					attributes: {
+						class: [
+							'ck-replace-buttons'
+						]
+					},
 					children: [
 						this.replaceAllButtonView,
 						this.replaceButtonView

--- a/packages/ckeditor5-find-and-replace/theme/findandreplaceform.css
+++ b/packages/ckeditor5-find-and-replace/theme/findandreplaceform.css
@@ -156,17 +156,17 @@
 		padding: var(--ck-spacing-extra-tiny) var(--ck-spacing-medium) var(--ck-spacing-extra-tiny) calc(var(--ck-spacing-medium) * 8);
 	}
 
-	& .ck .ck-find-and-replace-form  .ck-replace-form__wrapper {
+	& .ck .ck-find-and-replace-form .ck-replace-form__wrapper {
 		& .ck-replace-buttons {
 			display: flex;
 			flex-flow: row-reverse;
 
 			& .ck-button:last-child {
-				margin-left: var(--ck-spacing-standard)
+				margin-left: var(--ck-spacing-standard);
 			}
 		}
 		& .ck-labeled-field-view__input-wrapper .ck.ck-input-text{
-			padding: var(--ck-spacing-extra-tiny) var(--ck-spacing-medium) var(--ck-spacing-extra-tiny) var(--ck-spacing-medium)
+			padding: var(--ck-spacing-extra-tiny) var(--ck-spacing-medium);
 		}
 	}
 
@@ -187,39 +187,13 @@
 
 		& .ck-find-buttons {
 			flex-flow: row-reverse;
-
-			& .ck-button svg.ck-button__icon {
-				margin: 0;
-			}
-		}
-
-		&.ck-is-searching .ck-button.ck-button-find {
-			display: none;
-		}
-
-		&:not(.ck-is-searching) {
-			& .ck-button.ck-button-prev,
-			& .ck-button.ck-button-next {
-				display: none;
-			}
-
-			& .ck-button.ck-button-find {
-				display: flex;
-			}
 		}
 
 		&.ck-responsive-form .ck-find-checkboxes {
 			margin: 0;
 
-			& .ck-find-checkboxes__box {
-				& label {
-					margin-right: 5px;
-					line-height: calc(var(--ck-spacing-standard) * 2.2);
-				}
-
-				&:first-child {
-					margin-top: var(--ck-spacing-medium);
-				}
+			& .ck-find-checkboxes__box label {
+				margin-right: 5px;
 			}
 		}
 	}

--- a/packages/ckeditor5-find-and-replace/theme/findandreplaceform.css
+++ b/packages/ckeditor5-find-and-replace/theme/findandreplaceform.css
@@ -150,3 +150,77 @@
 		}
 	}
 }
+
+.ck[dir='rtl'] {
+	& .ck .ck-find-and-replace-form .ck-find-form__wrapper .ck-labeled-field-view__input-wrapper .ck.ck-input-text {
+		padding: var(--ck-spacing-extra-tiny) var(--ck-spacing-medium) var(--ck-spacing-extra-tiny) calc(var(--ck-spacing-medium) * 8);
+	}
+
+	& .ck .ck-find-and-replace-form  .ck-replace-form__wrapper {
+		& .ck-replace-buttons {
+			display: flex;
+			flex-flow: row-reverse;
+
+			& .ck-button:last-child {
+				margin-left: var(--ck-spacing-standard)
+			}
+		}
+		& .ck-labeled-field-view__input-wrapper .ck.ck-input-text{
+			padding: var(--ck-spacing-extra-tiny) var(--ck-spacing-medium) var(--ck-spacing-extra-tiny) var(--ck-spacing-medium)
+		}
+	}
+
+	& .ck.ck-responsive-form > :not(:last-child) {
+		margin-left: 0;
+	}
+
+	& .ck .ck-find-and-replace-form .ck-find-form__wrapper {
+		& .ck-button.ck-button-prev,
+		& .ck-button.ck-button-next {
+			margin-right: 1px;
+			margin-left: 0;
+		}
+
+		& span.ck-results-counter {
+			left: calc(var(--ck-spacing-standard) * 3);
+		}
+
+		& .ck-find-buttons {
+			flex-flow: row-reverse;
+
+			& .ck-button svg.ck-button__icon {
+				margin: 0;
+			}
+		}
+
+		&.ck-is-searching .ck-button.ck-button-find {
+			display: none;
+		}
+
+		&:not(.ck-is-searching) {
+			& .ck-button.ck-button-prev,
+			& .ck-button.ck-button-next {
+				display: none;
+			}
+
+			& .ck-button.ck-button-find {
+				display: flex;
+			}
+		}
+
+		&.ck-responsive-form .ck-find-checkboxes {
+			margin: 0;
+
+			& .ck-find-checkboxes__box {
+				& label {
+					margin-right: 5px;
+					line-height: calc(var(--ck-spacing-standard) * 2.2);
+				}
+
+				&:first-child {
+					margin-top: var(--ck-spacing-medium);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (find-and-replace): Added CSS styles for RTL editor support for the `find-and-replace` feature. Closes #9981.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._