### PR TITLE
Fixed compatibility issues with Paste from Office by skipping all comments

### DIFF
--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -411,7 +411,9 @@ export default class DomConverter {
 	 * @param {Object} [options] Conversion options.
 	 * @param {Boolean} [options.bind=false] Determines whether new elements will be bound.
 	 * @param {Boolean} [options.withChildren=true] If `true`, node's and document fragment's children will be converted too.
-	 * @param {Boolean} [options.keepOriginalCase=false] If `false`, node's tag name will be converter to lower case.
+	 * @param {Boolean} [options.keepOriginalCase=false] If `false`, node's tag name will be converted to lower case.
+	 * @param {Boolean} [options.skipComments=false] If `false`, comment nodes will be converted to `$comment`
+	 * {@link module:engine/view/uielement~UIElement view UI elements}.
 	 * @returns {module:engine/view/node~Node|module:engine/view/documentfragment~DocumentFragment|null} Converted node or document fragment
 	 * or `null` if DOM node is a {@link module:engine/view/filler filler} or the given node is an empty text node.
 	 */
@@ -425,6 +427,10 @@ export default class DomConverter {
 
 		if ( hostElement ) {
 			return hostElement;
+		}
+
+		if ( this.isComment( domNode ) && options.skipComments ) {
+			return null;
 		}
 
 		if ( isText( domNode ) ) {

--- a/packages/ckeditor5-engine/tests/view/domconverter/dom-to-view.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/dom-to-view.js
@@ -198,7 +198,7 @@ describe( 'DomConverter', () => {
 			expect( converter.mapViewToDom( viewComment ) ).to.equal( domComment );
 		} );
 
-		it( 'should not create UIElement for comment', () => {
+		it( 'should return `null` for a comment when the `skipComments` option is set to `true`', () => {
 			const domComment = document.createComment( 'abc' );
 
 			const viewComment = converter.domToView( domComment, { skipComments: true } );

--- a/packages/ckeditor5-engine/tests/view/domconverter/dom-to-view.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/dom-to-view.js
@@ -198,6 +198,14 @@ describe( 'DomConverter', () => {
 			expect( converter.mapViewToDom( viewComment ) ).to.equal( domComment );
 		} );
 
+		it( 'should not create UIElement for comment', () => {
+			const domComment = document.createComment( 'abc' );
+
+			const viewComment = converter.domToView( domComment, { skipComments: true } );
+
+			expect( viewComment ).to.be.null;
+		} );
+
 		describe( 'it should clear whitespaces', () => {
 			it( 'at the beginning of block element', () => {
 				const domDiv = createElement( document, 'div', {}, [

--- a/packages/ckeditor5-paste-from-office/src/filters/parse.js
+++ b/packages/ckeditor5-paste-from-office/src/filters/parse.js
@@ -56,7 +56,7 @@ export function parseHtml( htmlString, stylesProcessor ) {
 	};
 }
 
-// Transforms native `Document` object into {@link module:engine/view/documentfragment~DocumentFragment}.
+// Transforms native `Document` object into {@link module:engine/view/documentfragment~DocumentFragment}. Comments are skipped.
 //
 // @param {Document} htmlDocument Native `Document` object to be transformed.
 // @param {module:engine/view/stylesmap~StylesProcessor} stylesProcessor
@@ -71,7 +71,7 @@ function documentToView( htmlDocument, stylesProcessor ) {
 		fragment.appendChild( nodes[ 0 ] );
 	}
 
-	return domConverter.domToView( fragment );
+	return domConverter.domToView( fragment, { skipComments: true } );
 }
 
 // Extracts both `CSSStyleSheet` and string representation from all `style` elements available in a provided `htmlDocument`.

--- a/packages/ckeditor5-paste-from-office/src/normalizers/googledocsnormalizer.js
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/googledocsnormalizer.js
@@ -45,8 +45,11 @@ export default class GoogleDocsNormalizer {
 	 */
 	execute( data ) {
 		const writer = new UpcastWriter( this.document );
+		const { body } = data._parsedData;
 
-		removeBoldWrapper( data.content, writer );
-		unwrapParagraphInListItem( data.content, writer );
+		removeBoldWrapper( body, writer );
+		unwrapParagraphInListItem( body, writer );
+
+		data.content = body;
 	}
 }

--- a/packages/ckeditor5-paste-from-office/src/normalizers/googledocsnormalizer.js
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/googledocsnormalizer.js
@@ -45,11 +45,11 @@ export default class GoogleDocsNormalizer {
 	 */
 	execute( data ) {
 		const writer = new UpcastWriter( this.document );
-		const { body } = data._parsedData;
+		const { body: documentFragment } = data._parsedData;
 
-		removeBoldWrapper( body, writer );
-		unwrapParagraphInListItem( body, writer );
+		removeBoldWrapper( documentFragment, writer );
+		unwrapParagraphInListItem( documentFragment, writer );
 
-		data.content = body;
+		data.content = documentFragment;
 	}
 }

--- a/packages/ckeditor5-paste-from-office/src/normalizers/mswordnormalizer.js
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/mswordnormalizer.js
@@ -7,7 +7,6 @@
  * @module paste-from-office/normalizers/mswordnormalizer
  */
 
-import { parseHtml } from '../filters/parse';
 import { transformListItemLikeElementsIntoLists } from '../filters/list';
 import { replaceImagesSourceWithBase64 } from '../filters/image';
 
@@ -44,7 +43,7 @@ export default class MSWordNormalizer {
 	 * @inheritDoc
 	 */
 	execute( data ) {
-		const { body, stylesString } = parseHtml( data.dataTransfer.getData( 'text/html' ), this.document.stylesProcessor );
+		const { body, stylesString } = data._parsedData;
 
 		transformListItemLikeElementsIntoLists( body, stylesString );
 		replaceImagesSourceWithBase64( body, data.dataTransfer.getData( 'text/rtf' ) );

--- a/packages/ckeditor5-paste-from-office/src/normalizers/mswordnormalizer.js
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/mswordnormalizer.js
@@ -43,11 +43,11 @@ export default class MSWordNormalizer {
 	 * @inheritDoc
 	 */
 	execute( data ) {
-		const { body, stylesString } = data._parsedData;
+		const { body: documentFragment, stylesString } = data._parsedData;
 
-		transformListItemLikeElementsIntoLists( body, stylesString );
-		replaceImagesSourceWithBase64( body, data.dataTransfer.getData( 'text/rtf' ) );
+		transformListItemLikeElementsIntoLists( documentFragment, stylesString );
+		replaceImagesSourceWithBase64( documentFragment, data.dataTransfer.getData( 'text/rtf' ) );
 
-		data.content = body;
+		data.content = documentFragment;
 	}
 }

--- a/packages/ckeditor5-paste-from-office/src/pastefromoffice.js
+++ b/packages/ckeditor5-paste-from-office/src/pastefromoffice.js
@@ -13,6 +13,8 @@ import { ClipboardPipeline } from 'ckeditor5/src/clipboard';
 import GoogleDocsNormalizer from './normalizers/googledocsnormalizer';
 import MSWordNormalizer from './normalizers/mswordnormalizer';
 
+import { parseHtml } from './filters/parse';
+
 /**
  * The Paste from Office plugin.
  *
@@ -57,7 +59,7 @@ export default class PasteFromOffice extends Plugin {
 		editor.plugins.get( 'ClipboardPipeline' ).on(
 			'inputTransformation',
 			( evt, data ) => {
-				if ( data.isTransformedWithPasteFromOffice ) {
+				if ( data._isTransformedWithPasteFromOffice ) {
 					return;
 				}
 
@@ -65,9 +67,11 @@ export default class PasteFromOffice extends Plugin {
 				const activeNormalizer = normalizers.find( normalizer => normalizer.isActive( htmlString ) );
 
 				if ( activeNormalizer ) {
+					data._parsedData = parseHtml( htmlString, viewDocument.stylesProcessor );
+
 					activeNormalizer.execute( data );
 
-					data.isTransformedWithPasteFromOffice = true;
+					data._isTransformedWithPasteFromOffice = true;
 				}
 			},
 			{ priority: 'high' }

--- a/packages/ckeditor5-paste-from-office/tests/_utils/utils.js
+++ b/packages/ckeditor5-paste-from-office/tests/_utils/utils.js
@@ -248,6 +248,8 @@ function generateIntegrationTests( title, fixtures, editorConfig, skip ) {
 // these images are extracted (so HTML diff is readable) and compared
 // one by one separately (so it is visible if base64 representation is malformed).
 //
+// Comments are removed from the expected HTML struture, to be consistent with the actual pasted data in the plugin.
+//
 // This function is designed for comparing normalized data so expected input is preprocessed before comparing:
 //
 //		* Tabs on the lines beginnings are removed.
@@ -274,7 +276,7 @@ function expectNormalized( actualView, expectedHtml ) {
 	// We are ok with both spaces and non-breaking spaces in the actual content.
 	// Replace `&nbsp;` with regular spaces to align with expected content.
 	const actualNormalized = stringifyView( actualView ).replace( /\u00A0/g, ' ' );
-	const expectedNormalized = normalizeHtml( inlineData( expectedHtml ) );
+	const expectedNormalized = normalizeHtml( inlineData( expectedHtml ), { skipComments: true } );
 
 	compareContentWithBase64Images( actualNormalized, expectedNormalized );
 }

--- a/packages/ckeditor5-paste-from-office/tests/filters/parse.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/parse.js
@@ -161,6 +161,17 @@ describe( 'PasteFromOffice - filters', () => {
 
 				expect( stylesString ).to.equal( '' );
 			} );
+
+			it( 'should remove all comments', () => {
+				const html = '<body><!--c1--><p>Foo Bar</p><!--c2--></body>';
+				const { body } = parseHtml( html );
+
+				expect( body ).to.instanceof( DocumentFragment );
+
+				expect( body.childCount ).to.equal( 1 );
+
+				expect( body.getChild( 0 ).name ).to.equal( 'p' );
+			} );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
+++ b/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
@@ -62,7 +62,12 @@ describe( 'PasteFromOffice', () => {
 
 				clipboard.fire( 'inputTransformation', data );
 
-				expect( data.isTransformedWithPasteFromOffice ).to.be.true;
+				expect( data._isTransformedWithPasteFromOffice ).to.be.true;
+				expect( data._parsedData ).to.have.property( 'body' );
+				expect( data._parsedData ).to.have.property( 'bodyString' );
+				expect( data._parsedData ).to.have.property( 'styles' );
+				expect( data._parsedData ).to.have.property( 'stylesString' );
+
 				sinon.assert.called( getDataSpy );
 			}
 		} );
@@ -82,7 +87,9 @@ describe( 'PasteFromOffice', () => {
 
 				clipboard.fire( 'inputTransformation', data );
 
-				expect( data.isTransformedWithPasteFromOffice ).to.be.undefined;
+				expect( data._isTransformedWithPasteFromOffice ).to.be.undefined;
+				expect( data._parsedData ).to.be.undefined;
+
 				sinon.assert.called( getDataSpy );
 			}
 		} );
@@ -104,7 +111,9 @@ describe( 'PasteFromOffice', () => {
 
 				clipboard.fire( 'inputTransformation', data );
 
-				expect( data.isTransformedWithPasteFromOffice ).to.be.true;
+				expect( data._isTransformedWithPasteFromOffice ).to.be.true;
+				expect( data._parsedData ).to.be.undefined;
+
 				sinon.assert.notCalled( getDataSpy );
 			}
 		} );
@@ -120,7 +129,7 @@ describe( 'PasteFromOffice', () => {
 		};
 
 		if ( isTransformedWithPasteFromOffice ) {
-			data.isTransformedWithPasteFromOffice = true;
+			data._isTransformedWithPasteFromOffice = true;
 		}
 
 		return data;

--- a/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
+++ b/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
@@ -12,6 +12,7 @@ import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import { StylesProcessor } from '@ckeditor/ckeditor5-engine/src/view/stylesmap';
 import ViewDocument from '@ckeditor/ckeditor5-engine/src/view/document';
+import ViewDocumentFragment from '@ckeditor/ckeditor5-engine/src/view/documentfragment';
 
 describe( 'PasteFromOffice', () => {
 	const htmlDataProcessor = new HtmlDataProcessor( new ViewDocument( new StylesProcessor() ) );
@@ -67,6 +68,7 @@ describe( 'PasteFromOffice', () => {
 				expect( data._parsedData ).to.have.property( 'bodyString' );
 				expect( data._parsedData ).to.have.property( 'styles' );
 				expect( data._parsedData ).to.have.property( 'stylesString' );
+				expect( data._parsedData.body ).to.be.instanceOf( ViewDocumentFragment );
 
 				sinon.assert.called( getDataSpy );
 			}

--- a/packages/ckeditor5-utils/tests/_utils/normalizehtml.js
+++ b/packages/ckeditor5-utils/tests/_utils/normalizehtml.js
@@ -12,11 +12,13 @@ import Document from '@ckeditor/ckeditor5-engine/src/view/document';
  * Parses given string of HTML and returns normalized HTML.
  *
  * @param {String} html HTML string to normalize.
+ * @param {Object} [options] Conversion options. See {@link module:engine/view/domconverter~DomConverter#domToView} options parameter.
  * @returns {String} Normalized HTML string.
  */
-export default function normalizeHtml( html ) {
+export default function normalizeHtml( html, options = {} ) {
 	const processor = new HtmlDataProcessor( new Document( new StylesProcessor() ) );
-	const parsed = processor.toView( html );
+	const domFragment = processor._toDom( html );
+	const viewFragment = processor._domConverter.domToView( domFragment, options );
 
-	return stringify( parsed );
+	return stringify( viewFragment );
 }

--- a/packages/ckeditor5-utils/tests/_utils/normalizehtml.js
+++ b/packages/ckeditor5-utils/tests/_utils/normalizehtml.js
@@ -12,7 +12,7 @@ import Document from '@ckeditor/ckeditor5-engine/src/view/document';
  * Parses given string of HTML and returns normalized HTML.
  *
  * @param {String} html HTML string to normalize.
- * @param {Object} [options] Conversion options. See {@link module:engine/view/domconverter~DomConverter#domToView} options parameter.
+ * @param {Object} [options] DOM to View conversion options. See {@link module:engine/view/domconverter~DomConverter#domToView} options.
  * @returns {String} Normalized HTML string.
  */
 export default function normalizeHtml( html, options = {} ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (html-support): Fixed compatibility issues with Paste from Office by skipping all comments. Closes #10155.
