### PR TITLE
Make three Enter clicks necessary at the end of a code block to escape it

### DIFF
--- a/packages/ckeditor5-code-block/docs/features/code-blocks.md
+++ b/packages/ckeditor5-code-block/docs/features/code-blocks.md
@@ -96,7 +96,7 @@ The code language {@link module:code-block/codeblock~CodeBlockConfig#languages c
 
 There could be situations when there is no obvious way to set the caret before or after a block of code and type. This can happen when the code block is preceded or followed by a widget (e.g. a table) or when the code block is the first or the last child of the document (or both).
 
-* To type **before the code block**: Put the selection at the beginning of the first line of the code block and press <kbd>Enter</kbd>. Move the selection to the empty line that has been created and press <kbd>Enter</kbd> again. If you do this twice, a new paragraph that you can type in will be created before the code block.
+* To type **before the code block**: Put the selection at the beginning of the first line of the code block and press <kbd>Enter</kbd>. Move the selection to the empty line that has been created and press <kbd>Enter</kbd> again. A new paragraph that you can type in will be created before the code block.
 
 	{@img assets/img/code-blocks-typing-before.gif 770 The animation shows typing before the code blocks in CKEditor 5 rich text editor.}
 

--- a/packages/ckeditor5-code-block/docs/features/code-blocks.md
+++ b/packages/ckeditor5-code-block/docs/features/code-blocks.md
@@ -16,7 +16,7 @@ Code blocks is a perfect feature to present programming- or software-related iss
 
 ## Demo
 
-Use the code block toolbar button {@icon @ckeditor/ckeditor5-code-block/theme/icons/codeblock.svg Insert code block} and the type dropdown to insert a desired code block. Alternatively, start the line with `` ``` `` to format it as a code block thanks to the {@link features/autoformat autoformatting feature}. To add a paragraph underneath a code block, just use the double caret function (press <kbd>Enter</kbd> twice).
+Use the code block toolbar button {@icon @ckeditor/ckeditor5-code-block/theme/icons/codeblock.svg Insert code block} and the type dropdown to insert a desired code block. Alternatively, start the line with `` ``` `` to format it as a code block thanks to the {@link features/autoformat autoformatting feature}. To add a paragraph underneath a code block, just press <kbd>Enter</kbd> three times.
 
 {@snippet features/code-block}
 
@@ -96,11 +96,11 @@ The code language {@link module:code-block/codeblock~CodeBlockConfig#languages c
 
 There could be situations when there is no obvious way to set the caret before or after a block of code and type. This can happen when the code block is preceded or followed by a widget (e.g. a table) or when the code block is the first or the last child of the document (or both).
 
-* To type **before the code block**: Put the selection at the beginning of the first line of the code block and press <kbd>Enter</kbd>. Move the selection to the empty line that has been created and press <kbd>Enter</kbd> again. A new paragraph that you can type in will be created before the code block.
+* To type **before the code block**: Put the selection at the beginning of the first line of the code block and press <kbd>Enter</kbd>. Move the selection to the empty line that has been created and press <kbd>Enter</kbd> again. If you do this twice, a new paragraph that you can type in will be created before the code block.
 
 	{@img assets/img/code-blocks-typing-before.gif 770 The animation shows typing before the code blocks in CKEditor 5 rich text editor.}
 
-* To type **after the code block**: Put the selection at the end of the last line of the code block and press <kbd>Enter</kbd> twice. A new paragraph that you can type in will be created after the code block.
+* To type **after the code block**: Put the selection at the end of the last line of the code block and press <kbd>Enter</kbd> three times. A new paragraph that you can type in will be created after the code block.
 
 	{@img assets/img/code-blocks-typing-after.gif 770 The animation shows typing after the code blocks in CKEditor 5 rich text editor.}
 

--- a/packages/ckeditor5-code-block/src/codeblockediting.js
+++ b/packages/ckeditor5-code-block/src/codeblockediting.js
@@ -219,7 +219,7 @@ export default class CodeBlockEditing extends Plugin {
 
 		// Customize the response to the <kbd>Enter</kbd> and <kbd>Shift</kbd>+<kbd>Enter</kbd>
 		// key press when the selection is in the code block. Upon enter key press we can either
-		// leave the block if it's "three enters" in a row or create a new code block line, preserving
+		// leave the block if it's "two or three enters" in a row or create a new code block line, preserving
 		// previous line's indentation.
 		this.listenTo( editor.editing.view.document, 'enter', ( evt, data ) => {
 			const positionParent = editor.model.document.selection.getLastPosition().parent;

--- a/packages/ckeditor5-code-block/src/codeblockediting.js
+++ b/packages/ckeditor5-code-block/src/codeblockediting.js
@@ -301,7 +301,7 @@ function leaveBlockStartOnEnter( editor, isSoftEnter ) {
 		return false;
 	}
 
-	if ( !isSoftBreakNode( nodeAfter ) || !isSoftBreakNode( nodeAfter.nextSibling ) ) {
+	if ( !isSoftBreakNode( nodeAfter ) ) {
 		return false;
 	}
 
@@ -318,8 +318,7 @@ function leaveBlockStartOnEnter( editor, isSoftEnter ) {
 		writer.setSelection( newBlock, 'in' );
 		editor.model.schema.removeDisallowedAttributes( [ newBlock ], writer );
 
-		// Remove the <softBreak>s that originally followed the selection position.
-		writer.remove( nodeAfter.nextSibling );
+		// Remove the <softBreak> that originally followed the selection position.
 		writer.remove( nodeAfter );
 	} );
 

--- a/packages/ckeditor5-code-block/src/codeblockediting.js
+++ b/packages/ckeditor5-code-block/src/codeblockediting.js
@@ -219,7 +219,7 @@ export default class CodeBlockEditing extends Plugin {
 
 		// Customize the response to the <kbd>Enter</kbd> and <kbd>Shift</kbd>+<kbd>Enter</kbd>
 		// key press when the selection is in the code block. Upon enter key press we can either
-		// leave the block if it's "two enters" in a row or create a new code block line, preserving
+		// leave the block if it's "three enters" in a row or create a new code block line, preserving
 		// previous line's indentation.
 		this.listenTo( editor.editing.view.document, 'enter', ( evt, data ) => {
 			const positionParent = editor.model.document.selection.getLastPosition().parent;
@@ -301,7 +301,7 @@ function leaveBlockStartOnEnter( editor, isSoftEnter ) {
 		return false;
 	}
 
-	if ( !nodeAfter || !nodeAfter.is( 'element', 'softBreak' ) ) {
+	if ( !isSoftBreakNode( nodeAfter ) || !isSoftBreakNode( nodeAfter.nextSibling ) ) {
 		return false;
 	}
 
@@ -318,7 +318,8 @@ function leaveBlockStartOnEnter( editor, isSoftEnter ) {
 		writer.setSelection( newBlock, 'in' );
 		editor.model.schema.removeDisallowedAttributes( [ newBlock ], writer );
 
-		// Remove the <softBreak> that originally followed the selection position.
+		// Remove the <softBreak>s that originally followed the selection position.
+		writer.remove( nodeAfter.nextSibling );
 		writer.remove( nodeAfter );
 	} );
 
@@ -352,42 +353,61 @@ function leaveBlockEndOnEnter( editor, isSoftEnter ) {
 
 	let emptyLineRangeToRemoveOnEnter;
 
-	if ( isSoftEnter || !modelDoc.selection.isCollapsed || !lastSelectionPosition.isAtEnd || !nodeBefore ) {
+	if ( isSoftEnter || !modelDoc.selection.isCollapsed || !lastSelectionPosition.isAtEnd || !nodeBefore || !nodeBefore.previousSibling ) {
 		return false;
 	}
 
-	// When the position is directly preceded by a soft break
+	// When the position is directly preceded by two soft breaks
 	//
-	//		<codeBlock>foo<softBreak></softBreak>[]</codeBlock>
+	//		<codeBlock>foo<softBreak></softBreak><softBreak></softBreak>[]</codeBlock>
 	//
 	// it creates the following range that will be cleaned up before leaving:
 	//
-	//		<codeBlock>foo[<softBreak></softBreak>]</codeBlock>
+	//		<codeBlock>foo[<softBreak></softBreak><softBreak></softBreak>]</codeBlock>
 	//
-	if ( nodeBefore.is( 'element', 'softBreak' ) ) {
-		emptyLineRangeToRemoveOnEnter = model.createRangeOn( nodeBefore );
+	if ( isSoftBreakNode( nodeBefore ) && isSoftBreakNode( nodeBefore.previousSibling ) ) {
+		emptyLineRangeToRemoveOnEnter = model.createRange(
+			model.createPositionBefore( nodeBefore.previousSibling ), model.createPositionAfter( nodeBefore )
+		);
 	}
 
-	// When there's some text before the position made purely of white–space characters
+	// When there's some text before the position that is
+	// preceded by two soft breaks and made purely of white–space characters
 	//
-	//		<codeBlock>foo<softBreak></softBreak>    []</codeBlock>
-	//
-	// but NOT when it's the first one of the kind
-	//
-	//		<codeBlock>    []</codeBlock>
+	//		<codeBlock>foo<softBreak></softBreak><softBreak></softBreak>    []</codeBlock>
 	//
 	// it creates the following range to clean up before leaving:
 	//
-	//		<codeBlock>foo[<softBreak></softBreak>    ]</codeBlock>
+	//		<codeBlock>foo[<softBreak></softBreak><softBreak></softBreak>    ]</codeBlock>
 	//
 	else if (
-		nodeBefore.is( '$text' ) &&
-		!nodeBefore.data.match( /\S/ ) &&
-		nodeBefore.previousSibling &&
-		nodeBefore.previousSibling.is( 'element', 'softBreak' )
+		isEmptyishTextNode( nodeBefore ) &&
+		isSoftBreakNode( nodeBefore.previousSibling ) &&
+		isSoftBreakNode( nodeBefore.previousSibling.previousSibling )
 	) {
 		emptyLineRangeToRemoveOnEnter = model.createRange(
-			model.createPositionBefore( nodeBefore.previousSibling ), model.createPositionAfter( nodeBefore )
+			model.createPositionBefore( nodeBefore.previousSibling.previousSibling ), model.createPositionAfter( nodeBefore )
+		);
+	}
+
+	// When there's some text before the position that is made purely of white–space characters
+	// and is preceded by some other text made purely of white–space characters
+	//
+	//		<codeBlock>foo<softBreak></softBreak>    <softBreak></softBreak>    []</codeBlock>
+	//
+	// it creates the following range to clean up before leaving:
+	//
+	//		<codeBlock>foo[<softBreak></softBreak>    <softBreak></softBreak>    ]</codeBlock>
+	//
+	else if (
+		isEmptyishTextNode( nodeBefore ) &&
+		isSoftBreakNode( nodeBefore.previousSibling ) &&
+		isEmptyishTextNode( nodeBefore.previousSibling.previousSibling ) &&
+		isSoftBreakNode( nodeBefore.previousSibling.previousSibling.previousSibling )
+	) {
+		emptyLineRangeToRemoveOnEnter = model.createRange(
+			model.createPositionBefore( nodeBefore.previousSibling.previousSibling.previousSibling ),
+			model.createPositionAfter( nodeBefore )
 		);
 	}
 
@@ -395,8 +415,9 @@ function leaveBlockEndOnEnter( editor, isSoftEnter ) {
 	//
 	//		<codeBlock>    []</codeBlock>
 	//		<codeBlock>  a []</codeBlock>
-	//		<codeBlock>foo<softBreak></softBreak>bar[]</codeBlock>
-	//		<codeBlock>foo<softBreak></softBreak> a []</codeBlock>
+	//		<codeBlock>foo<softBreak></softBreak>[]</codeBlock>
+	//		<codeBlock>foo<softBreak></softBreak><softBreak></softBreak>bar[]</codeBlock>
+	//		<codeBlock>foo<softBreak></softBreak><softBreak></softBreak> a []</codeBlock>
 	//
 	else {
 		return false;
@@ -404,7 +425,7 @@ function leaveBlockEndOnEnter( editor, isSoftEnter ) {
 
 	// We're doing everything in a single change block to have a single undo step.
 	editor.model.change( writer => {
-		// Remove the last <softBreak> and all white space characters that followed it.
+		// Remove the last <softBreak>s and all white space characters that followed them.
 		writer.remove( emptyLineRangeToRemoveOnEnter );
 
 		// "Clone" the <codeBlock> in the standard way.
@@ -421,4 +442,12 @@ function leaveBlockEndOnEnter( editor, isSoftEnter ) {
 	view.scrollToTheSelection();
 
 	return true;
+}
+
+function isEmptyishTextNode( node ) {
+	return node && node.is( '$text' ) && !node.data.match( /\S/ );
+}
+
+function isSoftBreakNode( node ) {
+	return node && node.is( 'element', 'softBreak' );
 }

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -524,10 +524,10 @@ describe( 'CodeBlockEditing', () => {
 			} );
 
 			describe( 'leaving the block at the beginning', () => {
-				it( 'should leave the block when pressed at the beginning in a new line followed by a new line', () => {
+				it( 'should leave the block when pressed at the beginning in a new line', () => {
 					const spy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
 
-					setModelData( model, '<codeBlock language="css">[]<softBreak></softBreak><softBreak></softBreak>foo</codeBlock>' );
+					setModelData( model, '<codeBlock language="css">[]<softBreak></softBreak>foo</codeBlock>' );
 
 					viewDoc.fire( 'enter', getEvent() );
 
@@ -540,29 +540,20 @@ describe( 'CodeBlockEditing', () => {
 
 					editor.execute( 'undo' );
 					expect( getModelData( model ) ).to.equal(
-						'<codeBlock language="css">[]<softBreak></softBreak><softBreak></softBreak>foo</codeBlock>' );
-				} );
-
-				it( 'should not leave the block when pressed at the beginning in a new line not followed by a new line', () => {
-					setModelData( model, '<codeBlock language="css">[]<softBreak></softBreak>foo</codeBlock>' );
-
-					viewDoc.fire( 'enter', getEvent() );
-
-					expect( getModelData( model ) ).to.equal(
-						'<codeBlock language="css"><softBreak></softBreak>[]<softBreak></softBreak>foo</codeBlock>' );
+						'<codeBlock language="css">[]<softBreak></softBreak>foo</codeBlock>' );
 				} );
 
 				it( 'should not leave the block when the selection is not collapsed (#1)', () => {
-					setModelData( model, '<codeBlock language="css">[f]<softBreak></softBreak><softBreak></softBreak>oo</codeBlock>' );
+					setModelData( model, '<codeBlock language="css">[f]<softBreak></softBreak>oo</codeBlock>' );
 
 					viewDoc.fire( 'enter', getEvent() );
 
 					expect( getModelData( model ) ).to.equal(
-						'<codeBlock language="css"><softBreak></softBreak>[]<softBreak></softBreak><softBreak></softBreak>oo</codeBlock>' );
+						'<codeBlock language="css"><softBreak></softBreak>[]<softBreak></softBreak>oo</codeBlock>' );
 				} );
 
 				it( 'should not leave the block when the selection is not collapsed (#2)', () => {
-					setModelData( model, '<codeBlock language="css">[<softBreak></softBreak><softBreak></softBreak>oo]</codeBlock>' );
+					setModelData( model, '<codeBlock language="css">[<softBreak></softBreak>oo]</codeBlock>' );
 
 					viewDoc.fire( 'enter', getEvent() );
 
@@ -571,29 +562,25 @@ describe( 'CodeBlockEditing', () => {
 				} );
 
 				it( 'should not leave the block when pressed shift+enter at the beginning of the code', () => {
-					setModelData( model, '<codeBlock language="css">[]<softBreak></softBreak><softBreak></softBreak>foo</codeBlock>' );
+					setModelData( model, '<codeBlock language="css">[]<softBreak></softBreak>foo</codeBlock>' );
 
 					viewDoc.fire( 'enter', getEvent( { isSoft: true } ) );
 
 					expect( getModelData( model ) ).to.equal(
-						'<codeBlock language="css">' +
-						'<softBreak></softBreak>[]<softBreak></softBreak><softBreak></softBreak>foo' +
-						'</codeBlock>' );
+						'<codeBlock language="css"><softBreak></softBreak>[]<softBreak></softBreak>foo</codeBlock>' );
 				} );
 
 				it( 'should not leave the block when there is some text after the selection', () => {
-					setModelData( model, '<codeBlock language="css">[]foo<softBreak></softBreak><softBreak></softBreak>foo</codeBlock>' );
+					setModelData( model, '<codeBlock language="css">[]foo<softBreak></softBreak>foo</codeBlock>' );
 
 					viewDoc.fire( 'enter', getEvent() );
 
 					expect( getModelData( model ) ).to.equal(
-						'<codeBlock language="css">' +
-						'<softBreak></softBreak>[]foo<softBreak></softBreak><softBreak></softBreak>foo' +
-						'</codeBlock>' );
+						'<codeBlock language="css"><softBreak></softBreak>[]foo<softBreak></softBreak>foo</codeBlock>' );
 				} );
 
 				it( 'should not leave the block when there is some text before the selection', () => {
-					setModelData( model, '<codeBlock language="css">[]<softBreak></softBreak><softBreak></softBreak>foo</codeBlock>' );
+					setModelData( model, '<codeBlock language="css">[]<softBreak></softBreak>foo</codeBlock>' );
 
 					// <codeBlock language="css">    []<softBreak></softBreak>foo</codeBlock>
 					model.change( writer => {
@@ -604,9 +591,7 @@ describe( 'CodeBlockEditing', () => {
 
 					// Extra spaces before "[]" come from the indentation retention mechanism.
 					expect( getModelData( model ) ).to.equal(
-						'<codeBlock language="css">' +
-						'    <softBreak></softBreak>    []<softBreak></softBreak><softBreak></softBreak>foo' +
-						'</codeBlock>' );
+						'<codeBlock language="css">    <softBreak></softBreak>    []<softBreak></softBreak>foo</codeBlock>' );
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -394,7 +394,7 @@ describe( 'CodeBlockEditing', () => {
 
 		describe( 'leaving block using the enter key', () => {
 			describe( 'leaving the block end', () => {
-				it( 'should leave the block when pressed twice at the end', () => {
+				it( 'should leave the block when pressed three times at the end', () => {
 					const spy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
 
 					setModelData( model, '<codeBlock language="css">foo[]</codeBlock>' );
@@ -407,6 +407,11 @@ describe( 'CodeBlockEditing', () => {
 					viewDoc.fire( 'enter', getEvent() );
 
 					expect( getModelData( model ) ).to.equal(
+						'<codeBlock language="css">foo<softBreak></softBreak><softBreak></softBreak>[]</codeBlock>' );
+
+					viewDoc.fire( 'enter', getEvent() );
+
+					expect( getModelData( model ) ).to.equal(
 						'<codeBlock language="css">foo</codeBlock>' +
 						'<paragraph>[]</paragraph>'
 					);
@@ -415,14 +420,17 @@ describe( 'CodeBlockEditing', () => {
 
 					editor.execute( 'undo' );
 					expect( getModelData( model ) ).to.equal(
-						'<codeBlock language="css">foo<softBreak></softBreak>[]</codeBlock>' );
+						'<codeBlock language="css">foo<softBreak></softBreak><softBreak></softBreak>[]</codeBlock>' );
+
+					editor.execute( 'undo' );
+					expect( getModelData( model ) ).to.equal( '<codeBlock language="css">foo<softBreak></softBreak>[]</codeBlock>' );
 
 					editor.execute( 'undo' );
 					expect( getModelData( model ) ).to.equal( '<codeBlock language="css">foo[]</codeBlock>' );
 				} );
 
 				it( 'should not leave the block when the selection is not collapsed', () => {
-					setModelData( model, '<codeBlock language="css">f[oo<softBreak></softBreak>]</codeBlock>' );
+					setModelData( model, '<codeBlock language="css">f[oo<softBreak></softBreak><softBreak></softBreak>]</codeBlock>' );
 
 					viewDoc.fire( 'enter', getEvent() );
 
@@ -430,7 +438,7 @@ describe( 'CodeBlockEditing', () => {
 						'<codeBlock language="css">f<softBreak></softBreak>[]</codeBlock>' );
 				} );
 
-				it( 'should not leave the block when pressed twice when in the middle of the code', () => {
+				it( 'should not leave the block when pressed three times when in the middle of the code', () => {
 					setModelData( model, '<codeBlock language="css">fo[]o</codeBlock>' );
 
 					viewDoc.fire( 'enter', getEvent() );
@@ -442,9 +450,16 @@ describe( 'CodeBlockEditing', () => {
 
 					expect( getModelData( model ) ).to.equal(
 						'<codeBlock language="css">fo<softBreak></softBreak><softBreak></softBreak>[]o</codeBlock>' );
+
+					viewDoc.fire( 'enter', getEvent() );
+
+					expect( getModelData( model ) ).to.equal(
+						'<codeBlock language="css">' +
+						'fo<softBreak></softBreak><softBreak></softBreak><softBreak></softBreak>[]o' +
+						'</codeBlock>' );
 				} );
 
-				it( 'should not leave the block when pressed twice at the beginning of the code', () => {
+				it( 'should not leave the block when pressed three times at the beginning of the code', () => {
 					setModelData( model, '<codeBlock language="css">[]foo</codeBlock>' );
 
 					viewDoc.fire( 'enter', getEvent() );
@@ -456,23 +471,49 @@ describe( 'CodeBlockEditing', () => {
 
 					expect( getModelData( model ) ).to.equal(
 						'<codeBlock language="css"><softBreak></softBreak><softBreak></softBreak>[]foo</codeBlock>' );
+
+					viewDoc.fire( 'enter', getEvent() );
+
+					expect( getModelData( model ) ).to.equal(
+						'<codeBlock language="css">' +
+						'<softBreak></softBreak><softBreak></softBreak><softBreak></softBreak>[]foo' +
+						'</codeBlock>' );
 				} );
 
-				it( 'should not leave the block when pressed shift+enter twice at the end of the code', () => {
-					setModelData( model, '<codeBlock language="css">foo<softBreak></softBreak>[]</codeBlock>' );
+				it( 'should not leave the block when pressed shift+enter three times at the end of the code', () => {
+					setModelData( model, '<codeBlock language="css">foo<softBreak></softBreak><softBreak></softBreak>[]</codeBlock>' );
 
 					viewDoc.fire( 'enter', getEvent( { isSoft: true } ) );
 
 					expect( getModelData( model ) ).to.equal(
-						'<codeBlock language="css">foo<softBreak></softBreak><softBreak></softBreak>[]</codeBlock>' );
+						'<codeBlock language="css">' +
+						'foo<softBreak></softBreak><softBreak></softBreak><softBreak></softBreak>[]' +
+						'</codeBlock>' );
 				} );
 
-				it( 'should clean up the last line if has white–space characters only', () => {
-					setModelData( model, '<codeBlock language="css">foo<softBreak></softBreak>[]</codeBlock>' );
+				it( 'should clean up the last two lines if the last one has white-space characters only', () => {
+					setModelData( model, '<codeBlock language="css">foo<softBreak></softBreak><softBreak></softBreak>[]</codeBlock>' );
 
 					model.change( writer => {
-						// <codeBlock language="css">foo<softBreak></softBreak>  []</codeBlock>
+						// <codeBlock language="css">foo<softBreak></softBreak><softBreak></softBreak>  []</codeBlock>
+						writer.insertText( '  ', model.document.getRoot().getChild( 0 ), 5 );
+					} );
+
+					viewDoc.fire( 'enter', getEvent() );
+
+					expect( getModelData( model ) ).to.equal(
+						'<codeBlock language="css">foo</codeBlock><paragraph>[]</paragraph>' );
+				} );
+
+				it( 'should clean up the last two lines if both have white-space characters only', () => {
+					setModelData( model, '<codeBlock language="css">foo<softBreak></softBreak><softBreak></softBreak>[]</codeBlock>' );
+
+					model.change( writer => {
+						// <codeBlock language="css">foo<softBreak></softBreak>  <softBreak></softBreak>[]</codeBlock>
 						writer.insertText( '  ', model.document.getRoot().getChild( 0 ), 4 );
+
+						// <codeBlock language="css">foo<softBreak></softBreak>  <softBreak></softBreak>  []</codeBlock>
+						writer.insertText( '  ', model.document.getRoot().getChild( 0 ), 7 );
 					} );
 
 					viewDoc.fire( 'enter', getEvent() );
@@ -483,10 +524,10 @@ describe( 'CodeBlockEditing', () => {
 			} );
 
 			describe( 'leaving the block at the beginning', () => {
-				it( 'should leave the block when pressed at the beginning in a new line', () => {
+				it( 'should leave the block when pressed at the beginning in a new line followed by a new line', () => {
 					const spy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
 
-					setModelData( model, '<codeBlock language="css">[]<softBreak></softBreak>foo</codeBlock>' );
+					setModelData( model, '<codeBlock language="css">[]<softBreak></softBreak><softBreak></softBreak>foo</codeBlock>' );
 
 					viewDoc.fire( 'enter', getEvent() );
 
@@ -499,20 +540,29 @@ describe( 'CodeBlockEditing', () => {
 
 					editor.execute( 'undo' );
 					expect( getModelData( model ) ).to.equal(
-						'<codeBlock language="css">[]<softBreak></softBreak>foo</codeBlock>' );
+						'<codeBlock language="css">[]<softBreak></softBreak><softBreak></softBreak>foo</codeBlock>' );
 				} );
 
-				it( 'should not leave the block when the selection is not collapsed (#1)', () => {
-					setModelData( model, '<codeBlock language="css">[f]<softBreak></softBreak>oo</codeBlock>' );
+				it( 'should not leave the block when pressed at the beginning in a new line not followed by a new line', () => {
+					setModelData( model, '<codeBlock language="css">[]<softBreak></softBreak>foo</codeBlock>' );
 
 					viewDoc.fire( 'enter', getEvent() );
 
 					expect( getModelData( model ) ).to.equal(
-						'<codeBlock language="css"><softBreak></softBreak>[]<softBreak></softBreak>oo</codeBlock>' );
+						'<codeBlock language="css"><softBreak></softBreak>[]<softBreak></softBreak>foo</codeBlock>' );
+				} );
+
+				it( 'should not leave the block when the selection is not collapsed (#1)', () => {
+					setModelData( model, '<codeBlock language="css">[f]<softBreak></softBreak><softBreak></softBreak>oo</codeBlock>' );
+
+					viewDoc.fire( 'enter', getEvent() );
+
+					expect( getModelData( model ) ).to.equal(
+						'<codeBlock language="css"><softBreak></softBreak>[]<softBreak></softBreak><softBreak></softBreak>oo</codeBlock>' );
 				} );
 
 				it( 'should not leave the block when the selection is not collapsed (#2)', () => {
-					setModelData( model, '<codeBlock language="css">[<softBreak></softBreak>oo]</codeBlock>' );
+					setModelData( model, '<codeBlock language="css">[<softBreak></softBreak><softBreak></softBreak>oo]</codeBlock>' );
 
 					viewDoc.fire( 'enter', getEvent() );
 
@@ -521,25 +571,29 @@ describe( 'CodeBlockEditing', () => {
 				} );
 
 				it( 'should not leave the block when pressed shift+enter at the beginning of the code', () => {
-					setModelData( model, '<codeBlock language="css">[]<softBreak></softBreak>foo</codeBlock>' );
+					setModelData( model, '<codeBlock language="css">[]<softBreak></softBreak><softBreak></softBreak>foo</codeBlock>' );
 
 					viewDoc.fire( 'enter', getEvent( { isSoft: true } ) );
 
 					expect( getModelData( model ) ).to.equal(
-						'<codeBlock language="css"><softBreak></softBreak>[]<softBreak></softBreak>foo</codeBlock>' );
+						'<codeBlock language="css">' +
+						'<softBreak></softBreak>[]<softBreak></softBreak><softBreak></softBreak>foo' +
+						'</codeBlock>' );
 				} );
 
 				it( 'should not leave the block when there is some text after the selection', () => {
-					setModelData( model, '<codeBlock language="css">[]foo<softBreak></softBreak>foo</codeBlock>' );
+					setModelData( model, '<codeBlock language="css">[]foo<softBreak></softBreak><softBreak></softBreak>foo</codeBlock>' );
 
 					viewDoc.fire( 'enter', getEvent() );
 
 					expect( getModelData( model ) ).to.equal(
-						'<codeBlock language="css"><softBreak></softBreak>[]foo<softBreak></softBreak>foo</codeBlock>' );
+						'<codeBlock language="css">' +
+						'<softBreak></softBreak>[]foo<softBreak></softBreak><softBreak></softBreak>foo' +
+						'</codeBlock>' );
 				} );
 
 				it( 'should not leave the block when there is some text before the selection', () => {
-					setModelData( model, '<codeBlock language="css">[]<softBreak></softBreak>foo</codeBlock>' );
+					setModelData( model, '<codeBlock language="css">[]<softBreak></softBreak><softBreak></softBreak>foo</codeBlock>' );
 
 					// <codeBlock language="css">    []<softBreak></softBreak>foo</codeBlock>
 					model.change( writer => {
@@ -550,7 +604,9 @@ describe( 'CodeBlockEditing', () => {
 
 					// Extra spaces before "[]" come from the indentation retention mechanism.
 					expect( getModelData( model ) ).to.equal(
-						'<codeBlock language="css">    <softBreak></softBreak>    []<softBreak></softBreak>foo</codeBlock>' );
+						'<codeBlock language="css">' +
+						'    <softBreak></softBreak>    []<softBreak></softBreak><softBreak></softBreak>foo' +
+						'</codeBlock>' );
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-code-block/tests/manual/codeblock.md
+++ b/packages/ckeditor5-code-block/tests/manual/codeblock.md
@@ -14,9 +14,9 @@
 
 ### Block end
 
-- Create an empty line at the end of the block and put the selection there.
+- Create two empty lines at the end of the block and put the selection there.
 - Press <kbd>Enter</kbd> again.
-- The new line created in the code block should no longer be there.
+- The new lines created in the code block should no longer be there.
 - A new empty paragraph should be created after the code block.
 - The selection should be in that paragraph.
 


### PR DESCRIPTION
Improvement of the `CodeBlock` feature, described in https://github.com/ckeditor/ckeditor5/issues/6682.

Closes https://github.com/ckeditor/ckeditor5/issues/6682.