### PR TITLE
SourceEditing - monospace font on Safari browser

### DIFF
--- a/packages/ckeditor5-source-editing/theme/sourceediting.css
+++ b/packages/ckeditor5-source-editing/theme/sourceediting.css
@@ -10,7 +10,6 @@
 .ck-source-editing-area {
 	display: inline-grid;
 	width: 100%;
-	font-family: monospace;
 }
 
 .ck-source-editing-area::after,
@@ -21,6 +20,7 @@
 	border: 1px solid transparent;
 	line-height: var(--ck-line-height-base);
 	font-size: var(--ck-font-size-normal);
+	font-family: monospace;
 	white-space: pre-wrap;
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (source-editing): Safari browser use monospace font for text in source editing mode. Closes #10585.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._