### PR TITLE
Docs: updated table feature guide example config to remove warning

### DIFF
--- a/packages/ckeditor5-table/docs/_snippets/features/table-default-headings.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-default-headings.js
@@ -10,6 +10,16 @@ ClassicEditor
 		table: {
 			contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ],
 			defaultHeadings: { rows: 1, columns: 1 }
+		},
+		image: {
+			toolbar: [
+				'imageStyle:inline',
+				'imageStyle:block',
+				'imageStyle:side',
+				'|',
+				'toggleImageCaption',
+				'imageTextAlternative'
+			]
 		}
 	} )
 	.then( editor => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (table): Updated editor configuration for `table-default-headings` example to resolve warning in table feature guide. Closes #10424.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
