### PR TITLE
Fixed editor freezing when providing non-integer colspan or rowspan attributes values

### DIFF
--- a/packages/ckeditor5-table/src/tableediting.js
+++ b/packages/ckeditor5-table/src/tableediting.js
@@ -113,9 +113,29 @@ export default class TableEditing extends Plugin {
 			converterPriority: 'high'
 		} );
 
+		// Fixes invalid colspan and rowspan attrbutes values
+		const upcastCellSpan = type => {
+			return cell => {
+				const span = parseInt( cell.getAttribute( type ) );
+
+				if ( Number.isNaN( span ) || ( type === 'colspan' && span <= 0 ) || ( type === 'rowspan' && span < 0 ) ) {
+					return 1;
+				}
+
+				return span;
+			};
+		};
+
 		// Table attributes conversion.
-		conversion.attributeToAttribute( { model: 'colspan', view: 'colspan' } );
-		conversion.attributeToAttribute( { model: 'rowspan', view: 'rowspan' } );
+		conversion.for( 'downcast' ).attributeToAttribute( { model: 'colspan', view: 'colspan' } );
+		conversion.for( 'upcast' ).attributeToAttribute(
+			{ model: { key: 'colspan', value: upcastCellSpan( 'colspan' ) }, view: 'colspan' }
+		);
+
+		conversion.for( 'downcast' ).attributeToAttribute( { model: 'rowspan', view: 'rowspan' } );
+		conversion.for( 'upcast' ).attributeToAttribute(
+			{ model: { key: 'rowspan', value: upcastCellSpan( 'rowspan' ) }, view: 'rowspan' }
+		);
 
 		// Table heading columns conversion (a change of heading rows requires a reconversion of the whole table).
 		conversion.for( 'editingDowncast' ).add( downcastTableHeadingColumnsChange() );

--- a/packages/ckeditor5-table/src/tableediting.js
+++ b/packages/ckeditor5-table/src/tableediting.js
@@ -169,7 +169,7 @@ export default class TableEditing extends Plugin {
 	}
 }
 
-// Returns fixed colspan and rowspan attrbutes values
+// Returns fixed colspan and rowspan attrbutes values.
 //
 // @private
 // @param {String} type colspan or rowspan.

--- a/packages/ckeditor5-table/src/tableediting.js
+++ b/packages/ckeditor5-table/src/tableediting.js
@@ -113,29 +113,18 @@ export default class TableEditing extends Plugin {
 			converterPriority: 'high'
 		} );
 
-		// Fixes invalid colspan and rowspan attrbutes values
-		const upcastCellSpan = type => {
-			return cell => {
-				const span = parseInt( cell.getAttribute( type ) );
-
-				if ( Number.isNaN( span ) || ( type === 'colspan' && span <= 0 ) || ( type === 'rowspan' && span < 0 ) ) {
-					return 1;
-				}
-
-				return span;
-			};
-		};
-
 		// Table attributes conversion.
 		conversion.for( 'downcast' ).attributeToAttribute( { model: 'colspan', view: 'colspan' } );
-		conversion.for( 'upcast' ).attributeToAttribute(
-			{ model: { key: 'colspan', value: upcastCellSpan( 'colspan' ) }, view: 'colspan' }
-		);
+		conversion.for( 'upcast' ).attributeToAttribute( {
+			model: { key: 'colspan', value: upcastCellSpan( 'colspan' ) },
+			view: 'colspan'
+		} );
 
 		conversion.for( 'downcast' ).attributeToAttribute( { model: 'rowspan', view: 'rowspan' } );
-		conversion.for( 'upcast' ).attributeToAttribute(
-			{ model: { key: 'rowspan', value: upcastCellSpan( 'rowspan' ) }, view: 'rowspan' }
-		);
+		conversion.for( 'upcast' ).attributeToAttribute( {
+			model: { key: 'rowspan', value: upcastCellSpan( 'rowspan' ) },
+			view: 'rowspan'
+		} );
 
 		// Table heading columns conversion (a change of heading rows requires a reconversion of the whole table).
 		conversion.for( 'editingDowncast' ).add( downcastTableHeadingColumnsChange() );
