### PR TITLE
Implementing undo in Delete plugin & TextTransformation & others

### DIFF
--- a/packages/ckeditor5-image/src/autoimage.js
+++ b/packages/ckeditor5-image/src/autoimage.js
@@ -11,6 +11,7 @@ import { Plugin } from 'ckeditor5/src/core';
 import { Clipboard } from 'ckeditor5/src/clipboard';
 import { LivePosition, LiveRange } from 'ckeditor5/src/engine';
 import { Undo } from 'ckeditor5/src/undo';
+import { Delete } from 'ckeditor5/src/typing';
 import { global } from 'ckeditor5/src/utils';
 
 import ImageUtils from './imageutils';
@@ -32,7 +33,7 @@ export default class AutoImage extends Plugin {
 	 * @inheritDoc
 	 */
 	static get requires() {
-		return [ Clipboard, ImageUtils, Undo ];
+		return [ Clipboard, ImageUtils, Undo, Delete ];
 	}
 
 	/**
@@ -173,6 +174,8 @@ export default class AutoImage extends Plugin {
 				this._positionToInsert.detach();
 				this._positionToInsert = null;
 			} );
+
+			editor.plugins.get( 'Delete' ).requestUndoOnBackspace();
 		}, 100 );
 	}
 }

--- a/packages/ckeditor5-image/tests/autoimage.js
+++ b/packages/ckeditor5-image/tests/autoimage.js
@@ -102,6 +102,18 @@ describe( 'AutoImage - integration', () => {
 			);
 		} );
 
+		it( 'should request next backspace to undo auto-embeding', () => {
+			const deletePlugin = editor.plugins.get( 'Delete' );
+			const spy = deletePlugin.requestUndoOnBackspace = sinon.spy();
+
+			setData( editor.model, '<paragraph>[]</paragraph>' );
+			pasteHtml( editor, 'http://example.com/image.png' );
+
+			clock.tick( 100 );
+
+			expect( spy.calledOnce ).to.be.true;
+		} );
+
 		describe( 'supported URL', () => {
 			const supportedURLs = [
 				'example.com/image.png',

--- a/packages/ckeditor5-image/tests/autoimage.js
+++ b/packages/ckeditor5-image/tests/autoimage.js
@@ -14,13 +14,13 @@ import Table from '@ckeditor/ckeditor5-table/src/table';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
+import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 import Image from '../src/image';
 import ImageUtils from '../src/imageutils';
 import ImageCaption from '../src/imagecaption';
 import AutoImage from '../src/autoimage';
-import { DomEventData } from '@ckeditor/ckeditor5-engine';
 
 describe( 'AutoImage - integration', () => {
 	let editorElement, editor;

--- a/packages/ckeditor5-link/src/autolink.js
+++ b/packages/ckeditor5-link/src/autolink.js
@@ -8,7 +8,7 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core';
-import { TextWatcher, getLastTextLine } from 'ckeditor5/src/typing';
+import { Delete, TextWatcher, getLastTextLine } from 'ckeditor5/src/typing';
 
 import { addLinkProtocolIfApplicable } from './utils';
 
@@ -69,6 +69,13 @@ const URL_GROUP_IN_MATCH = 2;
  * @extends module:core/plugin~Plugin
  */
 export default class AutoLink extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
+	static get requires() {
+		return [ Delete ];
+	}
+
 	/**
 	 * @inheritDoc
 	 */
@@ -226,6 +233,7 @@ export default class AutoLink extends Plugin {
 	 */
 	_applyAutoLink( link, range ) {
 		const model = this.editor.model;
+		const deletePlugin = this.editor.plugins.get( 'Delete' );
 
 		if ( !this.isEnabled || !isLinkAllowedOnRange( range, model ) ) {
 			return;
@@ -236,6 +244,10 @@ export default class AutoLink extends Plugin {
 			const defaultProtocol = this.editor.config.get( 'link.defaultProtocol' );
 			const parsedUrl = addLinkProtocolIfApplicable( link, defaultProtocol );
 			writer.setAttribute( 'linkHref', parsedUrl, range );
+
+			model.enqueueChange( () => {
+				deletePlugin.requestUndoOnBackspace();
+			} );
 		} );
 	}
 }

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -10,8 +10,8 @@ import Input from '@ckeditor/ckeditor5-typing/src/input';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import ShiftEnter from '@ckeditor/ckeditor5-enter/src/shiftenter';
 import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
+import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-import { DomEventData } from '@ckeditor/ckeditor5-engine';
 
 import LinkEditing from '../src/linkediting';
 import AutoLink from '../src/autolink';

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -11,6 +11,7 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import ShiftEnter from '@ckeditor/ckeditor5-enter/src/shiftenter';
 import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import { DomEventData } from '@ckeditor/ckeditor5-engine';
 
 import LinkEditing from '../src/linkediting';
 import AutoLink from '../src/autolink';
@@ -389,13 +390,21 @@ describe( 'AutoLink', () => {
 			);
 		} );
 
