### PR TITLE
[GHS] Table feature integration

### DIFF
--- a/packages/ckeditor5-html-support/package.json
+++ b/packages/ckeditor5-html-support/package.json
@@ -40,6 +40,7 @@
     "@ckeditor/ckeditor5-list": "^29.0.0",
     "@ckeditor/ckeditor5-page-break": "^29.0.0",
     "@ckeditor/ckeditor5-paragraph": "^29.0.0",
+    "@ckeditor/ckeditor5-source-editing": "^29.0.0",
     "@ckeditor/ckeditor5-table": "^29.0.0",
     "@ckeditor/ckeditor5-theme-lark": "^29.0.0",
     "@ckeditor/ckeditor5-utils": "^29.0.0",

--- a/packages/ckeditor5-html-support/package.json
+++ b/packages/ckeditor5-html-support/package.json
@@ -31,6 +31,7 @@
     "@ckeditor/ckeditor5-engine": "^29.0.0",
     "@ckeditor/ckeditor5-essentials": "^29.0.0",
     "@ckeditor/ckeditor5-font": "^29.0.0",
+    "@ckeditor/ckeditor5-heading": "^29.0.0",
     "@ckeditor/ckeditor5-highlight": "^29.0.0",
     "@ckeditor/ckeditor5-horizontal-line": "^29.0.0",
     "@ckeditor/ckeditor5-html-embed": "^29.0.0",

--- a/packages/ckeditor5-html-support/src/generalhtmlsupport.js
+++ b/packages/ckeditor5-html-support/src/generalhtmlsupport.js
@@ -10,6 +10,7 @@
 import { Plugin } from 'ckeditor5/src/core';
 import DataFilter from './datafilter';
 import CodeBlockHtmlSupport from './integrations/codeblock';
+import TableElementSupport from './integrations/table';
 
 /**
  * The General HTML Support feature.
@@ -42,7 +43,8 @@ export default class GeneralHtmlSupport extends Plugin {
 	static get requires() {
 		return [
 			DataFilter,
-			CodeBlockHtmlSupport
+			CodeBlockHtmlSupport,
+			TableElementSupport
 		];
 	}
 }

--- a/packages/ckeditor5-html-support/src/integrations/table.js
+++ b/packages/ckeditor5-html-support/src/integrations/table.js
@@ -153,5 +153,4 @@ function getDescendantElement( conversionApi, containerElement, elementName ) {
 			return item;
 		}
 	}
-	return null;
 }

--- a/packages/ckeditor5-html-support/src/integrations/table.js
+++ b/packages/ckeditor5-html-support/src/integrations/table.js
@@ -1,0 +1,157 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module html-support/integrations/table
+ */
+
+import { Plugin } from 'ckeditor5/src/core';
+import { disallowedAttributesConverter } from '../converters';
+import { setViewAttributes } from '../conversionutils.js';
+
+import DataFilter from '../datafilter';
+
+/**
+ * Provides the General HTML Support integration with {@link module:table/table~Table Table} feature.
+ *
+ * @extends module:core/plugin~Plugin
+ */
+export default class TableElementSupport extends Plugin {
+	static get requires() {
+		return [ DataFilter ];
+	}
+
+	init() {
+		const editor = this.editor;
+
+		if ( !editor.plugins.has( 'TableEditing' ) ) {
+			return;
+		}
+
+		const schema = editor.model.schema;
+		const conversion = editor.conversion;
+		const dataFilter = editor.plugins.get( DataFilter );
+
+		dataFilter.on( 'register:table', ( evt, definition ) => {
+			if ( definition.model !== 'table' ) {
+				return;
+			}
+
+			schema.extend( 'table', {
+				allowAttributes: [
+					'htmlAttributes',
+					// Figure, thead and tbody elements don't have model counterparts.
+					// We will be preserving attributes on table element using these attribute keys.
+					'htmlFigureAttributes', 'htmlTheadAttributes', 'htmlTbodyAttributes'
+				]
+			} );
+
+			conversion.for( 'upcast' ).add( disallowedAttributesConverter( definition, dataFilter ) );
+			conversion.for( 'upcast' ).add( viewToModelTableAttributeConverter( dataFilter ) );
+			conversion.for( 'downcast' ).add( modelToViewTableAttributeConverter() );
+
+			evt.stop();
+		} );
+
+		// Consume figure if it contains table element child to avoid elementToElement conversion for figure with that context.
+		dataFilter.on( 'register:figure', () => {
+			conversion.for( 'upcast' ).add( dispatcher => {
+				dispatcher.on( 'element:figure', ( evt, data, conversionApi ) => {
+					for ( const childNode of data.viewItem.getChildren() ) {
+						if ( childNode.is( 'element', 'table' ) ) {
+							conversionApi.consumable.consume( data.viewItem, { name: true } );
+							return;
+						}
+					}
+				} );
+			} );
+		} );
+	}
+}
+
+// View-to-model conversion helper preserving allowed attributes on {@link module:table/table~Table Table}
+// feature model element.
+//
+// @private
+// @param {module:html-support/datafilter~DataFilter} dataFilter
+// @returns {Function} Returns a conversion callback.
+function viewToModelTableAttributeConverter( dataFilter ) {
+	return dispatcher => {
+		dispatcher.on( 'element:table', ( evt, data, conversionApi ) => {
+			const viewTableElement = data.viewItem;
+
+			preserveElementAttributes( viewTableElement, 'htmlAttributes' );
+
+			const viewFigureElement = viewTableElement.parent;
+			if ( viewFigureElement.is( 'element', 'figure' ) ) {
+				preserveElementAttributes( viewFigureElement, 'htmlFigureAttributes' );
+			}
+
+			for ( const childNode of viewTableElement.getChildren() ) {
+				if ( childNode.is( 'element', 'thead' ) ) {
+					preserveElementAttributes( childNode, 'htmlTheadAttributes' );
+				}
+
+				if ( childNode.is( 'element', 'tbody' ) ) {
+					preserveElementAttributes( childNode, 'htmlTbodyAttributes' );
+				}
+			}
+
+			function preserveElementAttributes( viewElement, attributeName ) {
+				const viewAttributes = dataFilter._consumeAllowedAttributes( viewElement, conversionApi );
+
+				if ( viewAttributes ) {
+					conversionApi.writer.setAttribute( attributeName, viewAttributes, data.modelRange );
+				}
+			}
+		}, { priority: 'low' } );
+	};
+}
+
+// Model-to-view conversion helper applying attributes from {@link module:table/table~Table Table}
+// feature.
+//
+// @private
+// @returns {Function} Returns a conversion callback.
+function modelToViewTableAttributeConverter() {
+	return dispatcher => {
+		addAttributeConversionDispatcherHandler( 'table', 'htmlAttributes' );
+		addAttributeConversionDispatcherHandler( 'figure', 'htmlFigureAttributes' );
+		addAttributeConversionDispatcherHandler( 'thead', 'htmlTheadAttributes' );
+		addAttributeConversionDispatcherHandler( 'tbody', 'htmlTbodyAttributes' );
+
+		function addAttributeConversionDispatcherHandler( elementName, attributeName ) {
+			dispatcher.on( `attribute:${ attributeName }:table`, ( evt, data, conversionApi ) => {
+				if ( !conversionApi.consumable.consume( data.item, evt.name ) ) {
+					return;
+				}
+
+				const containerElement = conversionApi.mapper.toViewElement( data.item );
+				const viewElement = getDescendantElement( conversionApi, containerElement, elementName );
+
+				setViewAttributes( conversionApi.writer, data.attributeNewValue, viewElement );
+			} );
+		}
+	};
+}
+
+// Returns the first view element descendant matching the given view name.
+// Includes view element itself.
+//
+// @private
+// @param {module:engine/conversion/downcastdispatcher~DowncastConversionApi} conversionApi
+// @param {module:engine/view/element~Element} containerElement
+// @param {String} elementName
+// @returns {module:engine/view/element~Element|null}
+function getDescendantElement( conversionApi, containerElement, elementName ) {
+	const range = conversionApi.writer.createRangeOn( containerElement );
+
+	for ( const { item } of range.getWalker() ) {
+		if ( item.is( 'element', elementName ) ) {
+			return item;
+		}
+	}
+	return null;
+}

