### PR TITLE
Feature (table): Option in table config to set rows/columns as headings by default

### DIFF
--- a/packages/ckeditor5-table/src/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/src/commands/inserttablecommand.js
@@ -49,8 +49,17 @@ export default class InsertTableCommand extends Command {
 		const model = this.editor.model;
 		const selection = model.document.selection;
 		const tableUtils = this.editor.plugins.get( 'TableUtils' );
+		const config = this.editor.config.get( 'table' );
 
 		const insertionRange = findOptimalInsertionRange( selection, model );
+
+		if ( config.autoHeading && config.autoHeading.rows ) {
+			options.headingRows = config.autoHeading.rows;
+		}
+
+		if ( config.autoHeading && config.autoHeading.columns ) {
+			options.headingColumns = config.autoHeading.columns;
+		}
 
 		model.change( writer => {
 			const table = tableUtils.createTable( writer, options );

--- a/packages/ckeditor5-table/src/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/src/commands/inserttablecommand.js
@@ -41,10 +41,12 @@ export default class InsertTableCommand extends Command {
 	 * @param {Object} options
 	 * @param {Number} [options.rows=2] The number of rows to create in the inserted table.
 	 * @param {Number} [options.columns=2] The number of columns to create in the inserted table.
-	 * @param {Number} [options.headingRows=0] The number of heading rows.
-	 * If not provided it will default to {@link module:table/table~TableConfig#defaultHeadings `defaultHeadings.rows`} table config.
-	 * @param {Number} [options.headingColumns=0] The number of heading columns.
-	 * If not provided it will default to {@link module:table/table~TableConfig#defaultHeadings `defaultHeadings.columns`} table config.
+	 * @param {Number} [options.headingRows] The number of heading rows.
+	 * If not provided it will default to {@link module:table/table~TableConfig#defaultHeadings `tableConfig.defaultHeadings.rows`}
+	 * table config.
+	 * @param {Number} [options.headingColumns] The number of heading columns.
+	 * If not provided it will default to {@link module:table/table~TableConfig#defaultHeadings `tableConfig.defaultHeadings.columns`}
+	 * table config.
 	 * @fires execute
 	 */
 	execute( options = {} ) {

--- a/packages/ckeditor5-table/src/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/src/commands/inserttablecommand.js
@@ -53,12 +53,15 @@ export default class InsertTableCommand extends Command {
 
 		const insertionRange = findOptimalInsertionRange( selection, model );
 
-		if ( config.defaultHeadings.rows ) {
-			options.headingRows = config.defaultHeadings.rows;
+		const defaultRows = config.defaultHeadings.rows;
+		const defaultColumns = config.defaultHeadings.columns;
+
+		if ( options.headingRows === undefined && defaultRows ) {
+			options.headingRows = Math.min( defaultRows, options.rows );
 		}
 
-		if ( config.defaultHeadings.columns ) {
-			options.headingColumns = config.defaultHeadings.columns;
+		if ( options.headingColumns === undefined && defaultColumns ) {
+			options.headingColumns = Math.min( defaultColumns, options.columns );
 		}
 
 		model.change( writer => {

--- a/packages/ckeditor5-table/src/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/src/commands/inserttablecommand.js
@@ -53,12 +53,12 @@ export default class InsertTableCommand extends Command {
 
 		const insertionRange = findOptimalInsertionRange( selection, model );
 
-		if ( config.autoHeading && config.autoHeading.rows ) {
-			options.headingRows = config.autoHeading.rows;
+		if ( config.defaultHeadings.rows ) {
+			options.headingRows = config.defaultHeadings.rows;
 		}
 
-		if ( config.autoHeading && config.autoHeading.columns ) {
-			options.headingColumns = config.autoHeading.columns;
+		if ( config.defaultHeadings.columns ) {
+			options.headingColumns = config.defaultHeadings.columns;
 		}
 
 		model.change( writer => {

--- a/packages/ckeditor5-table/src/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/src/commands/inserttablecommand.js
@@ -42,10 +42,10 @@ export default class InsertTableCommand extends Command {
 	 * @param {Number} [options.rows=2] The number of rows to create in the inserted table.
 	 * @param {Number} [options.columns=2] The number of columns to create in the inserted table.
 	 * @param {Number} [options.headingRows] The number of heading rows.
-	 * If not provided it will default to {@link module:table/table~TableConfig#defaultHeadings `tableConfig.defaultHeadings.rows`}
+	 * If not provided it will default to {@link module:table/table~TableConfig#defaultHeadings `config.table.defaultHeadings.rows`}
 	 * table config.
 	 * @param {Number} [options.headingColumns] The number of heading columns.
-	 * If not provided it will default to {@link module:table/table~TableConfig#defaultHeadings `tableConfig.defaultHeadings.columns`}
+	 * If not provided it will default to {@link module:table/table~TableConfig#defaultHeadings `config.table.defaultHeadings.columns`}
 	 * table config.
 	 * @fires execute
 	 */

--- a/packages/ckeditor5-table/src/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/src/commands/inserttablecommand.js
@@ -42,7 +42,9 @@ export default class InsertTableCommand extends Command {
 	 * @param {Number} [options.rows=2] The number of rows to create in the inserted table.
 	 * @param {Number} [options.columns=2] The number of columns to create in the inserted table.
 	 * @param {Number} [options.headingRows=0] The number of heading rows.
+	 * If not provided it will default to {@link module:table/table~TableConfig#defaultHeadings `defaultHeadings.rows`} table config.
 	 * @param {Number} [options.headingColumns=0] The number of heading columns.
+	 * If not provided it will default to {@link module:table/table~TableConfig#defaultHeadings `defaultHeadings.columns`} table config.
 	 * @fires execute
 	 */
 	execute( options = {} ) {
@@ -57,11 +59,11 @@ export default class InsertTableCommand extends Command {
 		const defaultColumns = config.defaultHeadings.columns;
 
 		if ( options.headingRows === undefined && defaultRows ) {
-			options.headingRows = Math.min( defaultRows, options.rows );
+			options.headingRows = defaultRows;
 		}
 
 		if ( options.headingColumns === undefined && defaultColumns ) {
-			options.headingColumns = Math.min( defaultColumns, options.columns );
+			options.headingColumns = defaultColumns;
 		}
 
 		model.change( writer => {

--- a/packages/ckeditor5-table/src/table.js
+++ b/packages/ckeditor5-table/src/table.js
@@ -80,7 +80,7 @@ export default class Table extends Plugin {
  * You can configure it like this:
  *
  *		const tableConfig = {
- *			autoHeading: {
+ *			defaultHeadings: {
  *				rows: 1,
  *				columns: 1
  *			}
@@ -88,7 +88,7 @@ export default class Table extends Plugin {
  *
  * Both rows and columns properties are optional defaulting to 0 (no heading).
  *
- * @member {Object} module:table/table~TableConfig#autoHeading
+ * @member {Object} module:table/table~TableConfig#defaultHeadings
  */
 
 /**

--- a/packages/ckeditor5-table/src/table.js
+++ b/packages/ckeditor5-table/src/table.js
@@ -75,6 +75,23 @@ export default class Table extends Plugin {
  */
 
 /**
+ * Number of rows and columns to render by default as table heading when inserting new tables.
+ *
+ * You can configure it like this:
+ *
+ *		const tableConfig = {
+ *			autoHeading: {
+ *				rows: 1,
+ *				columns: 1
+ *			}
+ *		};
+ *
+ * Both rows and columns properties are optional defaulting to 0 (no heading).
+ *
+ * @member {Object} module:table/table~TableConfig#autoHeading
+ */
+
+/**
  * An array of color definitions (either strings or objects).
  *
  *		const colors = [

--- a/packages/ckeditor5-table/src/tableediting.js
+++ b/packages/ckeditor5-table/src/tableediting.js
@@ -120,7 +120,7 @@ export default class TableEditing extends Plugin {
 		// Table heading columns conversion (a change of heading rows requires a reconversion of the whole table).
 		conversion.for( 'editingDowncast' ).add( downcastTableHeadingColumnsChange() );
 
-		// Define all the config
+		// Define the config.
 		editor.config.define( 'table.defaultHeadings.rows', 0 );
 		editor.config.define( 'table.defaultHeadings.columns', 0 );
 

--- a/packages/ckeditor5-table/src/tableediting.js
+++ b/packages/ckeditor5-table/src/tableediting.js
@@ -120,6 +120,10 @@ export default class TableEditing extends Plugin {
 		// Table heading columns conversion (a change of heading rows requires a reconversion of the whole table).
 		conversion.for( 'editingDowncast' ).add( downcastTableHeadingColumnsChange() );
 
+		// Define all the config
+		editor.config.define( 'table.autoHeading.row', 0 );
+		editor.config.define( 'table.autoHeading.column', 0 );
+
 		// Define all the commands.
 		editor.commands.add( 'insertTable', new InsertTableCommand( editor ) );
 		editor.commands.add( 'insertTableRowAbove', new InsertRowCommand( editor, { order: 'above' } ) );

--- a/packages/ckeditor5-table/src/tableediting.js
+++ b/packages/ckeditor5-table/src/tableediting.js
@@ -121,8 +121,8 @@ export default class TableEditing extends Plugin {
 		conversion.for( 'editingDowncast' ).add( downcastTableHeadingColumnsChange() );
 
 		// Define all the config
-		editor.config.define( 'table.autoHeading.row', 0 );
-		editor.config.define( 'table.autoHeading.column', 0 );
+		editor.config.define( 'table.defaultHeadings.rows', 0 );
+		editor.config.define( 'table.defaultHeadings.columns', 0 );
 
 		// Define all the commands.
 		editor.commands.add( 'insertTable', new InsertTableCommand( editor ) );

--- a/packages/ckeditor5-table/src/tableutils.js
+++ b/packages/ckeditor5-table/src/tableutils.js
@@ -106,11 +106,11 @@ export default class TableUtils extends Plugin {
 		createEmptyRows( writer, table, 0, rows, columns );
 
 		if ( options.headingRows ) {
-			updateNumericAttribute( 'headingRows', options.headingRows, table, writer, 0 );
+			updateNumericAttribute( 'headingRows', Math.min( options.headingRows, options.rows ), table, writer, 0 );
 		}
 
 		if ( options.headingColumns ) {
-			updateNumericAttribute( 'headingColumns', options.headingColumns, table, writer, 0 );
+			updateNumericAttribute( 'headingColumns', Math.min( options.headingColumns, options.columns ), table, writer, 0 );
 		}
 
 		return table;

--- a/packages/ckeditor5-table/src/tableutils.js
+++ b/packages/ckeditor5-table/src/tableutils.js
@@ -106,11 +106,11 @@ export default class TableUtils extends Plugin {
 		createEmptyRows( writer, table, 0, rows, columns );
 
 		if ( options.headingRows ) {
-			updateNumericAttribute( 'headingRows', Math.min( options.headingRows, options.rows ), table, writer, 0 );
+			updateNumericAttribute( 'headingRows', Math.min( options.headingRows, rows ), table, writer, 0 );
 		}
 
 		if ( options.headingColumns ) {
-			updateNumericAttribute( 'headingColumns', Math.min( options.headingColumns, options.columns ), table, writer, 0 );
+			updateNumericAttribute( 'headingColumns', Math.min( options.headingColumns, columns ), table, writer, 0 );
 		}
 
 		return table;

--- a/packages/ckeditor5-table/tests/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/tests/commands/inserttablecommand.js
@@ -194,5 +194,106 @@ describe( 'InsertTableCommand', () => {
 				);
 			} );
 		} );
+
+		describe( 'auto headings', () => {
+			it( 'should have first row as a heading by default', async () => {
+				const _editor = await ModelTestEditor
+					.create( {
+						plugins: [ Paragraph, TableEditing ],
+						table: {
+							autoHeading: { rows: 1 }
+						}
+					} );
+
+				const _model = _editor.model;
+				const _command = new InsertTableCommand( _editor );
+
+				setData( _model, '[]' );
+
+				_command.execute( { rows: 2, columns: 3 } );
+
+				expect( getData( _model ) ).to.equal(
+					modelTable( [
+						[ '[]', '', '' ],
+						[ '', '', '' ]
+					], { headingRows: 1 } )
+				);
+			} );
+
+			it( 'should have first column as a heading by default', async () => {
+				const _editor = await ModelTestEditor
+					.create( {
+						plugins: [ Paragraph, TableEditing ],
+						table: {
+							autoHeading: { columns: 1 }
+						}
+					} );
+
+				const _model = _editor.model;
+				const _command = new InsertTableCommand( _editor );
+
+				setData( _model, '[]' );
+
+				_command.execute( { rows: 2, columns: 3 } );
+
+				expect( getData( _model ) ).to.equal(
+					modelTable( [
+						[ '[]', '', '' ],
+						[ '', '', '' ]
+					], { headingColumns: 1 } )
+				);
+			} );
+
+			it( 'should have first row and first column as a heading by default', async () => {
+				const _editor = await ModelTestEditor
+					.create( {
+						plugins: [ Paragraph, TableEditing ],
+						table: {
+							autoHeading: { rows: 1, columns: 1 }
+						}
+					} );
+
+				const _model = _editor.model;
+				const _command = new InsertTableCommand( _editor );
+
+				setData( _model, '[]' );
+
+				_command.execute( { rows: 3, columns: 3 } );
+
+				expect( getData( _model ) ).to.equal(
+					modelTable( [
+						[ '[]', '', '' ],
+						[ '', '', '' ],
+						[ '', '', '' ]
+					], { headingRows: 1, headingColumns: 1 } )
+				);
+			} );
+
+			it( 'should have first three rows and two columns as a heading by default', async () => {
+				const _editor = await ModelTestEditor
+					.create( {
+						plugins: [ Paragraph, TableEditing ],
+						table: {
+							autoHeading: { rows: 3, columns: 2 }
+						}
+					} );
+
+				const _model = _editor.model;
+				const _command = new InsertTableCommand( _editor );
+
+				setData( _model, '[]' );
+
+				_command.execute( { rows: 4, columns: 3 } );
+
+				expect( getData( _model ) ).to.equal(
+					modelTable( [
+						[ '[]', '', '' ],
+						[ '', '', '' ],
+						[ '', '', '' ],
+						[ '', '', '' ]
+					], { headingRows: 3, headingColumns: 2 } )
+				);
+			} );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-table/tests/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/tests/commands/inserttablecommand.js
@@ -201,7 +201,7 @@ describe( 'InsertTableCommand', () => {
 					.create( {
 						plugins: [ Paragraph, TableEditing ],
 						table: {
-							autoHeading: { rows: 1 }
+							defaultHeadings: { rows: 1 }
 						}
 					} );
 
@@ -225,7 +225,7 @@ describe( 'InsertTableCommand', () => {
 					.create( {
 						plugins: [ Paragraph, TableEditing ],
 						table: {
-							autoHeading: { columns: 1 }
+							defaultHeadings: { columns: 1 }
 						}
 					} );
 
@@ -249,7 +249,7 @@ describe( 'InsertTableCommand', () => {
 					.create( {
 						plugins: [ Paragraph, TableEditing ],
 						table: {
-							autoHeading: { rows: 1, columns: 1 }
+							defaultHeadings: { rows: 1, columns: 1 }
 						}
 					} );
 
@@ -274,7 +274,7 @@ describe( 'InsertTableCommand', () => {
 					.create( {
 						plugins: [ Paragraph, TableEditing ],
 						table: {
-							autoHeading: { rows: 3, columns: 2 }
+							defaultHeadings: { rows: 3, columns: 2 }
 						}
 					} );
 

--- a/packages/ckeditor5-table/tests/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/tests/commands/inserttablecommand.js
@@ -218,6 +218,8 @@ describe( 'InsertTableCommand', () => {
 						[ '', '', '' ]
 					], { headingRows: 1 } )
 				);
+
+				editor.destroy();
 			} );
 
 			it( 'should have first column as a heading by default', async () => {
@@ -242,6 +244,8 @@ describe( 'InsertTableCommand', () => {
 						[ '', '', '' ]
 					], { headingColumns: 1 } )
 				);
+
+				editor.destroy();
 			} );
 
 			it( 'should have first row and first column as a heading by default', async () => {
@@ -267,6 +271,8 @@ describe( 'InsertTableCommand', () => {
 						[ '', '', '' ]
 					], { headingRows: 1, headingColumns: 1 } )
 				);
+
+				editor.destroy();
 			} );
 
 			it( 'should have first three rows and two columns as a heading by default', async () => {
@@ -293,6 +299,8 @@ describe( 'InsertTableCommand', () => {
 						[ '', '', '' ]
 					], { headingRows: 3, headingColumns: 2 } )
 				);
+
+				editor.destroy();
 			} );
 
 			it( 'should have auto headings not to be greater than table rows and columns', async () => {
@@ -317,6 +325,8 @@ describe( 'InsertTableCommand', () => {
 						[ '', '' ]
 					], { headingRows: 2, headingColumns: 2 } )
 				);
+
+				editor.destroy();
 			} );
 
 			it( 'should work when heading rows and columns are explicitly set to 0', async () => {
@@ -343,6 +353,8 @@ describe( 'InsertTableCommand', () => {
 						[ '', '', '' ]
 					] )
 				);
+
+				editor.destroy();
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-table/tests/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/tests/commands/inserttablecommand.js
@@ -197,7 +197,7 @@ describe( 'InsertTableCommand', () => {
 
 		describe( 'auto headings', () => {
 			it( 'should have first row as a heading by default', async () => {
-				const _editor = await ModelTestEditor
+				editor = await ModelTestEditor
 					.create( {
 						plugins: [ Paragraph, TableEditing ],
 						table: {
@@ -205,14 +205,14 @@ describe( 'InsertTableCommand', () => {
 						}
 					} );
 
-				const _model = _editor.model;
-				const _command = new InsertTableCommand( _editor );
+				model = editor.model;
+				command = new InsertTableCommand( editor );
 
-				setData( _model, '[]' );
+				setData( model, '[]' );
 
-				_command.execute( { rows: 2, columns: 3 } );
+				command.execute( { rows: 2, columns: 3 } );
 
-				expect( getData( _model ) ).to.equal(
+				expect( getData( model ) ).to.equal(
 					modelTable( [
 						[ '[]', '', '' ],
 						[ '', '', '' ]
@@ -221,7 +221,7 @@ describe( 'InsertTableCommand', () => {
 			} );
 
 			it( 'should have first column as a heading by default', async () => {
-				const _editor = await ModelTestEditor
+				editor = await ModelTestEditor
 					.create( {
 						plugins: [ Paragraph, TableEditing ],
 						table: {
@@ -229,14 +229,14 @@ describe( 'InsertTableCommand', () => {
 						}
 					} );
 
-				const _model = _editor.model;
-				const _command = new InsertTableCommand( _editor );
+				model = editor.model;
+				command = new InsertTableCommand( editor );
 
-				setData( _model, '[]' );
+				setData( model, '[]' );
 
-				_command.execute( { rows: 2, columns: 3 } );
+				command.execute( { rows: 2, columns: 3 } );
 
-				expect( getData( _model ) ).to.equal(
+				expect( getData( model ) ).to.equal(
 					modelTable( [
 						[ '[]', '', '' ],
 						[ '', '', '' ]
@@ -245,7 +245,7 @@ describe( 'InsertTableCommand', () => {
 			} );
 
 			it( 'should have first row and first column as a heading by default', async () => {
-				const _editor = await ModelTestEditor
+				editor = await ModelTestEditor
 					.create( {
 						plugins: [ Paragraph, TableEditing ],
 						table: {
@@ -253,14 +253,14 @@ describe( 'InsertTableCommand', () => {
 						}
 					} );
 
-				const _model = _editor.model;
-				const _command = new InsertTableCommand( _editor );
+				model = editor.model;
+				command = new InsertTableCommand( editor );
 
-				setData( _model, '[]' );
+				setData( model, '[]' );
 
-				_command.execute( { rows: 3, columns: 3 } );
+				command.execute( { rows: 3, columns: 3 } );
 
-				expect( getData( _model ) ).to.equal(
+				expect( getData( model ) ).to.equal(
 					modelTable( [
 						[ '[]', '', '' ],
 						[ '', '', '' ],
@@ -270,7 +270,7 @@ describe( 'InsertTableCommand', () => {
 			} );
 
 			it( 'should have first three rows and two columns as a heading by default', async () => {
-				const _editor = await ModelTestEditor
+				editor = await ModelTestEditor
 					.create( {
 						plugins: [ Paragraph, TableEditing ],
 						table: {
@@ -278,20 +278,70 @@ describe( 'InsertTableCommand', () => {
 						}
 					} );
 
-				const _model = _editor.model;
-				const _command = new InsertTableCommand( _editor );
+				model = editor.model;
+				command = new InsertTableCommand( editor );
 
-				setData( _model, '[]' );
+				setData( model, '[]' );
 
-				_command.execute( { rows: 4, columns: 3 } );
+				command.execute( { rows: 4, columns: 3 } );
 
-				expect( getData( _model ) ).to.equal(
+				expect( getData( model ) ).to.equal(
 					modelTable( [
 						[ '[]', '', '' ],
 						[ '', '', '' ],
 						[ '', '', '' ],
 						[ '', '', '' ]
 					], { headingRows: 3, headingColumns: 2 } )
+				);
+			} );
+
+			it( 'should have auto headings not to be greater than table rows and columns', async () => {
+				editor = await ModelTestEditor
+					.create( {
+						plugins: [ Paragraph, TableEditing ],
+						table: {
+							defaultHeadings: { rows: 3, columns: 3 }
+						}
+					} );
+
+				model = editor.model;
+				command = new InsertTableCommand( editor );
+
+				setData( model, '[]' );
+
+				command.execute( { rows: 2, columns: 2 } );
+
+				expect( getData( model ) ).to.equal(
+					modelTable( [
+						[ '[]', '' ],
+						[ '', '' ]
+					], { headingRows: 2, headingColumns: 2 } )
+				);
+			} );
+
+			it( 'should work when heading rows and columns are explicitly set to 0', async () => {
+				editor = await ModelTestEditor
+					.create( {
+						plugins: [ Paragraph, TableEditing ],
+						table: {
+							defaultHeadings: { rows: 3, columns: 2 }
+						}
+					} );
+
+				model = editor.model;
+				command = new InsertTableCommand( editor );
+
+				setData( model, '[]' );
+
+				command.execute( { rows: 4, columns: 3, headingRows: 0, headingColumns: 0 } );
+
+				expect( getData( model ) ).to.equal(
+					modelTable( [
+						[ '[]', '', '' ],
+						[ '', '', '' ],
+						[ '', '', '' ],
+						[ '', '', '' ]
+					] )
 				);
 			} );
 		} );

--- a/packages/ckeditor5-table/tests/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/tests/commands/inserttablecommand.js
@@ -219,7 +219,7 @@ describe( 'InsertTableCommand', () => {
 					], { headingRows: 1 } )
 				);
 
-				editor.destroy();
+				await editor.destroy();
 			} );
 
 			it( 'should have first column as a heading by default', async () => {
@@ -245,7 +245,7 @@ describe( 'InsertTableCommand', () => {
 					], { headingColumns: 1 } )
 				);
 
-				editor.destroy();
+				await editor.destroy();
 			} );
 
 			it( 'should have first row and first column as a heading by default', async () => {
@@ -272,7 +272,7 @@ describe( 'InsertTableCommand', () => {
 					], { headingRows: 1, headingColumns: 1 } )
 				);
 
-				editor.destroy();
+				await editor.destroy();
 			} );
 
 			it( 'should have first three rows and two columns as a heading by default', async () => {
@@ -300,7 +300,7 @@ describe( 'InsertTableCommand', () => {
 					], { headingRows: 3, headingColumns: 2 } )
 				);
 
-				editor.destroy();
+				await editor.destroy();
 			} );
 
 			it( 'should have auto headings not to be greater than table rows and columns', async () => {
@@ -326,7 +326,7 @@ describe( 'InsertTableCommand', () => {
 					], { headingRows: 2, headingColumns: 2 } )
 				);
 
-				editor.destroy();
+				await editor.destroy();
 			} );
 
 			it( 'should work when heading rows and columns are explicitly set to 0', async () => {
@@ -354,7 +354,7 @@ describe( 'InsertTableCommand', () => {
 					] )
 				);
 
-				editor.destroy();
+				await editor.destroy();
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-table/tests/commands/inserttablecommand.js
+++ b/packages/ckeditor5-table/tests/commands/inserttablecommand.js
@@ -197,7 +197,7 @@ describe( 'InsertTableCommand', () => {
 
 		describe( 'auto headings', () => {
 			it( 'should have first row as a heading by default', async () => {
-				editor = await ModelTestEditor
+				const editor = await ModelTestEditor
 					.create( {
 						plugins: [ Paragraph, TableEditing ],
 						table: {
@@ -205,8 +205,8 @@ describe( 'InsertTableCommand', () => {
 						}
 					} );
 
-				model = editor.model;
-				command = new InsertTableCommand( editor );
+				const model = editor.model;
+				const command = new InsertTableCommand( editor );
 
 				setData( model, '[]' );
 
@@ -221,7 +221,7 @@ describe( 'InsertTableCommand', () => {
 			} );
 
 			it( 'should have first column as a heading by default', async () => {
-				editor = await ModelTestEditor
+				const editor = await ModelTestEditor
 					.create( {
 						plugins: [ Paragraph, TableEditing ],
 						table: {
@@ -229,8 +229,8 @@ describe( 'InsertTableCommand', () => {
 						}
 					} );
 
-				model = editor.model;
-				command = new InsertTableCommand( editor );
+				const model = editor.model;
+				const command = new InsertTableCommand( editor );
 
 				setData( model, '[]' );
 
@@ -245,7 +245,7 @@ describe( 'InsertTableCommand', () => {
 			} );
 
 			it( 'should have first row and first column as a heading by default', async () => {
-				editor = await ModelTestEditor
+				const editor = await ModelTestEditor
 					.create( {
 						plugins: [ Paragraph, TableEditing ],
 						table: {
@@ -253,8 +253,8 @@ describe( 'InsertTableCommand', () => {
 						}
 					} );
 
-				model = editor.model;
-				command = new InsertTableCommand( editor );
+				const model = editor.model;
+				const command = new InsertTableCommand( editor );
 
 				setData( model, '[]' );
 
@@ -270,7 +270,7 @@ describe( 'InsertTableCommand', () => {
 			} );
 
 			it( 'should have first three rows and two columns as a heading by default', async () => {
-				editor = await ModelTestEditor
+				const editor = await ModelTestEditor
 					.create( {
 						plugins: [ Paragraph, TableEditing ],
 						table: {
@@ -278,8 +278,8 @@ describe( 'InsertTableCommand', () => {
 						}
 					} );
 
-				model = editor.model;
-				command = new InsertTableCommand( editor );
+				const model = editor.model;
+				const command = new InsertTableCommand( editor );
 
 				setData( model, '[]' );
 
@@ -296,7 +296,7 @@ describe( 'InsertTableCommand', () => {
 			} );
 
 			it( 'should have auto headings not to be greater than table rows and columns', async () => {
-				editor = await ModelTestEditor
+				const editor = await ModelTestEditor
 					.create( {
 						plugins: [ Paragraph, TableEditing ],
 						table: {
@@ -304,8 +304,8 @@ describe( 'InsertTableCommand', () => {
 						}
 					} );
 
-				model = editor.model;
-				command = new InsertTableCommand( editor );
+				const model = editor.model;
+				const command = new InsertTableCommand( editor );
 
 				setData( model, '[]' );
 
@@ -320,7 +320,7 @@ describe( 'InsertTableCommand', () => {
 			} );
 
 			it( 'should work when heading rows and columns are explicitly set to 0', async () => {
-				editor = await ModelTestEditor
+				const editor = await ModelTestEditor
 					.create( {
 						plugins: [ Paragraph, TableEditing ],
 						table: {
@@ -328,8 +328,8 @@ describe( 'InsertTableCommand', () => {
 						}
 					} );
 
-				model = editor.model;
-				command = new InsertTableCommand( editor );
+				const model = editor.model;
+				const command = new InsertTableCommand( editor );
 
 				setData( model, '[]' );
 

--- a/packages/ckeditor5-table/tests/manual/tableautoheadings.html
+++ b/packages/ckeditor5-table/tests/manual/tableautoheadings.html
@@ -1,0 +1,12 @@
+<h1>Editor 1: first row as a heading</h1>
+<div id="editor-1"></div>
+
+<h1>Editor 2: first column as a heading</h1>
+<div id="editor-2"></div>
+
+<h1>Editor 3: first row and column as a heading</h1>
+<div id="editor-3"></div>
+
+<h1>Editor 4: first three rows and two column as a heading</h1>
+<p>(pick size at least 3 by 4 to see the effect)</p>
+<div id="editor-4"></div>

--- a/packages/ckeditor5-table/tests/manual/tableautoheadings.js
+++ b/packages/ckeditor5-table/tests/manual/tableautoheadings.js
@@ -11,23 +11,23 @@ import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articleplugi
 const editors = [
 	{
 		id: 'editor-1',
-		autoHeading: { rows: 1 }
+		defaultHeadings: { rows: 1 }
 	},
 	{
 		id: 'editor-2',
-		autoHeading: { columns: 1 }
+		defaultHeadings: { columns: 1 }
 	},
 	{
 		id: 'editor-3',
-		autoHeading: { rows: 1, columns: 1 }
+		defaultHeadings: { rows: 1, columns: 1 }
 	},
 	{
 		id: 'editor-4',
-		autoHeading: { rows: 3, columns: 2 }
+		defaultHeadings: { rows: 3, columns: 2 }
 	}
 ];
 
-for ( const { id, autoHeading } of editors ) {
+for ( const { id, defaultHeadings } of editors ) {
 	ClassicEditor
 		.create( document.getElementById( id ), {
 			image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
@@ -38,7 +38,7 @@ for ( const { id, autoHeading } of editors ) {
 			table: {
 				contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ],
 				tableToolbar: [ 'bold', 'italic' ],
-				autoHeading
+				defaultHeadings
 			}
 		} )
 		.then( editor => {

--- a/packages/ckeditor5-table/tests/manual/tableautoheadings.js
+++ b/packages/ckeditor5-table/tests/manual/tableautoheadings.js
@@ -1,0 +1,50 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+
+const editors = [
+	{
+		id: 'editor-1',
+		autoHeading: { rows: 1 }
+	},
+	{
+		id: 'editor-2',
+		autoHeading: { columns: 1 }
+	},
+	{
+		id: 'editor-3',
+		autoHeading: { rows: 1, columns: 1 }
+	},
+	{
+		id: 'editor-4',
+		autoHeading: { rows: 3, columns: 2 }
+	}
+];
+
+for ( const { id, autoHeading } of editors ) {
+	ClassicEditor
+		.create( document.getElementById( id ), {
+			image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
+			plugins: [ ArticlePluginSet ],
+			toolbar: [
+				'heading', '|', 'insertTable', '|', 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo'
+			],
+			table: {
+				contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ],
+				tableToolbar: [ 'bold', 'italic' ],
+				autoHeading
+			}
+		} )
+		.then( editor => {
+			window.editor = editor;
+		} )
+		.catch( err => {
+			console.error( err.stack );
+		} );
+}

--- a/packages/ckeditor5-table/tests/manual/tableautoheadings.md
+++ b/packages/ckeditor5-table/tests/manual/tableautoheadings.md
@@ -1,0 +1,24 @@
+### Editor 1: Auto insert header in the first row
+
+1. Insert table of chosen size
+2. First row should be marked as header by default
+3. You should be able to make it back to a regular row
+
+### Editor 2: Auto insert header in the first column
+
+1. Insert table of chosen size
+2. First column should be marked as header by default
+3. You should be able to make it back to a regular column
+
+### Editor 3: Auto insert header in the first row and column
+
+1. Insert table of chosen size
+2. First row and first column should be marked as header by default
+3. You should be able to make it back to a regular row and column
+
+### Editor 4: Auto insert header in multiple rows and columns
+
+1. Insert table of chosen size (at least 3 by 4 to see the effect)
+2. First three rows and first two columns should be marked as header by default
+3. You should be able to make it back to a regular rows and columns
+4. In case of table smaller than 3 by 4, all cells in the table should be headings

--- a/packages/ckeditor5-table/tests/manual/tableautoheadings.md
+++ b/packages/ckeditor5-table/tests/manual/tableautoheadings.md
@@ -1,24 +1,24 @@
 ### Editor 1: Auto insert header in the first row
 
-1. Insert table of chosen size
-2. First row should be marked as header by default
-3. You should be able to make it back to a regular row
+1. Insert table of chosen size.
+1. First row should be marked as header by default.
+1. You should be able to make it back to a regular row.
 
 ### Editor 2: Auto insert header in the first column
 
-1. Insert table of chosen size
-2. First column should be marked as header by default
-3. You should be able to make it back to a regular column
+1. Insert table of chosen size.
+1. First column should be marked as header by default.
+1. You should be able to make it back to a regular column.
 
 ### Editor 3: Auto insert header in the first row and column
 
-1. Insert table of chosen size
-2. First row and first column should be marked as header by default
-3. You should be able to make it back to a regular row and column
+1. Insert table of chosen size.
+1. First row and first column should be marked as header by default.
+1. You should be able to make it back to a regular row and column.
 
 ### Editor 4: Auto insert header in multiple rows and columns
 
-1. Insert table of chosen size (at least 3 by 4 to see the effect)
-2. First three rows and first two columns should be marked as header by default
-3. You should be able to make it back to a regular rows and columns
-4. In case of table smaller than 3 by 4, all cells in the table should be headings
+1. Insert table of chosen size (at least 3 by 4 to see the effect).
+1. First three rows and first two columns should be marked as header by default.
+1. You should be able to make it back to a regular rows and columns.
+1. In case of table smaller than 3 by 4, all cells in the table should be headings.

--- a/packages/ckeditor5-table/tests/tableutils.js
+++ b/packages/ckeditor5-table/tests/tableutils.js
@@ -2005,5 +2005,20 @@ describe( 'TableUtils', () => {
 				[ '', '' ]
 			], { headingRows: 2, headingColumns: 1 } ) );
 		} );
+
+		it( 'should clamp table heading rows and columns to the rows and columns number', () => {
+			setData( model, '[]' );
+
+			model.change( writer => {
+				const table = tableUtils.createTable( writer, { rows: 2, columns: 2, headingRows: 3, headingColumns: 3 } );
+
+				model.insertContent( table, model.document.selection.focus );
+			} );
+
+			assertEqualMarkup( getData( model, { withoutSelection: true } ), modelTable( [
+				[ '', '' ],
+				[ '', '' ]
+			], { headingRows: 2, headingColumns: 2 } ) );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (table): Option in table config to set rows/columns as headings by default. Closes #10039.

---

### Additional information

To test run `yarn manual --files=table/manual/tableautoheadings.js`
