### PR TITLE
Various issues related to the documentation discovered after changing images docs.

### DIFF
--- a/docs/_snippets/examples/document-editor.html
+++ b/docs/_snippets/examples/document-editor.html
@@ -7,7 +7,7 @@
 
 			<p>Dear Guest,</p>
 			<p>We are delighted to welcome you to the annual <i>Flavorful Tuscany Meetup</i> and hope you will enjoy the programme as well as your stay at the <a href="http://ckeditor.com">Bilancino Hotel</a>.</p>
-			<figure class="image"><img src="%BASE_PATH%/assets/img/malta.jpg" srcset="%BASE_PATH%/assets/img/malta.jpg, %BASE_PATH%/assets/img//malta_2x.jpg 2x" alt="Bilancino Hotel" /><figcaption>Bilancino Hotel</figcaption></figure>
+			<figure class="image"><img src="%BASE_PATH%/assets/img/malta.jpg" srcset="%BASE_PATH%/assets/img/malta.jpg, %BASE_PATH%/assets/img/malta_2x.jpg 2x" alt="Bilancino Hotel" /><figcaption>Bilancino Hotel</figcaption></figure>
 			<p>Please find below the full schedule of the event.</p>
 
 			<figure class="table">

--- a/docs/builds/guides/migration/migration-to-29.md
+++ b/docs/builds/guides/migration/migration-to-29.md
@@ -148,7 +148,7 @@ We recommended one of the following configurations as the minimum set-up for the
 		...
 		image: {
 			toolbar: [
-				'imageCaption',
+				'toggleImageCaption',
 				'imageStyle:inline',
 				// A drop-down containing `alignLeft` and `alignRight` options
 				'imageStyle:wrapText',

--- a/packages/ckeditor5-image/docs/features/images-linking.md
+++ b/packages/ckeditor5-image/docs/features/images-linking.md
@@ -29,9 +29,9 @@ An example source code for block image would look similar to this one:
 An inline image code would look more like this:
 
 ```html
-	<a href="...">
+<a href="...">
 	Some text <img src="..." alt="..." style="width: 20px">
-	</a>
+</a>
 ```
 ## Demo
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: The image in the document editor demo should have a proper path for the large size. Closes #10125.
Docs (image): The code snippet in the image linking guide should have a proper indentation. See #10125.
Docs: The UI components' names should be properly named in the code snippet in the v.29 migration guide. See #10125.

---

### Additional information