### PR TITLE
Fix (engine): selection postfixer - merge intersecting ranges

### DIFF
--- a/packages/ckeditor5-engine/src/model/utils/selection-post-fixer.js
+++ b/packages/ckeditor5-engine/src/model/utils/selection-post-fixer.js
@@ -264,11 +264,10 @@ function checkSelectionOnNonLimitElements( start, end, schema ) {
 }
 
 /**
- * Returns a minimal non-intersecting array of ranges.
- * Remove duplicated ranges, merge intersecting ranges into one.
+ * Returns a minimal non-intersecting array of ranges without duplicates.
  *
- * @param {Array.<module:engine/model/range~Range>} ranges
- * @returns {Array.<module:engine/model/range~Range>}
+ * @param {Array.<module:engine/model/range~Range>} Ranges to merge.
+ * @returns {Array.<module:engine/model/range~Range>} Array of unique and nonIntersecting ranges.
  */
 export function mergeIntersectingRanges( ranges ) {
 	const rangesToMerge = [ ...ranges ];
@@ -290,7 +289,7 @@ export function mergeIntersectingRanges( ranges ) {
 				rangeIndexesToRemove.add( previousRangeIndex );
 				rangeIndexesToRemove.add( currentRangeIndex );
 
-				const mergedRange = createMergedRange( previousRange, currentRange );
+				const mergedRange = currentRange.getJoined( previousRange );
 				rangesToMerge.push( mergedRange );
 			}
 		}
