### PR TITLE
Downcast conversion should throw an error if some items were not consumed

### DIFF
--- a/packages/ckeditor5-clipboard/tests/pasteplaintext.js
+++ b/packages/ckeditor5-clipboard/tests/pasteplaintext.js
@@ -43,7 +43,7 @@ describe( 'PastePlainText', () => {
 					isInline: true
 				} );
 
-				editor.conversion.for( 'upcast' ).elementToElement( {
+				editor.conversion.elementToElement( {
 					model: 'softBreak',
 					view: 'br'
 				} );

--- a/packages/ckeditor5-engine/src/conversion/downcastdispatcher.js
+++ b/packages/ckeditor5-engine/src/conversion/downcastdispatcher.js
@@ -70,11 +70,10 @@ import mix from '@ckeditor/ckeditor5-utils/src/mix';
  * When providing custom listeners for a downcast dispatcher, remember to check whether a given change has not been
  * {@link module:engine/conversion/modelconsumable~ModelConsumable#consume consumed} yet.
  *
- * When providing custom listeners for downcast dispatcher, keep in mind that any callback that has
- * {@link module:engine/conversion/modelconsumable~ModelConsumable#consume consumed} a value from a consumable and
- * converted the change should also stop the event (for efficiency purposes).
+ * When providing custom listeners for a downcast dispatcher, keep in mind that you should not stop the event. If you stop it
+ * then the default converter at the `lowest` priority will not trigger conversion of attributes and child nodes.
  *
- * When providing custom listeners for downcast dispatcher, remember to use the provided
+ * When providing custom listeners for a downcast dispatcher, remember to use the provided
  * {@link module:engine/view/downcastwriter~DowncastWriter view downcast writer} to apply changes to the view document.
  *
  * You can read more about conversion in the following guides:
@@ -103,9 +102,6 @@ import mix from '@ckeditor/ckeditor5-utils/src/mix';
  *
  *			// Add the newly created view element to the view.
  *			conversionApi.writer.insert( viewPosition, viewElement );
- *
- *			// Remember to stop the event propagation.
- *			evt.stop();
  *		} );
  */
 export default class DowncastDispatcher {
@@ -189,7 +185,7 @@ export default class DowncastDispatcher {
 		conversionApi.mapper.flushDeferredBindings();
 
 		// Verify if all insert consumables were consumed.
-		conversionApi.consumable.verifyAllConsumed( [ 'insert' ] );
+		conversionApi.consumable.verifyAllConsumed( 'insert' );
 	}
 
 	/**
@@ -213,7 +209,7 @@ export default class DowncastDispatcher {
 		}
 
 		// Verify if all insert consumables were consumed.
-		conversionApi.consumable.verifyAllConsumed( [ 'insert' ] );
+		conversionApi.consumable.verifyAllConsumed( 'insert' );
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/conversion/downcastdispatcher.js
+++ b/packages/ckeditor5-engine/src/conversion/downcastdispatcher.js
@@ -70,8 +70,8 @@ import mix from '@ckeditor/ckeditor5-utils/src/mix';
  * When providing custom listeners for a downcast dispatcher, remember to check whether a given change has not been
  * {@link module:engine/conversion/modelconsumable~ModelConsumable#consume consumed} yet.
  *
- * When providing custom listeners for a downcast dispatcher, keep in mind that you should not stop the event. If you stop it
- * then the default converter at the `lowest` priority will not trigger conversion of attributes and child nodes.
+ * When providing custom listeners for a downcast dispatcher, keep in mind that you **should not** stop the event. If you stop it,
+ * then the default converter at the `lowest` priority will not trigger the conversion of this node's attributes and child nodes.
  *
  * When providing custom listeners for a downcast dispatcher, remember to use the provided
  * {@link module:engine/view/downcastwriter~DowncastWriter view downcast writer} to apply changes to the view document.

--- a/packages/ckeditor5-engine/src/conversion/downcastdispatcher.js
+++ b/packages/ckeditor5-engine/src/conversion/downcastdispatcher.js
@@ -187,6 +187,9 @@ export default class DowncastDispatcher {
 
 		// Remove mappings for all removed view elements.
 		conversionApi.mapper.flushDeferredBindings();
+
+		// Verify if all insert consumables were consumed.
+		conversionApi.consumable.verifyAllConsumed( [ 'insert' ] );
 	}
 
 	/**
@@ -208,6 +211,9 @@ export default class DowncastDispatcher {
 		for ( const [ name, range ] of markers ) {
 			this._convertMarkerAdd( name, range, conversionApi );
 		}
+
+		// Verify if all insert consumables were consumed.
+		conversionApi.consumable.verifyAllConsumed( [ 'insert' ] );
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/conversion/modelconsumable.js
+++ b/packages/ckeditor5-engine/src/conversion/modelconsumable.js
@@ -8,6 +8,7 @@
  */
 
 import TextProxy from '../model/textproxy';
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 /**
  * Manages a list of consumable values for {@link module:engine/model/item~Item model items}.
@@ -247,6 +248,37 @@ export default class ModelConsumable {
 	}
 
 	/**
+	 * TODO
+	 *
+	 * @param {Array.<String>} events The events group to verify.
+	 */
+	verifyAllConsumed( events ) {
+		const items = [];
+
+		for ( const [ item, consumables ] of this._consumable ) {
+			for ( const [ event, canConsume ] of consumables ) {
+				const eventPrefix = event.split( ':' )[ 0 ];
+
+				if ( canConsume && events.includes( eventPrefix ) ) {
+					items.push( {
+						event,
+						item: item.name || item.description
+					} );
+				}
+			}
+		}
+
+		if ( items.length ) {
+			/**
+			 * TODO
+			 *
+			 * @error conversion-model-consumable-not-consumed
+			 */
+			throw new CKEditorError( 'conversion-model-consumable-not-consumed', null, { items } );
+		}
+	}
+
+	/**
 	 * Gets a unique symbol for passed {@link module:engine/model/textproxy~TextProxy} instance. All `TextProxy` instances that
 	 * have same parent, same start index and same end index will get the same symbol.
 	 *
@@ -290,7 +322,7 @@ export default class ModelConsumable {
 		const end = textProxy.endOffset;
 		const parent = textProxy.parent;
 
-		const symbol = Symbol( 'textProxySymbol' );
+		const symbol = Symbol( '$textProxy:' + textProxy.data );
 		let startMap, endMap;
 
 		startMap = this._textProxyRegistry.get( start );

--- a/packages/ckeditor5-engine/src/conversion/modelconsumable.js
+++ b/packages/ckeditor5-engine/src/conversion/modelconsumable.js
@@ -248,7 +248,7 @@ export default class ModelConsumable {
 	}
 
 	/**
-	 * TODO
+	 * Verifies if all events from specified group were consumed.
 	 *
 	 * @param {Array.<String>} events The events group to verify.
 	 */

--- a/packages/ckeditor5-engine/src/conversion/modelconsumable.js
+++ b/packages/ckeditor5-engine/src/conversion/modelconsumable.js
@@ -250,16 +250,16 @@ export default class ModelConsumable {
 	/**
 	 * Verifies if all events from specified group were consumed.
 	 *
-	 * @param {Array.<String>} events The events group to verify.
+	 * @param {String} eventGroup The events group to verify.
 	 */
-	verifyAllConsumed( events ) {
+	verifyAllConsumed( eventGroup ) {
 		const items = [];
 
 		for ( const [ item, consumables ] of this._consumable ) {
 			for ( const [ event, canConsume ] of consumables ) {
 				const eventPrefix = event.split( ':' )[ 0 ];
 
-				if ( canConsume && events.includes( eventPrefix ) ) {
+				if ( canConsume && eventGroup == eventPrefix ) {
 					items.push( {
 						event,
 						item: item.name || item.description
@@ -270,7 +270,16 @@ export default class ModelConsumable {
 
 		if ( items.length ) {
 			/**
-			 * TODO
+			 * Some of the {@link module:engine/model/item~Item model items} were not consumed while downcasting the model to view.
+			 *
+			 * This might be an effect of:
+			 * * Missing converter for some model elements. Make sure that you registered downcast converters for all model elements.
+			 * * Custom converter that do not consume converted items. Make sure that you
+			 * {@link module:engine/conversion/modelconsumable~ModelConsumable#consume consumed} all model elements that you converted
+			 * from the model to the view.
+			 * * Custom converter that called `event.stop()`. When providing custom converter, keep in mind that you should not stop
+			 * the event. If you stop it then the default converter at the `lowest` priority will not trigger conversion of attributes
+			 * and child nodes.
 			 *
 			 * @error conversion-model-consumable-not-consumed
 			 */

--- a/packages/ckeditor5-engine/src/conversion/modelconsumable.js
+++ b/packages/ckeditor5-engine/src/conversion/modelconsumable.js
@@ -270,18 +270,20 @@ export default class ModelConsumable {
 
 		if ( items.length ) {
 			/**
-			 * Some of the {@link module:engine/model/item~Item model items} were not consumed while downcasting the model to view.
+			 * Some of {@link module:engine/model/item~Item model items} were not consumed while downcasting the model to view.
 			 *
 			 * This might be an effect of:
+			 *
 			 * * Missing converter for some model elements. Make sure that you registered downcast converters for all model elements.
-			 * * Custom converter that do not consume converted items. Make sure that you
+			 * * Custom converter that does not consume converted items. Make sure that you
 			 * {@link module:engine/conversion/modelconsumable~ModelConsumable#consume consumed} all model elements that you converted
 			 * from the model to the view.
-			 * * Custom converter that called `event.stop()`. When providing custom converter, keep in mind that you should not stop
-			 * the event. If you stop it then the default converter at the `lowest` priority will not trigger conversion of attributes
-			 * and child nodes.
+			 * * Custom converter that called `event.stop()`. When providing a custom converter, keep in mind that you should not stop
+			 * the event. If you stop it then the default converter at the `lowest` priority will not trigger the conversion of this node's
+			 * attributes and child nodes.
 			 *
 			 * @error conversion-model-consumable-not-consumed
+			 * @param {Array.<module:engine/model/item~Item>} items Items that were not consumed.
 			 */
 			throw new CKEditorError( 'conversion-model-consumable-not-consumed', null, { items } );
 		}

--- a/packages/ckeditor5-engine/src/model/differ.js
+++ b/packages/ckeditor5-engine/src/model/differ.js
@@ -540,13 +540,13 @@ export default class Differ {
 		this._changeCount = 0;
 
 		// Cache changes.
-		this._cachedChangesWithGraveyard = diffSet.slice();
+		this._cachedChangesWithGraveyard = diffSet;
 		this._cachedChanges = diffSet.filter( _changesInGraveyardFilter );
 
 		if ( options.includeChangesInGraveyard ) {
-			return this._cachedChangesWithGraveyard;
+			return this._cachedChangesWithGraveyard.slice();
 		} else {
-			return this._cachedChanges;
+			return this._cachedChanges.slice();
 		}
 	}
 

--- a/packages/ckeditor5-engine/tests/conversion/downcastdispatcher.js
+++ b/packages/ckeditor5-engine/tests/conversion/downcastdispatcher.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
+
 import DowncastDispatcher from '../../src/conversion/downcastdispatcher';
 import Mapper from '../../src/conversion/mapper';
 
@@ -51,7 +53,11 @@ describe( 'DowncastDispatcher', () => {
 
 	describe( 'convertChanges', () => {
 		it( 'should call _convertInsert for insert change', () => {
-			sinon.stub( dispatcher, '_convertInsert' );
+			let spyConsumableVerify;
+
+			sinon.stub( dispatcher, '_convertInsert' ).callsFake( ( range, conversionApi ) => {
+				spyConsumableVerify = spyConsumableVerify || sinon.spy( conversionApi.consumable, 'verifyAllConsumed' );
+			} );
 			sinon.stub( mapper, 'flushDeferredBindings' );
 
 			const position = model.createPositionFromPath( root, [ 0 ] );
@@ -69,6 +75,8 @@ describe( 'DowncastDispatcher', () => {
 			assertConversionApi( dispatcher._convertInsert.firstCall.args[ 1 ] );
 
 			expect( mapper.flushDeferredBindings.calledOnce ).to.be.true;
+			expect( spyConsumableVerify.calledOnce ).to.be.true;
+
 			expect( dispatcher._conversionApi.writer ).to.be.undefined;
 			expect( dispatcher._conversionApi.consumable ).to.be.undefined;
 		} );
@@ -520,6 +528,30 @@ describe( 'DowncastDispatcher', () => {
 
 			expect( spyBefore.calledOnce ).to.be.true;
 			expect( spyAfter.calledOnce ).to.be.true;
+
+			expect( dispatcher._conversionApi.writer ).to.be.undefined;
+			expect( dispatcher._conversionApi.consumable ).to.be.undefined;
+		} );
+
+		it( 'should throw if not all insert events were consumed', () => {
+			root._appendChild( [
+				new ModelElement( 'imageBlock', { src: 'foo.jpg' }, [
+					new ModelElement( 'caption', {}, new ModelText( 'title' ) )
+				] )
+			] );
+
+			const range = model.createRangeIn( root );
+			let spy;
+
+			dispatcher.on( 'insert:imageBlock', ( evt, data, conversionApi ) => {
+				spy = sinon.spy( conversionApi.consumable, 'verifyAllConsumed' );
+			} );
+
+			expect( () => {
+				dispatcher.convert( range, [] );
+			} ).to.throw( CKEditorError, 'conversion-model-consumable-not-consumed' );
+
+			expect( spy.calledOnce ).to.be.true;
 
 			expect( dispatcher._conversionApi.writer ).to.be.undefined;
 			expect( dispatcher._conversionApi.consumable ).to.be.undefined;

--- a/packages/ckeditor5-engine/tests/conversion/downcastdispatcher.js
+++ b/packages/ckeditor5-engine/tests/conversion/downcastdispatcher.js
@@ -365,20 +365,24 @@ describe( 'DowncastDispatcher', () => {
 
 			const loggedEvents = [];
 
-			dispatcher.on( 'insert', ( evt, data ) => {
+			dispatcher.on( 'insert', ( evt, data, conversionApi ) => {
 				const itemId = data.item.name ? data.item.name : '$text:' + data.item.data;
 				const log = 'insert:' + itemId + ':' + data.range.start.path + ':' + data.range.end.path;
 
 				loggedEvents.push( log );
+
+				conversionApi.consumable.consume( data.item, evt.name );
 			} );
 
-			dispatcher.on( 'attribute', ( evt, data ) => {
+			dispatcher.on( 'attribute', ( evt, data, conversionApi ) => {
 				const itemId = data.item.name ? data.item.name : '$text:' + data.item.data;
 				const key = data.attributeKey;
 				const value = data.attributeNewValue;
 				const log = 'attribute:' + key + ':' + value + ':' + itemId + ':' + data.range.start.path + ':' + data.range.end.path;
 
 				loggedEvents.push( log );
+
+				conversionApi.consumable.consume( data.item, evt.name );
 			} );
 
 			dispatcher.on( 'insert:imageBlock', ( evt, data, conversionApi ) => {

--- a/packages/ckeditor5-engine/tests/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/downcasthelpers.js
@@ -126,6 +126,10 @@ describe( 'DowncastHelpers', () => {
 				view: () => null
 			} );
 
+			controller.downcastDispatcher.on( 'insert:heading', ( evt, data, conversionApi ) => {
+				conversionApi.consumable.consume( data.item, evt.name );
+			}, { priority: 'lowest' } );
+
 			model.change( writer => {
 				writer.insertElement( 'heading', {}, modelRoot, 0 );
 			} );

--- a/packages/ckeditor5-engine/tests/conversion/modelconsumable.js
+++ b/packages/ckeditor5-engine/tests/conversion/modelconsumable.js
@@ -8,6 +8,8 @@ import ModelElement from '../../src/model/element';
 import ModelTextProxy from '../../src/model/textproxy';
 import ModelText from '../../src/model/text';
 
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
+
 describe( 'ModelConsumable', () => {
 	let modelConsumable, modelElement;
 
@@ -16,7 +18,7 @@ describe( 'ModelConsumable', () => {
 		modelElement = new ModelElement( 'paragraph', null, new ModelText( 'foobar' ) );
 	} );
 
-	describe( 'add', () => {
+	describe( 'add()', () => {
 		it( 'should add consumable value from given element of given type', () => {
 			modelConsumable.add( modelElement, 'type' );
 
@@ -77,7 +79,7 @@ describe( 'ModelConsumable', () => {
 		} );
 	} );
 
-	describe( 'consume', () => {
+	describe( 'consume()', () => {
 		it( 'should remove consumable value of given type for given element and return true', () => {
 			modelConsumable.add( modelElement, 'type' );
 
@@ -153,7 +155,7 @@ describe( 'ModelConsumable', () => {
 		} );
 	} );
 
-	describe( 'revert', () => {
+	describe( 'revert()', () => {
 		it( 'should re-add consumable value if it was already consumed and return true', () => {
 			modelConsumable.add( modelElement, 'type' );
 			modelConsumable.consume( modelElement, 'type' );
@@ -204,7 +206,7 @@ describe( 'ModelConsumable', () => {
 		} );
 	} );
 
-	describe( 'test', () => {
+	describe( 'test()', () => {
 		it( 'should return null if consumable value of given type has never been added for given element', () => {
 			expect( modelConsumable.test( modelElement, 'typeA' ) ).to.be.null;
 
@@ -226,6 +228,59 @@ describe( 'ModelConsumable', () => {
 			expect( modelConsumable.test( proxy1To5, 'type' ) ).to.be.null;
 			expect( modelConsumable.test( proxyOther1To4, 'type' ) ).to.be.null;
 			expect( modelConsumable.test( equalProxy1To4, 'type' ) ).to.be.true;
+		} );
+	} );
+
+	describe( 'verifyAllConsumed()', () => {
+		it( 'should not throw if all events were consumed', () => {
+			modelConsumable.add( modelElement, 'insert:paragraph' );
+			modelConsumable.add( modelElement, 'attribute:foo:paragraph' );
+			modelConsumable.add( new ModelTextProxy( modelElement.getChild( 0 ), 0, 6 ), 'insert:$text' );
+			modelConsumable.add( new ModelTextProxy( modelElement.getChild( 0 ), 0, 3 ), 'insert:$text' );
+			modelConsumable.add( new ModelTextProxy( modelElement.getChild( 0 ), 3, 3 ), 'insert:$text' );
+
+			modelConsumable.consume( modelElement, 'insert:paragraph' );
+			modelConsumable.consume( modelElement, 'attribute:foo:paragraph' );
+			modelConsumable.consume( new ModelTextProxy( modelElement.getChild( 0 ), 0, 6 ), 'insert:$text' );
+			modelConsumable.consume( new ModelTextProxy( modelElement.getChild( 0 ), 0, 3 ), 'insert:$text' );
+			modelConsumable.consume( new ModelTextProxy( modelElement.getChild( 0 ), 3, 3 ), 'insert:$text' );
+
+			expect( () => modelConsumable.verifyAllConsumed( 'insert' ) ).to.not.throw();
+		} );
+
+		it( 'should not throw if all events from specified group were consumed', () => {
+			modelConsumable.add( modelElement, 'insert:paragraph' );
+			modelConsumable.add( modelElement, 'attribute:foo:paragraph' );
+			modelConsumable.add( new ModelTextProxy( modelElement.getChild( 0 ), 0, 6 ), 'insert:$text' );
+			modelConsumable.add( new ModelTextProxy( modelElement.getChild( 0 ), 0, 3 ), 'insert:$text' );
+			modelConsumable.add( new ModelTextProxy( modelElement.getChild( 0 ), 3, 3 ), 'insert:$text' );
+
+			modelConsumable.consume( modelElement, 'insert:paragraph' );
+			modelConsumable.consume( new ModelTextProxy( modelElement.getChild( 0 ), 0, 6 ), 'insert:$text' );
+			modelConsumable.consume( new ModelTextProxy( modelElement.getChild( 0 ), 0, 3 ), 'insert:$text' );
+			modelConsumable.consume( new ModelTextProxy( modelElement.getChild( 0 ), 3, 3 ), 'insert:$text' );
+
+			expect( () => modelConsumable.verifyAllConsumed( 'insert' ) ).to.not.throw();
+		} );
+
+		it( 'should throw if some element event was not consumed', () => {
+			modelConsumable.add( modelElement, 'insert:paragraph' );
+			modelConsumable.add( new ModelTextProxy( modelElement.getChild( 0 ), 0, 6 ), 'insert:$text' );
+
+			modelConsumable.consume( new ModelTextProxy( modelElement.getChild( 0 ), 0, 6 ), 'insert:$text' );
+
+			expect( () => modelConsumable.verifyAllConsumed( 'insert' ) )
+				.to.throw( CKEditorError, 'conversion-model-consumable-not-consumed' );
+		} );
+
+		it( 'should throw if some text node event was not consumed', () => {
+			modelConsumable.add( modelElement, 'insert:paragraph' );
+			modelConsumable.add( new ModelTextProxy( modelElement.getChild( 0 ), 0, 6 ), 'insert:$text' );
+
+			modelConsumable.consume( modelElement, 'insert:paragraph' );
+
+			expect( () => modelConsumable.verifyAllConsumed( 'insert' ) )
+				.to.throw( CKEditorError, 'conversion-model-consumable-not-consumed' );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-heading/src/title.js
+++ b/packages/ckeditor5-heading/src/title.js
@@ -87,6 +87,10 @@ export default class Title extends Plugin {
 
 		// Conversion.
 		editor.conversion.for( 'downcast' ).elementToElement( { model: 'title-content', view: 'h1' } );
+		editor.conversion.for( 'downcast' ).add( dispatcher => dispatcher.on( 'insert:title', ( evt, data, conversionApi ) => {
+			conversionApi.consumable.consume( data.item, evt.name );
+		} ) );
+
 		// Custom converter is used for data v -> m conversion to avoid calling post-fixer when setting data.
 		// See https://github.com/ckeditor/ckeditor5/issues/2036.
 		editor.data.upcastDispatcher.on( 'element:h1', dataViewModelH1Insertion, { priority: 'high' } );

--- a/packages/ckeditor5-image/tests/imagecaption/imagecaptionediting.js
+++ b/packages/ckeditor5-image/tests/imagecaption/imagecaptionediting.js
@@ -179,6 +179,12 @@ describe( 'ImageCaptionEditing', () => {
 			} );
 
 			it( 'should not convert caption from other elements', () => {
+				editor.conversion.for( 'downcast' ).add(
+					dispatcher => dispatcher.on( 'insert:caption', ( evt, data, conversionApi ) => {
+						conversionApi.consumable.consume( data.item, evt.name );
+					}, { priority: 'lowest' } )
+				);
+
 				setModelData( model, '<widget>foo bar<caption></caption></widget>' );
 
 				expect( editor.getData() ).to.equal( '<widget>foo bar</widget>' );
@@ -203,6 +209,12 @@ describe( 'ImageCaptionEditing', () => {
 			} );
 
 			it( 'should not convert caption from other elements', () => {
+				editor.conversion.for( 'downcast' ).add(
+					dispatcher => dispatcher.on( 'insert:caption', ( evt, data, conversionApi ) => {
+						conversionApi.consumable.consume( data.item, evt.name );
+					}, { priority: 'lowest' } )
+				);
+
 				setModelData( model, '<widget>foo bar<caption></caption></widget>' );
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal( '<widget>foo bar</widget>' );
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (engine): The `DowncastDispatcher` will throw an error if any of the model items were not consumed while converting. Closes #10377.

Tests (clipboard): Added missing downcast conversion.

Internal (heading): Added missing consuming converter.

Tests (image): Tests updated to properly handle non-consumed errors fired by the `DowncastDispatcher`.

---

### Additional information