### PR TITLE
Add editor icons to guides #01

### DIFF
--- a/packages/ckeditor5-basic-styles/docs/features/basic-styles.md
+++ b/packages/ckeditor5-basic-styles/docs/features/basic-styles.md
@@ -12,10 +12,10 @@ The {@link api/basic-styles basic styles} feature allows you to apply the most f
 </info-box>
 
 Basic formatting options may be applied with the toolbar buttons (pictured below) or thanks to the {@link features/autoformat autoformatting feature} with Markdown code as you type. Use one these to format the text:
-* Bold &ndash; Use the {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/bold.svg} toolbar button or type `**text**` or `__text__`
-* Italic &ndash; Use the {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/italic.svg} toolbar button or type `*text*` or `_text_`
-* Code &ndash; Use the {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/code.svg} toolbar button or type ``` `text` ```
-* Strikethrough &ndash; Use the {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/strikethrough.svg} toolbar button or type `~~text~~`.
+* Bold &ndash; Use the bold toolbar button {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/bold.svg Bold} or type `**text**` or `__text__`
+* Italic &ndash; Use the italic toolbar button {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/italic.svg Italic} or type `*text*` or `_text_`
+* Code &ndash; Use the code toolbar button {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/code.svg Code} or type ``` `text` ```
+* Strikethrough &ndash; Use the strikethrough toolbar button {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/strikethrough.svg Strikethrough} or type `~~text~~`.
 
 ## Demo
 

--- a/packages/ckeditor5-basic-styles/docs/features/basic-styles.md
+++ b/packages/ckeditor5-basic-styles/docs/features/basic-styles.md
@@ -11,11 +11,11 @@ The {@link api/basic-styles basic styles} feature allows you to apply the most f
 	All basic text styles can be removed with the {@link features/remove-format remove format} feature.
 </info-box>
 
-Basic formatting options may be applied with the toolbar buttons or thanks to the {@link features/autoformat autoformatting feature} with Markdown code as you type. Use one these to format text on the go:
-* Bold &ndash; Type `**text**` or `__text__`,
-* Italic &ndash; Type `*text*` or `_text_`,
-* Code &ndash; Type ``` `text` ```,
-* Strikethrough &ndash; Type `~~text~~`.
+Basic formatting options may be applied with the toolbar buttons (pictured below) or thanks to the {@link features/autoformat autoformatting feature} with Markdown code as you type. Use one these to format the text:
+* Bold &ndash; Use {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/bold.svg} toolbar item or type `**text**` or `__text__`
+* Italic &ndash; Use {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/italic.svg} toolbar item or type `*text*` or `_text_`
+* Code &ndash; Use {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/code.svg} toolbar item or type ``` `text` ```
+* Strikethrough &ndash; Use {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/strikethrough.svg} or type `~~text~~`.
 
 ## Demo
 

--- a/packages/ckeditor5-basic-styles/docs/features/basic-styles.md
+++ b/packages/ckeditor5-basic-styles/docs/features/basic-styles.md
@@ -12,10 +12,10 @@ The {@link api/basic-styles basic styles} feature allows you to apply the most f
 </info-box>
 
 Basic formatting options may be applied with the toolbar buttons (pictured below) or thanks to the {@link features/autoformat autoformatting feature} with Markdown code as you type. Use one these to format the text:
-* Bold &ndash; Use {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/bold.svg} toolbar item or type `**text**` or `__text__`
-* Italic &ndash; Use {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/italic.svg} toolbar item or type `*text*` or `_text_`
-* Code &ndash; Use {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/code.svg} toolbar item or type ``` `text` ```
-* Strikethrough &ndash; Use {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/strikethrough.svg} or type `~~text~~`.
+* Bold &ndash; Use the {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/bold.svg} toolbar button or type `**text**` or `__text__`
+* Italic &ndash; Use the {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/italic.svg} toolbar button or type `*text*` or `_text_`
+* Code &ndash; Use the {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/code.svg} toolbar button or type ``` `text` ```
+* Strikethrough &ndash; Use the {@icon @ckeditor/ckeditor5-basic-styles/theme/icons/strikethrough.svg} toolbar button or type `~~text~~`.
 
 ## Demo
 

