### PR TITLE
Added HtmlComment plugin to package metadata

### DIFF
--- a/docs/builds/guides/integration/features-html-output-overview.md
+++ b/docs/builds/guides/integration/features-html-output-overview.md
@@ -983,7 +983,7 @@ The data used to generate the following tables comes from the package metadata. 
 			</td>
 			<td class="html-output">
 				<p>
-					None.
+					The plugin can output the HTML comments that exist in the editor data.
 				</p>
 			</td>
 		</tr>

--- a/docs/builds/guides/integration/features-html-output-overview.md
+++ b/docs/builds/guides/integration/features-html-output-overview.md
@@ -972,6 +972,21 @@ The data used to generate the following tables comes from the package metadata. 
 				</p>
 			</td>
 		</tr>
+		<tr>
+			<td class="plugin">
+				<p>
+					<a href="../../../features/general-html-support.html#html-comments">HTML comment</a>
+				</p>
+				<p>
+					<a href="../../../api/module_html-support_htmlcomment-HtmlComment.html"><code>HtmlComment</code></a>
+				</p>
+			</td>
+			<td class="html-output">
+				<p>
+					None.
+				</p>
+			</td>
+		</tr>
 	</tbody>
 </table>
 <h3 id="ckeditor5-image"><code>ckeditor5-image</code></h3>

--- a/packages/ckeditor5-html-support/ckeditor5-metadata.json
+++ b/packages/ckeditor5-html-support/ckeditor5-metadata.json
@@ -45,7 +45,7 @@
 			"path": "src/htmlcomment.js",
 			"htmlOutput": [
 				{
-					"_comment": "The plugin can output the HTML comments that exist in the editor data."
+					"_comment": "The plugin can output HTML comments that were added from the editor inital data or by the plugin API."
 				}
 			]
 		}

--- a/packages/ckeditor5-html-support/ckeditor5-metadata.json
+++ b/packages/ckeditor5-html-support/ckeditor5-metadata.json
@@ -40,7 +40,7 @@
 		{
 			"name": "HTML comment",
 			"className": "HtmlComment",
-			"description": "Preserves HTML comments in the editor data.",
+			"description": "Preserves the HTML comments in the editor data.",
 			"docs": "features/general-html-support.html#html-comments",
 			"path": "src/htmlcomment.js"
 		}

--- a/packages/ckeditor5-html-support/ckeditor5-metadata.json
+++ b/packages/ckeditor5-html-support/ckeditor5-metadata.json
@@ -42,7 +42,12 @@
 			"className": "HtmlComment",
 			"description": "Preserves the HTML comments in the editor data.",
 			"docs": "features/general-html-support.html#html-comments",
-			"path": "src/htmlcomment.js"
+			"path": "src/htmlcomment.js",
+			"htmlOutput": [
+				{
+					"_comment": "The plugin can output the HTML comments that exist in the editor data."
+				}
+			]
 		}
 	]
 }

--- a/packages/ckeditor5-html-support/ckeditor5-metadata.json
+++ b/packages/ckeditor5-html-support/ckeditor5-metadata.json
@@ -36,6 +36,13 @@
 			"className": "DataSchema",
 			"description": "Holds representation of the extended HTML document type definitions. Part of General HTML Support feature.",
 			"path": "src/dataschema.js"
+		},
+		{
+			"name": "HTML comment",
+			"className": "HtmlComment",
+			"description": "Preserves HTML comments in the editor data.",
+			"docs": "features/general-html-support.html#html-comments",
+			"path": "src/htmlcomment.js"
 		}
 	]
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (html-support): Added `HtmlComment` plugin to package metadata. Closes #10234.