@@ -310,16 +309,4 @@ export function mergeIntersectingRanges( ranges ) {
 // @returns {Boolean}
 function isSelectable( node, schema ) {
 	return node && schema.isSelectable( node );
-}
-
-// Create sum of two ranges
-//
-// @param {module:engine/model/range~Range} range1
-// @param {module:engine/model/range~Range} range2
-// @returns {module:engine/model/range~Range} mergedRange
-function createMergedRange( range1, range2 ) {
-	const start = range1.start.isAfter( range2.start ) ? range2.start : range1.start;
-	const end = range1.end.isAfter( range2.end ) ? range1.end : range2.end;
-
-	return new Range( start, end );
 }

--- a/packages/ckeditor5-engine/src/model/utils/selection-post-fixer.js
+++ b/packages/ckeditor5-engine/src/model/utils/selection-post-fixer.js
@@ -263,34 +263,42 @@ function checkSelectionOnNonLimitElements( start, end, schema ) {
 	return startIsOnBlock || endIsOnBlock;
 }
 
-// Returns a minimal non-intersecting array of ranges.
-//
-// @param {Array.<module:engine/model/range~Range>} ranges
-// @returns {Array.<module:engine/model/range~Range>}
-function mergeIntersectingRanges( ranges ) {
-	const nonIntersectingRanges = [];
+/**
+ * Returns a minimal non-intersecting array of ranges.
+ * Remove duplicated ranges, merge intersecting ranges into one.
+ *
+ * @param {Array.<module:engine/model/range~Range>} ranges
+ * @returns {Array.<module:engine/model/range~Range>}
+ */
+export function mergeIntersectingRanges( ranges ) {
+	const rangesToMerge = [ ...ranges ];
+	const rangeIndexesToRemove = new Set();
+	let currentRangeIndex = 1;
 
-	// First range will always be fine.
-	nonIntersectingRanges.push( ranges.shift() );
+	while ( currentRangeIndex < rangesToMerge.length ) {
+		const currentRange = rangesToMerge[ currentRangeIndex ];
+		const previousRanges = rangesToMerge.slice( 0, currentRangeIndex );
 
-	for ( const range of ranges ) {
-		const previousRange = nonIntersectingRanges.pop();
+		for ( const [ previousRangeIndex, previousRange ] of previousRanges.entries() ) {
+			if ( rangeIndexesToRemove.has( previousRangeIndex ) ) {
+				continue;
+			}
 
-		if ( range.isEqual( previousRange ) ) {
-			// Use only one of two identical ranges.
-			nonIntersectingRanges.push( previousRange );
-		} else if ( range.isIntersecting( previousRange ) ) {
-			// Get the sum of two ranges.
-			const start = previousRange.start.isAfter( range.start ) ? range.start : previousRange.start;
-			const end = previousRange.end.isAfter( range.end ) ? previousRange.end : range.end;
+			if ( currentRange.isEqual( previousRange ) ) {
+				rangeIndexesToRemove.add( previousRangeIndex );
+			} else if ( currentRange.isIntersecting( previousRange ) ) {
+				rangeIndexesToRemove.add( previousRangeIndex );
+				rangeIndexesToRemove.add( currentRangeIndex );
 
-			const merged = new Range( start, end );
-			nonIntersectingRanges.push( merged );
-		} else {
-			nonIntersectingRanges.push( previousRange );
-			nonIntersectingRanges.push( range );
+				const mergedRange = createMergedRange( previousRange, currentRange );
+				rangesToMerge.push( mergedRange );
+			}
 		}
+
+		currentRangeIndex++;
 	}
+
+	const nonIntersectingRanges = rangesToMerge.filter( ( _, index ) => !rangeIndexesToRemove.has( index ) );
 
 	return nonIntersectingRanges;
 }
@@ -302,4 +310,16 @@ function mergeIntersectingRanges( ranges ) {
 // @returns {Boolean}
 function isSelectable( node, schema ) {
 	return node && schema.isSelectable( node );
+}
+
+// Create sum of two ranges
+//
+// @param {module:engine/model/range~Range} range1
+// @param {module:engine/model/range~Range} range2
+// @returns {module:engine/model/range~Range} mergedRange
+function createMergedRange( range1, range2 ) {
+	const start = range1.start.isAfter( range2.start ) ? range2.start : range1.start;
+	const end = range1.end.isAfter( range2.end ) ? range1.end : range2.end;
+
+	return new Range( start, end );
 }

--- a/packages/ckeditor5-engine/tests/model/utils/selection-post-fixer.js
+++ b/packages/ckeditor5-engine/tests/model/utils/selection-post-fixer.js
@@ -5,9 +5,9 @@
 
 import Model from '../../../src/model/model';
 
-import { injectSelectionPostFixer } from '../../../src/model/utils/selection-post-fixer';
+import { stringify, getData as getModelData, setData as setModelData } from '../../../src/dev-utils/model';
+import { injectSelectionPostFixer, mergeIntersectingRanges } from '../../../src/model/utils/selection-post-fixer';
 
-import { getData as getModelData, setData as setModelData } from '../../../src/dev-utils/model';
 import { assertEqualMarkup } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 
 describe( 'Selection post-fixer', () => {
@@ -1095,6 +1095,66 @@ describe( 'Selection post-fixer', () => {
 					'</imageBlock>' +
 					'<paragraph>]bar</paragraph>'
 				);
+			} );
+		} );
+
+		describe( 'intersecting selection', () => {
+			it( 'should return one merged range: A+B+C - #1', () => {
+				setModelData( model,
+					'<paragraph>fo[o b][ar b]az</paragraph>'
+				);
+
+				const rangeA = model.document.selection.getFirstRange();
+				const rangeB = model.document.selection.getLastRange();
+				// A range containing both rangeA and rangeB.
+				const rangeC = model.createRange(
+					model.createPositionAt( modelRoot.getChild( 0 ), 0 ),
+					model.createPositionAt( modelRoot.getChild( 0 ), 11 )
+				);
+
+				const mergedRanges = mergeIntersectingRanges( [ rangeA, rangeB, rangeC ] );
+
+				expect( mergedRanges.length ).to.equal( 1 );
+				expect( stringify( model.document.getRoot(), mergedRanges[ 0 ] ) ).to.equal( '<paragraph>[foo bar baz]</paragraph>' );
+			} );
+
+			it( 'should return one merged range: A+B+C - #2', () => {
+				setModelData( model,
+					'<paragraph>f[oo b]a[r ba]z</paragraph>'
+				);
+
+				const rangeA = model.document.selection.getFirstRange();
+				const rangeB = model.document.selection.getLastRange();
+				// Range intersecting with rangeA and rangeB
+				const rangeC = model.createRange(
+					model.createPositionAt( modelRoot.getChild( 0 ), 4 ),
+					model.createPositionAt( modelRoot.getChild( 0 ), 11 )
+				);
+
+				const mergedRanges = mergeIntersectingRanges( [ rangeA, rangeB, rangeC ] );
+
+				expect( mergedRanges.length ).to.equal( 1 );
+				expect( stringify( model.document.getRoot(), mergedRanges[ 0 ] ) ).to.equal( '<paragraph>f[oo bar baz]</paragraph>' );
+			} );
+
+			it( 'should return two ranges: A, B+C', () => {
+				setModelData( model,
+					'<paragraph>f[oo] ba[r ba]z</paragraph>'
+				);
+
+				const rangeA = model.document.selection.getFirstRange();
+				const rangeB = model.document.selection.getLastRange();
+				// Range intersecting with rangeB
+				const rangeC = model.createRange(
+					model.createPositionAt( modelRoot.getChild( 0 ), 4 ),
+					model.createPositionAt( modelRoot.getChild( 0 ), 10 )
+				);
+
+				const mergedRanges = mergeIntersectingRanges( [ rangeA, rangeB, rangeC ] );
+
+				expect( mergedRanges.length ).to.equal( 2 );
+				expect( stringify( model.document.getRoot(), mergedRanges[ 0 ] ) ).to.equal( '<paragraph>f[oo] bar baz</paragraph>' );
+				expect( stringify( model.document.getRoot(), mergedRanges[ 1 ] ) ).to.equal( '<paragraph>foo [bar ba]z</paragraph>' );
 			} );
 		} );
 

--- a/packages/ckeditor5-engine/tests/model/utils/selection-post-fixer.js
+++ b/packages/ckeditor5-engine/tests/model/utils/selection-post-fixer.js
@@ -1098,7 +1098,7 @@ describe( 'Selection post-fixer', () => {
 			} );
 		} );
 
-		describe( 'intersecting selection', () => {
+		describe( 'intersecting selection - merge ranges', () => {
 			it( 'should return one merged range: A+B+C - #1', () => {
 				setModelData( model,
 					'<paragraph>fo[o b][ar b]az</paragraph>'
@@ -1155,6 +1155,26 @@ describe( 'Selection post-fixer', () => {
 				expect( mergedRanges.length ).to.equal( 2 );
 				expect( stringify( model.document.getRoot(), mergedRanges[ 0 ] ) ).to.equal( '<paragraph>f[oo] bar baz</paragraph>' );
 				expect( stringify( model.document.getRoot(), mergedRanges[ 1 ] ) ).to.equal( '<paragraph>foo [bar ba]z</paragraph>' );
+			} );
+
+			it( 'should return two ranges: A+B,C', () => {
+				setModelData( model,
+					'<paragraph>f[oo][ bar] baz</paragraph>'	// foo bar baz
+				);
+
+				const rangeA = model.document.selection.getFirstRange();
+				const rangeB = model.document.selection.getLastRange();
+				const rangeC = model.createRange(
+					model.createPositionAt( modelRoot.getChild( 0 ), 8 ),
+					model.createPositionAt( modelRoot.getChild( 0 ), 11 )
+				);
+
+				const mergedRanges = mergeIntersectingRanges( [ rangeA, rangeB, rangeC ] );
+
+				expect( mergedRanges.length ).to.equal( 3 );
+				expect( stringify( model.document.getRoot(), mergedRanges[ 0 ] ) ).to.equal( '<paragraph>f[oo] bar baz</paragraph>' );
+				expect( stringify( model.document.getRoot(), mergedRanges[ 1 ] ) ).to.equal( '<paragraph>foo[ bar] baz</paragraph>' );
+				expect( stringify( model.document.getRoot(), mergedRanges[ 2 ] ) ).to.equal( '<paragraph>foo bar [baz]</paragraph>' );
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): Merge intersecting ranges that aren't adjacent to each other on ranges array. Closes #10628.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._