### PR TITLE
Introduce "yarn docs [--skip-guides] [--guides=...]"

### DIFF
--- a/docs/framework/guides/contributing/development-environment.md
+++ b/docs/framework/guides/contributing/development-environment.md
@@ -97,22 +97,22 @@ This task accepts the following arguments:
 * `--skip-snippets` &ndash; Skips building live snippets.
 * `--snippets=snippet-name` &ndash; Snippets to build. Accepts glob patterns that are matched against snippet names used in `{@snippet ...}` tags. Examples:
 
-    ```
-    --snippets=image         // matches roughly {@snippet *image*}
-    --snippets="features/*"  // matches roughly {@snippet *features/*}
-    --snippets=classic-editor,build-classic-source
-    ```
+	```
+	--snippets=image         // matches roughly {@snippet *image*}
+	--snippets="features/*"  // matches roughly {@snippet *features/*}
+	--snippets=classic-editor,build-classic-source
+	```
 
-    Note: If a snippet that you want to build uses another snippet as a source that provides an editor instance, you need to specify both snippets (e.g. `--files=features/default-headings,build-classic-source`).
+	Note: If a snippet that you want to build uses another snippet as a source that provides an editor instance, you need to specify both snippets (e.g. `--files=features/default-headings,build-classic-source`).
 * `--skip-validation` &ndash; Skips the final link validation.
 * `--skip-guides` &ndash; Skips building all guides except `index.md` files to allows navigating over the partially built documentation.
 * `--guides=guide-name` &ndash; Guides to build. Accepts Accepts glob patterns that are matched against guide names. Examples:
 
-  ```
-  --guides=image         // matches roughly "*image*"
-  --guides="features/*"  // matches roughly "*features/*"
-  --guides=features/image
-  ```
+	```
+	--guides=image         // matches roughly "*image*"
+	--guides="features/*"  // matches roughly "*features/*"
+	--guides=features/image
+	```
 
 * `--watch` &ndash; Runs the documentation generator in a watch mode. It covers guides but it does not cover API docs.
 * `--production` &ndash; Minifies the assets and performs other actions which are unnecessary during CKEditor 5 development.

--- a/docs/framework/guides/contributing/development-environment.md
+++ b/docs/framework/guides/contributing/development-environment.md
@@ -97,14 +97,23 @@ This task accepts the following arguments:
 * `--skip-snippets` &ndash; Skips building live snippets.
 * `--snippets=snippet-name` &ndash; Snippets to build. Accepts glob patterns that are matched against snippet names used in `{@snippet ...}` tags. Examples:
 
-	```
-	--snippets=image         // matches roughly {@snippet *image*}
-	--snippets="features/*"  // matches roughly {@snippet *features/*}
-	--snippets=classic-editor,build-classic-source
-	```
+    ```
+    --snippets=image         // matches roughly {@snippet *image*}
+    --snippets="features/*"  // matches roughly {@snippet *features/*}
+    --snippets=classic-editor,build-classic-source
+    ```
 
-	Note: If a snippet that you want to build uses another snippet as a source that provides an editor instance, you need to specify both snippets (e.g. `--files=features/default-headings,build-classic-source`).
+    Note: If a snippet that you want to build uses another snippet as a source that provides an editor instance, you need to specify both snippets (e.g. `--files=features/default-headings,build-classic-source`).
 * `--skip-validation` &ndash; Skips the final link validation.
+* `--skip-guides` &ndash; Skips building all guides except `index.md` files to allows navigating over the partially built documentation.
+* `--guides=guide-name` &ndash; Guides to build. Accepts Accepts glob patterns that are matched against guide names. Examples:
+
+  ```
+  --guides=image         // matches roughly "*image*"
+  --guides="features/*"  // matches roughly "*features/*"
+  --guides=features/image
+  ```
+
 * `--watch` &ndash; Runs the documentation generator in a watch mode. It covers guides but it does not cover API docs.
 * `--production` &ndash; Minifies the assets and performs other actions which are unnecessary during CKEditor 5 development.
 * `--verbose` &ndash; Prints out more information.

