### PR TITLE
jsdoc: Mention>domwrapperview locale

### DIFF
--- a/packages/ckeditor5-mention/src/ui/domwrapperview.js
+++ b/packages/ckeditor5-mention/src/ui/domwrapperview.js
@@ -22,7 +22,7 @@ export default class DomWrapperView extends View {
 	 *
 	 * Also see {@link #render}.
 	 *
-	 * @param {module:utils/locale~Locale} [locale] The localization services instance.
+	 * @param {module:utils/locale~Locale} locale The localization services instance.
 	 * @param {Element} domElement
 	 */
 	constructor( locale, domElement ) {


### PR DESCRIPTION
Locale can't be optional if element is required.