### PR TITLE
Changed most theme-lark dependencies into dev-dependencies

### DIFF
--- a/packages/ckeditor5-theme-lark/package.json
+++ b/packages/ckeditor5-theme-lark/package.json
@@ -8,7 +8,7 @@
     "ckeditor 5",
     "ckeditor5-theme"
   ],
-  "dependencies":{
+  "dependencies": {
     "@ckeditor/ckeditor5-ui": "^29.0.0"
   },
   "devDependencies": {

--- a/packages/ckeditor5-theme-lark/package.json
+++ b/packages/ckeditor5-theme-lark/package.json
@@ -8,7 +8,10 @@
     "ckeditor 5",
     "ckeditor5-theme"
   ],
-  "dependencies": {
+  "dependencies":{
+    "@ckeditor/ckeditor5-ui": "^29.0.0"
+  },
+  "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^29.0.0",
     "@ckeditor/ckeditor5-ckfinder": "^29.0.0",
     "@ckeditor/ckeditor5-code-block": "^29.0.0",
@@ -31,7 +34,6 @@
     "@ckeditor/ckeditor5-select-all": "^29.0.0",
     "@ckeditor/ckeditor5-source-editing": "^29.0.0",
     "@ckeditor/ckeditor5-special-characters": "^29.0.0",
-    "@ckeditor/ckeditor5-ui": "^29.0.0",
     "@ckeditor/ckeditor5-undo": "^29.0.0",
     "@ckeditor/ckeditor5-utils": "^29.0.0",
     "@ckeditor/ckeditor5-table": "^29.0.0",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Tests: Changed most theme-lark dependencies into dev-dependencies. Closes #9998.

---

### Additional information

ckeditor5-ui is still marked as regular dependency - see [this](https://github.com/ckeditor/ckeditor5/issues/9998#issuecomment-879026870).