### PR TITLE
Made sure KeystrokeHandler and FocusTracker instances are destroyed across the project to avoid memory leaks

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.js
+++ b/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.js
@@ -353,6 +353,9 @@ export default class FindAndReplaceFormView extends View {
 		this._initKeystrokeHandling();
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 

--- a/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.js
+++ b/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.js
@@ -353,6 +353,13 @@ export default class FindAndReplaceFormView extends View {
 		this._initKeystrokeHandling();
 	}
 
+	destroy() {
+		super.destroy();
+
+		this._focusTracker.destroy();
+		this._keystrokes.destroy();
+	}
+
 	/**
 	 * Focuses the fist {@link #_focusables} in the form.
 	 */

--- a/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
+++ b/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
@@ -673,6 +673,24 @@ describe( 'FindAndReplaceFormView', () => {
 		} );
 	} );
 
+	describe( 'destroy()', () => {
+		it( 'should destroy the FocusTracker instance', () => {
+			const destroySpy = sinon.spy( view._focusTracker, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+
+		it( 'should destroy the KeystrokeHandler instance', () => {
+			const destroySpy = sinon.spy( view._keystrokes, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+	} );
+
 	describe( 'focus()', () => {
 		it( 'should focus the #findInputView', () => {
 			const spy = sinon.spy( view._findInputView, 'focus' );

--- a/packages/ckeditor5-font/src/ui/colortableview.js
+++ b/packages/ckeditor5-font/src/ui/colortableview.js
@@ -235,6 +235,13 @@ export default class ColorTableView extends View {
 		this.keystrokes.listenTo( this.element );
 	}
 
+	destroy() {
+		super.destroy();
+
+		this.focusTracker.destroy();
+		this.keystrokes.destroy();
+	}
+
 	/**
 	 * Appends {@link #staticColorsGrid} and {@link #documentColorsGrid} views.
 	 */

--- a/packages/ckeditor5-font/src/ui/colortableview.js
+++ b/packages/ckeditor5-font/src/ui/colortableview.js
@@ -235,6 +235,9 @@ export default class ColorTableView extends View {
 		this.keystrokes.listenTo( this.element );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 

--- a/packages/ckeditor5-font/tests/ui/colortableview.js
+++ b/packages/ckeditor5-font/tests/ui/colortableview.js
@@ -145,6 +145,24 @@ describe( 'ColorTableView', () => {
 		} );
 	} );
 
+	describe( 'destroy()', () => {
+		it( 'should destroy the FocusTracker instance', () => {
+			const destroySpy = sinon.spy( colorTableView.focusTracker, 'destroy' );
+
+			colorTableView.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+
+		it( 'should destroy the KeystrokeHandler instance', () => {
+			const destroySpy = sinon.spy( colorTableView.keystrokes, 'destroy' );
+
+			colorTableView.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+	} );
+
 	describe( 'focus tracker', () => {
 		it( 'should focus first child of colorTableView in DOM', () => {
 			const spy = sinon.spy( colorTableView._focusCycler, 'focusFirst' );

--- a/packages/ckeditor5-image/src/imageinsert/ui/imageinsertpanelview.js
+++ b/packages/ckeditor5-image/src/imageinsert/ui/imageinsertpanelview.js
@@ -203,6 +203,13 @@ export default class ImageInsertPanelView extends View {
 		}, { priority: 'high' } );
 	}
 
+	destroy() {
+		super.destroy();
+
+		this.focusTracker.destroy();
+		this.keystrokes.destroy();
+	}
+
 	/**
 	 * Returns a view of the integration.
 	 *

--- a/packages/ckeditor5-image/src/imageinsert/ui/imageinsertpanelview.js
+++ b/packages/ckeditor5-image/src/imageinsert/ui/imageinsertpanelview.js
@@ -203,6 +203,9 @@ export default class ImageInsertPanelView extends View {
 		}, { priority: 'high' } );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 

--- a/packages/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview.js
+++ b/packages/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview.js
@@ -151,6 +151,13 @@ export default class TextAlternativeFormView extends View {
 			} );
 	}
 
+	destroy() {
+		super.destroy();
+
+		this.focusTracker.destroy();
+		this.keystrokes.destroy();
+	}
+
 	/**
 	 * Creates the button view.
 	 *

--- a/packages/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview.js
+++ b/packages/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview.js
@@ -151,6 +151,9 @@ export default class TextAlternativeFormView extends View {
 			} );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 

--- a/packages/ckeditor5-image/tests/imageinsert/ui/imageinsertpanelview.js
+++ b/packages/ckeditor5-image/tests/imageinsert/ui/imageinsertpanelview.js
@@ -271,6 +271,24 @@ describe( 'ImageUploadPanelView', () => {
 		} );
 	} );
 
+	describe( 'destroy()', () => {
+		it( 'should destroy the FocusTracker instance', () => {
+			const destroySpy = sinon.spy( view.focusTracker, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+
+		it( 'should destroy the KeystrokeHandler instance', () => {
+			const destroySpy = sinon.spy( view.keystrokes, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+	} );
+
 	describe( 'focus()', () => {
 		it( 'should focus on the first integration', () => {
 			const spy = sinon.spy( view.getIntegration( 'insertImageViaUrl' ), 'focus' );

--- a/packages/ckeditor5-image/tests/imagetextalternative/ui/textalternativeformview.js
+++ b/packages/ckeditor5-image/tests/imagetextalternative/ui/textalternativeformview.js
@@ -150,6 +150,24 @@ describe( 'TextAlternativeFormView', () => {
 		} );
 	} );
 
+	describe( 'destroy()', () => {
+		it( 'should destroy the FocusTracker instance', () => {
+			const destroySpy = sinon.spy( view.focusTracker, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+
+		it( 'should destroy the KeystrokeHandler instance', () => {
+			const destroySpy = sinon.spy( view.keystrokes, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+	} );
+
 	describe( 'DOM bindings', () => {
 		describe( 'submit event', () => {
 			it( 'should trigger submit event', () => {

--- a/packages/ckeditor5-link/src/ui/linkactionsview.js
+++ b/packages/ckeditor5-link/src/ui/linkactionsview.js
@@ -155,6 +155,13 @@ export default class LinkActionsView extends View {
 		this.keystrokes.listenTo( this.element );
 	}
 
+	destroy() {
+		super.destroy();
+
+		this.focusTracker.destroy();
+		this.keystrokes.destroy();
+	}
+
 	/**
 	 * Focuses the fist {@link #_focusables} in the actions.
 	 */

--- a/packages/ckeditor5-link/src/ui/linkactionsview.js
+++ b/packages/ckeditor5-link/src/ui/linkactionsview.js
@@ -155,6 +155,9 @@ export default class LinkActionsView extends View {
 		this.keystrokes.listenTo( this.element );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 

--- a/packages/ckeditor5-link/src/ui/linkformview.js
+++ b/packages/ckeditor5-link/src/ui/linkformview.js
@@ -200,6 +200,13 @@ export default class LinkFormView extends View {
 		this.keystrokes.listenTo( this.element );
 	}
 
+	destroy() {
+		super.destroy();
+
+		this.focusTracker.destroy();
+		this.keystrokes.destroy();
+	}
+
 	/**
 	 * Focuses the fist {@link #_focusables} in the form.
 	 */

--- a/packages/ckeditor5-link/src/ui/linkformview.js
+++ b/packages/ckeditor5-link/src/ui/linkformview.js
@@ -200,6 +200,9 @@ export default class LinkFormView extends View {
 		this.keystrokes.listenTo( this.element );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 

--- a/packages/ckeditor5-link/tests/ui/linkactionsview.js
+++ b/packages/ckeditor5-link/tests/ui/linkactionsview.js
@@ -199,6 +199,24 @@ describe( 'LinkActionsView', () => {
 		} );
 	} );
 
+	describe( 'destroy()', () => {
+		it( 'should destroy the FocusTracker instance', () => {
+			const destroySpy = sinon.spy( view.focusTracker, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+
+		it( 'should destroy the KeystrokeHandler instance', () => {
+			const destroySpy = sinon.spy( view.keystrokes, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+	} );
+
 	describe( 'focus()', () => {
 		it( 'focuses the #previewButtonView', () => {
 			const spy = sinon.spy( view.previewButtonView, 'focus' );

--- a/packages/ckeditor5-link/tests/ui/linkformview.js
+++ b/packages/ckeditor5-link/tests/ui/linkformview.js
@@ -171,6 +171,24 @@ describe( 'LinkFormView', () => {
 		} );
 	} );
 
+	describe( 'destroy()', () => {
+		it( 'should destroy the FocusTracker instance', () => {
+			const destroySpy = sinon.spy( view.focusTracker, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+
+		it( 'should destroy the KeystrokeHandler instance', () => {
+			const destroySpy = sinon.spy( view.keystrokes, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+	} );
+
 	describe( 'DOM bindings', () => {
 		describe( 'submit event', () => {
 			it( 'should trigger submit event', () => {

--- a/packages/ckeditor5-media-embed/src/ui/mediaformview.js
+++ b/packages/ckeditor5-media-embed/src/ui/mediaformview.js
@@ -210,6 +210,9 @@ export default class MediaFormView extends View {
 		}, { priority: 'high' } );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 

--- a/packages/ckeditor5-media-embed/src/ui/mediaformview.js
+++ b/packages/ckeditor5-media-embed/src/ui/mediaformview.js
@@ -210,6 +210,13 @@ export default class MediaFormView extends View {
 		}, { priority: 'high' } );
 	}
 
+	destroy() {
+		super.destroy();
+
+		this.focusTracker.destroy();
+		this.keystrokes.destroy();
+	}
+
 	/**
 	 * Focuses the fist {@link #_focusables} in the form.
 	 */

--- a/packages/ckeditor5-media-embed/tests/ui/mediaformview.js
+++ b/packages/ckeditor5-media-embed/tests/ui/mediaformview.js
@@ -220,6 +220,24 @@ describe( 'MediaFormView', () => {
 		} );
 	} );
 
+	describe( 'destroy()', () => {
+		it( 'should destroy the FocusTracker instance', () => {
+			const destroySpy = sinon.spy( view.focusTracker, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+
+		it( 'should destroy the KeystrokeHandler instance', () => {
+			const destroySpy = sinon.spy( view.keystrokes, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+	} );
+
 	describe( 'DOM bindings', () => {
 		describe( 'submit event', () => {
 			it( 'should trigger submit event', () => {

--- a/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.js
+++ b/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.js
@@ -430,6 +430,9 @@ export default class TableCellPropertiesView extends View {
 		this.keystrokes.listenTo( this.element );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 

--- a/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.js
+++ b/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.js
@@ -430,6 +430,13 @@ export default class TableCellPropertiesView extends View {
 		this.keystrokes.listenTo( this.element );
 	}
 
+	destroy() {
+		super.destroy();
+
+		this.focusTracker.destroy();
+		this.keystrokes.destroy();
+	}
+
 	/**
 	 * Focuses the fist focusable field in the form.
 	 */

--- a/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.js
+++ b/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.js
@@ -379,6 +379,9 @@ export default class TablePropertiesView extends View {
 		this.keystrokes.listenTo( this.element );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 

--- a/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.js
+++ b/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.js
@@ -379,6 +379,13 @@ export default class TablePropertiesView extends View {
 		this.keystrokes.listenTo( this.element );
 	}
 
+	destroy() {
+		super.destroy();
+
+		this.focusTracker.destroy();
+		this.keystrokes.destroy();
+	}
+
 	/**
 	 * Focuses the fist focusable field in the form.
 	 */

--- a/packages/ckeditor5-table/tests/tablecellproperties/ui/tablecellpropertiesview.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/ui/tablecellpropertiesview.js
@@ -760,6 +760,24 @@ describe( 'table cell properties', () => {
 			} );
 		} );
 
+		describe( 'destroy()', () => {
+			it( 'should destroy the FocusTracker instance', () => {
+				const destroySpy = sinon.spy( view.focusTracker, 'destroy' );
+
+				view.destroy();
+
+				sinon.assert.calledOnce( destroySpy );
+			} );
+
+			it( 'should destroy the KeystrokeHandler instance', () => {
+				const destroySpy = sinon.spy( view.keystrokes, 'destroy' );
+
+				view.destroy();
+
+				sinon.assert.calledOnce( destroySpy );
+			} );
+		} );
+
 		describe( 'DOM bindings', () => {
 			describe( 'submit event', () => {
 				it( 'should trigger submit event', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/ui/tablepropertiesview.js
+++ b/packages/ckeditor5-table/tests/tableproperties/ui/tablepropertiesview.js
@@ -693,6 +693,24 @@ describe( 'table properties', () => {
 			} );
 		} );
 
+		describe( 'destroy()', () => {
+			it( 'should destroy the FocusTracker instance', () => {
+				const destroySpy = sinon.spy( view.focusTracker, 'destroy' );
+
+				view.destroy();
+
+				sinon.assert.calledOnce( destroySpy );
+			} );
+
+			it( 'should destroy the KeystrokeHandler instance', () => {
+				const destroySpy = sinon.spy( view.keystrokes, 'destroy' );
+
+				view.destroy();
+
+				sinon.assert.calledOnce( destroySpy );
+			} );
+		} );
+
 		describe( 'DOM bindings', () => {
 			describe( 'submit event', () => {
 				it( 'should trigger submit event', () => {

--- a/packages/ckeditor5-ui/src/colorgrid/colorgridview.js
+++ b/packages/ckeditor5-ui/src/colorgrid/colorgridview.js
@@ -176,6 +176,9 @@ export default class ColorGridView extends View {
 		this.keystrokes.listenTo( this.element );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 

--- a/packages/ckeditor5-ui/src/colorgrid/colorgridview.js
+++ b/packages/ckeditor5-ui/src/colorgrid/colorgridview.js
@@ -176,6 +176,13 @@ export default class ColorGridView extends View {
 		this.keystrokes.listenTo( this.element );
 	}
 
+	destroy() {
+		super.destroy();
+
+		this.focusTracker.destroy();
+		this.keystrokes.destroy();
+	}
+
 	/**
 	 * Fired when the `ColorTileView` for the picked item is executed.
 	 *

--- a/packages/ckeditor5-ui/src/dropdown/button/splitbuttonview.js
+++ b/packages/ckeditor5-ui/src/dropdown/button/splitbuttonview.js
@@ -155,6 +155,9 @@ export default class SplitButtonView extends View {
 		} );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 

--- a/packages/ckeditor5-ui/src/dropdown/button/splitbuttonview.js
+++ b/packages/ckeditor5-ui/src/dropdown/button/splitbuttonview.js
@@ -155,6 +155,13 @@ export default class SplitButtonView extends View {
 		} );
 	}
 
+	destroy() {
+		super.destroy();
+
+		this.focusTracker.destroy();
+		this.keystrokes.destroy();
+	}
+
 	/**
 	 * Focuses the {@link #actionView#element} of the action part of split button.
 	 */

--- a/packages/ckeditor5-ui/src/inputtext/inputtextview.js
+++ b/packages/ckeditor5-ui/src/inputtext/inputtextview.js
@@ -160,6 +160,9 @@ export default class InputTextView extends View {
 		} );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 

--- a/packages/ckeditor5-ui/src/inputtext/inputtextview.js
+++ b/packages/ckeditor5-ui/src/inputtext/inputtextview.js
@@ -160,6 +160,12 @@ export default class InputTextView extends View {
 		} );
 	}
 
+	destroy() {
+		super.destroy();
+
+		this.focusTracker.destroy();
+	}
+
 	/**
 	 * Moves the focus to the input and selects the value.
 	 */

--- a/packages/ckeditor5-ui/src/list/listview.js
+++ b/packages/ckeditor5-ui/src/list/listview.js
@@ -109,6 +109,9 @@ export default class ListView extends View {
 		this.keystrokes.listenTo( this.element );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 

--- a/packages/ckeditor5-ui/src/list/listview.js
+++ b/packages/ckeditor5-ui/src/list/listview.js
@@ -109,6 +109,13 @@ export default class ListView extends View {
 		this.keystrokes.listenTo( this.element );
 	}
 
+	destroy() {
+		super.destroy();
+
+		this.focusTracker.destroy();
+		this.keystrokes.destroy();
+	}
+
 	/**
 	 * Focuses the first focusable in {@link #items}.
 	 */

--- a/packages/ckeditor5-ui/src/panel/balloon/contextualballoon.js
+++ b/packages/ckeditor5-ui/src/panel/balloon/contextualballoon.js
@@ -628,6 +628,12 @@ class RotatorView extends View {
 		this.focusTracker.add( this.element );
 	}
 
+	destroy() {
+		super.destroy();
+
+		this.focusTracker.destroy();
+	}
+
 	/**
 	 * Shows a given view.
 	 *

--- a/packages/ckeditor5-ui/src/panel/balloon/contextualballoon.js
+++ b/packages/ckeditor5-ui/src/panel/balloon/contextualballoon.js
@@ -171,6 +171,17 @@ export default class ContextualBalloon extends Plugin {
 	}
 
 	/**
+	 * @inheritDoc
+	 */
+	destroy() {
+		super.destroy();
+
+		this.view.destroy();
+		this._rotatorView.destroy();
+		this._fakePanelsView.destroy();
+	}
+
+	/**
 	 * Returns `true` when the given view is in one of the stacks. Otherwise returns `false`.
 	 *
 	 * @param {module:ui/view~View} view
@@ -628,6 +639,9 @@ class RotatorView extends View {
 		this.focusTracker.add( this.element );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	destroy() {
 		super.destroy();
 

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.js
@@ -259,6 +259,8 @@ export default class ToolbarView extends View {
 	 */
 	destroy() {
 		this._behavior.destroy();
+		this.focusTracker.destroy();
+		this.keystrokes.destroy();
 
 		return super.destroy();
 	}

--- a/packages/ckeditor5-ui/tests/colorgrid/colorgridview.js
+++ b/packages/ckeditor5-ui/tests/colorgrid/colorgridview.js
@@ -141,6 +141,24 @@ describe( 'ColorGridView', () => {
 		} );
 	} );
 
+	describe( 'destroy()', () => {
+		it( 'should destroy the FocusTracker instance', () => {
+			const destroySpy = sinon.spy( view.focusTracker, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+
+		it( 'should destroy the KeystrokeHandler instance', () => {
+			const destroySpy = sinon.spy( view.keystrokes, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+	} );
+
 	describe( 'execute()', () => {
 		it( 'fires event for rendered tiles', () => {
 			const spy = sinon.spy();

--- a/packages/ckeditor5-ui/tests/dropdown/button/splitbuttonview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/button/splitbuttonview.js
@@ -153,6 +153,24 @@ describe( 'SplitButtonView', () => {
 		} );
 	} );
 
+	describe( 'destroy()', () => {
+		it( 'should destroy the FocusTracker instance', () => {
+			const destroySpy = sinon.spy( view.focusTracker, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+
+		it( 'should destroy the KeystrokeHandler instance', () => {
+			const destroySpy = sinon.spy( view.keystrokes, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+	} );
+
 	describe( 'bindings', () => {
 		it( 'delegates actionView#execute to view#execute', () => {
 			const spy = sinon.spy();

--- a/packages/ckeditor5-ui/tests/inputtext/inputtextview.js
+++ b/packages/ckeditor5-ui/tests/inputtext/inputtextview.js
@@ -208,6 +208,16 @@ describe( 'InputTextView', () => {
 		} );
 	} );
 
+	describe( 'destroy()', () => {
+		it( 'should destroy the FocusTracker instance', () => {
+			const destroySpy = sinon.spy( view.focusTracker, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+	} );
+
 	describe( 'select()', () => {
 		it( 'should select input value', () => {
 			const selectSpy = sinon.spy( view.element, 'select' );

--- a/packages/ckeditor5-ui/tests/list/listview.js
+++ b/packages/ckeditor5-ui/tests/list/listview.js
@@ -156,6 +156,24 @@ describe( 'ListView', () => {
 		} );
 	} );
 
+	describe( 'destroy()', () => {
+		it( 'should destroy the FocusTracker instance', () => {
+			const destroySpy = sinon.spy( view.focusTracker, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+
+		it( 'should destroy the KeystrokeHandler instance', () => {
+			const destroySpy = sinon.spy( view.keystrokes, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+	} );
+
 	describe( 'focus()', () => {
 		it( 'focuses the first focusable item in DOM', () => {
 			// No children to focus.

--- a/packages/ckeditor5-ui/tests/panel/balloon/contextualballoon.js
+++ b/packages/ckeditor5-ui/tests/panel/balloon/contextualballoon.js
@@ -775,6 +775,30 @@ describe( 'ContextualBalloon', () => {
 
 			expect( editor.ui.view.body.getIndex( balloon.view ) ).to.not.equal( -1 );
 		} );
+
+		it( 'should destroy the #view', () => {
+			const destroySpy = sinon.spy( balloon.view, 'destroy' );
+
+			balloon.destroy();
+
+			sinon.assert.called( destroySpy );
+		} );
+
+		it( 'should destroy the #_rotatorView', () => {
+			const destroySpy = sinon.spy( balloon._rotatorView, 'destroy' );
+
+			balloon.destroy();
+
+			sinon.assert.called( destroySpy );
+		} );
+
+		it( 'should destroy the #_fakePanelsView', () => {
+			const destroySpy = sinon.spy( balloon._rotatorView, 'destroy' );
+
+			balloon.destroy();
+
+			sinon.assert.called( destroySpy );
+		} );
 	} );
 
 	describe( 'rotator view', () => {
@@ -1081,6 +1105,16 @@ describe( 'ContextualBalloon', () => {
 					expect( rotatorView.buttonPrevView.labelView.element.textContent ).to.equal( 'Poprzedni' );
 					expect( rotatorView.buttonNextView.labelView.element.textContent ).to.equal( 'Następny' );
 				} );
+		} );
+
+		describe( 'destroy()', () => {
+			it( 'should destroy the FocusTracker instance', () => {
+				const destroySpy = sinon.spy( rotatorView.focusTracker, 'destroy' );
+
+				rotatorView.destroy();
+
+				sinon.assert.calledOnce( destroySpy );
+			} );
 		} );
 
 		describe( 'singleViewMode', () => {

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
@@ -430,6 +430,22 @@ describe( 'ToolbarView', () => {
 			view.destroy();
 			sinon.assert.calledOnce( view._behavior.destroy );
 		} );
+
+		it( 'should destroy the FocusTracker instance', () => {
+			const destroySpy = sinon.spy( view.focusTracker, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+
+		it( 'should destroy the KeystrokeHandler instance', () => {
+			const destroySpy = sinon.spy( view.keystrokes, 'destroy' );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
 	} );
 
 	describe( 'focus()', () => {

--- a/tests/manual/memory/memory-semi-automated.html
+++ b/tests/manual/memory/memory-semi-automated.html
@@ -1,0 +1,264 @@
+<head>
+	<meta http-equiv="Content-Security-Policy" content="script-src 'self' https://ckeditor.com 'unsafe-inline' 'unsafe-eval'">
+</head>
+
+<p>
+	<button id="start">Start the cycle of 10 init() followed by destroy()</button>
+</p>
+
+<div id="editor">
+	<h2>Lists in the table</h2>
+	<figure class="table">
+		<table style="width: 600px;border-bottom:2px dashed hsl(0, 0%, 60%);border-left:2px dashed hsl(0, 0%, 60%);border-right:2px dashed hsl(0, 0%, 60%);border-top:2px dashed hsl(0, 0%, 60%);">
+			<tbody>
+			<tr>
+				<td style="text-align: center"><span class="text-big" style="font-weight: bold">Bulleted list</span></td>
+				<td style="text-align: center"><span class="text-big" style="font-weight: bold">Numbered list</span></td>
+				<td style="text-align: center"><span class="text-big" style="font-weight: bold">To do list</span></td>
+			</tr>
+			<tr>
+				<td style="vertical-align:top; width: 33%">
+					<ul>
+						<li>UL List item 1</li>
+						<li>UL List item 2</li>
+					</ul>
+				</td>
+				<td style="vertical-align:top; width: 33%">
+					<ol>
+						<li>OL List item 1</li>
+						<li>OL List item 2</li>
+					</ol>
+				</td>
+				<td style="vertical-align:top; width: 33%">
+					<ul class="todo-list">
+						<li>
+							<label class="todo-list__label">
+								<input type="checkbox" />
+								<span class="todo-list__label__description">Foo</span>
+							</label>
+						</li>
+						<li>
+							<label class="todo-list__label">
+								<input type="checkbox" checked="checked" />
+								<span class="todo-list__label__description">Foo</span>
+							</label>
+						</li>
+					</ul>
+				</td>
+			</tr>
+			</tbody>
+		</table>
+	</figure>
+
+	<h2>Basic features overview</h2>
+	<p>Lorem <b>ipsum dolor sit </b>amet, consectetur <i>adipisicing elit</i>.<sub>1</sub></p>
+	<h3>Basic styles</h3>
+	<p>Ad alias, <s>architecto</s> culpa <b><i>cumque</i></b> dignissimos <code>dolor eos incidunt ipsa itaque</code> <u>laboriosam</u> magnam molestias nihil <i><u>numquam</u></i> odit quam, suscipit <i><s>veritatis</s></i> voluptate voluptatum.<sup>2</sup></p>
+	<h3>Image</h3>
+	<figure class="image">
+		<img alt="bar" src="../sample.jpg">
+		<figcaption>Caption</figcaption>
+	</figure>
+	<h3>Blockquote</h3>
+	<blockquote>
+		<p>Quote</p>
+		<ul>
+			<li><a href="#">Quoted</a> UL List item 1</li>
+			<li>Quoted UL List item 2</li>
+		</ul>
+		<p>Quote</p>
+	</blockquote>
+
+	<div class="page-break" style="page-break-after:always;"><span style="display:none;">&nbsp;</span></div>
+
+	<h2>Media with previews in the table</h2>
+	<figure class="table">
+		<table style="background-color:hsl(0,0%,90%);border-bottom:2px solid hsl(0, 0%, 0%);border-left:2px solid hsl(0, 0%, 0%);border-right:2px solid hsl(0, 0%, 0%);border-top:2px solid hsl(0, 0%, 0%);">
+			<tbody>
+			<tr>
+				<td style="text-align: center"><span class="text-big" style="font-weight: bold">Service</span></td>
+				<td style="text-align: center"><span class="text-big" style="font-weight: bold">Preview</span></td>
+				<td style="text-align: center"><span class="text-big" style="font-weight: bold">URL</span></td>
+			</tr>
+			<tr>
+				<td style="text-align: center"><u>YouTube</u></td>
+				<td>
+					<figure class="media">
+						<oembed url="https://www.youtube.com/watch?v=ZVv7UMQPEWk"></oembed>
+					</figure>
+				</td>
+				<td>
+					<span class="text-small"><a href="https://www.youtube.com/watch?v=ZVv7UMQPEWk">https://www.youtube.com/watch?v=ZVv7UMQPEWk</a></span>
+				</td>
+			</tr>
+			<tr>
+				<td style="text-align: center"><u>Vimeo</u></td>
+				<td>
+					<figure class="media">
+						<oembed url="https://vimeo.com/1084537"></oembed>
+					</figure>
+				</td>
+				<td>
+					<span class="text-small"><a href="https://vimeo.com/1084537">https://vimeo.com/1084537</a></span>
+				</td>
+			</tr>
+			</tbody>
+		</table>
+	</figure>
+
+	<h2>Code blocks in the table</h2>
+	<figure class="table">
+		<table style="border-bottom:2px dashed hsl(0, 0%, 60%);border-left:2px dashed hsl(0, 0%, 60%);border-right:2px dashed hsl(0, 0%, 60%);border-top:2px dashed hsl(0, 0%, 60%);">
+			<tbody>
+			<tr>
+				<td style="text-align: center"><span class="text-big" style="font-weight: bold">Language</span></td>
+				<td style="text-align: center"><span class="text-big" style="font-weight: bold">Code snippet</span></td>
+				<td style="text-align: center"><span class="text-big" style="font-weight: bold">Language</span></td>
+				<td style="text-align: center"><span class="text-big" style="font-weight: bold">Code snippet</span></td>
+			</tr>
+			<tr>
+				<td style="text-align: center;vertical-align:top">CSS</td>
+				<td style="vertical-align:top">
+					<pre><code class="language-css">body {
+	color: red;
+}
+
+p {
+	font-size: 10px;
+}</code></pre></td>
+				<td style="text-align: center;vertical-align:top">PHP</td>
+				<td style="vertical-align:top"><pre><code class="language-php">&lt;?php
+
+function dump( array ...$args ) {
+	foreach ( $args as $item ) {
+		var_dump( $item );
+	}
+
+	die;
+}</code></pre></td>
+			</tr>
+			<tr>
+				<td style="text-align: center;vertical-align:top">JavaScript</td>
+				<td style="vertical-align:top">
+					<pre><code class="language-javascript">function foo() {
+	console.log( 'indented using 1 tab' );
+}
+
+function bar() {
+    console.log( 'indented using spaces' );
+}</code></pre></td>
+				<td style="text-align: center;vertical-align:top">Plaintext</td>
+				<td style="vertical-align:top"><pre><code class="language-plaintext">Plain text</code></pre></td>
+			</tr>
+			</tbody>
+		</table>
+	</figure>
+
+	<hr>
+
+	<h2>Link images + Link decorators</h2>
+
+	<table>
+		<tr>
+			<td>Linked text</td>
+			<td>Linked image (<code>figure > a > img</code>)</td>
+			<td>Linked image (<code>a > img</code>)</td>
+		</tr>
+		<tr>
+			<td>
+				<p>
+					<a href="https://cksource.com" target="_blank" rel="noopener noreferrer" download="download">https://cksource.com</a>
+				</p>
+			</td>
+			<td>
+				<figure class="image">
+					<a class="gallery" href="https://cksource.com">
+						<img src="../sample.jpg" alt="bar">
+					</a>
+					<figcaption>Caption</figcaption>
+				</figure>
+			</td>
+			<td>
+				<a class="gallery" href="https://cksource.com" target="_blank" rel="noopener noreferrer" download="download">
+					<img src="../sample.jpg" alt="bar">
+				</a>
+			</td>
+		</tr>
+	</table>
+
+	<div class="page-break" style="page-break-after:always;"><span style="display:none;">&nbsp;</span></div>
+
+	<h2>HTML embed</h2>
+
+	<h3><code>&lt;details&gt;</code> and <code>&lt;summary&gt;</code> tags as HTML snippet</h3>
+	<div class="raw-html-embed">
+		<details open>
+			<summary>Details</summary>
+			Something small enough to escape casual notice.
+		</details>
+	</div>
+
+	<h3><code>&lt;video&gt;</code> tag as HTML snippet</h3>
+	<div class="raw-html-embed">
+		<video width="320" height="240" controls>
+			<source src="../sample.mp4" type="video/mp4">
+			Your browser does not support the video tag.
+		</video>
+	</div>
+
+	<h3><code>&lt;iframe&gt;</code> tag as HTML snippet</h3>
+	<div class="raw-html-embed">
+		<iframe src="../sample.txt"></iframe>
+	</div>
+
+	<h2>Paste from Office</h2>
+	<h3>Paste here: </h3>
+	<p></p>
+
+	<h2>Text part language</h2>
+	<p>
+		<span lang="es" dir="ltr">
+			<strong>Un lenguaje</strong> (del provenzal lenguatge y este del latín lingua) es un sistema de comunicación
+			estructurado para el que existe un contexto de uso y ciertos principios combinatorios formales. Existen
+			<strong>contextos</strong> tanto naturales como artificiales.
+		</span>
+	</p>
+	<p>
+		<span lang="ar" dir="rtl">
+			اللغة نسق من الإشارات والرموز، يشكل أداة من أدوات المعرفة، وتعتبر اللغة أهم <strong>وسائل</strong> التفاهم
+			والاحتكاك بين أفراد امجتمع في <strong>جميع</strong> ميادين الحياة. وبدون اللغة يتعذر نشاط الناس المعرفي.
+		</span>
+	</p>
+
+	<h2>HTML comments</h2>
+	<!-- C1 -->
+	<p><!-- C2 -->Paragraph<!-- C3 --></p>
+	<!-- C4 -->
+	<table>
+		<tr>
+			<td><!-- C5 -->Table cell #1<!-- C6 --></td>
+			<td>Table cell #2</td>
+			<td>Table cell #3</td>
+		</tr>
+	</table>
+	<ol>
+		<li><!-- C7 -->Item #1<!-- C8 --></li>
+		<li>Item #2</li>
+		<li>Item #3
+			<ul>
+				<li><!-- C9 -->Nested item #3.1<!-- C10 --></li>
+				<li>Nested item #3.2</li>
+				<li>Nested item #3.3</li>
+			</ul>
+		</li>
+	</ol>
+</div>
+
+<style>
+	.custom-class {
+		margin-top: 100px;
+		margin-left: 100px;
+		margin-bottom: 100px;
+		width: 450px;
+	}
+</style>

--- a/tests/manual/memory/memory-semi-automated.js
+++ b/tests/manual/memory/memory-semi-automated.js
@@ -1,0 +1,223 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console:false, document, window, setTimeout, gc */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import Alignment from '@ckeditor/ckeditor5-alignment/src/alignment';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import AutoImage from '@ckeditor/ckeditor5-image/src/autoimage';
+import AutoLink from '@ckeditor/ckeditor5-link/src/autolink';
+import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
+import CodeBlock from '@ckeditor/ckeditor5-code-block/src/codeblock';
+import EasyImage from '@ckeditor/ckeditor5-easy-image/src/easyimage';
+import FindAndReplace from '@ckeditor/ckeditor5-find-and-replace/src/findandreplace';
+import FontBackgroundColor from '@ckeditor/ckeditor5-font/src/fontbackgroundcolor';
+import FontColor from '@ckeditor/ckeditor5-font/src/fontcolor';
+import FontFamily from '@ckeditor/ckeditor5-font/src/fontfamily';
+import FontSize from '@ckeditor/ckeditor5-font/src/fontsize';
+import Highlight from '@ckeditor/ckeditor5-highlight/src/highlight';
+import HorizontalLine from '@ckeditor/ckeditor5-horizontal-line/src/horizontalline';
+import HtmlEmbed from '@ckeditor/ckeditor5-html-embed/src/htmlembed';
+import HtmlComment from '@ckeditor/ckeditor5-html-support/src/htmlcomment';
+import ImageResize from '@ckeditor/ckeditor5-image/src/imageresize';
+import IndentBlock from '@ckeditor/ckeditor5-indent/src/indentblock';
+import LinkImage from '@ckeditor/ckeditor5-link/src/linkimage';
+import ListStyle from '@ckeditor/ckeditor5-list/src/liststyle';
+import Mention from '@ckeditor/ckeditor5-mention/src/mention';
+import PageBreak from '@ckeditor/ckeditor5-page-break/src/pagebreak';
+import PasteFromOffice from '@ckeditor/ckeditor5-paste-from-office/src/pastefromoffice';
+import RemoveFormat from '@ckeditor/ckeditor5-remove-format/src/removeformat';
+import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
+import SpecialCharacters from '@ckeditor/ckeditor5-special-characters/src/specialcharacters';
+import SpecialCharactersEssentials from '@ckeditor/ckeditor5-special-characters/src/specialcharactersessentials';
+import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
+import Subscript from '@ckeditor/ckeditor5-basic-styles/src/subscript';
+import Superscript from '@ckeditor/ckeditor5-basic-styles/src/superscript';
+import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties';
+import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties';
+import TableCaption from '@ckeditor/ckeditor5-table/src/tablecaption';
+import TextTransformation from '@ckeditor/ckeditor5-typing/src/texttransformation';
+import TextPartLanguage from '@ckeditor/ckeditor5-language/src/textpartlanguage';
+import TodoList from '@ckeditor/ckeditor5-list/src/todolist';
+import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
+import WordCount from '@ckeditor/ckeditor5-word-count/src/wordcount';
+import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices';
+import ImageUpload from '@ckeditor/ckeditor5-image/src/imageupload';
+// import MathType from '@wiris/mathtype-ckeditor5';
+
+import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
+
+function initEditor() {
+	return ClassicEditor
+		.create( document.querySelector( '#editor' ), {
+			plugins: [
+				ArticlePluginSet, Underline, Strikethrough, Superscript, Subscript, Code, RemoveFormat,
+				FindAndReplace, FontColor, FontBackgroundColor, FontFamily, FontSize, Highlight,
+				CodeBlock, TodoList, ListStyle, TableProperties, TableCellProperties, TableCaption,
+				EasyImage, ImageResize, LinkImage, AutoImage, HtmlEmbed, HtmlComment,
+				AutoLink, Mention, TextTransformation,
+				Alignment, IndentBlock,
+				PasteFromOffice, PageBreak, HorizontalLine,
+				SpecialCharacters, SpecialCharactersEssentials, WordCount,
+				ImageUpload, CloudServices, TextPartLanguage, SourceEditing
+				// MathType
+			],
+			toolbar: [
+				// 'MathType', 'ChemType',
+				// '|',
+				'heading',
+				'|',
+				'removeFormat', 'bold', 'italic', 'strikethrough', 'underline', 'code', 'subscript', 'superscript', 'link',
+				'|',
+				'highlight', 'fontSize', 'fontFamily', 'fontColor', 'fontBackgroundColor',
+				'|',
+				'bulletedList', 'numberedList', 'todoList',
+				'|',
+				'blockQuote', 'uploadImage', 'insertTable', 'mediaEmbed', 'codeBlock',
+				'|',
+				'htmlEmbed',
+				'|',
+				'alignment', 'outdent', 'indent',
+				'|',
+				'pageBreak', 'horizontalLine', 'specialCharacters',
+				'|',
+				'textPartLanguage',
+				'|',
+				'sourceEditing',
+				'|',
+				'undo', 'redo', 'findAndReplace'
+			],
+			cloudServices: CS_CONFIG,
+			table: {
+				contentToolbar: [
+					'tableColumn', 'tableRow', 'mergeTableCells', 'tableProperties', 'tableCellProperties', 'toggleTableCaption'
+				]
+			},
+			image: {
+				styles: [
+					'alignCenter',
+					'alignLeft',
+					'alignRight'
+				],
+				resizeOptions: [
+					{
+						name: 'resizeImage:original',
+						label: 'Original size',
+						value: null
+					},
+					{
+						name: 'resizeImage:50',
+						label: '50%',
+						value: '50'
+					},
+					{
+						name: 'resizeImage:75',
+						label: '75%',
+						value: '75'
+					}
+				],
+				toolbar: [
+					'imageTextAlternative', 'toggleImageCaption', '|',
+					'imageStyle:inline', 'imageStyle:wrapText', 'imageStyle:breakText', 'imageStyle:side', '|',
+					'resizeImage'
+				],
+				insert: {
+					integrations: [
+						'insertImageViaUrl'
+					]
+				}
+			},
+			placeholder: 'Type the content here!',
+			mention: {
+				feeds: [
+					{
+						marker: '@',
+						feed: [
+							'@apple', '@bears', '@brownie', '@cake', '@cake', '@candy', '@canes', '@chocolate', '@cookie', '@cotton',
+							'@cream', '@cupcake', '@danish', '@donut', '@dragée', '@fruitcake', '@gingerbread', '@gummi', '@ice',
+							'@jelly-o', '@liquorice', '@macaroon', '@marzipan', '@oat', '@pie', '@plum', '@pudding', '@sesame', '@snaps',
+							'@soufflé', '@sugar', '@sweet', '@topping', '@wafer'
+						],
+						minimumCharacters: 1
+					}
+				]
+			},
+			link: {
+				decorators: {
+					isExternal: {
+						mode: 'manual',
+						label: 'Open in a new tab',
+						attributes: {
+							target: '_blank',
+							rel: 'noopener noreferrer'
+						}
+					},
+					isDownloadable: {
+						mode: 'manual',
+						label: 'Downloadable',
+						attributes: {
+							download: 'download'
+						}
+					},
+					isGallery: {
+						mode: 'manual',
+						label: 'Gallery link',
+						classes: 'gallery'
+					}
+				}
+			},
+			htmlEmbed: {
+				showPreviews: true,
+				sanitizeHtml: html => ( { html, hasChange: false } )
+			}
+		} )
+		.then( editor => {
+			window.memoryTestEditor = editor;
+
+			console.log( 'Editor was created.' );
+		} )
+		.catch( err => {
+			console.error( err.stack );
+		} );
+}
+
+function destroyEditor() {
+	return window.memoryTestEditor.destroy().then( () => {
+		window.memoryTestEditor = null;
+		console.log( 'Editor was destroyed.' );
+	} );
+}
+
+let i = 1;
+function runAnotherCycleOfInitsAndDestroys() {
+	if ( i > 10 ) {
+		i = 0;
+		return;
+	}
+
+	console.group( '#' + i );
+	console.log( 'Starting init/destroy cycle #' + i );
+
+	initEditor().then( () => {
+		setTimeout( () => {
+			destroyEditor().then( () => {
+				console.log( 'Forcing the garbage collector.' );
+
+				gc();
+				i++;
+
+				console.log( 'Finished the cycle.' );
+				console.groupEnd();
+
+				setTimeout( () => {
+					runAnotherCycleOfInitsAndDestroys();
+				}, 500 );
+			} );
+		}, 500 );
+	} );
+}
+
+document.getElementById( 'start' ).addEventListener( 'click', runAnotherCycleOfInitsAndDestroys );

--- a/tests/manual/memory/memory-semi-automated.md
+++ b/tests/manual/memory/memory-semi-automated.md
@@ -1,0 +1,26 @@
+## A semi-automated tests to analyze memory leaks
+
+**The list of features loaded by the editor in this test could be outdated. Make sure as many features as possible are loaded, the `all-features` test is the right place to copy from.**
+
+1. Open DevTools on Chrome.
+2. Go to Memory tab.
+3. Start the test by clicking the button (if you see the "gc is not defined" error, see Notes below).
+4. Take a snapshot (you don't need to GC manually).
+5. Run another cycle.
+6. Take another snapshot.
+7. Repeat the process a couple of times.
+8. Analyze the memory consumption by comparing the snapshots. It should not grow dramatically, that is more than ~.2MB per 10 initializations/destructions (1 cycle).
+
+## Notes:
+
+Browser extensions might attach event listeners to the DOM, so the safest way to run this test is by running Chrome in guest mode.
+
+This manual test also requires the browser to expose the `gc()` function.
+
+To prepare the browser, **close all Chrome windows first** (the whole app), then (on Mac):
+
+```
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --guest --js-flags="--expose-gc"
+```
+
+If you don't close all Chrome windows first, the `--expose-gc` flag will not work.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Made sure `KeystrokeHandler` and `FocusTracker` instances are destroyed across the UI in the project to avoid memory leaks. Closes #10749. Closes #6561.

Tests (ckeditor5): Added a semi-automated manual test to investigate memory leaks in the editor (see #10749).