### PR TITLE
Add editor icons to guides #04

### DIFF
--- a/docs/_snippets/features/mathtype.html
+++ b/docs/_snippets/features/mathtype.html
@@ -1,3 +1,10 @@
+<style>
+	.editor-icon__image[alt="MathType"],
+	.editor-icon__image[alt="ChemType"] {
+		filter: grayscale( 100% );
+	}
+</style>
+
 <div id="mathtype-editor">
 	<p>In elementary algebra, the <strong>quadratic formula</strong> is the solution of the quadratic equation.</p>
 

--- a/docs/features/math-equations.md
+++ b/docs/features/math-equations.md
@@ -18,7 +18,7 @@ Additionally, MathType offers a special tool designed to help you work with chem
 
 ## Demo
 
-In order to start creating math or chemical formulas in the WYSIWYG editor below, click the MathType or ChemType buttons in the toolbar. This will open the relevant dialog on the screen.
+To start creating math or chemical formulas in the WYSIWYG editor below, click the MathType {@icon @wiris/mathtype-ckeditor5/theme/icons/formula.svg MathType} or ChemType {@icon @wiris/mathtype-ckeditor5/theme/icons/chem.svg ChemType} buttons in the toolbar. This will open the relevant dialog on the screen.
 
 Use the toolbar to write your equation or formula. At any time you can also click the "Go to handwritten mode" button on the right side of the MathType editor to switch to handwriting.
 

--- a/packages/ckeditor5-link/docs/features/link.md
+++ b/packages/ckeditor5-link/docs/features/link.md
@@ -11,7 +11,7 @@ After you enable the optional [autolink](#autolink-feature) plugin, typed or pas
 
 ## Demo
 
-You can edit existing links by clicking them and using the balloon. Use the Link toolbar button or press <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>K</kbd> to create a new link.
+Use the Link toolbar button {@icon @ckeditor/ckeditor5-link/theme/icons/link.svg Link} or press <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>K</kbd> to create a new link. Clicking on a link will activate the contextual toolbar, from which you can edit existing links {@icon @ckeditor/ckeditor5-core/theme/icons/pencil.svg Edit link} or unlink them {@icon @ckeditor/ckeditor5-link/theme/icons/unlink.svg Unlink} with a click.
 
 {@snippet features/link}
 
@@ -42,7 +42,7 @@ There are two types of link decorators you can use:
 
 ### Demo
 
-In the editor below, all **external** links get the `target="_blank"` and `rel="noopener noreferrer"` attributes ([automatic decorator](#adding-attributes-to-links-based-on-predefined-rules-automatic-decorators)). Click a link and edit it to see that it is possible to control the `download` attribute of specific links using the switch button in the editing balloon ([manual decorator](#adding-attributes-to-links-using-the-ui-manual-decorators)). Take a look at the editor data below (updated live) to see the additional link attributes.
+In the editor below, all **external** links get the `target="_blank"` and `rel="noopener noreferrer"` attributes ([automatic decorator](#adding-attributes-to-links-based-on-predefined-rules-automatic-decorators)). Click a link and edit it {@icon @ckeditor/ckeditor5-core/theme/icons/pencil.svg Edit link} to see that it is possible to control the `download` attribute of specific links using the switch button in the editing balloon ([manual decorator](#adding-attributes-to-links-using-the-ui-manual-decorators)). Take a look at the editor data below (updated live) to see the additional link attributes.
 
 {@snippet features/linkdecorators}
 

--- a/packages/ckeditor5-list/docs/features/lists.md
+++ b/packages/ckeditor5-list/docs/features/lists.md
@@ -24,12 +24,14 @@ An unordered (bulleted) list can represent items where the order is not importan
 
 An ordered (numbered) list can be used if the order of the items matters, for example, when creating an instruction. Here, the sequence of steps that must be done is important.
 
-Use the editor below to see the list feature plugin in action. Lists can be introduced using toolbar buttons, or with Markdown code provided by the {@link features/autoformat autoformatting feature}:
+### Demo
+
+Use the editor below to see the list feature plugin in action. Toolbar buttons can be used to insert both ordered {@icon @ckeditor/ckeditor5-list/theme/icons/numberedlist.svg Insert ordered list} and unordered lists {@icon @ckeditor/ckeditor5-list/theme/icons/bulletedlist.svg Insert unordered list}.
+
+A Markdown code provided by the {@link features/autoformat autoformatting feature} can also be utilized:
 
 * Start a line with `*` or `-` followed by a space for a bulleted list.
 * Start a line with `1.` or `1)` followed by a space for a numbered list.
-
-### Demo
 
 {@snippet features/lists-basic}
 

--- a/packages/ckeditor5-list/docs/features/todo-lists.md
+++ b/packages/ckeditor5-list/docs/features/todo-lists.md
@@ -14,6 +14,8 @@ After reading this guide, you may find additional interesting details and exampl
 
 ## Demo
 
+Use the Insert to-do list toolbar button {@icon @ckeditor/ckeditor5-list/theme/icons/todolist.svg Insert a to-do list} to add a list to the editor content.
+
 {@snippet features/todo-list}
 
 ## Keyboard support

--- a/packages/ckeditor5-media-embed/docs/features/media-embed.md
+++ b/packages/ckeditor5-media-embed/docs/features/media-embed.md
@@ -10,7 +10,7 @@ The {@link module:media-embed/mediaembed~MediaEmbed} feature brings support for 
 
 ## Demo
 
-You can use the "Insert media" button in the toolbar to embed media like in the following examples. You can also paste the media URL directly into the editor content and it will be [automatically embedded](#automatic-media-embed-on-paste).
+You can use the Insert media button in the toolbar {@icon @ckeditor/ckeditor5-media-embed/theme/icons/media.svg Insert media} to embed media like in the following examples. You can also paste the media URL directly into the editor content and it will be [automatically embedded](#automatic-media-embed-on-paste).
 
 * <input class="example-input" type="text" value="https://www.youtube.com/watch?v=H08tGjXNHO4">
 * <input class="example-input" type="text" value="https://open.spotify.com/album/2IXlgvecaDqOeF3viUZnPI?si=ogVw7KlcQAGZKK4Jz9QzvA">

--- a/packages/ckeditor5-page-break/docs/features/page-break.md
+++ b/packages/ckeditor5-page-break/docs/features/page-break.md
@@ -11,7 +11,7 @@ The page break feature is further complemented by the [pagination feature](https
 
 ## Demo
 
-Use the editor to see the {@link module:page-break/pagebreak~PageBreak} plugin in action. Click the button below in order to open the print preview window.
+Use the Insert page break toolbar button {@icon @ckeditor/ckeditor5-page-break/theme/icons/pagebreak.svg Insert page break} to see the feature in action. Use the **Open print preview** the button below the editor in order to preview the content.
 
 {@snippet features/page-break}
 


### PR DESCRIPTION
Docs: Adding toolbar items icons to user guides.

Part of: [#10048](https://github.com/ckeditor/ckeditor5/issues/10048) 

This PR covers the following guides:

*   link
*   media embed
*   page break
*   math / chem formulas
*   lists (all 3 of these)

---

### **Additional information**

One reviewer should be enough from the technical point of view, so the first one is the winner and we merge, but the math/chem icons need more love before merging.