### PR TITLE
Find and replace: keyboard shortcut error

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.js
@@ -148,7 +148,9 @@ export default class FindAndReplaceUI extends Plugin {
 		// Configure the dropdown's button properties:
 		buttonView.set( {
 			icon,
-			tooltip: t( 'Find and replace' )
+			label: t( 'Find and replace' ),
+			keystroke: 'CTRL+F',
+			tooltip: true
 		} );
 
 		// Each time a dropdown is opened, the search text field should get focused.

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.js
@@ -88,7 +88,7 @@ export default class FindAndReplaceUI extends Plugin {
 			this.formView = formView;
 
 			editor.keystrokes.set( 'Ctrl+F', ( data, cancelEvent ) => {
-				dropdown.buttonView.actionView.fire( 'execute' );
+				dropdown.buttonView.fire( 'execute' );
 
 				cancelEvent();
 			} );

--- a/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
@@ -5,6 +5,8 @@ import FindAndReplaceUI from '../src/findandreplaceui';
 import FindAndReplace from '../src/findandreplace';
 import DropdownView from '@ckeditor/ckeditor5-ui/src/dropdown/dropdownview';
 import loupeIcon from '../theme/icons/find-replace.svg';
+import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 describe( 'FindAndReplaceUI', () => {
 	let editorElement;
@@ -107,6 +109,24 @@ describe( 'FindAndReplaceUI', () => {
 
 					button.fire( 'open' );
 					sinon.assert.callOrder( spy, selectSpy );
+				} );
+
+				it( 'should open the dropdown when CTRL+F was pressed', () => {
+					const spy = sinon.spy( form.findInputView.fieldView, 'select' );
+
+					const keyEventData = ( {
+						keyCode: keyCodes.f,
+						ctrlKey: !env.isMac,
+						metaKey: env.isMac,
+						preventDefault: sinon.spy(),
+						stopPropagation: sinon.spy()
+					} );
+
+					const wasHandled = editor.keystrokes.press( keyEventData );
+
+					expect( wasHandled ).to.be.true;
+					expect( keyEventData.preventDefault.calledOnce ).to.be.true;
+					sinon.assert.calledOnce( spy );
 				} );
 
 				it( 'should select the content of the input', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (find-and-replace): Fixed the regression caused by changing the split button to a regular dropdown button. Closes #10184.