### PR TITLE
Media-embed: fixed editor crashing after pasting embeddable link multiple times.

### DIFF
--- a/packages/ckeditor5-media-embed/src/automediaembed.js
+++ b/packages/ckeditor5-media-embed/src/automediaembed.js
@@ -164,6 +164,11 @@ export default class AutoMediaEmbed extends Plugin {
 
 				let insertionPosition;
 
+				// If position is not available, terminate the process. See #2765.
+				if ( !this._positionToInsert ) {
+					return;
+				}
+
 				// Check if position where the media element should be inserted is still valid.
 				// Otherwise leave it as undefined to use document.selection - default behavior of model.insertContent().
 				if ( this._positionToInsert.root.rootName !== '$graveyard' ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (media-embed): Editor should no longer crash after pasting embeddable link multiple times. Closes #2765.

---

### Additional information

This needs to be investigated a bit more before it's ready for review.
