### PR TITLE
Fixing "Can't use highlight while typing"

### DIFF
--- a/packages/ckeditor5-highlight/src/highlightcommand.js
+++ b/packages/ckeditor5-highlight/src/highlightcommand.js
@@ -57,8 +57,6 @@ export default class HighlightCommand extends Command {
 		const highlighter = options.value;
 
 		model.change( writer => {
-			const ranges = model.schema.getValidRanges( selection.getRanges(), 'highlight' );
-
 			if ( selection.isCollapsed ) {
 				const position = selection.getFirstPosition();
 
@@ -98,6 +96,8 @@ export default class HighlightCommand extends Command {
 					writer.setSelectionAttribute( 'highlight', highlighter );
 				}
 			} else {
+				const ranges = model.schema.getValidRanges( selection.getRanges(), 'highlight' );
+
 				for ( const range of ranges ) {
 					if ( highlighter ) {
 						writer.setAttribute( 'highlight', highlighter, range );

--- a/packages/ckeditor5-highlight/src/highlightcommand.js
+++ b/packages/ckeditor5-highlight/src/highlightcommand.js
@@ -72,16 +72,20 @@ export default class HighlightCommand extends Command {
 					const highlightStart = position.getLastMatchingPosition( isSameHighlight, { direction: 'backward' } );
 					const highlightEnd = position.getLastMatchingPosition( isSameHighlight );
 
-					const highlightRange = writer.createRange( highlightStart, highlightEnd );
+					const highlightRange = position.isEqual( highlightEnd ) ? null : writer.createRange( highlightStart, highlightEnd );
 
 					// Then depending on current value...
 					if ( !highlighter || this.value === highlighter ) {
 						// ...remove attribute when passing highlighter different then current or executing "eraser".
-						writer.removeAttribute( 'highlight', highlightRange );
+						if ( highlightRange ) {
+							writer.removeAttribute( 'highlight', highlightRange );
+						}
 						writer.removeSelectionAttribute( 'highlight' );
 					} else {
 						// ...update `highlight` value.
-						writer.setAttribute( 'highlight', highlighter, highlightRange );
+						if ( highlightRange ) {
+							writer.setAttribute( 'highlight', highlighter, highlightRange );
+						}
 						writer.setSelectionAttribute( 'highlight', highlighter );
 					}
 				} else if ( highlighter ) {

--- a/packages/ckeditor5-highlight/src/highlightcommand.js
+++ b/packages/ckeditor5-highlight/src/highlightcommand.js
@@ -72,20 +72,26 @@ export default class HighlightCommand extends Command {
 					const highlightStart = position.getLastMatchingPosition( isSameHighlight, { direction: 'backward' } );
 					const highlightEnd = position.getLastMatchingPosition( isSameHighlight );
 
-					const highlightRange = position.isEqual( highlightEnd ) ? null : writer.createRange( highlightStart, highlightEnd );
+					const highlightRange = writer.createRange( highlightStart, highlightEnd );
 
 					// Then depending on current value...
 					if ( !highlighter || this.value === highlighter ) {
 						// ...remove attribute when passing highlighter different then current or executing "eraser".
-						if ( highlightRange ) {
+
+						// If we're at the end of the highlighted range, we don't want to remove highlight of the range.
+						if ( !position.isEqual( highlightEnd ) ) {
 							writer.removeAttribute( 'highlight', highlightRange );
 						}
+
 						writer.removeSelectionAttribute( 'highlight' );
 					} else {
 						// ...update `highlight` value.
-						if ( highlightRange ) {
+
+						// If we're at the end of the highlighted range, we don't want to change the highlight of the range.
+						if ( !position.isEqual( highlightEnd ) ) {
 							writer.setAttribute( 'highlight', highlighter, highlightRange );
 						}
+
 						writer.setSelectionAttribute( 'highlight', highlighter );
 					}
 				} else if ( highlighter ) {

--- a/packages/ckeditor5-highlight/tests/highlightcommand.js
+++ b/packages/ckeditor5-highlight/tests/highlightcommand.js
@@ -188,7 +188,6 @@ describe( 'HighlightCommand', () => {
 					expect( doc.selection.getAttribute( 'highlight' ) ).to.equal( 'pinkMarker' );
 				} );
 
-				// https://github.com/ckeditor/ckeditor5/issues/2616
 				it( 'should not change entire highlight when at the end of highlighted text', () => {
 					setData( model, '<p>abc<$text highlight="yellowMarker">foobar</$text>[]xyz</p>' );
 
@@ -196,14 +195,13 @@ describe( 'HighlightCommand', () => {
 
 					command.execute( { value: 'greenMarker' } );
 
-					expect( getData( model ) ).to.equal(
-						'<p>abc<$text highlight="yellowMarker">foobar</$text><$text highlight="greenMarker">[]</$text>xyz</p>'
+					expect( getData( model, { withoutSelection: true } ) ).to.equal(
+						'<p>abc<$text highlight="yellowMarker">foobar</$text>xyz</p>'
 					);
 
 					expect( command.value ).to.equal( 'greenMarker' );
 				} );
 
-				// https://github.com/ckeditor/ckeditor5/issues/2616
 				it( 'should not remove entire highlight when at the end of highlighted text of the same value', () => {
 					setData( model, '<p>abc<$text highlight="yellowMarker">foobar</$text>[]xyz</p>' );
 
@@ -214,6 +212,14 @@ describe( 'HighlightCommand', () => {
 					expect( getData( model ) ).to.equal( '<p>abc<$text highlight="yellowMarker">foobar</$text>[]xyz</p>' );
 
 					expect( command.value ).to.be.undefined;
+				} );
+
+				it( 'should change selection attribute when at the end of highlighted text', () => {
+					setData( model, '<p>abc<$text highlight="yellowMarker">foobar</$text>[]xyz</p>' );
+
+					command.execute( { value: 'greenMarker' } );
+
+					expect( doc.selection.getAttribute( 'highlight' ) ).to.equal( 'greenMarker' );
 				} );
 			} );
 
@@ -279,7 +285,6 @@ describe( 'HighlightCommand', () => {
 					expect( command.value ).to.be.undefined;
 				} );
 
-				// https://github.com/ckeditor/ckeditor5/issues/2616
 				it( 'should not remove entire highlight when at the end of highlighted text', () => {
 					setData( model, '<p>abc<$text highlight="yellowMarker">foobar</$text>[]xyz</p>' );
 

--- a/packages/ckeditor5-highlight/tests/highlightcommand.js
+++ b/packages/ckeditor5-highlight/tests/highlightcommand.js
@@ -187,6 +187,34 @@ describe( 'HighlightCommand', () => {
 					expect( command.value ).to.equal( 'pinkMarker' );
 					expect( doc.selection.getAttribute( 'highlight' ) ).to.equal( 'pinkMarker' );
 				} );
+
+				// https://github.com/ckeditor/ckeditor5/issues/2616
+				it( 'should not change entire highlight when at the end of highlighted text', () => {
+					setData( model, '<p>abc<$text highlight="yellowMarker">foobar</$text>[]xyz</p>' );
+
+					expect( command.value ).to.equal( 'yellowMarker' );
+
+					command.execute( { value: 'greenMarker' } );
+
+					expect( getData( model ) ).to.equal(
+						'<p>abc<$text highlight="yellowMarker">foobar</$text><$text highlight="greenMarker">[]</$text>xyz</p>'
+					);
+
+					expect( command.value ).to.equal( 'greenMarker' );
+				} );
+
+				// https://github.com/ckeditor/ckeditor5/issues/2616
+				it( 'should not remove entire highlight when at the end of highlighted text of the same value', () => {
+					setData( model, '<p>abc<$text highlight="yellowMarker">foobar</$text>[]xyz</p>' );
+
+					expect( command.value ).to.equal( 'yellowMarker' );
+
+					command.execute( { value: 'yellowMarker' } );
+
+					expect( getData( model ) ).to.equal( '<p>abc<$text highlight="yellowMarker">foobar</$text>[]xyz</p>' );
+
+					expect( command.value ).to.be.undefined;
+				} );
 			} );
 
 			describe( 'on not collapsed range', () => {
@@ -247,6 +275,19 @@ describe( 'HighlightCommand', () => {
 					command.execute();
 
 					expect( getData( model ) ).to.equal( '<p>abcfoo[]barxyz</p>' );
+
+					expect( command.value ).to.be.undefined;
+				} );
+
+				// https://github.com/ckeditor/ckeditor5/issues/2616
+				it( 'should not remove entire highlight when at the end of highlighted text', () => {
+					setData( model, '<p>abc<$text highlight="yellowMarker">foobar</$text>[]xyz</p>' );
+
+					expect( command.value ).to.equal( 'yellowMarker' );
+
+					command.execute();
+
+					expect( getData( model ) ).to.equal( '<p>abc<$text highlight="yellowMarker">foobar</$text>[]xyz</p>' );
 
 					expect( command.value ).to.be.undefined;
 				} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (highlight): Toggling highlight doesn't remove it when the caret is at the end of highlighted range. Closes #2616.