### PR TITLE
HTML comments: compatibility with empty table cell

### DIFF
--- a/packages/ckeditor5-table/src/tableediting.js
+++ b/packages/ckeditor5-table/src/tableediting.js
@@ -121,8 +121,9 @@ export default class TableEditing extends Plugin {
 		conversion.for( 'editingDowncast' ).add( downcastTableHeadingColumnsChange() );
 
 		// Manually adjust model position mappings in a special case, when a table cell contains a paragraph, which is bound
-		// to its parent (to the table cell).
-		editor.data.mapper.on( 'modelToViewPosition', mapTableCellModelPositionToView( editor.editing.view ) );
+		// to its parent (to the table cell). This custom model-to-view position mapping is necessary in data pipeline only,
+		// because only during this conversion a paragraph can be bound to its parent.
+		editor.data.mapper.on( 'modelToViewPosition', mapTableCellModelPositionToView() );
 
 		// Define all the commands.
 		editor.commands.add( 'insertTable', new InsertTableCommand( editor ) );
@@ -173,9 +174,8 @@ export default class TableEditing extends Plugin {
 //
 // <tableCell><paragraph>foobar</paragraph>^</tableCell> -> <td>foobar^</td>
 //
-// @param {module:engine/view/view~View} editingView
 // @returns {Function}
-function mapTableCellModelPositionToView( editingView ) {
+function mapTableCellModelPositionToView() {
 	return ( evt, data ) => {
 		const modelParent = data.modelPosition.parent;
 		const modelNodeBefore = data.modelPosition.nodeBefore;
@@ -194,7 +194,7 @@ function mapTableCellModelPositionToView( editingView ) {
 		if ( viewNodeBefore === viewParent ) {
 			// Since the paragraph has already been bound to its parent, update the current position in the model with paragraph's
 			// max offset, so it points to the place which should normally (in all other cases) be the end position of this paragraph.
-			data.viewPosition = editingView.createPositionAt( viewParent, modelNodeBefore.maxOffset );
+			data.viewPosition = data.mapper.findPositionIn( viewParent, modelNodeBefore.maxOffset );
 		}
 	};
 }

--- a/packages/ckeditor5-table/src/tableediting.js
+++ b/packages/ckeditor5-table/src/tableediting.js
@@ -122,7 +122,7 @@ export default class TableEditing extends Plugin {
 
 		// Manually adjust model position mappings in a special case, when a table cell contains a paragraph, which is bound
 		// to its parent (to the table cell).
-		editor.data.mapper.on( 'modelToViewPosition', mapModelPositionToView( editor.editing.view ) );
+		editor.data.mapper.on( 'modelToViewPosition', mapTableCellModelPositionToView( editor.editing.view ) );
 
 		// Define all the commands.
 		editor.commands.add( 'insertTable', new InsertTableCommand( editor ) );
@@ -167,7 +167,7 @@ export default class TableEditing extends Plugin {
 // Creates a mapper callback to adjust model position mappings in a table cell containing a paragraph, which is bound to its parent
 // (to the table cell). Only positions after this paragraph have to be adjusted, because after binding this paragraph to the table cell,
 // elements located after this paragraph would point either to a non-existent offset inside `tableCell` (if paragraph is empty), or after
-// first character from paragraph's text. See https://github.com/ckeditor/ckeditor5/issues/10116.
+// the first character of the paragraph's text. See https://github.com/ckeditor/ckeditor5/issues/10116.
 //
 // <tableCell><paragraph></paragraph>^</tableCell> -> <td>^&nbsp;</td>
 //
@@ -175,7 +175,7 @@ export default class TableEditing extends Plugin {
 //
 // @param {module:engine/view/view~View} editingView
 // @returns {Function}
-function mapModelPositionToView( editingView ) {
+function mapTableCellModelPositionToView( editingView ) {
 	return ( evt, data ) => {
 		const modelParent = data.modelPosition.parent;
 		const modelNodeBefore = data.modelPosition.nodeBefore;

--- a/packages/ckeditor5-table/tests/table-integration.js
+++ b/packages/ckeditor5-table/tests/table-integration.js
@@ -224,4 +224,62 @@ describe( 'Table feature – integration with markers', () => {
 		expect( getModelData( editor.model, { withoutSelection: true } ) )
 			.to.equal( '<table><tableRow><tableCell><paragraph></paragraph></tableCell></tableRow></table>' );
 	} );
+
+	// https://github.com/ckeditor/ckeditor5/issues/10116
+	describe( 'markers converted to UI elements and vice versa', () => {
+		function CustomPlugin( editor ) {
+			editor.conversion.for( 'upcast' ).elementToMarker( { view: 'foo', model: 'bar' } );
+			editor.conversion.for( 'dataDowncast' ).markerToElement( { view: 'foo', model: 'bar' } );
+		}
+
+		beforeEach( async () => {
+			editor = await ClassicTestEditor.create( '', { plugins: [ CustomPlugin, Paragraph, TableEditing ] } );
+		} );
+
+		it( 'should not throw if marker is inside an empty table cell', async () => {
+			editor.setData( '<table><tr><td><foo></foo></td></tr></table>' );
+
+			expect( () => editor.getData() ).to.not.throw();
+		} );
+
+		it( 'should adjust the model position mapping - table cell containing marker only', async () => {
+			editor.setData( '<table><tr><td><foo></foo></td></tr></table>' );
+
+			expect( editor.getData() ).to.equal(
+				'<figure class="table"><table><tbody><tr><td><foo></foo>&nbsp;</td></tr></tbody></table></figure>'
+			);
+		} );
+
+		it( 'should adjust the model position mapping - table cell containing marker preceded by an empty paragraph', async () => {
+			editor.setData( '<table><tr><td><p></p><foo></foo></td></tr></table>' );
+
+			expect( editor.getData() ).to.equal(
+				'<figure class="table"><table><tbody><tr><td><foo></foo>&nbsp;</td></tr></tbody></table></figure>'
+			);
+		} );
+
+		it( 'should adjust the model position mapping - table cell containing marker followed by an empty paragraph', async () => {
+			editor.setData( '<table><tr><td><foo></foo><p></p></td></tr></table>' );
+
+			expect( editor.getData() ).to.equal(
+				'<figure class="table"><table><tbody><tr><td><foo></foo>&nbsp;</td></tr></tbody></table></figure>'
+			);
+		} );
+
+		it( 'should adjust the model position mapping - table cell containing marker preceded by a non-empty paragraph', async () => {
+			editor.setData( '<table><tr><td><p>foobar</p><foo></foo></td></tr></table>' );
+
+			expect( editor.getData() ).to.equal(
+				'<figure class="table"><table><tbody><tr><td>foobar<foo></foo></td></tr></tbody></table></figure>'
+			);
+		} );
+
+		it( 'should adjust the model position mapping - table cell containing marker followed by a non-empty paragraph', async () => {
+			editor.setData( '<table><tr><td><foo></foo><p>foobar</p></td></tr></table>' );
+
+			expect( editor.getData() ).to.equal(
+				'<figure class="table"><table><tbody><tr><td><foo></foo>foobar</td></tr></tbody></table></figure>'
+			);
+		} );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (table): Fixed model mappings in table cell if paragraph is bound to its parent. Closes #10116.
