### PR TITLE
Docs (html-support): custom html elements

### DIFF
--- a/packages/ckeditor5-html-support/tests/manual/customelements.html
+++ b/packages/ckeditor5-html-support/tests/manual/customelements.html
@@ -1,0 +1,11 @@
+<head>
+	<meta http-equiv="Content-Security-Policy"
+		content="script-src 'self' https://ckeditor.com 'unsafe-inline' 'unsafe-eval'">
+</head>
+
+<div id="editor">
+	<p>Sample inline element: <element-inline data-foo="foo">Element Inline</element-inline></p>
+	<p>Sample block element: <element-block data-foo="foo">Element Block</element-block></p>
+	<p> Sample inline object element: <object-inline data-foo="foo"></object-inline></p>
+	<p> Sample block object element: <object-block data-foo="foo"></object-block></p>
+</div>

--- a/packages/ckeditor5-html-support/tests/manual/customelements.js
+++ b/packages/ckeditor5-html-support/tests/manual/customelements.js
@@ -1,0 +1,104 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console:false, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
+
+import GeneralHtmlSupport from '../../src/generalhtmlsupport';
+
+/**
+ * Client custom plugin extending HTML support for compatibility.
+ */
+class ExtendHTMLSupport extends Plugin {
+	static get requires() {
+		return [ GeneralHtmlSupport ];
+	}
+
+	init() {
+		const dataFilter = this.editor.plugins.get( 'DataFilter' );
+		const dataSchema = this.editor.plugins.get( 'DataSchema' );
+
+		// Extend schema with custom HTML elements.
+
+		// Inline element
+		dataSchema.registerInlineElement( {
+			view: 'element-inline',
+			model: 'myElementInline'
+		} );
+
+		// Custom elements need to be filtered using direct API instead of config.
+		dataFilter.allowElement( 'element-inline' );
+		dataFilter.allowAttributes( { name: 'element-inline', attributes: { 'data-foo': false }, classes: [ 'foo' ] } );
+
+		// Block element
+		dataSchema.registerBlockElement( {
+			view: 'element-block',
+			model: 'myElementBlock',
+			modelSchema: {
+				inheritAllFrom: '$block'
+			}
+		} );
+
+		dataFilter.allowElement( 'element-block' );
+
+		// Inline object element
+		dataSchema.registerInlineElement( {
+			view: 'object-inline',
+			model: 'myObjectInline',
+			isObject: true,
+			modelSchema: {
+				inheritAllFrom: '$htmlObjectInline'
+			}
+		} );
+
+		dataFilter.allowElement( 'object-inline' );
+
+		// Block object element
+		dataSchema.registerBlockElement( {
+			view: 'object-block',
+			model: 'myObjectBlock',
+			isObject: true,
+			modelSchema: {
+				inheritAllFrom: '$htmlObjectBlock'
+			}
+		} );
+
+		dataFilter.allowElement( 'object-block' );
+	}
+}
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [
+			Essentials,
+			Paragraph,
+			SourceEditing,
+			ExtendHTMLSupport
+		],
+		toolbar: [
+			'sourceediting'
+		],
+		htmlSupport: {
+			allow: [
+				{
+					name: /.*/,
+					attributes: true,
+					classes: true,
+					styles: true
+				}
+			]
+		}
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-html-support/tests/manual/customelements.md
+++ b/packages/ckeditor5-html-support/tests/manual/customelements.md
@@ -1,0 +1,3 @@
+## GHS custom elements
+
+Add custom HTML elements to the editor.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (html-support): add missing documentation for using custom html elements. Closes #10454.

---