### PR TITLE
Support language configuration passed in `defaultConfig` option through editor's constructor

### DIFF
--- a/packages/ckeditor5-core/src/editor/editor.js
+++ b/packages/ckeditor5-core/src/editor/editor.js
@@ -52,6 +52,9 @@ export default class Editor {
 	 * @param {Object} [config={}] The editor configuration.
 	 */
 	constructor( config = {} ) {
+		// Prefer the language passed as the argument to the constructor instead of the constructor's `defaultConfig`, if both are set.
+		const language = config.language || ( this.constructor.defaultConfig && this.constructor.defaultConfig.language );
+
 		/**
 		 * The editor context.
 		 * When it is not provided through the configuration, the editor creates it.
@@ -59,7 +62,7 @@ export default class Editor {
 		 * @protected
 		 * @type {module:core/context~Context}
 		 */
-		this._context = config.context || new Context( { language: config.language } );
+		this._context = config.context || new Context( { language } );
 		this._context._addEditor( this, !config.context );
 
 		// Clone the plugins to make sure that the plugin array will not be shared

--- a/packages/ckeditor5-core/tests/editor/editor.js
+++ b/packages/ckeditor5-core/tests/editor/editor.js
@@ -306,10 +306,46 @@ describe( 'Editor', () => {
 			expect( editor.t ).to.equal( editor._context.t );
 		} );
 
-		it( 'should use locale instance with a proper configuration', () => {
+		it( 'should use locale instance with a proper configuration passed as the argument to the constructor', () => {
 			const editor = new TestEditor( {
 				language: 'pl'
 			} );
+
+			expect( editor.locale ).to.have.property( 'uiLanguage', 'pl' );
+			expect( editor.locale ).to.have.property( 'contentLanguage', 'pl' );
+		} );
+
+		it( 'should use locale instance with a proper configuration set as the defaultConfig option on the constructor', () => {
+			TestEditor.defaultConfig = {
+				language: 'pl'
+			};
+
+			const editor = new TestEditor();
+
+			expect( editor.locale ).to.have.property( 'uiLanguage', 'pl' );
+			expect( editor.locale ).to.have.property( 'contentLanguage', 'pl' );
+		} );
+
+		it( 'should prefer the language passed as the argument to the constructor instead of the defaultConfig if both are set', () => {
+			TestEditor.defaultConfig = {
+				language: 'de'
+			};
+
+			const editor = new TestEditor( {
+				language: 'pl'
+			} );
+
+			expect( editor.locale ).to.have.property( 'uiLanguage', 'pl' );
+			expect( editor.locale ).to.have.property( 'contentLanguage', 'pl' );
+		} );
+
+		it( 'should prefer the language from the context instead of the constructor config or defaultConfig if all are set', async () => {
+			TestEditor.defaultConfig = {
+				language: 'de'
+			};
+
+			const context = await Context.create( { language: 'pl' } );
+			const editor = new TestEditor( { context, language: 'ru' } );
 
 			expect( editor.locale ).to.have.property( 'uiLanguage', 'pl' );
 			expect( editor.locale ).to.have.property( 'contentLanguage', 'pl' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (core): Support language configuration passed in `defaultConfig` option through editor's constructor. Closes #8510.