@@ -178,4 +167,21 @@ export default class TableEditing extends Plugin {
 	static get requires() {
 		return [ TableUtils ];
 	}
+}
+
+// Returns fixed colspan and rowspan attrbutes values
+//
+// @private
+// @param {String} type colspan or rowspan.
+// @returns {Function} conversion value function.
+function upcastCellSpan( type ) {
+	return cell => {
+		const span = parseInt( cell.getAttribute( type ) );
+
+		if ( Number.isNaN( span ) || span <= 0 ) {
+			return null;
+		}
+
+		return span;
+	};
 }

--- a/packages/ckeditor5-table/tests/manual/tickets/10042.html
+++ b/packages/ckeditor5-table/tests/manual/tickets/10042.html
@@ -1,0 +1,18 @@
+<button id="editor1-button">Insert invalid cell with colspan 0</button>
+<br />
+<br />
+<div id="editor1"></div>
+
+<br />
+<br />
+<button id="editor2-button">Insert invalid cell with colspan "abc"</button>
+<br />
+<br />
+<div id="editor2"></div>
+
+<br />
+<br />
+<button id="editor3-button">Insert invalid cell with negative colspan and rowspan</button>
+<br />
+<br />
+<div id="editor3"></div>

--- a/packages/ckeditor5-table/tests/manual/tickets/10042.js
+++ b/packages/ckeditor5-table/tests/manual/tickets/10042.js
@@ -1,0 +1,55 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+
+const editors = [
+	{
+		id: 'editor1',
+		callback: editor => {
+			editor.setData( '<table><tr><td colspan="0"></td></tr></table>' );
+		}
+	},
+	{
+		id: 'editor2',
+		callback: editor => {
+			editor.setData( '<table><tr><td colspan="abc"></td></tr></table>' );
+		}
+	},
+	{
+		id: 'editor3',
+		callback: editor => {
+			editor.setData( '<table><tr><td colspan="-1" rowspan="-1"></td></tr></table>' );
+		}
+	}
+];
+
+for ( const { id, callback } of editors ) {
+	ClassicEditor
+		.create( document.querySelector( `#${ id }` ), {
+			image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
+			plugins: [ ArticlePluginSet ],
+			toolbar: [
+				'heading', '|', 'insertTable', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
+			],
+			table: {
+				contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ],
+				tableToolbar: [ 'bold', 'italic' ]
+			}
+		} )
+		.then( editor => {
+			window.editor = editor;
+
+			document.getElementById( `${ id }-button` ).addEventListener( 'click', () => {
+				callback( editor );
+			} );
+		} )
+		.catch( err => {
+			console.error( err.stack );
+		} );
+}

--- a/packages/ckeditor5-table/tests/manual/tickets/10042.md
+++ b/packages/ckeditor5-table/tests/manual/tickets/10042.md
@@ -1,0 +1,34 @@
+# Ticket test: [#10042](https://github.com/ckeditor/ckeditor5/issues/10042)
+
+## Case 1: colspan is 0
+
+1. Click "Insert invalid cell with colspan 0" button.
+
+Expected:
+
+* No errors.
+* Table should be inserted properly.
+* Editor should not freeze.
+* Inserted table cell should have colspan attribute fixed to 1
+
+## Case 2: colspan is string
+
+1. Click "Insert invalid cell with colspan "abc"" button.
+
+Expected:
+
+* No errors.
+* Table should be inserted properly.
+* Editor should not freeze.
+* Inserted table cell should have colspan attribute fixed to 1
+
+## Case 3: negative colspan and rowspan
+
+1. Click "Insert invalid cell with negative colspan and rowspan" button.
+
+Expected:
+
+* No errors.
+* Table should be inserted properly.
+* Editor should not freeze.
+* Inserted table cell should have colspan and rowspan attributes fixed to 1

--- a/packages/ckeditor5-table/tests/manual/tickets/10042.md
+++ b/packages/ckeditor5-table/tests/manual/tickets/10042.md
@@ -9,7 +9,7 @@ Expected:
 * No errors.
 * Table should be inserted properly.
 * Editor should not freeze.
-* Inserted table cell should have colspan attribute fixed to 1
+* Inserted table cell should have no colspan attribute
 
 ## Case 2: colspan is string
 
