### PR TITLE
Add more known key codes

### DIFF
--- a/packages/ckeditor5-utils/src/keyboard.js
+++ b/packages/ckeditor5-utils/src/keyboard.js
@@ -33,6 +33,7 @@ const modifiersToGlyphsNonMac = {
  * * `a-z`,
  * * `0-9`,
  * * `f1-f12`,
+ * * `` ` ``, `-`, `=`, `[`, `]`, `;`, `'`, `,`, `.`, `/`, `\`,
  * * `arrow(left|up|right|bottom)`,
  * * `backspace`, `delete`, `enter`, `esc`, `tab`,
  * * `ctrl`, `cmd`, `shift`, `alt`.
@@ -249,6 +250,11 @@ function generateKnownKeyCodes() {
 	// F1-F12
 	for ( let code = 112; code <= 123; code++ ) {
 		keyCodes[ 'f' + ( code - 111 ) ] = code;
+	}
+
+	// other characters
+	for ( const char of '`-=[];\',./\\' ) {
+		keyCodes[ char ] = char.charCodeAt( 0 );
 	}
 
 	return keyCodes;

--- a/packages/ckeditor5-utils/tests/keyboard.js
+++ b/packages/ckeditor5-utils/tests/keyboard.js
@@ -214,6 +214,8 @@ describe( 'Keyboard', () => {
 				expect( getEnvKeystrokeText( 'a' ) ).to.equal( 'A' );
 				expect( getEnvKeystrokeText( 'CTRL+a' ) ).to.equal( '⌘A' );
 				expect( getEnvKeystrokeText( 'ctrl+b' ) ).to.equal( '⌘B' );
+				expect( getEnvKeystrokeText( 'CTRL+[' ) ).to.equal( '⌘[' );
+				expect( getEnvKeystrokeText( 'CTRL+]' ) ).to.equal( '⌘]' );
 			} );
 		} );
 
@@ -234,6 +236,8 @@ describe( 'Keyboard', () => {
 				expect( getEnvKeystrokeText( 'SHIFT+A' ) ).to.equal( 'Shift+A' );
 				expect( getEnvKeystrokeText( 'alt+A' ) ).to.equal( 'Alt+A' );
 				expect( getEnvKeystrokeText( 'CTRL+SHIFT+A' ) ).to.equal( 'Ctrl+Shift+A' );
+				expect( getEnvKeystrokeText( 'CTRL+[' ) ).to.equal( 'Ctrl+[' );
+				expect( getEnvKeystrokeText( 'CTRL+]' ) ).to.equal( 'Ctrl+]' );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-utils/tests/keyboard.js
+++ b/packages/ckeditor5-utils/tests/keyboard.js
@@ -38,7 +38,8 @@ describe( 'Keyboard', () => {
 				'ctrl', 'cmd', 'shift', 'alt',
 				'arrowleft', 'arrowup', 'arrowright', 'arrowdown',
 				'backspace', 'delete', 'enter', 'space', 'esc', 'tab',
-				'f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9', 'f10', 'f11', 'f12'
+				'f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9', 'f10', 'f11', 'f12',
+				'`', '-', '=', '[', ']', ';', '\'', ',', '.', '/', '\\'
 			);
 		} );
 	} );
@@ -54,6 +55,10 @@ describe( 'Keyboard', () => {
 
 		it( 'gets code of a function key', () => {
 			expect( getCode( 'f6' ) ).to.equal( 117 );
+		} );
+
+		it( 'gets code of a punctuation character', () => {
+			expect( getCode( ']' ) ).to.equal( 93 );
 		} );
 
 		it( 'is case insensitive', () => {
@@ -94,6 +99,10 @@ describe( 'Keyboard', () => {
 				expect( parseKeystroke( 'ctrl+a' ) ).to.equal( 0x880000 + 65 );
 			} );
 
+			it( 'parses string without modifier', () => {
+				expect( parseKeystroke( '[' ) ).to.equal( 91 );
+			} );
+
 			it( 'allows spacing', () => {
 				expect( parseKeystroke( 'ctrl +   a' ) ).to.equal( 0x880000 + 65 );
 			} );
@@ -132,6 +141,10 @@ describe( 'Keyboard', () => {
 
 			it( 'parses string', () => {
 				expect( parseKeystroke( 'ctrl+a' ) ).to.equal( 0x110000 + 65 );
+			} );
+
+			it( 'parses string without modifier', () => {
+				expect( parseKeystroke( '[' ) ).to.equal( 91 );
 			} );
 
 			it( 'allows spacing', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix(utils): Adds more known key codes. For instance, to allow `CTRL-]`. Closes #10439.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._