### PR TITLE
Allow storing comment's content as the $root attribute

### DIFF
--- a/packages/ckeditor5-html-support/src/htmlcomment.js
+++ b/packages/ckeditor5-html-support/src/htmlcomment.js
@@ -31,6 +31,13 @@ export default class HtmlComment extends Plugin {
 	init() {
 		const editor = this.editor;
 
+		// Allow storing comment's content as the $root attribute with the name `$comment:<unique id>`.
+		editor.model.schema.addAttributeCheck( ( context, attributeName ) => {
+			if ( context.endsWith( '$root' ) && attributeName.startsWith( '$comment' ) ) {
+				return true;
+			}
+		} );
+
 		// Convert the `$comment` view element to `$comment:<unique id>` marker and store its content (the comment itself) as a $root
 		// attribute. The comment content is needed in the `dataDowncast` pipeline to re-create the comment node.
 		editor.conversion.for( 'upcast' ).elementToMarker( {

--- a/packages/ckeditor5-html-support/tests/htmlcomment.js
+++ b/packages/ckeditor5-html-support/tests/htmlcomment.js
@@ -39,6 +39,18 @@ describe( 'HtmlComment', () => {
 		expect( editor.plugins.get( 'HtmlComment' ) ).to.be.instanceOf( HtmlComment );
 	} );
 
+	describe( 'schema', () => {
+		it( 'should allow root attributes containing comment\'s content in the schema', () => {
+			editor.setData( '<p><!-- comment 1 -->Foo<!-- comment 2 --></p>' );
+
+			model.change( writer => {
+				model.schema.removeDisallowedAttributes( [ root ], writer );
+
+				expect( editor.getData() ).to.equal( '<p><!-- comment 1 -->Foo<!-- comment 2 --></p>' );
+			} );
+		} );
+	} );
+
 	describe( 'upcast conversion', () => {
 		it( 'should convert each comment node to a collapsed marker', () => {
 			editor.setData( '<p><!-- comment 1 -->Foo<!-- comment 2 --></p>' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (html-support): Extended schema definition for `$root` to allow storing comment's content as the `$root` attribute. Closes #10274.
