### PR TITLE
Other: Updated translations. [skip ci]

### DIFF
--- a/packages/ckeditor5-source-editing/lang/translations/zh-cn.po
+++ b/packages/ckeditor5-source-editing/lang/translations/zh-cn.po
@@ -1,0 +1,21 @@
+# Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+#
+#                                     !!! IMPORTANT !!!
+#
+#         Before you edit this file, please keep in mind that contributing to the project
+#                translations is possible ONLY via the Transifex online service.
+#
+#         To submit your translations, visit https://www.transifex.com/ckeditor/ckeditor5.
+#
+#                   To learn more, check out the official contributor's guide:
+#     https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/contributing.html
+#
+msgid ""
+msgstr ""
+"Language-Team: Chinese (China) (https://www.transifex.com/ckeditor/teams/11143/zh_CN/)\n"
+"Language: zh_CN\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgctxt "The label of the source editing feature toolbar button."
+msgid "Source"
+msgstr "原始码"


### PR DESCRIPTION
``### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other: Updated translations. [skip ci]

---

### Additional information

The lack of a language pack invalidates the `@ckeditor/ckeditor5-dev-webpack-plugin` `language` configuration, and the default language in the built code is English

```
new CKEditorWebpackPlugin({
      language: 'zh-cn' // Invalid configuration due to missing language pack
})
```