### PR TITLE
Add editor icons to guides #05

### DIFF
--- a/docs/features/spelling-and-grammar-checking.md
+++ b/docs/features/spelling-and-grammar-checking.md
@@ -18,7 +18,7 @@ After reading this guide, you may find additional interesting details and exampl
 
 ## Demo
 
-See the spelling and grammar checking feature working in the editor below.
+Use the toolbar button {@icon @webspellchecker/wproofreader-ckeditor5/theme/icons/wproofreader.svg Spelling and grammar check} to test the spelling and grammar checking feature in the editor below.
 
 {@snippet features/wproofreader}
 

--- a/packages/ckeditor5-alignment/docs/features/text-alignment.md
+++ b/packages/ckeditor5-alignment/docs/features/text-alignment.md
@@ -9,6 +9,8 @@ The {@link module:alignment/alignment~Alignment} feature enables support for tex
 
 ## Demo
 
+Click inside a paragraph or a header and use the toolbar dropdown {@icon @ckeditor/ckeditor5-core/theme/icons/align-right.svg Text alignment} to apply desired alignment to a paragraph
+
 {@snippet features/text-alignment}
 
 ## Related features

--- a/packages/ckeditor5-language/docs/features/language.md
+++ b/packages/ckeditor5-language/docs/features/language.md
@@ -13,7 +13,7 @@ The text part language feature implements the [WCAG 3.1.2 Language of Parts](htt
 
 ## Demo
 
-Use the editor below to see the text part language plugin in action. Select a text fragment and use the toolbar dropdown to choose from predefined available languages that can be applied to the content.
+Use the language toolbar dropdown in the editor below to see the feature in action. Select a text fragment and use the toolbar dropdown to choose from predefined available languages that can be applied to the content.
 
 {@snippet features/textpartlanguage}
 

--- a/packages/ckeditor5-restricted-editing/docs/features/restricted-editing.md
+++ b/packages/ckeditor5-restricted-editing/docs/features/restricted-editing.md
@@ -21,7 +21,7 @@ By using this feature, the users of your application will be able to create temp
 
 ## Demo
 
-The demo below allows you to emulate both modes. You can start from creating a template of the document in the standard editing mode. Use the toolbar button to turn selected area into an editable region or to remove an existing one.
+The demo below allows you to emulate both modes. You can start from creating a template of the document in the standard editing mode. Select a section of text and use the toolbar button {@icon @ckeditor/ckeditor5-restricted-editing/theme/icons/contentunlock.svg Enable editing} to turn selected area into an editable region or to remove an existing one.
 
 Then you can switch to the restricted editing mode to see how the editable and non-editable regions behave.
 

--- a/packages/ckeditor5-select-all/docs/features/select-all.md
+++ b/packages/ckeditor5-select-all/docs/features/select-all.md
@@ -9,7 +9,7 @@ The {@link module:select-all/selectall~SelectAll} feature allows selecting the e
 
 ## Demo
 
-Press <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>A</kbd> or use the toolbar button to select the entire content of the editor.
+Press <kbd>Ctrl</kbd>/<kbd>Cmd</kbd>+<kbd>A</kbd> or use the toolbar button {@icon @ckeditor/ckeditor5-select-all/theme/icons/select-all.svg Select all} to select the entire content of the editor.
 
 {@snippet features/select-all}
 

--- a/packages/ckeditor5-special-characters/docs/features/special-characters.md
+++ b/packages/ckeditor5-special-characters/docs/features/special-characters.md
@@ -9,7 +9,7 @@ The {@link module:special-characters/specialcharacters~SpecialCharacters} plugin
 
 ## Demo
 
-Use the editor below to see the special characters plugin in action.
+Use the toolbar button {@icon @ckeditor/ckeditor5-special-characters/theme/icons/specialcharacters.svg Special characters} in the editor below to gain access to a [configurable](#configuration) panel with a table of selectable special characters.
 
 {@snippet features/special-characters-source}
 


### PR DESCRIPTION
Docs: Adding toolbar items icons to user guides.

Part of: [#10048](https://github.com/ckeditor/ckeditor5/issues/10048) 

This PR covers the following guides:

*   restricted editing
*   select all
*   special characters
*   text part language (only reworded, no icon)
*   spelling / grammar checking
*   text alignment

---

### **Additional information**

You know the rules, and so do I.