### PR TITLE
Added docs guide for HTML comment feature

### DIFF
--- a/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support-source.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support-source.js
@@ -1,0 +1,57 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals window */
+
+import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
+
+import ClassicEditor from '@ckeditor/ckeditor5-build-classic/src/ckeditor';
+import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices';
+import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
+import EasyImage from '@ckeditor/ckeditor5-easy-image/src/easyimage';
+import ImageUpload from '@ckeditor/ckeditor5-image/src/imageupload';
+import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
+
+import GeneralHtmlSupport from '@ckeditor/ckeditor5-html-support/src/generalhtmlsupport';
+import HtmlComment from '@ckeditor/ckeditor5-html-support/src/htmlcomment';
+
+ClassicEditor.builtinPlugins.push(
+	CloudServices,
+	Code,
+	EasyImage,
+	ImageUpload,
+	SourceEditing
+);
+
+ClassicEditor.defaultConfig = {
+	cloudServices: CS_CONFIG,
+	toolbar: {
+		items: [
+			'sourceEditing',
+			'|',
+			'heading',
+			'|',
+			'bold',
+			'italic',
+			'code',
+			'bulletedList',
+			'numberedList',
+			'|',
+			'blockQuote',
+			'link',
+			'uploadImage',
+			'mediaEmbed',
+			'insertTable',
+			'|',
+			'undo',
+			'redo'
+		],
+		viewportTopOffset: window.getViewportTopOffsetConfig()
+	}
+};
+
+window.ClassicEditor = ClassicEditor;
+window.GeneralHtmlSupport = GeneralHtmlSupport;
+window.HtmlComment = HtmlComment;

