### PR TITLE
Find and replace: toolbar button is now using DropdownButtonView

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.js
@@ -8,7 +8,7 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core';
-import { createDropdown, SplitButtonView } from 'ckeditor5/src/ui';
+import { createDropdown } from 'ckeditor5/src/ui';
 import FindAndReplaceFormView from './ui/findandreplaceformview';
 // See: #8833.
 // eslint-disable-next-line ckeditor5-rules/ckeditor-imports
@@ -67,7 +67,7 @@ export default class FindAndReplaceUI extends Plugin {
 		const editor = this.editor;
 
 		editor.ui.componentFactory.add( 'findAndReplace', locale => {
-			const dropdown = createDropdown( locale, SplitButtonView );
+			const dropdown = createDropdown( locale );
 
 			const formView = new FindAndReplaceFormView( editor.locale );
 
@@ -179,9 +179,6 @@ export default class FindAndReplaceUI extends Plugin {
 			icon,
 			tooltip: t( 'Find and replace' )
 		} );
-
-		// Clicking the main button has the same effect as clicking the dropdown arrow.
-		buttonView.actionView.delegate( 'execute' ).to( buttonView.arrowView );
 
 		// Each time a dropdown is opened, the search text field should get focused.
 		buttonView.on( 'open', () => {

--- a/packages/ckeditor5-find-and-replace/tests/findandreplace.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplace.js
@@ -124,7 +124,7 @@ describe( 'FindAndReplace', () => {
 						item.buttonView && item.buttonView.tooltip == 'Find and replace'
 					)[ 0 ];
 
-				itemView.buttonView.arrowView.fire( 'execute' );
+				itemView.buttonView.fire( 'execute' );
 
 				expect( findAndReplaceUI.formView.findButtonView.isEnabled, 'findButtonView' ).to.be.false;
 				expect( findAndReplaceUI.formView.replaceAllButtonView.isEnabled, 'replaceAllButtonView' ).to.be.false;
@@ -141,14 +141,14 @@ describe( 'FindAndReplace', () => {
 					)[ 0 ];
 
 				// First search.
-				itemView.buttonView.arrowView.fire( 'execute' );
+				itemView.buttonView.fire( 'execute' );
 				findAndReplaceUI.formView.findInputView.fieldView.value = 'cake';
 				findAndReplaceUI.formView.findButtonView.fire( 'execute' );
 				// Close the panel.
 				itemView.isOpen = false;
 
 				// Second search, should retain search text.
-				itemView.buttonView.arrowView.fire( 'execute' );
+				itemView.buttonView.fire( 'execute' );
 
 				expect( findAndReplaceUI.formView.findInputView.fieldView.value ).to.equal( 'cake' );
 				expect( findAndReplaceUI.formView.findButtonView.isEnabled, 'findButtonView' ).to.be.true;
@@ -166,7 +166,7 @@ describe( 'FindAndReplace', () => {
 					)[ 0 ];
 
 				// First search.
-				itemView.buttonView.arrowView.fire( 'execute' );
+				itemView.buttonView.fire( 'execute' );
 				findAndReplaceUI.formView.findInputView.fieldView.value = 'nothingtobefound';
 				findAndReplaceUI.formView.findButtonView.fire( 'execute' );
 
@@ -186,7 +186,7 @@ describe( 'FindAndReplace', () => {
 					)[ 0 ];
 
 				// First search.
-				itemView.buttonView.arrowView.fire( 'execute' );
+				itemView.buttonView.fire( 'execute' );
 				findAndReplaceUI.formView.findInputView.fieldView.value = 'jujubes';
 				findAndReplaceUI.formView.findButtonView.fire( 'execute' );
 
@@ -206,7 +206,7 @@ describe( 'FindAndReplace', () => {
 					)[ 0 ];
 
 				// First search.
-				itemView.buttonView.arrowView.fire( 'execute' );
+				itemView.buttonView.fire( 'execute' );
 				findAndReplaceUI.formView.findInputView.fieldView.value = 'cake';
 				findAndReplaceUI.formView.findButtonView.fire( 'execute' );
 
@@ -224,8 +224,7 @@ describe( 'FindAndReplace', () => {
 						item.buttonView && item.buttonView.tooltip == 'Find and replace'
 					)[ 0 ];
 
-				itemView.buttonView.arrowView.fire( 'execute' );
-
+				itemView.buttonView.fire( 'execute' );
 				expect( itemView.panelView.isVisible ).to.be.true;
 			} );
 		} );

--- a/packages/ckeditor5-find-and-replace/tests/findandreplace.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplace.js
@@ -116,16 +116,6 @@ describe( 'FindAndReplace', () => {
 		describe( 'mocks', () => {
 			// Verifying mocks from https://github.com/ckeditor/ckeditor5/issues/9719#issuecomment-857557024.
 			it( 'has a proper initial state', () => {
-				// "Initial state" mock.
-				editor.setData( LONG_TEXT );
-
-				const itemView = Array.from( editor.ui.view.toolbar.items )
-					.filter( item =>
-						item.buttonView && item.buttonView.tooltip == 'Find and replace'
-					)[ 0 ];
-
-				itemView.buttonView.fire( 'execute' );
-
 				expect( findAndReplaceUI.formView.findButtonView.isEnabled, 'findButtonView' ).to.be.false;
 				expect( findAndReplaceUI.formView.replaceAllButtonView.isEnabled, 'replaceAllButtonView' ).to.be.false;
 				expect( findAndReplaceUI.formView.replaceButtonView.isEnabled, 'replaceButtonView' ).to.be.false;
@@ -160,13 +150,6 @@ describe( 'FindAndReplace', () => {
 				// "No/one result found" mock.
 				editor.setData( LONG_TEXT );
 
-				const itemView = Array.from( editor.ui.view.toolbar.items )
-					.filter( item =>
-						item.buttonView && item.buttonView.tooltip == 'Find and replace'
-					)[ 0 ];
-
-				// First search.
-				itemView.buttonView.fire( 'execute' );
 				findAndReplaceUI.formView.findInputView.fieldView.value = 'nothingtobefound';
 				findAndReplaceUI.formView.findButtonView.fire( 'execute' );
 
@@ -180,13 +163,6 @@ describe( 'FindAndReplace', () => {
 				// "No/one result found" mock.
 				editor.setData( LONG_TEXT );
 
-				const itemView = Array.from( editor.ui.view.toolbar.items )
-					.filter( item =>
-						item.buttonView && item.buttonView.tooltip == 'Find and replace'
-					)[ 0 ];
-
-				// First search.
-				itemView.buttonView.fire( 'execute' );
 				findAndReplaceUI.formView.findInputView.fieldView.value = 'jujubes';
 				findAndReplaceUI.formView.findButtonView.fire( 'execute' );
 
@@ -200,13 +176,6 @@ describe( 'FindAndReplace', () => {
 				// "Found results" mock.
 				editor.setData( LONG_TEXT );
 
-				const itemView = Array.from( editor.ui.view.toolbar.items )
-					.filter( item =>
-						item.buttonView && item.buttonView.tooltip == 'Find and replace'
-					)[ 0 ];
-
-				// First search.
-				itemView.buttonView.fire( 'execute' );
 				findAndReplaceUI.formView.findInputView.fieldView.value = 'cake';
 				findAndReplaceUI.formView.findButtonView.fire( 'execute' );
 
@@ -225,6 +194,7 @@ describe( 'FindAndReplace', () => {
 					)[ 0 ];
 
 				itemView.buttonView.fire( 'execute' );
+
 				expect( itemView.panelView.isVisible ).to.be.true;
 			} );
 		} );

--- a/packages/ckeditor5-find-and-replace/tests/findandreplace.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplace.js
@@ -116,6 +116,16 @@ describe( 'FindAndReplace', () => {
 		describe( 'mocks', () => {
 			// Verifying mocks from https://github.com/ckeditor/ckeditor5/issues/9719#issuecomment-857557024.
 			it( 'has a proper initial state', () => {
+				// "Initial state" mock.
+				editor.setData( LONG_TEXT );
+
+				const itemView = Array.from( editor.ui.view.toolbar.items )
+					.filter( item =>
+						item.buttonView && item.buttonView.tooltip == 'Find and replace'
+					)[ 0 ];
+
+				itemView.buttonView.fire( 'execute' );
+
 				expect( findAndReplaceUI.formView.findButtonView.isEnabled, 'findButtonView' ).to.be.false;
 				expect( findAndReplaceUI.formView.replaceAllButtonView.isEnabled, 'replaceAllButtonView' ).to.be.false;
 				expect( findAndReplaceUI.formView.replaceButtonView.isEnabled, 'replaceButtonView' ).to.be.false;
@@ -150,6 +160,13 @@ describe( 'FindAndReplace', () => {
 				// "No/one result found" mock.
 				editor.setData( LONG_TEXT );
 
+				const itemView = Array.from( editor.ui.view.toolbar.items )
+					.filter( item =>
+						item.buttonView && item.buttonView.tooltip == 'Find and replace'
+					)[ 0 ];
+
+				// First search.
+				itemView.buttonView.fire( 'execute' );
 				findAndReplaceUI.formView.findInputView.fieldView.value = 'nothingtobefound';
 				findAndReplaceUI.formView.findButtonView.fire( 'execute' );
 
@@ -163,6 +180,13 @@ describe( 'FindAndReplace', () => {
 				// "No/one result found" mock.
 				editor.setData( LONG_TEXT );
 
+				const itemView = Array.from( editor.ui.view.toolbar.items )
+					.filter( item =>
+						item.buttonView && item.buttonView.tooltip == 'Find and replace'
+					)[ 0 ];
+
+				// First search.
+				itemView.buttonView.fire( 'execute' );
 				findAndReplaceUI.formView.findInputView.fieldView.value = 'jujubes';
 				findAndReplaceUI.formView.findButtonView.fire( 'execute' );
 
@@ -176,6 +200,13 @@ describe( 'FindAndReplace', () => {
 				// "Found results" mock.
 				editor.setData( LONG_TEXT );
 
+				const itemView = Array.from( editor.ui.view.toolbar.items )
+					.filter( item =>
+						item.buttonView && item.buttonView.tooltip == 'Find and replace'
+					)[ 0 ];
+
+				// First search.
+				itemView.buttonView.fire( 'execute' );
 				findAndReplaceUI.formView.findInputView.fieldView.value = 'cake';
 				findAndReplaceUI.formView.findButtonView.fire( 'execute' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (find-and-replace): Find and replace toolbar button now uses `DropdownButtonView`. Closes #10007.