### PR TITLE
Replace relative paths to absolute in the live demos

### DIFF
--- a/docs/_snippets/assets.js
+++ b/docs/_snippets/assets.js
@@ -6,6 +6,7 @@
 /* global console, window, document */
 
 import tippy from 'tippy.js';
+import isRelativeUrl from 'is-relative-url';
 
 import 'tippy.js/dist/tippy.css';
 import 'tippy.js/themes/light-border.css';
@@ -128,3 +129,18 @@ window.findToolbarItem = function( toolbarView, indexOrCallback ) {
 
 	return item ? item.element : undefined;
 };
+
+// Replaces all relative paths inside the content container with absolute URLs
+// to avoid a broken user experience when copying images between editors.
+( () => {
+	[ ...document.querySelectorAll( '.main__content-inner img' ) ]
+		.filter( img => isRelativeUrl( img.getAttribute( 'src' ) ) )
+		.forEach( img => {
+			const { src } = img;
+			const srcAttr = img.getAttribute( 'src' );
+
+			if ( src !== srcAttr ) {
+				img.setAttribute( 'src', src );
+			}
+		} );
+} )();

--- a/docs/_snippets/assets.js
+++ b/docs/_snippets/assets.js
@@ -136,11 +136,24 @@ window.findToolbarItem = function( toolbarView, indexOrCallback ) {
 	[ ...document.querySelectorAll( '.main__content-inner img' ) ]
 		.filter( img => isRelativeUrl( img.getAttribute( 'src' ) ) )
 		.forEach( img => {
-			const { src } = img;
-			const srcAttr = img.getAttribute( 'src' );
+			img.setAttribute( 'src', img.src );
 
-			if ( src !== srcAttr ) {
-				img.setAttribute( 'src', src );
+			if ( img.srcset ) {
+				const srcset = img.srcset.split( ',' )
+					.map( item => {
+						const [ relativeUrl, ratio ] = item.trim().split( ' ' );
+
+						if ( !isRelativeUrl( relativeUrl ) ) {
+							return item;
+						}
+
+						const absoluteUrl = new window.URL( relativeUrl, window.location.href ).toString();
+
+						return [ absoluteUrl, ratio ].filter( i => i ).join( ' ' );
+					} )
+					.join( ', ' );
+
+				img.setAttribute( 'srcset', srcset );
 			}
 		} );
 } )();

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "glob": "^7.1.6",
     "http-server": "^0.12.3",
     "husky": "^4.2.5",
+    "is-relative-url": "^3.0.0",
     "lint-staged": "^10.2.6",
     "mini-css-extract-plugin": "^0.9.0",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Added a script for replacing all relative paths to absolute in the documentation executed on each page where live demos are available.

---

Closes cksource/ckeditor5-internal#852.


