### PR TITLE
Docs: add svg file upload type in Base64UploadAdapter docs

### DIFF
--- a/packages/ckeditor5-upload/docs/features/base64-upload-adapter.md
+++ b/packages/ckeditor5-upload/docs/features/base64-upload-adapter.md
@@ -65,7 +65,7 @@ The allowed file types that can be uploaded should actually be configured in two
 
 Use the {@link module:image/imageupload~ImageUploadConfig#types `image.upload.types`} configuration option to define the allowed image MIME types that can be uploaded to CKEditor 5.
 
-By default, users are allowed to upload `jpeg`, `png`, `gif`, `bmp`, `webp` and `tiff` files, but you can customize this behavior to accept, for example, SVG files.
+By default, users are allowed to upload `jpeg`, `png`, `gif`, `bmp`, `webp` and `tiff` files. You can customize this behavior to accept, for example, SVG files (in this case use `svg+xml` type).
 
 #### Server-side configuration
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: added svg file upload type in Base64UploadAdapter docs. Closes https://github.com/ckeditor/ckeditor5/issues/10624.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
