### PR TITLE
Linked block image should not trigger linkHref attributeToElement conversion

### DIFF
--- a/packages/ckeditor5-link/src/linkimageediting.js
+++ b/packages/ckeditor5-link/src/linkimageediting.js
@@ -182,6 +182,10 @@ function downcastImageLink( editor ) {
 
 	return dispatcher => {
 		dispatcher.on( 'attribute:linkHref:imageBlock', ( evt, data, conversionApi ) => {
+			if ( !conversionApi.consumable.consume( data.item, evt.name ) ) {
+				return;
+			}
+
 			// The image will be already converted - so it will be present in the view.
 			const viewFigure = conversionApi.mapper.toViewElement( data.item );
 			const writer = conversionApi.writer;
@@ -211,7 +215,7 @@ function downcastImageLink( editor ) {
 				// 3. Move the image to the link.
 				writer.move( writer.createRangeOn( viewImgOrPicture ), writer.createPositionAt( linkElement, 0 ) );
 			}
-		} );
+		}, { priority: 'high' } );
 	};
 }
 

--- a/packages/ckeditor5-link/tests/linkimageediting.js
+++ b/packages/ckeditor5-link/tests/linkimageediting.js
@@ -12,12 +12,15 @@ import ImageCaptionEditing from '@ckeditor/ckeditor5-image/src/imagecaption/imag
 import ImageBlockEditing from '@ckeditor/ckeditor5-image/src/image/imageblockediting';
 import ImageInlineEditing from '@ckeditor/ckeditor5-image/src/image/imageinlineediting';
 import PictureEditing from '@ckeditor/ckeditor5-image/src/pictureediting';
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 import LinkImageEditing from '../src/linkimageediting';
 import LinkEditing from '../src/linkediting';
 
 describe( 'LinkImageEditing', () => {
 	let editor, model, view;
+
+	testUtils.createSinonSandbox();
 
 	beforeEach( () => {
 		return VirtualTestEditor
@@ -108,6 +111,23 @@ describe( 'LinkImageEditing', () => {
 						'</a>' +
 					'</figure>'
 				);
+			} );
+
+			it( 'should be overridable', () => {
+				const spy = sinon.spy();
+
+				editor.data.downcastDispatcher.on( 'attribute:linkHref:imageBlock', ( evt, data, { consumable } ) => {
+					consumable.consume( data.item, evt.name );
+
+					spy();
+				}, { priority: 'highest' } );
+
+				setModelData( model, '<imageBlock src="/assets/sample.png" alt="alt text" linkHref="http://ckeditor.com"></imageBlock>' );
+
+				expect( editor.getData() ).to.equal(
+					'<figure class="image"><img alt="alt text" src="/assets/sample.png"></figure>'
+				);
+				expect( spy.calledOnce ).to.be.true;
 			} );
 
 			it( 'should convert a link containing an inline image as a single anchor element in data', async () => {
@@ -433,6 +453,25 @@ describe( 'LinkImageEditing', () => {
 						'<img alt="alt text" src="/assets/sample.png"></img>' +
 					'</figure>'
 				);
+			} );
+
+			it( 'should be overridable', () => {
+				const spy = sinon.spy();
+
+				editor.editing.downcastDispatcher.on( 'attribute:linkHref:imageBlock', ( evt, data, { consumable } ) => {
+					consumable.consume( data.item, evt.name );
+
+					spy();
+				}, { priority: 'highest' } );
+
+				setModelData( model, '<imageBlock linkHref="http://ckeditor.com" src="/assets/sample.png" alt="alt text"></imageBlock>' );
+
+				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
+					'<figure class="ck-widget image" contenteditable="false">' +
+						'<img alt="alt text" src="/assets/sample.png"></img>' +
+					'</figure>'
+				);
+				expect( spy.calledOnce ).to.be.true;
 			} );
 
 			it( 'should link a text including an inline image as a single anchor element', async () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (link): Linked block image should not trigger `linkHref` `attributeToElement` conversion. Closes #10231.

---

### Additional information