### PR TITLE
Add editor icons to guides #03

### DIFF
--- a/packages/ckeditor5-find-and-replace/docs/features/find-and-replace.md
+++ b/packages/ckeditor5-find-and-replace/docs/features/find-and-replace.md
@@ -10,7 +10,7 @@ The {@link module:find-and-replace/findandreplace~FindAndReplace} feature allows
 
 ## Demo
 
-Use the toolbar "Find and replace" button to find and replace parts of the text you would like to find, and/or replace. Or use the <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>F</kbd> keyboard shortcut to invoke the search and replace panel. For a starter, try replacing "steam" with "diesel" to make the demo content more up to date. Be careful to match the case, for there are different instances of the word present in the document!
+Use the find and replace toolbar button {@icon @ckeditor/ckeditor5-find-and-replace/theme/icons/find-replace.svg Find and replace} to invoke the search panel and find and replace desired words or phrases. Or use the <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>F</kbd> keyboard shortcut to invoke the search and replace panel. For a starter, try replacing "steam" with "diesel" to make the demo content more up to date. Be careful to match the case, for there are different instances of the word present in the document!
 
 {@snippet features/find-and-replace}
 

--- a/packages/ckeditor5-font/docs/features/font.md
+++ b/packages/ckeditor5-font/docs/features/font.md
@@ -5,17 +5,23 @@ category: features
 
 {@snippet features/build-font-source}
 
-The {@link module:font/font~Font} plugin provides extended text formatting options for the document content. It enables the following features in the rich-text editor:
+The {@link module:font/font~Font} plugin provides extended text formatting options for the document content.
+
+The font styles, just like the {@link features/basic-styles basic text styles} can serve numerous purposes. Font size setting can be applied globally or to a selected part of the text only making it catch the eye of the reader. Using different font families can help differentiate between sections of the content that serve various purposes (e.g. main text and a side quotation or a recap). Different font colors can work as markers and guides just like font background colors, that stand out even more and draw attention.
+
+The plugin enables the following features in the rich-text editor:
 * {@link module:font/fontfamily~FontFamily} &ndash; Allows to change the font family by applying inline `<span>` elements with a `font-family` in the `style` attribute.
 * {@link module:font/fontsize~FontSize} &ndash; Allows to control the font size by applying inline `<span>` elements that either have a CSS class or a `font-size` in the `style` attribute.
 * {@link module:font/fontcolor~FontColor} &ndash; Allows to control the font color by applying inline `<span>` elements with a `color` in the `style` attribute.
 * {@link module:font/fontbackgroundcolor~FontBackgroundColor} &ndash; Allows to control the font background color by applying inline `<span>` elements with a `background-color` in the `style` attribute.
 
 <info-box info>
-	All font features can be removed with the {@link features/remove-format remove format} feature.
+	All font formatting can be removed with the {@link features/remove-format remove format} feature.
 </info-box>
 
 ## Demo
+
+Use the toolbar dropdowns in the demo below to control font size {@icon @ckeditor/ckeditor5-font/theme/icons/font-size.svg Font size} and font family {@icon @ckeditor/ckeditor5-font/theme/icons/font-family.svg Font family}. You can also change both the font color {@icon @ckeditor/ckeditor5-font/theme/icons/font-color.svg Font color} and font background color {@icon @ckeditor/ckeditor5-font/theme/icons/font-background.svg Font background color}.
 
 {@snippet features/font}
 

--- a/packages/ckeditor5-highlight/docs/features/highlight.md
+++ b/packages/ckeditor5-highlight/docs/features/highlight.md
@@ -12,6 +12,8 @@ The highlight plugin always comes with a predefined and limited number of availa
 
 ## Demo
 
+Select the text you want to highlight, then use the highlight toolbar button {@icon @ckeditor/ckeditor5-highlight/theme/icons/marker.svg Highlight} to chose a desired color from the dropdown.
+
 {@snippet features/highlight}
 
 ## Related features

--- a/packages/ckeditor5-horizontal-line/docs/features/horizontal-line.md
+++ b/packages/ckeditor5-horizontal-line/docs/features/horizontal-line.md
@@ -11,7 +11,7 @@ Often known as the horizontal rule, it provides a visual way to separate the con
 
 ## Demo
 
-To insert horizontal line, use the toolbar button. Alternatively, start the line with `---` to insert horizontal line thanks to the {@link features/autoformat autoformatting feature}.
+To insert a horizontal line in the demo below, use the toolbar button {@icon @ckeditor/ckeditor5-horizontal-line/theme/icons/horizontalline.svg Horizontal line}. Alternatively, start new line with `---` to insert a horizontal line thanks to the {@link features/autoformat autoformatting feature}.
 
 {@snippet features/horizontal-line}
 

--- a/packages/ckeditor5-remove-format/docs/features/remove-format.md
+++ b/packages/ckeditor5-remove-format/docs/features/remove-format.md
@@ -12,7 +12,7 @@ Note that block-level formatting ({@link features/headings headings}, {@link fea
 
 ## Demo
 
-Select the content you want to clean up and press the "Remove Format" button in the toolbar:
+Select the content you want to clean up and press the remove format button {@icon @ckeditor/ckeditor5-remove-format/theme/icons/remove-format.svg remove format} in the toolbar:
 
 {@snippet features/remove-format}
 


### PR DESCRIPTION
Docs: Adding toolbar items icons to user guides.

Part of: [#10048](https://github.com/ckeditor/ckeditor5/issues/10048) 

This PR covers the following guides:

*   font
*   find and replace
*   highlight
*   horizontal line
*   remove formatting

---

### **Additional information**

One reviewer should be enough from the technical point of view, so the first one is the winner and we merge, but:

*   please read the font guide carefully, as an intro section has been added.