### PR TITLE
Fixed integration tests in HtmlComment plugin

### DIFF
--- a/packages/ckeditor5-html-support/tests/htmlcomment-integration.js
+++ b/packages/ckeditor5-html-support/tests/htmlcomment-integration.js
@@ -569,7 +569,7 @@ describe( 'HtmlComment integration', () => {
 				'<p>' +
 					'<!-- c1 -->' +
 					'<a href="path/to/resource">' +
-						'Link with inline image:' +
+						'Link with inline image: ' +
 						'<!-- c2 -->' +
 						'<img src="/assets/sample.png" alt="Example image">' +
 					'</a>' +
@@ -595,7 +595,7 @@ describe( 'HtmlComment integration', () => {
 				'<p>' +
 					'<!-- c1 -->' +
 					'<a target="_blank" rel="noopener noreferrer" href="http://example.com">' +
-						'External link with inline image:' +
+						'External link with inline image: ' +
 						'<!-- c2 -->' +
 						'<img src="/assets/sample.png" alt="Example image">' +
 					'</a>' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (html-support): Fixed integration tests in HtmlComment plugin.

---

### Additional information

Changes in whitespace handling caused that 2 integration tests started failing.
