### PR TITLE
Find and replace: Label won't animate on view opening

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.js
@@ -184,9 +184,16 @@ export default class FindAndReplaceUI extends Plugin {
 		buttonView.actionView.delegate( 'execute' ).to( buttonView.arrowView );
 
 		// Each time a dropdown is opened, the search text field should get focused.
+		// Note: Use the low priority to make sure the following listener starts working after the
+		// default action of the drop-down is executed (i.e. the panel showed up). Otherwise, the
+		// invisible form/input cannot be focused/selected.
 		buttonView.on( 'open', () => {
+			formView.disableCssTransitions();
+
 			formView.findInputView.fieldView.select();
 			formView.focus();
+
+			formView.enableCssTransitions();
 		}, { priority: 'low' } );
 	}
 }

--- a/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.js
+++ b/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.js
@@ -7,7 +7,16 @@
  * @module find-and-replace/ui/findandreplaceformview
  */
 
-import { ButtonView, FocusCycler, LabeledFieldView, createLabeledInputText, View, submitHandler, ViewCollection } from 'ckeditor5/src/ui';
+import {
+	ButtonView,
+	FocusCycler,
+	LabeledFieldView,
+	createLabeledInputText,
+	View,
+	submitHandler,
+	ViewCollection,
+	injectCssTransitionDisabler
+} from 'ckeditor5/src/ui';
 import { FocusTracker, KeystrokeHandler, uid } from 'ckeditor5/src/utils';
 
 // See: #8833.
@@ -237,6 +246,8 @@ export default class FindAndReplaceFormView extends View {
 				this.replaceView
 			]
 		} );
