### PR TITLE
Docs: Small adjustment in the plugincollection api docs

### DIFF
--- a/packages/ckeditor5-core/src/plugincollection.js
+++ b/packages/ckeditor5-core/src/plugincollection.js
@@ -108,7 +108,7 @@ export default class PluginCollection {
 	 * to check if a plugin is available.
 	 *
 	 * @param {Function|String} key The plugin constructor or {@link module:core/plugin~PluginInterface.pluginName name}.
-	 * @returns {module:core/plugin~PluginInterface}
+	 * @returns {module:core/plugin~PluginInterface|undefined}
 	 */
 	get( key ) {
 		const plugin = this._plugins.get( key );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Updated `PluginCollection.get()` as it should return `undefined` if a plugin cannot be found. Closes #10478.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._