### PR TITLE
Link decorators should use `classes` and `styles` properties

### DIFF
--- a/docs/builds/guides/migration/migration-to-30.md
+++ b/docs/builds/guides/migration/migration-to-30.md
@@ -14,7 +14,7 @@ Listed below are the most important changes that require your attention when upg
 
 ### Matcher pattern API change
 
-Starting from v30.0.0, the {@link module:engine/view/matcher~Matcher} feature deprecated matching `style` and `class` HTML attributes using `attributes` key->value object pattern.
+Starting from v30.0.0, the {@link module:engine/view/matcher~Matcher} feature deprecated matching `style` and `class` HTML attributes using `attributes` key-value pairs pattern.
 
 The {@link module:engine/view/matcher~Matcher} feature allows to match styles and classes by using dedicated `styles` and `classes` patterns. Since v29.0.0 it's also possible to match every possible value for these attributes by using Boolean type with `true` value. Therefore, to avoid confusion which pattern should be used to match classes and styles, we decided to deprecate matching classes and styles using `attributes` pattern.
 
@@ -42,4 +42,45 @@ new Matcher( {
 	styles: true,
 	classes: true
 } );
+```
+
+### Link decorators API change
+
+{@link builds/guides/migration/migration-to-30#matcher-pattern-api-change Matcher pattern API change} also improves how the {@link module:link/link~LinkDecoratorDefinition link decorators} should be defined (both {@link module:link/link~LinkDecoratorManualDefinition manual decorator} and {@link module:link/link~LinkDecoratorAutomaticDefinition automatic decorator}). Similary to the {@link module:engine/view/matcher~Matcher} feature API, `style` and `class` HTML attributes should be defined using respectively `classes` and `styles` properties.
+
+Here is an example of changes you may need for proper integration with the {@link module:link/link~LinkDecoratorDefinition link decorators} API change:
+
+```js
+// Old code.
+ClassicEditor
+    .create( ..., {
+        // ...
+        link: {
+            decorators: {
+                addGreenLink: {
+                    mode: 'automatic',
+                    attributes: {
+                        class: 'my-green-link',
+						style: 'color:green;'
+                    }
+                }
+            }
+        }
+    } )
+// New code.
+ClassicEditor
+    .create( ..., {
+        // ...
+        link: {
+            decorators: {
+                addGreenLink: {
+                    mode: 'automatic',
+                    classes: 'my-green-link',
+					styles: {
+						color: 'green'
+					}
+                }
+            }
+        }
+    } )
 ```

--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/conversion-extending-output.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/conversion-extending-output.md
@@ -64,9 +64,7 @@ ClassicEditor
 			decorators: {
 				addGreenLink: {
 					mode: 'automatic',
-					attributes: {
-						class: 'my-green-link'
-					}
+					classes: 'my-green-link'
 				}
 			}
 		}
@@ -227,9 +225,7 @@ ClassicEditor
 				markUnsafeLink: {
 					mode: 'automatic',
 					callback: url => /^(http:)?\/\//.test( url ),
-					attributes: {
-						class: 'unsafe-link'
-					}
+					classes: 'unsafe-link'
 				}
 			}
 		}

--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/conversion-preserving-custom-content.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/conversion-preserving-custom-content.md
@@ -43,9 +43,7 @@ ClassicEditor
 			decorators: {
 				addGreenLink: {
 					mode: 'automatic',
-					attributes: {
-						class: 'my-green-link'
-					}
+					classes: 'my-green-link'
 				}
 			}
 		}

--- a/packages/ckeditor5-engine/tests/view/matcher.js
+++ b/packages/ckeditor5-engine/tests/view/matcher.js
@@ -166,6 +166,8 @@ describe( 'Matcher', () => {
 		} );
 
 		it( 'should match style and class attributes using "attributes: key->value" pattern', () => {
+			// Stub console, otherwise it will break test coverage.
+			sinon.stub( console, 'warn' );
 			const pattern = {
 				attributes: {
 					style: true,

--- a/packages/ckeditor5-link/src/link.js
+++ b/packages/ckeditor5-link/src/link.js
@@ -215,9 +215,15 @@ export default class Link extends Plugin {
  * @typedef {Object} module:link/link~LinkDecoratorAutomaticDefinition
  * @property {'automatic'} mode Link decorator type. It is `'automatic'` for all automatic decorators.
  * @property {Function} callback Takes a `url` as a parameter and returns `true` if the `attributes` should be applied to the link.
- * @property {Object} attributes Key-value pairs used as link attributes added to the output during the
+ * @property {Object} [attributes] Key-value pairs used as link attributes added to the output during the
  * {@glink framework/guides/architecture/editing-engine#conversion downcasting}.
  * Attributes should follow the {@link module:engine/view/elementdefinition~ElementDefinition} syntax.
+ * @property {Object} [styles] Key-value pairs used as link styles added to the output during the
+ * {@glink framework/guides/architecture/editing-engine#conversion downcasting}.
+ * Styles should follow the {@link module:engine/view/elementdefinition~ElementDefinition} syntax.
+ * @property {String|Array.<String>} [classes] Class names used as link classes added to the output during the
+ * {@glink framework/guides/architecture/editing-engine#conversion downcasting}.
+ * Classes should follow the {@link module:engine/view/elementdefinition~ElementDefinition} syntax.
  */
 
 /**
@@ -241,8 +247,14 @@ export default class Link extends Plugin {
  * @typedef {Object} module:link/link~LinkDecoratorManualDefinition
  * @property {'manual'} mode Link decorator type. It is `'manual'` for all manual decorators.
  * @property {String} label The label of the UI button that the user can use to control the presence of link attributes.
- * @property {Object} attributes Key-value pairs used as link attributes added to the output during the
+ * @property {Object} [attributes] Key-value pairs used as link attributes added to the output during the
  * {@glink framework/guides/architecture/editing-engine#conversion downcasting}.
  * Attributes should follow the {@link module:engine/view/elementdefinition~ElementDefinition} syntax.
+ * @property {Object} [styles] Key-value pairs used as link styles added to the output during the
+ * {@glink framework/guides/architecture/editing-engine#conversion downcasting}.
+ * Styles should follow the {@link module:engine/view/elementdefinition~ElementDefinition} syntax.
+ * @property {String|Array.<String>} [classes] Class names used as link classes added to the output during the
+ * {@glink framework/guides/architecture/editing-engine#conversion downcasting}.
+ * Classes should follow the {@link module:engine/view/elementdefinition~ElementDefinition} syntax.
  * @property {Boolean} [defaultValue] Controls whether the decorator is "on" by default.
  */

--- a/packages/ckeditor5-link/src/linkediting.js
+++ b/packages/ckeditor5-link/src/linkediting.js
@@ -184,14 +184,24 @@ export default class LinkEditing extends Plugin {
 			editor.model.schema.extend( '$text', { allowAttributes: decorator.id } );
 
 			// Keeps reference to manual decorator to decode its name to attributes during downcast.
-			manualDecorators.add( new ManualDecorator( decorator ) );
+			decorator = new ManualDecorator( decorator );
+
+			manualDecorators.add( decorator );
 
 			editor.conversion.for( 'downcast' ).attributeToElement( {
 				model: decorator.id,
 				view: ( manualDecoratorName, { writer } ) => {
 					if ( manualDecoratorName ) {
-						const attributes = manualDecorators.get( decorator.id ).attributes;
-						const element = writer.createAttributeElement( 'a', attributes, { priority: 5 } );
+						const element = writer.createAttributeElement( 'a', decorator.attributes, { priority: 5 } );
+
+						if ( decorator.classes ) {
+							writer.addClass( decorator.classes, element );
+						}
+
+						for ( const key in decorator.styles ) {
+							writer.setStyle( key, decorator.styles[ key ], element );
+						}
+
 						writer.setCustomProperty( 'link', true, element );
 
 						return element;
@@ -201,7 +211,7 @@ export default class LinkEditing extends Plugin {
 			editor.conversion.for( 'upcast' ).elementToAttribute( {
 				view: {
 					name: 'a',
-					attributes: manualDecorators.get( decorator.id ).attributes
+					...decorator._createPattern()
 				},
 				model: {
 					key: decorator.id

--- a/packages/ckeditor5-link/src/linkimageediting.js
+++ b/packages/ckeditor5-link/src/linkimageediting.js
@@ -81,7 +81,6 @@ export default class LinkImageEditing extends Plugin {
 	_enableManualDecorators() {
 		const editor = this.editor;
 		const command = editor.commands.get( 'link' );
-		const manualDecorators = command.manualDecorators;
 
 		for ( const decorator of command.manualDecorators ) {
 			if ( editor.plugins.has( 'ImageBlockEditing' ) ) {
@@ -92,8 +91,8 @@ export default class LinkImageEditing extends Plugin {
 				editor.model.schema.extend( 'imageInline', { allowAttributes: decorator.id } );
 			}
 
-			editor.conversion.for( 'downcast' ).add( downcastImageLinkManualDecorator( manualDecorators, decorator ) );
-			editor.conversion.for( 'upcast' ).add( upcastImageLinkManualDecorator( manualDecorators, decorator ) );
+			editor.conversion.for( 'downcast' ).add( downcastImageLinkManualDecorator( decorator ) );
+			editor.conversion.for( 'upcast' ).add( upcastImageLinkManualDecorator( decorator ) );
 		}
 	}
 }
@@ -213,10 +212,9 @@ function downcastImageLink( dispatcher ) {
 //
 // @private
 // @returns {Function}
-function downcastImageLinkManualDecorator( manualDecorators, decorator ) {
+function downcastImageLinkManualDecorator( decorator ) {
 	return dispatcher => {
 		dispatcher.on( `attribute:${ decorator.id }:imageBlock`, ( evt, data, conversionApi ) => {
-			const attributes = manualDecorators.get( decorator.id ).attributes;
 			const viewFigure = conversionApi.mapper.toViewElement( data.item );
 			const linkInImage = Array.from( viewFigure.getChildren() ).find( child => child.name === 'a' );
 
@@ -227,8 +225,16 @@ function downcastImageLinkManualDecorator( manualDecorators, decorator ) {
 				return;
 			}
 
-			for ( const [ key, val ] of toMap( attributes ) ) {
+			for ( const [ key, val ] of toMap( decorator.attributes ) ) {
 				conversionApi.writer.setAttribute( key, val, linkInImage );
+			}
+
+			if ( decorator.classes ) {
+				conversionApi.writer.addClass( decorator.classes, linkInImage );
+			}
+
+			for ( const key in decorator.styles ) {
+				conversionApi.writer.setStyle( key, decorator.styles[ key ], linkInImage );
 			}
 		} );
 	};
@@ -238,7 +244,7 @@ function downcastImageLinkManualDecorator( manualDecorators, decorator ) {
 //
 // @private
 // @returns {Function}
-function upcastImageLinkManualDecorator( manualDecorators, decorator ) {
+function upcastImageLinkManualDecorator( decorator ) {
 	return dispatcher => {
 		dispatcher.on( 'element:a', ( evt, data, conversionApi ) => {
 			const viewLink = data.viewItem;
@@ -250,11 +256,7 @@ function upcastImageLinkManualDecorator( manualDecorators, decorator ) {
 				return;
 			}
 
-			const consumableAttributes = {
-				attributes: manualDecorators.get( decorator.id ).attributes
-			};
-
-			const matcher = new Matcher( consumableAttributes );
+			const matcher = new Matcher( decorator._createPattern() );
 			const result = matcher.match( viewLink );
 
 			// The link element does not have required attributes or/and proper values.

--- a/packages/ckeditor5-link/src/utils/automaticdecorators.js
+++ b/packages/ckeditor5-link/src/utils/automaticdecorators.js
@@ -78,10 +78,8 @@ export default class AutomaticDecorators {
 						viewWriter.addClass( item.classes, viewElement );
 					}
 
-					if ( item.styles ) {
-						for ( const key in item.styles ) {
-							viewWriter.setStyle( key, item.styles[ key ], viewElement );
-						}
+					for ( const key in item.styles ) {
+						viewWriter.setStyle( key, item.styles[ key ], viewElement );
 					}
 
 					viewWriter.setCustomProperty( 'link', true, viewElement );

--- a/packages/ckeditor5-link/src/utils/automaticdecorators.js
+++ b/packages/ckeditor5-link/src/utils/automaticdecorators.js
@@ -73,6 +73,17 @@ export default class AutomaticDecorators {
 					const viewElement = viewWriter.createAttributeElement( 'a', item.attributes, {
 						priority: 5
 					} );
+
+					if ( item.classes ) {
+						viewWriter.addClass( item.classes, viewElement );
+					}
+
+					if ( item.styles ) {
+						for ( const key in item.styles ) {
+							viewWriter.setStyle( key, item.styles[ key ], viewElement );
+						}
+					}
+
 					viewWriter.setCustomProperty( 'link', true, viewElement );
 					if ( item.callback( data.attributeNewValue ) ) {
 						if ( data.item.is( 'selection' ) ) {
@@ -97,8 +108,8 @@ export default class AutomaticDecorators {
 	 */
 	getDispatcherForLinkedImage() {
 		return dispatcher => {
-			dispatcher.on( 'attribute:linkHref:imageBlock', ( evt, data, conversionApi ) => {
-				const viewFigure = conversionApi.mapper.toViewElement( data.item );
+			dispatcher.on( 'attribute:linkHref:imageBlock', ( evt, data, { writer, mapper } ) => {
+				const viewFigure = mapper.toViewElement( data.item );
 				const linkInImage = Array.from( viewFigure.getChildren() ).find( child => child.name === 'a' );
 
 				for ( const item of this._definitions ) {
@@ -106,19 +117,37 @@ export default class AutomaticDecorators {
 
 					if ( item.callback( data.attributeNewValue ) ) {
 						for ( const [ key, val ] of attributes ) {
+							// Left for backward compatibility. Since v30 decorator should
+							// accept `classes` and `styles` separately from `attributes`.
 							if ( key === 'class' ) {
-								conversionApi.writer.addClass( val, linkInImage );
+								writer.addClass( val, linkInImage );
 							} else {
-								conversionApi.writer.setAttribute( key, val, linkInImage );
+								writer.setAttribute( key, val, linkInImage );
 							}
+						}
+
+						if ( item.classes ) {
+							writer.addClass( item.classes, linkInImage );
+						}
+
+						for ( const key in item.styles ) {
+							writer.setStyle( key, item.styles[ key ], linkInImage );
 						}
 					} else {
 						for ( const [ key, val ] of attributes ) {
 							if ( key === 'class' ) {
-								conversionApi.writer.removeClass( val, linkInImage );
+								writer.removeClass( val, linkInImage );
 							} else {
-								conversionApi.writer.removeAttribute( key, linkInImage );
+								writer.removeAttribute( key, linkInImage );
 							}
+						}
+
+						if ( item.classes ) {
+							writer.removeClass( item.classes, linkInImage );
+						}
+
+						for ( const key in item.styles ) {
+							writer.removeStyle( key, linkInImage );
 						}
 					}
 				}

--- a/packages/ckeditor5-link/src/utils/manualdecorator.js
+++ b/packages/ckeditor5-link/src/utils/manualdecorator.js
@@ -28,7 +28,7 @@ export default class ManualDecorator {
 	 * Attributes should keep the format of attributes defined in {@link module:engine/view/elementdefinition~ElementDefinition}.
 	 * @param {Boolean} [config.defaultValue] Controls whether the decorator is "on" by default.
 	 */
-	constructor( { id, label, attributes, defaultValue } ) {
+	constructor( { id, label, attributes, classes, styles, defaultValue } ) {
 		/**
 		 * An ID of a manual decorator which is the name of the attribute in the model, for example: 'linkManualDecorator0'.
 		 *
@@ -65,6 +65,36 @@ export default class ManualDecorator {
 		 * @type {Object}
 		 */
 		this.attributes = attributes;
+
+		/**
+		 * A set of classes added to downcasted data when the decorator is activated for a specific link.
+		 * Classes should be added in a form of classes defined in {@link module:engine/view/elementdefinition~ElementDefinition}.
+		 *
+		 * @type {Object}
+		 */
+		this.classes = classes;
+
+		/**
+		 * A set of styles added to downcasted data when the decorator is activated for a specific link.
+		 * Styles should be added in a form of styles defined in {@link module:engine/view/elementdefinition~ElementDefinition}.
+		 *
+		 * @type {Object}
+		 */
+		this.styles = styles;
+	}
+
+	/**
+	 * Returns {@link module:engine/view/matcher~MatcherPattern} with decorator attributes.
+	 *
+	 * @protected
+	 * @returns {module:engine/view/matcher~MatcherPattern}
+	 */
+	_createPattern() {
+		return {
+			attributes: this.attributes,
+			classes: this.classes,
+			styles: this.styles
+		};
 	}
 }
 

--- a/packages/ckeditor5-link/tests/linkediting.js
+++ b/packages/ckeditor5-link/tests/linkediting.js
@@ -711,6 +711,11 @@ describe( 'LinkEditing', () => {
 						attributes: {
 							class: 'mail-url'
 						}
+					}, {
+						url: 'ftp://example.com',
+						attributes: {
+							style: 'background:blue;color:yellow;'
+						}
 					}
 				];
 
@@ -739,8 +744,14 @@ describe( 'LinkEditing', () => {
 								isMail: {
 									mode: 'automatic',
 									callback: url => url.startsWith( 'mailto:' ),
-									attributes: {
-										class: 'mail-url'
+									classes: 'mail-url'
+								},
+								isFile: {
+									mode: 'automatic',
+									callback: url => url.startsWith( 'ftp' ),
+									styles: {
+										color: 'yellow',
+										background: 'blue'
 									}
 								}
 							}
@@ -774,7 +785,7 @@ describe( 'LinkEditing', () => {
 				} );
 
 				it( 'stores decorators in LinkCommand#automaticDecorators collection', () => {
-					expect( editor.commands.get( 'link' ).automaticDecorators.length ).to.equal( 3 );
+					expect( editor.commands.get( 'link' ).automaticDecorators.length ).to.equal( 4 );
 				} );
 			} );
 		} );
@@ -844,7 +855,8 @@ describe( 'LinkEditing', () => {
 			it( 'should upcast attributes from initial data', async () => {
 				editor = await ClassicTestEditor.create( element, {
 					initialData: '<p><a href="url" target="_blank" rel="noopener noreferrer" download="file">Foo</a>' +
-						'<a href="example.com" download="file">Bar</a></p>',
+						'<a href="example.com" class="file" style="text-decoration:underline;">Bar</a>' +
+						'<a href="example.com" download="file">Baz</a></p>',
 					plugins: [ Paragraph, LinkEditing, Enter ],
 					link: {
 						decorators: {
@@ -862,6 +874,14 @@ describe( 'LinkEditing', () => {
 								attributes: {
 									download: 'file'
 								}
+							},
+							isFile: {
+								mode: 'manual',
+								label: 'File',
+								classes: 'file',
+								styles: {
+									'text-decoration': 'underline'
+								}
 							}
 						}
 					}
@@ -872,7 +892,8 @@ describe( 'LinkEditing', () => {
 				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
 					'<paragraph>' +
 						'<$text linkHref="url" linkIsDownloadable="true" linkIsExternal="true">Foo</$text>' +
-						'<$text linkHref="example.com" linkIsDownloadable="true">Bar</$text>' +
+						'<$text linkHref="example.com" linkIsFile="true">Bar</$text>' +
+						'<$text linkHref="example.com" linkIsDownloadable="true">Baz</$text>' +
 					'</paragraph>'
 				);
 

--- a/packages/ckeditor5-link/tests/linkimageediting.js
+++ b/packages/ckeditor5-link/tests/linkimageediting.js
@@ -573,7 +573,7 @@ describe( 'LinkImageEditing', () => {
 						url: 'relative/url.html',
 						attributes: {}
 					}, {
-						url: 'http://exmaple.com',
+						url: 'http://example.com',
 						attributes: {
 							target: '_blank'
 						}
@@ -587,6 +587,12 @@ describe( 'LinkImageEditing', () => {
 						url: 'mailto:some@person.io',
 						attributes: {
 							class: 'mail-url'
+						}
+					}, {
+						url: 'ftp://example.com',
+						attributes: {
+							class: 'file',
+							style: 'text-decoration:underline;'
 						}
 					}
 				];
@@ -617,6 +623,14 @@ describe( 'LinkImageEditing', () => {
 									attributes: {
 										class: 'mail-url'
 									}
+								},
+								isFile: {
+									mode: 'automatic',
+									callback: url => url.startsWith( 'ftp' ),
+									classes: 'file',
+									styles: {
+										'text-decoration': 'underline'
+									}
 								}
 							}
 						}
@@ -631,7 +645,7 @@ describe( 'LinkImageEditing', () => {
 
 				testLinks.forEach( link => {
 					it( `Link: ${ link.url } should get attributes: ${ JSON.stringify( link.attributes ) }`, () => {
-						const ORDER = [ 'class', 'href', 'target', 'download' ];
+						const ORDER = [ 'class', 'style', 'href', 'target', 'download' ];
 						const attributes = Object.assign( {}, link.attributes, {
 							href: link.url
 						} );
@@ -689,8 +703,14 @@ describe( 'LinkImageEditing', () => {
 								isGallery: {
 									mode: 'manual',
 									label: 'Gallery link',
-									attributes: {
-										class: 'gallery'
+									classes: 'gallery'
+								},
+								isHighlighted: {
+									mode: 'manual',
+									label: 'Important',
+									classes: 'highlighted',
+									styles: {
+										'text-decoration': 'underline'
 									}
 								}
 							}
@@ -741,14 +761,16 @@ describe( 'LinkImageEditing', () => {
 			it( 'should upcast attributes', async () => {
 				editor.setData(
 					'<figure class="image">' +
-						'<a href="url" target="_blank" rel="noopener noreferrer" download="download">' +
+						'<a href="url" target="_blank" rel="noopener noreferrer" download="download" ' +
+						'class="highlighted" style="text-decoration:underline;">' +
 							'<img src="/assets/sample.png">' +
 						'</a>' +
 					'</figure>'
 				);
 
 				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
-					'<imageBlock linkHref="url" linkIsDownloadable="true" linkIsExternal="true" src="/assets/sample.png"></imageBlock>'
+					'<imageBlock linkHref="url" linkIsDownloadable="true" linkIsExternal="true" ' +
+					'linkIsHighlighted="true" src="/assets/sample.png"></imageBlock>'
 				);
 
 				await editor.destroy();
@@ -795,7 +817,8 @@ describe( 'LinkImageEditing', () => {
 				// (#7975)
 				editor.setData(
 					'<figure class="image">' +
-						'<a class="gallery" href="https://cksource.com" target="_blank" rel="noopener noreferrer" download="download">' +
+						'<a class="gallery highlighted" href="https://cksource.com" target="_blank" ' +
+						'rel="noopener noreferrer" download="download" style="text-decoration:underline;">' +
 							'<img src="sample.jpg" alt="bar">' +
 						'</a>' +
 						'<figcaption>Caption</figcaption>' +
@@ -813,6 +836,7 @@ describe( 'LinkImageEditing', () => {
 						'linkIsDownloadable="true" ' +
 						'linkIsExternal="true" ' +
 						'linkIsGallery="true" ' +
+						'linkIsHighlighted="true" ' +
 						'src="sample.jpg">' +
 					'</imageBlock>' +
 					'<paragraph>' +
@@ -826,7 +850,8 @@ describe( 'LinkImageEditing', () => {
 			it( 'should upcast the decorators when linked image (a > img)', () => {
 				// (#7975)
 				editor.setData(
-					'<a class="gallery" href="https://cksource.com" target="_blank" rel="noopener noreferrer" download="download">' +
+					'<a class="gallery highlighted" href="https://cksource.com" target="_blank" rel="noopener noreferrer"' +
+					'download="download" style="text-decoration:underline;">' +
 						'<img src="sample.jpg" alt="bar">' +
 					'</a>' +
 					'<p>' +
@@ -842,6 +867,7 @@ describe( 'LinkImageEditing', () => {
 						'linkIsDownloadable="true" ' +
 						'linkIsExternal="true" ' +
 						'linkIsGallery="true" ' +
+						'linkIsHighlighted="true" ' +
 						'src="sample.jpg">' +
 					'</imageBlock>' +
 					'<paragraph>' +
@@ -880,8 +906,14 @@ describe( 'LinkImageEditing', () => {
 								isGallery: {
 									mode: 'manual',
 									label: 'Gallery link',
-									attributes: {
-										class: 'gallery'
+									classes: 'gallery'
+								},
+								isHighlighted: {
+									mode: 'manual',
+									label: 'Important',
+									classes: 'highlighted',
+									styles: {
+										'text-decoration': 'underline'
 									}
 								}
 							}
@@ -908,7 +940,8 @@ describe( 'LinkImageEditing', () => {
 				editor.execute( 'link', 'https://cksource.com', {
 					linkIsDownloadable: true,
 					linkIsExternal: true,
-					linkIsGallery: true
+					linkIsGallery: true,
+					linkIsHighlighted: true
 				} );
 
 				model.change( writer => {
@@ -918,17 +951,20 @@ describe( 'LinkImageEditing', () => {
 				editor.execute( 'link', 'https://cksource.com', {
 					linkIsDownloadable: true,
 					linkIsExternal: true,
-					linkIsGallery: true
+					linkIsGallery: true,
+					linkIsHighlighted: true
 				} );
 
 				expect( editor.getData() ).to.equal(
 					'<figure class="image">' +
-						'<a class="gallery" href="https://cksource.com" download="download" target="_blank" rel="noopener noreferrer">' +
+						'<a class="gallery highlighted" style="text-decoration:underline;" href="https://cksource.com" ' +
+						'download="download" target="_blank" rel="noopener noreferrer">' +
 							'<img src="sample.jpg" alt="bar">' +
 						'</a>' +
 					'</figure>' +
 					'<p>' +
-						'<a class="gallery" href="https://cksource.com" download="download" target="_blank" rel="noopener noreferrer">' +
+						'<a class="gallery highlighted" style="text-decoration:underline;" href="https://cksource.com" ' +
+						'download="download" target="_blank" rel="noopener noreferrer">' +
 							'https://cksource.com' +
 						'</a>' +
 					'</p>'
@@ -944,7 +980,8 @@ describe( 'LinkImageEditing', () => {
 				editor.execute( 'link', 'https://cksource.com', {
 					linkIsDownloadable: true,
 					linkIsExternal: true,
-					linkIsGallery: true
+					linkIsGallery: true,
+					linkIsHighlighted: true
 				} );
 
 				// Attributes will be removed along with the link, but the downcast will be fired.
@@ -953,7 +990,8 @@ describe( 'LinkImageEditing', () => {
 					editor.execute( 'unlink', 'https://cksource.com', {
 						linkIsDownloadable: true,
 						linkIsExternal: true,
-						linkIsGallery: true
+						linkIsGallery: true,
+						linkIsHighlighted: true
 					} );
 				} ).to.not.throw();
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (link): Link decorators should use `classes` and `styles` properties instead of directly matching `style` and `class` HTML attributes . Closes #9813.

---

### Additional information

TBC
