### PR TITLE
Improving mention feature ui tests speed.

### DIFF
--- a/packages/ckeditor5-mention/tests/mentionui.js
+++ b/packages/ckeditor5-mention/tests/mentionui.js
@@ -23,7 +23,7 @@ import MentionsView from '../src/ui/mentionsview';
 import { assertCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 
 describe( 'MentionUI', () => {
-	let editor, model, doc, editingView, mentionUI, editorElement, mentionsView, panelView;
+	let editor, model, doc, editingView, mentionUI, editorElement, mentionsView, panelView, clock;
 
 	const staticConfig = {
 		feeds: [
@@ -37,6 +37,7 @@ describe( 'MentionUI', () => {
 	testUtils.createSinonSandbox();
 
 	beforeEach( () => {
+		clock = sinon.useFakeTimers( { now: Date.now() } );
 		editorElement = document.createElement( 'div' );
 		document.body.appendChild( editorElement );
 	} );
@@ -938,6 +939,7 @@ describe( 'MentionUI', () => {
 
 				function feedCallback( feedText ) {
 					return new Promise( resolve => {
+						// sinon.clock.tick( feedCallbackTimeout );
 						setTimeout( () => {
 							feedCallbackCallTimes++;
 							resolve( issuesNumbers.filter( number => number.includes( feedText ) ) );
@@ -2265,9 +2267,8 @@ describe( 'MentionUI', () => {
 
 	function wait( timeout ) {
 		return () => new Promise( resolve => {
-			setTimeout( () => {
-				resolve();
-			}, timeout );
+			clock.tick( timeout );
+			resolve();
 		} );
 	}
 

--- a/packages/ckeditor5-mention/tests/mentionui.js
+++ b/packages/ckeditor5-mention/tests/mentionui.js
@@ -44,6 +44,7 @@ describe( 'MentionUI', () => {
 
 	afterEach( () => {
 		sinon.restore();
+		clock.restore();
 		editorElement.remove();
 
 		if ( editor ) {

--- a/packages/ckeditor5-mention/tests/mentionui.js
+++ b/packages/ckeditor5-mention/tests/mentionui.js
@@ -939,7 +939,6 @@ describe( 'MentionUI', () => {
 
 				function feedCallback( feedText ) {
 					return new Promise( resolve => {
-						// sinon.clock.tick( feedCallbackTimeout );
 						setTimeout( () => {
 							feedCallbackCallTimes++;
 							resolve( issuesNumbers.filter( number => number.includes( feedText ) ) );
@@ -2272,8 +2271,8 @@ describe( 'MentionUI', () => {
 		} );
 	}
 
-	function waitForDebounce() {
-		return wait( 180 )();
+	async function waitForDebounce() {
+		return await wait( 180 )();
 	}
 
 	function fireKeyDownEvent( options ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Tests (mention): UI tests execution speed has been greatly increased by replacing `setTimeout` with Sinon `fakeTimer`. Closes #6619.

---

### Additional information

One of the `setTimeout` functions remain untouched:  
https://github.com/ckeditor/ckeditor5/blob/7d5848d5e43bb856042933bacc8852999fc28b2c/packages/ckeditor5-mention/tests/mentionui.js#L940-L947

Updating this would require a lot of additional effort, and the possible tests time decrease would be minor.  
  
Overall this change results in decreasing (on average):  
\- total time from `~28 secs` to `~5.5 secs`  
\- net time from `~24 secs` to `~2.3 secs`