### PR TITLE
Find and replace: Source mode integration added, manual test updated

### DIFF
--- a/packages/ckeditor5-find-and-replace/package.json
+++ b/packages/ckeditor5-find-and-replace/package.json
@@ -27,6 +27,7 @@
     "@ckeditor/ckeditor5-font": "^28.0.0",
     "@ckeditor/ckeditor5-highlight": "^28.0.0",
     "@ckeditor/ckeditor5-paragraph": "^28.0.0",
+    "@ckeditor/ckeditor5-source-editing": "^28.0.0",
     "@ckeditor/ckeditor5-theme-lark": "^28.0.0",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11"

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.js
@@ -122,6 +122,9 @@ export default class FindAndReplaceUI extends Plugin {
 				cancelEvent();
 			} );
 
+			// Dropdown won't be enabled when find command is disabled.
+			dropdown.bind( 'isEnabled' ).to( editor.commands.get( 'find' ) );
+
 			return dropdown;
 		} );
 	}

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.js
@@ -122,7 +122,7 @@ export default class FindAndReplaceUI extends Plugin {
 				cancelEvent();
 			} );
 
-			// Dropdown won't be enabled when find command is disabled.
+			// Dropdown should be disabled when in source editing mode. See #10001.
 			dropdown.bind( 'isEnabled' ).to( editor.commands.get( 'find' ) );
 
 			return dropdown;

--- a/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
@@ -9,6 +9,7 @@ describe( 'FindAndReplaceUI', () => {
 	let editorElement;
 	let editor;
 	let dropdown;
+	let command;
 
 	testUtils.createSinonSandbox();
 
@@ -23,6 +24,7 @@ describe( 'FindAndReplaceUI', () => {
 			.then( newEditor => {
 				editor = newEditor;
 				dropdown = editor.ui.componentFactory.create( 'findAndReplace' );
+				command = editor.commands.get( 'find' );
 			} );
 	} );
 
@@ -69,5 +71,13 @@ describe( 'FindAndReplaceUI', () => {
 		dropdown.fire( 'change:isOpen', 'isClosed', true );
 
 		expect( spy.calledOnce ).to.be.false;
+	} );
+
+	it( 'should not enable dropdown when find command is disabled', () => {
+		command.isEnabled = true;
+		expect( dropdown ).to.have.property( 'isEnabled', true );
+
+		command.isEnabled = false;
+		expect( dropdown ).to.have.property( 'isEnabled', false );
 	} );
 } );

--- a/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
@@ -9,7 +9,7 @@ describe( 'FindAndReplaceUI', () => {
 	let editorElement;
 	let editor;
 	let dropdown;
-	let command;
+	let findCommand;
 
 	testUtils.createSinonSandbox();
 
@@ -24,7 +24,7 @@ describe( 'FindAndReplaceUI', () => {
 			.then( newEditor => {
 				editor = newEditor;
 				dropdown = editor.ui.componentFactory.create( 'findAndReplace' );
-				command = editor.commands.get( 'find' );
+				findCommand = editor.commands.get( 'find' );
 			} );
 	} );
 
@@ -74,10 +74,10 @@ describe( 'FindAndReplaceUI', () => {
 	} );
 
 	it( 'should not enable dropdown when find command is disabled', () => {
-		command.isEnabled = true;
+		findCommand.isEnabled = true;
 		expect( dropdown ).to.have.property( 'isEnabled', true );
 
-		command.isEnabled = false;
+		findCommand.isEnabled = false;
 		expect( dropdown ).to.have.property( 'isEnabled', false );
 	} );
 } );

--- a/packages/ckeditor5-find-and-replace/tests/manual/findandreplace.js
+++ b/packages/ckeditor5-find-and-replace/tests/manual/findandreplace.js
@@ -13,12 +13,13 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Highlight from '@ckeditor/ckeditor5-highlight/src/highlight';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 import FontColor from '@ckeditor/ckeditor5-font/src/fontcolor';
+import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
 
 // Note: We need to load paragraph because we don't have inline editors yet.
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
-		plugins: [ Essentials, Paragraph, FindAndReplace, Highlight, ArticlePluginSet, FontColor ],
-		toolbar: [ 'heading', 'undo', 'redo', 'highlight', 'bold', 'fontColor', 'findAndReplace' ]
+		plugins: [ Essentials, Paragraph, FindAndReplace, Highlight, ArticlePluginSet, FontColor, SourceEditing ],
+		toolbar: [ 'sourceEditing', '|', 'heading', 'undo', 'redo', 'highlight', 'bold', 'fontColor', 'findAndReplace' ]
 	} )
 	.then( editor => {
 		window.editor = editor;

--- a/packages/ckeditor5-find-and-replace/tests/manual/findandreplace.md
+++ b/packages/ckeditor5-find-and-replace/tests/manual/findandreplace.md
@@ -1,20 +1,21 @@
 ## Find and replace
-
-Play around with find and replace text.
-
 Things to look for:
-
+* Find should be enabled in readonly mode
+* Find and replace should be disabled in source mode
 * Occurrences in the text input should be refreshed properly.
 
-### Matches color
+## Testing
+#### Find is enabled in readonly mode
+* Click on a 'Toggle editor readonly mode' button.
+* Click on a find and replace dropdown button.
+* Search for "cake" string.
+* FindNext, findPrevious buttons and 'Match case', 'Whole words only' checkboxes should be working normally.
 
+#### Find is disabled in source mode
+* Click on the 'Source' button in toolbar to start source editing mode.
+* Find and replace similarily to all buttons, except the source editing, should be disabled.
+
+#### Matches color
 * Open find dropdown.
 * Search for "cake" string.
-
-#### Expected
-
-The "cake" string in "Chocolate cake bar" (third paragraph) should be readable.
-
-#### Unexpected
-
-The "cake" text has yellow color and is not visible.
+* The "cake" string in "Chocolate cake bar" (third paragraph) should be readable.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (find-and-replace): The dropdown button should now be disabled when the source mode is active. Closes #10001.