+
+		injectCssTransitionDisabler( this );
 	}
 
 	render() {

--- a/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
@@ -124,6 +124,7 @@ describe( 'FindAndReplaceUI', () => {
 				} );
 
 				it( 'should disable CSS transitions to avoid unnecessary animations (and then enable them again)', () => {
+					// (#10008)
 					const disableCssTransitionsSpy = sinon.spy( form, 'disableCssTransitions' );
 					const enableCssTransitionsSpy = sinon.spy( form, 'enableCssTransitions' );
 					const selectSpy = sinon.spy( form.findInputView.fieldView, 'select' );

--- a/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
@@ -4,12 +4,15 @@ import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import FindAndReplaceUI from '../src/findandreplaceui';
 import FindAndReplace from '../src/findandreplace';
 import DropdownView from '@ckeditor/ckeditor5-ui/src/dropdown/dropdownview';
+import loupeIcon from '../theme/icons/find-replace.svg';
 
 describe( 'FindAndReplaceUI', () => {
 	let editorElement;
 	let editor;
 	let dropdown;
 	let findCommand;
+	let button;
+	let form;
 
 	testUtils.createSinonSandbox();
 
@@ -24,6 +27,8 @@ describe( 'FindAndReplaceUI', () => {
 			.then( newEditor => {
 				editor = newEditor;
 				dropdown = editor.ui.componentFactory.create( 'findAndReplace' );
+				form = dropdown.panelView.children.get( 0 );
+				button = dropdown.buttonView;
 				findCommand = editor.commands.get( 'find' );
 			} );
 	} );
@@ -51,33 +56,83 @@ describe( 'FindAndReplaceUI', () => {
 		expect( dropdown ).to.not.equal( secondInstance );
 	} );
 
-	it( 'should delegate dropdown:closed event', () => {
-		const plugin = editor.plugins.get( 'FindAndReplaceUI' );
-		const spy = sinon.spy();
+	describe( 'dropdown', () => {
+		it( 'should delegate dropdown:closed event', () => {
+			const plugin = editor.plugins.get( 'FindAndReplaceUI' );
+			const spy = sinon.spy();
 
-		plugin.on( 'dropdown:closed', spy );
+			plugin.on( 'dropdown:closed', spy );
 
-		dropdown.fire( 'change:isOpen', 'isClosed', false );
+			dropdown.fire( 'change:isOpen', 'isClosed', false );
 
-		expect( spy.calledOnce ).to.be.true;
-	} );
+			expect( spy.calledOnce ).to.be.true;
+		} );
 
-	it( 'should not delegate dropdown:closed event when the UI is opened', () => {
-		const plugin = editor.plugins.get( 'FindAndReplaceUI' );
-		const spy = sinon.spy();
+		it( 'should not delegate dropdown:closed event when the UI is opened', () => {
+			const plugin = editor.plugins.get( 'FindAndReplaceUI' );
+			const spy = sinon.spy();
 
-		plugin.on( 'dropdown:closed', spy );
+			plugin.on( 'dropdown:closed', spy );
 
-		dropdown.fire( 'change:isOpen', 'isClosed', true );
+			dropdown.fire( 'change:isOpen', 'isClosed', true );
 
-		expect( spy.calledOnce ).to.be.false;
-	} );
+			expect( spy.calledOnce ).to.be.false;
+		} );
 
-	it( 'should not enable dropdown when find command is disabled', () => {
-		findCommand.isEnabled = true;
-		expect( dropdown ).to.have.property( 'isEnabled', true );
+		it( 'should not enable dropdown when find command is disabled', () => {
+			findCommand.isEnabled = true;
+			expect( dropdown ).to.have.property( 'isEnabled', true );
 
-		findCommand.isEnabled = false;
-		expect( dropdown ).to.have.property( 'isEnabled', false );
+			findCommand.isEnabled = false;
+			expect( dropdown ).to.have.property( 'isEnabled', false );
+		} );
+
+		describe( 'button', () => {
+			it( 'should set an #icon of the #buttonView', () => {
+				expect( dropdown.buttonView.icon ).to.equal( loupeIcon );
+			} );
+
+			it( 'should set a #label of the #buttonView', () => {
+				expect( dropdown.buttonView.tooltip ).to.equal( 'Find and replace' );
+			} );
+
+			describe( '#open event', () => {
+				it( 'executes the actions with the "low" priority', () => {
+					const spy = sinon.spy();
+					const selectSpy = sinon.spy( form.findInputView.fieldView, 'select' );
+
+					button.on( 'open', () => {
+						spy();
+					} );
+
+					button.fire( 'open' );
+					sinon.assert.callOrder( spy, selectSpy );
+				} );
+
+				it( 'should select the content of the input', () => {
+					const spy = sinon.spy( form.findInputView.fieldView, 'select' );
+
+					button.fire( 'open' );
+					sinon.assert.calledOnce( spy );
+				} );
+
+				it( 'should focus the form', () => {
+					const spy = sinon.spy( form, 'focus' );
+
+					button.fire( 'open' );
+					sinon.assert.calledOnce( spy );
+				} );
+
+				it( 'should disable CSS transitions to avoid unnecessary animations (and then enable them again)', () => {
+					const disableCssTransitionsSpy = sinon.spy( form, 'disableCssTransitions' );
+					const enableCssTransitionsSpy = sinon.spy( form, 'enableCssTransitions' );
+					const selectSpy = sinon.spy( form.findInputView.fieldView, 'select' );
+
+					button.fire( 'open' );
+
+					sinon.assert.callOrder( disableCssTransitionsSpy, selectSpy, enableCssTransitionsSpy );
+				} );
+			} );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
+++ b/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
@@ -62,6 +62,10 @@ describe( 'FindAndReplaceFormView', () => {
 			expect( view._focusables ).to.be.instanceOf( ViewCollection );
 		} );
 
+		it( 'should implement the CSS transition disabling feature', () => {
+			expect( view.disableCssTransitions ).to.be.a( 'function' );
+		} );
+
 		describe( 'find input view', () => {
 			it( 'has label', () => {
 				expect( view.findInputView.label ).to.match( /^Find in text/ );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (find-and-replace):  Label animation on view opening has been removed. Closes #10008.

Tests (find-and-replace): Added missing tests for the dropdown's button.
