### PR TITLE
Method name syntax

### DIFF
--- a/docs/framework/guides/contributing/git-commit-message-convention.md
+++ b/docs/framework/guides/contributing/git-commit-message-convention.md
@@ -79,6 +79,14 @@ When creating PRs that address specific issues, use the following messages to in
 * `See #123` &ndash; when the PR only references an issue, but does not close it yet.
 * _No reference_ &ndash; when the PR does not reference any issue.
 
+### Methods name syntax
+
+ALl methods mentioned in the git commit message should use the **#** sign inbetween the class name and the method name. And example of a properly named method:
+
+```
+MarkerCollection#has()
+```
+
 ### Order of entries
 
 The proper order of sections for a commit message is as follows:

--- a/docs/framework/guides/contributing/git-commit-message-convention.md
+++ b/docs/framework/guides/contributing/git-commit-message-convention.md
@@ -166,11 +166,11 @@ Changelog
 
 ### MAJOR BREAKING CHANGES [ℹ️](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/versioning-policy.html#major-and-minor-breaking-changes)
 
-* **[utils](http://npmjs.com/package/@ckeditor/ckeditor5-utils)**: The `utils.foo()` method was moved to the `engine` package. See [#9](https://github.com/ckeditor/ckeditor5/issue/9).
+* **[utils](http://npmjs.com/package/@ckeditor/ckeditor5-utils)**: The `utils#foo()` method was moved to the `engine` package. See [#9](https://github.com/ckeditor/ckeditor5/issue/9).
 
 ### Features
 
-* **[engine](http://npmjs.com/package/@ckeditor/ckeditor5-engine)**: Introduced the `engine.foo()` method. Thanks to [@CKEditor](https://github.com/CKEditor). Closes [#9](https://github.com/ckeditor/ckeditor5/issue/9). ([e8cc04f](https://github.com/ckeditor/ckeditor5/commit/e8cc04f))
+* **[engine](http://npmjs.com/package/@ckeditor/ckeditor5-engine)**: Introduced the `engine#foo()` method. Thanks to [@CKEditor](https://github.com/CKEditor). Closes [#9](https://github.com/ckeditor/ckeditor5/issue/9). ([e8cc04f](https://github.com/ckeditor/ckeditor5/commit/e8cc04f))
 * **[ui](http://npmjs.com/package/@ckeditor/ckeditor5-ui)**: Added support for RTL languages. Closes [#1](https://github.com/ckeditor/ckeditor5/issue/1). ([adc59ed](https://github.com/ckeditor/ckeditor5/commit/adc59ed))
 
    RTL content will now be rendered correctly.
@@ -181,7 +181,7 @@ Changelog
 
 ### Other changes
 
-* **[utils](http://npmjs.com/package/@ckeditor/ckeditor5-utils)**: Extracted the `utils.foo()` to a separate package. Thanks to [@CKEditor](https://github.com/CKEditor). ([e8cc04f](https://github.com/ckeditor/ckeditor5/commit/e8cc04f))
+* **[utils](http://npmjs.com/package/@ckeditor/ckeditor5-utils)**: Extracted the `utils#foo()` to a separate package. Thanks to [@CKEditor](https://github.com/CKEditor). ([e8cc04f](https://github.com/ckeditor/ckeditor5/commit/e8cc04f))
 ```
 
 ## Handling pull requests

--- a/docs/framework/guides/contributing/git-commit-message-convention.md
+++ b/docs/framework/guides/contributing/git-commit-message-convention.md
@@ -149,11 +149,11 @@ Tests (widget): Introduced missing tests. Closes #5.
 An improvement that is not backward compatible and sent by a non-core contributor. Public API was changed:
 
 ```
-Other (utils): Extracted the `utils.foo()` to a separate package. Closes #9.
+Other (utils): Extracted the `utils#foo()` to a separate package. Closes #9.
 
-Feature (engine): Introduced the `engine.foo()` method. Closes #9.
+Feature (engine): Introduced the `engine#foo()` method. Closes #9.
 
-MAJOR BREAKING CHANGE (utils): The `utils.foo()` method was moved to the `engine` package. See #9.
+MAJOR BREAKING CHANGE (utils): The `utils#foo()` method was moved to the `engine` package. See #9.
 ```
 
 For the commits shown above the changelog will look like this:


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: correcting the method name syntax in commit message convention guide. Closes #10503.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._