### PR TITLE
Warn user if Source Editing is loaded together with Restricted Editing

### DIFF
--- a/packages/ckeditor5-source-editing/docs/features/source-editing.md
+++ b/packages/ckeditor5-source-editing/docs/features/source-editing.md
@@ -11,7 +11,7 @@ The {@link module:source-editing/sourceediting~SourceEditing} feature provides t
 The changes made to the document source will be applied to the editor's {@link framework/guides/architecture/editing-engine data model} only, if the editor understands (via loaded plugins) the given syntax. You will lose all changes that the editor features cannot understand. For example, if the editor does not have a {@link features/horizontal-line horizontal line} plugin loaded, the `<hr>` tag added in the document source will be removed upon exit from the source editing mode.
 
 <info-box>
-	Currently, the source editing mode is supported in the {@link examples/builds/classic-editor classic editor}. The source editing feature is not compatible with [CKEditor 5 collaboration features](https://ckeditor.com/docs/ckeditor5/latest/features/collaboration/collaboration.html). If you would like to use collaboration features, but for some reason you would like to also enable source editing, please [contact us](https://ckeditor.com/contact/).
+	Currently, the source editing mode is supported in the {@link examples/builds/classic-editor classic editor}. The source editing feature is not compatible with [collaboration features](https://ckeditor.com/docs/ckeditor5/latest/features/collaboration/collaboration.html) and [restricted editing](https://ckeditor.com/docs/ckeditor5/latest/features/restricted-editing.html). If you would like to use either of those features, but for some reason you would like to also enable source editing, please [contact us](https://ckeditor.com/contact/).
 </info-box>
 
 ## Demo

--- a/packages/ckeditor5-source-editing/docs/features/source-editing.md
+++ b/packages/ckeditor5-source-editing/docs/features/source-editing.md
@@ -11,7 +11,7 @@ The {@link module:source-editing/sourceediting~SourceEditing} feature provides t
 The changes made to the document source will be applied to the editor's {@link framework/guides/architecture/editing-engine data model} only, if the editor understands (via loaded plugins) the given syntax. You will lose all changes that the editor features cannot understand. For example, if the editor does not have a {@link features/horizontal-line horizontal line} plugin loaded, the `<hr>` tag added in the document source will be removed upon exit from the source editing mode.
 
 <info-box>
-	Currently, the source editing mode is supported in the {@link examples/builds/classic-editor classic editor}. The source editing feature is not compatible with [collaboration features](https://ckeditor.com/docs/ckeditor5/latest/features/collaboration/collaboration.html) and [restricted editing](https://ckeditor.com/docs/ckeditor5/latest/features/restricted-editing.html). If you would like to use either of those features, but for some reason you would like to also enable source editing, please [contact us](https://ckeditor.com/contact/).
+	Currently, the source editing mode is supported in the {@link examples/builds/classic-editor classic editor}. The source editing feature is not compatible with {@link features/collaboration collaboration features} and {@link features/restricted-editing restricted editing}. If you would like to use either of those features, but for some reason you would like to also enable source editing, please [contact us](https://ckeditor.com/contact/).
 </info-box>
 
 ## Demo

--- a/packages/ckeditor5-source-editing/src/sourceediting.js
+++ b/packages/ckeditor5-source-editing/src/sourceediting.js
@@ -162,7 +162,7 @@ export default class SourceEditing extends Plugin {
 	afterInit() {
 		const editor = this.editor;
 
-		const pluginNamesToWarn = [
+		const collaborationPluginNamesToWarn = [
 			'RealTimeCollaborativeEditing',
 			'CommentsEditing',
 			'TrackChangesEditing',
@@ -170,11 +170,20 @@ export default class SourceEditing extends Plugin {
 		];
 
 		// Currently, the basic integration with Collaboration Features is to display a warning in the console.
-		if ( pluginNamesToWarn.some( pluginName => editor.plugins.has( pluginName ) ) ) {
+		if ( collaborationPluginNamesToWarn.some( pluginName => editor.plugins.has( pluginName ) ) ) {
 			console.warn(
 				'You initialized the editor with the source editing feature and at least one of the collaboration features. ' +
 				'Please be advised that the source editing feature may not work, and be careful when editing document source ' +
 				'that contains markers created by the collaboration features.'
+			);
+		}
+
+		// Restricted Editing integration can also lead to problems. Warn the user accordingly.
+		if ( editor.plugins.has( 'RestrictedEditingModeEditing' ) ) {
+			console.warn(
+				'You initialized the editor with the source editing feature and restricted editing feature. ' +
+				'Please be advised that the source editing feature may not work, and be careful when editing document source ' +
+				'that contains markers created by the restricted editing feature.'
 			);
 		}
 	}

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -164,6 +164,34 @@ describe( 'SourceEditing', () => {
 
 			await editor.destroy();
 		} );
+
+		it( 'should display a warning in the console if restricted editing plugin is loaded', async () => {
+			sinon.stub( console, 'warn' );
+
+			class RestrictedEditingModeEditing extends Plugin {
+				static get pluginName() {
+					return 'RestrictedEditingModeEditing';
+				}
+			}
+
+			const editorElement = document.body.appendChild( document.createElement( 'div' ) );
+
+			const editor = await ClassicTestEditor.create( editorElement, {
+				plugins: [ SourceEditing, Paragraph, Essentials, RestrictedEditingModeEditing ],
+				initialData: '<p>Foo</p>'
+			} );
+
+			expect( console.warn.calledOnce ).to.be.true;
+			expect( console.warn.firstCall.args[ 0 ] ).to.equal(
+				'You initialized the editor with the source editing feature and restricted editing feature. ' +
+				'Please be advised that the source editing feature may not work, and be careful when editing document source ' +
+				'that contains markers created by the restricted editing feature.'
+			);
+
+			editorElement.remove();
+
+			await editor.destroy();
+		} );
 	} );
 
 	describe( 'default listener', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (source-editing): Source Editing plugin will send a warning to the console when Restricted Editing is loaded. Closes #10228.
