### PR TITLE
Fixing focus after escaping find and replace dropdown

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.js
@@ -60,7 +60,7 @@ export default class FindAndReplaceUI extends Plugin {
 			// the default action of the drop-down is executed (i.e. the panel showed up). Otherwise,
 			// the invisible form/input cannot be focused/selected.
 			//
-			// Each time a dropdown is closed, move the focus back to the editing root (to preserve it)
+			// Each time a dropdown is closed, move the focus back to the find and replace toolbar button
 			// and let the find and replace editing feature know that all search results can be invalidated
 			// and no longer should be marked in the content.
 			dropdown.on( 'change:isOpen', ( event, name, isOpen ) => {
@@ -73,7 +73,7 @@ export default class FindAndReplaceUI extends Plugin {
 
 					formView.enableCssTransitions();
 				} else {
-					editor.editing.view.focus();
+					formView.focus();
 
 					this.fire( 'searchReseted' );
 				}

--- a/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
@@ -122,10 +122,10 @@ describe( 'FindAndReplaceUI', () => {
 			} );
 
 			describe( 'upon dropdown close', () => {
-				it( 'the editing view should be focused', () => {
+				it( 'the form should be focused', () => {
 					dropdown.isOpen = true;
 
-					const spy = sinon.spy( editor.editing.view, 'focus' );
+					const spy = sinon.spy( form, 'focus' );
 
 					dropdown.isOpen = false;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (find-and-replace): The toolbar should not lose focus after escaping from the find and replace dropdown. Closes #10420.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._