### PR TITLE
Disable edit and save buttons in html embed if the editor is in read-only mode or updateHtmlEmbed command is disabled

### DIFF
--- a/packages/ckeditor5-html-embed/src/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/src/htmlembedediting.js
@@ -126,6 +126,8 @@ export default class HtmlEmbedEditing extends Plugin {
 			view: ( modelElement, { writer } ) => {
 				let domContentWrapper, state, props;
 
+				const command = editor.commands.get( 'updateHtmlEmbed' );
+
 				const viewContainer = writer.createContainerElement( 'div', {
 					class: 'raw-html-embed',
 					'data-html-embed-label': t( 'HTML snippet' ),
@@ -207,10 +209,14 @@ export default class HtmlEmbedEditing extends Plugin {
 					textareaPlaceholder: t( 'Paste raw HTML here...' ),
 
 					onEditClick() {
-						rawHtmlApi.makeEditable();
+						if ( command.isEnabled ) {
+							rawHtmlApi.makeEditable();
+						}
 					},
 					onSaveClick( newValue ) {
-						rawHtmlApi.save( newValue );
+						if ( command.isEnabled ) {
+							rawHtmlApi.save( newValue );
+						}
 					},
 					onCancelClick() {
 						rawHtmlApi.cancel();
@@ -286,12 +292,12 @@ export default class HtmlEmbedEditing extends Plugin {
 
 				clonedDomSaveButton.addEventListener( 'click', evt => {
 					evt.preventDefault();
-					props.onSaveClick( );
+					props.onSaveClick();
 				} );
 
 				clonedDomCancelButton.addEventListener( 'click', evt => {
 					evt.preventDefault();
-					props.onCancelClick( );
+					props.onCancelClick();
 				} );
 
 				domButtonsWrapper.appendChild( clonedDomSaveButton );
@@ -379,6 +385,7 @@ function createDomButton( editor, type ) {
 			label: t( 'Edit source' ),
 			class: 'raw-html-embed__edit-button'
 		} );
+		buttonView.bind( 'isEnabled' ).to( command, 'isEnabled' );
 	} else if ( type === 'save' ) {
 		buttonView.set( {
 			icon: icons.check,

--- a/packages/ckeditor5-html-embed/tests/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/tests/htmlembedediting.js
@@ -825,6 +825,38 @@ describe( 'HtmlEmbedEditing', () => {
 				}
 			} );
 		} );
+
+		describe( 'with updateHtmlEmbed command disabled', () => {
+			it( 'does not allow editing the source after clicking the "edit" button', () => {
+				setModelData( model, '<rawHtml value="foo"></rawHtml>' );
+				const widget = viewDocument.getRoot().getChild( 0 );
+				const contentWrapper = widget.getChild( 1 );
+				const domContentWrapper = editor.editing.view.domConverter.mapViewToDom( contentWrapper );
+
+				sinon.stub( editor.commands.get( 'updateHtmlEmbed' ), 'isEnabled' ).value( false );
+				const makeEditableStub = sinon.stub( widget.getCustomProperty( 'rawHtmlApi' ), 'makeEditable' );
+
+				domContentWrapper.querySelector( '.raw-html-embed__edit-button' ).click();
+
+				expect( makeEditableStub.callCount ).to.equal( 0 );
+			} );
+
+			it( 'does not allow saving the source after clicking the "save" button', () => {
+				setModelData( model, '<rawHtml value="foo"></rawHtml>' );
+				const widget = viewDocument.getRoot().getChild( 0 );
+				const contentWrapper = widget.getChild( 1 );
+				const domContentWrapper = editor.editing.view.domConverter.mapViewToDom( contentWrapper );
+
+				domContentWrapper.querySelector( '.raw-html-embed__edit-button' ).click();
+
+				sinon.stub( editor.commands.get( 'updateHtmlEmbed' ), 'isEnabled' ).value( false );
+				const makeEditableStub = sinon.stub( widget.getCustomProperty( 'rawHtmlApi' ), 'save' );
+
+				domContentWrapper.querySelector( '.raw-html-embed__save-button' ).click();
+
+				expect( makeEditableStub.callCount ).to.equal( 0 );
+			} );
+		} );
 	} );
 } );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (html-embed): Disable edit and save buttons in html embed element if the editor is in read-only mode or `updateHtmlEmbed` command is disabled. Closes #10182.

---

### Additional information

I played around with it and I found some interesting facts.

According to this [comment](https://github.com/ckeditor/ckeditor5/issues/10182#issuecomment-915018495) it was supposed to be enough to maybe add similar binding to `isEnabled` to the `edit` as in the `save` button case.

https://github.com/ckeditor/ckeditor5/blob/1fc24358c2bc70f0dbc674a49213bfbf955f67b9/packages/ckeditor5-html-embed/src/htmlembedediting.js#L376-L389

Well, indeed it was necessary, but not for the reason of blocking the button.

In case of buttons in html embed widget line

```js
buttonView.bind( 'isEnabled' ).to( command, 'isEnabled' ); 
```

will only make some button attributes react to the `updateHtmlEmbed` command `isEnabled`.

It won't stop any buttons from being clickable. You can try this easily by doing this:

1. Go to https://ckeditor.com/docs/ckeditor5/latest/features/html-embed.html
2. Try clicking "Edit" and "Save" buttons in demo editor. They are enabled and clickable.
3. Execute `editor.isReadOnly = true` in console.
4. Try clicking "Edit" and "Save" buttons in demo editor. They are still clickable! (but save button received `ck-disabled` class and `aria-disabled` attribute but not `disabled` attribute).

Not getting `disabled` attribute is done on purpose to keep buttons focusable and it's described in `buttonview.js`.

https://github.com/ckeditor/ckeditor5/blob/1fc24358c2bc70f0dbc674a49213bfbf955f67b9/packages/ckeditor5-ui/src/button/buttonview.js#L158-L168

The thing is, buttons in HTML embed feature are overriding default button on click handler!

That's why save button is still clickable even if we bound its `isEnabled` state to the `updateHtmlEmbed` command `isEnabled`.

https://github.com/ckeditor/ckeditor5/blob/1fc24358c2bc70f0dbc674a49213bfbf955f67b9/packages/ckeditor5-html-embed/src/htmlembedediting.js#L287-L295

https://github.com/ckeditor/ckeditor5/blob/1fc24358c2bc70f0dbc674a49213bfbf955f67b9/packages/ckeditor5-html-embed/src/htmlembedediting.js#L302-L305

So the solution here was to:

1. Bind edit button `isEnabled` similar to save button in order to apply some attributes.
2. Prevent `rawHtmlApi.makeEditable()` (edit button) and `rawHtmlApi.save( newValue );` (save button) if command or editor is disabled.