### PR TITLE
Fixed adjacent whole words being missed by find and replace

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/utils.js
+++ b/packages/ckeditor5-find-and-replace/src/utils.js
@@ -150,7 +150,7 @@ export function findByTextCallback( searchTerm, options ) {
 		}
 
 		if ( !new RegExp( nonLetterGroup + '$' ).test( searchTerm ) ) {
-			regExpQuery = `${ regExpQuery }(?:_|${ nonLetterGroup }|$)`;
+			regExpQuery = `${ regExpQuery }(?=_|${ nonLetterGroup }|$)`;
 		}
 	}
 

--- a/packages/ckeditor5-find-and-replace/tests/findcommand.js
+++ b/packages/ckeditor5-find-and-replace/tests/findcommand.js
@@ -299,6 +299,14 @@ describe( 'FindCommand', () => {
 					expect( results.length ).to.equal( 0 );
 				} );
 
+				it( 'set to true matches words separated by a single space', () => {
+					editor.setData( '<p>bar bar</p>' );
+
+					const { results } = command.execute( 'bar', { wholeWords: true } );
+
+					expect( results.length ).to.equal( 2 );
+				} );
+
 				it( 'is disabled by default', () => {
 					editor.setData( '<p>foo aabaraa</p>' );
 


### PR DESCRIPTION
Fix (find-and-replace): Fixed adjacent whole words being missed by find and replace. Closes #10719.