### PR TITLE
Preventing CI from running twice per PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ dist: xenial
 addons:
   chrome: stable
 language: node_js
+branches:
+  only:
+  - master
+  - stable
+  - release
 services:
 - xvfb
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ branches:
   - master
   - stable
   - release
+  - /^v\d+\.\d+\.\d+$/
 services:
 - xvfb
 node_js:


### PR DESCRIPTION
Internal: Limited CI to building only for the following branches: `#master`, `#stable`, and `#release`.