### PR TITLE
Docs: fixed typo in 29.1.0 migration guide

### DIFF
--- a/docs/builds/guides/migration/migration-to-29.md
+++ b/docs/builds/guides/migration/migration-to-29.md
@@ -10,7 +10,7 @@ modified_at: 2021-07-25
 
 ## Migration to CKEditor 5 v29.1.0
 
-For the entire list of changes introduced in version 27.1.0, see the [changelog for CKEditor 5 v29.1.0](https://github.com/ckeditor/ckeditor5/blob/master/CHANGELOG.md#2910-2021-08-02).
+For the entire list of changes introduced in version 29.1.0, see the [changelog for CKEditor 5 v29.1.0](https://github.com/ckeditor/ckeditor5/blob/master/CHANGELOG.md#2910-2021-08-02).
 
 Listed below are the most important changes that require your attention when upgrading to CKEditor 5 v29.1.0.
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Fixed typo in 29.1.0 migration guide. Closes https://github.com/ckeditor/ckeditor5/issues/10347.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
