### PR TITLE
Ck/10811 list package restructuring

### DIFF
--- a/docs/builds/guides/migration/migration-to-26.md
+++ b/docs/builds/guides/migration/migration-to-26.md
@@ -216,7 +216,7 @@ Command name changes (before → after):
 * `forwardDelete` → `deleteForward`
 * `todoListCheck` → `checkTodoList`
 
-The `TodoListCheckCommand` module was moved to {@link module:list/checktodolistcommand~CheckTodoListCommand `CheckTodoListCommand`}.
+The `TodoListCheckCommand` module was moved to {@link module:list/todolist/checktodolistcommand~CheckTodoListCommand `CheckTodoListCommand`}.
 
 The `ImageInsertCommand` module was moved to {@link module:image/image/insertimagecommand~InsertImageCommand `InsertImageCommand`}.
 

--- a/packages/ckeditor5-alignment/tests/alignmentediting.js
+++ b/packages/ckeditor5-alignment/tests/alignmentediting.js
@@ -6,7 +6,7 @@
 import AlignmentEditing from '../src/alignmentediting';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import ImageCaptionEditing from '@ckeditor/ckeditor5-image/src/imagecaption/imagecaptionediting';
-import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
+import ListEditing from '@ckeditor/ckeditor5-list/src/list/listediting';
 import HeadingEditing from '@ckeditor/ckeditor5-heading/src/headingediting';
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';

--- a/packages/ckeditor5-autoformat/tests/autoformat.js
+++ b/packages/ckeditor5-autoformat/tests/autoformat.js
@@ -6,8 +6,8 @@
 import Autoformat from '../src/autoformat';
 
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
-import TodoListEditing from '@ckeditor/ckeditor5-list/src/todolistediting';
+import ListEditing from '@ckeditor/ckeditor5-list/src/list/listediting';
+import TodoListEditing from '@ckeditor/ckeditor5-list/src/todolist/todolistediting';
 import HeadingEditing from '@ckeditor/ckeditor5-heading/src/headingediting';
 import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
 import StrikethroughEditing from '@ckeditor/ckeditor5-basic-styles/src/strikethrough/strikethroughediting';

--- a/packages/ckeditor5-autoformat/tests/undointegration.js
+++ b/packages/ckeditor5-autoformat/tests/undointegration.js
@@ -6,7 +6,7 @@
 import Autoformat from '../src/autoformat';
 
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
+import ListEditing from '@ckeditor/ckeditor5-list/src/list/listediting';
 import HeadingEditing from '@ckeditor/ckeditor5-heading/src/headingediting';
 import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
 import CodeEditing from '@ckeditor/ckeditor5-basic-styles/src/code/codeediting';

--- a/packages/ckeditor5-block-quote/tests/blockquoteediting.js
+++ b/packages/ckeditor5-block-quote/tests/blockquoteediting.js
@@ -5,7 +5,7 @@
 
 import BlockQuoteEditing from '../src/blockquoteediting';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
+import ListEditing from '@ckeditor/ckeditor5-list/src/list/listediting';
 import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';

--- a/packages/ckeditor5-engine/tests/model/operation/transform/utils.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/utils.js
@@ -5,7 +5,7 @@
 
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
 
-import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
+import ListEditing from '@ckeditor/ckeditor5-list/src/list/listediting';
 import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';

--- a/packages/ckeditor5-html-support/tests/htmlcomment-integration.js
+++ b/packages/ckeditor5-html-support/tests/htmlcomment-integration.js
@@ -29,9 +29,9 @@ import IndentEditing from '@ckeditor/ckeditor5-indent/src/indentediting';
 import LinkEditing from '@ckeditor/ckeditor5-link/src/linkediting';
 import LinkImageEditing from '@ckeditor/ckeditor5-link/src/linkimageediting';
 
-import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
-import ListStyleEditing from '@ckeditor/ckeditor5-list/src/liststyleediting';
-import TodoListEditing from '@ckeditor/ckeditor5-list/src/todolistediting';
+import ListEditing from '@ckeditor/ckeditor5-list/src/list/listediting';
+import ListStyleEditing from '@ckeditor/ckeditor5-list/src/liststyle/liststyleediting';
+import TodoListEditing from '@ckeditor/ckeditor5-list/src/todolist/todolistediting';
 
 import MediaEmbedEditing from '@ckeditor/ckeditor5-media-embed/src/mediaembedediting';
 

--- a/packages/ckeditor5-image/tests/image/imageinlineediting.js
+++ b/packages/ckeditor5-image/tests/image/imageinlineediting.js
@@ -11,7 +11,7 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import DataTransfer from '@ckeditor/ckeditor5-clipboard/src/datatransfer';
 import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import LinkImage from '@ckeditor/ckeditor5-link/src/linkimage';
