### PR TITLE
Fix typo. `observes` to `observers`

### DIFF
--- a/docs/framework/guides/architecture/editing-engine.md
+++ b/docs/framework/guides/architecture/editing-engine.md
@@ -330,7 +330,7 @@ By default, the view adds the following observers:
 Additionally, some features add their own observers. For instance, the {@link module:clipboard/clipboard~Clipboard clipboard feature} adds {@link module:clipboard/clipboardobserver~ClipboardObserver}.
 
 <info-box>
-	For a complete list of events fired by observes check the {@link module:engine/view/document~Document}'s list of events.
+	For a complete list of events fired by observers check the {@link module:engine/view/document~Document}'s list of events.
 </info-box>
 
 You can add your own observer (which should be a subclass of {@link module:engine/view/observer/observer~Observer}) by using the {@link module:engine/view/view~View#addObserver `view.addObserver()`} method. Check the code of existing observers to learn how to write them: https://github.com/ckeditor/ckeditor5-engine/tree/master/src/view/observer.


### PR DESCRIPTION
Text read

> ...  events fired by observes check

Change to:

> ...  events fired by observers check

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Type (Docs): Fix typo. observes to observers.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
