### PR TITLE
Mention panel disappear in read-only mode

### DIFF
--- a/packages/ckeditor5-mention/src/mentionui.js
+++ b/packages/ckeditor5-mention/src/mentionui.js
@@ -170,6 +170,7 @@ export default class MentionUI extends Plugin {
 			this._mentionsConfigurations.set( marker, definition );
 		}
 
+		editor.on( 'change:isReadOnly', () => this._hideUIAndRemoveMarker() );
 		this.on( 'requestFeed:response', ( evt, data ) => this._handleFeedResponse( data ) );
 		this.on( 'requestFeed:error', () => this._hideUIAndRemoveMarker() );
 

--- a/packages/ckeditor5-mention/tests/mentionui.js
+++ b/packages/ckeditor5-mention/tests/mentionui.js
@@ -121,6 +121,14 @@ describe( 'MentionUI', () => {
 		it( 'should add MentionView to a panel', () => {
 			expect( editor.plugins.get( ContextualBalloon ).visibleView ).to.be.instanceof( MentionsView );
 		} );
+
+		it( 'should hide contextual balloon when editor is in readonly mode', () => {
+			expect( panelView.isVisible ).to.be.true;
+
+			editor.isReadOnly = true;
+
+			expect( panelView.isVisible ).to.be.false;
+		} );
 	} );
 
 	describe( 'position', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (mention): Mention panel will now hide when the editor becomes read-only. Closes #4645.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._