### PR TITLE
Move the context for the 'Show more items' message to 'ckeditor5-core'.

### DIFF
--- a/packages/ckeditor5-core/lang/contexts.json
+++ b/packages/ckeditor5-core/lang/contexts.json
@@ -1,6 +1,7 @@
 {
-	"Save": "Label for the Save button.",
 	"Cancel": "Label for the Cancel button.",
 	"Remove color": "The label used by a button next to the color palette in the color picker that removes the color (resets it to an empty value, example usages in font color or table properties).",
-	"Restore default": "The label used by a button next to the color palette in the color picker that restores the default value if the default table properties are specified."
+	"Restore default": "The label used by a button next to the color palette in the color picker that restores the default value if the default table properties are specified.",
+	"Save": "Label for the Save button.",
+	"Show more items": "Label of a toolbar button which reveals more toolbar items."
 }

--- a/packages/ckeditor5-ui/lang/contexts.json
+++ b/packages/ckeditor5-ui/lang/contexts.json
@@ -7,7 +7,6 @@
 	"%0 of %1": "Label for a 'page X of Y' status of a typical next/previous page navigation.",
 	"Editor toolbar": "Label used by assistive technologies describing a generic editor toolbar.",
 	"Dropdown toolbar": "Label used by assistive technologies describing a toolbar displayed inside a dropdown.",
-	"Show more items": "Label of a toolbar button which reveals more toolbar items.",
 	"Black": "Label of a button that applies a black color in color pickers.",
 	"Dim grey": "Label of a button that applies a dim grey color in color pickers.",
 	"Grey": "Label of a button that applies a grey color in color pickers.",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Moved the context for the `Show more items` message to `ckeditor5-core`. Closes #9991.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._