--- a/docs/framework/guides/contributing/development-environment.md
+++ b/docs/framework/guides/contributing/development-environment.md
@@ -105,7 +105,7 @@ This task accepts the following arguments:
 
 	Note: If a snippet that you want to build uses another snippet as a source that provides an editor instance, you need to specify both snippets (e.g. `--files=features/default-headings,build-classic-source`).
 * `--skip-validation` &ndash; Skips the final link validation.
-* `--skip-guides` &ndash; Skips building all guides except `index.md` files to allows navigating over the partially built documentation.
+* `--skip-guides` &ndash; Skips building all guides except the `index.md` files which allowa navigating over the partially built documentation.
 * `--guides=guide-name` &ndash; Guides to build. Accepts glob patterns that are matched against guide names. Examples:
 
 	```

--- a/docs/framework/guides/contributing/development-environment.md
+++ b/docs/framework/guides/contributing/development-environment.md
@@ -106,7 +106,7 @@ This task accepts the following arguments:
 	Note: If a snippet that you want to build uses another snippet as a source that provides an editor instance, you need to specify both snippets (e.g. `--files=features/default-headings,build-classic-source`).
 * `--skip-validation` &ndash; Skips the final link validation.
 * `--skip-guides` &ndash; Skips building all guides except `index.md` files to allows navigating over the partially built documentation.
-* `--guides=guide-name` &ndash; Guides to build. Accepts Accepts glob patterns that are matched against guide names. Examples:
+* `--guides=guide-name` &ndash; Guides to build. Accepts glob patterns that are matched against guide names. Examples:
 
 	```
 	--guides=image         // matches roughly "*image*"

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "svgo": "^2.2.2",
     "terser-webpack-plugin": "^3.0.2",
     "tippy.js": "^6.2.7",
-    "umberto": "^1.13.0",
+    "umberto": "^1.14.0",
     "upath": "^2.0.0",
     "wait-on": "^5.2.1",
     "webpack": "^4.43.0",

