### PR TITLE
Undeprecate the elementToMarker upcast helper and improve API docs

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
@@ -273,8 +273,11 @@ export default class DowncastHelpers extends ConversionHelpers {
 	 * Model marker to view element conversion helper.
 	 *
 	 * **Note**: This method should be used mainly for editing downcast.
-	 * In case of the data downcast, this helper may produce an invalid HTML (e.g. a span between table cells) so the
-	 * {@link #markerToData `#markerToData()`} is the preferable way of downcasting markers.
+	 * In case of the data downcast, this helper may produce an invalid HTML (e.g. a span between table cells).
+	 * So it should be used either when the view elements can be placed everywhere between other tags
+	 * (like HTML comments) or when it is known that the view elements will be always placed in semantically correct places
+	 * (which can be achieved e.g. by post-fixers).
+	 * Thus, the {@link #markerToData `#markerToData()`} helper is preferred for downcasting markers.
 	 *
 	 * This conversion results in creating a view element on the boundaries of the converted marker. If the converted marker
 	 * is collapsed, only one element is created. For example, model marker set like this: `<paragraph>F[oo b]ar</paragraph>`

--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
@@ -272,8 +272,9 @@ export default class DowncastHelpers extends ConversionHelpers {
 	/**
 	 * Model marker to view element conversion helper.
 	 *
-	 * **Note**: This method should be used only for editing downcast. For data downcast, use
-	 * {@link #markerToData `#markerToData()`} that produces valid HTML data.
+	 * **Note**: This method should be used mainly for editing downcast.
+	 * In case of the data downcast, this helper may produce an invalid HTML (e.g. a span between table cells) so the
+	 * {@link #markerToData `#markerToData()`} is the preferable way of downcasting markers.
 	 *
 	 * This conversion results in creating a view element on the boundaries of the converted marker. If the converted marker
 	 * is collapsed, only one element is created. For example, model marker set like this: `<paragraph>F[oo b]ar</paragraph>`

--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
@@ -272,12 +272,11 @@ export default class DowncastHelpers extends ConversionHelpers {
 	/**
 	 * Model marker to view element conversion helper.
 	 *
-	 * **Note**: This method should be used mainly for editing downcast.
-	 * In case of the data downcast, this helper may produce an invalid HTML (e.g. a span between table cells).
-	 * So it should be used either when the view elements can be placed everywhere between other tags
-	 * (like HTML comments) or when it is known that the view elements will be always placed in semantically correct places
-	 * (which can be achieved e.g. by post-fixers).
-	 * Thus, the {@link #markerToData `#markerToData()`} helper is preferred for downcasting markers.
+	 * **Note**: This method should be used mainly for editing downcast and it is recommended
+	 * to use {@link #markerToData `#markerToData()`} helper instead.
+	 *
+	 * This helper may produce invalid HTML code (e.g. a span between table cells).
+	 * It should be used only when you are sure that the produced HTML will be semantically correct.
 	 *
 	 * This conversion results in creating a view element on the boundaries of the converted marker. If the converted marker
 	 * is collapsed, only one element is created. For example, model marker set like this: `<paragraph>F[oo b]ar</paragraph>`

--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
@@ -300,7 +300,8 @@ export default class UpcastHelpers extends ConversionHelpers {
 	 *
 	 * **Note**: When this helper is used in the data upcast in combination with
 	 * {@link module:engine/conversion/downcasthelpers~DowncastHelpers#markerToData `#markerToData()`} in the data downcast,
-	 * then an invalid HTML (e.g. a span between table cells) may be produced by the latter.
+	 * then an invalid HTML (e.g. a span between table cells) may be produced by the latter converter.
+	 *
 	 * In most of the cases, the {@link #dataToMarker} should be used instead.
 	 *
 	 *		editor.conversion.for( 'upcast' ).elementToMarker( {

--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
@@ -299,7 +299,7 @@ export default class UpcastHelpers extends ConversionHelpers {
 	 * {@link module:engine/model/model~Model#markers model document markers}.
 	 *
 	 * **Note**: When this helper is used in the data upcast in combination with
-	 * {@link module:engine/conversion/conversionhelpers~ConversionHelpers~dataToMarker} in the data downcast,
+	 * {@link module:engine/conversion/downcasthelpers~DowncastHelpers#markerToData `#markerToData()`} in the data downcast,
 	 * then an invalid HTML (e.g. a span between table cells) may be produced by the latter.
 	 * In most of the cases, the {@link #dataToMarker} should be used instead.
 	 *

--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
@@ -7,7 +7,6 @@ import Matcher from '../view/matcher';
 import ConversionHelpers from './conversionhelpers';
 
 import { cloneDeep } from 'lodash-es';
-import { logWarning } from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 import priorities from '@ckeditor/ckeditor5-utils/src/priorities';
 import { isParagraphable, wrapInParagraph } from '../model/utils/autoparagraphing';
@@ -294,8 +293,6 @@ export default class UpcastHelpers extends ConversionHelpers {
 	/**
 	 * View element to model marker conversion helper.
 	 *
-	 * **Note**: This method was deprecated. Please use {@link #dataToMarker} instead.
-	 *
 	 * This conversion results in creating a model marker. For example, if the marker was stored in a view as an element:
 	 * `<p>Fo<span data-marker="comment" data-comment-id="7"></span>o</p><p>B<span data-marker="comment" data-comment-id="7"></span>ar</p>`,
 	 * after the conversion is done, the marker will be available in
@@ -330,7 +327,6 @@ export default class UpcastHelpers extends ConversionHelpers {
 	 * See {@link module:engine/conversion/conversion~Conversion#for `conversion.for()`} to learn how to add a converter
 	 * to the conversion process.
 	 *
-	 * @deprecated
 	 * @method #elementToMarker
 	 * @param {Object} config Conversion configuration.
 	 * @param {module:engine/view/matcher~MatcherPattern} config.view Pattern matching all view elements which should be converted.
@@ -340,15 +336,6 @@ export default class UpcastHelpers extends ConversionHelpers {
 	 * @returns {module:engine/conversion/upcasthelpers~UpcastHelpers}
 	 */
 	elementToMarker( config ) {
-		/**
-		 * The {@link module:engine/conversion/upcasthelpers~UpcastHelpers#elementToMarker `UpcastHelpers#elementToMarker()`}
-		 * method was deprecated and will be removed in the near future.
-		 * Please use {@link module:engine/conversion/upcasthelpers~UpcastHelpers#dataToMarker `UpcastHelpers#dataToMarker()`} instead.
-		 *
-		 * @error upcast-helpers-element-to-marker-deprecated
-		 */
-		logWarning( 'upcast-helpers-element-to-marker-deprecated' );
-
 		return this.add( upcastElementToMarker( config ) );
 	}
 

--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
@@ -298,6 +298,11 @@ export default class UpcastHelpers extends ConversionHelpers {
 	 * after the conversion is done, the marker will be available in
 	 * {@link module:engine/model/model~Model#markers model document markers}.
 	 *
+	 * **Note**: When this helper is used in the data upcast in combination with
+	 * {@link module:engine/conversion/conversionhelpers~ConversionHelpers~dataToMarker} in the data downcast,
+	 * then an invalid HTML (e.g. a span between table cells) may be produced by the latter.
+	 * In most of the cases, the {@link #dataToMarker} should be used instead.
+	 *
 	 *		editor.conversion.for( 'upcast' ).elementToMarker( {
 	 *			view: 'marker-search',
 	 *			model: 'search'

--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
@@ -300,7 +300,7 @@ export default class UpcastHelpers extends ConversionHelpers {
 	 *
 	 * **Note**: When this helper is used in the data upcast in combination with
 	 * {@link module:engine/conversion/downcasthelpers~DowncastHelpers#markerToData `#markerToData()`} in the data downcast,
-	 * then an invalid HTML (e.g. a span between table cells) may be produced by the latter converter.
+	 * then invalid HTML code (e.g. a span between table cells) may be produced by the latter converter.
 	 *
 	 * In most of the cases, the {@link #dataToMarker} should be used instead.
 	 *

--- a/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
@@ -33,8 +33,6 @@ import Writer from '../../src/model/writer';
 
 import toArray from '@ckeditor/ckeditor5-utils/src/toarray';
 
-/* globals console */
-
 describe( 'UpcastHelpers', () => {
 	let upcastDispatcher, model, schema, upcastHelpers, viewDocument;
 
@@ -751,16 +749,6 @@ describe( 'UpcastHelpers', () => {
 	} );
 
 	describe( 'elementToMarker()', () => {
-		beforeEach( () => {
-			// Silence warning about deprecated method.
-			// This whole suite will be removed when the deprecated method is removed.
-			sinon.stub( console, 'warn' );
-		} );
-
-		afterEach( () => {
-			console.warn.restore();
-		} );
-
 		it( 'should be chainable', () => {
 			expect( upcastHelpers.elementToMarker( { view: 'marker-search', model: 'search' } ) ).to.equal( upcastHelpers );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Undeprecated the `elementToMarker` upcast helper. Improved API docs for `elementToMarker` and `markerToElement` helpers. Closes #10128.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._