### PR TITLE
i/9928: Resolving stylelint issues around CSS for find and replace feature.

### DIFF
--- a/packages/ckeditor5-find-and-replace/theme/findandreplaceform.css
+++ b/packages/ckeditor5-find-and-replace/theme/findandreplaceform.css
@@ -1,17 +1,11 @@
 /*
- * Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-/* stylelint-disable no-descending-specificity */
-
-/* disabled buttons bg color: #C3C3C3 */
-/* button color #4E8AE4 */
+* Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+* For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+*/
 
 @import "@ckeditor/ckeditor5-ui/theme/mixins/_rwd.css";
 
-.ck .ck-find-and-replace-form .ck-find-form__wrapper,
-.ck .ck-find-and-replace-form .ck-replace-form__wrapper {
+.ck .ck-find-and-replace-form .ck-responsive-form {
 	display: flex;
 	align-items: flex-start;
 	flex-direction: row;
@@ -22,23 +16,16 @@
 		background-color: var(--ck-color-base-active);
 		padding: 5px 10px;
 		text-transform: uppercase;
+		color: var(--ck-color-base-background);
+
+		&:hover {
+			background-color: var(--ck-color-base-focus);
+			cursor: pointer;
+		}
 
 		&.ck-disabled {
 			background-color: var(--ck-color-switch-button-off-background);
 		}
-
-		&:not(.ck-disabled) {
-			color: var(--ck-color-base-background);
-
-			&:hover {
-				background-color: var(--ck-color-base-focus);
-				cursor: pointer;
-			}
-		}
-	}
-
-	& .ck-labeled-field-view__input-wrapper .ck.ck-input-text{
-		padding: var(--ck-spacing-extra-tiny) calc(var(--ck-spacing-medium) * 8) var(--ck-spacing-extra-tiny) var(--ck-spacing-medium);
 	}
 
 	@mixin ck-media-phone {
@@ -54,34 +41,16 @@
 	}
 }
 
-.ck .ck-find-and-replace-form  .ck-replace-form__wrapper {
-	justify-content: flex-end;
-	border-top: 1px solid var(--ck-color-base-border);
-
-	& .ck-labeled-field-view__input-wrapper .ck.ck-input-text{
-		padding: var(--ck-spacing-extra-tiny) var(--ck-spacing-medium) var(--ck-spacing-extra-tiny) var(--ck-spacing-medium);
-	}
-
-	& .ck-button {
-		border-radius: 5px;
-		font-size: calc(var(--ck-font-size-normal) * 0.9);
-
-		&:last-child {
-			margin-left: var(--ck-spacing-standard)
-		}
-
-		& .ck.ck-button__label {
-			line-height: 20px;
-		}
-	}
-}
-
-.ck .ck-find-and-replace-form .ck-find-form__wrapper {
+.ck .ck-find-form__wrapper.ck-responsive-form  {
 	justify-content: space-between;
 
 	& .ck-button.ck-button-prev,
 	& .ck-button.ck-button-next {
 		margin-left: 1px;
+	}
+
+	& .ck.ck-input-text{
+		padding: var(--ck-spacing-extra-tiny) calc(var(--ck-spacing-medium) * 9) var(--ck-spacing-extra-tiny) var(--ck-spacing-medium);
 	}
 
 	& span.ck-results-counter {
@@ -160,7 +129,7 @@
 
 			& label:hover,
 			& input[type=checkbox]:hover
-			 {
+			{
 				cursor: pointer;
 			}
 
@@ -175,12 +144,30 @@
 	}
 }
 
-.ck[dir='rtl'] {
-	& .ck .ck-find-and-replace-form .ck-find-form__wrapper .ck-labeled-field-view__input-wrapper .ck.ck-input-text {
-		padding: var(--ck-spacing-extra-tiny) var(--ck-spacing-medium) var(--ck-spacing-extra-tiny) calc(var(--ck-spacing-medium) * 8);
+.ck .ck-replace-form__wrapper.ck-responsive-form {
+	justify-content: flex-end;
+	border-top: 1px solid var(--ck-color-base-border);
+
+	& .ck.ck-input-text{
+		padding: var(--ck-spacing-extra-tiny) var(--ck-spacing-medium);
 	}
 
-	& .ck .ck-find-and-replace-form .ck-replace-form__wrapper {
+	& .ck-replace-buttons .ck-button {
+		border-radius: 5px;
+		font-size: calc(var(--ck-font-size-normal) * 0.9);
+
+		&:last-child {
+			margin-left: var(--ck-spacing-standard)
+		}
+
+		& .ck.ck-button__label {
+			line-height: 20px;
+		}
+	}
+}
+
+.ck[dir='rtl'] {
+	& .ck.ck-replace-form__wrapper {
 		& .ck-replace-buttons {
 			display: flex;
 			flex-flow: row-reverse;
@@ -189,7 +176,8 @@
 				margin-left: var(--ck-spacing-standard);
 			}
 		}
-		& .ck-labeled-field-view__input-wrapper .ck.ck-input-text{
+
+		& .ck.ck-input-text {
 			padding: var(--ck-spacing-extra-tiny) var(--ck-spacing-medium);
 		}
 	}
@@ -198,7 +186,7 @@
 		margin-left: 0;
 	}
 
-	& .ck .ck-find-and-replace-form .ck-find-form__wrapper {
+	& .ck .ck-find-form__wrapper {
 		& .ck-button.ck-button-prev,
 		& .ck-button.ck-button-next {
 			margin-right: 1px;
@@ -213,14 +201,16 @@
 			flex-flow: row-reverse;
 		}
 
+		& .ck.ck-input-text {
+			padding: var(--ck-spacing-extra-tiny) var(--ck-spacing-medium) var(--ck-spacing-extra-tiny) calc(var(--ck-spacing-medium) * 8);
+		}
+
 		&.ck-responsive-form .ck-find-checkboxes {
 			margin: 0;
 
-			& .ck-find-checkboxes__box label {
+			& .ck-find-checkboxes__box input[type=checkbox]+label {
 				margin-right: 5px;
 			}
 		}
 	}
 }
-
-/* stylelint-enable no-descending-specificity */

--- a/packages/ckeditor5-find-and-replace/theme/findandreplaceform.css
+++ b/packages/ckeditor5-find-and-replace/theme/findandreplaceform.css
@@ -182,7 +182,7 @@
 		}
 	}
 
-	& .ck.ck-responsive-form > :not(:last-child) {
+	& .ck.ck-responsive-form :not(:last-child) {
 		margin-left: 0;
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (find-and-replace): Cleanup of the CSS code. Stylelint should not return any errors now. Closes #9928.

---

### Additional information

This was initially done in #9988 but a lot of changes have been made since that so we're comparing the most recent version of the find and replace feature.