-import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
+import ListEditing from '@ckeditor/ckeditor5-list/src/list/listediting';
 
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import normalizeHtml from '@ckeditor/ckeditor5-utils/tests/_utils/normalizehtml';

--- a/packages/ckeditor5-indent/src/indent.js
+++ b/packages/ckeditor5-indent/src/indent.js
@@ -19,7 +19,7 @@ import IndentUI from './indentui';
  *
  * The compatible features are:
  *
- * * The {@link module:list/list~List} or {@link module:list/listediting~ListEditing} feature for list indentation.
+ * * The {@link module:list/list~List} or {@link module:list/list/listediting~ListEditing} feature for list indentation.
  * * The {@link module:indent/indentblock~IndentBlock} feature for block indentation.
  *
  * This is a "glue" plugin that loads the following plugins:

--- a/packages/ckeditor5-list/docs/features/lists.md
+++ b/packages/ckeditor5-list/docs/features/lists.md
@@ -79,7 +79,7 @@ ClassicEditor
 </info-box>
 
 <info-box warning>
-	The {@link module:list/liststyle~ListStyle} feature overrides UI button implementations from the {@link module:list/listui~ListUI}.
+	The {@link module:list/liststyle~ListStyle} feature overrides UI button implementations from the {@link module:list/list/listui~ListUI}.
 </info-box>
 
 ## List indentation
@@ -90,16 +90,16 @@ Refer to the {@link features/indent Indenting lists} section of the Block indent
 
 The {@link module:list/list~List} plugin registers:
 
-* The {@link module:list/listcommand~ListCommand `'numberedList'`} command.
-* The {@link module:list/listcommand~ListCommand `'bulletedList'`} command.
-* The {@link module:list/indentcommand~IndentCommand `'indentList'`} command.
-* The {@link module:list/indentcommand~IndentCommand `'outdentList'`} command.
+* The {@link module:list/list/listcommand~ListCommand `'numberedList'`} command.
+* The {@link module:list/list/listcommand~ListCommand `'bulletedList'`} command.
+* The {@link module:list/list/indentcommand~IndentCommand `'indentList'`} command.
+* The {@link module:list/list/indentcommand~IndentCommand `'outdentList'`} command.
 * The `'numberedList'` UI button.
 * The `'bulletedList'` UI button.
 
 The {@link module:list/liststyle~ListStyle} plugin registers:
 
-* The {@link module:list/liststylecommand~ListStyleCommand `'listStyle'`} command that accepts a `type` of the list style to set.
+* The {@link module:list/liststyle/liststylecommand~ListStyleCommand `'listStyle'`} command that accepts a `type` of the list style to set.
     ```js
     editor.execute( 'listStyle', { type: 'decimal' } );
     ```

--- a/packages/ckeditor5-list/src/index.js
+++ b/packages/ckeditor5-list/src/index.js
@@ -8,11 +8,11 @@
  */
 
 export { default as List } from './list';
-export { default as ListEditing } from './listediting';
-export { default as ListUI } from './listui';
+export { default as ListEditing } from './list/listediting';
+export { default as ListUI } from './list/listui';
 export { default as ListStyle } from './liststyle';
-export { default as ListStyleEditing } from './liststyleediting';
-export { default as ListStyleUI } from './liststyleui';
+export { default as ListStyleEditing } from './liststyle/liststyleediting';
+export { default as ListStyleUI } from './liststyle/liststyleui';
 export { default as TodoList } from './todolist';
-export { default as TodoListEditing } from './todolistediting';
-export { default as TodoListUI } from './todolistui';
+export { default as TodoListEditing } from './todolist/todolistediting';
+export { default as TodoListUI } from './todolist/todolistui';

--- a/packages/ckeditor5-list/src/list.js
+++ b/packages/ckeditor5-list/src/list.js
@@ -7,16 +7,16 @@
  * @module list/list
  */
 
-import ListEditing from './listediting';
-import ListUI from './listui';
+import ListEditing from './list/listediting';
+import ListUI from './list/listui';
 
 import { Plugin } from 'ckeditor5/src/core';
 
 /**
  * The list feature.
  *
- * This is a "glue" plugin that loads the {@link module:list/listediting~ListEditing list editing feature}
- * and {@link module:list/listui~ListUI list UI feature}.
+ * This is a "glue" plugin that loads the {@link module:list/list/listediting~ListEditing list editing feature}
+ * and {@link module:list/list/listui~ListUI list UI feature}.
  *
  * @extends module:core/plugin~Plugin
  */

