### PR TITLE
Docs: change nightly to prod link target.

### DIFF
--- a/docs/assets/buildwarningbanner.js
+++ b/docs/assets/buildwarningbanner.js
@@ -5,9 +5,11 @@
 
 /* globals window */
 
-// Display a warning banner when browsing nightly documentation build.
+// Display a warning banner when browsing nightly documentation build. Source parameter for maintenance of 404 redirs.
 if ( window.location.host === 'ckeditor5.github.io' ) {
+	const stableUrl = window.location.href.replace( 'https://ckeditor5.github.io/docs/nightly', 'https://ckeditor.com/docs' );
+
 	window.umberto.showWarningBanner(
-		'Nightly documentation ahead. Switch to the <a href="https://ckeditor.com/docs/ckeditor5">stable editor documentation</a>.'
+		`Nightly documentation ahead. Switch to the <a href="${ stableUrl }&source=nightly">stable editor documentation</a>.`
 	);
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Type: Changin link from nightly to prod to cover specific guide. Closes #10756.

---

### Additional information

Added a `source` parameter for possible future 404 error/redir handling.