### PR TITLE
Removed unnecessary lookbehind and lookahead from regex in source editing

### DIFF
--- a/packages/ckeditor5-source-editing/src/utils/formathtml.js
+++ b/packages/ckeditor5-source-editing/src/utils/formathtml.js
@@ -73,10 +73,8 @@ export function formatHtml( input ) {
 
 	// It is not the fastest way to format the HTML markup but the performance should be good enough.
 	const lines = input
-		// Add new line before `<tag>` or `</tag>`, but only if it is not already preceded by a new line (negative lookbehind).
-		.replace( new RegExp( `(?<!\n)</?(${ elementNamesToFormat })( .*?)?>`, 'g' ), '\n$&' )
-		// Add new line after `<tag>` or `</tag>`, but only if it is not already followed by a new line (negative lookahead).
-		.replace( new RegExp( `</?(${ elementNamesToFormat })( .*?)?>(?!\n)`, 'g' ), '$&\n' )
+		// Add new line before and after `<tag>` and `</tag>`.
+		.replace( new RegExp( `</?(${ elementNamesToFormat })( .*?)?>`, 'g' ), '\n$&\n' )
 		// Divide input string into lines, which start with either an opening tag, a closing tag, or just a text.
 		.split( '\n' );
 

--- a/packages/ckeditor5-source-editing/src/utils/formathtml.js
+++ b/packages/ckeditor5-source-editing/src/utils/formathtml.js
@@ -74,6 +74,7 @@ export function formatHtml( input ) {
 	// It is not the fastest way to format the HTML markup but the performance should be good enough.
 	const lines = input
 		// Add new line before and after `<tag>` and `</tag>`.
+		// It may separate individual elements with two new lines, but this will be fixed below.
 		.replace( new RegExp( `</?(${ elementNamesToFormat })( .*?)?>`, 'g' ), '\n$&\n' )
 		// Divide input string into lines, which start with either an opening tag, a closing tag, or just a text.
 		.split( '\n' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (source-editing): Removed unnecessary lookbehind and lookahead from regex, which are not supported in Safari. Closes #10033.

---

### Additional information

Marked as `Internal`, because source editing is not yet released.
