### PR TITLE
Change viewportTopOffset config. Make viewportTopOffset writable in runtime

### DIFF
--- a/docs/_snippets/builds/saving-data/autosave.js
+++ b/docs/_snippets/builds/saving-data/autosave.js
@@ -16,8 +16,10 @@ document.querySelector( '#snippet-autosave-lag' ).addEventListener( 'change', ev
 ClassicEditor
 	.create( document.querySelector( '#snippet-autosave' ), {
 		cloudServices: CS_CONFIG,
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		autosave: {
 			save( editor ) {

--- a/docs/_snippets/builds/saving-data/manualsave.js
+++ b/docs/_snippets/builds/saving-data/manualsave.js
@@ -17,8 +17,10 @@ document.querySelector( '#snippet-manualsave-lag' ).addEventListener( 'change', 
 ClassicEditor
 	.create( document.querySelector( '#snippet-manualsave' ), {
 		cloudServices: CS_CONFIG,
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/docs/_snippets/examples/classic-editor-short.js
+++ b/docs/_snippets/examples/classic-editor-short.js
@@ -10,8 +10,10 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-classic-editor-short' ), {
 		cloudServices: CS_CONFIG,
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/docs/_snippets/examples/classic-editor.js
+++ b/docs/_snippets/examples/classic-editor.js
@@ -10,8 +10,10 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-classic-editor' ), {
 		cloudServices: CS_CONFIG,
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/docs/_snippets/examples/custom-build.js
+++ b/docs/_snippets/examples/custom-build.js
@@ -38,8 +38,12 @@ ClassicEditor
 			CloudServices
 		],
 		toolbar: {
-			items: [ 'bold', 'italic', 'underline', 'strikethrough', 'code', '|', 'highlight', '|', 'undo', 'redo' ],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			items: [ 'bold', 'italic', 'underline', 'strikethrough', 'code', '|', 'highlight', '|', 'undo', 'redo' ]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/docs/_snippets/examples/inline-editor.js
+++ b/docs/_snippets/examples/inline-editor.js
@@ -12,8 +12,10 @@ const inlineInjectElements = document.querySelectorAll( '#snippet-inline-editor 
 
 Array.from( inlineInjectElements ).forEach( inlineElement => {
 	const config = {
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		cloudServices: CS_CONFIG
 	};

--- a/docs/_snippets/features/image-upload.js
+++ b/docs/_snippets/features/image-upload.js
@@ -10,8 +10,10 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-upload' ), {
 		cloudServices: CS_CONFIG,
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/docs/_snippets/features/mathtype.js
+++ b/docs/_snippets/features/mathtype.js
@@ -44,8 +44,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/docs/_snippets/features/read-only.js
+++ b/docs/_snippets/features/read-only.js
@@ -10,8 +10,10 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-read-only' ), {
 		cloudServices: CS_CONFIG,
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/docs/_snippets/features/toolbar-breakpoint.js
+++ b/docs/_snippets/features/toolbar-breakpoint.js
@@ -23,8 +23,12 @@ ClassicEditor
 				'uploadImage', 'blockQuote', '|',
 				'undo', 'redo'
 			],
-			shouldNotGroupWhenFull: true,
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			shouldNotGroupWhenFull: true
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [ 'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|', 'toggleImageCaption', 'imageTextAlternative' ]

--- a/docs/_snippets/features/toolbar-grouping.js
+++ b/docs/_snippets/features/toolbar-grouping.js
@@ -19,8 +19,12 @@ ClassicEditor
 				'outdent', 'indent', '|',
 				'uploadImage', 'blockQuote', '|',
 				'undo', 'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [ 'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|', 'toggleImageCaption', 'imageTextAlternative' ]

--- a/docs/_snippets/features/toolbar-wrapping.js
+++ b/docs/_snippets/features/toolbar-wrapping.js
@@ -24,8 +24,12 @@ ClassicEditor
 				'uploadImage', 'blockQuote', '|',
 				'undo', 'redo'
 			],
-			shouldNotGroupWhenFull: true,
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			shouldNotGroupWhenFull: true
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [ 'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|', 'toggleImageCaption', 'imageTextAlternative' ]

--- a/docs/_snippets/features/ui-language-content.js
+++ b/docs/_snippets/features/ui-language-content.js
@@ -13,8 +13,10 @@ ClassicEditor
 			content: 'ar'
 		},
 		cloudServices: CS_CONFIG,
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/docs/_snippets/features/ui-language-rtl.js
+++ b/docs/_snippets/features/ui-language-rtl.js
@@ -11,8 +11,10 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-ui-language-rtl' ), {
 		language: 'ar',
 		cloudServices: CS_CONFIG,
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/docs/_snippets/features/ui-language.js
+++ b/docs/_snippets/features/ui-language.js
@@ -11,8 +11,10 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-ui-language' ), {
 		language: 'es',
 		cloudServices: CS_CONFIG,
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/docs/_snippets/features/wproofreader.js
+++ b/docs/_snippets/features/wproofreader.js
@@ -44,8 +44,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/docs/_snippets/framework/development-tools/inspector.js
+++ b/docs/_snippets/framework/development-tools/inspector.js
@@ -12,8 +12,10 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-classic-editor' ), {
 		cloudServices: CS_CONFIG,
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/docs/_snippets/framework/tutorials/block-widget.js
+++ b/docs/_snippets/framework/tutorials/block-widget.js
@@ -230,8 +230,12 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-block-widget' ), {
 		plugins: [ Essentials, Bold, Italic, Heading, List, Paragraph, SimpleBox ],
 		toolbar: {
-			items: [ 'heading', '|', 'bold', 'italic', 'numberedList', 'bulletedList', 'simpleBox' ],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			items: [ 'heading', '|', 'bold', 'italic', 'numberedList', 'bulletedList', 'simpleBox' ]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/docs/_snippets/framework/tutorials/using-react-in-widget.html
+++ b/docs/_snippets/framework/tutorials/using-react-in-widget.html
@@ -232,7 +232,6 @@ class App extends React.Component {
 				ProductPreviewEditing
 			],
 			toolbar: {
-				viewportTopOffset: window.getViewportTopOffsetConfig(),
 				items: [
 					'heading',
 					'|',
@@ -242,6 +241,11 @@ class App extends React.Component {
 					'|',
 					'undo', 'redo'
 				]
+			},
+			ui: {
+				viewportOffset: {
+					top: window.getViewportTopOffsetConfig()
+				}
 			},
 			table: {
 				contentToolbar: [

--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -4,7 +4,7 @@
 
 :root {
 	/* This custom property is read by the JS and passed to editor configurations
-	as config.toolbar.viewportTopOffset. */
+	as config.ui.viewportOffset.top. */
 	--ck-snippet-viewport-top-offset: 100
 }
 

--- a/docs/assets/snippet.js
+++ b/docs/assets/snippet.js
@@ -109,7 +109,7 @@ window.createNotification = function( title, message ) {
 };
 
 /**
- * Returns the `config.toolbar.viewportTopOffset` config value for editors using floating toolbars that
+ * Returns the `config.ui.viewportOffset.top` config value for editors using floating toolbars that
  * stick to the top of the viewport to remain visible to the user.
  *
  * The value is determined in styles by the `--ck-snippet-viewport-top-offset` custom property

--- a/docs/features/toolbar.md
+++ b/docs/features/toolbar.md
@@ -72,12 +72,6 @@ toolbar: {
 
  * **`removeItems`** &ndash; An array of toolbar item names. With this setting you can modify the default toolbar configuration without the need of defining the entire list (you can specify a couple of buttons that you want to remove instead of specifying all the buttons you want to keep). If, after removing an item, toolbar will have two or more consecutive separators (`'|'`), the duplicates will be removed automatically.
 
- * **`viewportTopOffset` (deprecated)** &ndash; The offset (in pixels) from the top of the viewport used when positioning a sticky toolbar. Useful when a page with which the editor is being integrated has some other sticky or fixed elements (e.g. the top menu). Thanks to setting the toolbar offset, the toolbar will not be positioned underneath or above the page's UI.
-
-	<info-box warning>
-		This property has been deprecated and will be removed in the future versions of CKEditor. Please use {@link module:core/editor/editorconfig~EditorConfig#ui `EditorConfig#ui.viewportOffset`} instead.
-	</info-box>
-
  * **`shouldNotGroupWhenFull`** &ndash; When set to `true`, the toolbar will stop grouping items and let them wrap to the next line when there is not enough space to display them in a single row. This setting is `false` by default, which enables items grouping.
 
 The demo below presents the "regular" toolbar look with `shouldNotGroupWhenFull` set to `false`. If there are excess toolbar items for the display width, the toolbar gets grouped and some of the items are accessible via the clickable "Show more items" (⋮) button.

--- a/docs/features/toolbar.md
+++ b/docs/features/toolbar.md
@@ -64,7 +64,6 @@ You can use the extended {@link module:core/editor/editorconfig~EditorConfig#too
 ```js
 toolbar: {
     items: [ 'bold', 'italic', '|', 'undo', 'redo', '-', 'numberedList', 'bulletedList' ],
-    viewportTopOffset: 30,
     shouldNotGroupWhenFull: true
 }
 ```
@@ -73,7 +72,11 @@ toolbar: {
 
  * **`removeItems`** &ndash; An array of toolbar item names. With this setting you can modify the default toolbar configuration without the need of defining the entire list (you can specify a couple of buttons that you want to remove instead of specifying all the buttons you want to keep). If, after removing an item, toolbar will have two or more consecutive separators (`'|'`), the duplicates will be removed automatically.
 
- * **`viewportTopOffset`** &ndash; The offset (in pixels) from the top of the viewport used when positioning a sticky toolbar. Useful when a page with which the editor is being integrated has some other sticky or fixed elements (e.g. the top menu). Thanks to setting the toolbar offset, the toolbar will not be positioned underneath or above the page's UI.
+ * **`viewportTopOffset` (deprecated)** &ndash; The offset (in pixels) from the top of the viewport used when positioning a sticky toolbar. Useful when a page with which the editor is being integrated has some other sticky or fixed elements (e.g. the top menu). Thanks to setting the toolbar offset, the toolbar will not be positioned underneath or above the page's UI.
+
+	<info-box warning>
+		This property has been deprecated and will be removed in the future versions of CKEditor. Please use {@link module:core/editor/editorconfig~EditorConfig#ui `EditorConfig#ui.viewportOffset`} instead.
+	</info-box>
 
  * **`shouldNotGroupWhenFull`** &ndash; When set to `true`, the toolbar will stop grouping items and let them wrap to the next line when there is not enough space to display them in a single row. This setting is `false` by default, which enables items grouping.
 

--- a/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-options.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-options.js
@@ -22,8 +22,12 @@ ClassicEditor
 				'alignment',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		alignment: {
 			options: [ 'left', 'right' ]

--- a/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-toolbar.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-toolbar.js
@@ -12,8 +12,12 @@ ClassicEditor
 		toolbar: {
 			items: [
 				'heading', '|', 'alignment:left', 'alignment:right', 'alignment:center', 'alignment:justify'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js
@@ -22,8 +22,12 @@ ClassicEditor
 				'alignment',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.js
+++ b/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.js
@@ -45,8 +45,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/packages/ckeditor5-basic-styles/docs/_snippets/features/basic-styles.js
+++ b/packages/ckeditor5-basic-styles/docs/_snippets/features/basic-styles.js
@@ -12,8 +12,12 @@ ClassicEditor
 		toolbar: {
 			items: [
 				'bold', 'italic', 'underline', 'strikethrough', 'subscript', 'superscript', 'code', '|', 'removeFormat', '|', 'undo', 'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote-source.js
+++ b/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote-source.js
@@ -26,8 +26,12 @@ ClassicEditor.defaultConfig = {
 			'|',
 			'undo',
 			'redo'
-		],
-		viewportTopOffset: window.getViewportTopOffsetConfig()
+		]
+	},
+	ui: {
+		viewportOffset: {
+			top: window.getViewportTopOffsetConfig()
+		}
 	},
 	image: {
 		toolbar: [ 'imageTextAlternative' ]

--- a/packages/ckeditor5-build-classic/tests/ckeditor.js
+++ b/packages/ckeditor5-build-classic/tests/ckeditor.js
@@ -189,8 +189,10 @@ describe( 'ClassicEditor build', () => {
 		it( 'allows configuring toolbar offset without overriding toolbar items', () => {
 			return ClassicEditor
 				.create( editorElement, {
-					toolbar: {
-						viewportTopOffset: 42
+					ui: {
+						viewportOffset: {
+							top: 42
+						}
 					}
 				} )
 				.then( newEditor => {

--- a/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder-options.js
+++ b/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder-options.js
@@ -10,8 +10,12 @@ ClassicEditor
 		toolbar: {
 			items: [
 				'heading', '|', 'bold', 'italic', '|', 'undo', 'redo', '|', 'ckfinder'
-			],
-			viewportTopOffset: 100
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		ckfinder: {
 			// eslint-disable-next-line max-len

--- a/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder-upload-only.js
+++ b/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder-upload-only.js
@@ -10,8 +10,12 @@ ClassicEditor
 		toolbar: {
 			items: [
 				'heading', '|', 'bold', 'italic', '|', 'undo', 'redo', '|', 'uploadImage'
-			],
-			viewportTopOffset: 100
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		ckfinder: {
 			// eslint-disable-next-line max-len

--- a/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder.js
+++ b/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder.js
@@ -10,8 +10,12 @@ ClassicEditor
 		toolbar: {
 			items: [
 				'heading', '|', 'bold', 'italic', '|', 'undo', 'redo', '|', 'ckfinder'
-			],
-			viewportTopOffset: 100
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		ckfinder: {
 			// eslint-disable-next-line max-len

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/drag-drop.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/drag-drop.js
@@ -252,8 +252,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		fontFamily: {
 			supportAllValues: true

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/paste-plain-text.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/paste-plain-text.js
@@ -25,8 +25,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		fontFamily: {
 			supportAllValues: true

--- a/packages/ckeditor5-code-block/docs/_snippets/features/code-block-custom-languages.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/code-block-custom-languages.js
@@ -25,8 +25,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		codeBlock: {
 			languages: [

--- a/packages/ckeditor5-code-block/docs/_snippets/features/code-block.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/code-block.js
@@ -25,8 +25,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-core/src/editor/editorconfig.jsdoc
+++ b/packages/ckeditor5-core/src/editor/editorconfig.jsdoc
@@ -144,8 +144,6 @@
  *			toolbar: {
  *				items: [ 'bold', 'italic', '|', 'undo', 'redo', '-', 'numberedList', 'bulletedList' ],
  *
- *				viewportTopOffset: 30,
- *
  *				shouldNotGroupWhenFull: true
  *			}
  *		};
@@ -167,9 +165,12 @@
  *
  *	Line break will work only in the extended format when `shouldNotGroupWhenFull` option is set to `true`.
  *
- * * **`toolbar.viewportTopOffset`** &ndash; The offset (in pixels) from the top of the viewport used when positioning a sticky toolbar.
+ * * **`toolbar.viewportTopOffset` (deprecated)** &ndash; The offset (in pixels) from the top of the viewport used when positioning a sticky toolbar.
  * Useful when a page with which the editor is being integrated has some other sticky or fixed elements
  * (e.g. the top menu). Thanks to setting the toolbar offset the toolbar will not be positioned underneath or above the page's UI.
+ *
+ * 	**This property has been deprecated and will be removed in the future versions of CKEditor. Please use `{@link module:core/editor/editorconfig~EditorConfig#ui EditorConfig#ui.viewportOffset}` instead.**
+ *
  * * **`toolbar.shouldNotGroupWhenFull`** &ndash; When set to `true`, the toolbar will stop grouping items
  * and let them wrap to the next line if there is not enough space to display them in a single row.
  *
@@ -296,4 +297,29 @@
  * See the {@glink features/editor-placeholder "Editor placeholder" guide} for more information and live examples.
  *
  * @member {String} module:core/editor/editorconfig~EditorConfig#placeholder
+ */
+
+/**
+ * The editor UI configuration.
+ *
+ *		ClassicEditor
+ *			.create( document.querySelector( '#editor' ), {
+ *				ui: { ... }
+ *			} )
+ *			.then( ... )
+ *			.catch( ... );
+ *
+ * Options which can be set using the UI config:
+ *
+ * * **`ui.viewportOffset`** &ndash; The offset (in pixels) of the viewport from every direction used when positioning a sticky toolbar or other absolutely positioned UI elements.
+ * Useful when a page with which the editor is being integrated has some other sticky or fixed elements
+ * (e.g. the top menu). Thanks to setting the UI viewport offset the toolbar and other contextual balloons will not be positioned underneath or above the page's UI.
+ *
+ *		ui: {
+ *			viewportOffset: { top: 10, right: 10, bottom: 10, left: 10 }
+ *		}
+ *
+ * 	**Note:** At the moment, only `top` property is supported. Support for other directions will be added in the future.
+ *
+ * @member {Object} module:core/editor/editorconfig~EditorConfig#ui
  */

--- a/packages/ckeditor5-core/src/editor/editorconfig.jsdoc
+++ b/packages/ckeditor5-core/src/editor/editorconfig.jsdoc
@@ -321,7 +321,7 @@
  *
  * 	**Note:** At the moment, only `top` property is supported. Support for other directions will be added in the future.
  *
- * 	**Note:** The `top` property is being used by both {@link module:editor-inline/inlineeditoruiview~InlineEditorUIView#viewportTopOffset `InlineEditorUIView#viewportTopOffset`} and {@link module:ui/panel/sticky/stickypanelview~StickyPanelView#viewportTopOffset `StickyPanelView#viewportTopOffset`}. This makes both inline editor toolbar and sticky contextual balloons to respect viewport top offset.
+ * 	**Note:** If you want to modify the viewport offset in runtime (after editor was created), you can do that by overriding {@link module:core/editor/editorui~EditorUI#viewportOffset `editor.ui.viewportOffset`}.
  *
  * @member {Object} module:core/editor/editorconfig~EditorConfig#ui
  */

--- a/packages/ckeditor5-core/src/editor/editorconfig.jsdoc
+++ b/packages/ckeditor5-core/src/editor/editorconfig.jsdoc
@@ -321,5 +321,7 @@
  *
  * 	**Note:** At the moment, only `top` property is supported. Support for other directions will be added in the future.
  *
+ * 	**Note:** The `top` property is being used by both {@link module:editor-inline/inlineeditoruiview~InlineEditorUIView#viewportTopOffset `InlineEditorUIView#viewportTopOffset`} and {@link module:ui/panel/sticky/stickypanelview~StickyPanelView#viewportTopOffset `StickyPanelView#viewportTopOffset`}. This makes both inline editor toolbar and sticky contextual balloons to respect viewport top offset.
+ *
  * @member {Object} module:core/editor/editorconfig~EditorConfig#ui
  */

--- a/packages/ckeditor5-core/src/editor/editorui.js
+++ b/packages/ckeditor5-core/src/editor/editorui.js
@@ -56,8 +56,12 @@ export default class EditorUI {
 		/**
 		 * Stores viewport offsets from every direction.
 		 *
+		 * Viewport offset can be used to constrain balloons or other UI elements into an element smaller than the viewport.
+		 * This can be useful if there are any other absolutely positioned elements that may interfere with editor UI.
+		 *
 		 * @readonly
 		 * @observable
+		 * @member {Object} #viewportOffset
 		 */
 		this.set( 'viewportOffset', this._viewportOffset );
 

--- a/packages/ckeditor5-core/src/editor/editorui.js
+++ b/packages/ckeditor5-core/src/editor/editorui.js
@@ -59,11 +59,22 @@ export default class EditorUI {
 		 * Viewport offset can be used to constrain balloons or other UI elements into an element smaller than the viewport.
 		 * This can be useful if there are any other absolutely positioned elements that may interfere with editor UI.
 		 *
+		 * Example:
+		 *
+		 * ```js
+		 * {
+		 * 	top: 50,
+		 * 	right: 50,
+		 * 	bottom: 50,
+		 * 	left: 50
+		 * }
+		 * ```
+		 *
 		 * @readonly
 		 * @observable
 		 * @member {Object} #viewportOffset
 		 */
-		this.set( 'viewportOffset', this._viewportOffset );
+		this.set( 'viewportOffset', this._readViewportOffsetFromConfig() );
 
 		/**
 		 * Stores all editable elements used by the editor instance.
@@ -185,14 +196,23 @@ export default class EditorUI {
 	}
 
 	/**
-	 * Returns viewport offsets object
-	 * { top: Number, right: Number, bottom: Number, left: Number }
-	 * Only top property is currently supported
+	 * Returns viewport offsets object:
+	 *
+	 * ```js
+	 * {
+	 * 	top: Number,
+	 * 	right: Number,
+	 * 	bottom: Number,
+	 * 	left: Number
+	 * }
+	 * ```
+	 *
+	 * Only top property is currently supported.
 	 *
 	 * @private
 	 * @return {Object}
 	 */
-	get _viewportOffset() {
+	_readViewportOffsetFromConfig() {
 		const editor = this.editor;
 		const viewportOffsetConfig = editor.config.get( 'ui.viewportOffset' );
 
@@ -202,7 +222,7 @@ export default class EditorUI {
 
 		const legacyOffsetConfig = editor.config.get( 'toolbar.viewportTopOffset' );
 
-		// Fall back to deprecated toolbar config
+		// Fall back to deprecated toolbar config.
 		if ( legacyOffsetConfig ) {
 			/**
 			 * The {@link module:core/editor/editorconfig~EditorConfig#toolbar `EditorConfig#toolbar.viewportTopOffset`}

--- a/packages/ckeditor5-core/src/editor/editorui.js
+++ b/packages/ckeditor5-core/src/editor/editorui.js
@@ -12,8 +12,7 @@
 import ComponentFactory from '@ckeditor/ckeditor5-ui/src/componentfactory';
 import FocusTracker from '@ckeditor/ckeditor5-utils/src/focustracker';
 
-import EmitterMixin from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import mix from '@ckeditor/ckeditor5-utils/src/mix';
+import { ObservableMixin, mix } from '@ckeditor/ckeditor5-utils';
 
 /**
  * A class providing the minimal interface that is required to successfully bootstrap any editor UI.
@@ -52,6 +51,13 @@ export default class EditorUI {
 		 * @member {module:utils/focustracker~FocusTracker} #focusTracker
 		 */
 		this.focusTracker = new FocusTracker();
+
+		/**
+		 * TODO
+		 *
+		 * @observable
+		 */
+		this.set( 'viewportOffset', this._viewportTopOffset );
 
 		/**
 		 * Stores all editable elements used by the editor instance.
@@ -173,6 +179,42 @@ export default class EditorUI {
 	}
 
 	/**
+	 * TODO
+	 *
+	 * @private
+	 * @return Object
+	 */
+	get _viewportTopOffset() {
+		const editor = this.editor;
+		const viewportOffsetConfig = editor.config.get( 'ui.viewportOffset' );
+
+		if ( viewportOffsetConfig ) {
+			return viewportOffsetConfig;
+		}
+
+		const legacyOffsetConfig = editor.config.get( 'toolbar.viewportTopOffset' );
+
+		// Fall back to deprecated toolbar config
+		if ( legacyOffsetConfig ) {
+			/**
+			 * TODO
+			 *
+			 * @error todo-error-name
+			 */
+			console.warn(
+				'todo-error-name: ' +
+				'The `toolbar.vieportTopOffset` configuration option is deprecated. ' +
+				'It will be removed from future CKEditor versions. Use `ui.viewportOffset.top` instead.'
+			);
+
+			return { top: legacyOffsetConfig };
+		}
+
+		// More keys to come in the future.
+		return { top: 0 };
+	}
+
+	/**
 	 * Fired when the editor UI is ready.
 	 *
 	 * Fired before {@link module:engine/controller/datacontroller~DataController#event:ready}.
@@ -190,4 +232,4 @@ export default class EditorUI {
 	 */
 }
 
-mix( EditorUI, EmitterMixin );
+mix( EditorUI, ObservableMixin );

--- a/packages/ckeditor5-core/src/editor/editorui.js
+++ b/packages/ckeditor5-core/src/editor/editorui.js
@@ -57,7 +57,7 @@ export default class EditorUI {
 		 *
 		 * @observable
 		 */
-		this.set( 'viewportOffset', this._viewportTopOffset );
+		this.set( 'viewportOffset', this._viewportOffset );
 
 		/**
 		 * Stores all editable elements used by the editor instance.
@@ -179,12 +179,14 @@ export default class EditorUI {
 	}
 
 	/**
-	 * TODO
+	 * Returns viewport offsets object
+	 * { top: Number, right: Number, bottom: Number, left: Number }
+	 * Only top property is currently supported
 	 *
 	 * @private
-	 * @return Object
+	 * @return {Object}
 	 */
-	get _viewportTopOffset() {
+	get _viewportOffset() {
 		const editor = this.editor;
 		const viewportOffsetConfig = editor.config.get( 'ui.viewportOffset' );
 
@@ -197,12 +199,14 @@ export default class EditorUI {
 		// Fall back to deprecated toolbar config
 		if ( legacyOffsetConfig ) {
 			/**
-			 * TODO
+			 * The {@link module:core/editor/editorconfig~EditorConfig#toolbar `EditorConfig#toolbar.viewportTopOffset`}
+			 * property has been deprecated and will be removed in the near future. Please use
+			 * {@link module:core/editor/editorconfig~EditorConfig#ui `EditorConfig#ui.viewportOffset`} instead.
 			 *
-			 * @error todo-error-name
+			 * @error editor-ui-deprecated-viewport-offset-config
 			 */
 			console.warn(
-				'todo-error-name: ' +
+				'editor-ui-deprecated-viewport-offset-config: ' +
 				'The `toolbar.vieportTopOffset` configuration option is deprecated. ' +
 				'It will be removed from future CKEditor versions. Use `ui.viewportOffset.top` instead.'
 			);

--- a/packages/ckeditor5-core/src/editor/editorui.js
+++ b/packages/ckeditor5-core/src/editor/editorui.js
@@ -59,7 +59,7 @@ export default class EditorUI {
 		 * Viewport offset can be used to constrain balloons or other UI elements into an element smaller than the viewport.
 		 * This can be useful if there are any other absolutely positioned elements that may interfere with editor UI.
 		 *
-		 * Example:
+		 * Example `editor.ui.viewportOffset` returns:
 		 *
 		 * ```js
 		 * {
@@ -70,7 +70,17 @@ export default class EditorUI {
 		 * }
 		 * ```
 		 *
-		 * @readonly
+		 * This property can be overriden after editor already being initialized:
+		 *
+		 * ```js
+		 * editor.ui.viewportOffset = {
+		 * 	top: 100,
+		 * 	right: 0,
+		 * 	bottom: 0,
+		 * 	left: 0
+		 * };
+		 * ```
+		 *
 		 * @observable
 		 * @member {Object} #viewportOffset
 		 */

--- a/packages/ckeditor5-core/src/editor/editorui.js
+++ b/packages/ckeditor5-core/src/editor/editorui.js
@@ -12,7 +12,8 @@
 import ComponentFactory from '@ckeditor/ckeditor5-ui/src/componentfactory';
 import FocusTracker from '@ckeditor/ckeditor5-utils/src/focustracker';
 
-import { ObservableMixin, mix } from '@ckeditor/ckeditor5-utils';
+import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
+import mix from '@ckeditor/ckeditor5-utils/src/mix';
 
 /**
  * A class providing the minimal interface that is required to successfully bootstrap any editor UI.

--- a/packages/ckeditor5-core/src/editor/editorui.js
+++ b/packages/ckeditor5-core/src/editor/editorui.js
@@ -53,8 +53,9 @@ export default class EditorUI {
 		this.focusTracker = new FocusTracker();
 
 		/**
-		 * TODO
+		 * Stores viewport offsets from every direction.
 		 *
+		 * @readonly
 		 * @observable
 		 */
 		this.set( 'viewportOffset', this._viewportOffset );

--- a/packages/ckeditor5-core/tests/editor/editorui.js
+++ b/packages/ckeditor5-core/tests/editor/editorui.js
@@ -203,21 +203,19 @@ describe( 'EditorUI', () => {
 		} );
 	} );
 
-	describe( '_viewportOffset()', () => {
+	describe( 'viewportOffset', () => {
 		it( 'should return offset object', () => {
-			const ui = new EditorUI( editor );
-
 			const stub = testUtils.sinon.stub( editor.config, 'get' )
 				.withArgs( 'ui.viewportOffset' )
 				.returns( { top: 200 } );
 
-			expect( ui._viewportOffset ).to.deep.equal( { top: 200 } );
+			const ui = new EditorUI( editor );
+
+			expect( ui.viewportOffset ).to.deep.equal( { top: 200 } );
 			sinon.assert.calledOnce( stub );
 		} );
 
 		it( 'should warn about deprecation', () => {
-			const ui = new EditorUI( editor );
-
 			testUtils.sinon.stub( editor.config, 'get' )
 				.withArgs( 'ui.viewportOffset' )
 				.returns( null )
@@ -226,7 +224,9 @@ describe( 'EditorUI', () => {
 
 			const consoleStub = testUtils.sinon.stub( console, 'warn' );
 
-			expect( ui._viewportOffset ).to.deep.equal( { top: 200 } );
+			const ui = new EditorUI( editor );
+
+			expect( ui.viewportOffset ).to.deep.equal( { top: 200 } );
 			sinon.assert.calledWithMatch( consoleStub, 'editor-ui-deprecated-viewport-offset-config' );
 		} );
 	} );

--- a/packages/ckeditor5-core/tests/editor/editorui.js
+++ b/packages/ckeditor5-core/tests/editor/editorui.js
@@ -202,4 +202,32 @@ describe( 'EditorUI', () => {
 			sinon.assert.calledWithMatch( stub, 'editor-ui-deprecated-editable-elements' );
 		} );
 	} );
+
+	describe( '_viewportOffset()', () => {
+		it( 'should return offset object', () => {
+			const ui = new EditorUI( editor );
+
+			const stub = testUtils.sinon.stub( editor.config, 'get' )
+				.withArgs( 'ui.viewportOffset' )
+				.returns( { top: 200 } );
+
+			expect( ui._viewportOffset ).to.deep.equal( { top: 200 } );
+			sinon.assert.calledOnce( stub );
+		} );
+
+		it( 'should warn about deprecation', () => {
+			const ui = new EditorUI( editor );
+
+			testUtils.sinon.stub( editor.config, 'get' )
+				.withArgs( 'ui.viewportOffset' )
+				.returns( null )
+				.withArgs( 'toolbar.viewportTopOffset' )
+				.returns( 200 );
+
+			const consoleStup = testUtils.sinon.stub( console, 'warn' );
+
+			expect( ui._viewportOffset ).to.deep.equal( { top: 200 } );
+			sinon.assert.calledWithMatch( consoleStup, 'editor-ui-deprecated-viewport-offset-config' );
+		} );
+	} );
 } );

--- a/packages/ckeditor5-core/tests/editor/editorui.js
+++ b/packages/ckeditor5-core/tests/editor/editorui.js
@@ -224,10 +224,10 @@ describe( 'EditorUI', () => {
 				.withArgs( 'toolbar.viewportTopOffset' )
 				.returns( 200 );
 
-			const consoleStup = testUtils.sinon.stub( console, 'warn' );
+			const consoleStub = testUtils.sinon.stub( console, 'warn' );
 
 			expect( ui._viewportOffset ).to.deep.equal( { top: 200 } );
-			sinon.assert.calledWithMatch( consoleStup, 'editor-ui-deprecated-viewport-offset-config' );
+			sinon.assert.calledWithMatch( consoleStub, 'editor-ui-deprecated-viewport-offset-config' );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-easy-image/docs/_snippets/features/easy-image.js
+++ b/packages/ckeditor5-easy-image/docs/_snippets/features/easy-image.js
@@ -10,8 +10,10 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-upload' ), {
 		cloudServices: CS_CONFIG,
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-editor-classic/src/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/src/classiceditorui.js
@@ -143,8 +143,10 @@ export default class ClassicEditorUI extends EditorUI {
 		view.stickyPanel.bind( 'isActive' ).to( this.focusTracker, 'isFocused' );
 		view.stickyPanel.limiterElement = view.element;
 
-		if ( this._toolbarConfig.viewportTopOffset ) {
-			view.stickyPanel.viewportTopOffset = this._toolbarConfig.viewportTopOffset;
+		if ( this._viewportTopOffset ) {
+			// TODO: Consider dropping `stickyPanel` from this, and leave just
+			// view.viewportTopOffset to keep consistency with InlineEditor
+			view.stickyPanel.viewportTopOffset = this._viewportTopOffset;
 		}
 
 		view.toolbar.fillFromConfig( this._toolbarConfig, this.componentFactory );
@@ -180,5 +182,29 @@ export default class ClassicEditorUI extends EditorUI {
 				keepOnFocus: true
 			} );
 		}
+	}
+
+	/**
+	 * TODO: Find better place for this to not duplicate it with inline editor
+	 * TODO: Also deprecation warning could be moved from toolbar config normalization function to here
+	 * Get viewport top offset.
+	 *
+	 * @private
+	 * @return Number|null
+	 */
+	get _viewportTopOffset() {
+		const editor = this.editor;
+		const viewportOffset = editor.config.get( 'ui.viewportOffset' );
+
+		if ( viewportOffset && viewportOffset.top ) {
+			return viewportOffset.top;
+		}
+
+		// Fall back to deprecated toolbar config
+		if ( this._toolbarConfig.viewportTopOffset ) {
+			return this._toolbarConfig.viewportTopOffset;
+		}
+
+		return null;
 	}
 }

--- a/packages/ckeditor5-editor-classic/src/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/src/classiceditorui.js
@@ -142,12 +142,7 @@ export default class ClassicEditorUI extends EditorUI {
 		// Set–up the sticky panel with toolbar.
 		view.stickyPanel.bind( 'isActive' ).to( this.focusTracker, 'isFocused' );
 		view.stickyPanel.limiterElement = view.element;
-
-		if ( this._viewportTopOffset ) {
-			// TODO: Consider dropping `stickyPanel` from this, and leave just
-			// view.viewportTopOffset to keep consistency with InlineEditor
-			view.stickyPanel.viewportTopOffset = this._viewportTopOffset;
-		}
+		view.stickyPanel.bind( 'viewportTopOffset' ).to( this, 'viewportOffset', ( { top } ) => top );
 
 		view.toolbar.fillFromConfig( this._toolbarConfig, this.componentFactory );
 
@@ -183,28 +178,5 @@ export default class ClassicEditorUI extends EditorUI {
 			} );
 		}
 	}
-
-	/**
-	 * TODO: Find better place for this to not duplicate it with inline editor
-	 * TODO: Also deprecation warning could be moved from toolbar config normalization function to here
-	 * Get viewport top offset.
-	 *
-	 * @private
-	 * @return Number|null
-	 */
-	get _viewportTopOffset() {
-		const editor = this.editor;
-		const viewportOffset = editor.config.get( 'ui.viewportOffset' );
-
-		if ( viewportOffset && viewportOffset.top ) {
-			return viewportOffset.top;
-		}
-
-		// Fall back to deprecated toolbar config
-		if ( this._toolbarConfig.viewportTopOffset ) {
-			return this._toolbarConfig.viewportTopOffset;
-		}
-
-		return null;
-	}
 }
+

--- a/packages/ckeditor5-editor-classic/tests/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditorui.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals document, Event */
+/* globals document, Event, console */
 
 import View from '@ckeditor/ckeditor5-ui/src/view';
 
@@ -86,6 +86,8 @@ describe( 'ClassicEditorUI', () => {
 			} );
 
 			it( 'sets view.stickyPanel#viewportTopOffset, if legacy toolbar.vierportTopOffset specified', () => {
+				sinon.stub( console, 'warn' );
+
 				return VirtualClassicTestEditor
 					.create( 'foo', {
 						toolbar: {

--- a/packages/ckeditor5-editor-classic/tests/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditorui.js
@@ -98,7 +98,7 @@ describe( 'ClassicEditorUI', () => {
 					.then( editor => {
 						expect( editor.ui.viewportOffset.top ).to.equal( 100 );
 						expect( editor.ui.view.stickyPanel.viewportTopOffset ).to.equal( 100 );
-						sinon.assert.calledOnce( spy );
+						sinon.assert.calledWithMatch( spy, 'editor-ui-deprecated-viewport-offset-config' );
 
 						return editor.destroy();
 					} );

--- a/packages/ckeditor5-editor-classic/tests/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditorui.js
@@ -86,8 +86,8 @@ describe( 'ClassicEditorUI', () => {
 					} );
 			} );
 
-			it( 'sets view.stickyPanel#viewportTopOffset, if legacy toolbar.vierportTopOffset specified', () => {
-				const spy = sinon.stub( console, 'warn' );
+			it( 'sets view.stickyPanel#viewportTopOffset if legacy toolbar.vierportTopOffset specified', () => {
+				sinon.stub( console, 'warn' );
 
 				return VirtualClassicTestEditor
 					.create( 'foo', {
@@ -98,6 +98,21 @@ describe( 'ClassicEditorUI', () => {
 					.then( editor => {
 						expect( editor.ui.viewportOffset.top ).to.equal( 100 );
 						expect( editor.ui.view.stickyPanel.viewportTopOffset ).to.equal( 100 );
+
+						return editor.destroy();
+					} );
+			} );
+
+			it( 'warns if legacy toolbar.vierportTopOffset specified', () => {
+				const spy = sinon.stub( console, 'warn' );
+
+				return VirtualClassicTestEditor
+					.create( 'foo', {
+						toolbar: {
+							viewportTopOffset: 100
+						}
+					} )
+					.then( editor => {
 						sinon.assert.calledWithMatch( spy, 'editor-ui-deprecated-viewport-offset-config' );
 
 						return editor.destroy();

--- a/packages/ckeditor5-editor-classic/tests/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditorui.js
@@ -72,6 +72,22 @@ describe( 'ClassicEditorUI', () => {
 			it( 'sets view.stickyPanel#viewportTopOffset, when specified in the config', () => {
 				return VirtualClassicTestEditor
 					.create( '', {
+						ui: {
+							viewportOffset: {
+								top: 100
+							}
+						}
+					} )
+					.then( editor => {
+						expect( editor.ui.view.stickyPanel.viewportTopOffset ).to.equal( 100 );
+
+						return editor.destroy();
+					} );
+			} );
+
+			it( 'sets view.stickyPanel#viewportTopOffset, if legacy toolbar.vierportTopOffset specified', () => {
+				return VirtualClassicTestEditor
+					.create( 'foo', {
 						toolbar: {
 							viewportTopOffset: 100
 						}
@@ -185,8 +201,7 @@ describe( 'ClassicEditorUI', () => {
 					return VirtualClassicTestEditor
 						.create( '', {
 							toolbar: {
-								items: [ 'foo', 'bar' ],
-								viewportTopOffset: 100
+								items: [ 'foo', 'bar' ]
 							}
 						} )
 						.then( editor => {

--- a/packages/ckeditor5-editor-classic/tests/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditorui.js
@@ -79,6 +79,7 @@ describe( 'ClassicEditorUI', () => {
 						}
 					} )
 					.then( editor => {
+						expect( editor.ui.viewportOffset.top ).to.equal( 100 );
 						expect( editor.ui.view.stickyPanel.viewportTopOffset ).to.equal( 100 );
 
 						return editor.destroy();

--- a/packages/ckeditor5-editor-classic/tests/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditorui.js
@@ -86,7 +86,7 @@ describe( 'ClassicEditorUI', () => {
 			} );
 
 			it( 'sets view.stickyPanel#viewportTopOffset, if legacy toolbar.vierportTopOffset specified', () => {
-				sinon.stub( console, 'warn' );
+				const spy = sinon.stub( console, 'warn' );
 
 				return VirtualClassicTestEditor
 					.create( 'foo', {
@@ -95,7 +95,9 @@ describe( 'ClassicEditorUI', () => {
 						}
 					} )
 					.then( editor => {
+						expect( editor.ui.viewportOffset.top ).to.equal( 100 );
 						expect( editor.ui.view.stickyPanel.viewportTopOffset ).to.equal( 100 );
+						sinon.assert.calledOnce( spy );
 
 						return editor.destroy();
 					} );

--- a/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.html
+++ b/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.html
@@ -1,0 +1,44 @@
+<div id="editor">
+	<h2>Hello world!</h2>
+	<p>This is an editor instance.</p>
+	<p>This is an editor instance.</p>
+	<p>This is an editor instance.</p>
+	<p>This is an editor instance.</p>
+	<p>This is an editor instance.</p>
+	<p>This is an editor instance.</p>
+</div>
+
+<div id="fixed">The toolbar should stick to me instead of the viewport.</div>
+
+<button id="change-offset">Set random top offset (100 - 200px)</button>
+
+<style>
+	:root {
+		--top-offset: 100px;
+	}
+
+	body {
+		height: 10000px;
+	}
+
+	.ck.ck-editor {
+		margin-top: calc(var(--top-offset) * 2);
+		margin-left: 100px;
+		margin-bottom: 100px;
+	}
+
+	#fixed {
+		display: flex;
+		align-items: center;
+		width: 100%;
+		height: var(--top-offset);
+		position: fixed;
+		top: 0;
+		z-index: 9999;
+		background: green;
+		opacity: .8;
+		color: #fff;
+		box-sizing: border-box;
+		padding: 40px;
+	}
+</style>

--- a/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.html
+++ b/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.html
@@ -11,6 +11,7 @@
 <div id="fixed">The toolbar should stick to me instead of the viewport.</div>
 
 <button id="change-offset">Set random top offset (100 - 200px)</button>
+<button id="change-offset-interval">Toggle updating offset (100 - 200px) randomly every 2 seconds</button>
 
 <style>
 	:root {

--- a/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.js
+++ b/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.js
@@ -44,5 +44,6 @@ button.addEventListener( 'click', () => {
 	const getRandomBetween = ( min, max ) => Math.random() * ( max - min ) + min;
 	const random = getRandomBetween( 100, 200 );
 	document.documentElement.style.setProperty( '--top-offset', `${ random }px` );
-	editor.ui.view.stickyPanel.viewportTopOffset = random;
+	editor.ui.viewportOffset = { top: random };
+	editor.editing.view.focus();
 } );

--- a/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.js
+++ b/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.js
@@ -1,0 +1,44 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console:false, document, window */
+
+import ClassicEditor from '../../../../src/classiceditor';
+import Enter from '@ckeditor/ckeditor5-enter/src/enter';
+import Typing from '@ckeditor/ckeditor5-typing/src/typing';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Undo from '@ckeditor/ckeditor5-undo/src/undo';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+
+let editor;
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ Enter, Typing, Paragraph, Undo, Heading, Bold, Italic ],
+		toolbar: {
+			items: [ 'heading', '|', 'bold', 'italic', 'undo', 'redo' ],
+			viewportTopOffset: 100
+		}
+	} )
+	.then( newEditor => {
+		console.log( 'Editor was initialized', newEditor );
+		console.log( 'You can now play with it using global `editor` and `editable` variables.' );
+
+		window.editor = editor = newEditor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );
+
+const button = document.querySelector( '#change-offset' );
+
+button.addEventListener( 'click', () => {
+	const getRandomBetween = ( min, max ) => Math.random() * ( max - min ) + min;
+	const random = getRandomBetween( 100, 200 );
+	document.documentElement.style.setProperty( '--top-offset', `${ random }px` );
+	editor.ui.view.stickyPanel.viewportTopOffset = random;
+} );

--- a/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.js
+++ b/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.js
@@ -20,8 +20,12 @@ ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [ Enter, Typing, Paragraph, Undo, Heading, Bold, Italic ],
 		toolbar: {
-			items: [ 'heading', '|', 'bold', 'italic', 'undo', 'redo' ],
-			viewportTopOffset: 100
+			items: [ 'heading', '|', 'bold', 'italic', 'undo', 'redo' ]
+		},
+		ui: {
+			viewportOffset: {
+				top: 100
+			}
 		}
 	} )
 	.then( newEditor => {

--- a/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.js
+++ b/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals console:false, document, window */
+/* globals console:false, document, window, setInterval, clearInterval */
 
 import ClassicEditor from '../../../../src/classiceditor';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
@@ -39,11 +39,42 @@ ClassicEditor
 	} );
 
 const button = document.querySelector( '#change-offset' );
+const buttonInterval = document.querySelector( '#change-offset-interval' );
 
-button.addEventListener( 'click', () => {
+let intervalRunning = false;
+let interval = null;
+
+const update = () => {
 	const getRandomBetween = ( min, max ) => Math.random() * ( max - min ) + min;
 	const random = getRandomBetween( 100, 200 );
 	document.documentElement.style.setProperty( '--top-offset', `${ random }px` );
 	editor.ui.viewportOffset = { top: random };
+};
+
+const updateAndFocus = () => {
+	update();
 	editor.editing.view.focus();
-} );
+};
+
+const updateAndChangeLayout = () => {
+	update();
+	editor.editing.view.document.fire( 'layoutChanged' );
+};
+
+const handleInterval = () => {
+	if ( intervalRunning ) {
+		clearInterval( interval );
+		intervalRunning = false;
+	} else {
+		interval = setInterval( updateAndChangeLayout, 2000 );
+		intervalRunning = true;
+	}
+};
+
+const updateFocusAndChangeLayout = () => {
+	editor.editing.view.focus();
+	handleInterval();
+};
+
+button.addEventListener( 'click', updateAndFocus );
+buttonInterval.addEventListener( 'click', updateFocusAndChangeLayout );

--- a/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.md
+++ b/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.md
@@ -1,0 +1,15 @@
+### The toolbar offset should be adjustable in runtime [#9672](https://github.com/ckeditor/ckeditor5/issues/9672)
+
+## Focus then scroll
+
+1. Focus the editor.
+2. Scroll the web page until the toolbar reaches the green box boundaries.
+3. Click "Set random top offset" button.
+4. Scroll the web page until the toolbar reaches the green box boundaries.
+
+**Expected:**
+
+1. The toolbar should stick to the green box instead of the viewport edge, respecting `ui.viewportOffset.top` configuration.
+2. At some point, the toolbar should disappear below the green box, leaving some space for the last paragraph of the content to remain visible.
+3. Each time you click "Set random top offset" the toolbar should stick to the resized green box when scrolling down.
+

--- a/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.md
+++ b/packages/ckeditor5-editor-classic/tests/manual/tickets/9672/1.md
@@ -13,3 +13,14 @@
 2. At some point, the toolbar should disappear below the green box, leaving some space for the last paragraph of the content to remain visible.
 3. Each time you click "Set random top offset" the toolbar should stick to the resized green box when scrolling down.
 
+## Auto update top offset
+
+In this example we do update `viewportOffset` without focusing out of the editor editable area.
+
+1. Click on "Toggle updating offset..." button.
+2. Wait 2 seconds.
+3. Observe the UI.
+
+**Expected:**
+
+1. The toolbar should be moving as we update the top offset.

--- a/packages/ckeditor5-editor-decoupled/tests/decouplededitorui.js
+++ b/packages/ckeditor5-editor-decoupled/tests/decouplededitorui.js
@@ -157,8 +157,12 @@ describe( 'DecoupledEditorUI', () => {
 					return VirtualDecoupledTestEditor
 						.create( '', {
 							toolbar: {
-								items: [ 'foo', 'bar' ],
-								viewportTopOffset: 100
+								items: [ 'foo', 'bar' ]
+							},
+							ui: {
+								viewportOffset: {
+									top: 100
+								}
 							}
 						} )
 						.then( editor => {

--- a/packages/ckeditor5-editor-inline/src/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/src/inlineeditorui.js
@@ -125,8 +125,8 @@ export default class InlineEditorUI extends EditorUI {
 		// Set–up the view#panel.
 		view.panel.bind( 'isVisible' ).to( this.focusTracker, 'isFocused' );
 
-		if ( this._toolbarConfig.viewportTopOffset ) {
-			view.viewportTopOffset = this._toolbarConfig.viewportTopOffset;
+		if ( this._viewportTopOffset ) {
+			view.viewportTopOffset = this._viewportTopOffset;
 		}
 
 		// https://github.com/ckeditor/ckeditor5-editor-inline/issues/4
@@ -174,5 +174,29 @@ export default class InlineEditorUI extends EditorUI {
 				keepOnFocus: true
 			} );
 		}
+	}
+
+	/**
+	 * TODO: Find better place for this to not duplicate it with inline editor
+	 * TODO: Also deprecation warning could be moved from toolbar config normalization function to here
+	 * Get viewport top offset.
+	 *
+	 * @private
+	 * @return Number|null
+	 */
+	get _viewportTopOffset() {
+		const editor = this.editor;
+		const viewportOffset = editor.config.get( 'ui.viewportOffset' );
+
+		if ( viewportOffset && viewportOffset.top ) {
+			return viewportOffset.top;
+		}
+
+		// Fall back to deprecated toolbar config
+		if ( this._toolbarConfig.viewportTopOffset ) {
+			return this._toolbarConfig.viewportTopOffset;
+		}
+
+		return null;
 	}
 }

--- a/packages/ckeditor5-editor-inline/src/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/src/inlineeditorui.js
@@ -125,9 +125,7 @@ export default class InlineEditorUI extends EditorUI {
 		// Set–up the view#panel.
 		view.panel.bind( 'isVisible' ).to( this.focusTracker, 'isFocused' );
 
-		if ( this._viewportTopOffset ) {
-			view.viewportTopOffset = this._viewportTopOffset;
-		}
+		view.bind( 'viewportTopOffset' ).to( this, 'viewportOffset', ( { top } ) => top );
 
 		// https://github.com/ckeditor/ckeditor5-editor-inline/issues/4
 		view.listenTo( editor.ui, 'update', () => {
@@ -174,29 +172,5 @@ export default class InlineEditorUI extends EditorUI {
 				keepOnFocus: true
 			} );
 		}
-	}
-
-	/**
-	 * TODO: Find better place for this to not duplicate it with inline editor
-	 * TODO: Also deprecation warning could be moved from toolbar config normalization function to here
-	 * Get viewport top offset.
-	 *
-	 * @private
-	 * @return Number|null
-	 */
-	get _viewportTopOffset() {
-		const editor = this.editor;
-		const viewportOffset = editor.config.get( 'ui.viewportOffset' );
-
-		if ( viewportOffset && viewportOffset.top ) {
-			return viewportOffset.top;
-		}
-
-		// Fall back to deprecated toolbar config
-		if ( this._toolbarConfig.viewportTopOffset ) {
-			return this._toolbarConfig.viewportTopOffset;
-		}
-
-		return null;
 	}
 }

--- a/packages/ckeditor5-editor-inline/src/inlineeditoruiview.js
+++ b/packages/ckeditor5-editor-inline/src/inlineeditoruiview.js
@@ -52,8 +52,16 @@ export default class InlineEditorUIView extends EditorUIView {
 		 * either using `position: fixed` or `position: sticky`, which would cover the
 		 * UI or vice–versa (depending on the `z-index` hierarchy).
 		 *
-		 * @readonly
+		 * Bound to {@link module:core/editor/editorui~EditorUI#viewportOffset `EditorUI.viewportOffset`}.
+		 *
+		 * If {@link module:core/editor/editorconfig~EditorConfig#ui `EditorConfig#ui.viewportOffset.top`} is defined then
+		 * it will be set as the value of this property overriding the default value.
+		 *
+		 * Everytime {@link module:core/editor/editorconfig~EditorConfig#ui `EditorConfig#ui.viewportOffset`} is updated,
+		 * this value will be updated as well.
+		 *
 		 * @observable
+		 * @default 0
 		 * @member {Number} #viewportTopOffset
 		 */
 		this.set( 'viewportTopOffset', 0 );

--- a/packages/ckeditor5-editor-inline/src/inlineeditoruiview.js
+++ b/packages/ckeditor5-editor-inline/src/inlineeditoruiview.js
@@ -52,13 +52,10 @@ export default class InlineEditorUIView extends EditorUIView {
 		 * either using `position: fixed` or `position: sticky`, which would cover the
 		 * UI or vice–versa (depending on the `z-index` hierarchy).
 		 *
-		 * Bound to {@link module:core/editor/editorui~EditorUI#viewportOffset `EditorUI.viewportOffset`}.
+		 * Bound to {@link module:core/editor/editorui~EditorUI#viewportOffset `EditorUI#viewportOffset`}.
 		 *
-		 * If {@link module:core/editor/editorconfig~EditorConfig#ui `EditorConfig#ui.viewportOffset.top`} is defined then
-		 * it will be set as the value of this property overriding the default value.
-		 *
-		 * Everytime {@link module:core/editor/editorconfig~EditorConfig#ui `EditorConfig#ui.viewportOffset`} is updated,
-		 * this value will be updated as well.
+		 * If {@link module:core/editor/editorconfig~EditorConfig#ui `EditorConfig#ui.viewportOffset.top`} is defined, then
+		 * it will override the default value.
 		 *
 		 * @observable
 		 * @default 0

--- a/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
@@ -68,6 +68,25 @@ describe( 'InlineEditorUI', () => {
 			it( 'sets view#viewportTopOffset, if specified', () => {
 				return VirtualInlineTestEditor
 					.create( 'foo', {
+						ui: {
+							viewportOffset: {
+								top: 100
+							}
+						}
+					} )
+					.then( editor => {
+						const ui = editor.ui;
+						const view = ui.view;
+
+						expect( view.viewportTopOffset ).to.equal( 100 );
+
+						return editor.destroy();
+					} );
+			} );
+
+			it( 'sets view#viewportTopOffset, if legacy toolbar.vierportTopOffset specified', () => {
+				return VirtualInlineTestEditor
+					.create( 'foo', {
 						toolbar: {
 							viewportTopOffset: 100
 						}
@@ -210,8 +229,7 @@ describe( 'InlineEditorUI', () => {
 				return VirtualInlineTestEditor
 					.create( '', {
 						toolbar: {
-							items: [ 'foo', 'bar' ],
-							viewportTopOffset: 100
+							items: [ 'foo', 'bar' ]
 						}
 					} )
 					.then( editor => {

--- a/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
@@ -78,6 +78,7 @@ describe( 'InlineEditorUI', () => {
 						const ui = editor.ui;
 						const view = ui.view;
 
+						expect( ui.viewportOffset.top ).to.equal( 100 );
 						expect( view.viewportTopOffset ).to.equal( 100 );
 
 						return editor.destroy();

--- a/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
@@ -85,8 +85,8 @@ describe( 'InlineEditorUI', () => {
 					} );
 			} );
 
-			it( 'sets view#viewportTopOffset, if legacy toolbar.vierportTopOffset specified', () => {
-				const spy = sinon.stub( console, 'warn' );
+			it( 'sets view#viewportTopOffset if legacy toolbar.vierportTopOffset specified', () => {
+				sinon.stub( console, 'warn' );
 
 				return VirtualInlineTestEditor
 					.create( 'foo', {
@@ -99,6 +99,21 @@ describe( 'InlineEditorUI', () => {
 
 						expect( ui.viewportOffset.top ).to.equal( 100 );
 						expect( ui.view.viewportTopOffset ).to.equal( 100 );
+
+						return editor.destroy();
+					} );
+			} );
+
+			it( 'warns if legacy toolbar.vierportTopOffset specified', () => {
+				const spy = sinon.stub( console, 'warn' );
+
+				return VirtualInlineTestEditor
+					.create( 'foo', {
+						toolbar: {
+							viewportTopOffset: 100
+						}
+					} )
+					.then( editor => {
 						sinon.assert.calledWithMatch( spy, 'editor-ui-deprecated-viewport-offset-config' );
 
 						return editor.destroy();

--- a/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
@@ -85,7 +85,7 @@ describe( 'InlineEditorUI', () => {
 			} );
 
 			it( 'sets view#viewportTopOffset, if legacy toolbar.vierportTopOffset specified', () => {
-				sinon.stub( console, 'warn' );
+				const spy = sinon.stub( console, 'warn' );
 
 				return VirtualInlineTestEditor
 					.create( 'foo', {
@@ -95,9 +95,10 @@ describe( 'InlineEditorUI', () => {
 					} )
 					.then( editor => {
 						const ui = editor.ui;
-						const view = ui.view;
 
-						expect( view.viewportTopOffset ).to.equal( 100 );
+						expect( ui.viewportOffset.top ).to.equal( 100 );
+						expect( ui.view.viewportTopOffset ).to.equal( 100 );
+						sinon.assert.calledOnce( spy );
 
 						return editor.destroy();
 					} );

--- a/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals document, Event */
+/* globals document, Event, console */
 
 import View from '@ckeditor/ckeditor5-ui/src/view';
 
@@ -85,6 +85,8 @@ describe( 'InlineEditorUI', () => {
 			} );
 
 			it( 'sets view#viewportTopOffset, if legacy toolbar.vierportTopOffset specified', () => {
+				sinon.stub( console, 'warn' );
+
 				return VirtualInlineTestEditor
 					.create( 'foo', {
 						toolbar: {

--- a/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
@@ -99,7 +99,7 @@ describe( 'InlineEditorUI', () => {
 
 						expect( ui.viewportOffset.top ).to.equal( 100 );
 						expect( ui.view.viewportTopOffset ).to.equal( 100 );
-						sinon.assert.calledOnce( spy );
+						sinon.assert.calledWithMatch( spy, 'editor-ui-deprecated-viewport-offset-config' );
 
 						return editor.destroy();
 					} );

--- a/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.html
+++ b/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.html
@@ -1,0 +1,44 @@
+<div id="editor">
+	<h2>Hello world!</h2>
+	<p>This is an editor instance.</p>
+	<p>This is an editor instance.</p>
+	<p>This is an editor instance.</p>
+	<p>This is an editor instance.</p>
+	<p>This is an editor instance.</p>
+	<p>This is an editor instance.</p>
+</div>
+
+<div id="fixed">The toolbar should stick to me instead of the viewport.</div>
+
+<button id="change-offset">Set random top offset (100 - 200px)</button>
+
+<style>
+	:root {
+		--top-offset: 100px;
+	}
+
+	body {
+		height: 10000px;
+	}
+
+	.ck.ck-editor__editable {
+		margin-top: calc(var(--top-offset) * 2);
+		margin-left: 100px;
+		margin-bottom: 100px;
+	}
+
+	#fixed {
+		display: flex;
+		align-items: center;
+		width: 100%;
+		height: var(--top-offset);
+		position: fixed;
+		top: 0;
+		z-index: 9999;
+		background: green;
+		opacity: .8;
+		color: #fff;
+		box-sizing: border-box;
+		padding: 40px;
+	}
+</style>

--- a/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.html
+++ b/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.html
@@ -11,6 +11,7 @@
 <div id="fixed">The toolbar should stick to me instead of the viewport.</div>
 
 <button id="change-offset">Set random top offset (100 - 200px)</button>
+<button id="change-offset-interval">Toggle updating offset (100 - 200px) randomly every 2 seconds</button>
 
 <style>
 	:root {

--- a/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.js
@@ -20,8 +20,12 @@ InlineEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [ Enter, Typing, Paragraph, Undo, Heading, Bold, Italic ],
 		toolbar: {
-			items: [ 'heading', '|', 'bold', 'italic', 'undo', 'redo' ],
-			viewportTopOffset: 100
+			items: [ 'heading', '|', 'bold', 'italic', 'undo', 'redo' ]
+		},
+		ui: {
+			viewportOffset: {
+				top: 100
+			}
 		}
 	} )
 	.then( newEditor => {

--- a/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.js
@@ -1,0 +1,44 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console:false, document, window */
+
+import InlineEditor from '../../../../src/inlineeditor';
+import Enter from '@ckeditor/ckeditor5-enter/src/enter';
+import Typing from '@ckeditor/ckeditor5-typing/src/typing';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Undo from '@ckeditor/ckeditor5-undo/src/undo';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+
+let editor;
+
+InlineEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ Enter, Typing, Paragraph, Undo, Heading, Bold, Italic ],
+		toolbar: {
+			items: [ 'heading', '|', 'bold', 'italic', 'undo', 'redo' ],
+			viewportTopOffset: 100
+		}
+	} )
+	.then( newEditor => {
+		console.log( 'Editor was initialized', newEditor );
+		console.log( 'You can now play with it using global `editor` and `editable` variables.' );
+
+		window.editor = editor = newEditor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );
+
+const button = document.querySelector( '#change-offset' );
+
+button.addEventListener( 'click', () => {
+	const getRandomBetween = ( min, max ) => Math.random() * ( max - min ) + min;
+	const random = getRandomBetween( 100, 200 );
+	document.documentElement.style.setProperty( '--top-offset', `${ random }px` );
+	editor.ui.view.viewportTopOffset = random;
+} );

--- a/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals console:false, document, window */
+/* globals console:false, document, window, setInterval, clearInterval */
 
 import InlineEditor from '../../../../src/inlineeditor';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
@@ -39,11 +39,42 @@ InlineEditor
 	} );
 
 const button = document.querySelector( '#change-offset' );
+const buttonInterval = document.querySelector( '#change-offset-interval' );
 
-button.addEventListener( 'click', () => {
+let intervalRunning = false;
+let interval = null;
+
+const update = () => {
 	const getRandomBetween = ( min, max ) => Math.random() * ( max - min ) + min;
 	const random = getRandomBetween( 100, 200 );
 	document.documentElement.style.setProperty( '--top-offset', `${ random }px` );
 	editor.ui.viewportOffset = { top: random };
+};
+
+const updateAndFocus = () => {
+	update();
 	editor.editing.view.focus();
-} );
+};
+
+const updateAndChangeLayout = () => {
+	update();
+	editor.editing.view.document.fire( 'layoutChanged' );
+};
+
+const handleInterval = () => {
+	if ( intervalRunning ) {
+		clearInterval( interval );
+		intervalRunning = false;
+	} else {
+		interval = setInterval( updateAndChangeLayout, 2000 );
+		intervalRunning = true;
+	}
+};
+
+const updateFocusAndChangeLayout = () => {
+	editor.editing.view.focus();
+	handleInterval();
+};
+
+button.addEventListener( 'click', updateAndFocus );
+buttonInterval.addEventListener( 'click', updateFocusAndChangeLayout );

--- a/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.js
+++ b/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.js
@@ -44,5 +44,6 @@ button.addEventListener( 'click', () => {
 	const getRandomBetween = ( min, max ) => Math.random() * ( max - min ) + min;
 	const random = getRandomBetween( 100, 200 );
 	document.documentElement.style.setProperty( '--top-offset', `${ random }px` );
-	editor.ui.view.viewportTopOffset = random;
+	editor.ui.viewportOffset = { top: random };
+	editor.editing.view.focus();
 } );

--- a/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.md
+++ b/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.md
@@ -12,3 +12,15 @@
 1. The toolbar should stick to the green box instead of the viewport edge, respecting `ui.viewportOffset.top` configuration.
 2. At some point, the toolbar should disappear below the green box, leaving some space for the last paragraph of the content to remain visible.
 3. Each time you click "Set random top offset" the toolbar should stick to the resized green box when scrolling down.
+
+## Auto update top offset
+
+In this example we do update `viewportOffset` without focusing out of the editor editable area.
+
+1. Click on "Toggle updating offset..." button.
+2. Wait 2 seconds.
+3. Observe the UI.
+
+**Expected:**
+
+1. The toolbar should be moving as we update the top offset.

--- a/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.md
+++ b/packages/ckeditor5-editor-inline/tests/manual/tickets/9672/1.md
@@ -1,0 +1,14 @@
+### The toolbar offset should be adjustable in runtime [#9672](https://github.com/ckeditor/ckeditor5/issues/9672)
+
+## Focus then scroll
+
+1. Focus the editor.
+2. Scroll the web page until the toolbar reaches the green box boundaries.
+3. Click "Set random top offset" button.
+4. Scroll the web page until the toolbar reaches the green box boundaries.
+
+**Expected:**
+
+1. The toolbar should stick to the green box instead of the viewport edge, respecting `ui.viewportOffset.top` configuration.
+2. At some point, the toolbar should disappear below the green box, leaving some space for the last paragraph of the content to remain visible.
+3. Each time you click "Set random top offset" the toolbar should stick to the resized green box when scrolling down.

--- a/packages/ckeditor5-engine/docs/_snippets/framework/element-reconversion-demo.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/element-reconversion-demo.js
@@ -343,8 +343,12 @@ ClassicEditor
 			]
 		},
 		toolbar: {
-			items: [ 'heading', '|', 'bold', 'italic', '|', 'insertCard' ],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			items: [ 'heading', '|', 'bold', 'italic', '|', 'insertCard' ]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-external-link-target.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-external-link-target.js
@@ -35,8 +35,10 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-link-external' ), {
 		cloudServices: CS_CONFIG,
 		extraPlugins: [ AddTargetToExternalLinks ],
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-heading-class.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-heading-class.js
@@ -21,8 +21,10 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-heading-class' ), {
 		cloudServices: CS_CONFIG,
 		extraPlugins: [ AddClassToAllHeading1 ],
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-link-class.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-link-class.js
@@ -31,8 +31,10 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-link-classes' ), {
 		cloudServices: CS_CONFIG,
 		extraPlugins: [ AddClassToAllLinks ],
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-unsafe-link-class.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-add-unsafe-link-class.js
@@ -31,8 +31,10 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-link-unsafe-classes' ), {
 		cloudServices: CS_CONFIG,
 		extraPlugins: [ AddClassToUnsafeLinks ],
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-allow-div-attributes.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-allow-div-attributes.js
@@ -62,8 +62,10 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-div-attributes' ), {
 		cloudServices: CS_CONFIG,
 		extraPlugins: [ ConvertDivAttributes ],
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-allow-link-target.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-allow-link-target.js
@@ -35,8 +35,10 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-link-target' ), {
 		cloudServices: CS_CONFIG,
 		extraPlugins: [ AllowLinkTarget ],
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-arbitrary-attribute-values.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-arbitrary-attribute-values.js
@@ -53,8 +53,12 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		extraPlugins: [ HandleFontSizeValue ],
 		toolbar: {
-			items: [ 'heading', '|', 'bold', 'italic', '|', 'fontSize' ],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			items: [ 'heading', '|', 'bold', 'italic', '|', 'fontSize' ]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		fontSize: {
 			options: [ 10, 12, 14, 'default', 18, 20, 22 ]

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-custom-element-converter.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-custom-element-converter.js
@@ -194,8 +194,10 @@ ClassicEditor
 				'mergeTableCells'
 			]
 		},
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-custom-figure-attributes.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-custom-figure-attributes.js
@@ -176,8 +176,10 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-custom-figure-attributes' ), {
 		cloudServices: CS_CONFIG,
 		extraPlugins: [ CustomFigureAttributes ],
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
+++ b/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
@@ -21,8 +21,12 @@ ClassicEditor
 				'redo',
 				'|',
 				'findAndReplace'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
@@ -24,8 +24,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		fontBackgroundColor: {
 			colors: [

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-family-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-family-options.js
@@ -23,8 +23,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		fontFamily: {
 			options: [

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-named-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-named-options.js
@@ -13,8 +13,12 @@ ClassicEditor
 		toolbar: {
 			items: [
 				'heading', '|', 'fontSize', 'bulletedList', 'numberedList', 'undo', 'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		fontSize: {
 			options: [

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-numeric-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-numeric-options.js
@@ -24,8 +24,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		fontSize: {
 			options: [

--- a/packages/ckeditor5-font/docs/_snippets/features/font.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/font.js
@@ -27,8 +27,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-elements.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-elements.js
@@ -27,8 +27,10 @@ ClassicEditor
 				}
 			]
 		},
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-levels.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-levels.js
@@ -17,8 +17,10 @@ ClassicEditor
 				{ model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' }
 			]
 		},
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-heading/docs/_snippets/features/default-headings.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/default-headings.js
@@ -18,8 +18,10 @@ ClassicEditor
 				{ model: 'heading3', view: 'h3', title: 'Heading 3', class: 'ck-heading_heading3' }
 			]
 		},
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-inline.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-inline.js
@@ -23,8 +23,12 @@ ClassicEditor
 				'highlight',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		highlight: {
 			options: [

--- a/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-variables.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-variables.js
@@ -23,8 +23,12 @@ ClassicEditor
 				'highlight',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		highlight: {
 			options: [

--- a/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-options.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-options.js
@@ -23,8 +23,12 @@ ClassicEditor
 				'highlight',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		highlight: {
 			options: [

--- a/packages/ckeditor5-highlight/docs/_snippets/features/highlight-buttons.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/highlight-buttons.js
@@ -23,8 +23,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-highlight/docs/_snippets/features/highlight.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/highlight.js
@@ -23,8 +23,12 @@ ClassicEditor
 				'highlight',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-horizontal-line/docs/_snippets/features/horizontal-line.js
+++ b/packages/ckeditor5-horizontal-line/docs/_snippets/features/horizontal-line.js
@@ -38,8 +38,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/packages/ckeditor5-html-embed/docs/_snippets/features/html-embed.js
+++ b/packages/ckeditor5-html-embed/docs/_snippets/features/html-embed.js
@@ -101,8 +101,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support-source.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support-source.js
@@ -48,8 +48,12 @@ ClassicEditor.defaultConfig = {
 			'|',
 			'undo',
 			'redo'
-		],
-		viewportTopOffset: window.getViewportTopOffsetConfig()
+		]
+	},
+	ui: {
+		viewportOffset: {
+			top: window.getViewportTopOffsetConfig()
+		}
 	}
 };
 

--- a/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support.js
@@ -37,8 +37,12 @@ ClassicEditor
 				'redo',
 				'|',
 				'sourceEditing'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/packages/ckeditor5-image/docs/_snippets/features/image-caption.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-caption.js
@@ -17,8 +17,10 @@ ClassicEditor
 				'toggleImageCaption'
 			]
 		},
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/packages/ckeditor5-image/docs/_snippets/features/image-full.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-full.js
@@ -10,8 +10,6 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-full' ), {
 		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig(),
-
 			items: [
 				'heading',
 				'|',
@@ -31,6 +29,11 @@ ClassicEditor
 				'undo',
 				'redo'
 			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/packages/ckeditor5-image/docs/_snippets/features/image-insert-via-url.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-insert-via-url.js
@@ -15,8 +15,12 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-image-insert-via-url' ), {
 		removePlugins: [ 'ImageToolbar', 'ImageCaption', 'ImageStyle', 'ImageResize', 'LinkImage', 'AutoImage' ],
 		toolbar: {
-			items: toolbarItems,
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			items: toolbarItems
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/packages/ckeditor5-image/docs/_snippets/features/image-link.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-link.js
@@ -10,8 +10,10 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-link' ), {
 		removePlugins: [ 'AutoImage' ],
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons-dropdown.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons-dropdown.js
@@ -10,8 +10,10 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-resize-buttons-dropdown' ), {
 		removePlugins: [ 'LinkImage', 'AutoImage' ],
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			resizeUnit: '%',

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons.js
@@ -10,8 +10,10 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-resize-buttons' ), {
 		removePlugins: [ 'LinkImage', 'AutoImage' ],
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			resizeOptions: [

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize-px.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize-px.js
@@ -31,8 +31,10 @@ ClassicEditor
 			],
 			toolbar: [ 'resizeImage' ]
 		},
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize.js
@@ -10,8 +10,10 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-resize' ), {
 		removePlugins: [ 'LinkImage', 'AutoImage' ],
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/packages/ckeditor5-image/docs/_snippets/features/image-semantical-style.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-semantical-style.js
@@ -10,8 +10,10 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-semantical-image-style-default' ), {
 		removePlugins: [ 'imageCaption' ],
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		cloudServices: CS_CONFIG,
 		image: {

--- a/packages/ckeditor5-image/docs/_snippets/features/image-style-custom.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-style-custom.js
@@ -15,8 +15,10 @@ import sideIcon from '@ckeditor/ckeditor5-image/docs/assets/img/icons/side.svg';
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-semantical-style-custom' ), {
 		removePlugins: [ 'ImageResize' ],
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		cloudServices: CS_CONFIG,
 		image: {

--- a/packages/ckeditor5-image/docs/_snippets/features/image-style-presentational.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-style-presentational.js
@@ -36,8 +36,10 @@ ClassicEditor
 				'resizeImage'
 			]
 		},
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/packages/ckeditor5-image/docs/_snippets/features/image-text-alternative.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-text-alternative.js
@@ -17,8 +17,10 @@ ClassicEditor
 				'toggleImageCaption'
 			]
 		},
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		cloudServices: CS_CONFIG
 	} )

--- a/packages/ckeditor5-indent/docs/_snippets/features/custom-indent-block-classes.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/custom-indent-block-classes.js
@@ -24,8 +24,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		indentBlock: {
 			classes: [

--- a/packages/ckeditor5-indent/docs/_snippets/features/indent.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/indent.js
@@ -22,8 +22,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-language/docs/_snippets/features/textpartlanguage.js
+++ b/packages/ckeditor5-language/docs/_snippets/features/textpartlanguage.js
@@ -39,8 +39,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-link/docs/_snippets/features/autolink.js
+++ b/packages/ckeditor5-link/docs/_snippets/features/autolink.js
@@ -11,8 +11,10 @@ ClassicEditor
 		extraPlugins: [
 			CKEditorPlugins.AutoLink
 		],
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-link/docs/_snippets/features/link.js
+++ b/packages/ckeditor5-link/docs/_snippets/features/link.js
@@ -8,8 +8,10 @@
 ClassicEditor
 	.create( document.querySelector( '#snippet-link' ), {
 		cloudServices: CS_CONFIG,
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-link/docs/_snippets/features/linkdecorators.js
+++ b/packages/ckeditor5-link/docs/_snippets/features/linkdecorators.js
@@ -8,8 +8,10 @@
 ClassicEditor
 	.create( document.querySelector( '#snippet-link-decorators' ), {
 		cloudServices: CS_CONFIG,
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		link: {
 			addTargetToExternalLinks: true,

--- a/packages/ckeditor5-list/docs/_snippets/features/lists-basic.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/lists-basic.js
@@ -28,8 +28,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/packages/ckeditor5-list/docs/_snippets/features/lists-style.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/lists-style.js
@@ -29,8 +29,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/packages/ckeditor5-list/docs/_snippets/features/todo-list.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/todo-list.js
@@ -32,8 +32,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed.js
+++ b/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed.js
@@ -10,8 +10,10 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-media-embed' ), {
 		cloudServices: CS_CONFIG,
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-mention/docs/_snippets/examples/chat-with-mentions.js
+++ b/packages/ckeditor5-mention/docs/_snippets/examples/chat-with-mentions.js
@@ -18,8 +18,12 @@ ClassicEditor
 		toolbar: {
 			items: [
 				'bold', 'italic', 'underline', 'strikethrough', '|', 'link', '|', 'undo', 'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		mention: {
 			feeds: [

--- a/packages/ckeditor5-mention/docs/_snippets/features/custom-mention-colors-variables.js
+++ b/packages/ckeditor5-mention/docs/_snippets/features/custom-mention-colors-variables.js
@@ -13,8 +13,12 @@ ClassicEditor
 		toolbar: {
 			items: [
 				'heading', '|', 'bold', 'italic', '|', 'undo', 'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		mention: {
 			feeds: [

--- a/packages/ckeditor5-mention/docs/_snippets/features/mention-customization.js
+++ b/packages/ckeditor5-mention/docs/_snippets/features/mention-customization.js
@@ -14,8 +14,12 @@ ClassicEditor
 		toolbar: {
 			items: [
 				'heading', '|', 'bold', 'italic', '|', 'undo', 'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		mention: {
 			feeds: [

--- a/packages/ckeditor5-mention/docs/_snippets/features/mention.js
+++ b/packages/ckeditor5-mention/docs/_snippets/features/mention.js
@@ -13,8 +13,12 @@ ClassicEditor
 		toolbar: {
 			items: [
 				'heading', '|', 'bold', 'italic', '|', 'undo', 'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		mention: {
 			feeds: [

--- a/packages/ckeditor5-page-break/docs/_snippets/features/page-break.js
+++ b/packages/ckeditor5-page-break/docs/_snippets/features/page-break.js
@@ -38,8 +38,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/packages/ckeditor5-paste-from-office/docs/_snippets/features/paste-from-office.js
+++ b/packages/ckeditor5-paste-from-office/docs/_snippets/features/paste-from-office.js
@@ -40,8 +40,12 @@ ClassicEditor
 				'undo',
 				'redo'
 			],
-			shouldNotGroupWhenFull: true,
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			shouldNotGroupWhenFull: true
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/packages/ckeditor5-remove-format/docs/_snippets/features/remove-format.js
+++ b/packages/ckeditor5-remove-format/docs/_snippets/features/remove-format.js
@@ -27,8 +27,12 @@ ClassicEditor
 				'redo',
 				'|',
 				'removeformat'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-select-all/docs/_snippets/features/select-all.js
+++ b/packages/ckeditor5-select-all/docs/_snippets/features/select-all.js
@@ -21,8 +21,12 @@ ClassicEditor
 				'redo',
 				'|',
 				'selectAll'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-imports.js
+++ b/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-imports.js
@@ -50,8 +50,12 @@ ClassicEditor.defaultConfig = {
 			'|',
 			'undo',
 			'redo'
-		],
-		viewportTopOffset: window.getViewportTopOffsetConfig()
+		]
+	},
+	ui: {
+		viewportOffset: {
+			top: window.getViewportTopOffsetConfig()
+		}
 	}
 };
 

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-extended-category.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-extended-category.js
@@ -41,8 +41,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-limited-categories.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-limited-categories.js
@@ -29,8 +29,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-new-category.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-new-category.js
@@ -39,8 +39,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters.js
@@ -29,8 +29,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [

--- a/packages/ckeditor5-table/docs/_snippets/features/build-table-source.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/build-table-source.js
@@ -38,8 +38,12 @@ ClassicEditor.defaultConfig = {
 			'link', 'blockQuote',
 			'|',
 			'undo', 'redo'
-		],
-		viewportTopOffset: window.getViewportTopOffsetConfig()
+		]
+	},
+	ui: {
+		viewportOffset: {
+			top: window.getViewportTopOffsetConfig()
+		}
 	},
 	indentBlock: { offset: 30, unit: 'px' }
 };

--- a/packages/ckeditor5-theme-lark/docs/_snippets/examples/theme-lark.js
+++ b/packages/ckeditor5-theme-lark/docs/_snippets/examples/theme-lark.js
@@ -32,8 +32,12 @@ ClassicEditor
 				'blockQuote',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		image: {
 			toolbar: [ 'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|', 'toggleImageCaption', 'imageTextAlternative' ]

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.js
@@ -11,8 +11,10 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-text-transformation-extended' ), {
 		cloudServices: CS_CONFIG,
 		placeholder: 'Type here...',
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		typing: {
 			transformations: {

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
@@ -11,8 +11,10 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-text-transformation' ), {
 		cloudServices: CS_CONFIG,
 		placeholder: 'Type here...',
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-ui/docs/_snippets/features/blocktoolbar.js
+++ b/packages/ckeditor5-ui/docs/_snippets/features/blocktoolbar.js
@@ -15,8 +15,12 @@ BalloonEditor
 	.create( document.querySelector( '#snippet-block-toolbar' ), {
 		plugins: BalloonEditor.builtinPlugins.concat( [ BlockToolbar, ParagraphButtonUI, HeadingButtonsUI ] ),
 		toolbar: {
-			items: [ 'bold', 'italic', 'link', 'undo', 'redo' ],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			items: [ 'bold', 'italic', 'link', 'undo', 'redo' ]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		blockToolbar: [
 			'paragraph', 'heading1', 'heading2', 'heading3',

--- a/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.js
+++ b/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.js
@@ -80,6 +80,14 @@ export default class StickyPanelView extends View {
 		 * either using `position: fixed` or `position: sticky`, which would cover the
 		 * sticky panel or vice–versa (depending on the `z-index` hierarchy).
 		 *
+		 * Bound to {@link module:core/editor/editorui~EditorUI#viewportOffset `EditorUI.viewportOffset`}.
+		 *
+		 * If {@link module:core/editor/editorconfig~EditorConfig#ui `EditorConfig#ui.viewportOffset.top`} is defined then
+		 * it will be set as the value of this property overriding the default value.
+		 *
+		 * Everytime {@link module:core/editor/editorconfig~EditorConfig#ui `EditorConfig#ui.viewportOffset`} is updated,
+		 * this value will be updated as well.
+		 *
 		 * @observable
 		 * @default 0
 		 * @member {Number} #viewportTopOffset

--- a/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.js
+++ b/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.js
@@ -80,13 +80,10 @@ export default class StickyPanelView extends View {
 		 * either using `position: fixed` or `position: sticky`, which would cover the
 		 * sticky panel or vice–versa (depending on the `z-index` hierarchy).
 		 *
-		 * Bound to {@link module:core/editor/editorui~EditorUI#viewportOffset `EditorUI.viewportOffset`}.
+		 * Bound to {@link module:core/editor/editorui~EditorUI#viewportOffset `EditorUI#viewportOffset`}.
 		 *
-		 * If {@link module:core/editor/editorconfig~EditorConfig#ui `EditorConfig#ui.viewportOffset.top`} is defined then
-		 * it will be set as the value of this property overriding the default value.
-		 *
-		 * Everytime {@link module:core/editor/editorconfig~EditorConfig#ui `EditorConfig#ui.viewportOffset`} is updated,
-		 * this value will be updated as well.
+		 * If {@link module:core/editor/editorconfig~EditorConfig#ui `EditorConfig#ui.viewportOffset.top`} is defined, then
+		 * it will override the default value.
 		 *
 		 * @observable
 		 * @default 0

--- a/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.js
+++ b/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.js
@@ -80,7 +80,6 @@ export default class StickyPanelView extends View {
 		 * either using `position: fixed` or `position: sticky`, which would cover the
 		 * sticky panel or vice–versa (depending on the `z-index` hierarchy).
 		 *
-		 * @readonly
 		 * @observable
 		 * @default 0
 		 * @member {Number} #viewportTopOffset

--- a/packages/ckeditor5-ui/src/toolbar/normalizetoolbarconfig.js
+++ b/packages/ckeditor5-ui/src/toolbar/normalizetoolbarconfig.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* global console */
-
 /**
  * @module ui/toolbar/normalizetoolbarconfig
  */
@@ -44,13 +42,6 @@ export default function normalizeToolbarConfig( config ) {
 			items: [],
 			removeItems: []
 		};
-	}
-
-	if ( Object.prototype.hasOwnProperty.call( config, 'viewportTopOffset' ) ) {
-		console.warn(
-			'The `toolbar.vieportTopOffset` configuration option is deprecated.' +
-			'It will be removed from future CKEditor versions. Use `ui.viewportOffset.top` instead.'
-		);
 	}
 
 	return Object.assign( {

--- a/packages/ckeditor5-ui/src/toolbar/normalizetoolbarconfig.js
+++ b/packages/ckeditor5-ui/src/toolbar/normalizetoolbarconfig.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+/* global console */
+
 /**
  * @module ui/toolbar/normalizetoolbarconfig
  */
@@ -42,6 +44,13 @@ export default function normalizeToolbarConfig( config ) {
 			items: [],
 			removeItems: []
 		};
+	}
+
+	if ( Object.prototype.hasOwnProperty.call( config, 'viewportTopOffset' ) ) {
+		console.warn(
+			'The `toolbar.vieportTopOffset` configuration option is deprecated.' +
+			'It will be removed from future CKEditor versions. Use `ui.viewportOffset.top` instead.'
+		);
 	}
 
 	return Object.assign( {

--- a/packages/ckeditor5-ui/tests/toolbar/normalizetoolbarconfig.js
+++ b/packages/ckeditor5-ui/tests/toolbar/normalizetoolbarconfig.js
@@ -3,8 +3,6 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals console */
-
 import normalizeToolbarConfig from '../../src/toolbar/normalizetoolbarconfig';
 
 describe( 'normalizeToolbarConfig()', () => {
@@ -54,16 +52,5 @@ describe( 'normalizeToolbarConfig()', () => {
 		expect( normalized ).to.be.an( 'object' );
 		expect( normalized.items ).to.be.an( 'array' ).of.length( 0 );
 		expect( normalized.removeItems ).to.be.an( 'array' ).of.length( 0 );
-	} );
-
-	it( 'warns when deprecated viewportTopOffset config property is used', () => {
-		const spy = sinon.stub( console, 'warn' );
-
-		const cfg = {
-			viewportTopOffset: 100
-		};
-
-		normalizeToolbarConfig( cfg );
-		sinon.assert.calledOnce( spy );
 	} );
 } );

--- a/packages/ckeditor5-ui/tests/toolbar/normalizetoolbarconfig.js
+++ b/packages/ckeditor5-ui/tests/toolbar/normalizetoolbarconfig.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+/* globals console */
+
 import normalizeToolbarConfig from '../../src/toolbar/normalizetoolbarconfig';
 
 describe( 'normalizeToolbarConfig()', () => {
@@ -52,5 +54,16 @@ describe( 'normalizeToolbarConfig()', () => {
 		expect( normalized ).to.be.an( 'object' );
 		expect( normalized.items ).to.be.an( 'array' ).of.length( 0 );
 		expect( normalized.removeItems ).to.be.an( 'array' ).of.length( 0 );
+	} );
+
+	it( 'warns when deprecated viewportTopOffset config property is used', () => {
+		const spy = sinon.stub( console, 'warn' );
+
+		const cfg = {
+			viewportTopOffset: 100
+		};
+
+		normalizeToolbarConfig( cfg );
+		sinon.assert.calledOnce( spy );
 	} );
 } );

--- a/packages/ckeditor5-upload/docs/_snippets/features/base64-upload.js
+++ b/packages/ckeditor5-upload/docs/_snippets/features/base64-upload.js
@@ -12,8 +12,10 @@ ClassicEditor.builtinPlugins.push( Base64UploadAdapter );
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-base64-upload' ), {
-		toolbar: {
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-word-count/docs/_snippets/features/word-count-update.js
+++ b/packages/ckeditor5-word-count/docs/_snippets/features/word-count-update.js
@@ -39,8 +39,12 @@ BalloonEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		placeholder: 'Text of the post',
 		table: {

--- a/packages/ckeditor5-word-count/docs/_snippets/features/word-count.js
+++ b/packages/ckeditor5-word-count/docs/_snippets/features/word-count.js
@@ -27,8 +27,12 @@ ClassicEditor
 				'|',
 				'undo',
 				'redo'
-			],
-			viewportTopOffset: window.getViewportTopOffsetConfig()
+			]
+		},
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
 		},
 		table: {
 			contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ]


### PR DESCRIPTION
WIP (check additional information)

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Type: Change viewportTopOffset config. Make viewportTopOffset writable in runtime. Closes #9672.

---

### Additional information

I added couple `TODO` comments to point out some stuff that could be improved in this PR IMO.

@oleq if you would find some time to check this one it would be awesome.

These two manual tests are best to see this in action:

```
yarn manual --files=editor-classic/manual/tickets/9672/1.js,editor-inline/manual/tickets/9672/1.js
```

Follow ups on this one:

- [x] ~~Update all our tests to use the new config (`ui.viewportOffset.top` instead of `toolbar.viewportTopOffset`)~~ done in d114b6b
- [x] ~~Update all docs snippets to use the new config~~ done in e4429e5
- [x] ~~Update docs to reflect this change~~ done in be2339d
- [x] ~~Update TODOs when discussed~~ done in 39597fd and 83b130c
