### PR TITLE
Move the selection of source editing textarea to the beginning

### DIFF
--- a/packages/ckeditor5-source-editing/src/sourceediting.js
+++ b/packages/ckeditor5-source-editing/src/sourceediting.js
@@ -227,6 +227,9 @@ export default class SourceEditing extends Plugin {
 
 			domSourceEditingElementTextarea.value = data;
 
+			// Setting a value to textarea moves the input cursor to the end. We want the selection at the beginning.
+			domSourceEditingElementTextarea.setSelectionRange( 0, 0 );
+
 			// Bind the textarea's value to the wrapper's `data-value` property. Each change of the textarea's value updates the
 			// wrapper's `data-value` property.
 			domSourceEditingElementTextarea.addEventListener( 'input', () => {

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -390,6 +390,16 @@ describe( 'SourceEditing', () => {
 			expect( document.activeElement ).to.equal( textarea );
 		} );
 
+		it( 'should move the input cursor to the beginning of textarea', () => {
+			button.fire( 'execute' );
+
+			const domRoot = editor.editing.view.getDomRoot();
+			const textarea = domRoot.nextSibling.children[ 0 ];
+
+			expect( textarea.selectionStart ).to.equal( 0 );
+			expect( textarea.selectionEnd ).to.equal( 0 );
+		} );
+
 		it( 'should focus the editing view after switching back from the source editing mode', () => {
 			const spy = sinon.spy( editor.editing.view, 'focus' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (source-editing): Selection is now set at the beginning of the source editing view. Closes #10180.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
