### PR TITLE
Do not block selection rendering while making a selection in Blink/Android

### DIFF
--- a/packages/ckeditor5-engine/src/view/renderer.js
+++ b/packages/ckeditor5-engine/src/view/renderer.js
@@ -109,17 +109,19 @@ export default class Renderer {
 		 * When they stop selecting, the property goes back to `false`.
 		 *
 		 * Note: In some browsers, the renderer will stop rendering the selection and inline fillers while the user is making
-		 * a selection to avoid glitches in DOM selection (https://github.com/ckeditor/ckeditor5/issues/10562).
+		 * a selection to avoid glitches in DOM selection
+		 * (https://github.com/ckeditor/ckeditor5/issues/10562, https://github.com/ckeditor/ckeditor5/issues/10723).
 		 *
 		 * @member {Boolean}
 		 * @observable
 		 */
 		this.set( 'isSelecting', false );
 
-		// Rendering the selection and inline filler manipulation should be postponed in Blink until the user finishes creating
-		// the selection in DOM to avoid accidental selection collapsing (https://github.com/ckeditor/ckeditor5/issues/10562).
+		// Rendering the selection and inline filler manipulation should be postponed in (non-Android) Blink until the user finishes
+		// creating the selection in DOM to avoid accidental selection collapsing
+		// (https://github.com/ckeditor/ckeditor5/issues/10562, https://github.com/ckeditor/ckeditor5/issues/10723).
 		// When the user stops, selecting, all pending changes should be rendered ASAP, though.
-		if ( env.isBlink ) {
+		if ( env.isBlink && !env.isAndroid ) {
 			this.on( 'change:isSelecting', () => {
 				if ( !this.isSelecting ) {
 					this.render();
@@ -196,15 +198,16 @@ export default class Renderer {
 	 */
 	render() {
 		let inlineFillerPosition;
-		const isInlineFillerRenderingPossible = env.isBlink ? !this.isSelecting : true;
+		const isInlineFillerRenderingPossible = env.isBlink && !env.isAndroid ? !this.isSelecting : true;
 
 		// Refresh mappings.
 		for ( const element of this.markedChildren ) {
 			this._updateChildrenMappings( element );
 		}
 
-		// Don't manipulate inline fillers while the selection is being made in Blink to prevent accidental
-		// DOM selection collapsing (https://github.com/ckeditor/ckeditor5/issues/10562).
+		// Don't manipulate inline fillers while the selection is being made in (non-Android) Blink to prevent accidental
+		// DOM selection collapsing
+		// (https://github.com/ckeditor/ckeditor5/issues/10562, https://github.com/ckeditor/ckeditor5/issues/10723).
 		if ( isInlineFillerRenderingPossible ) {
 			// There was inline filler rendered in the DOM but it's not
 			// at the selection position any more, so we can remove it
@@ -251,8 +254,9 @@ export default class Renderer {
 		//   For example, if the inline filler was deep in the created DOM structure, it will not be created.
 		//   Similarly, if it was removed at the beginning of this function and then neither text nor children were updated,
 		//   it will not be present. Fix those and similar scenarios.
-		// * Don't manipulate inline fillers while the selection is being made in Blink to prevent accidental
-		//   DOM selection collapsing (https://github.com/ckeditor/ckeditor5/issues/10562).
+		// * Don't manipulate inline fillers while the selection is being made in (non-Android) Blink to prevent accidental
+		//   DOM selection collapsing
+		//   (https://github.com/ckeditor/ckeditor5/issues/10562, https://github.com/ckeditor/ckeditor5/issues/10723).
 		if ( isInlineFillerRenderingPossible ) {
 			if ( inlineFillerPosition ) {
 				const fillerDomPosition = this.domConverter.viewPositionToDom( inlineFillerPosition );
@@ -736,11 +740,11 @@ export default class Renderer {
 	 * @private
 	 */
 	_updateSelection() {
-		// Block updating DOM selection in Blink while the user is selecting to prevent accidental selection collapsing.
+		// Block updating DOM selection in (non-Android) Blink while the user is selecting to prevent accidental selection collapsing.
 		// Note: Structural changes in DOM must trigger selection rendering, though. Nodes the selection was anchored
 		// to may disappear in DOM which would break the selection (e.g. in real-time collaboration scenarios).
-		// https://github.com/ckeditor/ckeditor5/issues/10562
-		if ( env.isBlink && this.isSelecting && !this.markedChildren.size ) {
+		// https://github.com/ckeditor/ckeditor5/issues/10562, https://github.com/ckeditor/ckeditor5/issues/10723
+		if ( env.isBlink && !env.isAndroid && this.isSelecting && !this.markedChildren.size ) {
 			return;
 		}
 

--- a/packages/ckeditor5-engine/tests/view/renderer.js
+++ b/packages/ckeditor5-engine/tests/view/renderer.js
@@ -4264,6 +4264,7 @@ describe( 'Renderer', () => {
 	} );
 
 	// https://github.com/ckeditor/ckeditor5/issues/10562
+	// https://github.com/ckeditor/ckeditor5/issues/10723
 	describe( 'Blocking selection rendering while making selection in Blink (#10562)', () => {
 		describe( 'constructor()', () => {
 			let viewDocument, selection, domConverter, renderer;
@@ -4285,6 +4286,26 @@ describe( 'Renderer', () => {
 				renderer.isSelecting = false;
 
 				sinon.assert.calledOnce( renderSpy );
+			} );
+
+			it( 'should not call #render() as soon as the user stops selecting in Blink on Android', () => {
+				testUtils.sinon.stub( env, 'isBlink' ).get( () => true );
+				testUtils.sinon.stub( env, 'isAndroid' ).get( () => true );
+
+				viewDocument = new ViewDocument( new StylesProcessor() );
+				selection = new DocumentSelection();
+				domConverter = new DomConverter( viewDocument, { renderingMode: 'editing' } );
+				renderer = new Renderer( domConverter, selection );
+				renderer.domDocuments.add( document );
+
+				const renderSpy = sinon.spy( renderer, 'render' );
+
+				expect( renderer.isSelecting ).to.be.false;
+
+				renderer.isSelecting = true;
+				renderer.isSelecting = false;
+
+				sinon.assert.notCalled( renderSpy );
 			} );
 
 			it( 'should not call #render() as soon as the user stops selecting in browsers other than Blink', () => {
@@ -4332,7 +4353,7 @@ describe( 'Renderer', () => {
 				domRoot.remove();
 			} );
 
-			describe( 'in Blink', () => {
+			describe( 'in Blink (non-Android)', () => {
 				beforeEach( () => {
 					testUtils.sinon.stub( env, 'isBlink' ).get( () => true );
 					renderer.isSelecting = false;
@@ -4508,6 +4529,120 @@ describe( 'Renderer', () => {
 				} );
 			} );
 
+			describe( 'in Blink (Android)', () => {
+				beforeEach( () => {
+					testUtils.sinon.stub( env, 'isBlink' ).get( () => true );
+					testUtils.sinon.stub( env, 'isAndroid' ).get( () => true );
+					renderer.isSelecting = false;
+				} );
+
+				it( 'should remove the inline filler despite the user making selection', () => {
+					const domSelection = document.getSelection();
+
+					const {
+						view: viewParagraph,
+						selection: viewSelection
+					} = parse( '<container:p>[]<attribute:b>foo</attribute:b></container:p>' );
+
+					viewRoot._appendChild( viewParagraph );
+					selection._setTo( viewSelection );
+
+					// -----------------------------------------------------------------------------------------------
+					// STEP #1: The first render() is to set the initial state of the editor.
+					renderer.markToSync( 'children', viewRoot );
+					renderer.render();
+
+					let domParagraph = domRoot.childNodes[ 0 ];
+
+					// The filler was inserted <p>"FILLER{}"<b>foo</b></p>.
+					expect( domParagraph.childNodes.length ).to.equal( 2 );
+					expect( domParagraph.childNodes[ 0 ].data ).to.equal( INLINE_FILLER );
+					expect( domParagraph.childNodes[ 1 ].outerHTML ).to.equal( '<b>foo</b>' );
+
+					expect( domSelection.rangeCount ).to.equal( 1 );
+					expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domParagraph.childNodes[ 0 ] );
+					expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( INLINE_FILLER_LENGTH );
+					expect( domSelection.getRangeAt( 0 ).collapsed ).to.be.true;
+
+					// -----------------------------------------------------------------------------------------------
+					// STEP #2: Now we're moving the selection somewhere else while isSelecting = true.
+					// Then comes the second render().
+					// * In Blink, the filler should stay:                    <p>"FILLER{}"<b>foo</b></p>
+					// * But in other browsers, it should disappear:          <p><b>foo</b></p>
+					renderer.isSelecting = true;
+
+					// <p><b>f{o}o</b></p>.
+					selection._setTo(
+						ViewRange._createFromParentsAndOffsets(
+							viewParagraph.getChild( 0 ).getChild( 0 ), 1,
+							viewParagraph.getChild( 0 ).getChild( 0 ), 2
+						)
+					);
+					renderer.render();
+
+					domParagraph = domRoot.childNodes[ 0 ];
+
+					// The filler is gone <p><b>f{o}o</b></p>.
+					expect( domParagraph.childNodes.length ).to.equal( 1 );
+					expect( domParagraph.childNodes[ 0 ].outerHTML ).to.equal( '<b>foo</b>' );
+
+					expect( domSelection.rangeCount ).to.equal( 1 );
+					expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domParagraph.childNodes[ 0 ].childNodes[ 0 ] );
+					expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( 1 );
+					expect( domSelection.getRangeAt( 0 ).endOffset ).to.equal( 2 );
+				} );
+
+				it( 'should add the inline filler despite the user making selection', () => {
+					const domSelection = document.getSelection();
+
+					const {
+						view: viewParagraph,
+						selection: viewSelection
+					} = parse( '<container:p><attribute:b>f{o}o</attribute:b></container:p>' );
+
+					viewRoot._appendChild( viewParagraph );
+					selection._setTo( viewSelection );
+
+					// -----------------------------------------------------------------------------------------------
+					// STEP #1: The first render() is to set the initial state of the editor.
+					renderer.markToSync( 'children', viewRoot );
+					renderer.render();
+
+					let domParagraph = domRoot.childNodes[ 0 ];
+
+					// There is no filler <p><b>f{o}o</b></p>.
+					expect( domParagraph.childNodes.length ).to.equal( 1 );
+					expect( domParagraph.childNodes[ 0 ].outerHTML ).to.equal( '<b>foo</b>' );
+
+					expect( domSelection.rangeCount ).to.equal( 1 );
+					expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domParagraph.childNodes[ 0 ].childNodes[ 0 ] );
+					expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( 1 );
+					expect( domSelection.getRangeAt( 0 ).endOffset ).to.equal( 2 );
+
+					// -----------------------------------------------------------------------------------------------
+					// STEP #2: Now we're moving the selection to a problematic place before <b></b> while isSelecting = true.
+					// Then comes the second render().
+					// * In Blink, nothing should happen:                     <p><b>f{o}o</b></p>
+					// * But in other browsers, the filler should show up:    <p>"FILLER{}"<b>foo</b></p>
+					renderer.isSelecting = true;
+					selection._setTo( viewParagraph, 0 );
+					renderer.render();
+
+					domParagraph = domRoot.childNodes[ 0 ];
+
+					// The filler was inserted <p>"FILLER{}"<b>foo</b></p> despite isSelecting = true.
+					expect( domParagraph.childNodes.length ).to.equal( 2 );
+					expect( domParagraph.childNodes[ 0 ].data ).to.equal( INLINE_FILLER );
+					expect( domParagraph.childNodes[ 1 ].outerHTML ).to.equal( '<b>foo</b>' );
+
+					// And the selection is after the inline filler.
+					expect( domSelection.rangeCount ).to.equal( 1 );
+					expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domParagraph.childNodes[ 0 ] );
+					expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( INLINE_FILLER_LENGTH );
+					expect( domSelection.getRangeAt( 0 ).collapsed ).to.be.true;
+				} );
+			} );
+
 			describe( 'in browsers other than Blink', () => {
 				beforeEach( () => {
 					testUtils.sinon.stub( env, 'isBlink' ).get( () => false );
@@ -4643,7 +4778,7 @@ describe( 'Renderer', () => {
 				domRoot.remove();
 			} );
 
-			describe( 'in Blink', () => {
+			describe( 'in Blink (non-Android)', () => {
 				beforeEach( () => {
 					testUtils.sinon.stub( env, 'isBlink' ).get( () => true );
 					renderer.isSelecting = false;
@@ -4744,6 +4879,56 @@ describe( 'Renderer', () => {
 					expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( 2 );
 					expect( domSelection.getRangeAt( 0 ).endOffset ).to.equal( 3 );
 				} );
+			} );
+
+			it( 'should update despite the selection being made in Blink on Android', () => {
+				testUtils.sinon.stub( env, 'isBlink' ).get( () => true );
+				testUtils.sinon.stub( env, 'isAndroid' ).get( () => true );
+				renderer.isSelecting = false;
+
+				const domSelection = document.getSelection();
+
+				const {
+					view: viewParagraph,
+					selection: viewSelection
+				} = parse( '<container:p><attribute:b>f{o}o</attribute:b></container:p>' );
+
+				viewRoot._appendChild( viewParagraph );
+				selection._setTo( viewSelection );
+
+				// -----------------------------------------------------------------------------------------------
+				// STEP #1: The first render() is to set the initial state of the editor.
+				renderer.markToSync( 'children', viewRoot );
+				renderer.render();
+
+				const domParagraph = domRoot.childNodes[ 0 ];
+
+				expect( domSelection.rangeCount ).to.equal( 1 );
+				expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domParagraph.childNodes[ 0 ].childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( 1 );
+				expect( domSelection.getRangeAt( 0 ).endOffset ).to.equal( 2 );
+
+				// -----------------------------------------------------------------------------------------------
+				// STEP #2: Now we're moving the selection somewhere else while isSelecting = true.
+				// Then comes the second render().
+				// * In browsers other than Blink, the selection should move despite isSelecting = true: <p><b>fo{o}</b></p>
+				renderer.isSelecting = true;
+
+				// <p><b>fo{o}</b></p>.
+				selection._setTo(
+					ViewRange._createFromParentsAndOffsets(
+						viewParagraph.getChild( 0 ).getChild( 0 ), 2,
+						viewParagraph.getChild( 0 ).getChild( 0 ), 3
+					)
+				);
+
+				renderer.render();
+
+				// <p><b>fo{o}</b></p>
+				expect( domSelection.rangeCount ).to.equal( 1 );
+				expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domParagraph.childNodes[ 0 ].childNodes[ 0 ] );
+				expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( 2 );
+				expect( domSelection.getRangeAt( 0 ).endOffset ).to.equal( 3 );
 			} );
 
 			it( 'should update despite the selection being made in browsers other than Blink', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (engine): Do not block selection rendering while making a selection in Blink/Android because it totally breaks the selection system. Closes #10723.

---

### Additional information

Fixes a regression introduced in #10562.