### PR TITLE
Docs: minor update to the "linking images" guide

### DIFF
--- a/packages/ckeditor5-image/docs/_snippets/features/image-link.html
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-link.html
@@ -16,6 +16,7 @@
 		margin-right: 20px;
 	}
 	.ck-content p {
+		/* https://github.com/ckeditor/ckeditor5/issues/10587 */
 		display: flow-root;
 	}
 </style>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (image): Image resize UI will not be cropped in the "linking images" guide. Closes #10587.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
