### PR TITLE
jsdoc: Engine>Model>Selection: optional arg in constructor

### DIFF
--- a/packages/ckeditor5-engine/src/model/selection.js
+++ b/packages/ckeditor5-engine/src/model/selection.js
@@ -71,7 +71,7 @@ export default class Selection {
 	 *		// Creates backward selection.
 	 *		const selection = writer.createSelection( range, { backward: true } );
 	 *
-	 * @param {module:engine/model/selection~Selectable} selectable
+	 * @param {module:engine/model/selection~Selectable} [selectable]
 	 * @param {Number|'before'|'end'|'after'|'on'|'in'} [placeOrOffset] Sets place or offset of the selection.
 	 * @param {Object} [options]
 	 * @param {Boolean} [options.backward] Sets this selection instance to be backward.


### PR DESCRIPTION
Given that `selectable` existence is checked at the end of the constructor, the argument is optional