### PR TITLE
Autosave improvements

### DIFF
--- a/packages/ckeditor5-autosave/src/autosave.js
+++ b/packages/ckeditor5-autosave/src/autosave.js
@@ -102,7 +102,7 @@ export default class Autosave extends Plugin {
 		this._debouncedSave = debounce( this._save.bind( this ), waitingTime );
 
 		/**
-		 * The last document version.
+		 * The last saved document version.
 		 *
 		 * @private
 		 * @type {Number}
@@ -150,25 +150,28 @@ export default class Autosave extends Plugin {
 
 		this._pendingActions = editor.plugins.get( PendingActions );
 
-		this.listenTo( doc, 'change:data', () => {
-			if ( !this._saveCallbacks.length ) {
-				return;
-			}
+		// Add the listener only after the editor is initialized to prevent firing save callback on data init.
+		this.listenTo( editor, 'ready', () => {
+			this.listenTo( doc, 'change:data', () => {
+				if ( !this._saveCallbacks.length ) {
+					return;
+				}
 
-			if ( this.state == 'synchronized' ) {
-				this._action = this._pendingActions.add( t( 'Saving changes' ) );
-				this.state = 'waiting';
+				if ( this.state == 'synchronized' ) {
+					this._action = this._pendingActions.add( t( 'Saving changes' ) );
+					this.state = 'waiting';
 
-				this._debouncedSave();
-			}
+					this._debouncedSave();
+				}
 
-			else if ( this.state == 'waiting' ) {
-				this._debouncedSave();
-			}
+				else if ( this.state == 'waiting' ) {
+					this._debouncedSave();
+				}
 
-			// If the plugin is in `saving` state, it will change its state later basing on the `document.version`.
-			// If the `document.version` will be higher than stored `#_lastDocumentVersion`, then it means, that some `change:data`
-			// event has fired in the meantime.
+				// If the plugin is in `saving` state, it will change its state later basing on the `document.version`.
+				// If the `document.version` will be higher than stored `#_lastDocumentVersion`, then it means, that some `change:data`
+				// event has fired in the meantime.
+			} );
 		} );
 
 		// Flush on the editor's destroy listener with the highest priority to ensure that
@@ -197,6 +200,14 @@ export default class Autosave extends Plugin {
 	}
 
 	/**
+	 * Calls autosave plugin callback and cancels any delayed callbacks that may have been already triggered.
+	 */
+	save() {
+		this._debouncedSave.cancel();
+		this._save();
+	}
+
+	/**
 	 * Invokes the remaining `_save()` method call.
 	 *
 	 * @protected
@@ -213,22 +224,8 @@ export default class Autosave extends Plugin {
 	 * @private
 	 */
 	_save() {
-		const version = this.editor.model.document.version;
-
-		// Change may not produce an operation, so the document's version
-		// can be the same after that change.
-		if (
-			version < this._lastDocumentVersion ||
-			this.editor.state === 'initializing'
-		) {
-			this._debouncedSave.cancel();
-
-			return;
-		}
-
-		this._lastDocumentVersion = version;
-
 		this.state = 'saving';
+		this._lastDocumentVersion = this.editor.model.document.version;
 
 		// Wait one promise cycle to be sure that save callbacks are not called
 		// inside a conversion or when the editor's state changes.

--- a/packages/ckeditor5-autosave/tests/manual/autosave.js
+++ b/packages/ckeditor5-autosave/tests/manual/autosave.js
@@ -16,6 +16,14 @@ ClassicEditor
 		toolbar: [ 'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo' ],
 		image: {
 			toolbar: [ 'imageStyle:block', 'imageStyle:side', '|', 'imageTextAlternative' ]
+		},
+		autosave: {
+			save( editor ) {
+				const data = editor.getData();
+
+				return wait( 1000 )
+					.then( () => console.log( `${ getTime() } Saved content: ${ data }` ) );
+			}
 		}
 	} )
 	.then( editor => {
@@ -25,14 +33,6 @@ ClassicEditor
 		destroyButton.addEventListener( 'click', () => editor.destroy() );
 
 		const autosave = editor.plugins.get( Autosave );
-		autosave.adapter = {
-			save() {
-				const data = editor.getData();
-
-				return wait( 1000 )
-					.then( () => console.log( `${ getTime() } Saved content: ${ data }` ) );
-			}
-		};
 
 		autosave.listenTo( autosave, 'change:state',
 			( evt, propName, newValue, oldValue ) => console.log( `${ getTime() } Changed state: ${ oldValue } -> ${ newValue }` ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (autosave): Autosave callback should not be called while the editor is initialized. Closes #10214.

Feature (autosave): Introduced \`Autosave#save()\`. Closes #10215.