### PR TITLE
Introduce removing HTML comments at the document boundaries when the content is removed

### DIFF
--- a/packages/ckeditor5-html-support/src/htmlcomment.js
+++ b/packages/ckeditor5-html-support/src/htmlcomment.js
@@ -104,15 +104,15 @@ export default class HtmlComment extends Plugin {
 				const firstPosition = editor.model.createPositionAt( limitElement, 0 );
 				const lastPosition = editor.model.createPositionAt( limitElement, 'end' );
 
-				let affectedCommentMarkerIDs;
+				let affectedCommentIDs;
 
 				if ( firstPosition.isTouching( range.start ) && lastPosition.isTouching( range.end ) ) {
-					affectedCommentMarkerIDs = this.getHtmlCommentsInRange( editor.model.createRange( firstPosition, lastPosition ) );
+					affectedCommentIDs = this.getHtmlCommentsInRange( editor.model.createRange( firstPosition, lastPosition ) );
 				} else {
-					affectedCommentMarkerIDs = this.getHtmlCommentsInRange( range, { skipBoundary: true } );
+					affectedCommentIDs = this.getHtmlCommentsInRange( range, { skipBoundary: true } );
 				}
 
-				for ( const commentMarkerID of affectedCommentMarkerIDs ) {
+				for ( const commentMarkerID of affectedCommentIDs ) {
 					this.removeHtmlComment( commentMarkerID );
 				}
 			}

--- a/packages/ckeditor5-html-support/src/htmlcomment.js
+++ b/packages/ckeditor5-html-support/src/htmlcomment.js
@@ -208,8 +208,8 @@ export default class HtmlComment extends Plugin {
 	 * By default it includes comments at the range boundaries.
 	 *
 	 * @param {module:engine/model/range~Range} range
-	 * @param {Object} options
-	 * @param {Boolean} options.skipBoundaries When set to `true` the range boundaries will be skipped.
+	 * @param {Object} [options]
+	 * @param {Boolean} [options.skipBoundaries=false] When set to `true` the range boundaries will be skipped.
 	 * @returns {Array.<String>} HTML comment IDs
 	 */
 	getHtmlCommentsInRange( range, { skipBoundaries = false } = {} ) {

--- a/packages/ckeditor5-html-support/src/htmlcomment.js
+++ b/packages/ckeditor5-html-support/src/htmlcomment.js
@@ -109,7 +109,7 @@ export default class HtmlComment extends Plugin {
 				if ( firstPosition.isTouching( range.start ) && lastPosition.isTouching( range.end ) ) {
 					affectedCommentIDs = this.getHtmlCommentsInRange( editor.model.createRange( firstPosition, lastPosition ) );
 				} else {
-					affectedCommentIDs = this.getHtmlCommentsInRange( range, { skipBoundary: true } );
+					affectedCommentIDs = this.getHtmlCommentsInRange( range, { skipBoundaries: true } );
 				}
 
 				for ( const commentMarkerID of affectedCommentIDs ) {
@@ -203,15 +203,19 @@ export default class HtmlComment extends Plugin {
 	}
 
 	/**
-	 * Gets all HTML comments in the given range including the comments existing at the range boundaries.
+	 * Gets all HTML comments in the given range.
+	 *
+	 * By default it includes comments at the range boundaries.
 	 *
 	 * @param {module:engine/model/range~Range} range
+	 * @param {Object} options
+	 * @param {Boolean} options.skipBoundaries When set to `true` the range boundaries will be skipped.
 	 * @returns {Array.<String>} HTML comment IDs
 	 */
-	getHtmlCommentsInRange( range, { skipBoundary = false } = {} ) {
-		const includeBoundary = !skipBoundary;
+	getHtmlCommentsInRange( range, { skipBoundaries = false } = {} ) {
+		const includeBoundaries = !skipBoundaries;
 
-		// Unfortunately MarkerCollection#getMarkersAtPosition() filters out collapsed markers.
+		// Unfortunately, MarkerCollection#getMarkersAtPosition() filters out collapsed markers.
 		return Array.from( this.editor.model.markers.getMarkersGroup( '$comment' ) )
 			.filter( marker => isCommentMarkerInRange( marker, range ) )
 			.map( marker => marker.name );
@@ -220,8 +224,8 @@ export default class HtmlComment extends Plugin {
 			const position = commentMarker.getRange().start;
 
 			return (
-				( position.isAfter( range.start ) || ( includeBoundary && position.isEqual( range.start ) ) ) &&
-				( position.isBefore( range.end ) || ( includeBoundary && position.isEqual( range.end ) ) )
+				( position.isAfter( range.start ) || ( includeBoundaries && position.isEqual( range.start ) ) ) &&
+				( position.isBefore( range.end ) || ( includeBoundaries && position.isEqual( range.end ) ) )
 			);
 		}
 	}

--- a/packages/ckeditor5-html-support/tests/htmlcomment-integration.js
+++ b/packages/ckeditor5-html-support/tests/htmlcomment-integration.js
@@ -969,7 +969,8 @@ describe( 'HtmlComment integration', () => {
 
 			editor.execute( 'delete' );
 
-			// The following output will be also correct:
+			// The following output could be considered as the correct and expected one,
+			// but currently the comment 4 is not removed, because it is not located at the limit element's boundary:
 			// expect( editor.getData() ).to.equal(
 			// 	'<p>' +
 			// 		'<!-- comment 1 -->' +

--- a/packages/ckeditor5-html-support/tests/htmlcomment-integration.js
+++ b/packages/ckeditor5-html-support/tests/htmlcomment-integration.js
@@ -969,9 +969,7 @@ describe( 'HtmlComment integration', () => {
 
 			editor.execute( 'delete' );
 
-			// Currently, comments inside a deleted content are moved to adjacent paragraph.
-			// See https://github.com/ckeditor/ckeditor5/issues/10119.
-			//
+			// The following output will be also correct:
 			// expect( editor.getData() ).to.equal(
 			// 	'<p>' +
 			// 		'<!-- comment 1 -->' +
@@ -985,7 +983,6 @@ describe( 'HtmlComment integration', () => {
 					'<!-- comment 1 -->' +
 					'Foo' +
 					'<!-- comment 4 -->' +
-					'<!-- comment 3 -->' +
 					'<!-- comment 2 -->' +
 				'</p>'
 			);
@@ -1086,19 +1083,6 @@ describe( 'HtmlComment integration', () => {
 
 			toggleSourceEditingModeButton.fire( 'execute' );
 
-			// Currently, comments at root boundary are not removed after setData() is called with new content.
-			// See https://github.com/ckeditor/ckeditor5/issues/10117.
-			//
-			// expect( editor.getData() ).to.equal(
-			// 	'<!-- comment 1 -->' +
-			// 	'<p>' +
-			// 		'<!-- comment 2 -->' +
-			// 		'Foo' +
-			// 		'<!-- comment 3 -->' +
-			// 	'</p>' +
-			// 	'<!-- comment 4 -->'
-			// );
-
 			expect( editor.getData() ).to.equal(
 				'<!-- comment 1 -->' +
 				'<p>' +
@@ -1106,9 +1090,7 @@ describe( 'HtmlComment integration', () => {
 					'Foo' +
 					'<!-- comment 3 -->' +
 				'</p>' +
-				'<!-- comment 4 -->' +
-				'<!-- comment 2 -->' +
-				'<!-- comment 1 -->'
+				'<!-- comment 4 -->'
 			);
 		} );
 	} );

--- a/packages/ckeditor5-html-support/tests/htmlcomment.js
+++ b/packages/ckeditor5-html-support/tests/htmlcomment.js
@@ -218,7 +218,7 @@ describe( 'HtmlComment', () => {
 			expect( commentMarkers ).to.have.length( 0 );
 		} );
 
-		it( 'should remove replace all comments with new comments when the whole content is replaced with editor.setData()', () => {
+		it( 'should replace all comments with new comments when the whole content is replaced with editor.setData()', () => {
 			editor.setData(
 				'<!-- comment 1 -->' +
 				'<p>F<!-- comment 2 -->oo</p>' +

--- a/packages/ckeditor5-html-support/tests/htmlcomment.js
+++ b/packages/ckeditor5-html-support/tests/htmlcomment.js
@@ -461,33 +461,51 @@ describe( 'HtmlComment', () => {
 			editor.setData( '<p>Foo</p><p>Bar</p><p>Baz</p>' );
 
 			htmlCommentPlugin.createHtmlComment( model.createPositionFromPath( root, [ 1, 0 ] ), 'foo' );
-
 			htmlCommentPlugin.createHtmlComment( model.createPositionFromPath( root, [ 2 ] ), 'bar' );
 
 			const posStart = model.createPositionFromPath( root, [ 2, 1 ] );
 			const posEnd = model.createPositionFromPath( root, [ 2, 3 ] );
 
+			const range = new Range( posStart, posEnd );
+
+			// Comments at the range boundaries.
 			const id3 = htmlCommentPlugin.createHtmlComment( posStart, 'baz' );
 			const id4 = htmlCommentPlugin.createHtmlComment( posEnd, 'biz' );
 
+			expect( htmlCommentPlugin.getHtmlCommentsInRange( range ) ).to.deep.equal( [ id3, id4 ] );
+		} );
+
+		it( 'should not return comments at range boundaries when the skipBoundaries option is set to true', () => {
+			editor.setData( '<p>Foo</p><p>Bar</p><p>Baz</p>' );
+
+			htmlCommentPlugin.createHtmlComment( model.createPositionFromPath( root, [ 1, 0 ] ), 'foo' );
+			htmlCommentPlugin.createHtmlComment( model.createPositionFromPath( root, [ 2 ] ), 'bar' );
+
+			const posStart = model.createPositionFromPath( root, [ 2, 1 ] );
+			const posEnd = model.createPositionFromPath( root, [ 2, 3 ] );
+
 			const range = new Range( posStart, posEnd );
 
-			expect( htmlCommentPlugin.getHtmlCommentsInRange( range ) ).to.deep.equal( [ id3, id4 ] );
+			// Comments at the range boundaries.
+			htmlCommentPlugin.createHtmlComment( posStart, 'baz' );
+			htmlCommentPlugin.createHtmlComment( posEnd, 'biz' );
+
+			expect( htmlCommentPlugin.getHtmlCommentsInRange( range, { skipBoundaries: true } ) ).to.deep.equal( [] );
 		} );
 
 		it( 'should return all comment marker IDs present in the specified collapsed range', () => {
 			editor.setData( '<p>Foo</p><p>Bar</p><p>Baz</p>' );
 
 			htmlCommentPlugin.createHtmlComment( model.createPositionFromPath( root, [ 2, 0 ] ), 'foo' );
-
 			htmlCommentPlugin.createHtmlComment( model.createPositionFromPath( root, [ 2, 2 ] ), 'bar' );
 
 			const position = model.createPositionFromPath( root, [ 2, 1 ] );
 
+			const range = new Range( position, position );
+
+			// Two comments at the position of the collapsed range.
 			const id1 = htmlCommentPlugin.createHtmlComment( position, 'baz' );
 			const id2 = htmlCommentPlugin.createHtmlComment( position, 'biz' );
-
-			const range = new Range( position, position );
 
 			expect( htmlCommentPlugin.getHtmlCommentsInRange( range ) ).to.deep.equal( [ id1, id2 ] );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Introduced removing HTML comments at the document boundaries when the document content is removed with `editor.data.set()` or `model.removeContent()` . Closes #10117.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._