### PR TITLE
Fixed the issue with restoring highlight artifacts after the undo

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/findandreplaceediting.js
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceediting.js
@@ -52,7 +52,7 @@ class FindAndReplaceState {
 							highlightedResultRemoved = true;
 						}
 
-						if ( model.markers.has( removedResult.marker ) ) {
+						if ( model.markers.has( removedResult.marker.name ) ) {
 							writer.removeMarker( removedResult.marker );
 						}
 					}

--- a/packages/ckeditor5-find-and-replace/tests/findandreplace.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplace.js
@@ -7,6 +7,7 @@ import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
 import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
 import Collection from '@ckeditor/ckeditor5-utils/src/collection';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
+import { stringify } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 import FindAndReplace from '../src/findandreplace';
 import FindAndReplaceUI from '../src/findandreplaceui';
@@ -339,6 +340,33 @@ describe( 'FindAndReplace', () => {
 			findAndReplaceUI.fire( 'replace', {
 				searchText: 'bar',
 				replaceText: 'new'
+			} );
+		} );
+
+		describe( 'undo', () => {
+			it( 'doesn\'t bring back highlighted content', () => {
+				editor.setData( FOO_BAR_PARAGRAPH );
+
+				const { results } = editor.execute( 'find', 'bar' );
+
+				editor.execute( 'replace', 'new', results.get( 0 ) );
+
+				editor.execute( 'undo' );
+
+				const markers = Array.from( editor.model.markers ).map( marker => {
+					// Replace markers id to a predefined value, as originally these are unique random ids.
+					if ( marker.name.startsWith( 'findResult:' ) ) {
+						marker.name = 'X';
+					} else if ( marker.name.startsWith( 'findResultHighlighted:' ) ) {
+						marker.name = 'Y';
+					}
+
+					return marker;
+				} );
+
+				expect( stringify( model.document.getRoot(), null, markers ) ).to.equal(
+					'<paragraph>Foo bar baz</paragraph>'
+				);
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-find-and-replace/tests/findandreplace.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplace.js
@@ -354,18 +354,7 @@ describe( 'FindAndReplace', () => {
 
 				editor.execute( 'undo' );
 
-				const markers = Array.from( editor.model.markers ).map( marker => {
-					// Replace markers id to a predefined value, as originally these are unique random ids.
-					if ( marker.name.startsWith( 'findResult:' ) ) {
-						marker.name = 'X';
-					} else if ( marker.name.startsWith( 'findResultHighlighted:' ) ) {
-						marker.name = 'Y';
-					}
-
-					return marker;
-				} );
-
-				expect( stringify( model.document.getRoot(), null, markers ) ).to.equal(
+				expect( stringify( model.document.getRoot(), null, editor.model.markers ) ).to.equal(
 					'<paragraph>Foo bar baz</paragraph>'
 				);
 			} );

--- a/packages/ckeditor5-find-and-replace/tests/findandreplace.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplace.js
@@ -345,6 +345,7 @@ describe( 'FindAndReplace', () => {
 
 		describe( 'undo', () => {
 			it( 'doesn\'t bring back highlighted content', () => {
+				// (#9974)
 				editor.setData( FOO_BAR_PARAGRAPH );
 
 				const { results } = editor.execute( 'find', 'bar' );

--- a/packages/ckeditor5-find-and-replace/tests/findcommand.js
+++ b/packages/ckeditor5-find-and-replace/tests/findcommand.js
@@ -259,6 +259,14 @@ describe( 'FindCommand', () => {
 			} );
 		} );
 
+		it( 'adds marker synchronously', () => {
+			editor.setData( '<p>foo bar baz</p>' );
+
+			const { results } = command.execute( 'bar' );
+
+			expect( editor.model.markers.has( results.get( 0 ).marker.name ) ).to.be.true;
+		} );
+
 		/**
 		 * Returns markers array from array. All markers have their name simplified to "X" as otherwise they're
 		 * random and unique.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (find-and-replace): Fixed the issue with restoring highlight artifacts after the undo. Closes #9974.