@@ -20,7 +20,7 @@ Expected:
 * No errors.
 * Table should be inserted properly.
 * Editor should not freeze.
-* Inserted table cell should have colspan attribute fixed to 1
+* Inserted table cell should have no colspan attribute
 
 ## Case 3: negative colspan and rowspan
 
@@ -31,4 +31,4 @@ Expected:
 * No errors.
 * Table should be inserted properly.
 * Editor should not freeze.
-* Inserted table cell should have colspan and rowspan attributes fixed to 1
+* Inserted table cell should have no colspan or rowspan attributes

--- a/packages/ckeditor5-table/tests/tableediting.js
+++ b/packages/ckeditor5-table/tests/tableediting.js
@@ -221,6 +221,29 @@ describe( 'TableEditing', () => {
 						'<media url="https://www.youtube.com/watch?v=H08tGjXNHO4"></media>' +
 					'</tableCell></tableRow></table>' );
 			} );
+
+			it( 'should convert table when colspan is string', () => {
+				editor.setData( '<table><tbody><tr><td colspan="abc">foo</td></tr></tbody></table>' );
+
+				expect( getModelData( model, { withoutSelection: true } ) )
+					.to.equal( '<table><tableRow><tableCell colspan="1"><paragraph>foo</paragraph></tableCell></tableRow></table>' );
+			} );
+
+			it( 'should convert table with colspan 0', () => {
+				editor.setData( '<table><tbody><tr><td colspan="0">foo</td></tr></tbody></table>' );
+
+				expect( getModelData( model, { withoutSelection: true } ) )
+					.to.equal( '<table><tableRow><tableCell colspan="1"><paragraph>foo</paragraph></tableCell></tableRow></table>' );
+			} );
+
+			it( 'should convert table with negative rowspan and colspan', () => {
+				editor.setData( '<table><tbody><tr><td colspan="-1" rowspan="-1">foo</td></tr></tbody></table>' );
+
+				expect( getModelData( model, { withoutSelection: true } ) )
+					.to.equal( '<table><tableRow><tableCell colspan="1" rowspan="1">' +
+						'<paragraph>foo</paragraph>' +
+					'</tableCell></tableRow></table>' );
+			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-table/tests/tableediting.js
+++ b/packages/ckeditor5-table/tests/tableediting.js
@@ -226,23 +226,21 @@ describe( 'TableEditing', () => {
 				editor.setData( '<table><tbody><tr><td colspan="abc">foo</td></tr></tbody></table>' );
 
 				expect( getModelData( model, { withoutSelection: true } ) )
-					.to.equal( '<table><tableRow><tableCell colspan="1"><paragraph>foo</paragraph></tableCell></tableRow></table>' );
+					.to.equal( '<table><tableRow><tableCell><paragraph>foo</paragraph></tableCell></tableRow></table>' );
 			} );
 
 			it( 'should convert table with colspan 0', () => {
 				editor.setData( '<table><tbody><tr><td colspan="0">foo</td></tr></tbody></table>' );
 
 				expect( getModelData( model, { withoutSelection: true } ) )
-					.to.equal( '<table><tableRow><tableCell colspan="1"><paragraph>foo</paragraph></tableCell></tableRow></table>' );
+					.to.equal( '<table><tableRow><tableCell><paragraph>foo</paragraph></tableCell></tableRow></table>' );
 			} );
 
 			it( 'should convert table with negative rowspan and colspan', () => {
 				editor.setData( '<table><tbody><tr><td colspan="-1" rowspan="-1">foo</td></tr></tbody></table>' );
 
 				expect( getModelData( model, { withoutSelection: true } ) )
-					.to.equal( '<table><tableRow><tableCell colspan="1" rowspan="1">' +
-						'<paragraph>foo</paragraph>' +
-					'</tableCell></tableRow></table>' );
+					.to.equal( '<table><tableRow><tableCell><paragraph>foo</paragraph></tableCell></tableRow></table>' );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): Fixed editor freezing when providing non-integer colspan or rowspan attributes values. Closes #10042.

---

### Additional information

Can be tested by running `yarn manual --files=table` and checking `tickets/10042.html` test case.
