### PR TITLE
Utils>Config>_getFromSource return early if not object

### DIFF
--- a/packages/ckeditor5-utils/src/config.js
+++ b/packages/ckeditor5-utils/src/config.js
@@ -202,8 +202,7 @@ export default class Config {
 		// Iterate over parts to check if currently stored configuration has proper structure.
 		for ( const part of parts ) {
 			if ( !isPlainObject( source[ part ] ) ) {
-				source = null;
-				break;
+				return undefined;
 			}
 
 			// Nested object becomes a source.


### PR DESCRIPTION
Trying to make TS understand the code base better, I suggest this change. If the `source` is not an object, just return early with `undefined`. Currently you are setting it to `null`, and breaking out of the loop. At the end, you ask if `source` is `null` and return `undefined` if so. I propose that you just return as soon as you tried to set `source` to `null`.