### PR TITLE
Ck/10131 Whole word search with spaces

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/utils.js
+++ b/packages/ckeditor5-find-and-replace/src/utils.js
@@ -133,7 +133,15 @@ export function findByTextCallback( searchTerm, options ) {
 	if ( options.wholeWords ) {
 		const nonLetterGroup = '[^a-zA-Z\u00C0-\u024F\u1E00-\u1EFF]';
 
-		regExpQuery = `(?<=^|${ nonLetterGroup }|_)` + regExpQuery + `(?=_|${ nonLetterGroup }|$)`;
+		if ( !new RegExp( '^' + nonLetterGroup ).test( searchTerm ) )
+		{
+			regExpQuery = `(?<=^|${ nonLetterGroup }|_)${ regExpQuery }`;
+		}
+
+		if ( !new RegExp( nonLetterGroup + '$' ).test( searchTerm ) )
+		{
+			regExpQuery = `${ regExpQuery }(?=_|${ nonLetterGroup }|$)`;
+		}
 	}
 
 	const regExp = new RegExp( regExpQuery, flags );

--- a/packages/ckeditor5-find-and-replace/src/utils.js
+++ b/packages/ckeditor5-find-and-replace/src/utils.js
@@ -139,13 +139,11 @@ export function findByTextCallback( searchTerm, options ) {
 	if ( options.wholeWords ) {
 		const nonLetterGroup = '[^a-zA-Z\u00C0-\u024F\u1E00-\u1EFF]';
 
-		if ( !new RegExp( '^' + nonLetterGroup ).test( searchTerm ) )
-		{
+		if ( !new RegExp( '^' + nonLetterGroup ).test( searchTerm ) ) {
 			regExpQuery = `(^|${ nonLetterGroup }|_)${ regExpQuery }`;
 		}
 
-		if ( !new RegExp( nonLetterGroup + '$' ).test( searchTerm ) )
-		{
+		if ( !new RegExp( nonLetterGroup + '$' ).test( searchTerm ) ) {
 			regExpQuery = `${ regExpQuery }(?:_|${ nonLetterGroup }|$)`;
 		}
 	}

--- a/packages/ckeditor5-find-and-replace/src/utils.js
+++ b/packages/ckeditor5-find-and-replace/src/utils.js
@@ -104,12 +104,7 @@ function findInsertIndex( resultsList, markerToInsert ) {
 function regexpMatchToFindResult( matchResult ) {
 	const lastGroupIndex = matchResult.length - 1;
 
-	let startOffset = matchResult.index;
-
-	// Searches with match all flag have an extra matching group with empty string or white space matched before the word.
-	if ( matchResult.length === 3 ) {
-		startOffset += matchResult[ 1 ].length;
-	}
+	const startOffset = matchResult.index;
 
 	return {
 		label: matchResult[ lastGroupIndex ],
@@ -138,7 +133,7 @@ export function findByTextCallback( searchTerm, options ) {
 	if ( options.wholeWords ) {
 		const nonLetterGroup = '[^a-zA-Z\u00C0-\u024F\u1E00-\u1EFF]';
 
-		regExpQuery = `(^|${ nonLetterGroup }|_)` + regExpQuery + `(?:_|${ nonLetterGroup }|$)`;
+		regExpQuery = `(?<=^|${ nonLetterGroup }|_)` + regExpQuery + `(?=_|${ nonLetterGroup }|$)`;
 	}
 
 	const regExp = new RegExp( regExpQuery, flags );

--- a/packages/ckeditor5-find-and-replace/src/utils.js
+++ b/packages/ckeditor5-find-and-replace/src/utils.js
@@ -104,7 +104,13 @@ function findInsertIndex( resultsList, markerToInsert ) {
 function regexpMatchToFindResult( matchResult ) {
 	const lastGroupIndex = matchResult.length - 1;
 
-	const startOffset = matchResult.index;
+	let startOffset = matchResult.index;
+
+	// Searches with match all flag have an extra matching group with empty string or white space matched before the word.
+	// If the search term starts with the space already, there is no extra group even with match all flag on.
+	if ( matchResult.length === 3 ) {
+		startOffset += matchResult[ 1 ].length;
+	}
 
 	return {
 		label: matchResult[ lastGroupIndex ],
@@ -135,12 +141,12 @@ export function findByTextCallback( searchTerm, options ) {
 
 		if ( !new RegExp( '^' + nonLetterGroup ).test( searchTerm ) )
 		{
-			regExpQuery = `(?<=^|${ nonLetterGroup }|_)${ regExpQuery }`;
+			regExpQuery = `(^|${ nonLetterGroup }|_)${ regExpQuery }`;
 		}
 
 		if ( !new RegExp( nonLetterGroup + '$' ).test( searchTerm ) )
 		{
-			regExpQuery = `${ regExpQuery }(?=_|${ nonLetterGroup }|$)`;
+			regExpQuery = `${ regExpQuery }(?:_|${ nonLetterGroup }|$)`;
 		}
 	}
 

--- a/packages/ckeditor5-find-and-replace/tests/findcommand.js
+++ b/packages/ckeditor5-find-and-replace/tests/findcommand.js
@@ -233,6 +233,30 @@ describe( 'FindCommand', () => {
 					expect( results.length ).to.equal( 1 );
 				} );
 
+				it( 'set to true matches a text ending with a space ', () => {
+					editor.setData( '<p>foo bar baz</p>' );
+
+					const { results } = command.execute( 'bar ', { wholeWords: true } );
+
+					expect( results.length ).to.equal( 1 );
+				} );
+
+				it( 'set to true matches a text starting with a space ', () => {
+					editor.setData( '<p>foo bar baz</p>' );
+
+					const { results } = command.execute( ' bar', { wholeWords: true } );
+
+					expect( results.length ).to.equal( 1 );
+				} );
+
+				it( 'set to true matches a text starting and ending with a space ', () => {
+					editor.setData( '<p>foo bar baz</p>' );
+
+					const { results } = command.execute( ' bar ', { wholeWords: true } );
+
+					expect( results.length ).to.equal( 1 );
+				} );
+
 				it( 'set to true doesn\'t match a word including diacritic characters', () => {
 					editor.setData( '<p>foo łbarę and Äbarè</p>' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (find-and-replace): Allows search term to contain trailing/leading space when searching 'whole word only'. Closes #10131.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