--- a/packages/ckeditor5-block-quote/docs/features/block-quote.md
+++ b/packages/ckeditor5-block-quote/docs/features/block-quote.md
@@ -12,7 +12,7 @@ The block quote feature provides an attractive way to draw the readers' attentio
 
 ## Demo
 
-Use the block quote toolbar button {@icon @ckeditor/ckeditor5-core/theme/icons/quote.svg} in the editor below to see the feature in action. You can also precede the quotation with the `>` inline code (followed by a space) to format it on the go thanks to the {@link features/autoformat autoformatting} feature.
+Use the block quote toolbar button {@icon @ckeditor/ckeditor5-core/theme/icons/quote.svg Insert block quote} in the editor below to see the feature in action. You can also precede the quotation with the `>` inline code (followed by a space) to format it on the go thanks to the {@link features/autoformat autoformatting} feature.
 
 {@snippet features/block-quote}
 

--- a/packages/ckeditor5-block-quote/docs/features/block-quote.md
+++ b/packages/ckeditor5-block-quote/docs/features/block-quote.md
@@ -12,7 +12,7 @@ The block quote feature provides an attractive way to draw the readers' attentio
 
 ## Demo
 
-Use the editor below to see the block quote plugin in action. You can also precede the quotation with the `>` inline code (followed by a space) to format it on the go thanks to the {@link features/autoformat autoformatting} feature or use {@icon @ckeditor/ckeditor5-core/theme/icons/quote.svg} toolbar item.
+Use the block quote toolbar button {@icon @ckeditor/ckeditor5-core/theme/icons/quote.svg} in the editor below to see the feature in action. You can also precede the quotation with the `>` inline code (followed by a space) to format it on the go thanks to the {@link features/autoformat autoformatting} feature.
 
 {@snippet features/block-quote}
 

--- a/packages/ckeditor5-block-quote/docs/features/block-quote.md
+++ b/packages/ckeditor5-block-quote/docs/features/block-quote.md
@@ -12,7 +12,7 @@ The block quote feature provides an attractive way to draw the readers' attentio
 
 ## Demo
 
-Use the editor below to see the block quote plugin in action. You can also precede the quotation with the `>` inline code (followed by a space) to format it on the go thanks to the {@link features/autoformat autoformatting} feature.
+Use the editor below to see the block quote plugin in action. You can also precede the quotation with the `>` inline code (followed by a space) to format it on the go thanks to the {@link features/autoformat autoformatting} feature or use {@icon @ckeditor/ckeditor5-core/theme/icons/quote.svg} toolbar item.
 
 {@snippet features/block-quote}
 

--- a/packages/ckeditor5-code-block/docs/features/code-blocks.md
+++ b/packages/ckeditor5-code-block/docs/features/code-blocks.md
@@ -16,7 +16,7 @@ Code blocks is a perfect feature to present programming- or software-related iss
 
 ## Demo
 
-Use the code block toolbar button {@icon @ckeditor/ckeditor5-code-block/theme/icons/codeblock.svg} and the type dropdown to insert a desired code block. Alternatively, start the line with `` ``` `` to format it as a code block thanks to the {@link features/autoformat autoformatting feature}. To add a paragraph underneath a code block, just use the double caret function (press <kbd>Enter</kbd> twice).
+Use the code block toolbar button {@icon @ckeditor/ckeditor5-code-block/theme/icons/codeblock.svg Insert code block} and the type dropdown to insert a desired code block. Alternatively, start the line with `` ``` `` to format it as a code block thanks to the {@link features/autoformat autoformatting feature}. To add a paragraph underneath a code block, just use the double caret function (press <kbd>Enter</kbd> twice).
 
 {@snippet features/code-block}
 

