### PR TITLE
jsdoc: core>Command replace readonly with protected

### DIFF
--- a/packages/ckeditor5-core/src/command.js
+++ b/packages/ckeditor5-core/src/command.js
@@ -50,7 +50,7 @@ export default class Command {
 		 * A concrete command class should control this value by overriding the {@link #refresh `refresh()`} method.
 		 *
 		 * @observable
-		 * @readonly
+		 * @protected
 		 * @member #value
 		 */
 		this.set( 'value', undefined );
@@ -91,7 +91,7 @@ export default class Command {
 		 *		enableBold();
 		 *
 		 * @observable
-		 * @readonly
+		 * @protected
 		 * @member {Boolean} #isEnabled
 		 */
 		this.set( 'isEnabled', false );


### PR DESCRIPTION
After reading the comment at https://github.com/ckeditor/ckeditor5/issues/504#issuecomment-893361105 about properties that are marked as `readonly` when they should be writable, I realized that maybe you people meant `protected` when you used `readonly` here. _Protected_ properties are writable but should only be modified by its own parent, not from the outside e.g. `isEnabled` that should be modified by `refresh()`.