### PR TITLE
Filtered out all pasted HTML comments

### DIFF
--- a/packages/ckeditor5-clipboard/src/utils/normalizeclipboarddata.js
+++ b/packages/ckeditor5-clipboard/src/utils/normalizeclipboarddata.js
@@ -9,6 +9,7 @@
 
 /**
  * Removes some popular browser quirks out of the clipboard data (HTML).
+ * Removes all HTML comments. Comments are considered as an internal thing and it makes little sense if they leak to editor data.
  *
  * @param {String} data The HTML data to normalize.
  * @returns {String} Normalized HTML.
@@ -23,5 +24,7 @@ export default function normalizeClipboardData( data ) {
 			}
 
 			return spaces;
-		} );
+		} )
+		// Remove all HTML comments.
+		.replace( /<!--[\s\S]*?-->/g, '' );
 }

--- a/packages/ckeditor5-clipboard/tests/utils/normalizeclipboarddata.js
+++ b/packages/ckeditor5-clipboard/tests/utils/normalizeclipboarddata.js
@@ -57,4 +57,28 @@ describe( 'normalizeClipboardData()', () => {
 			normalizeClipboardData( '<span class="Apple-converted-space"> </span><span foo>  </span><span>a</span>' )
 		).to.equal( ' <span foo>  </span><span>a</span>' );
 	} );
+
+	it( 'should strip HTML comments if clipboard data contains anything but HTML comments', () => {
+		expect(
+			normalizeClipboardData( '<!-- comment 1 --><!-- comment 2 --><!-- comment 3 -->' )
+		).to.equal( '' );
+	} );
+
+	it( 'should strip HTML comments if clipboard data contains anything but multiline HTML comments', () => {
+		expect(
+			normalizeClipboardData( '<!-- multi \n\n\n line \n\n\n comment 1 --><!-- multi \n\n\n line \n\n\n comment 2 -->' )
+		).to.equal( '' );
+	} );
+
+	it( 'should strip HTML comments if clipboard data contains HTML comments mixed with elements', () => {
+		expect(
+			normalizeClipboardData( '<!-- comment 1 --><div><p><!-- comment 2 -->foo<!-- comment 3 --></p></div><!-- comment 4 -->' )
+		).to.equal( '<div><p>foo</p></div>' );
+	} );
+
+	it( 'should strip HTML comments if clipboard data contains multiline HTML comments with commented out elements', () => {
+		expect(
+			normalizeClipboardData( '<p>foo</p><!-- multi \n\n\n line \n\n\n comment \n\n\n with element <p>bar</p> --><p>baz</p>' )
+		).to.equal( '<p>foo</p><p>baz</p>' );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (html-support): Filtered out all pasted HTML comments. Closes #10213.

---

### Additional information

I chose to use simple regular expression filtering instead of the recently added `skipComments` option in `DomConverter#domToView()`, because:
* to use `skipComments` option in the `ckeditor5-clipboard` package, I would have to make a few more changes: options that are now passed to `DomConverter#domToView()` would have to be additionally passed to `HtmlDataProcessor#toView()` and `XmlDataProcessor#toView()`. Alternatively, the two `toView()` methods could now only accept one `skipComments` option, but a single option would look silly.
* the existing `normalizeClipboardHtml()` function fits perfectly to the initial cleanup of the input data.