### PR TITLE
Docs: fixed wrong minimap imports

### DIFF
--- a/packages/ckeditor5-minimap/docs/features/minimap.md
+++ b/packages/ckeditor5-minimap/docs/features/minimap.md
@@ -108,7 +108,7 @@ Finally, the JavaScript to run the editor (learn how to [install](#installation)
 
 ```js
 import DecoupledEditor from '@ckeditor/ckeditor5-editor-decoupled/src/decouplededitor';
-import Minimap from '@ckeditor/ckeditor5-pagination/src/minimap';
+import Minimap from '@ckeditor/ckeditor5-minimap/src/minimap';
 
 DecoupledEditor
 	.create( document.querySelector( '#editor-content' ), {
@@ -137,7 +137,7 @@ Then add the `Minimap` plugin to your plugin list and [configure](#configuration
 
 ```js
 import DecoupledEditor from '@ckeditor/ckeditor5-editor-decoupled/src/decouplededitor';
-import Minimap from '@ckeditor/ckeditor5-pagination/src/minimap';
+import Minimap from '@ckeditor/ckeditor5-minimap/src/minimap';
 
 DecoupledEditor
 	.create( document.querySelector( '#editor' ), {
@@ -166,7 +166,7 @@ The container element is essential for the minimap to render. You should pass th
 
 ```js
 import DecoupledEditor from '@ckeditor/ckeditor5-editor-decoupled/src/decouplededitor';
-import Minimap from '@ckeditor/ckeditor5-pagination/src/minimap';
+import Minimap from '@ckeditor/ckeditor5-minimap/src/minimap';
 
 DecoupledEditor
 	.create( document.querySelector( '#editor' ), {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Fixed wrong imports in minimap documentation page. Closes https://github.com/ckeditor/ckeditor5/issues/10320.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
