### PR TITLE
Adds System Colors names

### DIFF
--- a/packages/ckeditor5-engine/src/view/styles/utils.js
+++ b/packages/ckeditor5-engine/src/view/styles/utils.js
@@ -37,7 +37,10 @@ const COLOR_NAMES = new Set( [
 	'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow',
 	'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen',
 	// CSS Color Module Level 3 (System Colors)
-	'windowtext',
+	'activeborder', 'activecaption', 'appworkspace', 'background', 'buttonface', 'buttonhighlight', 'buttonshadow',
+	'buttontext', 'captiontext', 'graytext', 'highlight', 'highlighttext', 'inactiveborder', 'inactivecaption',
+	'inactivecaptiontext', 'infobackground', 'infotext', 'menu', 'menutext', 'scrollbar', 'threeddarkshadow',
+	'threedface', 'threedhighlight', 'threedlightshadow', 'threedshadow', 'window', 'windowframe', 'windowtext',
 	// CSS Color Module Level 4
 	'rebeccapurple',
 	// Keywords

--- a/packages/ckeditor5-engine/src/view/styles/utils.js
+++ b/packages/ckeditor5-engine/src/view/styles/utils.js
@@ -36,6 +36,8 @@ const COLOR_NAMES = new Set( [
 	'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon',
 	'sandybrown', 'seagreen', 'seashell', 'sienna', 'skyblue', 'slateblue', 'slategray', 'slategrey', 'snow',
 	'springgreen', 'steelblue', 'tan', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'whitesmoke', 'yellowgreen',
+	// CSS Color Module Level 3 (System Colors)
+	'windowtext',
 	// CSS Color Module Level 4
 	'rebeccapurple',
 	// Keywords

--- a/packages/ckeditor5-engine/tests/view/styles/utils.js
+++ b/packages/ckeditor5-engine/tests/view/styles/utils.js
@@ -126,6 +126,8 @@ describe( 'Styles utils', () => {
 				'orange',
 				// CSS Level 3
 				'cyan', 'azure', 'wheat',
+				// CSS Level 3 System Colors
+				'windowtext',
 				// CSS Level 4
 				'rebeccapurple'
 			], isColor );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): Adds System Colors names from CSS Color Module Level 3 so that pasting tables from MS Word works correctly. Closes #10383.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._