--- a/scripts/docs/build-docs.js
+++ b/scripts/docs/build-docs.js
@@ -156,9 +156,9 @@ function splitOptionsToArray( options, keys ) {
  *
  * @param {Boolean} [verbose=false] Whether to print additional logs.
  *
- * @param {Array.<String>} [snippets=[]] An array containing name of snippets that the snippet adapter should process.
+ * @param {Array.<String>} [snippets=[]] An array containing the names of snippets that the snippet adapter should process.
  * An empty array means that the filtering mechanism is disabled.
  *
- * @param {Array.<String>} [guides=[]] An array containing name of guides that should be processed by Umberto.
+ * @param {Array.<String>} [guides=[]] An array containing the names of guides that should be processed by Umberto.
  * An empty array means that the filtering mechanism is disabled.
  */

--- a/scripts/docs/build-docs.js
+++ b/scripts/docs/build-docs.js
@@ -10,36 +10,24 @@
 'use strict';
 
 const buildApiDocs = require( './buildapi' );
-
-const skipLiveSnippets = process.argv.includes( '--skip-snippets' );
-const skipApi = process.argv.includes( '--skip-api' );
-const skipValidation = process.argv.includes( '--skip-validation' );
-const production = process.argv.includes( '--production' );
-const watch = process.argv.includes( '--watch' );
-const verbose = process.argv.includes( '--verbose' );
-const allowedSnippets = process.argv.find( item => item.startsWith( '--snippets=' ) );
+const minimist = require( 'minimist' );
 
 buildDocs();
 
 function buildDocs() {
+	const options = parseArguments( process.argv.slice( 2 ) );
+
 	let promise;
 
-	if ( skipApi ) {
+	if ( options.skipApi ) {
 		promise = Promise.resolve();
 	} else {
 		promise = buildApiDocs();
 	}
 
-	promise
+	return promise
 		.then( () => {
-			return runUmberto( {
-				skipLiveSnippets,
-				skipApi,
-				skipValidation,
-				production,
-				watch,
-				verbose
-			} );
+			return runUmberto( options );
 		} )
 		.catch( err => {
 			console.error( err );
@@ -48,6 +36,10 @@ function buildDocs() {
 		} );
 }
 
+/**
+ * @param {DocumentationOptions} options
+ * @return {Promise}
+ */
 function runUmberto( options ) {
 	const umberto = require( 'umberto' );
 
@@ -55,14 +47,118 @@ function runUmberto( options ) {
 		configDir: 'docs',
 		clean: true,
 		dev: !options.production,
-		skipLiveSnippets: options.skipLiveSnippets,
+		skipLiveSnippets: options.skpiSnippets,
 		skipValidation: options.skipValidation,
 		snippetOptions: {
 			production: options.production,
-			allowedSnippets: allowedSnippets ? allowedSnippets.replace( '--snippets=', '' ).split( ',' ) : []
+			allowedSnippets: options.snippets
 		},
 		skipApi: options.skipApi,
+		skipGuides: options.skipGuides,
 		verbose: options.verbose,
-		watch: options.watch
+		watch: options.watch,
+		guides: options.guides
 	} );
 }
+
+/**
+ * @param {Array.<String>} args An array containing modifiers for the executed command.
+ * @return {DocumentationOptions}
+ */
+function parseArguments( args ) {
+	const options = minimist( args, {
+		boolean: [
+			'skip-api',
+			'skip-snippets',
+			'skip-validation',
+			'skip-guides',
+			'production',
+			'watch',
+			'verbose'
+		],
+		string: [
+			'snippets',
+			'guides'
+		],
+		default: {
+			'skip-api': false,
+			'skip-snippets': false,
+			'skip-validation': false,
+			'skip-guides': false,
+			production: false,
+			watch: false,
+			verbose: false,
+			snippets: [],
+			guides: []
+		}
+	} );
+
+	splitOptionsToArray( options, [
+		'snippets',
+		'guides'
+	] );
+
+	replaceKebabCaseWithCamelCase( options, [
+		'skip-api',
+		'skip-snippets',
+		'skip-validation',
+		'skip-guides'
+	] );
+
+	return options;
+}
+
+/**
+ * Replaces all kebab-case keys in the `options` object with camelCase entries.
+ * Kebab-case keys will be removed.
+ *
+ * @param {Object} options
+ * @param {Array.<String>} keys Kebab-case keys in `options` object.
+ */
+function replaceKebabCaseWithCamelCase( options, keys ) {
+	for ( const key of keys ) {
+		const camelCaseKey = key.replace( /-./g, match => match[ 1 ].toUpperCase() );
+
+		options[ camelCaseKey ] = options[ key ];
+		delete options[ key ];
+	}
+}
+
+/**
+ * Splits by a comma (`,`) all values specified under keys to array.
+ *
+ * @param {Object} options
+ * @param {Array.<String>} keys Kebab-case keys in `options` object.
+ */
+function splitOptionsToArray( options, keys ) {
+	for ( const key of keys ) {
+		if ( typeof options[ key ] === 'string' ) {
+			options[ key ] = options[ key ].split( ',' ).filter( item => item.length );
+		}
+	}
+}
+
+/**
+ * @typedef {Object} DocumentationOptions
+ *
+ * @param {Boolean} [skipApi=false] Whether to skip building API docs.
+ *
+ * @param {Boolean} [skipSnippets=false] Whether to skip building live snippets.
+ *
+ * @param {Boolean} [skipValidation=false] Whether to skip validating URLs in the generated documentation.
+ *
+ * @param {Boolean} [skipGuides=false] Whether to skip processing guides.
+ *
+ * @param {Boolean} [production=false] Whether the documentation is being built on the production environment. It means that all files
+ * will be minified. Increases the time needed for processing all files.
+ *
+ * @param {Boolean} [watch=false] Whether to watch source files.
+ *
+ * @param {Boolean} [verbose=false] Whether to print additional logs.
+ *
+ * @param {Array.<String>} [snippets=[]] An array containing name of snippets that the snippet adapter should process.
+ * An empty array means that the filtering mechanism is disabled.
+ *
+ * @param {Array.<String>} [guides=[]] An array containing name of guides that should be processed by Umberto.
+ * An empty array means that the filtering mechanism is disabled.
+ */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Added new options that allow filtering guides to build in the "Generating documentation" section in the "Development environment" guide.

---

### Additional information

It targets the `#stable` branch. We need to bump the Umberto version after releasing new changes.

PR: https://github.com/cksource/umberto/pull/948
