### PR TITLE
Remove references to and destroy resizers of widgets no longer in the document

### DIFF
--- a/packages/ckeditor5-widget/src/widgetresize.js
+++ b/packages/ckeditor5-widget/src/widgetresize.js
@@ -38,6 +38,9 @@ export default class WidgetResize extends Plugin {
 	 * @inheritDoc
 	 */
 	init() {
+		const editing = this.editor.editing;
+		const domDocument = global.window.document;
+
 		/**
 		 * The currently visible resizer.
 		 *
@@ -65,13 +68,11 @@ export default class WidgetResize extends Plugin {
 		 */
 		this._resizers = new Map();
 
-		const domDocument = global.window.document;
-
-		this.editor.editing.view.addObserver( MouseObserver );
+		editing.view.addObserver( MouseObserver );
 
 		this._observer = Object.create( DomEmitterMixin );
 
-		this.listenTo( this.editor.editing.view.document, 'mousedown', this._mouseDownListener.bind( this ), { priority: 'high' } );
+		this.listenTo( editing.view.document, 'mousedown', this._mouseDownListener.bind( this ), { priority: 'high' } );
 
 		this._observer.listenTo( domDocument, 'mousemove', this._mouseMoveListener.bind( this ) );
 		this._observer.listenTo( domDocument, 'mouseup', this._mouseUpListener.bind( this ) );
@@ -90,6 +91,17 @@ export default class WidgetResize extends Plugin {
 
 		// Redrawing on any change of the UI of the editor (including content changes).
 		this.editor.ui.on( 'update', this._redrawFocusedResizerThrottled );
+
+		// Remove view widget-resizer mappings for widgets that have been removed from the document.
+		// https://github.com/ckeditor/ckeditor5/issues/10156
+		this.editor.model.document.on( 'change', () => {
+			for ( const [ viewElement, resizer ] of this._resizers ) {
+				if ( editing.mapper.toModelElement( viewElement ).root.rootName === '$graveyard' ) {
+					this._resizers.delete( viewElement );
+					resizer.destroy();
+				}
+			}
+		} );
 
 		// Resizers need to be redrawn upon window resize, because new window might shrink resize host.
 		this._observer.listenTo( global.window, 'resize', this._redrawFocusedResizerThrottled );

--- a/packages/ckeditor5-widget/tests/widgetresize.js
+++ b/packages/ckeditor5-widget/tests/widgetresize.js
@@ -557,24 +557,6 @@ describe( 'WidgetResize', () => {
 
 			expect( widgetResizePlugin.visibleResizer ).to.eql( resizer );
 		} );
-
-		function gerResizerOptions( editor ) {
-			return {
-				modelElement: editor.model.document.getRoot().getChild( 0 ),
-				viewElement: editor.editing.view.document.getRoot().getChild( 0 ),
-				editor,
-
-				isCentered: () => false,
-				getHandleHost( domWidgetElement ) {
-					return domWidgetElement;
-				},
-				getResizeHost( domWidgetElement ) {
-					return domWidgetElement;
-				},
-
-				onCommit: commitStub
-			};
-		}
 	} );
 
 	describe( 'init()', () => {
@@ -593,6 +575,22 @@ describe( 'WidgetResize', () => {
 			} );
 
 			expect( redrawSpy.callCount ).to.equal( 1 );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/10156
+		it( 'removes references to and destroys resizers removed from the document', () => {
+			const plugin = editor.plugins.get( WidgetResize );
+			const resizer = plugin.attachTo( gerResizerOptions( editor ) );
+			const widgetViewElement = editor.editing.view.document.getRoot().getChild( 0 );
+			const resizerDestroySpy = sinon.spy( resizer, 'destroy' );
+
+			expect( plugin.getResizerByViewElement( widgetViewElement ) ).to.equal( resizer );
+			sinon.assert.notCalled( resizerDestroySpy );
+
+			editor.setData( '' );
+
+			expect( plugin.getResizerByViewElement( widgetViewElement ) ).to.be.undefined;
+			sinon.assert.calledOnce( resizerDestroySpy );
 		} );
 	} );
 
@@ -720,5 +718,23 @@ describe( 'WidgetResize', () => {
 		};
 
 		return editor.plugins.get( WidgetResize ).attachTo( Object.assign( defaultOptions, resizerOptions ) );
+	}
+
+	function gerResizerOptions( editor ) {
+		return {
+			modelElement: editor.model.document.getRoot().getChild( 0 ),
+			viewElement: editor.editing.view.document.getRoot().getChild( 0 ),
+			editor,
+
+			isCentered: () => false,
+			getHandleHost( domWidgetElement ) {
+				return domWidgetElement;
+			},
+			getResizeHost( domWidgetElement ) {
+				return domWidgetElement;
+			},
+
+			onCommit: commitStub
+		};
 	}
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (widget): Remove references to and destroy resizers of widgets no longer in the document. Closes #10156.