--- a/packages/ckeditor5-code-block/docs/features/code-blocks.md
+++ b/packages/ckeditor5-code-block/docs/features/code-blocks.md
@@ -16,7 +16,7 @@ Code blocks is a perfect feature to present programming- or software-related iss
 
 ## Demo
 
-Use the code block toolbar button and the type dropdown to insert a desired code block. Alternatively, start the line with `` ``` `` to format it as a code block thanks to the {@link features/autoformat autoformatting feature}. To add a paragraph underneath a code block, just use the double caret function (press <kbd>Enter</kbd> twice).
+Use the code block toolbar button {@icon @ckeditor/ckeditor5-code-block/theme/icons/codeblock.svg} and the type dropdown to insert a desired code block. Alternatively, start the line with `` ``` `` to format it as a code block thanks to the {@link features/autoformat autoformatting feature}. To add a paragraph underneath a code block, just use the double caret function (press <kbd>Enter</kbd> twice).
 
 {@snippet features/code-block}
 

--- a/packages/ckeditor5-html-embed/docs/features/html-embed.md
+++ b/packages/ckeditor5-html-embed/docs/features/html-embed.md
@@ -28,7 +28,7 @@ It is recommended to use the {@link features/media-embed media embed} feature fo
 
 ## Demo
 
-Use the editor below to see the plugin in action. Click the **"Preview editor data"** button below the editor to see a preview of the editor content, including the embedded HTML.
+Use the HTML embed toolbar button {@icon @ckeditor/ckeditor5-html-embed/theme/icons/html.svg} in the editor below to see the plugin in action. Click the **"Preview editor data"** button below the editor to see a preview of the editor content, including the embedded HTML.
 
 {@snippet features/html-embed}
 

--- a/packages/ckeditor5-html-embed/docs/features/html-embed.md
+++ b/packages/ckeditor5-html-embed/docs/features/html-embed.md
@@ -28,7 +28,7 @@ It is recommended to use the {@link features/media-embed media embed} feature fo
 
 ## Demo
 
-Use the HTML embed toolbar button {@icon @ckeditor/ckeditor5-html-embed/theme/icons/html.svg} in the editor below to see the plugin in action. Click the **"Preview editor data"** button below the editor to see a preview of the editor content, including the embedded HTML.
+Use the HTML embed toolbar button {@icon @ckeditor/ckeditor5-html-embed/theme/icons/html.svg HTML embed} in the editor below to see the plugin in action. Click the **"Preview editor data"** button below the editor to see a preview of the editor content, including the embedded HTML.
 
 {@snippet features/html-embed}
 

--- a/packages/ckeditor5-indent/docs/features/indent.md
+++ b/packages/ckeditor5-indent/docs/features/indent.md
@@ -15,6 +15,8 @@ Its main purpose is to visually distinguish parts of the content. Block indentat
 
 ## Demo
 
+Use the indent {@icon @ckeditor/ckeditor5-indent/theme/icons/indent.svg Indent} or outdent {@icon @ckeditor/ckeditor5-indent/theme/icons/outdent.svg Outdent} toolbar buttons in the editor below to control the level of indentation of the content, both for paragraph text, headers and list items.
+
 {@snippet features/indent}
 
 ## Related features