--- a/packages/ckeditor5-list/src/list/converters.js
+++ b/packages/ckeditor5-list/src/list/converters.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module list/converters
+ * @module list/list/converters
  */
 
 import { TreeWalker } from 'ckeditor5/src/engine';
@@ -97,11 +97,11 @@ export function modelViewRemove( model ) {
  * A model-to-view converter for the `type` attribute change on the `listItem` model element.
  *
  * This change means that the `<li>` element parent changes from `<ul>` to `<ol>` (or vice versa). This is accomplished
- * by breaking view elements and changing their name. The next {@link module:list/converters~modelViewMergeAfterChangeType}
+ * by breaking view elements and changing their name. The next {@link module:list/list/converters~modelViewMergeAfterChangeType}
  * converter will attempt to merge split nodes.
  *
  * Splitting this conversion into 2 steps makes it possible to add an additional conversion in the middle.
- * Check {@link module:list/todolistconverters~modelViewChangeType} to see an example of it.
+ * Check {@link module:list/todolist/todolistconverters~modelViewChangeType} to see an example of it.
  *
  * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:attribute
  * @param {module:utils/eventinfo~EventInfo} evt An object containing information about the fired event.
@@ -130,7 +130,7 @@ export function modelViewChangeType( evt, data, conversionApi ) {
 }
 
 /**
- * A model-to-view converter that attempts to merge nodes split by {@link module:list/converters~modelViewChangeType}.
+ * A model-to-view converter that attempts to merge nodes split by {@link module:list/list/converters~modelViewChangeType}.
  *
  * @see module:engine/conversion/downcastdispatcher~DowncastDispatcher#event:attribute
  * @param {module:utils/eventinfo~EventInfo} evt An object containing information about the fired event.

--- a/packages/ckeditor5-list/src/list/indentcommand.js
+++ b/packages/ckeditor5-list/src/list/indentcommand.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module list/indentcommand
+ * @module list/list/indentcommand
  */
 
 import { Command } from 'ckeditor5/src/core';

--- a/packages/ckeditor5-list/src/list/listcommand.js
+++ b/packages/ckeditor5-list/src/list/listcommand.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module list/listcommand
+ * @module list/list/listcommand
  */
 
 import { Command } from 'ckeditor5/src/core';

--- a/packages/ckeditor5-list/src/list/listediting.js
+++ b/packages/ckeditor5-list/src/list/listediting.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module list/listediting
+ * @module list/list/listediting
  */
 
 import ListCommand from './listcommand';

--- a/packages/ckeditor5-list/src/list/listui.js
+++ b/packages/ckeditor5-list/src/list/listui.js
@@ -4,13 +4,13 @@
  */
 
 /**
- * @module list/listui
+ * @module list/list/listui
  */
 
 import { createUIComponent } from './utils';
 
-import numberedListIcon from '../theme/icons/numberedlist.svg';
-import bulletedListIcon from '../theme/icons/bulletedlist.svg';
+import numberedListIcon from '../../theme/icons/numberedlist.svg';
+import bulletedListIcon from '../../theme/icons/bulletedlist.svg';
 
 import { Plugin } from 'ckeditor5/src/core';
 

--- a/packages/ckeditor5-list/src/list/utils.js
+++ b/packages/ckeditor5-list/src/list/utils.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module list/utils
+ * @module list/list/utils
  */
 
 import { TreeWalker, getFillerOffset } from 'ckeditor5/src/engine';

--- a/packages/ckeditor5-list/src/liststyle.js
+++ b/packages/ckeditor5-list/src/liststyle.js
@@ -8,14 +8,14 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core';
-import ListStyleEditing from './liststyleediting';
-import ListStyleUI from './liststyleui';
+import ListStyleEditing from './liststyle/liststyleediting';
+import ListStyleUI from './liststyle/liststyleui';
 
 /**
  * The list style feature.
  *
- * This is a "glue" plugin that loads the {@link module:list/liststyleediting~ListStyleEditing list style editing feature}
- * and the {@link module:list/liststyleui~ListStyleUI list style UI feature}.
+ * This is a "glue" plugin that loads the {@link module:list/liststyle/liststyleediting~ListStyleEditing list style editing feature}
+ * and the {@link module:list/liststyle/liststyleui~ListStyleUI list style UI feature}.
  *
  * @extends module:core/plugin~Plugin
  */

--- a/packages/ckeditor5-list/src/liststyle/liststylecommand.js
+++ b/packages/ckeditor5-list/src/liststyle/liststylecommand.js
@@ -4,11 +4,11 @@
  */
 
 /**
- * @module list/liststylecommand
+ * @module list/liststyle/liststylecommand
  */
 
 import { Command } from 'ckeditor5/src/core';
-import { getSiblingNodes } from './utils';
+import { getSiblingNodes } from '../list/utils';
 
 /**
  * The list style command. It is used by the {@link module:list/liststyle~ListStyle list style feature}.

--- a/packages/ckeditor5-list/src/liststyle/liststyleediting.js
+++ b/packages/ckeditor5-list/src/liststyle/liststyleediting.js
@@ -4,13 +4,13 @@
  */
 
 /**
- * @module list/liststyleediting
+ * @module list/liststyle/liststyleediting
  */
 
 import { Plugin } from 'ckeditor5/src/core';
-import ListEditing from './listediting';
+import ListEditing from '../list/listediting';
 import ListStyleCommand from './liststylecommand';
-import { getSiblingListItem, getSiblingNodes } from './utils';
+import { getSiblingListItem, getSiblingNodes } from '../list/utils';
 
 const DEFAULT_LIST_TYPE = 'default';
 

--- a/packages/ckeditor5-list/src/liststyle/liststyleui.js
+++ b/packages/ckeditor5-list/src/liststyle/liststyleui.js
@@ -4,32 +4,32 @@
  */
 
 /**
- * @module list/liststyleui
+ * @module list/liststyle/liststyleui
  */
 
 import { Plugin } from 'ckeditor5/src/core';
 import { ButtonView, SplitButtonView, createDropdown, addToolbarToDropdown } from 'ckeditor5/src/ui';
 
-import bulletedListIcon from '../theme/icons/bulletedlist.svg';
-import numberedListIcon from '../theme/icons/numberedlist.svg';
+import bulletedListIcon from '../../theme/icons/bulletedlist.svg';
+import numberedListIcon from '../../theme/icons/numberedlist.svg';
 
-import listStyleDiscIcon from '../theme/icons/liststyledisc.svg';
-import listStyleCircleIcon from '../theme/icons/liststylecircle.svg';
-import listStyleSquareIcon from '../theme/icons/liststylesquare.svg';
-import listStyleDecimalIcon from '../theme/icons/liststyledecimal.svg';
-import listStyleDecimalWithLeadingZeroIcon from '../theme/icons/liststyledecimalleadingzero.svg';
-import listStyleLowerRomanIcon from '../theme/icons/liststylelowerroman.svg';
-import listStyleUpperRomanIcon from '../theme/icons/liststyleupperroman.svg';
-import listStyleLowerLatinIcon from '../theme/icons/liststylelowerlatin.svg';
-import listStyleUpperLatinIcon from '../theme/icons/liststyleupperlatin.svg';
+import listStyleDiscIcon from '../../theme/icons/liststyledisc.svg';
+import listStyleCircleIcon from '../../theme/icons/liststylecircle.svg';
+import listStyleSquareIcon from '../../theme/icons/liststylesquare.svg';
+import listStyleDecimalIcon from '../../theme/icons/liststyledecimal.svg';
+import listStyleDecimalWithLeadingZeroIcon from '../../theme/icons/liststyledecimalleadingzero.svg';
+import listStyleLowerRomanIcon from '../../theme/icons/liststylelowerroman.svg';
+import listStyleUpperRomanIcon from '../../theme/icons/liststyleupperroman.svg';
+import listStyleLowerLatinIcon from '../../theme/icons/liststylelowerlatin.svg';
+import listStyleUpperLatinIcon from '../../theme/icons/liststyleupperlatin.svg';
 
-import '../theme/liststyles.css';
+import '../../theme/liststyles.css';
 
 /**
  * The list style UI plugin. It introduces the extended `'bulletedList'` and `'numberedList'` toolbar
  * buttons that allow users to change styles of individual lists in the content.
  *
- * **Note**: Buttons introduced by this plugin override implementations from the {@link module:list/listui~ListUI}
+ * **Note**: Buttons introduced by this plugin override implementations from the {@link module:list/list/listui~ListUI}
  * (because they share the same names).
  *
  * @extends module:core/plugin~Plugin
@@ -174,7 +174,7 @@ function getSplitButtonCreator( { editor, parentCommandName, buttonLabel, button
 //
 // @param {Object} options
 // @param {module:core/editor/editor~Editor} options.editor
-// @param {module:list/liststylecommand~ListStylesCommand} options.listStyleCommand The instance of the `ListStylesCommand` class.
+// @param {module:list/liststyle/liststylecommand~ListStylesCommand} options.listStyleCommand The instance of the `ListStylesCommand` class.
 // @param {'bulletedList'|'numberedList'} options.parentCommandName The name of the higher-order command associated with a
 // particular list style (e.g. "bulletedList" is associated with "square" and "numberedList" is associated with "roman").
 // @returns {Function} A function that can be passed straight into {@link module:ui/componentfactory~ComponentFactory#add}.

--- a/packages/ckeditor5-list/src/todolist.js
+++ b/packages/ckeditor5-list/src/todolist.js
@@ -7,16 +7,16 @@
  * @module list/todolist
  */
 
-import TodoListEditing from './todolistediting';
-import TodoListUI from './todolistui';
+import TodoListEditing from './todolist/todolistediting';
+import TodoListUI from './todolist/todolistui';
 import { Plugin } from 'ckeditor5/src/core';
 import '../theme/todolist.css';
 
 /**
  * The to-do list feature.
  *
- * This is a "glue" plugin that loads the {@link module:list/todolistediting~TodoListEditing to-do list editing feature}
- * and the {@link module:list/todolistui~TodoListUI to-do list UI feature}.
+ * This is a "glue" plugin that loads the {@link module:list/todolist/todolistediting~TodoListEditing to-do list editing feature}
+ * and the {@link module:list/todolist/todolistui~TodoListUI to-do list UI feature}.
  *
  * @extends module:core/plugin~Plugin
  */

--- a/packages/ckeditor5-list/src/todolist/checktodolistcommand.js
+++ b/packages/ckeditor5-list/src/todolist/checktodolistcommand.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module list/checktodolistcommand
+ * @module list/todolist/checktodolistcommand
  */
 
 import { Command } from 'ckeditor5/src/core';
@@ -14,7 +14,7 @@ const attributeKey = 'todoListChecked';
 /**
  * The check to-do command.
  *
- * The command is registered by the {@link module:list/todolistediting~TodoListEditing} as
+ * The command is registered by the {@link module:list/todolist/todolistediting~TodoListEditing} as
  * the `checkTodoList` editor command and it is also available via aliased `todoListCheck` name.
  *
  * @extends module:core/command~Command

--- a/packages/ckeditor5-list/src/todolist/todolistconverters.js
+++ b/packages/ckeditor5-list/src/todolist/todolistconverters.js
@@ -4,14 +4,14 @@
  */
 
 /**
- * @module list/todolistconverters
+ * @module list/todolist/todolistconverters
  */
 
 /* global document */
 
 import { createElement } from 'ckeditor5/src/utils';
 
-import { generateLiInUl, injectViewList, positionAfterUiElements, findNestedList } from './utils';
+import { generateLiInUl, injectViewList, positionAfterUiElements, findNestedList } from '../list/utils';
 
 /**
  * A model-to-view converter for the `listItem` model element insertion.
@@ -171,8 +171,8 @@ export function dataViewModelCheckmarkInsertion( evt, data, conversionApi ) {
  * {@link module:engine/view/uielement~UIElement checkbox UI element} is added at the beginning
  * of the list item element (or vice versa).
  *
- * This converter is preceded by {@link module:list/converters~modelViewChangeType} and followed by
- * {@link module:list/converters~modelViewMergeAfterChangeType} to handle splitting and merging surrounding lists of the same type.
+ * This converter is preceded by {@link module:list/list/converters~modelViewChangeType} and followed by
+ * {@link module:list/list/converters~modelViewMergeAfterChangeType} to handle splitting and merging surrounding lists of the same type.
  *
  * It is used by {@link module:engine/controller/editingcontroller~EditingController}.
  *

--- a/packages/ckeditor5-list/src/todolist/todolistediting.js
+++ b/packages/ckeditor5-list/src/todolist/todolistediting.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module list/todolistediting
+ * @module list/todolist/todolistediting
  */
 
 import { Plugin } from 'ckeditor5/src/core';
@@ -14,8 +14,8 @@ import {
 	getLocalizedArrowKeyCodeDirection
 } from 'ckeditor5/src/utils';
 
-import ListCommand from './listcommand';
-import ListEditing from './listediting';
+import ListCommand from '../list/listcommand';
+import ListEditing from '../list/listediting';
 import CheckTodoListCommand from './checktodolistcommand';
 import {
 	dataModelViewInsertion,
@@ -31,7 +31,7 @@ const ITEM_TOGGLE_KEYSTROKE = parseKeystroke( 'Ctrl+Enter' );
 /**
  * The engine of the to-do list feature. It handles creating, editing and removing to-do lists and their items.
  *
- * It registers the entire functionality of the {@link module:list/listediting~ListEditing list editing plugin} and extends
+ * It registers the entire functionality of the {@link module:list/list/listediting~ListEditing list editing plugin} and extends
  * it with the commands:
  *
  * - `'todoList'`,

--- a/packages/ckeditor5-list/src/todolist/todolistui.js
+++ b/packages/ckeditor5-list/src/todolist/todolistui.js
@@ -4,11 +4,11 @@
  */
 
 /**
- * @module list/todolistui
+ * @module list/todolist/todolistui
  */
 
-import { createUIComponent } from './utils';
-import todoListIcon from '../theme/icons/todolist.svg';
+import { createUIComponent } from '../list/utils';
+import todoListIcon from '../../theme/icons/todolist.svg';
 import { Plugin } from 'ckeditor5/src/core';
 
 /**

--- a/packages/ckeditor5-list/tests/list.js
+++ b/packages/ckeditor5-list/tests/list.js
@@ -4,8 +4,8 @@
  */
 
 import List from '../src/list';
-import ListEditing from '../src/listediting';
-import ListUI from '../src/listui';
+import ListEditing from '../src/list/listediting';
+import ListUI from '../src/list/listui';
 
 describe( 'List', () => {
 	it( 'should be named', () => {

--- a/packages/ckeditor5-list/tests/list/indentcommand.js
+++ b/packages/ckeditor5-list/tests/list/indentcommand.js
@@ -5,7 +5,7 @@
 
 import Editor from '@ckeditor/ckeditor5-core/src/editor/editor';
 import Model from '@ckeditor/ckeditor5-engine/src/model/model';
-import IndentCommand from '../src/indentcommand';
+import IndentCommand from '../../src/list/indentcommand';
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 describe( 'IndentCommand', () => {

--- a/packages/ckeditor5-list/tests/list/listcommand.js
+++ b/packages/ckeditor5-list/tests/list/listcommand.js
@@ -5,7 +5,7 @@
 
 import Editor from '@ckeditor/ckeditor5-core/src/editor/editor';
 import Model from '@ckeditor/ckeditor5-engine/src/model/model';
-import ListCommand from '../src/listcommand';
+import ListCommand from '../../src/list/listcommand';
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
 describe( 'ListCommand', () => {

--- a/packages/ckeditor5-list/tests/list/listediting.js
+++ b/packages/ckeditor5-list/tests/list/listediting.js
@@ -3,9 +3,9 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import ListEditing from '../src/listediting';
-import ListCommand from '../src/listcommand';
-import IndentCommand from '../src/indentcommand';
+import ListEditing from '../../src/list/listediting';
+import ListCommand from '../../src/list/listcommand';
+import IndentCommand from '../../src/list/indentcommand';
 
 import ModelRange from '@ckeditor/ckeditor5-engine/src/model/range';
 

--- a/packages/ckeditor5-list/tests/list/listui.js
+++ b/packages/ckeditor5-list/tests/list/listui.js
@@ -5,8 +5,8 @@
 
 /* globals document */
 
-import ListEditing from '../src/listediting';
-import ListUI from '../src/listui';
+import ListEditing from '../../src/list/listediting';
+import ListUI from '../../src/list/listui';
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';

--- a/packages/ckeditor5-list/tests/list/utils.js
+++ b/packages/ckeditor5-list/tests/list/utils.js
@@ -8,10 +8,10 @@ import ViewDowncastWriter from '@ckeditor/ckeditor5-engine/src/view/downcastwrit
 import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 
-import ListEditing from '../src/listediting';
-import ListStyleEditing from '../src/liststyleediting';
+import ListEditing from '../../src/list/listediting';
+import ListStyleEditing from '../../src/liststyle/liststyleediting';
 
-import { createViewListItemElement, getSiblingListItem, getSiblingNodes } from '../src/utils';
+import { createViewListItemElement, getSiblingListItem, getSiblingNodes } from '../../src/list/utils';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 
 describe( 'utils', () => {

--- a/packages/ckeditor5-list/tests/liststyle.js
+++ b/packages/ckeditor5-list/tests/liststyle.js
@@ -4,8 +4,8 @@
  */
 
 import ListStyle from '../src/liststyle';
-import ListStyleEditing from '../src/liststyleediting';
-import ListStyleUI from '../src/liststyleui';
+import ListStyleEditing from '../src/liststyle/liststyleediting';
+import ListStyleUI from '../src/liststyle/liststyleui';
 
 describe( 'ListStyle', () => {
 	it( 'should be named', () => {

--- a/packages/ckeditor5-list/tests/liststyle/liststylecommand.js
+++ b/packages/ckeditor5-list/tests/liststyle/liststylecommand.js
@@ -6,7 +6,7 @@
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import ListStyleEditing from '../src/liststyleediting';
+import ListStyleEditing from '../../src/liststyle/liststyleediting';
 
 describe( 'ListStyleCommand', () => {
 	let editor, model, bulletedListCommand, numberedListCommand, listStyleCommand;

--- a/packages/ckeditor5-list/tests/liststyle/liststyleediting.js
+++ b/packages/ckeditor5-list/tests/liststyle/liststyleediting.js
@@ -14,9 +14,9 @@ import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 
-import ListStyleEditing from '../src/liststyleediting';
-import TodoListEditing from '../src/todolistediting';
-import ListStyleCommand from '../src/liststylecommand';
+import ListStyleEditing from '../../src/liststyle/liststyleediting';
+import TodoListEditing from '../../src/todolist/todolistediting';
+import ListStyleCommand from '../../src/liststyle/liststylecommand';
 import FontColor from '@ckeditor/ckeditor5-font/src/fontcolor';
 
 describe( 'ListStyleEditing', () => {

--- a/packages/ckeditor5-list/tests/liststyle/liststyleui.js
+++ b/packages/ckeditor5-list/tests/liststyle/liststyleui.js
@@ -10,23 +10,23 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import BlockQuote from '@ckeditor/ckeditor5-block-quote/src/blockquote';
 import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
-import ListStyle from '../src/liststyle';
-import ListStyleUI from '../src/liststyleui';
+import ListStyle from '../../src/liststyle';
+import ListStyleUI from '../../src/liststyle/liststyleui';
 import DropdownView from '@ckeditor/ckeditor5-ui/src/dropdown/dropdownview';
 import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
 
-import bulletedListIcon from '../theme/icons/bulletedlist.svg';
-import numberedListIcon from '../theme/icons/numberedlist.svg';
+import bulletedListIcon from '../../theme/icons/bulletedlist.svg';
+import numberedListIcon from '../../theme/icons/numberedlist.svg';
 
-import listStyleDiscIcon from '../theme/icons/liststyledisc.svg';
-import listStyleCircleIcon from '../theme/icons/liststylecircle.svg';
-import listStyleSquareIcon from '../theme/icons/liststylesquare.svg';
-import listStyleDecimalIcon from '../theme/icons/liststyledecimal.svg';
-import listStyleDecimalWithLeadingZeroIcon from '../theme/icons/liststyledecimalleadingzero.svg';
-import listStyleLowerRomanIcon from '../theme/icons/liststylelowerroman.svg';
-import listStyleUpperRomanIcon from '../theme/icons/liststyleupperroman.svg';
-import listStyleLowerLatinIcon from '../theme/icons/liststylelowerlatin.svg';
-import listStyleUpperLatinIcon from '../theme/icons/liststyleupperlatin.svg';
+import listStyleDiscIcon from '../../theme/icons/liststyledisc.svg';
+import listStyleCircleIcon from '../../theme/icons/liststylecircle.svg';
+import listStyleSquareIcon from '../../theme/icons/liststylesquare.svg';
+import listStyleDecimalIcon from '../../theme/icons/liststyledecimal.svg';
+import listStyleDecimalWithLeadingZeroIcon from '../../theme/icons/liststyledecimalleadingzero.svg';
+import listStyleLowerRomanIcon from '../../theme/icons/liststylelowerroman.svg';
+import listStyleUpperRomanIcon from '../../theme/icons/liststyleupperroman.svg';
+import listStyleLowerLatinIcon from '../../theme/icons/liststylelowerlatin.svg';
+import listStyleUpperLatinIcon from '../../theme/icons/liststyleupperlatin.svg';
 
 describe( 'ListStyleUI', () => {
 	let editorElement, editor, model, listStyleCommand;

--- a/packages/ckeditor5-list/tests/todolist.js
+++ b/packages/ckeditor5-list/tests/todolist.js
@@ -4,8 +4,8 @@
  */
 
 import TodoList from '../src/todolist';
-import TodoListEditing from '../src/todolistediting';
-import TodoListUI from '../src/todolistui';
+import TodoListEditing from '../src/todolist/todolistediting';
+import TodoListUI from '../src/todolist/todolistui';
 
 describe( 'TodoList', () => {
 	it( 'should be named', () => {

--- a/packages/ckeditor5-list/tests/todolist/checktodolistcommand.js
+++ b/packages/ckeditor5-list/tests/todolist/checktodolistcommand.js
@@ -3,8 +3,8 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import TodoListEditing from '../src/todolistediting';
-import CheckTodoListCommand from '../src/checktodolistcommand';
+import TodoListEditing from '../../src/todolist/todolistediting';
+import CheckTodoListCommand from '../../src/todolist/checktodolistcommand';
 
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';

--- a/packages/ckeditor5-list/tests/todolist/todolistediting.js
+++ b/packages/ckeditor5-list/tests/todolist/todolistediting.js
@@ -3,13 +3,13 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import TodoListEditing from '../src/todolistediting';
-import ListEditing from '../src/listediting';
+import TodoListEditing from '../../src/todolist/todolistediting';
+import ListEditing from '../../src/list/listediting';
 import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
 import BlockQuoteEditing from '@ckeditor/ckeditor5-block-quote/src/blockquoteediting';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
-import ListCommand from '../src/listcommand';
-import CheckTodoListCommand from '../src/checktodolistcommand';
+import ListCommand from '../../src/list/listcommand';
+import CheckTodoListCommand from '../../src/todolist/checktodolistcommand';
 import ModelElement from '@ckeditor/ckeditor5-engine/src/model/element';
 import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/inlineeditableuiview';
 import LinkEditing from '@ckeditor/ckeditor5-link/src/linkediting';

--- a/packages/ckeditor5-list/tests/todolist/todolistui.js
+++ b/packages/ckeditor5-list/tests/todolist/todolistui.js
@@ -5,8 +5,8 @@
 
 /* globals document */
 
-import TodoListEditing from '../src/todolistediting';
-import TodoListUI from '../src/todolistui';
+import TodoListEditing from '../../src/todolist/todolistediting';
+import TodoListUI from '../../src/todolist/todolistui';
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';

--- a/packages/ckeditor5-table/tests/table-integration.js
+++ b/packages/ckeditor5-table/tests/table-integration.js
@@ -8,7 +8,7 @@ import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
-import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
+import ListEditing from '@ckeditor/ckeditor5-list/src/list/listediting';
 import BlockQuoteEditing from '@ckeditor/ckeditor5-block-quote/src/blockquoteediting';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -10,7 +10,7 @@ import BlockQuoteEditing from '@ckeditor/ckeditor5-block-quote/src/blockquoteedi
 import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 import HorizontalLineEditing from '@ckeditor/ckeditor5-horizontal-line/src/horizontallineediting';
 import ImageCaptionEditing from '@ckeditor/ckeditor5-image/src/imagecaption/imagecaptionediting';
-import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
+import ListEditing from '@ckeditor/ckeditor5-list/src/list/listediting';
 import ImageBlockEditing from '@ckeditor/ckeditor5-image/src/image/imageblockediting';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Input from '@ckeditor/ckeditor5-typing/src/input';

--- a/packages/ckeditor5-word-count/tests/utils.js
+++ b/packages/ckeditor5-word-count/tests/utils.js
@@ -13,7 +13,7 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import BlockQuoteEditing from '@ckeditor/ckeditor5-block-quote/src/blockquoteediting';
 import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
 import LinkEditing from '@ckeditor/ckeditor5-link/src/linkediting';
-import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
+import ListEditing from '@ckeditor/ckeditor5-list/src/list/listediting';
 import TableEditing from '@ckeditor/ckeditor5-table/src/tableediting';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
 import ShiftEnter from '@ckeditor/ckeditor5-enter/src/shiftenter';

--- a/packages/ckeditor5-word-count/tests/wordcount.js
+++ b/packages/ckeditor5-word-count/tests/wordcount.js
@@ -16,7 +16,7 @@ import Position from '@ckeditor/ckeditor5-engine/src/model/position';
 import ShiftEnter from '@ckeditor/ckeditor5-enter/src/shiftenter';
 import TableEditing from '@ckeditor/ckeditor5-table/src/tableediting';
 import env from '@ckeditor/ckeditor5-utils/src/env';
-import ListEditing from '@ckeditor/ckeditor5-list/src/listediting';
+import ListEditing from '@ckeditor/ckeditor5-list/src/list/listediting';
 import LinkEditing from '@ckeditor/ckeditor5-link/src/linkediting';
 import ImageCaptionEditing from '@ckeditor/ckeditor5-image/src/imagecaption/imagecaptionediting';
 import ImageBlockEditing from '@ckeditor/ckeditor5-image/src/image/imageblockediting';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (list): The `ckeditor5-list` package was restructured into subdirectories. Closes #10811.

Tests (alignment, autoformat, block-quote, engine, html-support, image, indent, table, word-count): Tests updated after list package restructuring.

BREAKING CHANGE (list): The `ListEditing`, `ListUI`, `ListStyleEditing`, `ListStyleUI`, `TodoListEditing`, `TodoListUI` plugins were moved to the dedicated subdirectories (`list`, `liststyle`, `todolist`).

---

### Additional information