### PR TITLE
It should be possible to unlink some text or inline image while GHS is enabled to allow all

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
@@ -872,15 +872,19 @@ function prepareToAttributeConverter( config, shallow ) {
 			return;
 		}
 
+		const matchToTestConsumable = {
+			...match.match
+		};
+
 		if ( onlyViewNameIsDefined( config.view, data.viewItem ) ) {
-			match.match.name = true;
+			matchToTestConsumable.name = true;
 		} else {
 			// Do not test or consume `name` consumable.
-			delete match.match.name;
+			delete matchToTestConsumable.name;
 		}
 
 		// Try to consume appropriate values from consumable values list.
-		if ( !conversionApi.consumable.test( data.viewItem, match.match ) ) {
+		if ( !conversionApi.consumable.test( data.viewItem, matchToTestConsumable ) ) {
 			return;
 		}
 

--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.js
@@ -944,6 +944,13 @@ function prepareToAttributeConsumingConverter( config ) {
 			return;
 		}
 
+		// We need to convert children if some higher priority converter did not convert them.
+		// After the element got consumed the default handler for converting children will not trigger.
+		if ( !data.modelRange ) {
+			// Convert children and set conversion result as a current data.
+			Object.assign( data, conversionApi.convertChildren( data.viewItem, data.modelCursor ) );
+		}
+
 		// Consume the element itself for element-to-attribute conversion so it won't get converted by any other converter
 		// since this element's whole purpose was to provide some attributes (for example <a href=""> or <span style="font-size: ...">).
 		conversionApi.consumable.consume( data.viewItem, { name: true } );

--- a/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
@@ -368,14 +368,29 @@ describe( 'UpcastHelpers', () => {
 					return;
 				}
 
-				for ( const node of data.modelRange.getItems() ) {
-					conversionApi.writer.setAttribute( 'htmlA', 'true', node );
-				}
+				conversionApi.writer.setAttribute( 'htmlA', 'true', data.modelRange );
 			}, { priority: priorities.get( 'low' ) - 1 } );
 
 			expectResult(
 				new ViewAttributeElement( viewDocument, 'a', { href: 'foo' }, new ViewText( viewDocument, 'foo' ) ),
 				'<$text attribA="true">foo</$text>'
+			);
+		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/10800
+		it( 'should convert children even if some custom converter consumed attributes without triggering children conversion', () => {
+			upcastHelpers.elementToAttribute( {
+				model: 'attribA',
+				view: { name: 'a', attributes: 'href' }
+			} );
+
+			upcastDispatcher.on( 'element:a', ( evt, data, conversionApi ) => {
+				conversionApi.consumable.consume( data.viewItem, { attributes: [ 'href' ] } );
+			}, { priority: 'high' } );
+
+			expectResult(
+				new ViewAttributeElement( viewDocument, 'a', { href: 'foo' }, new ViewText( viewDocument, 'foo' ) ),
+				'foo'
 			);
 		} );
 