--- a/packages/ckeditor5-html-support/src/integrations/table.js
+++ b/packages/ckeditor5-html-support/src/integrations/table.js
@@ -55,18 +55,8 @@ export default class TableElementSupport extends Plugin {
 			evt.stop();
 		} );
 
-		// Consume figure if it contains table element child to avoid elementToElement conversion for figure with that context.
 		dataFilter.on( 'register:figure', () => {
-			conversion.for( 'upcast' ).add( dispatcher => {
-				dispatcher.on( 'element:figure', ( evt, data, conversionApi ) => {
-					for ( const childNode of data.viewItem.getChildren() ) {
-						if ( childNode.is( 'element', 'table' ) ) {
-							conversionApi.consumable.consume( data.viewItem, { name: true } );
-							return;
-						}
-					}
-				} );
-			} );
+			conversion.for( 'upcast' ).add( consumeTableFigureConverter() );
 		} );
 	}
 }
@@ -153,4 +143,22 @@ function getDescendantElement( conversionApi, containerElement, elementName ) {
 			return item;
 		}
 	}
+}
+
+// Conversion helper consuming figure element if it's a part of the Table feature
+// to avoid elementToElement conversion for figure with that context.
+//
+// @private
+// @returns {Function} Returns a conversion callback.
+function consumeTableFigureConverter() {
+	return dispatcher => {
+		dispatcher.on( 'element:figure', ( evt, data, conversionApi ) => {
+			for ( const childNode of data.viewItem.getChildren() ) {
+				if ( childNode.is( 'element', 'table' ) ) {
+					conversionApi.consumable.consume( data.viewItem, { name: true } );
+					return;
+				}
+			}
+		} );
+	};
 }

--- a/packages/ckeditor5-html-support/src/schemadefinitions.js
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.js
@@ -87,6 +87,30 @@ export default {
 			model: 'rawHtml',
 			view: 'div'
 		},
