### PR TITLE
MarkerCollection has() method accept instance of marker

### DIFF
--- a/packages/ckeditor5-engine/src/model/markercollection.js
+++ b/packages/ckeditor5-engine/src/model/markercollection.js
@@ -52,7 +52,7 @@ export default class MarkerCollection {
 	}
 
 	/**
-	 * Checks if given {@link ~Marker marker} or marker with given name is in the collection.
+	 * Checks if given {@link ~Marker marker} or marker name is in the collection.
 	 *
 	 * @param {String|module:engine/model/markercollection~Marker} markerOrName Name of marker or marker instance to check.
 	 * @returns {Boolean} `true` if marker is in the collection, `false` otherwise.

--- a/packages/ckeditor5-engine/src/model/markercollection.js
+++ b/packages/ckeditor5-engine/src/model/markercollection.js
@@ -52,12 +52,13 @@ export default class MarkerCollection {
 	}
 
 	/**
-	 * Checks if marker with given `markerName` is in the collection.
+	 * Checks if given {@link ~Marker marker} or marker with given name is in the collection.
 	 *
-	 * @param {String} markerName Marker name.
-	 * @returns {Boolean} `true` if marker with given `markerName` is in the collection, `false` otherwise.
+	 * @param {String|module:engine/model/markercollection~Marker} markerOrName Name of marker or marker instance to check.
+	 * @returns {Boolean} `true` if marker is in the collection, `false` otherwise.
 	 */
-	has( markerName ) {
+	has( markerOrName ) {
+		const markerName = markerOrName instanceof Marker ? markerOrName.name : markerOrName;
 		return this._markers.has( markerName );
 	}
 

--- a/packages/ckeditor5-engine/tests/model/markercollection.js
+++ b/packages/ckeditor5-engine/tests/model/markercollection.js
@@ -143,7 +143,7 @@ describe( 'MarkerCollection', () => {
 
 		it( 'should return false if given instance of marker is not in the collection', () => {
 			const markerCollection = new MarkerCollection();
-			const marker = markerCollection._set( 'name', range );
+			const marker = markerCollection._set( 'differentName', range );
 			expect( markers.has( marker ) ).to.be.false;
 		} );
 

--- a/packages/ckeditor5-engine/tests/model/markercollection.js
+++ b/packages/ckeditor5-engine/tests/model/markercollection.js
@@ -140,6 +140,17 @@ describe( 'MarkerCollection', () => {
 			markers._set( 'name', range );
 			expect( markers.has( 'name' ) ).to.be.true;
 		} );
+
+		it( 'should return false if given instance of marker is not in the collection', () => {
+			const markerCollection = new MarkerCollection();
+			const marker = markerCollection._set( 'name', range );
+			expect( markers.has( marker ) ).to.be.false;
+		} );
+
+		it( 'should return true if given instance of marker is in the collection', () => {
+			const marker = markers._set( 'name', range );
+			expect( markers.has( marker ) ).to.be.true;
+		} );
 	} );
 
 	describe( 'get', () => {

--- a/packages/ckeditor5-engine/tests/model/markercollection.js
+++ b/packages/ckeditor5-engine/tests/model/markercollection.js
@@ -142,8 +142,8 @@ describe( 'MarkerCollection', () => {
 		} );
 
 		it( 'should return false if given instance of marker is not in the collection', () => {
-			const markerCollection = new MarkerCollection();
-			const marker = markerCollection._set( 'differentName', range );
+			const differentMarkerCollection = new MarkerCollection();
+			const marker = differentMarkerCollection._set( 'differentName', range );
 			expect( markers.has( marker ) ).to.be.false;
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (engine): The `MarkerCollection#has()` method now also accepts an instance of a marker. Closes #9985.

---

### Additional information