### PR TITLE
Restrict mathematical text transformation not to interfere with dates

### DIFF
--- a/packages/ckeditor5-typing/src/texttransformation.js
+++ b/packages/ckeditor5-typing/src/texttransformation.js
@@ -19,11 +19,11 @@ const TRANSFORMATIONS = {
 	trademark: { from: '(tm)', to: '™' },
 
 	// Mathematical:
-	oneHalf: { from: /(^|[^/a-z0-9])(1\/2)([^/a-z0-9])/i, to: [ null, '½', null ] },
-	oneThird: { from: /(^|[^/a-z0-9])(1\/3)([^/a-z0-9])/i, to: [ null, '⅓', null ] },
-	twoThirds: { from: /(^|[^/a-z0-9])(2\/3)([^/a-z0-9])/i, to: [ null, '⅔', null ] },
-	oneForth: { from: /(^|[^/a-z0-9])(1\/4)([^/a-z0-9])/i, to: [ null, '¼', null ] },
-	threeQuarters: { from: /(^|[^/a-z0-9])(3\/4)([^/a-z0-9])/i, to: [ null, '¾', null ] },
+	oneHalf: { from: /(^|[^/a-z0-9])(1\/2)([^/a-z0-9])$/i, to: [ null, '½', null ] },
+	oneThird: { from: /(^|[^/a-z0-9])(1\/3)([^/a-z0-9])$/i, to: [ null, '⅓', null ] },
+	twoThirds: { from: /(^|[^/a-z0-9])(2\/3)([^/a-z0-9])$/i, to: [ null, '⅔', null ] },
+	oneForth: { from: /(^|[^/a-z0-9])(1\/4)([^/a-z0-9])$/i, to: [ null, '¼', null ] },
+	threeQuarters: { from: /(^|[^/a-z0-9])(3\/4)([^/a-z0-9])$/i, to: [ null, '¾', null ] },
 	lessThanOrEqual: { from: '<=', to: '≤' },
 	greaterThanOrEqual: { from: '>=', to: '≥' },
 	notEqual: { from: '!=', to: '≠' },

--- a/packages/ckeditor5-typing/src/texttransformation.js
+++ b/packages/ckeditor5-typing/src/texttransformation.js
@@ -19,11 +19,11 @@ const TRANSFORMATIONS = {
 	trademark: { from: '(tm)', to: '™' },
 
 	// Mathematical:
-	oneHalf: { from: '1/2', to: '½' },
-	oneThird: { from: '1/3', to: '⅓' },
-	twoThirds: { from: '2/3', to: '⅔' },
-	oneForth: { from: '1/4', to: '¼' },
-	threeQuarters: { from: '3/4', to: '¾' },
+	oneHalf: { from: /(^|[^/a-z0-9])(1\/2)([^/a-z0-9])/i, to: [ null, '½', null ] },
+	oneThird: { from: /(^|[^/a-z0-9])(1\/3)([^/a-z0-9])/i, to: [ null, '⅓', null ] },
+	twoThirds: { from: /(^|[^/a-z0-9])(2\/3)([^/a-z0-9])/i, to: [ null, '⅔', null ] },
+	oneForth: { from: /(^|[^/a-z0-9])(1\/4)([^/a-z0-9])/i, to: [ null, '¼', null ] },
+	threeQuarters: { from: /(^|[^/a-z0-9])(3\/4)([^/a-z0-9])/i, to: [ null, '¾', null ] },
 	lessThanOrEqual: { from: '<=', to: '≤' },
 	greaterThanOrEqual: { from: '>=', to: '≥' },
 	notEqual: { from: '!=', to: '≠' },

--- a/packages/ckeditor5-typing/tests/texttransformation.js
+++ b/packages/ckeditor5-typing/tests/texttransformation.js
@@ -105,7 +105,13 @@ describe( 'Text transformation feature', () => {
 		} );
 
 		describe( 'mathematical', () => {
-			testTransformation( '1/2', '½' );
+			testTransformation( '1/2 ', '½ ', '' );
+			testTransformation( '1/2.', '½.', 'A foo ' );
+			testTransformation( '1/2+', '½+', '+' );
+			testShouldNotTransform( 'x1/2 ', '½ ' );
+			testShouldNotTransform( '1/22', '½2' );
+			testShouldNotTransform( '11/2', '1½' );
+			testShouldNotTransform( '1/2A', '½A' );
 			testTransformation( '<=', '≤' );
 		} );
 
@@ -191,12 +197,12 @@ describe( 'Text transformation feature', () => {
 		it( 'can undo transformation', () => {
 			setData( model, '<paragraph>Foo[]</paragraph>' );
 
-			simulateTyping( '1/2' );
+			simulateTyping( '(c)' );
 
 			editor.commands.execute( 'undo' );
 
 			expect( getData( model, { withoutSelection: true } ) )
-				.to.equal( '<paragraph>Foo1/2</paragraph>' );
+				.to.equal( '<paragraph>Foo(c)</paragraph>' );
 		} );
 
 		it( 'can undo transformation by pressing backspace', () => {
@@ -209,12 +215,12 @@ describe( 'Text transformation feature', () => {
 
 			setData( model, '<paragraph>Foo[]</paragraph>' );
 
-			simulateTyping( '1/2' );
+			simulateTyping( '(c)' );
 
 			viewDocument.fire( 'delete', deleteEvent );
 
 			expect( getData( model, { withoutSelection: true } ) )
-				.to.equal( '<paragraph>Foo1/2</paragraph>' );
+				.to.equal( '<paragraph>Foo(c)</paragraph>' );
 		} );
 
 		function testTransformation( transformFrom, transformTo, textInParagraph = 'A foo' ) {
@@ -242,6 +248,17 @@ describe( 'Text transformation feature', () => {
 
 				expect( getData( model, { withoutSelection: true } ) )
 					.to.equal( `<paragraph>${ textInParagraph }${ transformFrom } bar </paragraph>` );
+			} );
+		}
+
+		function testShouldNotTransform( transformFrom, transformTo ) {
+			it( `should not transform "${ transformFrom }" to "${ transformTo }"`, () => {
+				setData( model, '<paragraph>[]</paragraph>' );
+
+				simulateTyping( transformFrom );
+
+				expect( getData( model, { withoutSelection: true } ) )
+					.to.equal( `<paragraph>${ transformFrom }</paragraph>` );
 			} );
 		}
 	} );

--- a/packages/ckeditor5-typing/tests/texttransformation.js
+++ b/packages/ckeditor5-typing/tests/texttransformation.js
@@ -249,6 +249,20 @@ describe( 'Text transformation feature', () => {
 				expect( getData( model, { withoutSelection: true } ) )
 					.to.equal( `<paragraph>${ textInParagraph }${ transformFrom } bar </paragraph>` );
 			} );
+
+			it( `should not transform "${ transformFrom }" to "${ transformTo } if not right before selection"`, () => {
+				setData( model, '<paragraph>[]</paragraph>' );
+
+				// Insert text - should not be transformed.
+				model.enqueueChange( model.createBatch(), writer => {
+					writer.insertText( `${ textInParagraph }${ transformFrom }`, doc.selection.focus );
+				} );
+
+				simulateTyping( ' ' );
+
+				expect( getData( model, { withoutSelection: true } ) )
+					.to.equal( `<paragraph>${ textInParagraph }${ transformFrom } </paragraph>` );
+			} );
 		}
 
 		function testShouldNotTransform( transformFrom, transformTo ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (typing): Restricts mathematical text transformation, so it requires no alphanumeric character before and after the fraction. Closes #9170.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._