-		it( 'should request next backspace to undo the transformation', () => {
-			const deletePlugin = editor.plugins.get( 'Delete' );
-			const spy = deletePlugin.requestUndoOnBackspace = sinon.spy();
+		it( 'should undo auto-linking by pressing backspace', () => {
+			const viewDocument = editor.editing.view.document;
+			const deleteEvent = new DomEventData(
+				viewDocument,
+				{ preventDefault: sinon.spy() },
+				{ direction: 'backward', unit: 'codePoint', sequence: 1 }
+			);
 
 			simulateTyping( ' ' );
 
-			expect( spy.calledOnce ).to.be.true;
+			viewDocument.fire( 'delete', deleteEvent );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph>https://www.cksource.com []</paragraph>'
+			);
 		} );
 	} );
 

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -388,6 +388,15 @@ describe( 'AutoLink', () => {
 				'<paragraph>[]</paragraph>'
 			);
 		} );
+
+		it( 'should request next backspace to undo the transformation', () => {
+			const deletePlugin = editor.plugins.get( 'Delete' );
+			const spy = deletePlugin.requestUndoOnBackspace = sinon.spy();
+
+			simulateTyping( ' ' );
+
+			expect( spy.calledOnce ).to.be.true;
+		} );
 	} );
 
 	describe( 'Code blocks integration', () => {

--- a/packages/ckeditor5-media-embed/src/automediaembed.js
+++ b/packages/ckeditor5-media-embed/src/automediaembed.js
@@ -10,6 +10,7 @@
 import { Plugin } from 'ckeditor5/src/core';
 import { LiveRange, LivePosition } from 'ckeditor5/src/engine';
 import { Clipboard } from 'ckeditor5/src/clipboard';
+import { Delete } from 'ckeditor5/src/typing';
 import { Undo } from 'ckeditor5/src/undo';
 import { global } from 'ckeditor5/src/utils';
 
@@ -29,7 +30,7 @@ export default class AutoMediaEmbed extends Plugin {
 	 * @inheritDoc
 	 */
 	static get requires() {
-		return [ Clipboard, Undo ];
+		return [ Clipboard, Delete, Undo ];
 	}
 
 	/**
@@ -174,6 +175,8 @@ export default class AutoMediaEmbed extends Plugin {
 				this._positionToInsert.detach();
 				this._positionToInsert = null;
 			} );
+
+			editor.plugins.get( 'Delete' ).requestUndoOnBackspace();
 		}, 100 );
 	}
 }

--- a/packages/ckeditor5-media-embed/tests/automediaembed.js
+++ b/packages/ckeditor5-media-embed/tests/automediaembed.js
@@ -17,8 +17,8 @@ import Image from '@ckeditor/ckeditor5-image/src/image';
 import ImageCaption from '@ckeditor/ckeditor5-image/src/imagecaption';
 import Table from '@ckeditor/ckeditor5-table/src/table';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
+import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-import { DomEventData } from '@ckeditor/ckeditor5-engine';
 
 describe( 'AutoMediaEmbed - integration', () => {
 	let editorElement, editor;

--- a/packages/ckeditor5-media-embed/tests/automediaembed.js
+++ b/packages/ckeditor5-media-embed/tests/automediaembed.js
@@ -96,6 +96,18 @@ describe( 'AutoMediaEmbed - integration', () => {
 			);
 		} );
 
+		it( 'should request next backspace to undo auto-embeding', () => {
+			const deletePlugin = editor.plugins.get( 'Delete' );
+			const spy = deletePlugin.requestUndoOnBackspace = sinon.spy();
+
+			setData( editor.model, '<paragraph>[]</paragraph>' );
+			pasteHtml( editor, 'https://www.youtube.com/watch?v=H08tGjXNHO4' );
+
+			clock.tick( 100 );
+
+			expect( spy.calledOnce ).to.be.true;
+		} );
+
 		it( 'works for a full URL (https + "www" sub-domain)', () => {
 			setData( editor.model, '<paragraph>[]</paragraph>' );
 			pasteHtml( editor, 'https://www.youtube.com/watch?v=H08tGjXNHO4' );

--- a/packages/ckeditor5-typing/src/delete.js
+++ b/packages/ckeditor5-typing/src/delete.js
@@ -51,7 +51,7 @@ export default class Delete extends Plugin {
 		editor.commands.add( 'delete', new DeleteCommand( editor, 'backward' ) );
 
 		this.listenTo( viewDocument, 'delete', ( evt, data ) => {
-			if ( this._undoOnBackspace && data.direction == 'backward' && data.sequence == 1 ) {
+			if ( this._undoOnBackspace && data.direction == 'backward' && data.sequence == 1 && data.unit == 'codePoint' ) {
 				this._undoOnBackspace = false;
 
 				editor.execute( 'undo' );

--- a/packages/ckeditor5-typing/src/delete.js
+++ b/packages/ckeditor5-typing/src/delete.js
@@ -26,7 +26,7 @@ export default class Delete extends Plugin {
 	 * Whether pressing backspace should trigger undo action
 	 *
 	 * @private
-	 * @member {Boolean} #_undoByBackspace
+	 * @member {Boolean} #_undoOnBackspace
 	 */
 
 	/**
@@ -44,7 +44,7 @@ export default class Delete extends Plugin {
 
 		view.addObserver( DeleteObserver );
 
-		this._undoByBackspace = false;
+		this._undoOnBackspace = false;
 
 		const deleteForwardCommand = new DeleteCommand( editor, 'forward' );
 
@@ -55,8 +55,8 @@ export default class Delete extends Plugin {
 		editor.commands.add( 'delete', new DeleteCommand( editor, 'backward' ) );
 
 		this.listenTo( viewDocument, 'delete', ( evt, data ) => {
-			if ( this._undoByBackspace && data.direction == 'backward' && data.sequence == 1 ) {
-				this._undoByBackspace = false;
+			if ( this._undoOnBackspace && data.direction == 'backward' && data.sequence == 1 ) {
+				this._undoOnBackspace = false;
 
 				editor.execute( 'undo' );
 			} else {
@@ -120,14 +120,14 @@ export default class Delete extends Plugin {
 		}
 
 		this.listenTo( modelDocument, 'change', () => {
-			this._undoByBackspace = false;
+			this._undoOnBackspace = false;
 		} );
 	}
 
 	/**
 	 * If the next user action after calling this method is pressing backspace, it would undo the last change.
 	 */
-	enableUndoOnDelete() {
-		this._undoByBackspace = true;
+	enableUndoOnBackspace() {
+		this._undoOnBackspace = true;
 	}
 }

--- a/packages/ckeditor5-typing/src/delete.js
+++ b/packages/ckeditor5-typing/src/delete.js
@@ -53,8 +53,7 @@ export default class Delete extends Plugin {
 		this.listenTo( viewDocument, 'delete', ( evt, data ) => {
 			const deleteCommandParams = { unit: data.unit, sequence: data.sequence };
 
-			// If a specific (view) selection to remove was set,
-			// convert it to a model selection and set as a parameter for `DeleteCommand`.
+			// If a specific (view) selection to remove was set, convert it to a model selection and set as a parameter for `DeleteCommand`.
 			if ( data.selectionToRemove ) {
 				const modelSelection = editor.model.createSelection();
 				const ranges = [];

--- a/packages/ckeditor5-typing/src/delete.js
+++ b/packages/ckeditor5-typing/src/delete.js
@@ -125,7 +125,7 @@ export default class Delete extends Plugin {
 	 *
 	 * Requires {@link module:undo/undoediting~UndoEditing} plugin. If not loaded, does nothing.
 	 */
-	enableUndoOnBackspace() {
+	requestUndoOnBackspace() {
 		if ( this.editor.plugins.has( 'UndoEditing' ) ) {
 			this._undoOnBackspace = true;
 		}

--- a/packages/ckeditor5-typing/src/delete.js
+++ b/packages/ckeditor5-typing/src/delete.js
@@ -18,10 +18,6 @@ import env from '@ckeditor/ckeditor5-utils/src/env';
  * @extends module:core/plugin~Plugin
  */
 export default class Delete extends Plugin {
-	static get requires() {
-		return [ 'Undo' ];
-	}
-
 	/**
 	 * Whether pressing backspace should trigger undo action
 	 *
@@ -126,8 +122,12 @@ export default class Delete extends Plugin {
 
 	/**
 	 * If the next user action after calling this method is pressing backspace, it would undo the last change.
+	 *
+	 * Requires {@link module:undo/undoediting~UndoEditing} plugin. If not loaded, does nothing.
 	 */
 	enableUndoOnBackspace() {
-		this._undoOnBackspace = true;
+		if ( this.editor.plugins.has( 'UndoEditing' ) ) {
+			this._undoOnBackspace = true;
+		}
 	}
 }

--- a/packages/ckeditor5-typing/src/deleteobserver.js
+++ b/packages/ckeditor5-typing/src/deleteobserver.js
@@ -111,7 +111,7 @@ export default class DeleteObserver extends Observer {
  * @event module:engine/view/document~Document#event:delete
  * @param {module:engine/view/observer/domeventdata~DomEventData} data
  * @param {'forward'|'delete'} data.direction The direction in which the deletion should happen.
- * @param {'character'|'word'} data.unit The "amount" of content that should be deleted.
+ * @param {'character'|'codePoint'|'word'} data.unit The "amount" of content that should be deleted.
  * @param {Number} data.sequence A number describing which subsequent delete event it is without the key being released.
  * If it's 2 or more it means that the key was pressed and hold.
  * @param {module:engine/view/selection~Selection} [data.selectionToRemove] View selection which content should be removed. If not set,

--- a/packages/ckeditor5-typing/src/texttransformation.js
+++ b/packages/ckeditor5-typing/src/texttransformation.js
@@ -74,6 +74,10 @@ const DEFAULT_TRANSFORMATIONS = [
  * @extends module:core/plugin~Plugin
  */
 export default class TextTransformation extends Plugin {
+	static get requires() {
+		return [ 'Delete', 'Input' ];
+	}
+
 	/**
 	 * @inheritDoc
 	 */
@@ -117,7 +121,8 @@ export default class TextTransformation extends Plugin {
 	_enableTransformationWatchers() {
 		const editor = this.editor;
 		const model = editor.model;
-		const input = editor.plugins.get( 'Input' );
+		const inputPlugin = editor.plugins.get( 'Input' );
+		const deletePlugin = editor.plugins.get( 'Delete' );
 		const normalizedTransformations = normalizeTransformations( editor.config.get( 'typing.transformations' ) );
 
 		const testCallback = text => {
@@ -132,7 +137,7 @@ export default class TextTransformation extends Plugin {
 		};
 
 		const watcherCallback = ( evt, data ) => {
-			if ( !input.isInput( data.batch ) ) {
+			if ( !inputPlugin.isInput( data.batch ) ) {
 				return;
 			}
 
@@ -164,6 +169,10 @@ export default class TextTransformation extends Plugin {
 
 					changeIndex += replaceWith.length;
 				}
+
+				model.enqueueChange( () => {
+					deletePlugin.enableUndoOnDelete();
+				} );
 			} );
 		};
 

--- a/packages/ckeditor5-typing/src/texttransformation.js
+++ b/packages/ckeditor5-typing/src/texttransformation.js
@@ -171,7 +171,7 @@ export default class TextTransformation extends Plugin {
 				}
 
 				model.enqueueChange( () => {
-					deletePlugin.enableUndoOnBackspace();
+					deletePlugin.requestUndoOnBackspace();
 				} );
 			} );
 		};

--- a/packages/ckeditor5-typing/src/texttransformation.js
+++ b/packages/ckeditor5-typing/src/texttransformation.js
@@ -74,6 +74,9 @@ const DEFAULT_TRANSFORMATIONS = [
  * @extends module:core/plugin~Plugin
  */
 export default class TextTransformation extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
 	static get requires() {
 		return [ 'Delete', 'Input' ];
 	}

--- a/packages/ckeditor5-typing/src/texttransformation.js
+++ b/packages/ckeditor5-typing/src/texttransformation.js
@@ -171,7 +171,7 @@ export default class TextTransformation extends Plugin {
 				}
 
 				model.enqueueChange( () => {
-					deletePlugin.enableUndoOnDelete();
+					deletePlugin.enableUndoOnBackspace();
 				} );
 			} );
 		};

--- a/packages/ckeditor5-typing/tests/delete.js
+++ b/packages/ckeditor5-typing/tests/delete.js
@@ -259,14 +259,10 @@ describe( 'Delete feature - undo by pressing backspace', () => {
 
 		expect( domEvt.preventDefault.calledOnce ).to.be.true;
 
-		viewDocument.fire( 'delete', new DomEventData( viewDocument, getDomEvent(), {
-			direction: 'backward',
-			unit: 'character',
-			sequence: 5
-		} ) );
+		viewDocument.fire( 'delete', new DomEventData( viewDocument, getDomEvent(), deleteEventEventData ) );
 
 		expect( spy.calledTwice ).to.be.true;
-		expect( spy.calledWithMatch( 'delete', { unit: 'character', sequence: 5 } ) ).to.be.true;
+		expect( spy.calledWithMatch( 'delete', {} ) ).to.be.true;
 	} );
 
 	describe( 'does not execute `undo` instead of deleting', () => {

--- a/packages/ckeditor5-typing/tests/delete.js
+++ b/packages/ckeditor5-typing/tests/delete.js
@@ -8,9 +8,10 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
 import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
+import Batch from '@ckeditor/ckeditor5-engine/src/model/batch';
 import env from '@ckeditor/ckeditor5-utils/src/env';
 import { getCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
-import Batch from '@ckeditor/ckeditor5-engine/src/model/batch';
 
 /* globals window, document */
 
@@ -249,14 +250,16 @@ describe( 'Delete feature - undo by pressing backspace', () => {
 	it( 'executes `undo` once on pressing backspace after requestUndoOnBackspace()', () => {
 		const spy = editor.execute = sinon.spy();
 		const domEvt = getDomEvent();
+		const event = new EventInfo( viewDocument, 'delete' );
 
 		plugin.requestUndoOnBackspace();
 
-		viewDocument.fire( 'delete', new DomEventData( viewDocument, domEvt, deleteEventEventData ) );
+		viewDocument.fire( event, new DomEventData( viewDocument, domEvt, deleteEventEventData ) );
 
 		expect( spy.calledOnce ).to.be.true;
 		expect( spy.calledWithMatch( 'undo' ) ).to.be.true;
 
+		expect( event.stop.called ).to.be.true;
 		expect( domEvt.preventDefault.calledOnce ).to.be.true;
 
 		viewDocument.fire( 'delete', new DomEventData( viewDocument, getDomEvent(), deleteEventEventData ) );

--- a/packages/ckeditor5-typing/tests/delete.js
+++ b/packages/ckeditor5-typing/tests/delete.js
@@ -5,10 +5,12 @@
 
 import Delete from '../src/delete';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
 import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import env from '@ckeditor/ckeditor5-utils/src/env';
 import { getCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
+import Batch from '@ckeditor/ckeditor5-engine/src/model/batch';
 
 /* globals window, document */
 
@@ -106,12 +108,6 @@ describe( 'Delete feature', () => {
 		sinon.assert.calledOnce( scrollSpy );
 		sinon.assert.callOrder( executeSpy, scrollSpy );
 	} );
-
-	function getDomEvent() {
-		return {
-			preventDefault: sinon.spy()
-		};
-	}
 } );
 
 describe( 'Delete feature - Android', () => {
@@ -222,3 +218,137 @@ describe( 'Delete feature - Android', () => {
 		} ).not.to.throw();
 	} );
 } );
+
+describe( 'Delete feature - undo by pressing backspace', () => {
+	let element, editor, viewDocument, plugin;
+
+	const deleteEventEventData = {
+		direction: 'backward',
+		unit: 'codePoint',
+		sequence: 1
+	};
+
+	beforeEach( () => {
+		element = document.createElement( 'div' );
+		document.body.appendChild( element );
+
+		return ClassicTestEditor
+			.create( element, { plugins: [ Delete, UndoEditing ] } )
+			.then( newEditor => {
+				editor = newEditor;
+				viewDocument = editor.editing.view.document;
+				plugin = newEditor.plugins.get( 'Delete' );
+			} );
+	} );
+
+	afterEach( () => {
+		element.remove();
+		return editor.destroy();
+	} );
+
+	it( 'executes `undo` once on pressing backspace after requestUndoOnBackspace()', () => {
+		const spy = editor.execute = sinon.spy();
+		const domEvt = getDomEvent();
+
+		plugin.requestUndoOnBackspace();
+
+		viewDocument.fire( 'delete', new DomEventData( viewDocument, domEvt, deleteEventEventData ) );
+
+		expect( spy.calledOnce ).to.be.true;
+		expect( spy.calledWithMatch( 'undo' ) ).to.be.true;
+
+		expect( domEvt.preventDefault.calledOnce ).to.be.true;
+
+		viewDocument.fire( 'delete', new DomEventData( viewDocument, getDomEvent(), {
+			direction: 'backward',
+			unit: 'character',
+			sequence: 5
+		} ) );
+
+		expect( spy.calledTwice ).to.be.true;
+		expect( spy.calledWithMatch( 'delete', { unit: 'character', sequence: 5 } ) ).to.be.true;
+	} );
+
+	describe( 'does not execute `undo` instead of deleting', () => {
+		const testCases = [
+			{
+				condition: 'it\'s forward deletion',
+				eventData: { direction: 'forward', unit: 'codePoint', sequence: 1 }
+			},
+			{
+				condition: 'the sequence doesn\'t equal 1',
+				eventData: { direction: 'backward', unit: 'codePoint', sequence: 2 }
+			},
+			{
+				condition: 'the unit is not `codePoint`',
+				eventData: { direction: 'backward', unit: 'word', sequence: 1 }
+			}
+		];
+
+		testCases.forEach( ( { condition, eventData } ) => {
+			it( 'if ' + condition, () => {
+				const spy = editor.execute = sinon.spy();
+
+				plugin.requestUndoOnBackspace();
+
+				viewDocument.fire( 'delete', new DomEventData( viewDocument, getDomEvent(), eventData ) );
+
+				expect( spy.calledOnce ).to.be.true;
+				expect( spy.calledWithMatch( 'undo' ) ).to.be.false;
+				expect( spy.calledWithMatch( 'delete', {} ) ).to.be.true;
+			} );
+		} );
+
+		it( 'if requestUndoOnBackspace() hasn\'t been called', () => {
+			const spy = editor.execute = sinon.spy();
+
+			viewDocument.fire( 'delete', new DomEventData( viewDocument, getDomEvent(), deleteEventEventData ) );
+
+			expect( spy.calledOnce ).to.be.true;
+			expect( spy.calledWithMatch( 'undo' ) ).to.be.false;
+			expect( spy.calledWithMatch( 'delete', {} ) ).to.be.true;
+		} );
+
+		it( 'if `UndoEditing` plugin is not loaded', async () => {
+			await editor.destroy();
+
+			editor = await ClassicTestEditor.create( element, { plugins: [ Delete ] } );
+			viewDocument = editor.editing.view.document;
+			plugin = editor.plugins.get( 'Delete' );
+
+			const spy = editor.execute = sinon.spy();
+
+			plugin.requestUndoOnBackspace();
+
+			viewDocument.fire( 'delete', new DomEventData( viewDocument, getDomEvent(), {
+				direction: 'backward',
+				unit: 'word',
+				sequence: 1
+			} ) );
+
+			expect( spy.calledOnce ).to.be.true;
+			expect( spy.calledWithMatch( 'undo' ) ).to.be.false;
+			expect( spy.calledWithMatch( 'delete', {} ) ).to.be.true;
+		} );
+
+		it( 'after model has changed', () => {
+			const modelDocument = editor.model.document;
+			const spy = editor.execute = sinon.spy();
+
+			plugin.requestUndoOnBackspace();
+
+			modelDocument.fire( 'change', new Batch() );
+			viewDocument.fire( 'delete', new DomEventData( viewDocument, getDomEvent(), deleteEventEventData ) );
+
+			expect( spy.calledOnce ).to.be.true;
+			expect( spy.calledWithMatch( 'undo' ) ).to.be.false;
+			expect( spy.calledWithMatch( 'delete', {} ) ).to.be.true;
+		} );
+	} );
+} );
+
+function getDomEvent() {
+	return {
+		preventDefault: sinon.spy()
+	};
+}

--- a/packages/ckeditor5-typing/tests/texttransformation.js
+++ b/packages/ckeditor5-typing/tests/texttransformation.js
@@ -186,6 +186,17 @@ describe( 'Text transformation feature', () => {
 				.to.equal( '<codeBlock language="plaintext">some 1/2 code</codeBlock>' );
 		} );
 
+		it( 'should request next backspace to undo the transformation', () => {
+			const deletePlugin = editor.plugins.get( 'Delete' );
+			const spy = deletePlugin.requestUndoOnBackspace = sinon.spy();
+
+			setData( model, '<paragraph>Foo[]</paragraph>' );
+
+			simulateTyping( '1/2' );
+
+			expect( spy.calledOnce ).to.be.true;
+		} );
+
 		function testTransformation( transformFrom, transformTo, textInParagraph = 'A foo' ) {
 			it( `should transform "${ transformFrom }" to "${ transformTo }"`, () => {
 				setData( model, `<paragraph>${ textInParagraph }[]</paragraph>` );

--- a/packages/ckeditor5-typing/tests/texttransformation.js
+++ b/packages/ckeditor5-typing/tests/texttransformation.js
@@ -13,7 +13,7 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import CodeBlock from '@ckeditor/ckeditor5-code-block/src/codeblock';
 import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
-import { DomEventData } from '@ckeditor/ckeditor5-engine';
+import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
 
 describe( 'Text transformation feature', () => {
 	let editorElement, editor, model, doc;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature: Allows using backspace to undo certain operations. Closes #10413.

---

### Additional information

_Features that allows undo by backspace:_

*   _Text transformation_
*   _Auto linking_
*   _Auto media embed_
*   _Auto image_