### PR TITLE
Fixed JSDoc typedef for HTML comments interface

### DIFF
--- a/packages/ckeditor5-html-support/src/htmlcomment.js
+++ b/packages/ckeditor5-html-support/src/htmlcomment.js
@@ -201,7 +201,7 @@ export default class HtmlComment extends Plugin {
  *
  * It consists of the {@link module:engine/model/position~Position `position`} and `content`.
  *
- * @typedef {Object} HtmlCommentData
+ * @typedef {Object} module:html-support/htmlcomment~HtmlCommentData
  *
  * @property {module:engine/model/position~Position} position
  * @property {String} content


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (html-support): Fixed JSDoc typedef for HTML comments interface. See #9661.