--- a/packages/ckeditor5-html-support/src/converters.js
+++ b/packages/ckeditor5-html-support/src/converters.js
@@ -89,6 +89,11 @@ export function viewToAttributeInlineConverter( { view: viewName, model: attribu
 		dispatcher.on( `element:${ viewName }`, ( evt, data, conversionApi ) => {
 			const viewAttributes = dataFilter._consumeAllowedAttributes( data.viewItem, conversionApi );
 
+			// Do not convert element itself if it was already consumed and does not have any not consumed attributes.
+			if ( !viewAttributes && !conversionApi.consumable.consume( data.viewItem, { name: true } ) ) {
+				return;
+			}
+
 			// Since we are converting to attribute we need a range on which we will set the attribute.
 			// If the range is not created yet, we will create it.
 			if ( !data.modelRange ) {

--- a/packages/ckeditor5-html-support/src/converters.js
+++ b/packages/ckeditor5-html-support/src/converters.js
@@ -9,6 +9,7 @@
 
 import { toWidget } from 'ckeditor5/src/widget';
 import { setViewAttributes, mergeViewElementAttributes } from './conversionutils';
+import { priorities } from 'ckeditor5/src/utils';
 
 /**
  * View-to-model conversion helper for object elements.
@@ -111,7 +112,11 @@ export function viewToAttributeInlineConverter( { view: viewName, model: attribu
 					conversionApi.writer.setAttribute( attributeKey, attributesToAdd, node );
 				}
 			}
-		}, { priority: 'low' } );
+		}, {
+			// With the low - 10 priority to execute after the element-to-attribute converters and their fallback converters
+			// for consuming the element itself so after consuming <a href="..."> both an attribute and the element should be consumed.
+			priority: priorities.get( 'low' ) - 10
+		} );
 	};
 }
 

--- a/packages/ckeditor5-html-support/tests/datafilter.js
+++ b/packages/ckeditor5-html-support/tests/datafilter.js
@@ -1200,13 +1200,11 @@ describe( 'DataFilter', () => {
 
 		// Font feature should take over color CSS property.
 		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
-			data: '<paragraph><$text fontColor="blue" htmlSpan="(1)">foobar</$text></paragraph>',
-			attributes: {
-				1: {}
-			}
+			data: '<paragraph><$text fontColor="blue">foobar</$text></paragraph>',
+			attributes: {}
 		} );
 
-		expect( editor.getData() ).to.equal( '<p><span style="color:blue;"><span>foobar</span></span></p>' );
+		expect( editor.getData() ).to.equal( '<p><span style="color:blue;">foobar</span></p>' );
 	} );
 
 	describe( 'existing features', () => {

--- a/packages/ckeditor5-html-support/tests/integrations/image.js
+++ b/packages/ckeditor5-html-support/tests/integrations/image.js
@@ -1332,10 +1332,8 @@ describe( 'ImageElementSupport', () => {
 			);
 
 			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
-				data: '<paragraph><imageInline htmlA="(1)" linkHref="www.example.com" src="/assets/sample.png"></imageInline></paragraph>',
-				attributes: {
-					1: {}
-				}
+				data: '<paragraph><imageInline linkHref="www.example.com" src="/assets/sample.png"></imageInline></paragraph>',
+				attributes: {}
 			} );
 
 			expect( editor.getData() ).to.equal(
@@ -1359,10 +1357,8 @@ describe( 'ImageElementSupport', () => {
 			);
 
 			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
-				data: '<paragraph><imageInline htmlA="(1)" linkHref="www.example.com" src="/assets/sample.png"></imageInline></paragraph>',
-				attributes: {
-					1: {}
-				}
+				data: '<paragraph><imageInline linkHref="www.example.com" src="/assets/sample.png"></imageInline></paragraph>',
+				attributes: {}
 			} );
 
 			expect( editor.getData() ).to.equal(
@@ -1390,10 +1386,8 @@ describe( 'ImageElementSupport', () => {
 			);
 
 			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
-				data: '<paragraph><imageInline htmlA="(1)" linkHref="www.example.com" src="/assets/sample.png"></imageInline></paragraph>',
-				attributes: {
-					1: {}
-				}
+				data: '<paragraph><imageInline linkHref="www.example.com" src="/assets/sample.png"></imageInline></paragraph>',
+				attributes: {}
 			} );
 
 			expect( editor.getData() ).to.equal(

--- a/packages/ckeditor5-html-support/tests/manual/features.js
+++ b/packages/ckeditor5-html-support/tests/manual/features.js
@@ -33,6 +33,7 @@ import TodoList from '@ckeditor/ckeditor5-list/src/todolist';
 import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
 import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices';
 import ImageUpload from '@ckeditor/ckeditor5-image/src/imageupload';
+import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
 
 import GeneralHtmlSupport from '../../src/generalhtmlsupport';
 
@@ -46,9 +47,11 @@ ClassicEditor
 			Alignment, IndentBlock,
 			PageBreak, HorizontalLine,
 			ImageUpload, CloudServices,
-			GeneralHtmlSupport
+			GeneralHtmlSupport, SourceEditing
 		],
 		toolbar: [
+			'sourceEditing',
+			'|',
 			'heading',
 			'|',
 			'bold', 'italic', 'strikethrough', 'underline', 'code', 'subscript', 'superscript', 'link',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (html-support): It should be possible to unlink some text or inline images while GHS is enabled to allow all. Closes #10800.

Other (engine): The `elementToAttribute` upcast helper should consume the element itself if its purpose was consumed. For example `<a href="...">` should consume `<a>` element after the `href` attribute was consumed. See #10800.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._