### PR TITLE
Ck/10436 remove trim from list converter

### DIFF
--- a/packages/ckeditor5-list/src/converters.js
+++ b/packages/ckeditor5-list/src/converters.js
@@ -435,29 +435,16 @@ export function cleanListItem( evt, data, conversionApi ) {
 		const children = [ ...data.viewItem.getChildren() ];
 
 		let foundList = false;
-		let firstNode = true;
 
 		for ( const child of children ) {
 			if ( foundList && !isList( child ) ) {
 				child._remove();
 			}
 
-			if ( child.is( '$text' ) ) {
-				// If this is the first node and it's a text node, left-trim it.
-				if ( firstNode ) {
-					child._data = child.data.trimStart();
-				}
-
-				// If this is the last text node before <ul> or <ol>, right-trim it.
-				if ( !child.nextSibling || isList( child.nextSibling ) ) {
-					child._data = child.data.trimEnd();
-				}
-			} else if ( isList( child ) ) {
+			if ( isList( child ) ) {
 				// If this is a <ul> or <ol>, do not process it, just mark that we already visited list element.
 				foundList = true;
 			}
-
-			firstNode = false;
 		}
 	}
 }

--- a/packages/ckeditor5-list/tests/listediting.js
+++ b/packages/ckeditor5-list/tests/listediting.js
@@ -429,6 +429,7 @@ describe( 'ListEditing', () => {
 			}
 
 			testList( 'single item', '<ul><li>x</li></ul>' );
+			testList( 'single item with spaces', '<ul><li>&nbsp;x&nbsp;</li></ul>' );
 			testList( 'multiple items', '<ul><li>a</li><li>b</li><li>c</li></ul>' );
 			testList( 'items and text', '<p>xxx</p><ul><li>a</li><li>b</li></ul><p>yyy</p><ul><li>c</li><li>d</li></ul>' );
 			testList( 'numbered list', '<ol><li>a</li><li>b</li></ol>' );

--- a/packages/ckeditor5-list/tests/listediting.js
+++ b/packages/ckeditor5-list/tests/listediting.js
@@ -431,6 +431,8 @@ describe( 'ListEditing', () => {
 			testList( 'single item', '<ul><li>x</li></ul>' );
 			testList( 'single item with spaces', '<ul><li>&nbsp;x&nbsp;</li></ul>' );
 			testList( 'multiple items', '<ul><li>a</li><li>b</li><li>c</li></ul>' );
+			testList( 'multiple items with leading space in first', '<ul><li>&nbsp;a</li><li>b</li><li>c</li></ul>' );
+			testList( 'multiple items with trailing space in last', '<ul><li>a</li><li>b</li><li>c&nbsp;</li></ul>' );
 			testList( 'items and text', '<p>xxx</p><ul><li>a</li><li>b</li></ul><p>yyy</p><ul><li>c</li><li>d</li></ul>' );
 			testList( 'numbered list', '<ol><li>a</li><li>b</li></ol>' );
 			testList( 'mixed list and content #1', '<p>xxx</p><ul><li>a</li><li>b</li></ul><ol><li>c</li><li>d</li></ol><p>yyy</p>' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (list): Remove text trimming from list upcast converter. Closes #10436.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._