### PR TITLE
Table - console warning on cancel table and table cell properties

### DIFF
--- a/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.js
+++ b/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.js
@@ -799,7 +799,6 @@ export default class TableCellPropertiesView extends View {
 			label: t( 'Cancel' ),
 			icon: icons.cancel,
 			class: 'ck-button-cancel',
-			type: 'cancel',
 			withText: true
 		} );
 

--- a/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.js
+++ b/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.js
@@ -690,7 +690,6 @@ export default class TablePropertiesView extends View {
 			label: t( 'Cancel' ),
 			icon: icons.cancel,
 			class: 'ck-button-cancel',
-			type: 'cancel',
 			withText: true
 		} );
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/ui/tablecellpropertiesview.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/ui/tablecellpropertiesview.js
@@ -605,6 +605,7 @@ describe( 'table cell properties', () => {
 						expect( view.cancelButtonView.label ).to.equal( 'Cancel' );
 						expect( view.cancelButtonView.withText ).to.be.true;
 						expect( view.cancelButtonView.class ).to.equal( 'ck-button-cancel' );
+						expect( view.cancelButtonView.type ).to.equal( 'button' );
 					} );
 
 					it( 'should make the cancel button fire the #cancel event when executed', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/ui/tablepropertiesview.js
+++ b/packages/ckeditor5-table/tests/tableproperties/ui/tablepropertiesview.js
@@ -527,6 +527,7 @@ describe( 'table properties', () => {
 						expect( view.cancelButtonView.label ).to.equal( 'Cancel' );
 						expect( view.cancelButtonView.withText ).to.be.true;
 						expect( view.cancelButtonView.class ).to.equal( 'ck-button-cancel' );
+						expect( view.cancelButtonView.type ).to.equal( 'button' );
 					} );
 
 					it( 'should make the cancel button fire the #cancel event when executed', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): Cancelling the table cell properties UI no longer results with a warning in the console. Closes #6266.

---

### Additional information

As the same console warn occurred for canceling table cell properties, both cases (table and table cell properties) have been fixed