### PR TITLE
Added guide section explaining our custom linter rules, added link to said section in linter errors in console

### DIFF
--- a/docs/framework/guides/contributing/code-style.md
+++ b/docs/framework/guides/contributing/code-style.md
@@ -777,3 +777,58 @@ Widely used standard files do not obey the above rules:
 * `README.md`, `LICENSE.md`, `CONTRIBUTING.md`, `CHANGES.md`
 * `.gitignore` and all standard "dot-files"
 * `node_modules`
+
+## CKEditor 5 custom ESLint rules
+### Importing from the same package
+While importing modules from the same package it is allowed to use relative paths, like so:
+```js
+import Foo from '../foo';
+import Foo from '../../foo';
+```
+### Importing from other packages
+While importing modules from other packages it is disallowed to use relative paths, and absolute paths must be used instead, like so:
+```js
+import Position from '@ckeditor5/ckeditor5-engine/src/model/position';
+```
+👎 Examples of incorrect code for this rule:
+```js
+import Foo from '../ckeditor5-media-embed/src/foo';
+import Position from '../ckeditor5-engine/src/model/position';
+import Position from '../../ckeditor5-engine/src/model/position';
+import Position from '../../../../../../../../../../ckeditor5-engine/src/model/position';
+```
+👍 Examples of correct code for this rule:
+```js
+import Foo from '@ckeditor/ckeditor5-media-embed/src/foo';
+import Position from '@ckeditor/ckeditor5-engine/src/model/position';
+```
+### Docs for new errors
+Each time new type of error is created, it needs a comment that contains description, and `@error error-name` expression, like so:
+```js
+/**
+ * Description of why the error was thrown
+ *
+ * @error method-id-is-kebab
+ */
+throw new CKEditorError( 'method-id-is-kebab', this );
+```
+### Errors that already have docs elsewhere
+In case the error is already documented elsewhere, this expression can be used to avoid ESLint errors:
+`// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message`
+And while it is not required, it is a good practice to include a note above the expression that explains where is the already existing documentation, like so:
+```js
+// Documented in core/editor/editor.js
+// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
+throw new CKEditorError( 'method-id-is-kebab', null );
+```
+### DLL
+paczki dll mogą importować “jak chcą”
+paczki nie-DLL muszą importować paczki DLL-owe używając ckeditor5
+👎 Examples of incorrect code for this rule:
+```js
+//
+```
+👍 Examples of correct code for this rule:
+```js
+//
+```

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "url": "https://github.com/ckeditor/ckeditor5.git"
   },
   "scripts": {
-    "lint": "eslint --quiet '**/*.js'",
+    "lint": "eslint --quiet 'packages/ckeditor5-basic-styles/**/*.js' --format ./scripts/eslint-formatter.js",
     "stylelint": "stylelint --quiet --allow-empty-input 'packages/**/*.css' 'docs/**/*.css'",
     "test": "node --max_old_space_size=8192 node_modules/@ckeditor/ckeditor5-dev-tests/bin/test.js",
     "manual": "node --max_old_space_size=8192 node_modules/@ckeditor/ckeditor5-dev-tests/bin/test-manual.js",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "url": "https://github.com/ckeditor/ckeditor5.git"
   },
   "scripts": {
-    "lint": "eslint --quiet 'packages/ckeditor5-basic-styles/**/*.js' --format ./scripts/eslint-formatter.js",
+    "lint": "eslint --quiet '**/*.js' --format ./scripts/eslint-formatter.js",
     "stylelint": "stylelint --quiet --allow-empty-input 'packages/**/*.css' 'docs/**/*.css'",
     "test": "node --max_old_space_size=8192 node_modules/@ckeditor/ckeditor5-dev-tests/bin/test.js",
     "manual": "node --max_old_space_size=8192 node_modules/@ckeditor/ckeditor5-dev-tests/bin/test-manual.js",

--- a/scripts/eslint-formatter.js
+++ b/scripts/eslint-formatter.js
@@ -1,0 +1,43 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+'use strict';
+
+/* eslint-env node */
+
+// See: https://eslint.org/docs/user-guide/formatters/#stylish.
+const eslintStylishFormatter = require( 'eslint/lib/cli-engine/formatters/stylish' );
+const chalk = require( 'chalk' );
+
+// eslint-disable-next-line max-len
+const CODE_STYLE_URL = 'https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/code-style.html#ckeditor-5-custom-eslint-rules';
+
+/**
+ * Overwrite the default ESLint formatter. If CKEditor 5 related error occurred,
+ * let's print a URL to the documentation where all custom rules are explained.
+ *
+ * @param {Array} results
+ */
+module.exports = results => {
+	console.log( eslintStylishFormatter( results ) );
+
+	const hasCKEditorErrors = results.some( item => {
+		if ( !Array.isArray( item.messages ) ) {
+			return false;
+		}
+
+		return item.messages.some( message => {
+			return message.ruleId.startsWith( 'ckeditor5-rules' );
+		} );
+	} );
+
+	if ( !hasCKEditorErrors ) {
+		return;
+	}
+
+	console.log( chalk.cyan( 'CKEditor 5 custom ESLint rules are described in the "Code style" guide in the documentation.' ) );
+	console.log( chalk.underline( CODE_STYLE_URL ) );
+	console.log( '' );
+};


### PR DESCRIPTION
Docs: Added guide section explaining our custom linter rules. Closes #10051.  
  
Internal: Linter errors will now display a link to custom linter rules page.