### PR TITLE
Added missing html-support package files

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,18 @@ See CKEditor 5 release blog posts [on the CKEditor blog](https://ckeditor.com/bl
 
 <tr>
 	<td>
+		<a href="https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-html-support"><code>@ckeditor/ckeditor5-html-support</code></a>
+	</td>
+	<td>
+		<a href="https://www.npmjs.com/package/@ckeditor/ckeditor5-html-support"><img src="https://img.shields.io/npm/v/@ckeditor/ckeditor5-html-support.svg" alt="@ckeditor/ckeditor5-html-support npm package badge"></a>
+	</td>
+	<td>
+		The General HTML Support feature.
+	</td>
+</tr>
+
+<tr>
+	<td>
 		<a href="https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-image"><code>@ckeditor/ckeditor5-image</code></a>
 	</td>
 	<td>

--- a/docs/builds/guides/integration/features-html-output-overview.md
+++ b/docs/builds/guides/integration/features-html-output-overview.md
@@ -909,6 +909,40 @@ The data used to generate the following tables comes from the package metadata. 
 		</tr>
 	</tbody>
 </table>
+<h3 id="ckeditor5-html-support"><code>ckeditor5-html-support</code></h3>
+<p>
+	Source file: <a href="https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-html-support/ckeditor5-metadata.json"><code>@ckeditor/ckeditor5-html-support/ckeditor5-metadata.json</code></a>
+</p>
+<table class="features-html-output">
+	<thead>
+		<tr>
+			<th class="plugin">
+				Plugin
+			</th>
+			<th class="html-output">
+				HTML output
+			</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td class="plugin">
+				<p>
+					<a href="../../../features/general-html-support.html">General HTML Support</a>
+				</p>
+				<p>
+					<a href="../../../api/module_html-support_generalhtmlsupport-GeneralHtmlSupport.html"><code>GeneralHtmlSupport</code></a>
+				</p>
+			</td>
+			<td class="html-output">
+				<code>&lt;<strong>*</strong><br>    <strong>class</strong>="*"<br>    <strong>style</strong>="*:*"<br>    <strong>*</strong>="*"<br>&gt;</code>
+				<p>
+					The plugin can output any arbitrary HTML configured by config.htmlSupport option.
+				</p>
+			</td>
+		</tr>
+	</tbody>
+</table>
 <h3 id="ckeditor5-image"><code>ckeditor5-image</code></h3>
 <p>
 	Source file: <a href="https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-image/ckeditor5-metadata.json"><code>@ckeditor/ckeditor5-image/ckeditor5-metadata.json</code></a>

--- a/packages/ckeditor5-html-support/CHANGELOG.md
+++ b/packages/ckeditor5-html-support/CHANGELOG.md
@@ -1,0 +1,4 @@
+Changelog
+=========
+
+All changes in the package are documented in the main repository. See: https://github.com/ckeditor/ckeditor5/blob/master/CHANGELOG.md.

--- a/packages/ckeditor5-html-support/CONTRIBUTING.md
+++ b/packages/ckeditor5-html-support/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+Contributing
+========================================
+
+See the [official contributors' guide to CKEditor 5](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/contributing.html) to learn more.

--- a/packages/ckeditor5-html-support/CONTRIBUTING.md
+++ b/packages/ckeditor5-html-support/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 Contributing
-========================================
+============
 
 See the [official contributors' guide to CKEditor 5](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/contributing.html) to learn more.

--- a/packages/ckeditor5-html-support/LICENSE.md
+++ b/packages/ckeditor5-html-support/LICENSE.md
@@ -1,0 +1,17 @@
+Software License Agreement
+==========================
+
+**CKEditor 5 HTML Support feature**  – https://github.com/ckeditor/ckeditor5-html-support <br>
+Copyright (c) 2003-2021, [CKSource](http://cksource.com) Frederico Knabben. All rights reserved.
+
+Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+
+Sources of Intellectual Property Included in CKEditor
+-----------------------------------------------------
+
+Where not otherwise indicated, all CKEditor content is authored by CKSource engineers and consists of CKSource-owned intellectual property. In some specific instances, CKEditor will incorporate work done by developers outside of CKSource with their express permission.
+
+Trademarks
+----------
+
+**CKEditor** is a trademark of [CKSource](http://cksource.com) Frederico Knabben. All other brand and product names are trademarks, registered trademarks or service marks of their respective holders.

--- a/packages/ckeditor5-html-support/README.md
+++ b/packages/ckeditor5-html-support/README.md
@@ -1,0 +1,20 @@
+CKEditor 5 General HTML Support feature
+=============================
+
+[![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-html-support.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-html-support)
+[![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
+[![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://travis-ci.com/ckeditor/ckeditor5)
+
+This package implements the General HTML Support feature for CKEditor 5. It allows enabling unsupported HTML features in the rich-text editor at low cost.
+
+## Demo
+
+Check out the demo in the [General HTML Support feature](https://ckeditor.com/docs/ckeditor5/latest/features/general-html-support.html) guide.
+
+## Documentation
+
+See the [`@ckeditor/ckeditor5-html-support` package](https://ckeditor.com/docs/ckeditor5/latest/api/html-support.html) page as well as the [General HTML Support feature guide](https://ckeditor.com/docs/ckeditor5/latest/features/general-html-support.html) in [CKEditor 5 documentation](https://ckeditor.com/docs/ckeditor5/latest/).
+
+## License
+
+Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).

--- a/packages/ckeditor5-html-support/README.md
+++ b/packages/ckeditor5-html-support/README.md
@@ -1,5 +1,5 @@
-CKEditor 5 General HTML Support feature
-=============================
+CKEditor 5 HTML Support feature
+===============================
 
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-html-support.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-html-support)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)

--- a/packages/ckeditor5-html-support/ckeditor5-metadata.json
+++ b/packages/ckeditor5-html-support/ckeditor5-metadata.json
@@ -1,0 +1,20 @@
+{
+	"plugins": [
+		{
+			"name": "General HTML Support",
+			"className": "GeneralHtmlSupport",
+			"description": "Allows enabling unsupported HTML features at low cost.",
+			"docs": "features/general-html-support.html",
+			"path": "src/generalhtmlsupport.js",
+			"htmlOutput": [
+				{
+					"elements": "*",
+					"attributes": "*",
+					"classes": "*",
+					"styles": "*",
+					"_comment": "The plugin can output any arbitrary HTML configured by config.htmlSupport option."
+				}
+			]
+		}
+	]
+}

--- a/packages/ckeditor5-html-support/docs/api/html-support.md
+++ b/packages/ckeditor5-html-support/docs/api/html-support.md
@@ -1,0 +1,34 @@
+---
+category: api-reference
+---
+
+# CKEditor 5 General HTML Support feature
+
+[![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-image.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-html-support)
+
+This package implements the General HTML Support feature for CKEditor 5.
+
+## Demo
+
+Check out the demos in the {@link features/general-html-support General HTML Support feature} guide.
+
+## Documentation
+
+See the {@link features/general-html-support General HTML Support feature} guide.
+
+## Installation
+
+```bash
+npm install --save @ckeditor/ckeditor5-html-support
+```
+
+## Contribute
+
+The source code of this package is available on GitHub in https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-html-support.
+
+## External links
+
+* [`@ckeditor/ckeditor5-html-support` on npm](https://www.npmjs.com/package/@ckeditor/ckeditor5-html-support)
+* [`ckeditor/ckeditor5-html-support` on GitHub](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-html-support)
+* [Issue tracker](https://github.com/ckeditor/ckeditor5/issues)
+* [Changelog](https://github.com/ckeditor/ckeditor5/blob/master/CHANGELOG.md)

--- a/packages/ckeditor5-html-support/docs/api/html-support.md
+++ b/packages/ckeditor5-html-support/docs/api/html-support.md
@@ -8,6 +8,14 @@ category: api-reference
 
 This package implements the General HTML Support feature for CKEditor 5.
 
+<info-box>
+	The General HTML Support feature is **experimental and not yet production-ready**.
+
+	The API of the "GHS" feature is may change without further notice.
+
+	Follow the ["Stabilize and release a production-ready General HTML Support feature"](https://github.com/ckeditor/ckeditor5/issues/9856) issue for more updates and related issues.
+</info-box>
+
 ## Demo
 
 Check out the demos in the {@link features/general-html-support General HTML Support feature} guide.

--- a/packages/ckeditor5-html-support/docs/api/html-support.md
+++ b/packages/ckeditor5-html-support/docs/api/html-support.md
@@ -11,7 +11,7 @@ This package implements the General HTML Support feature for CKEditor 5.
 <info-box>
 	The General HTML Support feature is **experimental and not yet production-ready**.
 
-	The API of the "GHS" feature is may change without further notice.
+	The API of the "GHS" feature may change without further notice.
 
 	Follow the ["Stabilize and release a production-ready General HTML Support feature"](https://github.com/ckeditor/ckeditor5/issues/9856) issue for more updates and related issues.
 </info-box>

--- a/packages/ckeditor5-html-support/docs/api/html-support.md
+++ b/packages/ckeditor5-html-support/docs/api/html-support.md
@@ -2,9 +2,9 @@
 category: api-reference
 ---
 
-# CKEditor 5 General HTML Support feature
+# CKEditor 5 HTML Support feature
 
-[![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-image.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-html-support)
+[![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-html-support.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-html-support)
 
 This package implements the General HTML Support feature for CKEditor 5.
 

--- a/packages/ckeditor5-html-support/package.json
+++ b/packages/ckeditor5-html-support/package.json
@@ -25,6 +25,7 @@
     "@ckeditor/ckeditor5-cloud-services": "^28.0.0",
     "@ckeditor/ckeditor5-code-block": "^28.0.0",
     "@ckeditor/ckeditor5-core": "^28.0.0",
+    "@ckeditor/ckeditor5-dev-utils": "^25.0.0",
     "@ckeditor/ckeditor5-easy-image": "^28.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^28.0.0",
     "@ckeditor/ckeditor5-engine": "^28.0.0",
@@ -40,6 +41,7 @@
     "@ckeditor/ckeditor5-page-break": "^28.0.0",
     "@ckeditor/ckeditor5-paragraph": "^28.0.0",
     "@ckeditor/ckeditor5-table": "^28.0.0",
+    "@ckeditor/ckeditor5-theme-lark": "^28.0.0",
     "@ckeditor/ckeditor5-utils": "^28.0.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"

--- a/packages/ckeditor5-html-support/webpack.config.js
+++ b/packages/ckeditor5-html-support/webpack.config.js
@@ -1,0 +1,17 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+'use strict';
+
+/* eslint-env node */
+
+const { builds } = require( '@ckeditor/ckeditor5-dev-utils' );
+
+module.exports = builds.getDllPluginWebpackConfig( {
+	themePath: require.resolve( '@ckeditor/ckeditor5-theme-lark' ),
+	packagePath: __dirname,
+	manifestPath: require.resolve( 'ckeditor5/build/ckeditor5-dll.manifest.json' ),
+	isDevelopmentMode: process.argv.includes( '--dev' )
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (html-support): Added missing package files. Closes #10034.

---

### Additional information

* I'm not totally sure how OB works, so I didn't verify if `ckeditor5-metadata.json` works correctly
* I'm not sure if we want to publish API docs of GHS right now as it's in beta stage, but it's required to publish `config.htmlSupport` option
