### PR TITLE
InputTextView should update its #isEmpty property more often

### DIFF
--- a/packages/ckeditor5-ui/src/inputtext/inputtextview.js
+++ b/packages/ckeditor5-ui/src/inputtext/inputtextview.js
@@ -125,7 +125,10 @@ export default class InputTextView extends View {
 				'aria-describedby': bind.to( 'ariaDescribedById' )
 			},
 			on: {
-				input: bind.to( 'input' ),
+				input: bind.to( ( ...args ) => {
+					this.fire( 'input', ...args );
+					this._updateIsEmpty();
+				} ),
 				change: bind.to( this._updateIsEmpty.bind( this ) )
 			}
 		} );

--- a/packages/ckeditor5-ui/tests/inputtext/inputtextview.js
+++ b/packages/ckeditor5-ui/tests/inputtext/inputtextview.js
@@ -83,6 +83,15 @@ describe( 'InputTextView', () => {
 
 				expect( view.element.value ).to.equal( 'baz' );
 			} );
+
+			it( 'should update along with the #isEmpty property', () => {
+				view.value = 'foo';
+
+				expect( view.isEmpty ).to.be.false;
+
+				view.value = '';
+				expect( view.isEmpty ).to.be.true;
+			} );
 		} );
 
 		describe( 'id', () => {
@@ -171,18 +180,18 @@ describe( 'InputTextView', () => {
 
 				view.element.dispatchEvent( new Event( 'input' ) );
 				sinon.assert.calledOnce( spy );
+				sinon.assert.calledWith( spy, sinon.match.object );
 			} );
-		} );
 
-		describe( 'change event', () => {
+			// https://github.com/ckeditor/ckeditor5/issues/10431
 			it( 'should trigger update of the #isEmpty property', () => {
 				view.element.value = 'foo';
-				view.element.dispatchEvent( new Event( 'change' ) );
+				view.element.dispatchEvent( new Event( 'input' ) );
 
 				expect( view.isEmpty ).to.be.false;
 
 				view.element.value = '';
-				view.element.dispatchEvent( new Event( 'change' ) );
+				view.element.dispatchEvent( new Event( 'input' ) );
 
 				expect( view.isEmpty ).to.be.true;
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (ui): `InputTextView` should update its `#isEmpty` property on every `#input` instead of `#change` to stay in sync. Closes #10431.