### PR TITLE
Prefixed unsafe attributes in the editing pipeline

### DIFF
--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -395,7 +395,7 @@ export default class DomConverter {
 
 				// Copy element's attributes.
 				for ( const key of viewNode.getAttributeKeys() ) {
-					this.setDomElementAttribute( domElement, key, viewNode.getAttribute( key ) );
+					this.setDomElementAttribute( domElement, key, viewNode.getAttribute( key ), viewNode );
 				}
 			}
 
@@ -412,11 +412,11 @@ export default class DomConverter {
 	/**
 	 * TODO
 	 */
-	setDomElementAttribute( domElement, key, value ) {
+	setDomElementAttribute( domElement, key, value, relatedViewElement = null ) {
 		this.removeDomElementAttribute( domElement, key );
 
-		const viewNode = this._domToViewMapping.get( domElement );
-		const shouldRenderAttribute = this.shouldRenderAttribute( key, value ) || viewNode && viewNode.shouldRenderUnsafeAttribute( key );
+		const shouldRenderAttribute = this.shouldRenderAttribute( key, value ) ||
+			relatedViewElement && relatedViewElement.shouldRenderUnsafeAttribute( key );
 
 		// If the attribute should not be rendered, rename it (instead of removing) to give developers some idea of what
 		// is going on (https://github.com/ckeditor/ckeditor5/issues/10801).
@@ -429,12 +429,9 @@ export default class DomConverter {
 	 * TODO
 	 */
 	removeDomElementAttribute( domElement, key ) {
-		if ( this._shouldRenameElement( domElement.tagName ) && key == UNSAFE_ELEMENT_REPLACEMENT_ATTRIBUTE ) {
+		if ( key == UNSAFE_ELEMENT_REPLACEMENT_ATTRIBUTE ) {
 			return;
 		}
-
-		// If the attribute should not be rendered, rename it (instead of removing) to give developers some idea of what
-		// is going on (https://github.com/ckeditor/ckeditor5/issues/10801).
 
 		domElement.removeAttribute( key );
 		domElement.removeAttribute( UNSAFE_ATTRIBUTE_NAME_PREFIX + key );

--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -410,7 +410,16 @@ export default class DomConverter {
 	}
 
 	/**
-	 * TODO
+	 * Sets the attribute on a DOM element.
+	 *
+	 * **Note**: To remove the attribute, use {@link #removeDomElementAttribute}.
+	 *
+	 * @param {HTMLElement} domElement The DOM element the attribute should be set on.
+	 * @param {String} key The name of the attribute
+	 * @param {String} value The value of the attribute
+	 * @param {module:engine/view/element~Element} [relatedViewElement] The view element related to the `domElement` (if there is any).
+	 * It helps decide whether the attribute set is unsafe. For instance, view elements created via
+	 * {@link module:engine/view/downcastwriter~DowncastWriter} methods can allow certain attributes that would normally be filtered out.
 	 */
 	setDomElementAttribute( domElement, key, value, relatedViewElement = null ) {
 		this.removeDomElementAttribute( domElement, key );
@@ -420,20 +429,26 @@ export default class DomConverter {
 
 		// If the attribute should not be rendered, rename it (instead of removing) to give developers some idea of what
 		// is going on (https://github.com/ckeditor/ckeditor5/issues/10801).
-		const attributeName = shouldRenderAttribute ? key : UNSAFE_ATTRIBUTE_NAME_PREFIX + key;
-
-		domElement.setAttribute( attributeName, value );
+		domElement.setAttribute( shouldRenderAttribute ? key : UNSAFE_ATTRIBUTE_NAME_PREFIX + key, value );
 	}
 
 	/**
-	 * TODO
+	 * Removes an attribute from a DOM element.
+	 *
+	 * **Note**: To set the attribute, use {@link #setDomElementAttribute}.
+	 *
+	 * @param {HTMLElement} domElement The DOM element the attribute should be removed from.
+	 * @param {String} key The name of the attribute.
 	 */
 	removeDomElementAttribute( domElement, key ) {
+		// See #_createReplacementDomElement() to learn what this is.
 		if ( key == UNSAFE_ELEMENT_REPLACEMENT_ATTRIBUTE ) {
 			return;
 		}
 
 		domElement.removeAttribute( key );
+
+		// See setDomElementAttribute() to learn what this is.
 		domElement.removeAttribute( UNSAFE_ATTRIBUTE_NAME_PREFIX + key );
 	}
 

--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -1500,7 +1500,7 @@ export default class DomConverter {
 		const newDomElement = document.createElement( 'span' );
 
 		// Mark the span replacing a script as hidden.
-		newDomElement.setAttribute( 'data-ck-hidden', elementName );
+		newDomElement.setAttribute( 'data-ck-unsafe-element', elementName );
 
 		if ( originalDomElement ) {
 			while ( originalDomElement.firstChild ) {

--- a/packages/ckeditor5-engine/src/view/renderer.js
+++ b/packages/ckeditor5-engine/src/view/renderer.js
@@ -555,7 +555,7 @@ export default class Renderer {
 
 		// Add or overwrite attributes.
 		for ( const key of viewAttrKeys ) {
-			this.domConverter.setDomElementAttribute( domElement, key, viewElement.getAttribute( key ) );
+			this.domConverter.setDomElementAttribute( domElement, key, viewElement.getAttribute( key ), viewElement );
 		}
 
 		// Remove from DOM attributes which do not exists in the view.

--- a/packages/ckeditor5-engine/src/view/renderer.js
+++ b/packages/ckeditor5-engine/src/view/renderer.js
@@ -12,7 +12,6 @@
 import ViewText from './text';
 import ViewPosition from './position';
 import { INLINE_FILLER, INLINE_FILLER_LENGTH, startsWithFiller, isInlineFiller } from './filler';
-import { UNSAFE_ATTRIBUTE_NAME_PREFIX, UNSAFE_ELEMENT_ATTRIBUTE_REPLACEMENT } from './domconverter';
 
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import diff from '@ckeditor/ckeditor5-utils/src/diff';
@@ -556,28 +555,14 @@ export default class Renderer {
 
 		// Add or overwrite attributes.
 		for ( const key of viewAttrKeys ) {
-			const value = viewElement.getAttribute( key );
-
-			if ( this.domConverter.shouldRenderAttribute( key, value ) || viewElement.shouldRenderUnsafeAttribute( key ) ) {
-				domElement.setAttribute( key, value );
-			} else {
-				// If the attribute should not be rendered, rename it (instead of removing) to give developers some idea of what
-				// is going on (https://github.com/ckeditor/ckeditor5/issues/10801).
-				domElement.removeAttribute( key );
-				domElement.setAttribute( UNSAFE_ATTRIBUTE_NAME_PREFIX + key, value );
-			}
+			this.domConverter.setDomElementAttribute( domElement, key, viewElement.getAttribute( key ) );
 		}
 
 		// Remove from DOM attributes which do not exists in the view.
 		for ( const key of domAttrKeys ) {
-			// Do not remove attributes on `script` elements with special data attributes `data-ck-unsafe-element`.
-			if ( viewElement.name === 'script' && key === UNSAFE_ELEMENT_ATTRIBUTE_REPLACEMENT ) {
-				continue;
-			}
-
 			// All other attributes not present in the DOM should be removed.
 			if ( !viewElement.hasAttribute( key ) ) {
-				domElement.removeAttribute( key );
+				this.domConverter.removeDomElementAttribute( domElement, key );
 			}
 		}
 	}

--- a/packages/ckeditor5-engine/src/view/renderer.js
+++ b/packages/ckeditor5-engine/src/view/renderer.js
@@ -566,8 +566,8 @@ export default class Renderer {
 
 		// Remove from DOM attributes which do not exists in the view.
 		for ( const key of domAttrKeys ) {
-			// Do not remove attributes on `script` elements with special data attributes `data-ck-hidden`.
-			if ( viewElement.name === 'script' && key === 'data-ck-hidden' ) {
+			// Do not remove attributes on `script` elements with special data attributes `data-ck-unsafe-element`.
+			if ( viewElement.name === 'script' && key === 'data-ck-unsafe-element' ) {
 				continue;
 			}
 

--- a/packages/ckeditor5-engine/src/view/renderer.js
+++ b/packages/ckeditor5-engine/src/view/renderer.js
@@ -12,6 +12,7 @@
 import ViewText from './text';
 import ViewPosition from './position';
 import { INLINE_FILLER, INLINE_FILLER_LENGTH, startsWithFiller, isInlineFiller } from './filler';
+import { UNSAFE_ATTRIBUTE_NAME_PREFIX, UNSAFE_ELEMENT_ATTRIBUTE_REPLACEMENT } from './domconverter';
 
 import mix from '@ckeditor/ckeditor5-utils/src/mix';
 import diff from '@ckeditor/ckeditor5-utils/src/diff';
@@ -560,14 +561,17 @@ export default class Renderer {
 			if ( this.domConverter.shouldRenderAttribute( key, value ) || viewElement.shouldRenderUnsafeAttribute( key ) ) {
 				domElement.setAttribute( key, value );
 			} else {
+				// If the attribute should not be rendered, rename it (instead of removing) to give developers some idea of what
+				// is going on (https://github.com/ckeditor/ckeditor5/issues/10801).
 				domElement.removeAttribute( key );
+				domElement.setAttribute( UNSAFE_ATTRIBUTE_NAME_PREFIX + key, value );
 			}
 		}
 
 		// Remove from DOM attributes which do not exists in the view.
 		for ( const key of domAttrKeys ) {
 			// Do not remove attributes on `script` elements with special data attributes `data-ck-unsafe-element`.
-			if ( viewElement.name === 'script' && key === 'data-ck-unsafe-element' ) {
+			if ( viewElement.name === 'script' && key === UNSAFE_ELEMENT_ATTRIBUTE_REPLACEMENT ) {
 				continue;
 			}
 

--- a/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
@@ -593,8 +593,11 @@ describe( 'DomConverter', () => {
 							'</div>',
 						expected: '<div data-foo="bar">' +
 							'foo' +
-							'<span class="foo-class" style="border:1px solid blue" data-foo="bar">' +
-							'bar' +
+							'<span ' +
+								'class="foo-class" ' +
+								'style="border:1px solid blue" ' +
+								'data-foo="bar" ' +
+								'data-ck-unsafe-attribute-onclick="foobar">bar' +
 							'</span>' +
 							'</div>'
 					},
@@ -607,8 +610,11 @@ describe( 'DomConverter', () => {
 							'</div>',
 						expected: '<div data-foo="bar">' +
 							'foo' +
-							'<span class="foo-class" style="border:1px solid blue" data-foo="bar">' +
-							'bar' +
+							'<span ' +
+								'class="foo-class" ' +
+								'style="border:1px solid blue" ' +
+								'data-foo="bar" ' +
+								'data-ck-unsafe-attribute-value="javascript:baz">bar' +
 							'</span>' +
 							'</div>'
 					},
@@ -621,8 +627,11 @@ describe( 'DomConverter', () => {
 							'</div>',
 						expected: '<div data-foo="bar">' +
 							'foo' +
-							'<span class="foo-class" style="border:1px solid blue" data-foo="bar">' +
-							'bar' +
+							'<span ' +
+								'class="foo-class" ' +
+								'style="border:1px solid blue" ' +
+								'data-foo="bar" ' +
+								'data-ck-unsafe-attribute-value="data:application/html">bar' +
 							'</span>' +
 							'</div>'
 					},
@@ -635,8 +644,11 @@ describe( 'DomConverter', () => {
 							'</div>',
 						expected: '<div data-foo="bar">' +
 							'foo' +
-							'<span class="foo-class" style="border:1px solid blue" data-foo="bar">' +
-							'bar' +
+							'<span ' +
+								'class="foo-class" ' +
+								'style="border:1px solid blue" ' +
+								'data-foo="bar" ' +
+								'data-ck-unsafe-attribute-value="<script>baz</script>">bar' +
 							'</span>' +
 							'</div>'
 					}

--- a/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
@@ -656,7 +656,7 @@ describe( 'DomConverter', () => {
 				converter.setContentOf( element, html );
 
 				expect( element.innerHTML ).to.equal(
-					'<div>foo<span data-ck-hidden="script" class="foo-class" style="foo-style" data-foo="bar">bar</span></div>'
+					'<div>foo<span data-ck-unsafe-element="script" class="foo-class" style="foo-style" data-foo="bar">bar</span></div>'
 				);
 			} );
 		} );

--- a/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
@@ -238,7 +238,8 @@ describe( 'DomConverter', () => {
 
 				expect( domP ).to.be.an.instanceof( HTMLElement );
 				expect( domP.tagName ).to.equal( 'P' );
-				expect( domP.attributes.length ).to.equal( 0 );
+				expect( domP.attributes.length ).to.equal( 1 );
+				expect( domP.dataset.ckUnsafeAttributeOnclick ).to.equal( 'bar' );
 
 				expect( domP.childNodes.length ).to.equal( 2 );
 				expect( domP.childNodes[ 0 ].tagName ).to.equal( 'IMG' );
@@ -292,7 +293,9 @@ describe( 'DomConverter', () => {
 						onkeydown: 'bar'
 					}, { renderUnsafeAttributes: [ 'onclick' ] } );
 
-					expect( converter.viewToDom( viewElement, document ).outerHTML ).to.equal( '<span onclick="foo"></span>' );
+					expect( converter.viewToDom( viewElement, document ).outerHTML ).to.equal(
+						'<span onclick="foo" data-ck-unsafe-attribute-onkeydown="bar"></span>'
+					);
 				} );
 
 				it( 'should not be rejected when set on container elements', () => {
@@ -303,7 +306,9 @@ describe( 'DomConverter', () => {
 
 					viewElement.getFillerOffset = () => null;
 
-					expect( converter.viewToDom( viewElement, document ).outerHTML ).to.equal( '<p onclick="foo"></p>' );
+					expect( converter.viewToDom( viewElement, document ).outerHTML ).to.equal(
+						'<p onclick="foo" data-ck-unsafe-attribute-onkeydown="bar"></p>'
+					);
 				} );
 
 				it( 'should not be rejected when set on editable elements', () => {
@@ -314,7 +319,9 @@ describe( 'DomConverter', () => {
 
 					viewElement.getFillerOffset = () => null;
 
-					expect( converter.viewToDom( viewElement, document ).outerHTML ).to.equal( '<div onclick="foo"></div>' );
+					expect( converter.viewToDom( viewElement, document ).outerHTML ).to.equal(
+						'<div onclick="foo" data-ck-unsafe-attribute-onkeydown="bar"></div>'
+					);
 				} );
 
 				it( 'should not be rejected when set on empty elements', () => {
@@ -323,7 +330,9 @@ describe( 'DomConverter', () => {
 						onkeydown: 'bar'
 					}, { renderUnsafeAttributes: [ 'onclick' ] } );
 
-					expect( converter.viewToDom( viewElement, document ).outerHTML ).to.equal( '<img onclick="foo">' );
+					expect( converter.viewToDom( viewElement, document ).outerHTML ).to.equal(
+						'<img onclick="foo" data-ck-unsafe-attribute-onkeydown="bar">'
+					);
 				} );
 
 				it( 'should not be rejected when set on raw elements', () => {
@@ -336,7 +345,9 @@ describe( 'DomConverter', () => {
 						renderUnsafeAttributes: [ 'onclick' ]
 					} );
 
-					expect( converter.viewToDom( viewElement, document ).outerHTML ).to.equal( '<p onclick="foo">foo</p>' );
+					expect( converter.viewToDom( viewElement, document ).outerHTML ).to.equal(
+						'<p onclick="foo" data-ck-unsafe-attribute-onkeydown="bar">foo</p>'
+					);
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
@@ -270,7 +270,7 @@ describe( 'DomConverter', () => {
 
 				expect( domP.childNodes.length ).to.equal( 2 );
 				expect( domP.childNodes[ 0 ].tagName ).to.equal( 'SPAN' );
-				expect( domP.childNodes[ 0 ].getAttribute( 'data-ck-hidden' ) ).to.equal( 'script' );
+				expect( domP.childNodes[ 0 ].getAttribute( 'data-ck-unsafe-element' ) ).to.equal( 'script' );
 				expect( domP.childNodes[ 1 ].data ).to.equal( 'foo' );
 			} );
 

--- a/packages/ckeditor5-engine/tests/view/renderer.js
+++ b/packages/ckeditor5-engine/tests/view/renderer.js
@@ -4013,7 +4013,7 @@ describe( 'Renderer', () => {
 
 				expect( window.spy.calledOnce ).to.be.false;
 				expect( getViewData( view ) ).to.equal( '<script>spy()</script>' );
-				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<span data-ck-hidden="script">spy()</span>' );
+				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<span data-ck-unsafe-element="script">spy()</span>' );
 
 				delete window.spy;
 			} );
@@ -4086,28 +4086,29 @@ describe( 'Renderer', () => {
 
 				expect( getViewData( view ) ).to.equal( '<script>bar</script>' );
 				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal(
-					'<span data-ck-hidden="script">bar</span>'
+					'<span data-ck-unsafe-element="script">bar</span>'
 				);
 			} );
 
-			it( 'should remove attributes not present in the DOM if the view node is not script, but has data-ck-hidden attribute', () => {
-				setViewData( view,
-					'<container:p data-ck-hidden="foo">' +
-						'bar' +
-					'</container:p>'
-				);
+			it( 'should remove attributes not present in the DOM if the view node is not script, but has data-ck-unsafe-element attribute',
+				() => {
+					setViewData( view,
+						'<container:p data-ck-unsafe-element="foo">' +
+							'bar' +
+						'</container:p>'
+					);
 
-				view.forceRender();
+					view.forceRender();
 
-				view.change( writer => {
-					writer.removeAttribute( 'data-ck-hidden', viewRoot.getChild( 0 ) );
+					view.change( writer => {
+						writer.removeAttribute( 'data-ck-unsafe-element', viewRoot.getChild( 0 ) );
+					} );
+
+					view.forceRender();
+
+					expect( getViewData( view ) ).to.equal( '<p>bar</p>' );
+					expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<p>bar</p>' );
 				} );
-
-				view.forceRender();
-
-				expect( getViewData( view ) ).to.equal( '<p>bar</p>' );
-				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<p>bar</p>' );
-			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-engine/tests/view/renderer.js
+++ b/packages/ckeditor5-engine/tests/view/renderer.js
@@ -4091,26 +4091,6 @@ describe( 'Renderer', () => {
 					'<span data-ck-unsafe-element="script">bar</span>'
 				);
 			} );
-
-			it( 'should remove attributes not present in the DOM if the view node is not script, but has data-ck-unsafe-element attribute',
-				() => {
-					setViewData( view,
-						'<container:p data-ck-unsafe-element="foo">' +
-							'bar' +
-						'</container:p>'
-					);
-
-					view.forceRender();
-
-					view.change( writer => {
-						writer.removeAttribute( 'data-ck-unsafe-element', viewRoot.getChild( 0 ) );
-					} );
-
-					view.forceRender();
-
-					expect( getViewData( view ) ).to.equal( '<p>bar</p>' );
-					expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<p>bar</p>' );
-				} );
 		} );
 	} );
 

--- a/packages/ckeditor5-engine/tests/view/renderer.js
+++ b/packages/ckeditor5-engine/tests/view/renderer.js
@@ -4018,7 +4018,7 @@ describe( 'Renderer', () => {
 				delete window.spy;
 			} );
 
-			it( 'should remove attributes that can affect editing pipeline', () => {
+			it( 'should rename attributes that can affect editing pipeline', () => {
 				setViewData( view,
 					'<container:p onclick="test">' +
 						'foo' +
@@ -4028,10 +4028,10 @@ describe( 'Renderer', () => {
 				view.forceRender();
 
 				expect( getViewData( view ) ).to.equal( '<p onclick="test">foo</p>' );
-				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<p>foo</p>' );
+				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<p data-ck-unsafe-attribute-onclick="test">foo</p>' );
 			} );
 
-			it( 'should remove attributes that can affect editing pipeline unless permitted when the element was created', () => {
+			it( 'should rename attributes that can affect editing pipeline unless permitted when the element was created', () => {
 				view.change( writer => {
 					const containerElement = writer.createContainerElement( 'p', {
 						onclick: 'foo',
@@ -4047,10 +4047,12 @@ describe( 'Renderer', () => {
 				view.forceRender();
 
 				expect( getViewData( view ) ).to.equal( '<p onclick="foo" onkeydown="bar">baz</p>' );
-				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<p onclick="foo">baz</p>' );
+				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal(
+					'<p data-ck-unsafe-attribute-onkeydown="bar" onclick="foo">baz</p>'
+				);
 			} );
 
-			it( 'should remove attributes from the View that can are not present in the DOM', () => {
+			it( 'should rename attributes that can not be rendered in the editing pipeline', () => {
 				setViewData( view,
 					'<container:p>' +
 						'bar' +
@@ -4066,7 +4068,7 @@ describe( 'Renderer', () => {
 				view.forceRender();
 
 				expect( getViewData( view ) ).to.equal( '<p onclick="foo">bar</p>' );
-				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<p>bar</p>' );
+				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( '<p data-ck-unsafe-attribute-onclick="foo">bar</p>' );
 			} );
 
 			it( 'should remove attributes not present in the DOM if the view node is just a script element', () => {

--- a/packages/ckeditor5-engine/theme/renderer.css
+++ b/packages/ckeditor5-engine/theme/renderer.css
@@ -4,6 +4,6 @@
  */
 
 /* Elements marked by the Renderer as hidden should be invisible in the editor. */
-.ck.ck-editor__editable span[data-ck-hidden] {
+.ck.ck-editor__editable span[data-ck-unsafe-element] {
 	display: none;
 }

--- a/packages/ckeditor5-html-support/tests/datafilter.js
+++ b/packages/ckeditor5-html-support/tests/datafilter.js
@@ -198,7 +198,7 @@ describe( 'DataFilter', () => {
 				'<p>' +
 					'<span class="ck-widget html-object-embed" contenteditable="false" data-html-object-embed-label="HTML object">' +
 						'<video class="html-object-embed__content">' +
-							'<source src="https://example.com/video.mp4" type="video/mp4">' +
+							'<source src="https://example.com/video.mp4" type="video/mp4" data-ck-unsafe-attribute-onclick="action()">' +
 							'Your browser does not support the video tag.' +
 						'</video>' +
 					'</span>' +

--- a/packages/ckeditor5-media-embed/tests/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedediting.js
@@ -1072,7 +1072,7 @@ describe( 'MediaEmbedEditing', () => {
 					} ) ).to.equal(
 						'<figure class="ck-widget media" contenteditable="false">' +
 							'<div class="ck-media__wrapper" data-oembed-url="https://foo.com">' +
-								'<div>foo</div>' +
+								'<div data-ck-unsafe-attribute-onclick="action()">foo</div>' +
 							'</div>' +
 						'</figure>'
 					);


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (engine): Unsafe attributes should be prefixed with `data-ck-unsafe-attribute-` in the editing pipeline instead of being removed. Closes #10801.

---

### Additional information

I wanted to write a few words in some guide for anyone who debugs their integration, noticed their attribute got removed, and decided to google it but I don't know where would it make the most sense.