### PR TITLE
Fixes bug in selection postfixer

### DIFF
--- a/packages/ckeditor5-engine/src/model/utils/selection-post-fixer.js
+++ b/packages/ckeditor5-engine/src/model/utils/selection-post-fixer.js
@@ -128,9 +128,17 @@ function tryFixingCollapsedRange( range, schema ) {
 
 	const nearestSelectionRange = schema.getNearestSelectionRange( originalPosition );
 
-	// This might be null ie when editor data is empty.
-	// In such cases there is no need to fix the selection range.
+	// This might be null ie when editor data is empty or the selection is inside limit element
+	// that doesn't allow text inside.
+	// In the first case there is no need to fix the selection range.
+	// In the second let's go up to the outer selectable element
 	if ( !nearestSelectionRange ) {
+		const ancestorObject = originalPosition.getAncestors().reverse().find( item => schema.isObject( item ) );
+
+		if ( ancestorObject ) {
+			return Range._createOn( ancestorObject );
+		}
+
 		return null;
 	}
 

--- a/packages/ckeditor5-engine/tests/model/utils/selection-post-fixer.js
+++ b/packages/ckeditor5-engine/tests/model/utils/selection-post-fixer.js
@@ -1410,6 +1410,14 @@ describe( 'Selection post-fixer', () => {
 				);
 			} );
 
+			it( 'should fix #4 (selection inside limit element that doesn\'t allow text)', () => {
+				setModelData( model, '<imageBlock>[]</imageBlock>' );
+
+				assertEqualMarkup( getModelData( model ),
+					'[<imageBlock></imageBlock>]'
+				);
+			} );
+
 			it( 'should fix multiple ranges outside block element (but not merge them)', () => {
 				setModelData( model,
 					'[]<paragraph>foo</paragraph>[]' +

--- a/packages/ckeditor5-engine/tests/model/utils/selection-post-fixer.js
+++ b/packages/ckeditor5-engine/tests/model/utils/selection-post-fixer.js
@@ -1418,6 +1418,16 @@ describe( 'Selection post-fixer', () => {
 				);
 			} );
 
+			it( 'should fix #5 (selection inside limit element that doesn\'t allow text - closest ancestor)', () => {
+				setModelData( model,
+					'<table><tableRow><tableCell><imageBlock>[]</imageBlock></tableCell></tableRow></table>'
+				);
+
+				assertEqualMarkup( getModelData( model ),
+					'<table><tableRow><tableCell>[<imageBlock></imageBlock>]</tableCell></tableRow></table>'
+				);
+			} );
+
 			it( 'should fix multiple ranges outside block element (but not merge them)', () => {
 				setModelData( model,
 					'[]<paragraph>foo</paragraph>[]' +

--- a/packages/ckeditor5-table/tests/tabletoolbar.js
+++ b/packages/ckeditor5-table/tests/tabletoolbar.js
@@ -87,7 +87,7 @@ describe( 'TableToolbar', () => {
 
 				editor.ui.focusTracker.isFocused = true;
 
-				setData( model, '<table><tableRow><tableCell>[]</tableCell></tableRow></table>' );
+				setData( model, '<table><tableRow><tableCell><paragraph>[]</paragraph></tableCell></tableRow></table>' );
 
 				sinon.assert.calledWithMatch( spy, sinon.match( ( { balloonClassName, view } ) => {
 					return view === toolbar && balloonClassName === 'ck-toolbar-container';
@@ -107,7 +107,7 @@ describe( 'TableToolbar', () => {
 			it( 'should show the toolbar when the editor gains focus and the table is selected', () => {
 				editor.ui.focusTracker.isFocused = true;
 
-				setData( model, '<table><tableRow><tableCell>[]</tableCell></tableRow></table>' );
+				setData( model, '<table><tableRow><tableCell><paragraph>[]</paragraph></tableCell></tableRow></table>' );
 
 				editor.ui.focusTracker.isFocused = false;
 				expect( balloon.visibleView ).to.be.null;
@@ -119,7 +119,7 @@ describe( 'TableToolbar', () => {
 			it( 'should hide the toolbar when the editor loses focus and the table is selected', () => {
 				editor.ui.focusTracker.isFocused = false;
 
-				setData( model, '<table><tableRow><tableCell>[]</tableCell></tableRow></table>' );
+				setData( model, '<table><tableRow><tableCell><paragraph>[]</paragraph></tableCell></tableRow></table>' );
 
 				editor.ui.focusTracker.isFocused = true;
 				expect( balloon.visibleView ).to.equal( toolbar );
@@ -360,7 +360,7 @@ describe( 'TableToolbar', () => {
 			} );
 
 			it( 'should not show the toolbar on ui#update when the selection is inside a table cell', () => {
-				setData( editor.model, '<table><tableRow><tableCell>[]</tableCell></tableRow></table>' );
+				setData( editor.model, '<table><tableRow><tableCell><paragraph>[]</paragraph></tableCell></tableRow></table>' );
 
 				expect( balloon.visibleView ).to.be.null;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): Fixes bug in selection postfixer (when the selection stuck in a limit element that can't contain text). Closes #10487.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._