### PR TITLE
Fixed autoformat not remembering previous language choice for codeblock

### DIFF
--- a/packages/ckeditor5-autoformat/src/autoformat.js
+++ b/packages/ckeditor5-autoformat/src/autoformat.js
@@ -178,7 +178,11 @@ export default class Autoformat extends Plugin {
 	 */
 	_addCodeBlockAutoformats() {
 		if ( this.editor.commands.get( 'codeBlock' ) ) {
-			blockAutoformatEditing( this.editor, this, /^```$/, 'codeBlock' );
+			blockAutoformatEditing( this.editor, this, /^```$/, () => {
+				this.editor.execute( 'codeBlock', {
+					usePreviousLanguageChoice: true
+				} );
+			} );
 		}
 	}
 

--- a/packages/ckeditor5-autoformat/src/autoformat.js
+++ b/packages/ckeditor5-autoformat/src/autoformat.js
@@ -177,8 +177,13 @@ export default class Autoformat extends Plugin {
 	 * @private
 	 */
 	_addCodeBlockAutoformats() {
-		if ( this.editor.commands.get( 'codeBlock' ) ) {
-			blockAutoformatEditing( this.editor, this, /^```$/, () => {
+		const editor = this.editor;
+		const selection = editor.model.document.selection;
+		if ( editor.commands.get( 'codeBlock' ) ) {
+			blockAutoformatEditing( editor, this, /^```$/, () => {
+				if ( selection.getFirstPosition().parent.is( 'element', 'listItem' ) ) {
+					return false;
+				}
 				this.editor.execute( 'codeBlock', {
 					usePreviousLanguageChoice: true
 				} );

--- a/packages/ckeditor5-autoformat/src/autoformat.js
+++ b/packages/ckeditor5-autoformat/src/autoformat.js
@@ -179,6 +179,7 @@ export default class Autoformat extends Plugin {
 	_addCodeBlockAutoformats() {
 		const editor = this.editor;
 		const selection = editor.model.document.selection;
+
 		if ( editor.commands.get( 'codeBlock' ) ) {
 			blockAutoformatEditing( editor, this, /^```$/, () => {
 				if ( selection.getFirstPosition().parent.is( 'element', 'listItem' ) ) {

--- a/packages/ckeditor5-autoformat/tests/autoformat.js
+++ b/packages/ckeditor5-autoformat/tests/autoformat.js
@@ -497,6 +497,20 @@ describe( 'Autoformat', () => {
 	} );
 
 	describe( 'Code block', () => {
+		it( 'should remember the last used language', () => {
+			setData( model, '<paragraph>[]</paragraph>' );
+			editor.execute( 'codeBlock', { language: 'cpp' } );
+			editor.execute( 'codeBlock' );
+			model.change( writer => {
+				writer.insertText( '``', doc.selection.getFirstPosition() );
+			} );
+			model.change( writer => {
+				writer.insertText( '`', doc.selection.getFirstPosition() );
+			} );
+
+			expect( getData( model ) ).to.equal( '<codeBlock language="cpp">[]</codeBlock>' );
+		} );
+
 		it( 'should replace triple grave accents with a code block', () => {
 			setData( model, '<paragraph>``[]</paragraph>' );
 			model.change( writer => {

--- a/packages/ckeditor5-autoformat/tests/autoformat.js
+++ b/packages/ckeditor5-autoformat/tests/autoformat.js
@@ -497,20 +497,6 @@ describe( 'Autoformat', () => {
 	} );
 
 	describe( 'Code block', () => {
-		it( 'should remember the last used language', () => {
-			setData( model, '<paragraph>[]</paragraph>' );
-			editor.execute( 'codeBlock', { language: 'cpp' } );
-			editor.execute( 'codeBlock' );
-			model.change( writer => {
-				writer.insertText( '``', doc.selection.getFirstPosition() );
-			} );
-			model.change( writer => {
-				writer.insertText( '`', doc.selection.getFirstPosition() );
-			} );
-
-			expect( getData( model ) ).to.equal( '<codeBlock language="cpp">[]</codeBlock>' );
-		} );
-
 		it( 'should replace triple grave accents with a code block', () => {
 			setData( model, '<paragraph>``[]</paragraph>' );
 			model.change( writer => {
@@ -563,6 +549,25 @@ describe( 'Autoformat', () => {
 			} );
 
 			expect( getData( model ) ).to.equal( '<codeBlock language="plaintext">```[]</codeBlock>' );
+		} );
+
+		it( 'should remember the last used language', () => {
+			setData( model, '<paragraph>[]</paragraph>' );
+
+			// Mock the UI usage: execute the command with the specified language.
+			editor.execute( 'codeBlock', { language: 'cpp' } );
+			editor.execute( 'codeBlock' );
+
+			// Typing '```' in a single change does not trigger the autoformat feature.
+			model.change( writer => {
+				writer.insertText( '``', doc.selection.getFirstPosition() );
+			} );
+
+			model.change( writer => {
+				writer.insertText( '`', doc.selection.getFirstPosition() );
+			} );
+
+			expect( getData( model ) ).to.equal( '<codeBlock language="cpp">[]</codeBlock>' );
 		} );
 	} );
 


### PR DESCRIPTION
Fix (autoformat): Autoformat will apply the previous language choice for the code block feature. Closes #10005.