### PR TITLE
Fix inline editor withArrow property.

### DIFF
--- a/packages/ckeditor5-editor-inline/src/inlineeditoruiview.js
+++ b/packages/ckeditor5-editor-inline/src/inlineeditoruiview.js
@@ -71,8 +71,6 @@ export default class InlineEditorUIView extends EditorUIView {
 		 */
 		this.panel = new BalloonPanelView( locale );
 
-		this.panel.withArrow = false;
-
 		/**
 		 * A set of positioning functions used by the {@link #panel} to float around
 		 * {@link #element editableElement}.
@@ -217,14 +215,20 @@ export default class InlineEditorUIView extends EditorUIView {
 				return {
 					top: this._getPanelPositionTop( editableRect, panelRect ),
 					left: editableRect.left,
-					name: 'toolbar_west'
+					name: 'toolbar_west',
+					config: {
+						withArrow: false
+					}
 				};
 			},
 			( editableRect, panelRect ) => {
 				return {
 					top: this._getPanelPositionTop( editableRect, panelRect ),
 					left: editableRect.left + editableRect.width - panelRect.width,
-					name: 'toolbar_east'
+					name: 'toolbar_east',
+					config: {
+						withArrow: false
+					}
 				};
 			}
 		];

--- a/packages/ckeditor5-editor-inline/tests/inlineeditoruiview.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditoruiview.js
@@ -89,10 +89,6 @@ describe( 'InlineEditorUIView', () => {
 				expect( view.panel.locale ).to.equal( locale );
 			} );
 
-			it( 'gets view.panel#withArrow set', () => {
-				expect( view.panel.withArrow ).to.be.false;
-			} );
-
 			it( 'is not rendered', () => {
 				expect( view.panel.isRendered ).to.be.false;
 			} );

--- a/packages/ckeditor5-editor-inline/tests/inlineeditoruiview.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditoruiview.js
@@ -245,6 +245,27 @@ describe( 'InlineEditorUIView', () => {
 			expect( positions[ 1 ]( editableRect, panelRect ).name ).to.equal( 'toolbar_west' );
 		} );
 
+		it( 'returned positions ahould have no arrow', () => {
+			const uiView = new InlineEditorUIView( locale, editingView );
+			const positions = uiView.panelPositions;
+			const editableRect = {
+				top: 100,
+				bottom: 200,
+				left: 100,
+				right: 100,
+				width: 100,
+				height: 100
+			};
+			const panelRect = {
+				width: 50,
+				height: 50
+			};
+
+			expect( positions ).to.have.length( 2 );
+			expect( positions[ 0 ]( editableRect, panelRect ).config.withArrow ).to.be.false;
+			expect( positions[ 1 ]( editableRect, panelRect ).config.withArrow ).to.be.false;
+		} );
+
 		describe( 'west', () => {
 			testTopPositions( 0, 100 );
 		} );

--- a/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
+++ b/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
@@ -211,6 +211,38 @@ describe( 'BalloonPanelView', () => {
 			expect( view.left ).to.equal( 10 );
 		} );
 
+		it( 'should set and override withArrow property', () => {
+			testUtils.sinon.stub( BalloonPanelView, '_getOptimalPosition' ).returns( {
+				top: 10.345,
+				left: 10.345,
+				name: 'position'
+			} );
+
+			view.withArrow = false;
+			view.attachTo( { target, limiter } );
+
+			expect( view.withArrow ).to.be.true;
+
+			view.set( 'withArrow', false );
+			view.attachTo( { target, limiter } );
+
+			expect( view.withArrow ).to.be.true;
+
+			BalloonPanelView._getOptimalPosition.restore();
+
+			testUtils.sinon.stub( BalloonPanelView, '_getOptimalPosition' ).returns( {
+				top: 10.345,
+				left: 10.345,
+				name: 'position',
+				config: {
+					withArrow: false
+				}
+			} );
+
+			view.attachTo( { target, limiter } );
+			expect( view.withArrow ).to.be.false;
+		} );
+
 		describe( 'limited by limiter element', () => {
 			beforeEach( () => {
 				// Mock limiter element dimensions.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (editor-inline): Set `withArrow` to `false` in inline editor toolbar balloon. Closes #10529.
