### PR TITLE
Ck/10619 dataprocessor public properties

### DIFF
--- a/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js
+++ b/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js
@@ -28,26 +28,26 @@ export default class HtmlDataProcessor {
 		/**
 		 * A DOM parser instance used to parse an HTML string to an HTML document.
 		 *
-		 * @private
+		 * @public
 		 * @member {DOMParser}
 		 */
-		this._domParser = new DOMParser();
+		this.domParser = new DOMParser();
 
 		/**
 		 * A DOM converter used to convert DOM elements to view elements.
 		 *
-		 * @private
+		 * @public
 		 * @member {module:engine/view/domconverter~DomConverter}
 		 */
-		this._domConverter = new DomConverter( document, { renderingMode: 'data' } );
+		this.domConverter = new DomConverter( document, { renderingMode: 'data' } );
 
 		/**
 		 * A basic HTML writer instance used to convert DOM elements to an HTML string.
 		 *
-		 * @private
-		 * @member {module:engine/dataprocessor/basichtmlwriter~BasicHtmlWriter}
+		 * @public
+		 * @member {module:engine/dataprocessor/htmlwriter~HtmlWriter}
 		 */
-		this._htmlWriter = new BasicHtmlWriter();
+		this.htmlWriter = new BasicHtmlWriter();
 	}
 
 	/**
@@ -59,10 +59,10 @@ export default class HtmlDataProcessor {
 	 */
 	toData( viewFragment ) {
 		// Convert view DocumentFragment to DOM DocumentFragment.
-		const domFragment = this._domConverter.viewToDom( viewFragment, document );
+		const domFragment = this.domConverter.viewToDom( viewFragment, document );
 
 		// Convert DOM DocumentFragment to HTML output.
-		return this._htmlWriter.getHtml( domFragment );
+		return this.htmlWriter.getHtml( domFragment );
 	}
 
 	/**
@@ -76,7 +76,7 @@ export default class HtmlDataProcessor {
 		const domFragment = this._toDom( data );
 
 		// Convert DOM DocumentFragment to view DocumentFragment.
-		return this._domConverter.domToView( domFragment );
+		return this.domConverter.domToView( domFragment );
 	}
 
 	/**
@@ -90,7 +90,7 @@ export default class HtmlDataProcessor {
 	 * be treated as raw data.
 	 */
 	registerRawContentMatcher( pattern ) {
-		this._domConverter.registerRawContentMatcher( pattern );
+		this.domConverter.registerRawContentMatcher( pattern );
 	}
 
 	/**
@@ -105,7 +105,7 @@ export default class HtmlDataProcessor {
 	 * @param {'default'|'marked'} type Whether to use the default or the marked `&nbsp;` block fillers.
 	 */
 	useFillerType( type ) {
-		this._domConverter.blockFillerMode = type == 'marked' ? 'markedNbsp' : 'nbsp';
+		this.domConverter.blockFillerMode = type == 'marked' ? 'markedNbsp' : 'nbsp';
 	}
 
 	/**
@@ -117,7 +117,7 @@ export default class HtmlDataProcessor {
 	 * @returns {DocumentFragment}
 	 */
 	_toDom( data ) {
-		const document = this._domParser.parseFromString( data, 'text/html' );
+		const document = this.domParser.parseFromString( data, 'text/html' );
 		const fragment = document.createDocumentFragment();
 
 		// The rules for parsing an HTML string can be read on https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inhtml.

--- a/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js
+++ b/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js
@@ -28,7 +28,6 @@ export default class HtmlDataProcessor {
 		/**
 		 * A DOM parser instance used to parse an HTML string to an HTML document.
 		 *
-		 * @public
 		 * @member {DOMParser}
 		 */
 		this.domParser = new DOMParser();
@@ -36,7 +35,6 @@ export default class HtmlDataProcessor {
 		/**
 		 * A DOM converter used to convert DOM elements to view elements.
 		 *
-		 * @public
 		 * @member {module:engine/view/domconverter~DomConverter}
 		 */
 		this.domConverter = new DomConverter( document, { renderingMode: 'data' } );
@@ -44,7 +42,6 @@ export default class HtmlDataProcessor {
 		/**
 		 * A basic HTML writer instance used to convert DOM elements to an HTML string.
 		 *
-		 * @public
 		 * @member {module:engine/dataprocessor/htmlwriter~HtmlWriter}
 		 */
 		this.htmlWriter = new BasicHtmlWriter();

--- a/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.js
+++ b/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.js
@@ -26,7 +26,7 @@ export default class XmlDataProcessor {
 	 *
 	 * @param {module:engine/view/document~Document} document The view document instance.
 	 * @param {Object} options Configuration options.
-	 * @param {Array<String>} [options.namespaces=[]] A list of namespaces allowed to use in the XML input.
+	 * @param {Array.<String>} [options.namespaces=[]] A list of namespaces allowed to use in the XML input.
 	 */
 	constructor( document, options = {} ) {
 		/**
@@ -35,7 +35,6 @@ export default class XmlDataProcessor {
 		 * For example, registering namespaces [ 'attribute', 'container' ] allows to use `<attirbute:tagName></attribute:tagName>`
 		 * and `<container:tagName></container:tagName>` input. It is mainly for debugging.
 		 *
-		 * @public
 		 * @member {Array.<String>}
 		 */
 		this.namespaces = options.namespaces || [];
@@ -43,7 +42,6 @@ export default class XmlDataProcessor {
 		/**
 		 * DOM parser instance used to parse an XML string to an XML document.
 		 *
-		 * @public
 		 * @member {DOMParser}
 		 */
 		this.domParser = new DOMParser();
@@ -51,7 +49,6 @@ export default class XmlDataProcessor {
 		/**
 		 * DOM converter used to convert DOM elements to view elements.
 		 *
-		 * @public
 		 * @member {module:engine/view/domconverter~DomConverter}
 		 */
 		this.domConverter = new DomConverter( document, { renderingMode: 'data' } );
@@ -60,7 +57,6 @@ export default class XmlDataProcessor {
 		 * A basic HTML writer instance used to convert DOM elements to an XML string.
 		 * There is no need to use a dedicated XML writer because the basic HTML writer works well in this case.
 		 *
-		 * @public
 		 * @member {module:engine/dataprocessor/htmlwriter~HtmlWriter}
 		 */
 		this.htmlWriter = new BasicHtmlWriter();

--- a/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.js
+++ b/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.js
@@ -36,34 +36,34 @@ export default class XmlDataProcessor {
 		 * and `<container:tagName></container:tagName>` input. It is mainly for debugging.
 		 *
 		 * @public
-		 * @member {DOMParser}
+		 * @member {Array.<String>}
 		 */
 		this.namespaces = options.namespaces || [];
 
 		/**
 		 * DOM parser instance used to parse an XML string to an XML document.
 		 *
-		 * @private
+		 * @public
 		 * @member {DOMParser}
 		 */
-		this._domParser = new DOMParser();
+		this.domParser = new DOMParser();
 
 		/**
 		 * DOM converter used to convert DOM elements to view elements.
 		 *
-		 * @private
+		 * @public
 		 * @member {module:engine/view/domconverter~DomConverter}
 		 */
-		this._domConverter = new DomConverter( document, { renderingMode: 'data' } );
+		this.domConverter = new DomConverter( document, { renderingMode: 'data' } );
 
 		/**
 		 * A basic HTML writer instance used to convert DOM elements to an XML string.
 		 * There is no need to use a dedicated XML writer because the basic HTML writer works well in this case.
 		 *
-		 * @private
-		 * @member {module:engine/dataprocessor/basichtmlwriter~BasicHtmlWriter}
+		 * @public
+		 * @member {module:engine/dataprocessor/htmlwriter~HtmlWriter}
 		 */
-		this._htmlWriter = new BasicHtmlWriter();
+		this.htmlWriter = new BasicHtmlWriter();
 	}
 
 	/**
@@ -75,11 +75,11 @@ export default class XmlDataProcessor {
 	 */
 	toData( viewFragment ) {
 		// Convert view DocumentFragment to DOM DocumentFragment.
-		const domFragment = this._domConverter.viewToDom( viewFragment, document );
+		const domFragment = this.domConverter.viewToDom( viewFragment, document );
 
 		// Convert DOM DocumentFragment to XML output.
 		// There is no need to use dedicated for XML serializing method because BasicHtmlWriter works well in this case.
-		return this._htmlWriter.getHtml( domFragment );
+		return this.htmlWriter.getHtml( domFragment );
 	}
 
 	/**
@@ -93,7 +93,7 @@ export default class XmlDataProcessor {
 		const domFragment = this._toDom( data );
 
 		// Convert DOM DocumentFragment to view DocumentFragment.
-		return this._domConverter.domToView( domFragment, { keepOriginalCase: true } );
+		return this.domConverter.domToView( domFragment, { keepOriginalCase: true } );
 	}
 
 	/**
@@ -107,7 +107,7 @@ export default class XmlDataProcessor {
 	 * be treated as raw data.
 	 */
 	registerRawContentMatcher( pattern ) {
-		this._domConverter.registerRawContentMatcher( pattern );
+		this.domConverter.registerRawContentMatcher( pattern );
 	}
 
 	/**
@@ -122,7 +122,7 @@ export default class XmlDataProcessor {
 	 * @param {'default'|'marked'} type Whether to use the default or the marked `&nbsp;` block fillers.
 	 */
 	useFillerType( type ) {
-		this._domConverter.blockFillerMode = type == 'marked' ? 'markedNbsp' : 'nbsp';
+		this.domConverter.blockFillerMode = type == 'marked' ? 'markedNbsp' : 'nbsp';
 	}
 
 	/**
@@ -140,7 +140,7 @@ export default class XmlDataProcessor {
 		// Wrap data into root element with optional namespace definitions.
 		data = `<xml ${ namespaces }>${ data }</xml>`;
 
-		const parsedDocument = this._domParser.parseFromString( data, 'text/xml' );
+		const parsedDocument = this.domParser.parseFromString( data, 'text/xml' );
 
 		// Parse validation.
 		const parserError = parsedDocument.querySelector( 'parsererror' );

--- a/packages/ckeditor5-engine/tests/dataprocessor/htmldataprocessor.js
+++ b/packages/ckeditor5-engine/tests/dataprocessor/htmldataprocessor.js
@@ -3,9 +3,11 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals setTimeout, window, Node */
+/* globals setTimeout, window, Node, DOMParser */
 
 import HtmlDataProcessor from '../../src/dataprocessor/htmldataprocessor';
+import BasicHtmlWriter from '../../src/dataprocessor/basichtmlwriter';
+import DomConverter from '../../src//view/domconverter';
 import xssTemplates from '../../tests/dataprocessor/_utils/xsstemplates';
 import ViewDocumentFragment from '../../src/view/documentfragment';
 import { stringify, parse } from '../../src/dev-utils/view';
@@ -18,6 +20,18 @@ describe( 'HtmlDataProcessor', () => {
 	beforeEach( () => {
 		viewDocument = new ViewDocument( new StylesProcessor() );
 		dataProcessor = new HtmlDataProcessor( viewDocument );
+	} );
+
+	describe( 'constructor', () => {
+		it( 'should set public properties', () => {
+			expect( dataProcessor ).to.have.property( 'domParser' );
+			expect( dataProcessor ).to.have.property( 'domConverter' );
+			expect( dataProcessor ).to.have.property( 'htmlWriter' );
+
+			expect( dataProcessor.domParser ).to.be.an.instanceOf( DOMParser );
+			expect( dataProcessor.domConverter ).to.be.an.instanceOf( DomConverter );
+			expect( dataProcessor.htmlWriter ).to.be.an.instanceOf( BasicHtmlWriter );
+		} );
 	} );
 
 	describe( 'toView()', () => {

--- a/packages/ckeditor5-engine/tests/dataprocessor/xmldataprocessor.js
+++ b/packages/ckeditor5-engine/tests/dataprocessor/xmldataprocessor.js
@@ -3,9 +3,11 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals window */
+/* globals window, DOMParser */
 
 import XmlDataProcessor from '../../src/dataprocessor/xmldataprocessor';
+import BasicHtmlWriter from '../../src/dataprocessor/basichtmlwriter';
+import DomConverter from '../../src//view/domconverter';
 import xssTemplates from '../../tests/dataprocessor/_utils/xsstemplates';
 import ViewDocumentFragment from '../../src/view/documentfragment';
 import ViewDocument from '../../src/view/document';
@@ -18,6 +20,20 @@ describe( 'XmlDataProcessor', () => {
 	beforeEach( () => {
 		viewDocument = new ViewDocument( new StylesProcessor() );
 		dataProcessor = new XmlDataProcessor( viewDocument );
+	} );
+
+	describe( 'constructor', () => {
+		it( 'should set public properties', () => {
+			expect( dataProcessor ).to.have.property( 'namespaces' );
+			expect( dataProcessor ).to.have.property( 'domParser' );
+			expect( dataProcessor ).to.have.property( 'domConverter' );
+			expect( dataProcessor ).to.have.property( 'htmlWriter' );
+
+			expect( dataProcessor.namespaces ).to.be.an.instanceOf( Array );
+			expect( dataProcessor.domParser ).to.be.an.instanceOf( DOMParser );
+			expect( dataProcessor.domConverter ).to.be.an.instanceOf( DomConverter );
+			expect( dataProcessor.htmlWriter ).to.be.an.instanceOf( BasicHtmlWriter );
+		} );
 	} );
 
 	describe( 'toView', () => {

--- a/packages/ckeditor5-utils/tests/_utils/normalizehtml.js
+++ b/packages/ckeditor5-utils/tests/_utils/normalizehtml.js
@@ -18,7 +18,7 @@ import Document from '@ckeditor/ckeditor5-engine/src/view/document';
 export default function normalizeHtml( html, options = {} ) {
 	const processor = new HtmlDataProcessor( new Document( new StylesProcessor() ) );
 	const domFragment = processor._toDom( html );
-	const viewFragment = processor._domConverter.domToView( domFragment, options );
+	const viewFragment = processor.domConverter.domToView( domFragment, options );
 
 	return stringify( viewFragment );
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (engine): Makes properties of `XmlDataProcessor` and `HtmlDataProcessor` public to allow overriding e.g. the HTML writer. Closes #10619.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._