### PR TITLE
Fix html-support DLL build

### DIFF
--- a/packages/ckeditor5-html-support/package.json
+++ b/packages/ckeditor5-html-support/package.json
@@ -10,7 +10,7 @@
     "ckeditor5-plugin",
     "compatibility",
     "content compatibility",
-	"html support",
+    "html support",
     "generic html support"
   ],
   "main": "src/index.js",
@@ -25,6 +25,7 @@
     "@ckeditor/ckeditor5-cloud-services": "^28.0.0",
     "@ckeditor/ckeditor5-code-block": "^28.0.0",
     "@ckeditor/ckeditor5-core": "^28.0.0",
+    "@ckeditor/ckeditor5-dev-utils": "^25.0.0",
     "@ckeditor/ckeditor5-easy-image": "^28.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^28.0.0",
     "@ckeditor/ckeditor5-engine": "^28.0.0",
@@ -40,6 +41,7 @@
     "@ckeditor/ckeditor5-page-break": "^28.0.0",
     "@ckeditor/ckeditor5-paragraph": "^28.0.0",
     "@ckeditor/ckeditor5-table": "^28.0.0",
+    "@ckeditor/ckeditor5-theme-lark": "^28.0.0",
     "@ckeditor/ckeditor5-utils": "^28.0.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"

--- a/packages/ckeditor5-html-support/webpack.config.js
+++ b/packages/ckeditor5-html-support/webpack.config.js
@@ -1,0 +1,17 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+'use strict';
+
+/* eslint-env node */
+
+const { builds } = require( '@ckeditor/ckeditor5-dev-utils' );
+
+module.exports = builds.getDllPluginWebpackConfig( {
+	themePath: require.resolve( '@ckeditor/ckeditor5-theme-lark' ),
+	packagePath: __dirname,
+	manifestPath: require.resolve( 'ckeditor5/build/ckeditor5-dll.manifest.json' ),
+	isDevelopmentMode: process.argv.includes( '--dev' )
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (html-support): Fix DLL build.

---

### Additional information

I was trying to run `yarn dll:build` and it failed to build html-support package due to missing webpack.config.js.