+		{
+			model: 'table',
+			view: 'table'
+		},
+		{
+			model: 'tableRow',
+			view: 'tr'
+		},
+		{
+			model: 'tableCell',
+			view: 'td'
+		},
+		{
+			model: 'tableCell',
+			view: 'th'
+		},
+		{
+			model: 'caption',
+			view: 'caption'
+		},
+		{
+			model: 'caption',
+			view: 'figcaption'
+		},
 
 		// Compatibility features
 		{

--- a/packages/ckeditor5-html-support/tests/manual/pfo-table.html
+++ b/packages/ckeditor5-html-support/tests/manual/pfo-table.html
@@ -1,0 +1,139 @@
+<head>
+	<meta http-equiv="Content-Security-Policy" content="script-src 'self' https://ckeditor.com 'unsafe-inline' 'unsafe-eval'">
+</head>
+<div style="display: flex">
+	<div style="width: 40%; margin-right: 20px">
+		<div id="editor">
+			<h3>Table #1</h3>
+			<table cellspacing="0" class="MsoTableGrid" style="border-collapse:collapse; border:none; width:597px">
+			   <tbody>
+				  <tr>
+					 <td style="background-color:#cccccc; border-bottom:1px solid black; border-left:1px solid black; border-right:1px solid black; border-top:1px solid black; width:59%px">
+						<p style="text-align:center"><span style="font-size:11pt"><span style="font-family:Arial,sans-serif"><span style="color:#333333"><strong><span style="font-family:Georgia,serif">Project Phase</span></strong></span></span></span></p>
+					 </td>
+					 <td style="background-color:#cccccc; border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:1px solid black; width:24%px">
+						<p style="text-align:center"><span style="font-size:11pt"><span style="font-family:Arial,sans-serif"><span style="color:#333333"><strong><span style="font-family:Georgia,serif">Deadline</span></strong></span></span></span></p>
+					 </td>
+					 <td style="background-color:#cccccc; border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:1px solid black; width:17%px">
+						<p style="text-align:center"><span style="font-size:11pt"><span style="font-family:Arial,sans-serif"><span style="color:#333333"><strong><span style="font-family:Georgia,serif">Status</span></strong></span></span></span></p>
+					 </td>
+				  </tr>
+				  <tr>
+					 <td style="border-bottom:1px solid black; border-left:1px solid black; border-right:1px solid black; border-top:none; width:59%px">
+						<p><span style="font-size:11pt"><span style="font-family:Arial,sans-serif"><span style="color:#333333"><span style="font-family:Georgia,serif">Phase 1: Market research</span></span></span></span></p>
+					 </td>
+					 <td style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; width:24%px">
+						<p style="text-align:center"><span style="font-size:11pt"><span style="font-family:Arial,sans-serif"><span style="color:#333333"><span style="font-family:Georgia,serif">2021-04-15</span></span></span></span></p>
+					 </td>
+					 <td style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; width:17%px">
+						<p style="text-align:center"><span style="font-size:11pt"><span style="font-family:Arial,sans-serif"><span style="color:#333333"><span style="font-family:'Segoe UI Symbol',sans-serif"><span style="color:#19b159">✓</span></span></span></span></span></p>
+					 </td>
+				  </tr>
+				  <tr>
+					 <td style="background-color:#eeeeee; border-bottom:1px solid black; border-left:1px solid black; border-right:1px solid black; border-top:none; width:59%px">
+						<p><span style="font-size:11pt"><span style="font-family:Arial,sans-serif"><span style="color:#333333"><span style="font-family:Georgia,serif">Phase 2: Editor implementation</span></span></span></span></p>
+					 </td>
+					 <td style="background-color:#eeeeee; border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; width:24%px">
+						<p style="text-align:center"><span style="font-size:11pt"><span style="font-family:Arial,sans-serif"><span style="color:#333333"><span style="font-family:Georgia,serif">2021-04-20</span></span></span></span></p>
+					 </td>
+					 <td style="background-color:#eeeeee; border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; width:17%px">
+						<p style="text-align:center"><span style="font-size:11pt"><span style="font-family:Arial,sans-serif"><span style="color:#333333"><span style="font-family:'Segoe UI Symbol',sans-serif"><span style="color:#19b159">✓</span></span></span></span></span></p>
+					 </td>
+				  </tr>
+				  <tr>
+					 <td style="border-bottom:1px solid black; border-left:1px solid black; border-right:1px solid black; border-top:none; width:59%px">
+						<p><span style="font-size:11pt"><span style="font-family:Arial,sans-serif"><span style="color:#333333"><span style="font-family:Georgia,serif">Phase 3: Rollout to Production</span></span></span></span></p>
+					 </td>
+					 <td style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; width:24%px">
+						<p style="text-align:center"><span style="font-size:11pt"><span style="font-family:Arial,sans-serif"><span style="color:#333333"><span style="font-family:Georgia,serif">2021-04-22</span></span></span></span></p>
+					 </td>
+					 <td style="border-bottom:1px solid black; border-left:none; border-right:1px solid black; border-top:none; width:17%px">
+						<p style="text-align:center"><span style="font-size:11pt"><span style="font-family:Arial,sans-serif"><span style="color:#333333"><span style="font-family:'Segoe UI Symbol',sans-serif"><span style="color:#19b159">✓</span></span></span></span></span></p>
+					 </td>
+				  </tr>
+			   </tbody>
+			</table>
+			<h3>Table #2</h3>
+			<table class="Table" style="width:100.0%; border-collapse:collapse" width="100%">
+			   <tbody>
+				  <tr>
+					 <td style="border-bottom:4px dotted red; width:35%; padding:0cm 7px 0cm 7px; background-color:#d9e2f3; border-top:3px solid black; border-right:4px double #ed7d31; border-left:1px solid black" valign="top">
+						<p style="margin-bottom:11px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif">&frac12;</span></span></span></p>
+					 </td>
+					 <td style="border-bottom:4px dotted red; width:40%; padding:0cm 7px 0cm 7px; background-color:#fff2cc; border-top:3px solid black; border-right:4px double #ed7d31; border-left:none" valign="top">
+						<h1><span style="font-size:16pt"><span style="line-height:normal"><span style="font-family:&quot;Calibri Light&quot;,sans-serif"><span style="color:#2e74b5"><span style="font-weight:normal"><span lang="EN-US" style="color:#f4b083">1</span></span></span></span></span></span></h1>
+					 </td>
+					 <td style="border-bottom:4px dotted red; width:25%; padding:0cm 7px 0cm 7px; border-top:3px solid black; border-right:4px double #ed7d31; border-left:none" valign="top">
+						<p style="margin-bottom:11px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><b><i><u>2</u></i></b></span></span></span></p>
+					 </td>
+				  </tr>
+				  <tr>
+					 <td style="border-bottom:1px solid black; width:35%; padding:0cm 7px 0cm 7px; background-color:#d9e2f3; border-top:none; border-right:4px dotted red; border-left:1px solid black" valign="top">
+						<ol>
+						   <li style="margin-left:8px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="font-family:&quot;Georgia&quot;,serif"><span style="color:black">This (Georgia)</span></span></span></span></span></li>
+						   <li style="margin-left:8px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="font-family:&quot;Arial&quot;,sans-serif"><span style="color:black">Is (Arial)</span></span></span></span></span></li>
+						   <li style="margin-left:8px">
+							  <span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="color:black">A</span></span></span></span>
+							  <ol style="list-style-type:lower-alpha">
+								 <li style="margin-left:8px">
+									<span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="color:black">Multi</span></span></span></span>
+									<ol style="list-style-type:lower-roman">
+									   <li style="margin-left:8px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="color:black">Level</span></span></span></span></li>
+									</ol>
+								 </li>
+								 <li style="margin-left:8px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="color:black">Ordered</span></span></span></span></li>
+							  </ol>
+						   </li>
+						   <li style="margin-left:8px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="color:black">List</span></span></span></span></li>
+						</ol>
+					 </td>
+					 <td style="border-bottom:4px dotted red; width:40%; padding:0cm 7px 0cm 7px; background-color:#fff2cc; border-top:none; border-right:4px dotted red; border-left:none" valign="top">
+						<ul>
+						   <li style="margin-left:8px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="color:black">This</span></span></span></span></li>
+						   <li style="margin-left:8px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="color:black">Is</span></span></span></span></li>
+						   <li style="margin-left:8px">
+							  <span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="color:black">A</span></span></span></span>
+							  <ul style="list-style-type:circle">
+								 <li style="margin-left:8px">
+									<span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="color:black">Multi</span></span></span></span>
+									<ul style="list-style-type:square">
+									   <li style="margin-left:8px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="color:black">Level</span></span></span></span></li>
+									</ul>
+								 </li>
+								 <li style="margin-left:8px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="font-family:&quot;Times New Roman&quot;,serif"><span style="color:black">Unordered</span></span></span></span></span></li>
+							  </ul>
+						   </li>
+						   <li style="margin-bottom:11px; margin-left:8px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="color:black">List</span></span></span></span></li>
+						</ul>
+					 </td>
+					 <td style="border-bottom:4px dotted red; width:25%; padding:0cm 7px 0cm 7px; border-top:none; border-right:1px solid black; border-left:none" valign="top">
+						<p style="margin-bottom:11px"><span style="font-size:11pt"><span style="line-height:300%"><span style="font-family:Calibri,sans-serif">Cell 1,2</span></span></span></p>
+					 </td>
+				  </tr>
+				  <tr>
+					 <td style="border-bottom:1px solid black; width:35%; padding:0cm 7px 0cm 7px; background-color:#d9e2f3; border-top:none; border-right:4px dotted red; border-left:1px solid black" valign="top">
+						<p style="margin-bottom:11px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="color:black">Left</span></span></span></span></p>
+						<p align="right" style="text-align:right; margin-bottom:11px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="color:black">Right</span></span></span></span></p>
+						<p align="center" style="text-align:center; margin-bottom:11px"><span style="font-size:11pt"><span style="line-height:107%"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="color:black">Center</span></span></span></span></p>
+					 </td>
+					 <td style="border-bottom:1px solid black; width:40%; padding:0cm 7px 0cm 7px; background-color:#fff2cc; border-top:none; border-right:4px dotted red; border-left:none" valign="top">
+						<p style="margin-bottom:11px"><span style="font-size:11pt"><span style="line-height:normal"><span style="font-family:Calibri,sans-serif"><span lang="EN-US" style="font-family:&quot;Comic Sans MS&quot;"><span style="color:black">Comic Sans&hellip;</span></span></span></span></span></p>
+						<p style="margin-bottom:11px"><span style="font-size:11pt"><span style="line-height:normal"><span style="font-family:Calibri,sans-serif"><b><span lang="EN-US" style="font-size:28.0pt"><span style="color:red">R</span></span></b><b><span lang="EN-US" style="font-size:28.0pt"><span style="color:#ffc000">A</span></span></b><b><span lang="EN-US" style="font-size:28.0pt"><span style="font-family:&quot;Verdana&quot;,sans-serif"><span style="color:yellow">I</span></span></span></b><b><span lang="EN-US" style="font-size:28.0pt"><span style="background:lightgrey"><span style="font-family:&quot;Verdana&quot;,sans-serif"><span style="color:#00b050">N</span></span></span></span></b><b><sub><span lang="EN-US" style="font-size:28.0pt"><span style="background:lightgrey"><span style="font-family:&quot;Verdana&quot;,sans-serif"><span style="color:#00b0f0">B</span></span></span></span></sub></b><b><sub><span lang="EN-US" style="font-size:28.0pt"><span style="background:lightgrey"><span style="font-family:&quot;Verdana&quot;,sans-serif"><span style="color:#0070c0">O</span></span></span></span></sub></b><b><sub><span lang="EN-US" style="font-size:28.0pt"><span style="background:lightgrey"><span style="color:#7030a0">W</span></span></span></sub></b></span></span></span></p>
+					 </td>
+					 <td style="border-bottom:1px solid black; width:25%; padding:0cm 7px 0cm 7px; border-top:none; border-right:1px solid black; border-left:none" valign="top">
+						<p align="center" style="text-align:center; margin-bottom:11px"><span style="font-size:11pt"><span style="line-height:300%"><span style="font-family:Calibri,sans-serif"><img src="sample.jpg" style="width:100px; height:100px" /></span></span></span></p>
+					 </td>
+				  </tr>
+			   </tbody>
+			</table>
+		</div>
+	</div>
+
+	<div style="width: 40%">
+		<h1 style="margin:12px 0 0 0; padding:0 0 5px 0; font-size: 18px; border-bottom: solid 1px grey">Source content:</h1>
+		<div id="preview"></div>
+	</div>
+</div>
+<script>
+	document.getElementById( 'preview' ).innerHTML = document.getElementById( 'editor' ).innerHTML;
+</script>

--- a/packages/ckeditor5-html-support/tests/manual/pfo-table.js
+++ b/packages/ckeditor5-html-support/tests/manual/pfo-table.js
@@ -1,0 +1,56 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console:false, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading';
+import List from '@ckeditor/ckeditor5-list/src/list';
+import Image from '@ckeditor/ckeditor5-image/src/image';
+import Table from '@ckeditor/ckeditor5-table/src/table';
+import TableCaption from '@ckeditor/ckeditor5-table/src/tablecaption';
+import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
+
+import GeneralHtmlSupport from '../../src/generalhtmlsupport';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [
+			Bold,
+			Essentials,
+			GeneralHtmlSupport,
+			Italic,
+			Heading,
+			List,
+			Image,
+			Paragraph,
+			SourceEditing,
+			Strikethrough,
+			Table,
+			TableCaption
+		],
+		toolbar: [ 'insertTable', '|', 'bold', 'italic', 'strikethrough', '|', 'sourceEditing' ],
+		htmlSupport: {
+			allow: [
+				{
+					name: /^(figure|table|tbody|thead|tr|th|td|caption|figcaption|span|p|img)$/,
+					attributes: [ 'valign' ],
+					styles: true,
+					classes: true
+				}
+			]
+		}
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-html-support/tests/manual/pfo-table.md
+++ b/packages/ckeditor5-html-support/tests/manual/pfo-table.md
@@ -1,0 +1,3 @@
+## Table from Word
+
+Compare HTML content with the content on the right side of the editor.

--- a/packages/ckeditor5-html-support/tests/manual/table.html
+++ b/packages/ckeditor5-html-support/tests/manual/table.html
@@ -1,0 +1,82 @@
+<head>
+	<meta http-equiv="Content-Security-Policy"
+		  content="script-src 'self' https://ckeditor.com 'unsafe-inline' 'unsafe-eval'">
+</head>
+
+<style>
+[contenteditable="true"] [data-validation-allow]{
+	border: 1px solid blue !important;
+}
+
+[contenteditable="true"] [data-validation-disallow]{
+	border: 1px solid red !important;
+}
+</style>
+
+<div id="editor">
+	<figure class="table">
+		<table>
+			<caption>caption</caption>
+			<thead>
+				<tr>
+					<th>1</th>
+					<th>2</th>
+					<th>3</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>1.1</td>
+					<td>1.2</td>
+					<td>1.3</td>
+				</tr>
+				<tr>
+					<td>2.1</td>
+					<td>2.2</td>
+					<td>2.3</td>
+				</tr>
+				<tr>
+					<td>3.1</td>
+					<td>3.2</td>
+					<td>3.3</td>
+				</tr>
+			</tbody>
+		</table>
+	</figure>
+
+	<figure class="table">
+		<table>
+			<thead>
+				<tr>
+					<th>1</th>
+					<th>2</th>
+					<th>3</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>1.1</td>
+					<td>1.2</td>
+					<td>1.3</td>
+				</tr>
+				<tr>
+					<td>2.1</td>
+					<td>2.2</td>
+					<td>2.3</td>
+				</tr>
+				<tr>
+					<td>3.1</td>
+					<td>3.2</td>
+					<td>3.3</td>
+				</tr>
+			</tbody>
+		</table>
+		<figcaption>figcaption</figcaption>
+	</figure>
+</div>
+<script>
+	document.getElementById( 'editor' ).querySelectorAll( 'figure, table, caption, figcaption, tbody, thead, tr, th, td' ).forEach( node => {
+		node.setAttribute( 'data-validation-allow', true );
+		node.setAttribute( 'data-validation-disallow', true );
+	} );
+</script>

--- a/packages/ckeditor5-html-support/tests/manual/table.js
+++ b/packages/ckeditor5-html-support/tests/manual/table.js
@@ -1,0 +1,52 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console:false, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
+import Table from '@ckeditor/ckeditor5-table/src/table';
+import TableCaption from '@ckeditor/ckeditor5-table/src/tablecaption';
+
+import GeneralHtmlSupport from '../../src/generalhtmlsupport';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [
+			Bold,
+			Table,
+			Essentials,
+			Italic,
+			Paragraph,
+			Strikethrough,
+			GeneralHtmlSupport,
+			TableCaption
+		],
+		toolbar: [ 'insertTable', '|', 'bold', 'italic', 'strikethrough' ],
+		htmlSupport: {
+			allow: [
+				{
+					name: /^(figure|table|tbody|thead|tr|th|td|caption|figcaption)$/,
+					attributes: [ 'data-validation-allow', 'data-validation-disallow' ]
+				}
+			],
+			disallow: [
+				{
+					name: /^(figure|table|tbody|thead|tr|th|td|caption|figcaption)$/,
+					attributes: 'data-validation-disallow'
+				}
+			]
+		}
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-html-support/tests/manual/table.js
+++ b/packages/ckeditor5-html-support/tests/manual/table.js
@@ -13,6 +13,7 @@ import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
 import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
 import Table from '@ckeditor/ckeditor5-table/src/table';
 import TableCaption from '@ckeditor/ckeditor5-table/src/tablecaption';
+import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
 
 import GeneralHtmlSupport from '../../src/generalhtmlsupport';
 
@@ -20,15 +21,16 @@ ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [
 			Bold,
-			Table,
 			Essentials,
+			GeneralHtmlSupport,
 			Italic,
 			Paragraph,
+			SourceEditing,
 			Strikethrough,
-			GeneralHtmlSupport,
+			Table,
 			TableCaption
 		],
-		toolbar: [ 'insertTable', '|', 'bold', 'italic', 'strikethrough' ],
+		toolbar: [ 'insertTable', '|', 'bold', 'italic', 'strikethrough', '|', 'sourceEditing' ],
 		htmlSupport: {
 			allow: [
 				{

--- a/packages/ckeditor5-html-support/tests/manual/table.md
+++ b/packages/ckeditor5-html-support/tests/manual/table.md
@@ -1,0 +1,17 @@
+## Table
+
+Verify if every table structure element:
+
+* `figure`
+* `table`
+* `tbody`
+* `thead`
+* `caption`
+* `figurecaption`
+* `tr`
+* `th`
+* `td`
+
+**Case 1:** Has its own `data-validation-allow` attribute and blue border.
+
+**Case 2:** Doesn't have `data-validation-disallow` attribute or red border.

--- a/packages/ckeditor5-html-support/tests/table.js
+++ b/packages/ckeditor5-html-support/tests/table.js
@@ -1,0 +1,1120 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Table from '@ckeditor/ckeditor5-table/src/table';
+import TableCaption from '@ckeditor/ckeditor5-table/src/tablecaption';
+import GeneralHtmlSupport from '../src/generalhtmlsupport';
+import { getModelDataWithAttributes } from './_utils/utils';
+import { range } from 'lodash-es';
+
+/* global document */
+
+describe( 'TableElementSupport', () => {
+	let editor, model, editorElement, dataFilter;
+
+	beforeEach( () => {
+		editorElement = document.createElement( 'div' );
+		document.body.appendChild( editorElement );
+
+		return ClassicTestEditor
+			.create( editorElement, {
+				plugins: [ Table, TableCaption, Paragraph, GeneralHtmlSupport ]
+			} )
+			.then( newEditor => {
+				editor = newEditor;
+				model = editor.model;
+
+				dataFilter = editor.plugins.get( 'DataFilter' );
+			} );
+	} );
+
+	afterEach( () => {
+		editorElement.remove();
+
+		return editor.destroy();
+	} );
+
+	it( 'should allow attributes', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /^(figure|table|tbody|thead|tr|th|td)$/,
+			attributes: /^data-.*$/
+		} ] );
+
+		const expectedHtml =
+		'<figure class="table" data-figure="figure">' +
+			'<table data-table="table">' +
+				'<thead data-thead="thead">' +
+					'<tr data-tr="tr">' +
+						'<th data-th="th">1</th>' +
+						'<th data-th="th">2</th>' +
+						'<th data-th="th">3</th>' +
+					'</tr>' +
+				'</thead>' +
+				'<tbody data-tbody="tbody">' +
+					'<tr data-tr="tr">' +
+						'<td data-td="td">1.1</td>' +
+						'<td data-td="td">1.2</td>' +
+						'<td data-td="td">1.3</td>' +
+					'</tr>' +
+					'<tr data-tr="tr">' +
+						'<td data-td="td">2.1</td>' +
+						'<td data-td="td">2.2</td>' +
+						'<td data-td="td">2.3</td>' +
+					'</tr>' +
+				'</tbody>' +
+			'</table>' +
+		'</figure>';
+
+		editor.setData( expectedHtml );
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+			'<table headingRows="1" htmlAttributes="(1)" htmlFigureAttributes="(2)" htmlTbodyAttributes="(3)" htmlTheadAttributes="(4)">' +
+				'<tableRow htmlAttributes="(5)">' +
+					'<tableCell htmlAttributes="(6)">' +
+						'<paragraph>1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(7)">' +
+						'<paragraph>2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(8)">' +
+						'<paragraph>3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow htmlAttributes="(9)">' +
+					'<tableCell htmlAttributes="(10)">' +
+						'<paragraph>1.1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(11)">' +
+						'<paragraph>1.2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(12)">' +
+						'<paragraph>1.3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow htmlAttributes="(13)">' +
+					'<tableCell htmlAttributes="(14)">' +
+						'<paragraph>2.1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(15)">' +
+						'<paragraph>2.2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(16)">' +
+						'<paragraph>2.3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>',
+			attributes: {
+				1: {
+					attributes: {
+						'data-table': 'table'
+					}
+				},
+				2: {
+					attributes: {
+						'data-figure': 'figure'
+					}
+				},
+				3: {
+					attributes: {
+						'data-tbody': 'tbody'
+					}
+				},
+				4: {
+					attributes: {
+						'data-thead': 'thead'
+					}
+				},
+				5: {
+					attributes: {
+						'data-tr': 'tr'
+					}
+				},
+				6: {
+					attributes: {
+						'data-th': 'th'
+					}
+				},
+				7: {
+					attributes: {
+						'data-th': 'th'
+					}
+				},
+				8: {
+					attributes: {
+						'data-th': 'th'
+					}
+				},
+				9: {
+					attributes: {
+						'data-tr': 'tr'
+					}
+				},
+				10: {
+					attributes: {
+						'data-td': 'td'
+					}
+				},
+				11: {
+					attributes: {
+						'data-td': 'td'
+					}
+				},
+				12: {
+					attributes: {
+						'data-td': 'td'
+					}
+				},
+				13: {
+					attributes: {
+						'data-tr': 'tr'
+					}
+				},
+				14: {
+					attributes: {
+						'data-td': 'td'
+					}
+				},
+				15: {
+					attributes: {
+						'data-td': 'td'
+					}
+				},
+				16: {
+					attributes: {
+						'data-td': 'td'
+					}
+				}
+			}
+		} );
+
+		expect( editor.getData() ).to.equal( expectedHtml );
+	} );
+
+	it( 'should allow classes', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /^(figure|table|tbody|thead|tr|th|td)$/,
+			classes: 'foobar'
+		} ] );
+
+		const expectedHtml =
+		'<figure class="table foobar">' +
+			'<table class="foobar">' +
+				'<thead class="foobar">' +
+					'<tr class="foobar">' +
+						'<th class="foobar">1</th>' +
+						'<th class="foobar">2</th>' +
+						'<th class="foobar">3</th>' +
+					'</tr>' +
+				'</thead>' +
+				'<tbody class="foobar">' +
+					'<tr class="foobar">' +
+						'<td class="foobar">1.1</td>' +
+						'<td class="foobar">1.2</td>' +
+						'<td class="foobar">1.3</td>' +
+					'</tr>' +
+					'<tr class="foobar">' +
+						'<td class="foobar">2.1</td>' +
+						'<td class="foobar">2.2</td>' +
+						'<td class="foobar">2.3</td>' +
+					'</tr>' +
+				'</tbody>' +
+			'</table>' +
+		'</figure>';
+
+		editor.setData( expectedHtml );
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+			'<table headingRows="1" htmlAttributes="(1)" htmlFigureAttributes="(2)" htmlTbodyAttributes="(3)" htmlTheadAttributes="(4)">' +
+				'<tableRow htmlAttributes="(5)">' +
+					'<tableCell htmlAttributes="(6)">' +
+						'<paragraph>1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(7)">' +
+						'<paragraph>2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(8)">' +
+						'<paragraph>3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow htmlAttributes="(9)">' +
+					'<tableCell htmlAttributes="(10)">' +
+						'<paragraph>1.1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(11)">' +
+						'<paragraph>1.2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(12)">' +
+						'<paragraph>1.3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow htmlAttributes="(13)">' +
+					'<tableCell htmlAttributes="(14)">' +
+						'<paragraph>2.1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(15)">' +
+						'<paragraph>2.2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(16)">' +
+						'<paragraph>2.3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>',
+			attributes: range( 1, 17 ).reduce( ( attributes, index ) => {
+				attributes[ index ] = {
+					classes: [ 'foobar' ]
+				};
+				return attributes;
+			}, {} )
+		} );
+
+		expect( editor.getData() ).to.equal( expectedHtml );
+	} );
+
+	it( 'should allow styles', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /^(figure|table|tbody|thead|tr|th|td)$/,
+			styles: 'color'
+		} ] );
+
+		const expectedHtml =
+		'<figure class="table" style="color:red;">' +
+			'<table style="color:red;">' +
+				'<thead style="color:red;">' +
+					'<tr style="color:red;">' +
+						'<th style="color:red;">1</th>' +
+						'<th style="color:red;">2</th>' +
+						'<th style="color:red;">3</th>' +
+					'</tr>' +
+				'</thead>' +
+				'<tbody style="color:red;">' +
+					'<tr style="color:red;">' +
+						'<td style="color:red;">1.1</td>' +
+						'<td style="color:red;">1.2</td>' +
+						'<td style="color:red;">1.3</td>' +
+					'</tr>' +
+					'<tr style="color:red;">' +
+						'<td style="color:red;">2.1</td>' +
+						'<td style="color:red;">2.2</td>' +
+						'<td style="color:red;">2.3</td>' +
+					'</tr>' +
+				'</tbody>' +
+			'</table>' +
+		'</figure>';
+
+		editor.setData( expectedHtml );
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+			'<table headingRows="1" htmlAttributes="(1)" htmlFigureAttributes="(2)" htmlTbodyAttributes="(3)" htmlTheadAttributes="(4)">' +
+				'<tableRow htmlAttributes="(5)">' +
+					'<tableCell htmlAttributes="(6)">' +
+						'<paragraph>1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(7)">' +
+						'<paragraph>2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(8)">' +
+						'<paragraph>3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow htmlAttributes="(9)">' +
+					'<tableCell htmlAttributes="(10)">' +
+						'<paragraph>1.1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(11)">' +
+						'<paragraph>1.2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(12)">' +
+						'<paragraph>1.3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow htmlAttributes="(13)">' +
+					'<tableCell htmlAttributes="(14)">' +
+						'<paragraph>2.1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(15)">' +
+						'<paragraph>2.2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell htmlAttributes="(16)">' +
+						'<paragraph>2.3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>',
+			attributes: range( 1, 17 ).reduce( ( attributes, index ) => {
+				attributes[ index ] = {
+					styles: {
+						color: 'red'
+					}
+				};
+				return attributes;
+			}, {} )
+		} );
+
+		expect( editor.getData() ).to.equal( expectedHtml );
+	} );
+
+	it( 'should disallow attributes', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /^(figure|table|tbody|thead|tr|th|td)$/,
+			attributes: /^data-.*$/
+		} ] );
+
+		dataFilter.loadDisallowedConfig( [ {
+			name: /^(figure|table|tbody|thead|tr|th|td)$/,
+			attributes: /^data-.*$/
+		} ] );
+
+		editor.setData(
+			'<figure class="table" data-figure="figure">' +
+				'<table data-table="table">' +
+					'<thead data-thead="thead">' +
+						'<tr data-tr="tr">' +
+							'<th data-th="th">1</th>' +
+							'<th data-th="th">2</th>' +
+							'<th data-th="th">3</th>' +
+						'</tr>' +
+					'</thead>' +
+					'<tbody data-tbody="tbody">' +
+						'<tr data-tr="tr">' +
+							'<td data-td="td">1.1</td>' +
+							'<td data-td="td">1.2</td>' +
+							'<td data-td="td">1.3</td>' +
+						'</tr>' +
+						'<tr data-tr="tr">' +
+							'<td data-td="td">2.1</td>' +
+							'<td data-td="td">2.2</td>' +
+							'<td data-td="td">2.3</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+			'<table headingRows="1">' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>1.1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>1.2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>1.3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>2.1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>2.2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>2.3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>',
+			attributes: {}
+		} );
+
+		expect( editor.getData() ).to.equal(
+			'<figure class="table">' +
+				'<table>' +
+					'<thead>' +
+						'<tr>' +
+							'<th>1</th>' +
+							'<th>2</th>' +
+							'<th>3</th>' +
+						'</tr>' +
+					'</thead>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>1.1</td>' +
+							'<td>1.2</td>' +
+							'<td>1.3</td>' +
+						'</tr>' +
+						'<tr>' +
+							'<td>2.1</td>' +
+							'<td>2.2</td>' +
+							'<td>2.3</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+	} );
+
+	it( 'should disallow classes', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /^(figure|table|tbody|thead|tr|th|td)$/,
+			classes: 'foobar'
+		} ] );
+
+		dataFilter.loadDisallowedConfig( [ {
+			name: /^(figure|table|tbody|thead|tr|th|td)$/,
+			classes: 'foobar'
+		} ] );
+
+		editor.setData(
+			'<figure class="table foobar">' +
+				'<table class="foobar">' +
+					'<thead class="foobar">' +
+						'<tr class="foobar">' +
+							'<th class="foobar">1</th>' +
+							'<th class="foobar">2</th>' +
+							'<th class="foobar">3</th>' +
+						'</tr>' +
+					'</thead>' +
+					'<tbody class="foobar">' +
+						'<tr class="foobar">' +
+							'<td class="foobar">1.1</td>' +
+							'<td class="foobar">1.2</td>' +
+							'<td class="foobar">1.3</td>' +
+						'</tr>' +
+						'<tr class="foobar">' +
+							'<td class="foobar">2.1</td>' +
+							'<td class="foobar">2.2</td>' +
+							'<td class="foobar">2.3</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+			'<table headingRows="1">' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>1.1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>1.2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>1.3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>2.1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>2.2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>2.3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>',
+			attributes: {}
+		} );
+
+		expect( editor.getData() ).to.equal(
+			'<figure class="table">' +
+				'<table>' +
+					'<thead>' +
+						'<tr>' +
+							'<th>1</th>' +
+							'<th>2</th>' +
+							'<th>3</th>' +
+						'</tr>' +
+					'</thead>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>1.1</td>' +
+							'<td>1.2</td>' +
+							'<td>1.3</td>' +
+						'</tr>' +
+						'<tr>' +
+							'<td>2.1</td>' +
+							'<td>2.2</td>' +
+							'<td>2.3</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+	} );
+
+	it( 'should disallow styles', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /^(figure|table|tbody|thead|tr|th|td)$/,
+			styles: 'color'
+		} ] );
+
+		dataFilter.loadDisallowedConfig( [ {
+			name: /^(figure|table|tbody|thead|tr|th|td)$/,
+			styles: 'color'
+		} ] );
+
+		editor.setData(
+			'<figure class="table" style="color:red;">' +
+				'<table style="color:red;">' +
+					'<thead style="color:red;">' +
+						'<tr style="color:red;">' +
+							'<th style="color:red;">1</th>' +
+							'<th style="color:red;">2</th>' +
+							'<th style="color:red;">3</th>' +
+						'</tr>' +
+					'</thead>' +
+					'<tbody style="color:red;">' +
+						'<tr style="color:red;">' +
+							'<td style="color:red;">1.1</td>' +
+							'<td style="color:red;">1.2</td>' +
+							'<td style="color:red;">1.3</td>' +
+						'</tr>' +
+						'<tr style="color:red;">' +
+							'<td style="color:red;">2.1</td>' +
+							'<td style="color:red;">2.2</td>' +
+							'<td style="color:red;">2.3</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+			'<table headingRows="1">' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>1.1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>1.2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>1.3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>2.1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>2.2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>2.3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>',
+			attributes: {}
+		} );
+
+		expect( editor.getData() ).to.equal(
+			'<figure class="table">' +
+				'<table>' +
+					'<thead>' +
+						'<tr>' +
+							'<th>1</th>' +
+							'<th>2</th>' +
+							'<th>3</th>' +
+						'</tr>' +
+					'</thead>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>1.1</td>' +
+							'<td>1.2</td>' +
+							'<td>1.3</td>' +
+						'</tr>' +
+						'<tr>' +
+							'<td>2.1</td>' +
+							'<td>2.2</td>' +
+							'<td>2.3</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+	} );
+
+	it( 'should not set attributes on non existing figure', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /^(figure|table|tbody|tr|td)$/,
+			attributes: true
+		} ] );
+
+		editor.setData(
+			'<table data-foo="foo">' +
+				'<tbody>' +
+					'<tr>' +
+						'<td>1.1</td>' +
+						'<td>1.2</td>' +
+						'<td>1.3</td>' +
+					'</tr>' +
+				'</tbody>' +
+			'</table>'
+		);
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+			'<table htmlAttributes="(1)">' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>1.1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>1.2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>1.3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>',
+			attributes: {
+				1: {
+					attributes: { 'data-foo': 'foo' }
+				}
+			}
+		} );
+
+		expect( editor.getData() ).to.equal(
+			'<figure class="table">' +
+				'<table data-foo="foo">' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>1.1</td>' +
+							'<td>1.2</td>' +
+							'<td>1.3</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+	} );
+
+	it( 'should not break figure integration for other features', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /^(figure|figcaption|table|tbody|tr|td)$/,
+			attributes: /^data-.*$/
+		} ] );
+
+		const expectedHtml =
+			'<figure class="table" data-figure="table">' +
+				'<table>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>1.1</td>' +
+							'<td>1.2</td>' +
+							'<td>1.3</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>' +
+			'<figure data-figure="standalone">' +
+				'<figcaption data-figcaption="figcaption">foobar</figcaption>' +
+			'</figure>';
+
+		editor.setData( expectedHtml );
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+			'<table htmlFigureAttributes="(1)">' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>1.1</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>1.2</paragraph>' +
+					'</tableCell>' +
+					'<tableCell>' +
+						'<paragraph>1.3</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>' +
+			'<htmlFigure htmlAttributes="(2)">' +
+				'<htmlFigcaption htmlAttributes="(3)">foobar</htmlFigcaption>' +
+			'</htmlFigure>',
+			attributes: {
+				1: {
+					attributes: {
+						'data-figure': 'table'
+					}
+				},
+				2: {
+					attributes: {
+						'data-figure': 'standalone'
+					}
+				},
+				3: {
+					attributes: {
+						'data-figcaption': 'figcaption'
+					}
+				}
+			}
+		} );
+
+		expect( editor.getData() ).to.equal( expectedHtml );
+	} );
+
+	it( 'should not consume attributes already consumed (downcast)', () => {
+		[
+			'htmlAttributes',
+			'htmlFigureAttributes',
+			'htmlTbodyAttributes',
+			'htmlTheadAttributes'
+		].forEach( attributeName => {
+			editor.conversion.for( 'downcast' ).add( dispatcher => {
+				dispatcher.on( `attribute:${ attributeName }:table`, ( evt, data, conversionApi ) => {
+					conversionApi.consumable.consume( data.item, evt.name );
+				}, { priority: 'high' } );
+			} );
+		} );
+
+		dataFilter.allowElement( /^(figure|table|tbody|thead)$/ );
+		dataFilter.allowAttributes( {
+			name: /^(figure|table|tbody|thead)$/,
+			attributes: { 'data-foo': true }
+		} );
+
+		editor.setData(
+			'<figure class="table" data-foo="foo">' +
+				'<table data-foo="foo">' +
+					'<thead data-foo="foo">' +
+						'<tr>' +
+							'<th>1</th>' +
+							'<th>2</th>' +
+							'<th>3</th>' +
+						'</tr>' +
+					'</tbody>' +
+					'<tbody data-foo="foo">' +
+						'<tr>' +
+							'<td>1.1</td>' +
+							'<td>1.2</td>' +
+							'<td>1.3</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+
+		expect( editor.getData() ).to.equal(
+			'<figure class="table">' +
+				'<table>' +
+					'<thead>' +
+						'<tr>' +
+							'<th>1</th>' +
+							'<th>2</th>' +
+							'<th>3</th>' +
+						'</tr>' +
+					'</thead>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>1.1</td>' +
+							'<td>1.2</td>' +
+							'<td>1.3</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+	} );
+
+	describe( 'TableCaption', () => {
+		// Sanity tests verifying if table caption is correctly handled by default converters.
+
+		it( 'should allow attributes (caption)', () => {
+			dataFilter.loadAllowedConfig( [ {
+				// caption is changed to figcaption by TableCaption feature.
+				name: /^(caption|figcaption)$/,
+				attributes: 'data-foo',
+				styles: 'color',
+				classes: 'foobar'
+			} ] );
+
+			editor.setData(
+				'<figure class="table">' +
+					'<table>' +
+						'<caption class="foobar" style="color:red;" data-foo="foo">caption</caption>' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>1.1</td>' +
+								'<td>1.2</td>' +
+								'<td>1.3</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+				'</figure>'
+			);
+
+			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+				data:
+				'<table>' +
+					'<tableRow>' +
+						'<tableCell>' +
+							'<paragraph>1.1</paragraph>' +
+						'</tableCell>' +
+						'<tableCell>' +
+							'<paragraph>1.2</paragraph>' +
+						'</tableCell>' +
+						'<tableCell>' +
+							'<paragraph>1.3</paragraph>' +
+						'</tableCell>' +
+					'</tableRow>' +
+					'<caption htmlAttributes="(1)">caption</caption>' +
+				'</table>',
+				attributes: {
+					1: {
+						attributes: { 'data-foo': 'foo' },
+						styles: { color: 'red' },
+						classes: [ 'foobar' ]
+					}
+				}
+			} );
+
+			expect( editor.getData() ).to.equal(
+				'<figure class="table">' +
+					'<table>' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>1.1</td>' +
+								'<td>1.2</td>' +
+								'<td>1.3</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+					'<figcaption class="foobar" style="color:red;" data-foo="foo">caption</figcaption>' +
+				'</figure>'
+			);
+		} );
+
+		it( 'should disallow attributes (caption)', () => {
+			dataFilter.loadAllowedConfig( [ {
+				// caption is changed to figcaption by TableCaption feature.
+				name: /^(caption|figcaption)$/,
+				attributes: 'data-foo',
+				styles: 'color',
+				classes: 'foobar'
+			} ] );
+
+			dataFilter.loadDisallowedConfig( [ {
+				// caption is changed to figcaption by TableCaption feature.
+				name: /^(caption|figcaption)$/,
+				attributes: 'data-foo',
+				styles: 'color',
+				classes: 'foobar'
+			} ] );
+
+			editor.setData(
+				'<figure class="table">' +
+					'<table>' +
+						'<caption class="foobar" style="color:red;" data-foo="foo">caption</caption>' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>1.1</td>' +
+								'<td>1.2</td>' +
+								'<td>1.3</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+				'</figure>'
+			);
+
+			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+				data:
+				'<table>' +
+					'<tableRow>' +
+						'<tableCell>' +
+							'<paragraph>1.1</paragraph>' +
+						'</tableCell>' +
+						'<tableCell>' +
+							'<paragraph>1.2</paragraph>' +
+						'</tableCell>' +
+						'<tableCell>' +
+							'<paragraph>1.3</paragraph>' +
+						'</tableCell>' +
+					'</tableRow>' +
+					'<caption>caption</caption>' +
+				'</table>',
+				attributes: {}
+			} );
+
+			expect( editor.getData() ).to.equal(
+				'<figure class="table">' +
+					'<table>' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>1.1</td>' +
+								'<td>1.2</td>' +
+								'<td>1.3</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+					'<figcaption>caption</figcaption>' +
+				'</figure>'
+			);
+		} );
+
+		it( 'should allow attributes (figcaption)', () => {
+			dataFilter.loadAllowedConfig( [ {
+				name: 'figcaption',
+				attributes: 'data-foo',
+				styles: 'color',
+				classes: 'foobar'
+			} ] );
+
+			editor.setData(
+				'<figure class="table">' +
+					'<table>' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>1.1</td>' +
+								'<td>1.2</td>' +
+								'<td>1.3</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+					'<figcaption class="foobar" style="color:red;" data-foo="foo">caption</figcaption>' +
+				'</figure>'
+			);
+
+			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+				data:
+				'<table>' +
+					'<tableRow>' +
+						'<tableCell>' +
+							'<paragraph>1.1</paragraph>' +
+						'</tableCell>' +
+						'<tableCell>' +
+							'<paragraph>1.2</paragraph>' +
+						'</tableCell>' +
+						'<tableCell>' +
+							'<paragraph>1.3</paragraph>' +
+						'</tableCell>' +
+					'</tableRow>' +
+					'<caption htmlAttributes="(1)">caption</caption>' +
+				'</table>',
+				attributes: {
+					1: {
+						attributes: { 'data-foo': 'foo' },
+						styles: { color: 'red' },
+						classes: [ 'foobar' ]
+					}
+				}
+			} );
+
+			expect( editor.getData() ).to.equal(
+				'<figure class="table">' +
+					'<table>' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>1.1</td>' +
+								'<td>1.2</td>' +
+								'<td>1.3</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+					'<figcaption class="foobar" style="color:red;" data-foo="foo">caption</figcaption>' +
+				'</figure>'
+			);
+		} );
+
+		it( 'should disallow attributes (figcaption)', () => {
+			dataFilter.loadAllowedConfig( [ {
+				name: 'figcaption',
+				attributes: 'data-foo',
+				styles: 'color',
+				classes: 'foobar'
+			} ] );
+
+			dataFilter.loadDisallowedConfig( [ {
+				name: 'figcaption',
+				attributes: 'data-foo',
+				styles: 'color',
+				classes: 'foobar'
+			} ] );
+
+			editor.setData(
+				'<figure class="table">' +
+					'<table>' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>1.1</td>' +
+								'<td>1.2</td>' +
+								'<td>1.3</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+					'<figcaption class="foobar" style="color:red;" data-foo="foo">caption</figcaption>' +
+				'</figure>'
+			);
+
+			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+				data:
+				'<table>' +
+					'<tableRow>' +
+						'<tableCell>' +
+							'<paragraph>1.1</paragraph>' +
+						'</tableCell>' +
+						'<tableCell>' +
+							'<paragraph>1.2</paragraph>' +
+						'</tableCell>' +
+						'<tableCell>' +
+							'<paragraph>1.3</paragraph>' +
+						'</tableCell>' +
+					'</tableRow>' +
+					'<caption>caption</caption>' +
+				'</table>',
+				attributes: {}
+			} );
+
+			expect( editor.getData() ).to.equal(
+				'<figure class="table">' +
+					'<table>' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>1.1</td>' +
+								'<td>1.2</td>' +
+								'<td>1.3</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+					'<figcaption>caption</figcaption>' +
+				'</figure>'
+			);
+		} );
+	} );
+} );

