### PR TITLE
Fixing ckeditor5-react/issues/249

### DIFF
--- a/packages/ckeditor5-ui/src/icon/iconview.js
+++ b/packages/ckeditor5-ui/src/icon/iconview.js
@@ -95,7 +95,8 @@ export default class IconView extends View {
 	 */
 	_updateXMLContent() {
 		if ( this.content ) {
-			const parsed = new DOMParser().parseFromString( this.content.trim(), 'image/svg+xml' );
+			const trimmedContent = typeof this.content === 'string' ? this.content : this.content.content;
+			const parsed = new DOMParser().parseFromString( trimmedContent.trim(), 'image/svg+xml' );
 			const svg = parsed.querySelector( 'svg' );
 			const viewBox = svg.getAttribute( 'viewBox' );
 


### PR DESCRIPTION
Fix (ckeditor5-ui): Fixing object member error calling this.content.trim().
### Additional information

This fix the issue encountered on https://github.com/ckeditor/ckeditor5-react/issues/249