--- a/packages/ckeditor5-table/docs/features/table.md
+++ b/packages/ckeditor5-table/docs/features/table.md
@@ -16,15 +16,15 @@ You may look for more interesting details in the [Tables in CKEditor 5](https://
 
 ### Basic table features
 
-The editor bellow shows the basic set of table features focusing on the **structure and semantics**. Click anywhere inside the table to invoke the table toolbar. The features available in there allow users to insert new tables into the content, add or remove columns and rows, define headers, add caption, and merge multiple cells. It is also worth noting that you will find them out–of–the–box in all {@link builds/guides/overview ready–to–use editor builds}.
+The editor bellow shows the basic set of table features focusing on the **structure and semantics**. Use the **Insert table** toolbar button {@icon @ckeditor/ckeditor5-table/theme/icons/table.svg Insert table} in the editor below to create new tables. Focus any cell in the table to display the toolbar with buttons that will help you further shape the structure of the table.
 
-Use the **"Insert table"** toolbar button {@icon @ckeditor/ckeditor5-table/theme/icons/table.svg} in the toolbar to create new tables. Focus any cell in the table to display the toolbar with buttons that will help you further shape the structure of the table.
+Click anywhere inside the table to invoke the table toolbar. The features available in there allow users to add or remove columns {@icon @ckeditor/ckeditor5-table/theme/icons/table-column.svg Table column} and rows {@icon @ckeditor/ckeditor5-table/theme/icons/table-row.svg Table row} and merge or split cells {@icon @ckeditor/ckeditor5-table/theme/icons/table-merge-cell.svg Table cell}. It is also worth noting that you will find them out–of–the–box in all {@link builds/guides/overview ready–to–use editor builds}.
 
 {@snippet features/table}
 
 ### Table and cell styling tools
 
-In addition to the default table features described in the [previous section](#basic-table-features), the editor below comes with some additional tools that will help you modify **the look of tables and table cells**, for instance, their border color and style, background color, padding, or text alignment. The table and cell properties are available from the table toolbar on click, just like basic table features.
+In addition to the default table features described in the [previous section](#basic-table-features), the editor below comes with some additional tools that will help you modify **the look of tables and table cells**, for instance, their border color and style, background color, padding, or text alignment. The table {@icon @ckeditor/ckeditor5-table/theme/icons/table-properties.svg Table properties} and cell properties {@icon @ckeditor/ckeditor5-table/theme/icons/table-cell-properties.svg Cell properties} are available from the table toolbar on click, just like basic table features.
 
 {@snippet features/table-styling}
 
@@ -40,7 +40,7 @@ Put the caret anywhere inside the table to invoke the table toolbar. Then click 
 
 The {@link module:table/tablecaption~TableCaption} plugin adds support for table captions. These work very much like image captions &mdash; the caption informs the reader about the content of the table. Using captions is also beneficial from the accessability point of view as they would be read by screen readers.
 
-Click on the table caption in the demo to edit it or use the table toolbar to toggle the caption on and off.
+Click on the table caption in the demo to edit it or use the table toolbar button {@icon @ckeditor/ckeditor5-core/theme/icons/caption.svg Table caption} to toggle the caption on and off.
 
 {@snippet features/table-caption}
 

--- a/packages/ckeditor5-table/docs/features/table.md
+++ b/packages/ckeditor5-table/docs/features/table.md
@@ -18,9 +18,9 @@ You may look for more interesting details in the [Tables in CKEditor 5](https://
 
 The editor bellow shows the basic set of table features focusing on the **structure and semantics**. Click anywhere inside the table to invoke the table toolbar. The features available in there allow users to insert new tables into the content, add or remove columns and rows, define headers, add caption, and merge multiple cells. It is also worth noting that you will find them out–of–the–box in all {@link builds/guides/overview ready–to–use editor builds}.
 
-{@snippet features/table}
+Use the **"Insert table"** toolbar button {@icon @ckeditor/ckeditor5-table/theme/icons/table.svg} in the toolbar to create new tables. Focus any cell in the table to display the toolbar with buttons that will help you further shape the structure of the table.
 
-Use the **"Insert table"** button in the toolbar to create new tables. Focus any cell in the table to display the toolbar with buttons that will help you further shape the structure of the table.
+{@snippet features/table}
 
 ### Table and cell styling tools
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Adding toolbar items icons to user guides.

Part of: #10048   
  
This PR covers the following guides:

*   basic text styles
*   block indentation
*   block quote
*   code blocks
*   HTML embed
*   tables

---

### Additional information

This is a test PR for toolbar items icons adding them in selected few guides.

However, one reviewer should be enough from the technical point of view, so the first one is the winner and we merge.