--- a/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support.js
@@ -3,56 +3,11 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals console, window, document */
-
-import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config.js';
-
-import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
-import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
-import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
-import EasyImage from '@ckeditor/ckeditor5-easy-image/src/easyimage';
-import ImageUpload from '@ckeditor/ckeditor5-image/src/imageupload';
-import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices';
-
-import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
-import GeneralHtmlSupport from '@ckeditor/ckeditor5-html-support/src/generalhtmlsupport';
+/* globals console, window, document, ClassicEditor, GeneralHtmlSupport */
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-general-html-support' ), {
-		plugins: [
-			ArticlePluginSet,
-			Code,
-			EasyImage,
-			ImageUpload,
-			CloudServices,
-			SourceEditing,
-			GeneralHtmlSupport
-		],
-		toolbar: {
-			items: [
-				'sourceEditing',
-				'|',
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'code',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'blockQuote',
-				'link',
-				'mediaEmbed',
-				'insertTable',
-				'|',
-				'undo',
-				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
-		},
+		extraPlugins: [ GeneralHtmlSupport ],
 		image: {
 			toolbar: [
 				'imageStyle:inline',
@@ -66,8 +21,6 @@ ClassicEditor
 		table: {
 			contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ]
 		},
-		cloudServices: CS_CONFIG,
-
 		htmlSupport: {
 			allow: [
 				// Enables <div>, <details>, and <summary> elements with all kind of attributes.

--- a/packages/ckeditor5-html-support/docs/_snippets/features/html-comment.html
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/html-comment.html
@@ -1,0 +1,11 @@
+<div id="snippet-html-comment">
+	<h2>The three greatest things you learn from traveling</h2>
+
+	<figure class="image"><img src="%BASE_PATH%/assets/img/volcano.jpg" alt="A lone wanderer looking at Mount Bromo volcano in Indonesia."></figure>
+
+	<p><!-- Like all the great things on Earth, traveling teaches us by example. Here are some of the most precious lessons I’ve learned over the years of traveling. --></p>
+
+	<h3>Appreciation of diversity</h3>
+
+	<p>Getting used to an entirely different culture can be challenging. While it’s also nice to learn about cultures online or from books, nothing comes close to experiencing the cultural diversity in person. You learn to appreciate each and every single one of the differences while you become more culturally fluid.</p>
+</div>

--- a/packages/ckeditor5-html-support/docs/_snippets/features/html-comment.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/html-comment.js
@@ -1,0 +1,37 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console, window, document, ClassicEditor, HtmlComment */
+
+ClassicEditor
+	.create( document.querySelector( '#snippet-html-comment' ), {
+		extraPlugins: [ HtmlComment ],
+		image: {
+			toolbar: [
+				'imageStyle:inline',
+				'imageStyle:wrapText',
+				'imageStyle:breakText',
+				'|',
+				'toggleImageCaption',
+				'imageTextAlternative'
+			]
+		},
+		table: {
+			contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ]
+		}
+	} )
+	.then( editor => {
+		window.editor2 = editor;
+
+		window.attachTourBalloon( {
+			target: window.findToolbarItem( editor.ui.view.toolbar,
+				item => item.label && item.label === 'Source' ),
+			text: 'Switch to the source mode to check out the source of the content and play with it.',
+			editor
+		} );
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-html-support/docs/api/html-comment.md
+++ b/packages/ckeditor5-html-support/docs/api/html-comment.md
@@ -1,5 +1,0 @@
----
-category: api-reference
----
-
-# CKEditor 5 HTML comment feature

--- a/packages/ckeditor5-html-support/docs/features/general-html-support.md
+++ b/packages/ckeditor5-html-support/docs/features/general-html-support.md
@@ -237,7 +237,7 @@ The above configuration will work similarly to [`allowedContent: true`](/docs/ck
 
 ## HTML comments
 
-By default, all HTML comments are filtered out during the editor initialization. The {@link module:html-support/htmlcomment~HtmlComment} feature allows developers to keep comments in the document content and retrieve them back, i.e. during {@link builds/guides/integration/saving-data saving editor data}. Comments are transparent from the user point of view and they are not displayed in the editable element.
+By default, all HTML comments are filtered out during the editor initialization. The {@link module:html-support/htmlcomment~HtmlComment} feature allows developers to keep them in the document content and retrieve them back, e.g. during {@link builds/guides/integration/saving-data saving the editor data}. Comments are transparent from the user point of view and they are not displayed in the editable element.
 
 Please note that the support for HTML comments is at the basic level so far - see the [known issues](#known-issues) section below.
 

--- a/packages/ckeditor5-html-support/docs/features/general-html-support.md
+++ b/packages/ckeditor5-html-support/docs/features/general-html-support.md
@@ -250,7 +250,7 @@ We're open for feedback, so if you find any issue, feel free to report it in the
 
 ## HTML comments
 
-By default, all HTML comments are filtered out during the editor initialization. The {@link module:html-support/htmlcomment~HtmlComment} feature allows developers to keep them in the document content and retrieve them back, e.g. during {@link builds/guides/integration/saving-data saving the editor data}. Comments are transparent from the user point of view and they are not displayed in the editable element.
+By default, all HTML comments are filtered out during the editor initialization. The {@link module:html-support/htmlcomment~HtmlComment} feature allows developers to keep them in the document content and retrieve them back, e.g. while {@link builds/guides/integration/saving-data saving the editor data}. The comments are transparent from the users point of view and they are not displayed in the editable content.
 
 <info-box>
 	The HTML comment feature is **experimental and not yet production-ready**.
@@ -260,7 +260,7 @@ By default, all HTML comments are filtered out during the editor initialization.
 
 ### Demo
 
-The CKEditor 5 instance below is configured to keep the HTML comments in the document content. You can view the source of the document using {@link features/source-editing source editing} feature. Toggle the source editing mode {@icon @ckeditor/ckeditor5-source-editing/theme/icons/source-editing.svg Source editing} to see that HTML comment is present in the document source. You can uncomment the paragraph that is below the picture and after leaving the source editing mode, you will see this paragraph in the editable area.
+The CKEditor 5 instance below is configured to keep the HTML comments in the document content. You can view the source of the document using {@link features/source-editing source editing} feature. Toggle the source editing mode {@icon @ckeditor/ckeditor5-source-editing/theme/icons/source-editing.svg Source editing} to see that the HTML comment is present in the document source. You can uncomment the paragraph below the picture and upon leaving the source editing mode, you will see this paragraph in the editable area.
 
 {@snippet features/html-comment}
 
@@ -293,9 +293,9 @@ HTML comment feature does not require any configuration.
 
 ### Known issues
 
-The main issue in HTML comment feature is that comments can be easily repositioned or lost in various cases [#10118](https://github.com/ckeditor/ckeditor5/issues/10118), [#10119](https://github.com/ckeditor/ckeditor5/issues/10119). Also copying and pasting (or dragging and dropping) elements containing HTML comments within the editor does not work as expected [#10127](https://github.com/ckeditor/ckeditor5/issues/10127).
+The main issue with the HTML comments feature is that comments can be easily repositioned or lost in various cases [#10118](https://github.com/ckeditor/ckeditor5/issues/10118), [#10119](https://github.com/ckeditor/ckeditor5/issues/10119). Also copying and pasting (or dragging and dropping) elements containing HTML comments within the editor does not work as expected [#10127](https://github.com/ckeditor/ckeditor5/issues/10127).
 
-We're open for feedback, so if you find any issue, feel free to report it in the [main CKEditor 5 repository](https://github.com/ckeditor/ckeditor5/issues/).
+We are open for feedback, so if you find any issue, feel free to report it in the [main CKEditor 5 repository](https://github.com/ckeditor/ckeditor5/issues/).
 
 ## Related features
 

--- a/packages/ckeditor5-html-support/docs/features/general-html-support.md
+++ b/packages/ckeditor5-html-support/docs/features/general-html-support.md
@@ -235,19 +235,32 @@ htmlSupport: {
 
 The above configuration will work similarly to [`allowedContent: true`](/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-allowedContent) option from CKEditor 4.
 
+## Known issues
+
+It is possible to add support for arbitrary styles, classes and other attributes to existing CKEditor 5 features (such as paragraphs, headings, list items, etc.).
+
+Most of the existing CKEditor 5 features can already be extended this way, however, some cannot yet. This includes:
+
+* Some of the table markup [#9914](https://github.com/ckeditor/ckeditor5/issues/9914).
+* Some of the image features' markup [#9916](https://github.com/ckeditor/ckeditor5/issues/9916).
+* Some of the media embed features' markup [#9918](https://github.com/ckeditor/ckeditor5/issues/9918).
+* The `<ul>` and `<ol>` elements of the list feature [#9917](https://github.com/ckeditor/ckeditor5/issues/9917).
+
+We're open for feedback, so if you find any issue, feel free to report it in the [main CKEditor 5 repository](https://github.com/ckeditor/ckeditor5/issues/).
+
 ## HTML comments
 
 By default, all HTML comments are filtered out during the editor initialization. The {@link module:html-support/htmlcomment~HtmlComment} feature allows developers to keep them in the document content and retrieve them back, e.g. during {@link builds/guides/integration/saving-data saving the editor data}. Comments are transparent from the user point of view and they are not displayed in the editable element.
 
-Please note that the support for HTML comments is at the basic level so far - see the [known issues](#known-issues) section below.
-
 <info-box>
 	The HTML comment feature is **experimental and not yet production-ready**.
+
+	The support for HTML comments is at the basic level so far - see the [known issues](#known-issues-2) section below.
 </info-box>
 
 ### Demo
 
-The CKEditor 5 instance below is configured to keep the HTML comments in the document content. You can view the source of the document using {@link features/source-editing source editing} feature. Toggle the source editing mode {@icon @ckeditor/ckeditor5-source-editing/theme/icons/source-editing.svg Source editing} to see that HTML comments are present in the document source. You can uncomment the paragraph that is below the picture and after leaving the source editing mode, you will see this paragraph in the editable area.
+The CKEditor 5 instance below is configured to keep the HTML comments in the document content. You can view the source of the document using {@link features/source-editing source editing} feature. Toggle the source editing mode {@icon @ckeditor/ckeditor5-source-editing/theme/icons/source-editing.svg Source editing} to see that HTML comment is present in the document source. You can uncomment the paragraph that is below the picture and after leaving the source editing mode, you will see this paragraph in the editable area.
 
 {@snippet features/html-comment}
 
@@ -278,18 +291,9 @@ ClassicEditor
 
 HTML comment feature does not require any configuration.
 
-## Known issues
+### Known issues
 
-It is possible to add support for arbitrary styles, classes and other attributes to existing CKEditor 5 features (such as paragraphs, headings, list items, etc.).
-
-Most of the existing CKEditor 5 features can already be extended this way, however, some cannot yet. This includes:
-
-* Some of the table markup [#9914](https://github.com/ckeditor/ckeditor5/issues/9914).
-* Some of the image features' markup [#9916](https://github.com/ckeditor/ckeditor5/issues/9916).
-* Some of the media embed features' markup [#9918](https://github.com/ckeditor/ckeditor5/issues/9918).
-* The `<ul>` and `<ol>` elements of the list feature [#9917](https://github.com/ckeditor/ckeditor5/issues/9917).
-
-The main issue in HTML comment feature is that comments can be easily repositioned or lost in various cases [#10118](https://github.com/ckeditor/ckeditor5/issues/10118), [#10119](https://github.com/ckeditor/ckeditor5/issues/10119).
+The main issue in HTML comment feature is that comments can be easily repositioned or lost in various cases [#10118](https://github.com/ckeditor/ckeditor5/issues/10118), [#10119](https://github.com/ckeditor/ckeditor5/issues/10119). Also copying and pasting (or dragging and dropping) elements containing HTML comments within the editor does not work as expected [#10127](https://github.com/ckeditor/ckeditor5/issues/10127).
 
 We're open for feedback, so if you find any issue, feel free to report it in the [main CKEditor 5 repository](https://github.com/ckeditor/ckeditor5/issues/).
 

--- a/packages/ckeditor5-html-support/docs/features/general-html-support.md
+++ b/packages/ckeditor5-html-support/docs/features/general-html-support.md
@@ -75,6 +75,8 @@ ClassicEditor
 	.catch( ... );
 ```
 
+{@snippet features/general-html-support-source}
+
 {@snippet features/general-html-support}
 
 ## Level of support
@@ -233,6 +235,49 @@ htmlSupport: {
 
 The above configuration will work similarly to [`allowedContent: true`](/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-allowedContent) option from CKEditor 4.
 
+## HTML comments
+
+By default, all HTML comments are filtered out during the editor initialization. The {@link module:html-support/htmlcomment~HtmlComment} feature allows developers to keep comments in the document content and retrieve them back, i.e. during {@link builds/guides/integration/saving-data saving editor data}. Comments are transparent from the user point of view and they are not displayed in the editable element.
+
+Please note that the support for HTML comments is at the basic level so far - see the [known issues](#known-issues) section below.
+
+<info-box>
+	The HTML comment feature is **experimental and not yet production-ready**.
+</info-box>
+
+### Demo
+
+The CKEditor 5 instance below is configured to keep the HTML comments in the document content. You can view the source of the document using {@link features/source-editing source editing} feature. Toggle the source editing mode {@icon @ckeditor/ckeditor5-source-editing/theme/icons/source-editing.svg Source editing} to see that HTML comments are present in the document source. You can uncomment the paragraph that is below the picture and after leaving the source editing mode, you will see this paragraph in the editable area.
+
+{@snippet features/html-comment}
+
+### Installation
+
+To add this feature to your rich-text editor, install the [`@ckeditor/ckeditor5-html-support`](https://www.npmjs.com/package/@ckeditor/ckeditor5-html-support) package:
+
+```plaintext
+npm install --save @ckeditor/ckeditor5-html-support
+```
+
+Then add it to the editor configuration:
+
+```js
+import HtmlComment from '@ckeditor/ckeditor5-html-support/src/htmlcomment';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ HtmlComment, ... ],
+	} )
+	.then( ... )
+	.catch( ... );
+```
+
+<info-box info>
+	Read more about {@link builds/guides/integration/installing-plugins installing plugins}.
+</info-box>
+
+HTML comment feature does not require any configuration.
+
 ## Known issues
 
 It is possible to add support for arbitrary styles, classes and other attributes to existing CKEditor 5 features (such as paragraphs, headings, list items, etc.).
@@ -243,6 +288,8 @@ Most of the existing CKEditor 5 features can already be extended this way, howev
 * Some of the image features' markup [#9916](https://github.com/ckeditor/ckeditor5/issues/9916).
 * Some of the media embed features' markup [#9918](https://github.com/ckeditor/ckeditor5/issues/9918).
 * The `<ul>` and `<ol>` elements of the list feature [#9917](https://github.com/ckeditor/ckeditor5/issues/9917).
+
+The main issue in HTML comment feature is that comments can be easily repositioned or lost in various cases [#10118](https://github.com/ckeditor/ckeditor5/issues/10118), [#10119](https://github.com/ckeditor/ckeditor5/issues/10119).
 
 We're open for feedback, so if you find any issue, feel free to report it in the [main CKEditor 5 repository](https://github.com/ckeditor/ckeditor5/issues/).
 

--- a/packages/ckeditor5-html-support/docs/features/html-comment.md
+++ b/packages/ckeditor5-html-support/docs/features/html-comment.md
@@ -1,7 +1,0 @@
----
-category: features
-menu-title: HTML comments
-modified_at: 2021-07-14
----
-
-# HTML comments

--- a/packages/ckeditor5-html-support/src/htmlcomment.js
+++ b/packages/ckeditor5-html-support/src/htmlcomment.js
@@ -11,7 +11,7 @@ import { Plugin } from 'ckeditor5/src/core';
 import { uid } from 'ckeditor5/src/utils';
 
 /**
- * The HTML comment feature.
+ * The HTML comment feature. It preserves HTML comments (<!-- -->) in the editor data.
  *
  * For a detailed overview, check the {@glink features/general-html-support#html-comments HTML comment feature documentation}.
  *

--- a/packages/ckeditor5-html-support/src/htmlcomment.js
+++ b/packages/ckeditor5-html-support/src/htmlcomment.js
@@ -13,7 +13,7 @@ import { uid } from 'ckeditor5/src/utils';
 /**
  * The HTML comment feature.
  *
- * For a detailed overview, check the {@glink features/html-comment HTML comment feature documentation}.
+ * For a detailed overview, check the {@glink features/general-html-support#html-comments HTML comment feature documentation}.
  *
  * @extends module:core/plugin~Plugin
  */

--- a/packages/ckeditor5-html-support/src/htmlcomment.js
+++ b/packages/ckeditor5-html-support/src/htmlcomment.js
@@ -11,7 +11,7 @@ import { Plugin } from 'ckeditor5/src/core';
 import { uid } from 'ckeditor5/src/utils';
 
 /**
- * The HTML comment feature. It preserves HTML comments (<!-- -->) in the editor data.
+ * The HTML comment feature. It preserves HTML comments (`<!-- -->`) in the editor data.
  *
  * For a detailed overview, check the {@glink features/general-html-support#html-comments HTML comment feature documentation}.
  *

--- a/packages/ckeditor5-html-support/src/htmlcomment.js
+++ b/packages/ckeditor5-html-support/src/htmlcomment.js
@@ -11,7 +11,7 @@ import { Plugin } from 'ckeditor5/src/core';
 import { uid } from 'ckeditor5/src/utils';
 
 /**
- * The HTML comment feature. It preserves HTML comments (`<!-- -->`) in the editor data.
+ * The HTML comment feature. It preserves the HTML comments (`<!-- -->`) in the editor data.
  *
  * For a detailed overview, check the {@glink features/general-html-support#html-comments HTML comment feature documentation}.
  *


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (html-support): Added docs guide for HTML comment feature. Closes #10159.
