### PR TITLE
Docs: Removed bigger margin-bottom from the first block quote paragraph

### DIFF
--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -220,10 +220,6 @@ It breaks CKEditor 5 (see how <p><code>[]</code></p> looks). */
 	margin: 0 auto;
 }
 
-.live-snippet blockquote p:first-of-type {
-	margin-bottom: 1.5rem;
-}
-
 /* https://github.com/ckeditor/ckeditor5/issues/899 */
 .live-snippet .ck-dropdown .ck.ck-list {
 	margin: 0;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: First paragraph in block quotes will no longer have a bigger margin-bottom. Closes #8579.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