--- a/packages/ckeditor5-html-support/tests/table.js
+++ b/packages/ckeditor5-html-support/tests/table.js
@@ -1,7 +1,7 @@
 /**
  * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
+*/
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
@@ -1115,6 +1115,127 @@ describe( 'TableElementSupport', () => {
 					'<figcaption>caption</figcaption>' +
 				'</figure>'
 			);
+		} );
+
+		it( 'should handle mixed allowed and disallowed attributes', () => {
+			dataFilter.loadAllowedConfig( [ {
+				name: /^(figure|table|tbody|thead|tr|th|td)$/,
+				attributes: /^data-.*$/,
+				classes: [ 'allow', 'disallow' ],
+				styles: [ 'color', 'background' ]
+			} ] );
+
+			dataFilter.loadDisallowedConfig( [ {
+				name: /^(figure|table|tbody|thead|tr|th|td)$/,
+				attributes: 'data-disallow',
+				classes: 'disallow',
+				styles: 'background'
+			} ] );
+
+			/* eslint-disable max-len */
+			editor.setData(
+				'<figure class="table allow disallow" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">' +
+					'<table class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">' +
+						'<thead class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">' +
+							'<tr class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">' +
+								'<th class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">1</th>' +
+								'<th class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">2</th>' +
+								'<th class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">3</th>' +
+							'</tr>' +
+						'</thead>' +
+						'<tbody class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">' +
+							'<tr class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">' +
+								'<td class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">1.1</td>' +
+								'<td class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">1.2</td>' +
+								'<td class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">1.3</td>' +
+							'</tr>' +
+							'<tr class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">' +
+								'<td class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">2.1</td>' +
+								'<td class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">2.2</td>' +
+								'<td class="allow disallow invalid" invalid-attribute="invalid" data-allow="allow" data-disallow="disallow" style="color:red;background:blue;width:10px;">2.3</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+				'</figure>'
+			);
+
+			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+				data:
+				'<table headingRows="1" htmlAttributes="(1)" htmlFigureAttributes="(2)" htmlTbodyAttributes="(3)" htmlTheadAttributes="(4)">' +
+					'<tableRow htmlAttributes="(5)">' +
+						'<tableCell htmlAttributes="(6)">' +
+							'<paragraph>1</paragraph>' +
+						'</tableCell>' +
+						'<tableCell htmlAttributes="(7)">' +
+							'<paragraph>2</paragraph>' +
+						'</tableCell>' +
+						'<tableCell htmlAttributes="(8)">' +
+							'<paragraph>3</paragraph>' +
+						'</tableCell>' +
+					'</tableRow>' +
+					'<tableRow htmlAttributes="(9)">' +
+						'<tableCell htmlAttributes="(10)">' +
+							'<paragraph>1.1</paragraph>' +
+						'</tableCell>' +
+						'<tableCell htmlAttributes="(11)">' +
+							'<paragraph>1.2</paragraph>' +
+						'</tableCell>' +
+						'<tableCell htmlAttributes="(12)">' +
+							'<paragraph>1.3</paragraph>' +
+						'</tableCell>' +
+					'</tableRow>' +
+					'<tableRow htmlAttributes="(13)">' +
+						'<tableCell htmlAttributes="(14)">' +
+							'<paragraph>2.1</paragraph>' +
+						'</tableCell>' +
+						'<tableCell htmlAttributes="(15)">' +
+							'<paragraph>2.2</paragraph>' +
+						'</tableCell>' +
+						'<tableCell htmlAttributes="(16)">' +
+							'<paragraph>2.3</paragraph>' +
+						'</tableCell>' +
+					'</tableRow>' +
+				'</table>',
+				attributes: range( 1, 17 ).reduce( ( attributes, index ) => {
+					attributes[ index ] = {
+						attributes: {
+							'data-allow': 'allow'
+						},
+						styles: {
+							color: 'red'
+						},
+						classes: [ 'allow' ]
+					};
+					return attributes;
+				}, {} )
+			} );
+
+			expect( editor.getData() ).to.equal(
+				'<figure class="table allow" style="color:red;" data-allow="allow">' +
+					'<table class="allow" style="color:red;" data-allow="allow">' +
+						'<thead class="allow" style="color:red;" data-allow="allow">' +
+							'<tr class="allow" style="color:red;" data-allow="allow">' +
+								'<th class="allow" style="color:red;" data-allow="allow">1</th>' +
+								'<th class="allow" style="color:red;" data-allow="allow">2</th>' +
+								'<th class="allow" style="color:red;" data-allow="allow">3</th>' +
+							'</tr>' +
+						'</thead>' +
+						'<tbody class="allow" style="color:red;" data-allow="allow">' +
+							'<tr class="allow" style="color:red;" data-allow="allow">' +
+								'<td class="allow" style="color:red;" data-allow="allow">1.1</td>' +
+								'<td class="allow" style="color:red;" data-allow="allow">1.2</td>' +
+								'<td class="allow" style="color:red;" data-allow="allow">1.3</td>' +
+							'</tr>' +
+							'<tr class="allow" style="color:red;" data-allow="allow">' +
+								'<td class="allow" style="color:red;" data-allow="allow">2.1</td>' +
+								'<td class="allow" style="color:red;" data-allow="allow">2.2</td>' +
+								'<td class="allow" style="color:red;" data-allow="allow">2.3</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+				'</figure>'
+			);
+			/* eslint-enable max-len */
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (html-support): Added General HTML Support integration for Tables feature. Closes #9914.

---

### Additional information

No support for `tfooter` as it's not supported by Table feature itself. `caption`/`figcaption` elements are supported by default GHS itself and don't require any additional integration.

The class name for integration (`TableElementSupport`) doesn't follow the same naming pattern as `CodeBlockHtmlSupport` because it's something we are currently changing in https://github.com/ckeditor/ckeditor5/pull/9891 - although I have some small doubts if actually `*HtmlSupport` is not a better name as we are not providing simple element support (which is already done by GHS) but existing feature integration.
