### PR TITLE
Docs: add information about missing Watchdog integration in Vue docs

### DIFF
--- a/docs/builds/guides/frameworks/vuejs-v2.md
+++ b/docs/builds/guides/frameworks/vuejs-v2.md
@@ -24,6 +24,10 @@ The easiest way to use CKEditor 5 in your Vue.js application is by choosing one 
 
 Additionally, you can [integrate CKEditor 5 from source](#using-ckeditor-from-source) which is a much more flexible and powerful solution, but requires some additional configuration.
 
+<info-box>
+	The {@link features/watchdog watchdog feature}, which is available for {@link builds/guides/frameworks/react React} and {@link builds/guides/frameworks/angular Angular} integrations, is not supported in Vue yet.
+</info-box>
+
 ## Quick start
 
 Install the [CKEditor 5 WYSIWYG editor component for Vue.js](https://www.npmjs.com/package/@ckeditor/ckeditor5-vue2) and the {@link builds/guides/overview#available-builds editor build of your choice}.

--- a/docs/builds/guides/frameworks/vuejs-v3.md
+++ b/docs/builds/guides/frameworks/vuejs-v3.md
@@ -24,6 +24,10 @@ The easiest way to use CKEditor 5 in your Vue.js application is by choosing one 
 
 Additionally, you can [integrate CKEditor 5 from source](#using-ckeditor-from-source) which is a much more flexible and powerful solution, but requires some additional configuration.
 
+<info-box>
+	The {@link features/watchdog watchdog feature}, which is available for {@link builds/guides/frameworks/react React} and {@link builds/guides/frameworks/angular Angular} integrations, is not supported in Vue yet.
+</info-box>
+
 ## Quick start
 
 Install the [CKEditor 5 WYSIWYG editor component for Vue.js](https://www.npmjs.com/package/@ckeditor/ckeditor5-vue) and the {@link builds/guides/overview#available-builds editor build of your choice}.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: added information about missing Watchdog integration in Vue docs. Closes #10754.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._