### PR TITLE
Add metadata files to html-support

### DIFF
--- a/docs/builds/guides/integration/features-html-output-overview.md
+++ b/docs/builds/guides/integration/features-html-output-overview.md
@@ -941,6 +941,37 @@ The data used to generate the following tables comes from the package metadata. 
 				</p>
 			</td>
 		</tr>
+		<tr>
+			<td class="plugin">
+				<p>
+					Data Filter
+				</p>
+				<p>
+					<a href="../../../api/module_html-support_datafilter-DataFilter.html"><code>DataFilter</code></a>
+				</p>
+			</td>
+			<td class="html-output">
+				<code>&lt;<strong>*</strong><br>    <strong>class</strong>="*"<br>    <strong>style</strong>="*:*"<br>    <strong>*</strong>="*"<br>&gt;</code>
+				<p>
+					The plugin can output any arbitrary HTML depending on its configuration.
+				</p>
+			</td>
+		</tr>
+		<tr>
+			<td class="plugin">
+				<p>
+					Data Schema
+				</p>
+				<p>
+					<a href="../../../api/module_html-support_dataschema-DataSchema.html"><code>DataSchema</code></a>
+				</p>
+			</td>
+			<td class="html-output">
+				<p>
+					None.
+				</p>
+			</td>
+		</tr>
 	</tbody>
 </table>
 <h3 id="ckeditor5-image"><code>ckeditor5-image</code></h3>

--- a/packages/ckeditor5-html-support/ckeditor5-metadata.json
+++ b/packages/ckeditor5-html-support/ckeditor5-metadata.json
@@ -15,6 +15,27 @@
 					"_comment": "The plugin can output any arbitrary HTML configured by config.htmlSupport option."
 				}
 			]
+		},
+		{
+			"name": "Data Filter",
+			"className": "DataFilter",
+			"description": "Adds support for enabling and disabling HTML features and their attributes. Part of General HTML Support feature.",
+			"path": "src/datafilter.js",
+			"htmlOutput": [
+				{
+					"elements": "*",
+					"attributes": "*",
+					"classes": "*",
+					"styles": "*",
+					"_comment": "The plugin can output any arbitrary HTML depending on its configuration."
+				}
+			]
+		},
+		{
+			"name": "Data Schema",
+			"className": "DataSchema",
+			"description": "Holds representation of the extended HTML document type definitions. Part of General HTML Support feature.",
+			"path": "src/dataschema.js"
 		}
 	]
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (html-support): Added missing metadata files for exposed plugins. Closes #10069.

