### PR TITLE
jsdoc: remove support for string in values for _t

### DIFF
--- a/packages/ckeditor5-utils/src/locale.js
+++ b/packages/ckeditor5-utils/src/locale.js
@@ -149,7 +149,7 @@ export default class Locale {
 	 *
 	 * @private
 	 * @param {String|module:utils/translation-service~Message} message
-	 * @param {Number|String|Array.<Number>} [values]
+	 * @param {Number|Array.<Number>} [values]
 	 * @returns {String}
 	 */
 	_t( message, values = [] ) {

--- a/packages/ckeditor5-utils/src/locale.js
+++ b/packages/ckeditor5-utils/src/locale.js
@@ -149,7 +149,7 @@ export default class Locale {
 	 *
 	 * @private
 	 * @param {String|module:utils/translation-service~Message} message
-	 * @param {Number|String|Array.<Number|String>} [values]
+	 * @param {Number|String|Array.<Number>} [values]
 	 * @returns {String}
 	 */
 	_t( message, values = [] ) {


### PR DESCRIPTION
`_t` calls `_translate` with one item from `values`, which is an array of either number or string.
But `translate` expects the `quantity` param to be a number.