### PR TITLE
The editor should not crash when a widget with a resizer is moved in the model document

### DIFF
--- a/packages/ckeditor5-widget/src/widgetresize.js
+++ b/packages/ckeditor5-widget/src/widgetresize.js
@@ -94,14 +94,15 @@ export default class WidgetResize extends Plugin {
 
 		// Remove view widget-resizer mappings for widgets that have been removed from the document.
 		// https://github.com/ckeditor/ckeditor5/issues/10156
+		// https://github.com/ckeditor/ckeditor5/issues/10266
 		this.editor.model.document.on( 'change', () => {
 			for ( const [ viewElement, resizer ] of this._resizers ) {
-				if ( editing.mapper.toModelElement( viewElement ).root.rootName === '$graveyard' ) {
+				if ( !viewElement.isAttached() ) {
 					this._resizers.delete( viewElement );
 					resizer.destroy();
 				}
 			}
-		} );
+		}, { priority: 'lowest' } );
 
 		// Resizers need to be redrawn upon window resize, because new window might shrink resize host.
 		this._observer.listenTo( global.window, 'resize', this._redrawFocusedResizerThrottled );

--- a/packages/ckeditor5-widget/tests/widgetresize.js
+++ b/packages/ckeditor5-widget/tests/widgetresize.js
@@ -578,7 +578,7 @@ describe( 'WidgetResize', () => {
 		} );
 
 		// https://github.com/ckeditor/ckeditor5/issues/10156
-		it( 'removes references to and destroys resizers removed from the document', () => {
+		it( 'removes references to and destroys resizers of widget removed from the model document', () => {
 			const plugin = editor.plugins.get( WidgetResize );
 			const resizer = plugin.attachTo( gerResizerOptions( editor ) );
 			const widgetViewElement = editor.editing.view.document.getRoot().getChild( 0 );
@@ -588,6 +588,34 @@ describe( 'WidgetResize', () => {
 			sinon.assert.notCalled( resizerDestroySpy );
 
 			editor.setData( '' );
+
+			expect( plugin.getResizerByViewElement( widgetViewElement ) ).to.be.undefined;
+			sinon.assert.calledOnce( resizerDestroySpy );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/10266
+		it( 'removes references to and destroys resizers of widgets moved in the model document (but re-rendered in view)', () => {
+			const plugin = editor.plugins.get( WidgetResize );
+			const resizer = plugin.attachTo( gerResizerOptions( editor ) );
+			const widgetViewElement = editor.editing.view.document.getRoot().getChild( 0 );
+			const resizerDestroySpy = sinon.spy( resizer, 'destroy' );
+
+			editor.model.schema.register( 'wrapperBlock', {
+				allowIn: '$root',
+				allowChildren: [ 'widget' ]
+			} );
+
+			editor.conversion.elementToElement( {
+				model: 'wrapperBlock',
+				view: 'wrapperBlock'
+			} );
+
+			expect( plugin.getResizerByViewElement( widgetViewElement ) ).to.equal( resizer );
+			sinon.assert.notCalled( resizerDestroySpy );
+
+			editor.model.change( writer => {
+				writer.wrap( writer.createRangeIn( editor.model.document.getRoot() ), 'wrapperBlock' );
+			} );
 
 			expect( plugin.getResizerByViewElement( widgetViewElement ) ).to.be.undefined;
 			sinon.assert.calledOnce( resizerDestroySpy );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (widget): The editor should not crash when a widget with a resizer is moved in the model document. Closes #10266.

---

### Additional information

@ckeditor/qa-team Can you check this out, please?