### PR TITLE
Manual link decorators of block images should not break decorators for links on the inline images

### DIFF
--- a/packages/ckeditor5-image/src/image/imageinlineediting.js
+++ b/packages/ckeditor5-image/src/image/imageinlineediting.js
@@ -64,6 +64,7 @@ export default class ImageInlineEditing extends Plugin {
 			isObject: true,
 			isInline: true,
 			allowWhere: '$text',
+			allowAttributesOf: '$text',
 			allowAttributes: [ 'alt', 'src', 'srcset' ]
 		} );
 

--- a/packages/ckeditor5-image/tests/image/insertimagecommand.js
+++ b/packages/ckeditor5-image/tests/image/insertimagecommand.js
@@ -254,10 +254,6 @@ describe( 'InsertImageCommand', () => {
 		it( 'should set document selection attributes on an image to maintain their continuity in downcast (e.g. links)', () => {
 			editor.model.schema.extend( '$text', { allowAttributes: [ 'foo', 'bar', 'baz' ] } );
 
-			editor.model.schema.extend( 'imageInline', {
-				allowAttributes: [ 'foo', 'bar' ]
-			} );
-
 			const imgSrc = 'foo/bar.jpg';
 
 			setModelData( model, '<paragraph><$text bar="b" baz="c" foo="a">f[o]o</$text></paragraph>' );
@@ -267,7 +263,7 @@ describe( 'InsertImageCommand', () => {
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
 					'<$text bar="b" baz="c" foo="a">f</$text>' +
-					'[<imageInline bar="b" foo="a" src="foo/bar.jpg"></imageInline>]' +
+					'[<imageInline bar="b" baz="c" foo="a" src="foo/bar.jpg"></imageInline>]' +
 					'<$text bar="b" baz="c" foo="a">o</$text>' +
 				'</paragraph>'
 			);

--- a/packages/ckeditor5-image/tests/imageupload/uploadimagecommand.js
+++ b/packages/ckeditor5-image/tests/imageupload/uploadimagecommand.js
@@ -223,10 +223,6 @@ describe( 'UploadImageCommand', () => {
 		it( 'should set document selection attributes on an image to maintain attribute continuity in downcast (e.g. links)', () => {
 			editor.model.schema.extend( '$text', { allowAttributes: [ 'foo', 'bar', 'baz' ] } );
 
-			editor.model.schema.extend( 'imageInline', {
-				allowAttributes: [ 'foo', 'bar' ]
-			} );
-
 			const file = createNativeFileMock();
 			setModelData( model, '<paragraph><$text bar="b" baz="c" foo="a">f[o]o</$text></paragraph>' );
 
@@ -237,7 +233,7 @@ describe( 'UploadImageCommand', () => {
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
 					'<$text bar="b" baz="c" foo="a">f</$text>' +
-					`[<imageInline bar="b" foo="a" uploadId="${ id }"></imageInline>]` +
+					`[<imageInline bar="b" baz="c" foo="a" uploadId="${ id }"></imageInline>]` +
 					'<$text bar="b" baz="c" foo="a">o</$text>' +
 				'</paragraph>'
 			);
@@ -245,10 +241,6 @@ describe( 'UploadImageCommand', () => {
 
 		it( 'should set document selection attributes on multiple images to maintain attribute continuity in downcast (e.g. links)', () => {
 			editor.model.schema.extend( '$text', { allowAttributes: [ 'foo', 'bar', 'baz' ] } );
-
-			editor.model.schema.extend( 'imageInline', {
-				allowAttributes: [ 'foo', 'bar' ]
-			} );
 
 			const file = [ createNativeFileMock(), createNativeFileMock(), createNativeFileMock() ];
 			setModelData( model, '<paragraph><$text bar="b" baz="c" foo="a">f[o]o</$text></paragraph>' );
@@ -262,9 +254,9 @@ describe( 'UploadImageCommand', () => {
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
 					'<$text bar="b" baz="c" foo="a">f</$text>' +
-					`<imageInline bar="b" foo="a" uploadId="${ idA }"></imageInline>` +
-					`<imageInline bar="b" foo="a" uploadId="${ idB }"></imageInline>` +
-					`[<imageInline bar="b" foo="a" uploadId="${ idC }"></imageInline>]` +
+					`<imageInline bar="b" baz="c" foo="a" uploadId="${ idA }"></imageInline>` +
+					`<imageInline bar="b" baz="c" foo="a" uploadId="${ idB }"></imageInline>` +
+					`[<imageInline bar="b" baz="c" foo="a" uploadId="${ idC }"></imageInline>]` +
 					'<$text bar="b" baz="c" foo="a">o</$text>' +
 				'</paragraph>'
 			);

--- a/packages/ckeditor5-link/src/linkimageediting.js
+++ b/packages/ckeditor5-link/src/linkimageediting.js
@@ -45,7 +45,7 @@ export default class LinkImageEditing extends Plugin {
 		}
 
 		if ( editor.plugins.has( 'ImageInlineEditing' ) ) {
-			schema.extend( 'imageInline', { allowAttributes: [ 'linkHref' ] } );
+			schema.extend( 'imageInline', { allowAttributesOf: '$text' } );
 		}
 
 		editor.conversion.for( 'upcast' ).add( upcastLink( editor ) );
@@ -256,6 +256,7 @@ function downcastImageLinkManualDecorator( decorator ) {
 // @private
 // @returns {Function}
 function upcastImageLinkManualDecorator( editor, decorator ) {
+	const isImageInlinePluginLoaded = editor.plugins.has( 'ImageInlineEditing' );
 	const imageUtils = editor.plugins.get( 'ImageUtils' );
 
 	return dispatcher => {
@@ -266,6 +267,12 @@ function upcastImageLinkManualDecorator( editor, decorator ) {
 			// We need to check whether an image is inside a link because the converter handles
 			// only manual decorators for linked images. See #7975.
 			if ( !imageInLink ) {
+				return;
+			}
+
+			const blockImageView = imageInLink.findAncestor( element => imageUtils.isBlockImageView( element ) );
+
+			if ( isImageInlinePluginLoaded && !blockImageView ) {
 				return;
 			}
 

--- a/packages/ckeditor5-link/src/linkimageediting.js
+++ b/packages/ckeditor5-link/src/linkimageediting.js
@@ -44,10 +44,6 @@ export default class LinkImageEditing extends Plugin {
 			schema.extend( 'imageBlock', { allowAttributes: [ 'linkHref' ] } );
 		}
 
-		if ( editor.plugins.has( 'ImageInlineEditing' ) ) {
-			schema.extend( 'imageInline', { allowAttributesOf: '$text' } );
-		}
-
 		editor.conversion.for( 'upcast' ).add( upcastLink( editor ) );
 		editor.conversion.for( 'downcast' ).add( downcastImageLink( editor ) );
 

--- a/packages/ckeditor5-link/tests/linkimageediting.js
+++ b/packages/ckeditor5-link/tests/linkimageediting.js
@@ -976,6 +976,44 @@ describe( 'LinkImageEditing', () => {
 					'</paragraph>'
 				);
 			} );
+
+			it( 'should properly upcast manual decorators for linked inline images', async () => {
+				const newEditor = await VirtualTestEditor.create( {
+					plugins: [ Paragraph, ImageBlockEditing, ImageInlineEditing, LinkImageEditing ],
+					link: {
+						decorators: {
+							isGallery: {
+								mode: 'manual',
+								classes: 'gallery'
+							}
+						}
+					}
+				} );
+
+				newEditor.setData(
+					'<p>' +
+						'foo ' +
+						'<a class="gallery" href="https://cksource.com">' +
+							'abc ' +
+							'<img src="sample.jpg" alt="bar">' +
+							' 123' +
+						'</a>' +
+						' bar' +
+					'</p>'
+				);
+
+				expect( getModelData( newEditor.model, { withoutSelection: true } ) ).to.equal(
+					'<paragraph>' +
+						'foo ' +
+						'<$text linkHref="https://cksource.com" linkIsGallery="true">abc </$text>' +
+						'<imageInline alt="bar" linkHref="https://cksource.com" linkIsGallery="true" src="sample.jpg"></imageInline>' +
+						'<$text linkHref="https://cksource.com" linkIsGallery="true"> 123</$text>' +
+						' bar' +
+					'</paragraph>'
+				);
+
+				await newEditor.destroy();
+			} );
 		} );
 
 		describe( 'downcast converter', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (link, image): Manual decorators on the linked inline images should be preserved while loading editor content. Closes #10828.