### PR TITLE
JSDoc: Add DOMRect to getOptimalPosition and Rect

### DIFF
--- a/packages/ckeditor5-utils/src/dom/position.js
+++ b/packages/ckeditor5-utils/src/dom/position.js
@@ -377,7 +377,7 @@ function getAbsoluteRectCoordinates( { left, top } ) {
 /**
  * Target with respect to which the `element` is to be positioned.
  *
- * @member {HTMLElement|Range|ClientRect|Rect|Function} #target
+ * @member {HTMLElement|Range|Window|ClientRect|DOMRect|module:utils/dom/rect~Rect|Object|Function} #target
  */
 
 /**
@@ -393,7 +393,7 @@ function getAbsoluteRectCoordinates( { left, top } ) {
  * When set, the algorithm will chose position which fits the most in the
  * limiter's bounding rect.
  *
- * @member {HTMLElement|Range|ClientRect|Rect|Function} #limiter
+ * @member {HTMLElement|Range|Window|ClientRect|DOMRect|module:utils/dom/rect~Rect|Object|Function} #limiter
  */
 
 /**

--- a/packages/ckeditor5-utils/src/dom/rect.js
+++ b/packages/ckeditor5-utils/src/dom/rect.js
@@ -46,7 +46,7 @@ export default class Rect {
 	 * ant the rect of a `window` includes scrollbars too. Use {@link #excludeScrollbarsAndBorders}
 	 * to get the inner part of the rect.
 	 *
-	 * @param {HTMLElement|Range|Window|ClientRect|module:utils/dom/rect~Rect|Object} source A source object to create the rect.
+	 * @param {HTMLElement|Range|Window|ClientRect|DOMRect|module:utils/dom/rect~Rect|Object} source A source object to create the rect.
 	 */
 	constructor( source ) {
 		const isSourceRange = isRange( source );
@@ -56,7 +56,7 @@ export default class Rect {
 		 *
 		 * @protected
 		 * @readonly
-		 * @member {HTMLElement|Range|ClientRect|module:utils/dom/rect~Rect|Object} #_source
+		 * @member {HTMLElement|Range|Window|ClientRect|DOMRect|module:utils/dom/rect~Rect|Object} #_source
 		 */
 		Object.defineProperty( this, '_source', {
 			// If the source is a Rect instance, copy it's #_source.


### PR DESCRIPTION
The constructor for `Rect` shows this example:

```js
document.body.getClientRects().item( 0 )
```

The return type in every browser but IE is [`DOMRect`](https://developer.mozilla.org/en-US/docs/Web/API/DOMRect) so I'm adding it to
the possible values of the `Rect` constructor. I'm also adding `Window`
cause `Rect` can handle it.

For the `target` property of `Options` interface, I'm adding the same
types cause that property is used to create a new `Rect`.