### PR TITLE
ButtonView - editor crashed with withKeystroke set to true and keystroke undefined.

### DIFF
--- a/packages/ckeditor5-ui/src/button/buttonview.js
+++ b/packages/ckeditor5-ui/src/button/buttonview.js
@@ -184,7 +184,7 @@ export default class ButtonView extends View {
 		this.children.add( this.tooltipView );
 		this.children.add( this.labelView );
 
-		if ( this.withKeystroke ) {
+		if ( this.withKeystroke && this.keystroke ) {
 			this.children.add( this.keystrokeView );
 		}
 	}

--- a/packages/ckeditor5-ui/tests/button/buttonview.js
+++ b/packages/ckeditor5-ui/tests/button/buttonview.js
@@ -343,7 +343,7 @@ describe( 'ButtonView', () => {
 	} );
 
 	describe( '#keystrokeView', () => {
-		it( 'is omited in #children when view#icon is not defined', () => {
+		it( 'is omitted in #children when view#withKeystroke is false', () => {
 			view = new ButtonView( locale );
 			view.render();
 
@@ -369,7 +369,16 @@ describe( 'ButtonView', () => {
 			expect( view.keystrokeView.element.textContent ).to.equal( 'Ctrl+A' );
 		} );
 
-		it( 'usese fancy kesytroke preview on Mac', () => {
+		it( 'is omitted in #children when view#keystroke is not defined', () => {
+			view = new ButtonView( locale );
+			view.withKeystroke = true;
+			view.render();
+
+			expect( view.element.childNodes ).to.have.length( 2 );
+			expect( view.keystrokeView.element ).to.be.null;
+		} );
+
+		it( 'usese fancy keystroke preview on Mac', () => {
 			testUtils.sinon.stub( env, 'isMac' ).value( true );
 
 			view = new ButtonView( locale );

--- a/packages/ckeditor5-ui/tests/button/buttonview.js
+++ b/packages/ckeditor5-ui/tests/button/buttonview.js
@@ -343,7 +343,7 @@ describe( 'ButtonView', () => {
 	} );
 
 	describe( '#keystrokeView', () => {
-		it( 'is omitted in #children when view#withKeystroke is false', () => {
+		it( 'is omitted in #children when view#withKeystroke is not set', () => {
 			view = new ButtonView( locale );
 			view.render();
 
@@ -370,6 +370,7 @@ describe( 'ButtonView', () => {
 		} );
 
 		it( 'is omitted in #children when view#keystroke is not defined', () => {
+			// (#9412)
 			view = new ButtonView( locale );
 			view.withKeystroke = true;
 			view.render();

--- a/packages/ckeditor5-ui/tests/manual/tickets/9412/1.html
+++ b/packages/ckeditor5-ui/tests/manual/tickets/9412/1.html
@@ -1,0 +1,4 @@
+<div class="wrapper">
+	<div id="editor">
+	</div>
+</div>

--- a/packages/ckeditor5-ui/tests/manual/tickets/9412/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/9412/1.js
@@ -1,0 +1,50 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals window, document, console:false */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
+import List from '@ckeditor/ckeditor5-list/src/list';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading';
+import HeadingButtonsUI from '@ckeditor/ckeditor5-heading/src/headingbuttonsui';
+import ParagraphButtonUI from '@ckeditor/ckeditor5-paragraph/src/paragraphbuttonui';
+import boldIcon from '@ckeditor/ckeditor5-basic-styles/theme/icons/bold.svg';
+import ButtonView from '../../../../src/button/buttonview';
+
+function customButtonView( editor ) {
+	editor.ui.componentFactory.add( 'customButtonView', locale => {
+		const view = new ButtonView( locale );
+		view.set( {
+			label: 'Custom Button',
+			icon: boldIcon,
+			tooltip: true,
+			withKeystroke: true
+		} );
+
+		return view;
+	} );
+}
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [
+			Essentials,
+			List,
+			Paragraph,
+			Heading,
+			HeadingButtonsUI,
+			ParagraphButtonUI,
+			customButtonView
+		],
+		toolbar: [ 'customButtonView' ]
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-ui/tests/manual/tickets/9412/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/9412/1.js
@@ -7,11 +7,8 @@
 
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
-import List from '@ckeditor/ckeditor5-list/src/list';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Heading from '@ckeditor/ckeditor5-heading/src/heading';
-import HeadingButtonsUI from '@ckeditor/ckeditor5-heading/src/headingbuttonsui';
-import ParagraphButtonUI from '@ckeditor/ckeditor5-paragraph/src/paragraphbuttonui';
 import boldIcon from '@ckeditor/ckeditor5-basic-styles/theme/icons/bold.svg';
 import ButtonView from '../../../../src/button/buttonview';
 
@@ -33,11 +30,8 @@ ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [
 			Essentials,
-			List,
 			Paragraph,
 			Heading,
-			HeadingButtonsUI,
-			ParagraphButtonUI,
 			customButtonView
 		],
 		toolbar: [ 'customButtonView' ]

--- a/packages/ckeditor5-ui/tests/manual/tickets/9412/1.md
+++ b/packages/ckeditor5-ui/tests/manual/tickets/9412/1.md
@@ -1,0 +1,3 @@
+## Editor crash with keystroke undefined [#9412](https://github.com/ckeditor/ckeditor5/issues/9412)
+
+**Expected**: The editor should create ButtonView without keystrokeView and there shouldn't be any error in console.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (ui): Editor no longer crashes when a button has `withKeystroke` set to `true` but no `keystroke` property is provided. Closes #9412.

---

### Additional information