### PR TITLE
Disable text alignment button for table

### DIFF
--- a/docs/framework/guides/package-generator.md
+++ b/docs/framework/guides/package-generator.md
@@ -32,14 +32,14 @@ Available modifiers for the command are:
 
 After successfully creating the new package, enter it by executing the following command:
 
-```
-// assuming that your package was created with `ckeditor5-foo` as its name
+```bash
+# Assuming that your package was created with `ckeditor5-foo` as its name.
 cd ckeditor5-foo
 ```
 
 Then run the test environment for the plugin by executing:
 
-```
+```bash
 npm run start
 ```
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/table/tablecellproperties/model.html
+++ b/packages/ckeditor5-paste-from-office/tests/_data/table/tablecellproperties/model.html
@@ -1,47 +1,47 @@
 <table borderColor="{}" borderWidth="{}">
 	<tableRow>
-		<tableCell backgroundColor="#CCCCCC" borderColor="windowtext" borderStyle="solid" borderWidth="1.0pt" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="59.0%">
-			<paragraph><$text bold="true">Project Phase</$text></paragraph>
-		</tableCell>
-		<tableCell backgroundColor="#CCCCCC" borderColor="windowtext" borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"none"}" borderWidth="1.0pt" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="24.0%">
-			<paragraph><$text bold="true">Deadline</$text></paragraph>
-		</tableCell>
-		<tableCell backgroundColor="#CCCCCC" borderColor="windowtext" borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"none"}" borderWidth="1.0pt" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="17.0%">
-			<paragraph><$text bold="true">Status</$text></paragraph>
-		</tableCell>
+			<tableCell borderColor="windowtext" borderStyle="solid" borderWidth="1.0pt" tableCellBackgroundColor="#CCCCCC" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
+					<paragraph><$text bold="true">Project Phase</$text></paragraph>
+			</tableCell>
+			<tableCell borderColor="windowtext" borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"none"}" borderWidth="1.0pt" tableCellBackgroundColor="#CCCCCC" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="24.0%">
+					<paragraph><$text bold="true">Deadline</$text></paragraph>
+			</tableCell>
+			<tableCell borderColor="windowtext" borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"none"}" borderWidth="1.0pt" tableCellBackgroundColor="#CCCCCC" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="17.0%">
+					<paragraph><$text bold="true">Status</$text></paragraph>
+			</tableCell>
 	</tableRow>
 	<tableRow>
-		<tableCell borderColor="windowtext" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="1.0pt" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="59.0%">
-			<paragraph>Phase 1: Market research</paragraph>
-		</tableCell>
-		<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="24.0%">
-			<paragraph><$text fontBackgroundColor="red">2019-10-15</$text></paragraph>
-		</tableCell>
-		<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="17.0%">
-			<paragraph><$text fontColor="#00B050">✓</$text></paragraph>
-		</tableCell>
-		</tableRow>
+			<tableCell borderColor="windowtext" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="1.0pt" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
+					<paragraph>Phase 1: Market research</paragraph>
+			</tableCell>
+			<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="24.0%">
+					<paragraph><$text fontBackgroundColor="red">2019-10-15</$text></paragraph>
+			</tableCell>
+			<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="17.0%">
+					<paragraph><$text fontColor="#00B050">✓</$text></paragraph>
+			</tableCell>
+			</tableRow>
 	<tableRow>
-		<tableCell backgroundColor="#EEEEEE" borderColor="windowtext" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="1.0pt" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="59.0%">
-			<paragraph>Phase 2: Editor features implementation</paragraph>
-		</tableCell>
-		<tableCell backgroundColor="#EEEEEE" borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="24.0%">
-			<paragraph>2019-10-20</paragraph>
-		</tableCell>
-		<tableCell backgroundColor="#EEEEEE" borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="17.0%">
-			<paragraph><$text fontColor="#00B050">✓</$text></paragraph>
-		</tableCell>
+			<tableCell borderColor="windowtext" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="1.0pt" tableCellBackgroundColor="#EEEEEE" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
+					<paragraph>Phase 2: Editor features implementation</paragraph>
+			</tableCell>
+			<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellBackgroundColor="#EEEEEE" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="24.0%">
+					<paragraph>2019-10-20</paragraph>
+			</tableCell>
+			<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellBackgroundColor="#EEEEEE" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="17.0%">
+					<paragraph><$text fontColor="#00B050">✓</$text></paragraph>
+			</tableCell>
 	</tableRow>
 	<tableRow>
-		<tableCell borderColor="windowtext" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="1.0pt" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="59.0%">
-			<paragraph>Phase 3: Rollout to Production</paragraph>
-		</tableCell>
-		<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="24.0%">
-			<paragraph>2019-10-22</paragraph>
-		</tableCell>
-		<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" padding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" width="17.0%">
-			<paragraph><$text fontColor="#00B050">✓</$text></paragraph>
-		</tableCell>
+			<tableCell borderColor="windowtext" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="1.0pt" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
+					<paragraph>Phase 3: Rollout to Production</paragraph>
+			</tableCell>
+			<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="24.0%">
+					<paragraph>2019-10-22</paragraph>
+			</tableCell>
+			<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="17.0%">
+					<paragraph><$text fontColor="#00B050">✓</$text></paragraph>
+			</tableCell>
 	</tableRow>
 </table>
 <paragraph></paragraph>

--- a/packages/ckeditor5-paste-from-office/tests/_data/table/tablecellproperties/model.html
+++ b/packages/ckeditor5-paste-from-office/tests/_data/table/tablecellproperties/model.html
@@ -1,46 +1,46 @@
-<table borderColor="{}" borderWidth="{}">
+<table tableBorderColor="{}" tableBorderWidth="{}">
 	<tableRow>
-			<tableCell borderColor="windowtext" borderStyle="solid" borderWidth="1.0pt" tableCellBackgroundColor="#CCCCCC" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
-					<paragraph><$text bold="true">Project Phase</$text></paragraph>
+		<tableCell tableCellBackgroundColor="#CCCCCC" tableCellBorderColor="windowtext" tableCellBorderStyle="solid" tableCellBorderWidth="1.0pt" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
+				<paragraph><$text bold="true">Project Phase</$text></paragraph>
 			</tableCell>
-			<tableCell borderColor="windowtext" borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"none"}" borderWidth="1.0pt" tableCellBackgroundColor="#CCCCCC" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="24.0%">
-					<paragraph><$text bold="true">Deadline</$text></paragraph>
+			<tableCell tableCellBackgroundColor="#CCCCCC" tableCellBorderColor="windowtext" tableCellBorderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"none"}" tableCellBorderWidth="1.0pt" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="24.0%">
+				<paragraph><$text bold="true">Deadline</$text></paragraph>
 			</tableCell>
-			<tableCell borderColor="windowtext" borderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"none"}" borderWidth="1.0pt" tableCellBackgroundColor="#CCCCCC" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="17.0%">
-					<paragraph><$text bold="true">Status</$text></paragraph>
+			<tableCell tableCellBackgroundColor="#CCCCCC" tableCellBorderColor="windowtext" tableCellBorderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"none"}" tableCellBorderWidth="1.0pt" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="17.0%">
+				<paragraph><$text bold="true">Status</$text></paragraph>
 			</tableCell>
 	</tableRow>
 	<tableRow>
-			<tableCell borderColor="windowtext" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="1.0pt" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
-					<paragraph>Phase 1: Market research</paragraph>
+		<tableCell tableCellBorderColor="windowtext" tableCellBorderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" tableCellBorderWidth="1.0pt" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
+				<paragraph>Phase 1: Market research</paragraph>
 			</tableCell>
-			<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="24.0%">
-					<paragraph><$text fontBackgroundColor="red">2019-10-15</$text></paragraph>
+			<tableCell tableCellBorderColor="{"bottom":"windowtext","right":"windowtext"}" tableCellBorderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" tableCellBorderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="24.0%">
+				<paragraph><$text fontBackgroundColor="red">2019-10-15</$text></paragraph>
 			</tableCell>
-			<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="17.0%">
-					<paragraph><$text fontColor="#00B050">✓</$text></paragraph>
+			<tableCell tableCellBorderColor="{"bottom":"windowtext","right":"windowtext"}" tableCellBorderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" tableCellBorderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="17.0%">
+				<paragraph><$text fontColor="#00B050">✓</$text></paragraph>
 			</tableCell>
 			</tableRow>
 	<tableRow>
-			<tableCell borderColor="windowtext" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="1.0pt" tableCellBackgroundColor="#EEEEEE" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
-					<paragraph>Phase 2: Editor features implementation</paragraph>
+		<tableCell tableCellBackgroundColor="#EEEEEE" tableCellBorderColor="windowtext" tableCellBorderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" tableCellBorderWidth="1.0pt" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
+				<paragraph>Phase 2: Editor features implementation</paragraph>
 			</tableCell>
-			<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellBackgroundColor="#EEEEEE" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="24.0%">
-					<paragraph>2019-10-20</paragraph>
+			<tableCell tableCellBackgroundColor="#EEEEEE" tableCellBorderColor="{"bottom":"windowtext","right":"windowtext"}" tableCellBorderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" tableCellBorderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="24.0%">
+				<paragraph>2019-10-20</paragraph>
 			</tableCell>
-			<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellBackgroundColor="#EEEEEE" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="17.0%">
-					<paragraph><$text fontColor="#00B050">✓</$text></paragraph>
+			<tableCell tableCellBackgroundColor="#EEEEEE" tableCellBorderColor="{"bottom":"windowtext","right":"windowtext"}" tableCellBorderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" tableCellBorderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="17.0%">
+				<paragraph><$text fontColor="#00B050">✓</$text></paragraph>
 			</tableCell>
 	</tableRow>
 	<tableRow>
-			<tableCell borderColor="windowtext" borderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" borderWidth="1.0pt" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
-					<paragraph>Phase 3: Rollout to Production</paragraph>
+		<tableCell tableCellBorderColor="windowtext" tableCellBorderStyle="{"top":"none","bottom":"solid","right":"solid","left":"solid"}" tableCellBorderWidth="1.0pt" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
+				<paragraph>Phase 3: Rollout to Production</paragraph>
 			</tableCell>
-			<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="24.0%">
-					<paragraph>2019-10-22</paragraph>
+			<tableCell tableCellBorderColor="{"bottom":"windowtext","right":"windowtext"}" tableCellBorderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" tableCellBorderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="24.0%">
+				<paragraph>2019-10-22</paragraph>
 			</tableCell>
-			<tableCell borderColor="{"bottom":"windowtext","right":"windowtext"}" borderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" borderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="17.0%">
-					<paragraph><$text fontColor="#00B050">✓</$text></paragraph>
+			<tableCell tableCellBorderColor="{"bottom":"windowtext","right":"windowtext"}" tableCellBorderStyle="{"top":"none","left":"none","bottom":"solid","right":"solid"}" tableCellBorderWidth="{"bottom":"1.0pt","right":"1.0pt"}" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="17.0%">
+				<paragraph><$text fontColor="#00B050">✓</$text></paragraph>
 			</tableCell>
 	</tableRow>
 </table>

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
@@ -31,6 +31,6 @@ export default class TableCellBackgroundColorCommand extends TableCellPropertyCo
 	 * @param {String} defaultValue The default value of the attribute.
 	 */
 	constructor( editor, defaultValue ) {
-		super( editor, 'backgroundColor', defaultValue );
+		super( editor, 'tableCellBackgroundColor', defaultValue );
 	}
 }

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellheightcommand.js
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellheightcommand.js
@@ -40,7 +40,7 @@ export default class TableCellHeightCommand extends TableCellPropertyCommand {
 	 * @param {String} defaultValue The default value of the attribute.
 	 */
 	constructor( editor, defaultValue ) {
-		super( editor, 'height', defaultValue );
+		super( editor, 'tableCellHeight', defaultValue );
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
@@ -31,6 +31,6 @@ export default class TableCellHorizontalAlignmentCommand extends TableCellProper
 	 * @param {String} defaultValue The default value for the "alignment" attribute.
 	 */
 	constructor( editor, defaultValue ) {
-		super( editor, 'horizontalAlignment', defaultValue );
+		super( editor, 'tableCellHorizontalAlignment', defaultValue );
 	}
 }

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellpaddingcommand.js
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellpaddingcommand.js
@@ -40,7 +40,7 @@ export default class TableCellPaddingCommand extends TableCellPropertyCommand {
 	 * @param {String} defaultValue The default value of the attribute.
 	 */
 	constructor( editor, defaultValue ) {
-		super( editor, 'padding', defaultValue );
+		super( editor, 'tableCellPadding', defaultValue );
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellverticalalignmentcommand.js
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellverticalalignmentcommand.js
@@ -39,6 +39,6 @@ export default class TableCellVerticalAlignmentCommand extends TableCellProperty
 	 * @param {String} defaultValue The default value for the "alignment" attribute.
 	 */
 	constructor( editor, defaultValue ) {
-		super( editor, 'verticalAlignment', defaultValue );
+		super( editor, 'tableCellVerticalAlignment', defaultValue );
 	}
 }

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellwidthcommand.js
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellwidthcommand.js
@@ -40,7 +40,7 @@ export default class TableCellWidthCommand extends TableCellPropertyCommand {
 	 * @param {String} defaultValue The default value of the attribute.
 	 */
 	constructor( editor, defaultValue ) {
-		super( editor, 'width', defaultValue );
+		super( editor, 'tableCellWidth', defaultValue );
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.js
@@ -31,11 +31,11 @@ const ALIGN_VALUES_REG_EXP = /^(left|center|right|justify)$/;
  *
  * Introduces table cell model attributes and their conversion:
  *
- * - border: `borderStyle`, `borderColor` and `borderWidth`
- * - background color: `backgroundColor`
- * - cell padding: `padding`
- * - horizontal and vertical alignment: `horizontalAlignment`, `verticalAlignment`
- * - cell width and height: `width`, `height`
+ * - border: `tableCellBorderStyle`, `tableCellBorderColor` and `tableCellBorderWidth`
+ * - background color: `tableCellBackgroundColor`
+ * - cell padding: `tableCellPadding`
+ * - horizontal and vertical alignment: `tableCellHorizontalAlignment`, `tableCellVerticalAlignment`
+ * - cell width and height: `tableCellWidth`, `tableCellHeight`
  *
  * It also registers commands used to manipulate the above attributes:
  *
@@ -92,12 +92,6 @@ export default class TableCellPropertiesEditing extends Plugin {
 		editor.commands.add( 'tableCellBorderColor', new TableCellBorderColorCommand( editor, defaultTableCellProperties.borderColor ) );
 		editor.commands.add( 'tableCellBorderWidth', new TableCellBorderWidthCommand( editor, defaultTableCellProperties.borderWidth ) );
 
-		enableHorizontalAlignmentProperty( schema, conversion, defaultTableCellProperties.horizontalAlignment );
-		editor.commands.add(
-			'tableCellHorizontalAlignment',
-			new TableCellHorizontalAlignmentCommand( editor, defaultTableCellProperties.horizontalAlignment )
-		);
-
 		enableProperty( schema, conversion, {
 			modelAttribute: 'tableCellWidth',
 			styleName: 'width',
@@ -132,6 +126,12 @@ export default class TableCellPropertiesEditing extends Plugin {
 			new TableCellBackgroundColorCommand( editor, defaultTableCellProperties.backgroundColor )
 		);
 
+		enableHorizontalAlignmentProperty( schema, conversion, defaultTableCellProperties.horizontalAlignment );
+		editor.commands.add(
+			'tableCellHorizontalAlignment',
+			new TableCellHorizontalAlignmentCommand( editor, defaultTableCellProperties.horizontalAlignment )
+		);
+
 		enableVerticalAlignmentProperty( schema, conversion, defaultTableCellProperties.verticalAlignment );
 		editor.commands.add(
 			'tableCellVerticalAlignment',
@@ -140,14 +140,14 @@ export default class TableCellPropertiesEditing extends Plugin {
 	}
 }
 
-// Enables the `'borderStyle'`, `'borderColor'` and `'borderWidth'` attributes for table cells.
+// Enables the `'tableCellBorderStyle'`, `'tableCellBorderColor'` and `'tableCellBorderWidth'` attributes for table cells.
 //
 // @param {module:engine/model/schema~Schema} schema
 // @param {module:engine/conversion/conversion~Conversion} conversion
 // @param {Object} defaultBorder The default border values.
-// @param {String} defaultBorder.color The default `borderColor` value.
-// @param {String} defaultBorder.style The default `borderStyle` value.
-// @param {String} defaultBorder.width The default `borderWidth` value.
+// @param {String} defaultBorder.color The default `tableCellBorderColor` value.
+// @param {String} defaultBorder.style The default `tableCellBorderStyle` value.
+// @param {String} defaultBorder.width The default `tableCellBorderWidth` value.
 function enableBorderProperties( schema, conversion, defaultBorder ) {
 	const modelAttributes = {
 		width: 'tableCellBorderWidth',
@@ -166,7 +166,7 @@ function enableBorderProperties( schema, conversion, defaultBorder ) {
 	downcastAttributeToStyle( conversion, { modelElement: 'tableCell', modelAttribute: modelAttributes.width, styleName: 'border-width' } );
 }
 
-// Enables the `'horizontalAlignment'` attribute for table cells.
+// Enables the `'tableCellHorizontalAlignment'` attribute for table cells.
 //
 // @param {module:engine/model/schema~Schema} schema
 // @param {module:engine/conversion/conversion~Conversion} conversion
@@ -174,14 +174,14 @@ function enableBorderProperties( schema, conversion, defaultBorder ) {
 // @param {String} defaultValue The default horizontal alignment value.
 function enableHorizontalAlignmentProperty( schema, conversion, defaultValue ) {
 	schema.extend( 'tableCell', {
-		allowAttributes: [ 'horizontalAlignment' ]
+		allowAttributes: [ 'tableCellHorizontalAlignment' ]
 	} );
 
 	conversion.for( 'downcast' )
 		.attributeToAttribute( {
 			model: {
 				name: 'tableCell',
-				key: 'horizontalAlignment'
+				key: 'tableCellHorizontalAlignment'
 			},
 			view: alignment => ( {
 				key: 'style',
@@ -201,7 +201,7 @@ function enableHorizontalAlignmentProperty( schema, conversion, defaultValue ) {
 				}
 			},
 			model: {
-				key: 'horizontalAlignment',
+				key: 'tableCellHorizontalAlignment',
 				value: viewElement => {
 					const align = viewElement.getStyle( 'text-align' );
 
@@ -218,7 +218,7 @@ function enableHorizontalAlignmentProperty( schema, conversion, defaultValue ) {
 				}
 			},
 			model: {
-				key: 'horizontalAlignment',
+				key: 'tableCellHorizontalAlignment',
 				value: viewElement => {
 					const align = viewElement.getAttribute( 'align' );
 
@@ -235,14 +235,14 @@ function enableHorizontalAlignmentProperty( schema, conversion, defaultValue ) {
 // @param {String} defaultValue The default vertical alignment value.
 function enableVerticalAlignmentProperty( schema, conversion, defaultValue ) {
 	schema.extend( 'tableCell', {
-		allowAttributes: [ 'verticalAlignment' ]
+		allowAttributes: [ 'tableCellVerticalAlignment' ]
 	} );
 
 	conversion.for( 'downcast' )
 		.attributeToAttribute( {
 			model: {
 				name: 'tableCell',
-				key: 'verticalAlignment'
+				key: 'tableCellVerticalAlignment'
 			},
 			view: alignment => ( {
 				key: 'style',
@@ -262,7 +262,7 @@ function enableVerticalAlignmentProperty( schema, conversion, defaultValue ) {
 				}
 			},
 			model: {
-				key: 'verticalAlignment',
+				key: 'tableCellVerticalAlignment',
 				value: viewElement => {
 					const align = viewElement.getStyle( 'vertical-align' );
 
@@ -279,7 +279,7 @@ function enableVerticalAlignmentProperty( schema, conversion, defaultValue ) {
 				}
 			},
 			model: {
-				key: 'verticalAlignment',
+				key: 'tableCellVerticalAlignment',
 				value: viewElement => {
 					const valign = viewElement.getAttribute( 'valign' );
 

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.js
@@ -99,14 +99,14 @@ export default class TableCellPropertiesEditing extends Plugin {
 		);
 
 		enableProperty( schema, conversion, {
-			modelAttribute: 'width',
+			modelAttribute: 'tableCellWidth',
 			styleName: 'width',
 			defaultValue: defaultTableCellProperties.width
 		} );
 		editor.commands.add( 'tableCellWidth', new TableCellWidthCommand( editor, defaultTableCellProperties.width ) );
 
 		enableProperty( schema, conversion, {
-			modelAttribute: 'height',
+			modelAttribute: 'tableCellHeight',
 			styleName: 'height',
 			defaultValue: defaultTableCellProperties.height
 		} );
@@ -114,7 +114,7 @@ export default class TableCellPropertiesEditing extends Plugin {
 
 		editor.data.addStyleProcessorRules( addPaddingRules );
 		enableProperty( schema, conversion, {
-			modelAttribute: 'padding',
+			modelAttribute: 'tableCellPadding',
 			styleName: 'padding',
 			reduceBoxSides: true,
 			defaultValue: defaultTableCellProperties.padding
@@ -123,7 +123,7 @@ export default class TableCellPropertiesEditing extends Plugin {
 
 		editor.data.addStyleProcessorRules( addBackgroundRules );
 		enableProperty( schema, conversion, {
-			modelAttribute: 'backgroundColor',
+			modelAttribute: 'tableCellBackgroundColor',
 			styleName: 'background-color',
 			defaultValue: defaultTableCellProperties.backgroundColor
 		} );

--- a/packages/ckeditor5-table/src/tableproperties/commands/tablealignmentcommand.js
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tablealignmentcommand.js
@@ -31,6 +31,6 @@ export default class TableAlignmentCommand extends TablePropertyCommand {
 	 * @param {String} defaultValue The default value for the "alignment" attribute.
 	 */
 	constructor( editor, defaultValue ) {
-		super( editor, 'alignment', defaultValue );
+		super( editor, 'tableAlignment', defaultValue );
 	}
 }

--- a/packages/ckeditor5-table/src/tableproperties/commands/tablebackgroundcolorcommand.js
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tablebackgroundcolorcommand.js
@@ -31,6 +31,6 @@ export default class TableBackgroundColorCommand extends TablePropertyCommand {
 	 * @param {String} defaultValue The default value of the attribute.
 	 */
 	constructor( editor, defaultValue ) {
-		super( editor, 'backgroundColor', defaultValue );
+		super( editor, 'tableBackgroundColor', defaultValue );
 	}
 }

--- a/packages/ckeditor5-table/src/tableproperties/commands/tablebordercolorcommand.js
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tablebordercolorcommand.js
@@ -32,7 +32,7 @@ export default class TableBorderColorCommand extends TablePropertyCommand {
 	 * @param {String} defaultValue The default value of the attribute.
 	 */
 	constructor( editor, defaultValue ) {
-		super( editor, 'borderColor', defaultValue );
+		super( editor, 'tableBorderColor', defaultValue );
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tableproperties/commands/tableborderstylecommand.js
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tableborderstylecommand.js
@@ -32,7 +32,7 @@ export default class TableBorderStyleCommand extends TablePropertyCommand {
 	 * @param {String} defaultValue The default value of the attribute.
 	 */
 	constructor( editor, defaultValue ) {
-		super( editor, 'borderStyle', defaultValue );
+		super( editor, 'tableBorderStyle', defaultValue );
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tableproperties/commands/tableborderwidthcommand.js
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tableborderwidthcommand.js
@@ -40,7 +40,7 @@ export default class TableBorderWidthCommand extends TablePropertyCommand {
 	 * @param {String} defaultValue The default value of the attribute.
 	 */
 	constructor( editor, defaultValue ) {
-		super( editor, 'borderWidth', defaultValue );
+		super( editor, 'tableBorderWidth', defaultValue );
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tableproperties/commands/tableheightcommand.js
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tableheightcommand.js
@@ -40,7 +40,7 @@ export default class TableHeightCommand extends TablePropertyCommand {
 	 * @param {String} defaultValue The default value of the attribute.
 	 */
 	constructor( editor, defaultValue ) {
-		super( editor, 'height', defaultValue );
+		super( editor, 'tableHeight', defaultValue );
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tableproperties/commands/tablewidthcommand.js
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tablewidthcommand.js
@@ -40,7 +40,7 @@ export default class TableWidthCommand extends TablePropertyCommand {
 	 * @param {String} defaultValue The default value of the attribute.
 	 */
 	constructor( editor, defaultValue ) {
-		super( editor, 'width', defaultValue );
+		super( editor, 'tableWidth', defaultValue );
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.js
@@ -91,14 +91,14 @@ export default class TablePropertiesEditing extends Plugin {
 		editor.commands.add( 'tableAlignment', new TableAlignmentCommand( editor, defaultTableProperties.alignment ) );
 
 		enableTableToFigureProperty( schema, conversion, {
-			modelAttribute: 'width',
+			modelAttribute: 'tableWidth',
 			styleName: 'width',
 			defaultValue: defaultTableProperties.width
 		} );
 		editor.commands.add( 'tableWidth', new TableWidthCommand( editor, defaultTableProperties.width ) );
 
 		enableTableToFigureProperty( schema, conversion, {
-			modelAttribute: 'height',
+			modelAttribute: 'tableHeight',
 			styleName: 'height',
 			defaultValue: defaultTableProperties.height
 		} );
@@ -106,7 +106,7 @@ export default class TablePropertiesEditing extends Plugin {
 
 		editor.data.addStyleProcessorRules( addBackgroundRules );
 		enableProperty( schema, conversion, {
-			modelAttribute: 'backgroundColor',
+			modelAttribute: 'tableBackgroundColor',
 			styleName: 'background-color',
 			defaultValue: defaultTableProperties.backgroundColor
 		} );
@@ -130,9 +130,9 @@ function enableBorderProperties( schema, conversion, defaultBorder ) {
 		allowAttributes: [ 'borderWidth', 'borderColor', 'borderStyle' ]
 	} );
 	upcastBorderStyles( conversion, 'table', defaultBorder );
-	downcastTableAttribute( conversion, { modelAttribute: 'borderColor', styleName: 'border-color' } );
-	downcastTableAttribute( conversion, { modelAttribute: 'borderStyle', styleName: 'border-style' } );
-	downcastTableAttribute( conversion, { modelAttribute: 'borderWidth', styleName: 'border-width' } );
+	downcastTableAttribute( conversion, { modelAttribute: 'tableBorderColor', styleName: 'border-color' } );
+	downcastTableAttribute( conversion, { modelAttribute: 'tableBorderStyle', styleName: 'border-style' } );
+	downcastTableAttribute( conversion, { modelAttribute: 'tableBorderWidth', styleName: 'border-width' } );
 }
 
 // Enables the `'alignment'` attribute for table.
@@ -142,14 +142,14 @@ function enableBorderProperties( schema, conversion, defaultBorder ) {
 // @param {String} defaultValue The default alignment value.
 function enableAlignmentProperty( schema, conversion, defaultValue ) {
 	schema.extend( 'table', {
-		allowAttributes: [ 'alignment' ]
+		allowAttributes: [ 'tableAlignment' ]
 	} );
 
 	conversion.for( 'downcast' )
 		.attributeToAttribute( {
 			model: {
 				name: 'table',
-				key: 'alignment'
+				key: 'tableAlignment'
 			},
 			view: alignment => ( {
 				key: 'style',
@@ -171,7 +171,7 @@ function enableAlignmentProperty( schema, conversion, defaultValue ) {
 				}
 			},
 			model: {
-				key: 'alignment',
+				key: 'tableAlignment',
 				value: viewElement => {
 					let align = viewElement.getStyle( 'float' );
 
@@ -193,7 +193,7 @@ function enableAlignmentProperty( schema, conversion, defaultValue ) {
 			},
 			model: {
 				name: 'table',
-				key: 'alignment',
+				key: 'tableAlignment',
 				value: viewElement => {
 					const align = viewElement.getAttribute( 'align' );
 

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.js
@@ -34,10 +34,10 @@ const FLOAT_VALUES_REG_EXP = /^(left|none|right)$/;
  *
  * Introduces table's model attributes and their conversion:
  *
- * - border: `borderStyle`, `borderColor` and `borderWidth`
- * - background color: `backgroundColor`
- * - horizontal alignment: `alignment`
- * - width & height: `width` & `height`
+ * - border: `tableBorderStyle`, `tableBorderColor` and `tableBorderWidth`
+ * - background color: `tableBackgroundColor`
+ * - horizontal alignment: `tableAlignment`
+ * - width & height: `tableWidth` & `tableHeight`
  *
  * It also registers commands used to manipulate the above attributes:
  *
@@ -117,14 +117,14 @@ export default class TablePropertiesEditing extends Plugin {
 	}
 }
 
-// Enables `'borderStyle'`, `'borderColor'` and `'borderWidth'` attributes for table.
+// Enables `tableBorderStyle'`, `tableBorderColor'` and `tableBrderWidth'` attributes for table.
 //
 // @param {module:engine/model/schema~Schema} schema
 // @param {module:engine/conversion/conversion~Conversion} conversion
 // @param {Object} defaultBorder The default border values.
-// @param {String} defaultBorder.color The default `borderColor` value.
-// @param {String} defaultBorder.style The default `borderStyle` value.
-// @param {String} defaultBorder.width The default `borderWidth` value.
+// @param {String} defaultBorder.color The default `tableBorderColor` value.
+// @param {String} defaultBorder.style The default `tableBorderStyle` value.
+// @param {String} defaultBorder.width The default `tableBorderWidth` value.
 function enableBorderProperties( schema, conversion, defaultBorder ) {
 	const modelAttributes = {
 		width: 'tableBorderWidth',

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellbackgroundcolorcommand.js
@@ -70,14 +70,14 @@ describe( 'table cell properties', () => {
 
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should be undefined if selected table cell has no backgroundColor property', () => {
+					it( 'should be undefined if selected table cell has no tableCellBackgroundColor property', () => {
 						setData( model, modelTable( [ [ '[]foo' ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if selected table cell has backgroundColor property', () => {
-						setData( model, modelTable( [ [ { backgroundColor: 'blue', contents: '[]foo' } ] ] ) );
+					it( 'should be set if selected table cell has tableCellBackgroundColor property', () => {
+						setData( model, modelTable( [ [ { tableCellBackgroundColor: 'blue', contents: '[]foo' } ] ] ) );
 
 						expect( command.value ).to.equal( 'blue' );
 					} );
@@ -91,14 +91,14 @@ describe( 'table cell properties', () => {
 					} );
 
 					it( 'should be true is selection has table cell', () => {
-						setData( model, modelTable( [ [ { backgroundColor: 'blue', contents: 'f[o]o' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellBackgroundColor: 'blue', contents: 'f[o]o' } ] ] ) );
 
 						expect( command.value ).to.equal( 'blue' );
 					} );
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cell have the "backgroundColor" property', () => {
+					it( 'should be undefined if no table cell have the "tableCellBackgroundColor" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },
@@ -113,45 +113,46 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cells have the "backgroundColor" property', () => {
+					it( 'should be undefined if only some table cells have the "tableCellBackgroundColor" property', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, backgroundColor: '#f00' },
+								{ contents: '00', isSelected: true, tableCellBackgroundColor: '#f00' },
 								{ contents: '01', isSelected: true }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, backgroundColor: '#f00' }
+								{ contents: '11', isSelected: true, tableCellBackgroundColor: '#f00' }
 							]
 						] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has a different "backgroundColor" property value', () => {
+					it( `should be undefined if one of selected table cells
+						has a different "tableCellBackgroundColor" property value`, () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, backgroundColor: '#f00' },
-								{ contents: '01', isSelected: true, backgroundColor: 'pink' }
+								{ contents: '00', isSelected: true, tableCellBackgroundColor: '#f00' },
+								{ contents: '01', isSelected: true, tableCellBackgroundColor: 'pink' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, backgroundColor: '#f00' }
+								{ contents: '11', isSelected: true, tableCellBackgroundColor: '#f00' }
 							]
 						] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cell have the same "backgroundColor" property value', () => {
+					it( 'should be set if all table cell have the same "tableCellBackgroundColor" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, backgroundColor: '#f00' },
-								{ contents: '01', isSelected: true, backgroundColor: '#f00' }
+								{ contents: '00', isSelected: true, tableCellBackgroundColor: '#f00' },
+								{ contents: '01', isSelected: true, tableCellBackgroundColor: '#f00' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, backgroundColor: '#f00' }
+								{ contents: '11', isSelected: true, tableCellBackgroundColor: '#f00' }
 							]
 						] ) );
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellbordercolorcommand.js
@@ -70,21 +70,21 @@ describe( 'table cell properties', () => {
 
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should be undefined if selected table cell has no borderColor property', () => {
+					it( 'should be undefined if selected table cell has no tableCellBorderColor property', () => {
 						setData( model, modelTable( [ [ '[]foo' ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if selected table cell has borderColor property (single string)', () => {
-						setData( model, modelTable( [ [ { borderColor: 'blue', contents: '[]foo' } ] ] ) );
+					it( 'should be set if selected table cell has tableCellBorderColor property (single string)', () => {
+						setData( model, modelTable( [ [ { tableCellBorderColor: 'blue', contents: '[]foo' } ] ] ) );
 
 						expect( command.value ).to.equal( 'blue' );
 					} );
 
-					it( 'should be set if selected table cell has borderColor property object with same values', () => {
+					it( 'should be set if selected table cell has tableCellBorderColor property object with same values', () => {
 						setTableCellWithObjectAttributes( model, {
-							borderColor: {
+							tableCellBorderColor: {
 								top: 'blue',
 								right: 'blue',
 								bottom: 'blue',
@@ -94,9 +94,9 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.equal( 'blue' );
 					} );
 
-					it( 'should be undefined if selected table cell has borderColor property object with different values', () => {
+					it( 'should be undefined if selected table cell has tableCellBorderColor property object with different values', () => {
 						setTableCellWithObjectAttributes( model, {
-							borderColor: {
+							tableCellBorderColor: {
 								top: 'blue',
 								right: 'red',
 								bottom: 'blue',
@@ -116,14 +116,14 @@ describe( 'table cell properties', () => {
 					} );
 
 					it( 'should be true is selection has table cell', () => {
-						setData( model, modelTable( [ [ { borderColor: 'blue', contents: 'f[o]o' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellBorderColor: 'blue', contents: 'f[o]o' } ] ] ) );
 
 						expect( command.value ).to.equal( 'blue' );
 					} );
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cells have the "borderColor" property', () => {
+					it( 'should be undefined if no table cells have the "tableCellBorderColor" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },
@@ -138,45 +138,45 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cells have the "borderColor" property', () => {
+					it( 'should be undefined if only some table cells have the "tableCellBorderColor" property', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, borderColor: '#f00' },
+								{ contents: '00', isSelected: true, tableCellBorderColor: '#f00' },
 								{ contents: '01', isSelected: true }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, borderColor: '#f00' }
+								{ contents: '11', isSelected: true, tableCellBorderColor: '#f00' }
 							]
 						] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has a different "borderColor" property value', () => {
+					it( 'should be undefined if one of selected table cells has a different "tableCellBorderColor" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, borderColor: '#f00' },
-								{ contents: '01', isSelected: true, borderColor: 'pink' }
+								{ contents: '00', isSelected: true, tableCellBorderColor: '#f00' },
+								{ contents: '01', isSelected: true, tableCellBorderColor: 'pink' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, borderColor: '#f00' }
+								{ contents: '11', isSelected: true, tableCellBorderColor: '#f00' }
 							]
 						] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cells have the same "borderColor" property value', () => {
+					it( 'should be set if all table cells have the same "tableCellBorderColor" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, borderColor: '#f00' },
-								{ contents: '01', isSelected: true, borderColor: '#f00' }
+								{ contents: '00', isSelected: true, tableCellBorderColor: '#f00' },
+								{ contents: '01', isSelected: true, tableCellBorderColor: '#f00' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, borderColor: '#f00' }
+								{ contents: '11', isSelected: true, tableCellBorderColor: '#f00' }
 							]
 						] ) );
 
@@ -196,7 +196,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'collapsed selection', () => {
-					it( 'should set selected table cell borderColor to a passed value', () => {
+					it( 'should set selected table cell tableCellBorderColor to a passed value', () => {
 						setData( model, modelTable( [ [ 'foo[]' ] ] ) );
 
 						command.execute( { value: '#f00' } );
@@ -204,16 +204,16 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'border-color:#f00;' );
 					} );
 
-					it( 'should change selected table cell borderColor to a passed value', () => {
-						setData( model, modelTable( [ [ { borderColor: 'blue', contents: '[]foo' } ] ] ) );
+					it( 'should change selected table cell tableCellBorderColor to a passed value', () => {
+						setData( model, modelTable( [ [ { tableCellBorderColor: 'blue', contents: '[]foo' } ] ] ) );
 
 						command.execute( { value: '#f00' } );
 
 						assertTableCellStyle( editor, 'border-color:#f00;' );
 					} );
 
-					it( 'should remove borderColor from a selected table cell if no value is passed', () => {
-						setData( model, modelTable( [ [ { borderColor: 'blue', contents: '[]foo' } ] ] ) );
+					it( 'should remove tableCellBorderColor from a selected table cell if no value is passed', () => {
+						setData( model, modelTable( [ [ { tableCellBorderColor: 'blue', contents: '[]foo' } ] ] ) );
 
 						command.execute();
 
@@ -222,7 +222,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'non-collapsed selection', () => {
-					it( 'should set selected table cell borderColor to a passed value', () => {
+					it( 'should set selected table cell tableCellBorderColor to a passed value', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute( { value: '#f00' } );
@@ -230,7 +230,7 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'border-color:#f00;' );
 					} );
 
-					it( 'should change selected table cell borderColor to a passed value', () => {
+					it( 'should change selected table cell tableCellBorderColor to a passed value', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute( { value: '#f00' } );
@@ -238,7 +238,7 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'border-color:#f00;' );
 					} );
 
-					it( 'should remove borderColor from a selected table cell if no value is passed', () => {
+					it( 'should remove tableCellBorderColor from a selected table cell if no value is passed', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute();
@@ -255,7 +255,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should set the "borderColor" attribute value of selected table cells', () => {
+					it( 'should set the "tableCellBorderColor" attribute value of selected table cells', () => {
 						command.execute( { value: '#f00' } );
 
 						assertEqualMarkup( editor.getData(), viewTable( [
@@ -266,8 +266,8 @@ describe( 'table cell properties', () => {
 
 					it( 'should remove "borderColor" from the selected table cell if no value is passed', () => {
 						setData( model, modelTable( [
-							[ { contents: '00', isSelected: true, borderColor: '#f00' }, '01' ],
-							[ '10', { contents: '11', isSelected: true, borderColor: '#f00' } ]
+							[ { contents: '00', isSelected: true, tableCellBorderColor: '#f00' }, '01' ],
+							[ '10', { contents: '11', isSelected: true, tableCellBorderColor: '#f00' } ]
 						] ) );
 
 						command.execute();
@@ -299,15 +299,16 @@ describe( 'table cell properties', () => {
 
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should be undefined if selected table cell has the default borderColor property (single string)', () => {
-						setData( model, modelTable( [ [ { borderColor: 'red', contents: '[]foo' } ] ] ) );
+					it( 'should be undefined if selected table cell has the default tableCellBorderColor property (single string)', () => {
+						setData( model, modelTable( [ [ { tableCellBorderColor: 'red', contents: '[]foo' } ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if selected table cell has the default borderColor property object with same values', () => {
+					it( `should be undefined if selected table cell
+						has the default tableCellBorderColor property object with same values`, () => {
 						setTableCellWithObjectAttributes( model, {
-							borderColor: {
+							tableCellBorderColor: {
 								top: 'red',
 								right: 'red',
 								bottom: 'red',
@@ -320,7 +321,7 @@ describe( 'table cell properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should be undefined is selection contains the default value', () => {
-						setData( model, modelTable( [ [ { borderColor: 'red', contents: 'f[o]o' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellBorderColor: 'red', contents: 'f[o]o' } ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
@@ -332,12 +333,12 @@ describe( 'table cell properties', () => {
 						() => {
 							setData( model, modelTable( [
 								[
-									{ contents: '00', isSelected: true, borderColor: 'red' },
-									{ contents: '01', isSelected: true, borderColor: 'red' }
+									{ contents: '00', isSelected: true, tableCellBorderColor: 'red' },
+									{ contents: '01', isSelected: true, tableCellBorderColor: 'red' }
 								],
 								[
 									'10',
-									{ contents: '11', isSelected: true, borderColor: 'red' }
+									{ contents: '11', isSelected: true, tableCellBorderColor: 'red' }
 								]
 							] ) );
 
@@ -348,8 +349,8 @@ describe( 'table cell properties', () => {
 
 			describe( 'execute()', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should remove borderColor from a selected table cell if the default value is passed', () => {
-						setData( model, modelTable( [ [ { borderColor: 'blue', contents: '[]foo' } ] ] ) );
+					it( 'should remove tableCellBorderColor from a selected table cell if the default value is passed', () => {
+						setData( model, modelTable( [ [ { tableCellBorderColor: 'blue', contents: '[]foo' } ] ] ) );
 
 						command.execute( { value: 'red' } );
 
@@ -358,7 +359,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'non-collapsed selection', () => {
-					it( 'should remove borderColor from a selected table cell if the default value is passed', () => {
+					it( 'should remove tableCellBorderColor from a selected table cell if the default value is passed', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute( { value: 'red' } );
@@ -370,8 +371,8 @@ describe( 'table cell properties', () => {
 				describe( 'multi-cell selection', () => {
 					it( 'should remove "borderColor" from the selected table cell if the default value is passed', () => {
 						setData( model, modelTable( [
-							[ { contents: '00', isSelected: true, borderColor: '#f00' }, '01' ],
-							[ '10', { contents: '11', isSelected: true, borderColor: '#f00' } ]
+							[ { contents: '00', isSelected: true, tableCellBorderColor: '#f00' }, '01' ],
+							[ '10', { contents: '11', isSelected: true, tableCellBorderColor: '#f00' } ]
 						] ) );
 
 						command.execute( { value: 'red' } );

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellborderstylecommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellborderstylecommand.js
@@ -70,21 +70,21 @@ describe( 'table cell properties', () => {
 
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should be undefined if selected table cell has no borderStyle property', () => {
+					it( 'should be undefined if selected table cell has no tableCellBorderStyle property', () => {
 						setData( model, modelTable( [ [ '[]foo' ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if selected table cell has borderStyle property (single string)', () => {
-						setData( model, modelTable( [ [ { borderStyle: 'ridge', contents: '[]foo' } ] ] ) );
+					it( 'should be set if selected table cell has tableCellBorderStyle property (single string)', () => {
+						setData( model, modelTable( [ [ { tableCellBorderStyle: 'ridge', contents: '[]foo' } ] ] ) );
 
 						expect( command.value ).to.equal( 'ridge' );
 					} );
 
-					it( 'should be set if selected table cell has borderStyle property object with same values', () => {
+					it( 'should be set if selected table cell has tableCellBorderStyle property object with same values', () => {
 						setTableCellWithObjectAttributes( model, {
-							borderStyle: {
+							tableCellBorderStyle: {
 								top: 'ridge',
 								right: 'ridge',
 								bottom: 'ridge',
@@ -94,9 +94,9 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.equal( 'ridge' );
 					} );
 
-					it( 'should be undefined if selected table cell has borderStyle property object with different values', () => {
+					it( 'should be undefined if selected table cell has tableCellBorderStyle property object with different values', () => {
 						setTableCellWithObjectAttributes( model, {
-							borderStyle: {
+							tableCellBorderStyle: {
 								top: 'ridge',
 								right: 'dashed',
 								bottom: 'ridge',
@@ -116,7 +116,7 @@ describe( 'table cell properties', () => {
 					} );
 
 					it( 'should be true is selection has table cell', () => {
-						setData( model, modelTable( [ [ { borderStyle: 'ridge', contents: 'f[o]o' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellBorderStyle: 'ridge', contents: 'f[o]o' } ] ] ) );
 
 						expect( command.value ).to.equal( 'ridge' );
 					} );
@@ -141,12 +141,12 @@ describe( 'table cell properties', () => {
 					it( 'should be undefined if only some table cells have the "borderStyle" property', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, borderStyle: 'solid' },
+								{ contents: '00', isSelected: true, tableCellBorderStyle: 'solid' },
 								{ contents: '01', isSelected: true }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, borderStyle: 'solid' }
+								{ contents: '11', isSelected: true, tableCellBorderStyle: 'solid' }
 							]
 						] ) );
 
@@ -156,12 +156,12 @@ describe( 'table cell properties', () => {
 					it( 'should be undefined if one of selected table cells has a different "borderStyle" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, borderStyle: 'solid' },
-								{ contents: '01', isSelected: true, borderStyle: 'ridge' }
+								{ contents: '00', isSelected: true, tableCellBorderStyle: 'solid' },
+								{ contents: '01', isSelected: true, tableCellBorderStyle: 'ridge' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, borderStyle: 'solid' }
+								{ contents: '11', isSelected: true, tableCellBorderStyle: 'solid' }
 							]
 						] ) );
 
@@ -171,12 +171,12 @@ describe( 'table cell properties', () => {
 					it( 'should be set if all table cells have the same "borderStyle" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, borderStyle: 'solid' },
-								{ contents: '01', isSelected: true, borderStyle: 'solid' }
+								{ contents: '00', isSelected: true, tableCellBorderStyle: 'solid' },
+								{ contents: '01', isSelected: true, tableCellBorderStyle: 'solid' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, borderStyle: 'solid' }
+								{ contents: '11', isSelected: true, tableCellBorderStyle: 'solid' }
 							]
 						] ) );
 
@@ -196,7 +196,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'collapsed selection', () => {
-					it( 'should set selected table cell borderStyle to a passed value', () => {
+					it( 'should set selected table cell tableCellBorderStyle to a passed value', () => {
 						setData( model, modelTable( [ [ 'foo[]' ] ] ) );
 
 						command.execute( { value: 'solid' } );
@@ -204,16 +204,16 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'border-style:solid;' );
 					} );
 
-					it( 'should change selected table cell borderStyle to a passed value', () => {
-						setData( model, modelTable( [ [ { borderStyle: 'ridge', contents: '[]foo' } ] ] ) );
+					it( 'should change selected table cell tableCellBorderStyle to a passed value', () => {
+						setData( model, modelTable( [ [ { tableCellBorderStyle: 'ridge', contents: '[]foo' } ] ] ) );
 
 						command.execute( { value: 'solid' } );
 
 						assertTableCellStyle( editor, 'border-style:solid;' );
 					} );
 
-					it( 'should remove borderStyle from a selected table cell if no value is passed', () => {
-						setData( model, modelTable( [ [ { borderStyle: 'ridge', contents: '[]foo' } ] ] ) );
+					it( 'should remove tableCellBorderStyle from a selected table cell if no value is passed', () => {
+						setData( model, modelTable( [ [ { tableCellBorderStyle: 'ridge', contents: '[]foo' } ] ] ) );
 
 						command.execute();
 
@@ -222,7 +222,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'non-collapsed selection', () => {
-					it( 'should set selected table cell borderStyle to a passed value', () => {
+					it( 'should set selected table cell tableCellBorderStyle to a passed value', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute( { value: 'solid' } );
@@ -230,7 +230,7 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'border-style:solid;' );
 					} );
 
-					it( 'should change selected table cell borderStyle to a passed value', () => {
+					it( 'should change selected table cell tableCellBorderStyle to a passed value', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute( { value: 'solid' } );
@@ -238,7 +238,7 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'border-style:solid;' );
 					} );
 
-					it( 'should remove borderStyle from a selected table cell if no value is passed', () => {
+					it( 'should remove tableCellBorderStyle from a selected table cell if no value is passed', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute();
@@ -272,8 +272,8 @@ describe( 'table cell properties', () => {
 
 					it( 'should remove "borderStyle" from selected table cells if no value is passed', () => {
 						setData( model, modelTable( [
-							[ { contents: '00', isSelected: true, borderStyle: 'solid' }, '01' ],
-							[ '10', { contents: '11', isSelected: true, borderStyle: 'solid' } ]
+							[ { contents: '00', isSelected: true, tableCellBorderStyle: 'solid' }, '01' ],
+							[ '10', { contents: '11', isSelected: true, tableCellBorderStyle: 'solid' } ]
 						] ) );
 
 						command.execute();
@@ -305,15 +305,16 @@ describe( 'table cell properties', () => {
 
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should be undefined if selected table cell has the default borderStyle property (single string)', () => {
-						setData( model, modelTable( [ [ { borderStyle: 'solid', contents: '[]foo' } ] ] ) );
+					it( 'should be undefined if selected table cell has the default tableCellBorderStyle property (single string)', () => {
+						setData( model, modelTable( [ [ { tableCellBorderStyle: 'solid', contents: '[]foo' } ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if selected table cell has the default borderStyle property object with same values', () => {
+					it( `should be undefined if selected table cell
+						has the default tableCellBorderStyle property object with same values`, () => {
 						setTableCellWithObjectAttributes( model, {
-							borderStyle: {
+							tableCellBorderStyle: {
 								top: 'solid',
 								right: 'solid',
 								bottom: 'solid',
@@ -326,7 +327,7 @@ describe( 'table cell properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should be undefined is selection contains the default value', () => {
-						setData( model, modelTable( [ [ { borderStyle: 'solid', contents: 'f[o]o' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellBorderStyle: 'solid', contents: 'f[o]o' } ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
@@ -338,12 +339,12 @@ describe( 'table cell properties', () => {
 						() => {
 							setData( model, modelTable( [
 								[
-									{ contents: '00', isSelected: true, borderStyle: 'solid' },
-									{ contents: '01', isSelected: true, borderStyle: 'solid' }
+									{ contents: '00', isSelected: true, tableCellBorderStyle: 'solid' },
+									{ contents: '01', isSelected: true, tableCellBorderStyle: 'solid' }
 								],
 								[
 									'10',
-									{ contents: '11', isSelected: true, borderStyle: 'solid' }
+									{ contents: '11', isSelected: true, tableCellBorderStyle: 'solid' }
 								]
 							] ) );
 
@@ -355,8 +356,8 @@ describe( 'table cell properties', () => {
 
 			describe( 'execute()', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should remove borderStyle from a selected table cell if the default value is passed', () => {
-						setData( model, modelTable( [ [ { borderStyle: 'ridge', contents: '[]foo' } ] ] ) );
+					it( 'should remove tableCellBorderStyle from a selected table cell if the default value is passed', () => {
+						setData( model, modelTable( [ [ { tableCellBorderStyle: 'ridge', contents: '[]foo' } ] ] ) );
 
 						command.execute( { value: 'solid' } );
 
@@ -365,8 +366,8 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'non-collapsed selection', () => {
-					it( 'should remove borderStyle from a selected table cell if the default value is passed', () => {
-						setData( model, modelTable( [ [ { borderStyle: 'ridge', contents: '[foo]' } ] ] ) );
+					it( 'should remove tableCellBorderStyle from a selected table cell if the default value is passed', () => {
+						setData( model, modelTable( [ [ { tableCellBorderStyle: 'ridge', contents: '[foo]' } ] ] ) );
 
 						command.execute( { value: 'solid' } );
 
@@ -377,8 +378,8 @@ describe( 'table cell properties', () => {
 				describe( 'multi-cell selection', () => {
 					it( 'should remove "borderStyle" from selected table cells if the default value is passed', () => {
 						setData( model, modelTable( [
-							[ { contents: '00', isSelected: true, borderStyle: 'solid' }, '01' ],
-							[ '10', { contents: '11', isSelected: true, borderStyle: 'solid' } ]
+							[ { contents: '00', isSelected: true, tableCellBorderStyle: 'solid' }, '01' ],
+							[ '10', { contents: '11', isSelected: true, tableCellBorderStyle: 'solid' } ]
 						] ) );
 
 						command.execute( { value: 'solid' } );

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellborderwidthcommand.js
@@ -70,21 +70,21 @@ describe( 'table cell properties', () => {
 
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should be undefined if selected table cell has no borderWidth property', () => {
+					it( 'should be undefined if selected table cell has no tableCellBorderWidth property', () => {
 						setData( model, modelTable( [ [ '[]foo' ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if selected table cell has borderWidth property (single string)', () => {
-						setData( model, modelTable( [ [ { borderWidth: '2em', contents: '[]foo' } ] ] ) );
+					it( 'should be set if selected table cell has tableCellBorderWidth property (single string)', () => {
+						setData( model, modelTable( [ [ { tableCellBorderWidth: '2em', contents: '[]foo' } ] ] ) );
 
 						expect( command.value ).to.equal( '2em' );
 					} );
 
-					it( 'should be set if selected table cell has borderWidth property object with same values', () => {
+					it( 'should be set if selected table cell has tableCellBorderWidth property object with same values', () => {
 						setTableCellWithObjectAttributes( model, {
-							borderWidth: {
+							tableCellBorderWidth: {
 								top: '2em',
 								right: '2em',
 								bottom: '2em',
@@ -94,9 +94,9 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.equal( '2em' );
 					} );
 
-					it( 'should be undefined if selected table cell has borderWidth property object with different values', () => {
+					it( 'should be undefined if selected table cell has tableCellBorderWidth property object with different values', () => {
 						setTableCellWithObjectAttributes( model, {
-							borderWidth: {
+							tableCellBorderWidth: {
 								top: '2em',
 								right: '333px',
 								bottom: '2em',
@@ -116,7 +116,7 @@ describe( 'table cell properties', () => {
 					} );
 
 					it( 'should be true is selection has table cell', () => {
-						setData( model, modelTable( [ [ { borderWidth: '2em', contents: 'f[o]o' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellBorderWidth: '2em', contents: 'f[o]o' } ] ] ) );
 
 						expect( command.value ).to.equal( '2em' );
 					} );
@@ -141,12 +141,12 @@ describe( 'table cell properties', () => {
 					it( 'should be undefined if only some table cells have the "borderWidth" property', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, borderWidth: '1px' },
+								{ contents: '00', isSelected: true, tableCellBorderWidth: '1px' },
 								{ contents: '01', isSelected: true }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, borderWidth: '1px' }
+								{ contents: '11', isSelected: true, tableCellBorderWidth: '1px' }
 							]
 						] ) );
 
@@ -156,12 +156,12 @@ describe( 'table cell properties', () => {
 					it( 'should be undefined if one of selected table cells has a different "borderWidth" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, borderWidth: '1px' },
-								{ contents: '01', isSelected: true, borderWidth: '20px' }
+								{ contents: '00', isSelected: true, tableCellBorderWidth: '1px' },
+								{ contents: '01', isSelected: true, tableCellBorderWidth: '20px' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, borderWidth: '1px' }
+								{ contents: '11', isSelected: true, tableCellBorderWidth: '1px' }
 							]
 						] ) );
 
@@ -171,12 +171,12 @@ describe( 'table cell properties', () => {
 					it( 'should be set if all table cells have the same "borderWidth" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, borderWidth: '1px' },
-								{ contents: '01', isSelected: true, borderWidth: '1px' }
+								{ contents: '00', isSelected: true, tableCellBorderWidth: '1px' },
+								{ contents: '01', isSelected: true, tableCellBorderWidth: '1px' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, borderWidth: '1px' }
+								{ contents: '11', isSelected: true, tableCellBorderWidth: '1px' }
 							]
 						] ) );
 
@@ -252,7 +252,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'collapsed selection', () => {
-					it( 'should set selected table cell borderWidth to a passed value', () => {
+					it( 'should set selected table cell tableCellBorderWidth to a passed value', () => {
 						setData( model, modelTable( [ [ 'foo[]' ] ] ) );
 
 						command.execute( { value: '1px' } );
@@ -260,16 +260,16 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'border-width:1px;' );
 					} );
 
-					it( 'should change selected table cell borderWidth to a passed value', () => {
-						setData( model, modelTable( [ [ { borderWidth: '2em', contents: '[]foo' } ] ] ) );
+					it( 'should change selected table cell tableCellBorderWidth to a passed value', () => {
+						setData( model, modelTable( [ [ { tableCellBorderWidth: '2em', contents: '[]foo' } ] ] ) );
 
 						command.execute( { value: '1px' } );
 
 						assertTableCellStyle( editor, 'border-width:1px;' );
 					} );
 
-					it( 'should remove borderWidth from a selected table cell if no value is passed', () => {
-						setData( model, modelTable( [ [ { borderWidth: '2em', contents: '[]foo' } ] ] ) );
+					it( 'should remove tableCellBorderWidth from a selected table cell if no value is passed', () => {
+						setData( model, modelTable( [ [ { tableCellBorderWidth: '2em', contents: '[]foo' } ] ] ) );
 
 						command.execute();
 
@@ -278,7 +278,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'non-collapsed selection', () => {
-					it( 'should set selected table cell borderWidth to a passed value', () => {
+					it( 'should set selected table cell tableCellBorderWidth to a passed value', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute( { value: '1px' } );
@@ -286,7 +286,7 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'border-width:1px;' );
 					} );
 
-					it( 'should change selected table cell borderWidth to a passed value', () => {
+					it( 'should change selected table cell tableCellBorderWidth to a passed value', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute( { value: '1px' } );
@@ -294,7 +294,7 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'border-width:1px;' );
 					} );
 
-					it( 'should remove borderWidth from a selected table cell if no value is passed', () => {
+					it( 'should remove tableCellBorderWidth from a selected table cell if no value is passed', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute();
@@ -328,8 +328,8 @@ describe( 'table cell properties', () => {
 
 					it( 'should remove "borderWidth" from selected table cells if no value is passed', () => {
 						setData( model, modelTable( [
-							[ { contents: '00', isSelected: true, borderWidth: '1px' }, '01' ],
-							[ '10', { contents: '11', isSelected: true, borderWidth: '1px' } ]
+							[ { contents: '00', isSelected: true, tableCellBorderWidth: '1px' }, '01' ],
+							[ '10', { contents: '11', isSelected: true, tableCellBorderWidth: '1px' } ]
 						] ) );
 
 						command.execute();
@@ -361,15 +361,16 @@ describe( 'table cell properties', () => {
 
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should be undefined if selected table cell has the default borderWidth property (single string)', () => {
-						setData( model, modelTable( [ [ { borderWidth: '3px', contents: '[]foo' } ] ] ) );
+					it( 'should be undefined if selected table cell has the default tableCellBorderWidth property (single string)', () => {
+						setData( model, modelTable( [ [ { tableCellBorderWidth: '3px', contents: '[]foo' } ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if selected table cell hast the default borderWidth property object with same values', () => {
+					it( `should be undefined if selected table cell hast the default
+						tableCellBorderWidth property object with same values`, () => {
 						setTableCellWithObjectAttributes( model, {
-							borderWidth: {
+							tableCellBorderWidth: {
 								top: '3px',
 								right: '3px',
 								bottom: '3px',
@@ -382,7 +383,7 @@ describe( 'table cell properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should be undefined is selection contains the default valuel', () => {
-						setData( model, modelTable( [ [ { borderWidth: '3px', contents: 'f[o]o' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellBorderWidth: '3px', contents: 'f[o]o' } ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
@@ -394,12 +395,12 @@ describe( 'table cell properties', () => {
 						() => {
 							setData( model, modelTable( [
 								[
-									{ contents: '00', isSelected: true, borderWidth: '3px' },
-									{ contents: '01', isSelected: true, borderWidth: '3px' }
+									{ contents: '00', isSelected: true, tableCellBorderWidth: '3px' },
+									{ contents: '01', isSelected: true, tableCellBorderWidth: '3px' }
 								],
 								[
 									'10',
-									{ contents: '11', isSelected: true, borderWidth: '3px' }
+									{ contents: '11', isSelected: true, tableCellBorderWidth: '3px' }
 								]
 							] ) );
 
@@ -411,8 +412,8 @@ describe( 'table cell properties', () => {
 
 			describe( 'execute()', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should remove borderWidth from a selected table cell if the default value is passed', () => {
-						setData( model, modelTable( [ [ { borderWidth: '2em', contents: '[]foo' } ] ] ) );
+					it( 'should remove tableCellBorderWidth from a selected table cell if the default value is passed', () => {
+						setData( model, modelTable( [ [ { tableCellBorderWidth: '2em', contents: '[]foo' } ] ] ) );
 
 						command.execute( { value: '3px' } );
 
@@ -421,7 +422,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'non-collapsed selection', () => {
-					it( 'should remove borderWidth from a selected table cell if the default value is passed', () => {
+					it( 'should remove tableCellBorderWidth from a selected table cell if the default value is passed', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute( { value: '3px' } );
@@ -433,8 +434,8 @@ describe( 'table cell properties', () => {
 				describe( 'multi-cell selection', () => {
 					it( 'should remove "borderWidth" from selected table cells if the default value is passed', () => {
 						setData( model, modelTable( [
-							[ { contents: '00', isSelected: true, borderWidth: '1px' }, '01' ],
-							[ '10', { contents: '11', isSelected: true, borderWidth: '1px' } ]
+							[ { contents: '00', isSelected: true, tableCellBorderWidth: '1px' }, '01' ],
+							[ '10', { contents: '11', isSelected: true, tableCellBorderWidth: '1px' } ]
 						] ) );
 
 						command.execute( { value: '3px' } );

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellheightcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellheightcommand.js
@@ -70,14 +70,14 @@ describe( 'table cell properties', () => {
 
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should be undefined if selected table cell has no height property', () => {
+					it( 'should be undefined if selected table cell has no tableCellHeight property', () => {
 						setData( model, modelTable( [ [ '[]foo' ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if selected table cell has height property', () => {
-						setData( model, modelTable( [ [ { height: '100px', contents: '[]foo' } ] ] ) );
+					it( 'should be set if selected table cell has tableCellHeight property', () => {
+						setData( model, modelTable( [ [ { tableCellHeight: '100px', contents: '[]foo' } ] ] ) );
 
 						expect( command.value ).to.equal( '100px' );
 					} );
@@ -91,14 +91,14 @@ describe( 'table cell properties', () => {
 					} );
 
 					it( 'should be true is selection has table cell', () => {
-						setData( model, modelTable( [ [ { height: '100px', contents: 'f[o]o' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellHeight: '100px', contents: 'f[o]o' } ] ] ) );
 
 						expect( command.value ).to.equal( '100px' );
 					} );
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cell have the "height" property', () => {
+					it( 'should be undefined if no table cell have the "tableCellHeight" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },
@@ -113,45 +113,45 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cells have the "height" property', () => {
+					it( 'should be undefined if only some table cells have the "tableCellHeight" property', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, height: '100px' },
+								{ contents: '00', isSelected: true, tableCellHeight: '100px' },
 								{ contents: '01', isSelected: true }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, height: '100px' }
+								{ contents: '11', isSelected: true, tableCellHeight: '100px' }
 							]
 						] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has a different "height" property value', () => {
+					it( 'should be undefined if one of selected table cells has a different "tableCellHeight" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, height: '100px' },
-								{ contents: '01', isSelected: true, height: '23px' }
+								{ contents: '00', isSelected: true, tableCellHeight: '100px' },
+								{ contents: '01', isSelected: true, tableCellHeight: '23px' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, height: '100px' }
+								{ contents: '11', isSelected: true, tableCellHeight: '100px' }
 							]
 						] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cell have the same "height" property value', () => {
+					it( 'should be set if all table cell have the same "tableCellHeight" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, height: '100px' },
-								{ contents: '01', isSelected: true, height: '100px' }
+								{ contents: '00', isSelected: true, tableCellHeight: '100px' },
+								{ contents: '01', isSelected: true, tableCellHeight: '100px' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, height: '100px' }
+								{ contents: '11', isSelected: true, tableCellHeight: '100px' }
 							]
 						] ) );
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellhorizontalalignmentcommand.js
@@ -70,14 +70,14 @@ describe( 'table cell properties', () => {
 
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should be undefined if selected table cell has no horizontalAlignment property', () => {
+					it( 'should be undefined if selected table cell has no tableCellHorizontalAlignment property', () => {
 						setData( model, modelTable( [ [ '[]foo' ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if selected table cell has horizontalAlignment property', () => {
-						setData( model, modelTable( [ [ { horizontalAlignment: 'center', contents: '[]foo' } ] ] ) );
+					it( 'should be set if selected table cell has tableCellHorizontalAlignment property', () => {
+						setData( model, modelTable( [ [ { tableCellHorizontalAlignment: 'center', contents: '[]foo' } ] ] ) );
 
 						expect( command.value ).to.equal( 'center' );
 					} );
@@ -91,14 +91,14 @@ describe( 'table cell properties', () => {
 					} );
 
 					it( 'should be true is selection has table cell', () => {
-						setData( model, modelTable( [ [ { horizontalAlignment: 'center', contents: 'f[o]o' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellHorizontalAlignment: 'center', contents: 'f[o]o' } ] ] ) );
 
 						expect( command.value ).to.equal( 'center' );
 					} );
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cells have the "horizontalAlignment" property', () => {
+					it( 'should be undefined if no table cells have the "tableCellHorizontalAlignment" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },
@@ -113,45 +113,46 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cells have the "horizontalAlignment" property', () => {
+					it( 'should be undefined if only some table cells have the "tableCellHorizontalAlignment" property', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, horizontalAlignment: 'center' },
+								{ contents: '00', isSelected: true, tableCellHorizontalAlignment: 'center' },
 								{ contents: '01', isSelected: true }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, horizontalAlignment: 'center' }
+								{ contents: '11', isSelected: true, tableCellHorizontalAlignment: 'center' }
 							]
 						] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has a different "horizontalAlignment" property value', () => {
+					it( `should be undefined if one of selected table cells
+						has a different "tableCellHorizontalAlignment" property value`, () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, horizontalAlignment: 'center' },
-								{ contents: '01', isSelected: true, horizontalAlignment: 'right' }
+								{ contents: '00', isSelected: true, tableCellHorizontalAlignment: 'center' },
+								{ contents: '01', isSelected: true, tableCellHorizontalAlignment: 'right' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, horizontalAlignment: 'center' }
+								{ contents: '11', isSelected: true, tableCellHorizontalAlignment: 'center' }
 							]
 						] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cells have the same "horizontalAlignment" property value', () => {
+					it( 'should be set if all table cells have the same "tableCellHorizontalAlignment" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, horizontalAlignment: 'center' },
-								{ contents: '01', isSelected: true, horizontalAlignment: 'center' }
+								{ contents: '00', isSelected: true, tableCellHorizontalAlignment: 'center' },
+								{ contents: '01', isSelected: true, tableCellHorizontalAlignment: 'center' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, horizontalAlignment: 'center' }
+								{ contents: '11', isSelected: true, tableCellHorizontalAlignment: 'center' }
 							]
 						] ) );
 
@@ -171,7 +172,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'collapsed selection', () => {
-					it( 'should set selected table cell horizontalAlignment to a passed value', () => {
+					it( 'should set selected table cell tableCellHorizontalAlignment to a passed value', () => {
 						setData( model, modelTable( [ [ 'foo[]' ] ] ) );
 
 						command.execute( { value: 'right' } );
@@ -179,16 +180,16 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'text-align:right;' );
 					} );
 
-					it( 'should change selected table cell horizontalAlignment to a passed value', () => {
-						setData( model, modelTable( [ [ { horizontalAlignment: 'center', contents: '[]foo' } ] ] ) );
+					it( 'should change selected table cell tableCellHorizontalAlignment to a passed value', () => {
+						setData( model, modelTable( [ [ { tableCellHorizontalAlignment: 'center', contents: '[]foo' } ] ] ) );
 
 						command.execute( { value: 'right' } );
 
 						assertTableCellStyle( editor, 'text-align:right;' );
 					} );
 
-					it( 'should remove horizontalAlignment from a selected table cell if no value is passed', () => {
-						setData( model, modelTable( [ [ { horizontalAlignment: 'center', contents: '[]foo' } ] ] ) );
+					it( 'should remove tableCellHorizontalAlignment from a selected table cell if no value is passed', () => {
+						setData( model, modelTable( [ [ { tableCellHorizontalAlignment: 'center', contents: '[]foo' } ] ] ) );
 
 						command.execute();
 
@@ -197,7 +198,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'non-collapsed selection', () => {
-					it( 'should set selected table cell horizontalAlignment to a passed value', () => {
+					it( 'should set selected table cell tableCellHorizontalAlignment to a passed value', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute( { value: 'right' } );
@@ -205,7 +206,7 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'text-align:right;' );
 					} );
 
-					it( 'should change selected table cell horizontalAlignment to a passed value', () => {
+					it( 'should change selected table cell tableCellHorizontalAlignment to a passed value', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute( { value: 'right' } );
@@ -213,7 +214,7 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'text-align:right;' );
 					} );
 
-					it( 'should remove horizontalAlignment from a selected table cell if no value is passed', () => {
+					it( 'should remove tableCellHorizontalAlignment from a selected table cell if no value is passed', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute();
@@ -230,7 +231,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should set the "horizontalAlignment" attribute value of selected table cells', () => {
+					it( 'should set the "tableCellHorizontalAlignment" attribute value of selected table cells', () => {
 						command.execute( { value: 'right' } );
 
 						assertEqualMarkup( editor.getData(), viewTable( [
@@ -239,10 +240,11 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should remove the "horizontalAlignment" attribute from selected table cells if no value is passed', () => {
+					it( `should remove the "tableCellHorizontalAlignment" attribute
+						from selected table cells if no value is passed`, () => {
 						setData( model, modelTable( [
-							[ { contents: '00', isSelected: true, horizontalAlignment: 'right' }, '01' ],
-							[ '10', { contents: '11', isSelected: true, horizontalAlignment: 'right' } ]
+							[ { contents: '00', isSelected: true, tableCellHorizontalAlignment: 'right' }, '01' ],
+							[ '10', { contents: '11', isSelected: true, tableCellHorizontalAlignment: 'right' } ]
 						] ) );
 
 						command.execute();
@@ -275,7 +277,7 @@ describe( 'table cell properties', () => {
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
 					it( 'should be undefined if selected table cell has the default value', () => {
-						setData( model, modelTable( [ [ { horizontalAlignment: 'left', contents: '[]foo' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellHorizontalAlignment: 'left', contents: '[]foo' } ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
@@ -283,7 +285,7 @@ describe( 'table cell properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should be undefined is selection contains the default value', () => {
-						setData( model, modelTable( [ [ { horizontalAlignment: 'left', contents: 'f[o]o' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellHorizontalAlignment: 'left', contents: 'f[o]o' } ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
@@ -291,16 +293,17 @@ describe( 'table cell properties', () => {
 
 				describe( 'multi-cell selection', () => {
 					it(
-						'should be set if all table cells have the same "horizontalAlignment" property value which is the default value',
+						`should be set if all table cells have the same
+						"tableCellHorizontalAlignment" property value which is the default value`,
 						() => {
 							setData( model, modelTable( [
 								[
-									{ contents: '00', isSelected: true, horizontalAlignment: 'left' },
-									{ contents: '01', isSelected: true, horizontalAlignment: 'left' }
+									{ contents: '00', isSelected: true, tableCellHorizontalAlignment: 'left' },
+									{ contents: '01', isSelected: true, tableCellHorizontalAlignment: 'left' }
 								],
 								[
 									'10',
-									{ contents: '11', isSelected: true, horizontalAlignment: 'left' }
+									{ contents: '11', isSelected: true, tableCellHorizontalAlignment: 'left' }
 								]
 							] ) );
 
@@ -311,8 +314,8 @@ describe( 'table cell properties', () => {
 
 			describe( 'execute()', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should remove horizontalAlignment from a selected table cell if the default value is passed', () => {
-						setData( model, modelTable( [ [ { horizontalAlignment: 'center', contents: '[]foo' } ] ] ) );
+					it( 'should remove tableCellHorizontalAlignment from a selected table cell if the default value is passed', () => {
+						setData( model, modelTable( [ [ { tableCellHorizontalAlignment: 'center', contents: '[]foo' } ] ] ) );
 
 						command.execute( { value: 'left' } );
 
@@ -321,7 +324,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'non-collapsed selection', () => {
-					it( 'should remove horizontalAlignment from a selected table cell if the default value is passed', () => {
+					it( 'should remove tableCellHorizontalAlignment from a selected table cell if the default value is passed', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute( { value: 'left' } );
@@ -332,11 +335,12 @@ describe( 'table cell properties', () => {
 
 				describe( 'multi-cell selection', () => {
 					it(
-						'should remove the "horizontalAlignment" attribute from selected table cells if the default value is passed',
+						`should remove the "tableCellHorizontalAlignment" attribute
+						from selected table cells if the default value is passed`,
 						() => {
 							setData( model, modelTable( [
-								[ { contents: '00', isSelected: true, horizontalAlignment: 'right' }, '01' ],
-								[ '10', { contents: '11', isSelected: true, horizontalAlignment: 'right' } ]
+								[ { contents: '00', isSelected: true, tableCellHorizontalAlignment: 'right' }, '01' ],
+								[ '10', { contents: '11', isSelected: true, tableCellHorizontalAlignment: 'right' } ]
 							] ) );
 
 							command.execute( { value: 'left' } );

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellpaddingcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellpaddingcommand.js
@@ -70,21 +70,21 @@ describe( 'table cell properties', () => {
 
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should be undefined if selected table cell has no padding property', () => {
+					it( 'should be undefined if selected table cell has no tableCellPadding property', () => {
 						setData( model, modelTable( [ [ '[]foo' ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if selected table cell has padding property (single string)', () => {
-						setData( model, modelTable( [ [ { padding: '2em', contents: '[]foo' } ] ] ) );
+					it( 'should be set if selected table cell has tableCellPadding property (single string)', () => {
+						setData( model, modelTable( [ [ { tableCellPadding: '2em', contents: '[]foo' } ] ] ) );
 
 						expect( command.value ).to.equal( '2em' );
 					} );
 
-					it( 'should be set if selected table cell has padding property object with same values', () => {
+					it( 'should be set if selected table cell has tableCellPadding property object with same values', () => {
 						setTableCellWithObjectAttributes( model, {
-							padding: {
+							tableCellPadding: {
 								top: '2em',
 								right: '2em',
 								bottom: '2em',
@@ -94,9 +94,9 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.equal( '2em' );
 					} );
 
-					it( 'should be undefined if selected table cell has padding property object with different values', () => {
+					it( 'should be undefined if selected table cell has tableCellPadding property object with different values', () => {
 						setTableCellWithObjectAttributes( model, {
-							padding: {
+							tableCellPadding: {
 								top: '2em',
 								right: '1px',
 								bottom: '2em',
@@ -116,14 +116,14 @@ describe( 'table cell properties', () => {
 					} );
 
 					it( 'should be true is selection has table cell', () => {
-						setData( model, modelTable( [ [ { padding: '2em', contents: 'f[o]o' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellPadding: '2em', contents: 'f[o]o' } ] ] ) );
 
 						expect( command.value ).to.equal( '2em' );
 					} );
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cells have the "padding" property', () => {
+					it( 'should be undefined if no table cells have the "tableCellPadding" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },
@@ -138,45 +138,45 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cells have the "padding" property', () => {
+					it( 'should be undefined if only some table cells have the "tableCellPadding" property', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, padding: '2em' },
+								{ contents: '00', isSelected: true, tableCellPadding: '2em' },
 								{ contents: '01', isSelected: true }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, padding: '2em' }
+								{ contents: '11', isSelected: true, tableCellPadding: '2em' }
 							]
 						] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has a different "padding" property value', () => {
+					it( 'should be undefined if one of selected table cells has a different "tableCellPadding" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, padding: '2em' },
-								{ contents: '01', isSelected: true, padding: '3em' }
+								{ contents: '00', isSelected: true, tableCellPadding: '2em' },
+								{ contents: '01', isSelected: true, tableCellPadding: '3em' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, padding: '2em' }
+								{ contents: '11', isSelected: true, tableCellPadding: '2em' }
 							]
 						] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cells have the same "padding" property value', () => {
+					it( 'should be set if all table cells have the same "tableCellPadding" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, padding: '2em' },
-								{ contents: '01', isSelected: true, padding: '2em' }
+								{ contents: '00', isSelected: true, tableCellPadding: '2em' },
+								{ contents: '01', isSelected: true, tableCellPadding: '2em' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, padding: '2em' }
+								{ contents: '11', isSelected: true, tableCellPadding: '2em' }
 							]
 						] ) );
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellverticalalignmentcommand.js
@@ -70,14 +70,14 @@ describe( 'table cell properties', () => {
 
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should be undefined if selected table cell has no verticalAlignment property', () => {
+					it( 'should be undefined if selected table cell has no tableCellVerticalAlignment property', () => {
 						setData( model, modelTable( [ [ '[]foo' ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if selected table cell has verticalAlignment property', () => {
-						setData( model, modelTable( [ [ { verticalAlignment: 'bottom', contents: '[]foo' } ] ] ) );
+					it( 'should be set if selected table cell has tableCellVerticalAlignment property', () => {
+						setData( model, modelTable( [ [ { tableCellVerticalAlignment: 'bottom', contents: '[]foo' } ] ] ) );
 
 						expect( command.value ).to.equal( 'bottom' );
 					} );
@@ -91,14 +91,14 @@ describe( 'table cell properties', () => {
 					} );
 
 					it( 'should be true is selection has table cell', () => {
-						setData( model, modelTable( [ [ { verticalAlignment: 'bottom', contents: 'f[o]o' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellVerticalAlignment: 'bottom', contents: 'f[o]o' } ] ] ) );
 
 						expect( command.value ).to.equal( 'bottom' );
 					} );
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cells have the "verticalAlignment" property', () => {
+					it( 'should be undefined if no table cells have the "tableCellVerticalAlignment" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },
@@ -113,45 +113,46 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cells have the "verticalAlignment" property', () => {
+					it( 'should be undefined if only some table cells have the "tableCellVerticalAlignment" property', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, verticalAlignment: 'bottom' },
+								{ contents: '00', isSelected: true, tableCellVerticalAlignment: 'bottom' },
 								{ contents: '01', isSelected: true }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, verticalAlignment: 'bottom' }
+								{ contents: '11', isSelected: true, tableCellVerticalAlignment: 'bottom' }
 							]
 						] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has a different "verticalAlignment" property value', () => {
+					it( `should be undefined if one of selected table cells has
+						a different "tableCellVerticalAlignment" property value`, () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, verticalAlignment: 'bottom' },
-								{ contents: '01', isSelected: true, verticalAlignment: 'top' }
+								{ contents: '00', isSelected: true, tableCellVerticalAlignment: 'bottom' },
+								{ contents: '01', isSelected: true, tableCellVerticalAlignment: 'top' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, verticalAlignment: 'bottom' }
+								{ contents: '11', isSelected: true, tableCellVerticalAlignment: 'bottom' }
 							]
 						] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cells have the same "verticalAlignment" property value', () => {
+					it( 'should be set if all table cells have the same "tableCellVerticalAlignment" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, verticalAlignment: 'bottom' },
-								{ contents: '01', isSelected: true, verticalAlignment: 'bottom' }
+								{ contents: '00', isSelected: true, tableCellVerticalAlignment: 'bottom' },
+								{ contents: '01', isSelected: true, tableCellVerticalAlignment: 'bottom' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, verticalAlignment: 'bottom' }
+								{ contents: '11', isSelected: true, tableCellVerticalAlignment: 'bottom' }
 							]
 						] ) );
 
@@ -171,7 +172,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'collapsed selection', () => {
-					it( 'should set selected table cell verticalAlignment to a passed value', () => {
+					it( 'should set selected table cell tableCellVerticalAlignment to a passed value', () => {
 						setData( model, modelTable( [ [ 'foo[]' ] ] ) );
 
 						command.execute( { value: 'top' } );
@@ -179,16 +180,16 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'vertical-align:top;' );
 					} );
 
-					it( 'should change selected table cell verticalAlignment to a passed value', () => {
-						setData( model, modelTable( [ [ { verticalAlignment: 'bottom', contents: '[]foo' } ] ] ) );
+					it( 'should change selected table cell tableCellVerticalAlignment to a passed value', () => {
+						setData( model, modelTable( [ [ { tableCellVerticalAlignment: 'bottom', contents: '[]foo' } ] ] ) );
 
 						command.execute( { value: 'top' } );
 
 						assertTableCellStyle( editor, 'vertical-align:top;' );
 					} );
 
-					it( 'should remove verticalAlignment from a selected table cell if no value is passed', () => {
-						setData( model, modelTable( [ [ { verticalAlignment: 'bottom', contents: '[]foo' } ] ] ) );
+					it( 'should remove tableCellVerticalAlignment from a selected table cell if no value is passed', () => {
+						setData( model, modelTable( [ [ { tableCellVerticalAlignment: 'bottom', contents: '[]foo' } ] ] ) );
 
 						command.execute();
 
@@ -197,7 +198,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'non-collapsed selection', () => {
-					it( 'should set selected table cell verticalAlignment to a passed value', () => {
+					it( 'should set selected table cell tableCellVerticalAlignment to a passed value', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute( { value: 'top' } );
@@ -205,7 +206,7 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'vertical-align:top;' );
 					} );
 
-					it( 'should change selected table cell verticalAlignment to a passed value', () => {
+					it( 'should change selected table cell tableCellVerticalAlignment to a passed value', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute( { value: 'top' } );
@@ -213,7 +214,7 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'vertical-align:top;' );
 					} );
 
-					it( 'should remove verticalAlignment from a selected table cell if no value is passed', () => {
+					it( 'should remove tableCellVerticalAlignment from a selected table cell if no value is passed', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute();
@@ -230,7 +231,7 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should set the "verticalAlignment" attribute value of selected table cells', () => {
+					it( 'should set the "tableCellVerticalAlignment" attribute value of selected table cells', () => {
 						command.execute( { value: 'top' } );
 
 						assertEqualMarkup( editor.getData(), viewTable( [
@@ -239,10 +240,10 @@ describe( 'table cell properties', () => {
 						] ) );
 					} );
 
-					it( 'should remove "verticalAlignment" from selected table cells if no value is passed', () => {
+					it( 'should remove "tableCellVerticalAlignment" from selected table cells if no value is passed', () => {
 						setData( model, modelTable( [
-							[ { contents: '00', isSelected: true, verticalAlignment: 'top' }, '01' ],
-							[ '10', { contents: '11', isSelected: true, verticalAlignment: 'top' } ]
+							[ { contents: '00', isSelected: true, tableCellVerticalAlignment: 'top' }, '01' ],
+							[ '10', { contents: '11', isSelected: true, tableCellVerticalAlignment: 'top' } ]
 						] ) );
 
 						command.execute();
@@ -274,8 +275,8 @@ describe( 'table cell properties', () => {
 
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should be undefined if selected table cell has the default verticalAlignment property', () => {
-						setData( model, modelTable( [ [ { verticalAlignment: 'bottom', contents: '[]foo' } ] ] ) );
+					it( 'should be undefined if selected table cell has the default tableCellVerticalAlignment property', () => {
+						setData( model, modelTable( [ [ { tableCellVerticalAlignment: 'bottom', contents: '[]foo' } ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
@@ -283,7 +284,7 @@ describe( 'table cell properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should be undefined is selection contains the default value', () => {
-						setData( model, modelTable( [ [ { verticalAlignment: 'bottom', contents: 'f[o]o' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellVerticalAlignment: 'bottom', contents: 'f[o]o' } ] ] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
@@ -291,17 +292,17 @@ describe( 'table cell properties', () => {
 
 				describe( 'multi-cell selection', () => {
 					it(
-						'should be undefined if all table cells have the same "verticalAlignment" property ' +
+						'should be undefined if all table cells have the same "tableCellVerticalAlignment" property ' +
 						'value which is the default value',
 						() => {
 							setData( model, modelTable( [
 								[
-									{ contents: '00', isSelected: true, verticalAlignment: 'bottom' },
-									{ contents: '01', isSelected: true, verticalAlignment: 'bottom' }
+									{ contents: '00', isSelected: true, tableCellVerticalAlignment: 'bottom' },
+									{ contents: '01', isSelected: true, tableCellVerticalAlignment: 'bottom' }
 								],
 								[
 									'10',
-									{ contents: '11', isSelected: true, verticalAlignment: 'bottom' }
+									{ contents: '11', isSelected: true, tableCellVerticalAlignment: 'bottom' }
 								]
 							] ) );
 
@@ -313,8 +314,8 @@ describe( 'table cell properties', () => {
 
 			describe( 'execute()', () => {
 				describe( 'collapsed selection', () => {
-					it( 'should remove verticalAlignment from a selected table cell if the default value is passed', () => {
-						setData( model, modelTable( [ [ { verticalAlignment: 'bottom', contents: '[]foo' } ] ] ) );
+					it( 'should remove tableCellVerticalAlignment from a selected table cell if the default value is passed', () => {
+						setData( model, modelTable( [ [ { tableCellVerticalAlignment: 'bottom', contents: '[]foo' } ] ] ) );
 
 						command.execute( { value: 'bottom' } );
 
@@ -323,7 +324,7 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'non-collapsed selection', () => {
-					it( 'should remove verticalAlignment from a selected table cell if the default value is passed', () => {
+					it( 'should remove tableCellVerticalAlignment from a selected table cell if the default value is passed', () => {
 						setData( model, modelTable( [ [ '[foo]' ] ] ) );
 
 						command.execute( { value: 'bottom' } );
@@ -333,10 +334,10 @@ describe( 'table cell properties', () => {
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should remove "verticalAlignment" from selected table cells if the default value is passed', () => {
+					it( 'should remove "tableCellVerticalAlignment" from selected table cells if the default value is passed', () => {
 						setData( model, modelTable( [
-							[ { contents: '00', isSelected: true, verticalAlignment: 'top' }, '01' ],
-							[ '10', { contents: '11', isSelected: true, verticalAlignment: 'top' } ]
+							[ { contents: '00', isSelected: true, tableCellVerticalAlignment: 'top' }, '01' ],
+							[ '10', { contents: '11', isSelected: true, tableCellVerticalAlignment: 'top' } ]
 						] ) );
 
 						command.execute( { value: 'bottom' } );

--- a/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellwidthcommand.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/commands/tablecellwidthcommand.js
@@ -76,8 +76,8 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if selected table cell has width property', () => {
-						setData( model, modelTable( [ [ { width: '100px', contents: '[]foo' } ] ] ) );
+					it( 'should be set if selected table cell has tableCellWidth property', () => {
+						setData( model, modelTable( [ [ { tableCellWidth: '100px', contents: '[]foo' } ] ] ) );
 
 						expect( command.value ).to.equal( '100px' );
 					} );
@@ -91,14 +91,14 @@ describe( 'table cell properties', () => {
 					} );
 
 					it( 'should be true is selection has table cell', () => {
-						setData( model, modelTable( [ [ { width: '100px', contents: 'f[o]o' } ] ] ) );
+						setData( model, modelTable( [ [ { tableCellWidth: '100px', contents: 'f[o]o' } ] ] ) );
 
 						expect( command.value ).to.equal( '100px' );
 					} );
 				} );
 
 				describe( 'multi-cell selection', () => {
-					it( 'should be undefined if no table cells have the "width" property', () => {
+					it( 'should be undefined if no table cells have the "tableCellWidth" property', () => {
 						setData( model, modelTable( [
 							[
 								{ contents: '00', isSelected: true },
@@ -113,45 +113,45 @@ describe( 'table cell properties', () => {
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if only some table cells have the "width" property', () => {
+					it( 'should be undefined if only some table cells have the "tableCellWidth" property', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, width: '100px' },
+								{ contents: '00', isSelected: true, tableCellWidth: '100px' },
 								{ contents: '01', isSelected: true }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, width: '100px' }
+								{ contents: '11', isSelected: true, tableCellWidth: '100px' }
 							]
 						] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be undefined if one of selected table cells has a different "width" property value', () => {
+					it( 'should be undefined if one of selected table cells has a different "tableCellWidth" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, width: '100px' },
-								{ contents: '01', isSelected: true, width: '25px' }
+								{ contents: '00', isSelected: true, tableCellWidth: '100px' },
+								{ contents: '01', isSelected: true, tableCellWidth: '25px' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, width: '100px' }
+								{ contents: '11', isSelected: true, tableCellWidth: '100px' }
 							]
 						] ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
-					it( 'should be set if all table cells have the same "width" property value', () => {
+					it( 'should be set if all table cells have the same "tableCellWidth" property value', () => {
 						setData( model, modelTable( [
 							[
-								{ contents: '00', isSelected: true, width: '100px' },
-								{ contents: '01', isSelected: true, width: '100px' }
+								{ contents: '00', isSelected: true, tableCellWidth: '100px' },
+								{ contents: '01', isSelected: true, tableCellWidth: '100px' }
 							],
 							[
 								'10',
-								{ contents: '11', isSelected: true, width: '100px' }
+								{ contents: '11', isSelected: true, tableCellWidth: '100px' }
 							]
 						] ) );
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -89,9 +89,9 @@ describe( 'table cell properties', () => {
 
 		describe( 'border', () => {
 			it( 'should set proper schema rules', () => {
-				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'borderColor' ) ).to.be.true;
-				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'borderStyle' ) ).to.be.true;
-				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'borderWidth' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'tableCellBorderColor' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'tableCellBorderStyle' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'tableCellBorderWidth' ) ).to.be.true;
 			} );
 
 			describe( 'upcast conversion', () => {
@@ -100,9 +100,9 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'borderColor' ) ).to.equal( '#f00' );
-					expect( tableCell.getAttribute( 'borderStyle' ) ).to.equal( 'solid' );
-					expect( tableCell.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
+					expect( tableCell.getAttribute( 'tableCellBorderColor' ) ).to.equal( '#f00' );
+					expect( tableCell.getAttribute( 'tableCellBorderStyle' ) ).to.equal( 'solid' );
+					expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.equal( '1px' );
 				} );
 
 				it( 'should upcast border-color shorthand', () => {
@@ -110,7 +110,7 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'borderColor' ) ).to.equal( '#f00' );
+					expect( tableCell.getAttribute( 'tableCellBorderColor' ) ).to.equal( '#f00' );
 				} );
 
 				it( 'should upcast border-style shorthand', () => {
@@ -118,7 +118,7 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'borderStyle' ) ).to.equal( 'ridge' );
+					expect( tableCell.getAttribute( 'tableCellBorderStyle' ) ).to.equal( 'ridge' );
 				} );
 
 				it( 'should upcast border-width shorthand', () => {
@@ -126,7 +126,7 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
+					expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.equal( '1px' );
 				} );
 
 				it( 'should upcast border-top shorthand', () => {
@@ -134,9 +134,9 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					assertTRBLAttribute( tableCell, 'borderColor', '#f00', null, null, null );
-					assertTRBLAttribute( tableCell, 'borderStyle', 'solid', null, null, null );
-					assertTRBLAttribute( tableCell, 'borderWidth', '1px', null, null, null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderColor', '#f00', null, null, null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderStyle', 'solid', null, null, null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderWidth', '1px', null, null, null );
 				} );
 
 				it( 'should upcast border-right shorthand', () => {
@@ -144,9 +144,9 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					assertTRBLAttribute( tableCell, 'borderColor', null, '#f00', null, null );
-					assertTRBLAttribute( tableCell, 'borderStyle', null, 'solid', null, null );
-					assertTRBLAttribute( tableCell, 'borderWidth', null, '1px', null, null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderColor', null, '#f00', null, null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderStyle', null, 'solid', null, null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderWidth', null, '1px', null, null );
 				} );
 
 				it( 'should upcast border-bottom shorthand', () => {
@@ -154,9 +154,9 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					assertTRBLAttribute( tableCell, 'borderColor', null, null, '#f00', null );
-					assertTRBLAttribute( tableCell, 'borderStyle', null, null, 'solid', null );
-					assertTRBLAttribute( tableCell, 'borderWidth', null, null, '1px', null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderColor', null, null, '#f00', null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderStyle', null, null, 'solid', null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderWidth', null, null, '1px', null );
 				} );
 
 				it( 'should upcast border-left shorthand', () => {
@@ -164,9 +164,9 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					assertTRBLAttribute( tableCell, 'borderColor', null, null, null, '#f00' );
-					assertTRBLAttribute( tableCell, 'borderStyle', null, null, null, 'solid' );
-					assertTRBLAttribute( tableCell, 'borderWidth', null, null, null, '1px' );
+					assertTRBLAttribute( tableCell, 'tableCellBorderColor', null, null, null, '#f00' );
+					assertTRBLAttribute( tableCell, 'tableCellBorderStyle', null, null, null, 'solid' );
+					assertTRBLAttribute( tableCell, 'tableCellBorderWidth', null, null, null, '1px' );
 				} );
 
 				it( 'should upcast mixed shorthands', () => {
@@ -176,9 +176,9 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					assertTRBLAttribute( tableCell, 'borderColor', '#f00', null, 'rgba(255, 0, 0, 1)', null );
-					assertTRBLAttribute( tableCell, 'borderStyle', 'solid', null, 'ridge', null );
-					assertTRBLAttribute( tableCell, 'borderWidth', '1px', null, '2em', null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderColor', '#f00', null, 'rgba(255, 0, 0, 1)', null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderStyle', 'solid', null, 'ridge', null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderWidth', '1px', null, '2em', null );
 				} );
 
 				it( 'should upcast border-top-* styles', () => {
@@ -188,9 +188,9 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					assertTRBLAttribute( tableCell, 'borderColor', '#f00', null, null, null );
-					assertTRBLAttribute( tableCell, 'borderStyle', 'solid', null, null, null );
-					assertTRBLAttribute( tableCell, 'borderWidth', '1px', null, null, null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderColor', '#f00', null, null, null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderStyle', 'solid', null, null, null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderWidth', '1px', null, null, null );
 				} );
 
 				it( 'should upcast border-right-* styles', () => {
@@ -204,9 +204,9 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					assertTRBLAttribute( tableCell, 'borderColor', null, '#f00', null, null );
-					assertTRBLAttribute( tableCell, 'borderStyle', null, 'solid', null, null );
-					assertTRBLAttribute( tableCell, 'borderWidth', null, '1px', null, null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderColor', null, '#f00', null, null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderStyle', null, 'solid', null, null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderWidth', null, '1px', null, null );
 				} );
 
 				it( 'should upcast border-bottom-* styles', () => {
@@ -220,9 +220,9 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					assertTRBLAttribute( tableCell, 'borderColor', null, null, '#f00', null );
-					assertTRBLAttribute( tableCell, 'borderStyle', null, null, 'solid', null );
-					assertTRBLAttribute( tableCell, 'borderWidth', null, null, '1px', null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderColor', null, null, '#f00', null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderStyle', null, null, 'solid', null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderWidth', null, null, '1px', null );
 				} );
 
 				it( 'should upcast border-left-* styles', () => {
@@ -236,9 +236,9 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					assertTRBLAttribute( tableCell, 'borderColor', null, null, null, '#f00' );
-					assertTRBLAttribute( tableCell, 'borderStyle', null, null, null, 'solid' );
-					assertTRBLAttribute( tableCell, 'borderWidth', null, null, null, '1px' );
+					assertTRBLAttribute( tableCell, 'tableCellBorderColor', null, null, null, '#f00' );
+					assertTRBLAttribute( tableCell, 'tableCellBorderStyle', null, null, null, 'solid' );
+					assertTRBLAttribute( tableCell, 'tableCellBorderWidth', null, null, null, '1px' );
 				} );
 
 				it( 'should allow to be overriden (only border-top consumed)', () => {
@@ -252,9 +252,9 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'borderColor' ) ).to.be.undefined;
-					expect( tableCell.getAttribute( 'borderStyle' ) ).to.be.undefined;
-					expect( tableCell.getAttribute( 'borderWidth' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellBorderColor' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellBorderStyle' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.be.undefined;
 				} );
 			} );
 
@@ -275,28 +275,28 @@ describe( 'table cell properties', () => {
 					tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 				} );
 
-				it( 'should consume converted item borderColor attribute', () => {
+				it( 'should consume converted item tableCellBorderColor attribute', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:borderColor:tableCell', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellBorderColor:tableCell', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
 						} ) );
 
-					model.change( writer => writer.setAttribute( 'borderColor', '#f00', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellBorderColor', '#f00', tableCell ) );
 				} );
 
 				it( 'should be overridable', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:borderColor:tableCell', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellBorderColor:tableCell', ( evt, data, conversionApi ) => {
 							conversionApi.consumable.consume( data.item, evt.name );
 						}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'borderColor', '#f00', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellBorderColor', '#f00', tableCell ) );
 
 					assertTableCellStyle( editor, '' );
 				} );
 
-				it( 'should downcast borderColor attribute (same top, right, bottom, left)', () => {
-					model.change( writer => writer.setAttribute( 'borderColor', {
+				it( 'should downcast tableCellBorderColor attribute (same top, right, bottom, left)', () => {
+					model.change( writer => writer.setAttribute( 'tableCellBorderColor', {
 						top: '#f00',
 						right: '#f00',
 						bottom: '#f00',
@@ -306,8 +306,8 @@ describe( 'table cell properties', () => {
 					assertTableCellStyle( editor, 'border-color:#f00;' );
 				} );
 
-				it( 'should downcast borderColor attribute (different top, right, bottom, left)', () => {
-					model.change( writer => writer.setAttribute( 'borderColor', {
+				it( 'should downcast tableCellBorderColor attribute (different top, right, bottom, left)', () => {
+					model.change( writer => writer.setAttribute( 'tableCellBorderColor', {
 						top: '#f00',
 						right: 'hsla(0, 100%, 50%, 0.5)',
 						bottom: 'deeppink',
@@ -322,28 +322,28 @@ describe( 'table cell properties', () => {
 					);
 				} );
 
-				it( 'should consume converted item borderStyle attribute', () => {
+				it( 'should consume converted item tableCellBorderStyle attribute', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:borderStyle:tableCell', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellBorderStyle:tableCell', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
 						} ) );
 
-					model.change( writer => writer.setAttribute( 'borderStyle', 'ridge', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellBorderStyle', 'ridge', tableCell ) );
 				} );
 
-				it( 'should be overridable for borderStyle', () => {
+				it( 'should be overridable for tableCellBorderStyle', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:borderStyle:tableCell', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellBorderStyle:tableCell', ( evt, data, conversionApi ) => {
 							conversionApi.consumable.consume( data.item, evt.name );
 						}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'borderStyle', 'ridge', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellBorderStyle', 'ridge', tableCell ) );
 
 					assertTableCellStyle( editor, '' );
 				} );
 
-				it( 'should downcast borderStyle attribute (same top, right, bottom, left)', () => {
-					model.change( writer => writer.setAttribute( 'borderStyle', {
+				it( 'should downcast tableCellBorderStyle attribute (same top, right, bottom, left)', () => {
+					model.change( writer => writer.setAttribute( 'tableCellBorderStyle', {
 						top: 'solid',
 						right: 'solid',
 						bottom: 'solid',
@@ -353,8 +353,8 @@ describe( 'table cell properties', () => {
 					assertTableCellStyle( editor, 'border-style:solid;' );
 				} );
 
-				it( 'should downcast borderStyle attribute (different top, right, bottom, left)', () => {
-					model.change( writer => writer.setAttribute( 'borderStyle', {
+				it( 'should downcast tableCellBorderStyle attribute (different top, right, bottom, left)', () => {
+					model.change( writer => writer.setAttribute( 'tableCellBorderStyle', {
 						top: 'solid',
 						right: 'ridge',
 						bottom: 'dotted',
@@ -369,28 +369,28 @@ describe( 'table cell properties', () => {
 					);
 				} );
 
-				it( 'should consume converted item borderWidth attribute', () => {
+				it( 'should consume converted item tableCellBorderWidth attribute', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:borderWidth:tableCell', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellBorderWidth:tableCell', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
 						} ) );
 
-					model.change( writer => writer.setAttribute( 'borderWidth', '2px', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellBorderWidth', '2px', tableCell ) );
 				} );
 
-				it( 'should be overridable for borderWidth', () => {
+				it( 'should be overridable for tableCellBorderWidth', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:borderWidth:tableCell', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellBorderWidth:tableCell', ( evt, data, conversionApi ) => {
 							conversionApi.consumable.consume( data.item, evt.name );
 						}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'borderWidth', '2px', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellBorderWidth', '2px', tableCell ) );
 
 					assertTableCellStyle( editor, '' );
 				} );
 
-				it( 'should downcast borderWidth attribute (same top, right, bottom, left)', () => {
-					model.change( writer => writer.setAttribute( 'borderWidth', {
+				it( 'should downcast tableCellBorderWidth attribute (same top, right, bottom, left)', () => {
+					model.change( writer => writer.setAttribute( 'tableCellBorderWidth', {
 						top: '42px',
 						right: '.1em',
 						bottom: '1337rem',
@@ -405,8 +405,8 @@ describe( 'table cell properties', () => {
 					);
 				} );
 
-				it( 'should downcast borderWidth attribute (different top, right, bottom, left)', () => {
-					model.change( writer => writer.setAttribute( 'borderWidth', {
+				it( 'should downcast tableCellBorderWidth attribute (different top, right, bottom, left)', () => {
+					model.change( writer => writer.setAttribute( 'tableCellBorderWidth', {
 						top: '42px',
 						right: '42px',
 						bottom: '42px',
@@ -416,23 +416,24 @@ describe( 'table cell properties', () => {
 					assertTableCellStyle( editor, 'border-width:42px;' );
 				} );
 
-				it( 'should downcast borderColor, borderStyle and borderWidth attributes together (same top, right, bottom, left)', () => {
+				it( `should downcast tableCellBorderColor, tableCellBorderStyle
+					and tableCellBorderWidth attributes together (same top, right, bottom, left)`, () => {
 					model.change( writer => {
-						writer.setAttribute( 'borderColor', {
+						writer.setAttribute( 'tableCellBorderColor', {
 							top: '#f00',
 							right: '#f00',
 							bottom: '#f00',
 							left: '#f00'
 						}, tableCell );
 
-						writer.setAttribute( 'borderStyle', {
+						writer.setAttribute( 'tableCellBorderStyle', {
 							top: 'solid',
 							right: 'solid',
 							bottom: 'solid',
 							left: 'solid'
 						}, tableCell );
 
-						writer.setAttribute( 'borderWidth', {
+						writer.setAttribute( 'tableCellBorderWidth', {
 							top: '42px',
 							right: '42px',
 							bottom: '42px',
@@ -444,24 +445,25 @@ describe( 'table cell properties', () => {
 				} );
 
 				it(
-					'should downcast borderColor, borderStyle and borderWidth attributes together (different top, right, bottom, left)',
+					`should downcast tableCellBorderColor, tableCellBorderStyle
+					and tableCellBorderWidth attributes together (different top, right, bottom, left)`,
 					() => {
 						model.change( writer => {
-							writer.setAttribute( 'borderColor', {
+							writer.setAttribute( 'tableCellBorderColor', {
 								top: '#f00',
 								right: 'hsla(0, 100%, 50%, 0.5)',
 								bottom: 'deeppink',
 								left: 'rgb(255, 0, 0)'
 							}, tableCell );
 
-							writer.setAttribute( 'borderStyle', {
+							writer.setAttribute( 'tableCellBorderStyle', {
 								top: 'solid',
 								right: 'ridge',
 								bottom: 'dotted',
 								left: 'dashed'
 							}, tableCell );
 
-							writer.setAttribute( 'borderWidth', {
+							writer.setAttribute( 'tableCellBorderWidth', {
 								top: '42px',
 								right: '.1em',
 								bottom: '1337rem',
@@ -481,21 +483,21 @@ describe( 'table cell properties', () => {
 				describe( 'change attribute', () => {
 					beforeEach( () => {
 						model.change( writer => {
-							writer.setAttribute( 'borderColor', {
+							writer.setAttribute( 'tableCellBorderColor', {
 								top: '#f00',
 								right: '#f00',
 								bottom: '#f00',
 								left: '#f00'
 							}, tableCell );
 
-							writer.setAttribute( 'borderStyle', {
+							writer.setAttribute( 'tableCellBorderStyle', {
 								top: 'solid',
 								right: 'solid',
 								bottom: 'solid',
 								left: 'solid'
 							}, tableCell );
 
-							writer.setAttribute( 'borderWidth', {
+							writer.setAttribute( 'tableCellBorderWidth', {
 								top: '42px',
 								right: '42px',
 								bottom: '42px',
@@ -504,8 +506,8 @@ describe( 'table cell properties', () => {
 						} );
 					} );
 
-					it( 'should downcast borderColor attribute change', () => {
-						model.change( writer => writer.setAttribute( 'borderColor', {
+					it( 'should downcast tableCellBorderColor attribute change', () => {
+						model.change( writer => writer.setAttribute( 'tableCellBorderColor', {
 							top: 'deeppink',
 							right: 'deeppink',
 							bottom: 'deeppink',
@@ -515,8 +517,8 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'border:42px solid deeppink;' );
 					} );
 
-					it( 'should downcast borderStyle attribute change', () => {
-						model.change( writer => writer.setAttribute( 'borderStyle', {
+					it( 'should downcast tableCellBorderStyle attribute change', () => {
+						model.change( writer => writer.setAttribute( 'tableCellBorderStyle', {
 							top: 'ridge',
 							right: 'ridge',
 							bottom: 'ridge',
@@ -526,8 +528,8 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'border:42px ridge #f00;' );
 					} );
 
-					it( 'should downcast borderWidth attribute change', () => {
-						model.change( writer => writer.setAttribute( 'borderWidth', {
+					it( 'should downcast tableCellBorderWidth attribute change', () => {
+						model.change( writer => writer.setAttribute( 'tableCellBorderWidth', {
 							top: 'thick',
 							right: 'thick',
 							bottom: 'thick',
@@ -537,8 +539,8 @@ describe( 'table cell properties', () => {
 						assertTableCellStyle( editor, 'border:thick solid #f00;' );
 					} );
 
-					it( 'should downcast borderColor attribute removal', () => {
-						model.change( writer => writer.removeAttribute( 'borderColor', tableCell ) );
+					it( 'should downcast tableCellBorderColor attribute removal', () => {
+						model.change( writer => writer.removeAttribute( 'tableCellBorderColor', tableCell ) );
 
 						assertTableCellStyle( editor,
 							'border-style:solid;' +
@@ -546,8 +548,8 @@ describe( 'table cell properties', () => {
 						);
 					} );
 
-					it( 'should downcast borderStyle attribute removal', () => {
-						model.change( writer => writer.removeAttribute( 'borderStyle', tableCell ) );
+					it( 'should downcast tableCellBorderStyle attribute removal', () => {
+						model.change( writer => writer.removeAttribute( 'tableCellBorderStyle', tableCell ) );
 
 						assertTableCellStyle( editor,
 							'border-color:#f00;' +
@@ -555,8 +557,8 @@ describe( 'table cell properties', () => {
 						);
 					} );
 
-					it( 'should downcast borderWidth attribute removal', () => {
-						model.change( writer => writer.removeAttribute( 'borderWidth', tableCell ) );
+					it( 'should downcast tableCellBorderWidth attribute removal', () => {
+						model.change( writer => writer.removeAttribute( 'tableCellBorderWidth', tableCell ) );
 
 						assertTableCellStyle( editor,
 							'border-color:#f00;' +
@@ -564,11 +566,11 @@ describe( 'table cell properties', () => {
 						);
 					} );
 
-					it( 'should downcast borderColor, borderStyle and borderWidth attributes removal', () => {
+					it( 'should downcast tableCellBorderColor, tableCellBorderStyle and tableCellBorderWidth attributes removal', () => {
 						model.change( writer => {
-							writer.removeAttribute( 'borderColor', tableCell );
-							writer.removeAttribute( 'borderStyle', tableCell );
-							writer.removeAttribute( 'borderWidth', tableCell );
+							writer.removeAttribute( 'tableCellBorderColor', tableCell );
+							writer.removeAttribute( 'tableCellBorderStyle', tableCell );
+							writer.removeAttribute( 'tableCellBorderWidth', tableCell );
 						} );
 
 						assertEqualMarkup(
@@ -1073,7 +1075,7 @@ describe( 'table cell properties', () => {
 					tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 				} );
 
-				it( 'should consume converted item borderColor attribute', () => {
+				it( 'should consume converted item tableCellBorderColor attribute', () => {
 					editor.conversion.for( 'downcast' )
 						.add( dispatcher => dispatcher.on( 'attribute:tableCellPadding:tableCell', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
@@ -1338,9 +1340,9 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'borderColor' ) ).to.be.undefined;
-					expect( tableCell.getAttribute( 'borderStyle' ) ).to.be.undefined;
-					expect( tableCell.getAttribute( 'borderWidth' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellBorderColor' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellBorderStyle' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default `border` values from <th>', () => {
@@ -1348,9 +1350,9 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'borderColor' ) ).to.be.undefined;
-					expect( tableCell.getAttribute( 'borderStyle' ) ).to.be.undefined;
-					expect( tableCell.getAttribute( 'borderWidth' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellBorderColor' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellBorderStyle' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default `border-color` value from <td>', () => {
@@ -1358,7 +1360,7 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'borderColor' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellBorderColor' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default `border-style` value from <th>', () => {
@@ -1366,7 +1368,7 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'borderStyle' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellBorderStyle' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default `border-width` value from <td>', () => {
@@ -1374,7 +1376,7 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'borderWidth' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default `border-width` value from <th>', () => {
@@ -1382,7 +1384,7 @@ describe( 'table cell properties', () => {
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'borderWidth' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.be.undefined;
 				} );
 			} );
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -582,7 +582,7 @@ describe( 'table cell properties', () => {
 
 		describe( 'background color', () => {
 			it( 'should set proper schema rules', () => {
-				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'backgroundColor' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'tableCellBackgroundColor' ) ).to.be.true;
 			} );
 
 			describe( 'upcast conversion', () => {
@@ -590,21 +590,21 @@ describe( 'table cell properties', () => {
 					editor.setData( '<table><tr><td style="background-color:#f00">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'backgroundColor' ) ).to.equal( '#f00' );
+					expect( tableCell.getAttribute( 'tableCellBackgroundColor' ) ).to.equal( '#f00' );
 				} );
 
-				it( 'should upcast from background shorthand', () => {
+				it( 'should upcast from tableCellBackgroundColor shorthand', () => {
 					editor.setData( '<table><tr><td style="background:#f00 center center">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'backgroundColor' ) ).to.equal( '#f00' );
+					expect( tableCell.getAttribute( 'tableCellBackgroundColor' ) ).to.equal( '#f00' );
 				} );
 
-				it( 'should upcast from background shorthand (rbg color value with spaces)', () => {
+				it( 'should upcast from tableCellBackgroundColor shorthand (rbg color value with spaces)', () => {
 					editor.setData( '<table><tr><td style="background:rgb(253, 253, 119) center center">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'backgroundColor' ) ).to.equal( 'rgb(253, 253, 119)' );
+					expect( tableCell.getAttribute( 'tableCellBackgroundColor' ) ).to.equal( 'rgb(253, 253, 119)' );
 				} );
 			} );
 
@@ -625,46 +625,46 @@ describe( 'table cell properties', () => {
 					tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 				} );
 
-				it( 'should consume converted item backgroundColor attribute', () => {
+				it( 'should consume converted item tableCellBackgroundColor attribute', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:backgroundColor:tableCell', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellBackgroundColor:tableCell', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
 						} ) );
 
-					model.change( writer => writer.setAttribute( 'backgroundColor', '#f00', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellBackgroundColor', '#f00', tableCell ) );
 				} );
 
 				it( 'should be overridable', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:backgroundColor:tableCell', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellBackgroundColor:tableCell', ( evt, data, conversionApi ) => {
 							conversionApi.consumable.consume( data.item, evt.name );
 						}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'backgroundColor', '#f00', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellBackgroundColor', '#f00', tableCell ) );
 
 					assertTableCellStyle( editor, '' );
 				} );
 
-				it( 'should downcast backgroundColor', () => {
-					model.change( writer => writer.setAttribute( 'backgroundColor', '#f00', tableCell ) );
+				it( 'should downcast tableCellBackgroundColor', () => {
+					model.change( writer => writer.setAttribute( 'tableCellBackgroundColor', '#f00', tableCell ) );
 
 					assertTableCellStyle( editor, 'background-color:#f00;' );
 				} );
 
-				it( 'should downcast backgroundColor removal', () => {
-					model.change( writer => writer.setAttribute( 'backgroundColor', '#f00', tableCell ) );
+				it( 'should downcast tableCellBackgroundColor removal', () => {
+					model.change( writer => writer.setAttribute( 'tableCellBackgroundColor', '#f00', tableCell ) );
 
-					model.change( writer => writer.removeAttribute( 'backgroundColor', tableCell ) );
+					model.change( writer => writer.removeAttribute( 'tableCellBackgroundColor', tableCell ) );
 
 					assertTableCellStyle( editor );
 				} );
 
-				it( 'should downcast backgroundColor change', () => {
-					model.change( writer => writer.setAttribute( 'backgroundColor', '#f00', tableCell ) );
+				it( 'should downcast tableCellBackgroundColor change', () => {
+					model.change( writer => writer.setAttribute( 'tableCellBackgroundColor', '#f00', tableCell ) );
 
 					assertTableCellStyle( editor, 'background-color:#f00;' );
 
-					model.change( writer => writer.setAttribute( 'backgroundColor', '#ba7', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellBackgroundColor', '#ba7', tableCell ) );
 
 					assertTableCellStyle( editor, 'background-color:#ba7;' );
 				} );
@@ -1044,7 +1044,7 @@ describe( 'table cell properties', () => {
 
 		describe( 'padding', () => {
 			it( 'should set proper schema rules', () => {
-				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'padding' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'tableCellPadding' ) ).to.be.true;
 			} );
 
 			describe( 'upcast conversion', () => {
@@ -1052,7 +1052,7 @@ describe( 'table cell properties', () => {
 					editor.setData( '<table><tr><td style="padding:2px 4em">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					assertTRBLAttribute( tableCell, 'padding', '2px', '4em' );
+					assertTRBLAttribute( tableCell, 'tableCellPadding', '2px', '4em' );
 				} );
 			} );
 
@@ -1075,26 +1075,26 @@ describe( 'table cell properties', () => {
 
 				it( 'should consume converted item borderColor attribute', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:padding:tableCell', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellPadding:tableCell', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
 						} ) );
 
-					model.change( writer => writer.setAttribute( 'padding', '1px', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellPadding', '1px', tableCell ) );
 				} );
 
 				it( 'should be overridable', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:padding:tableCell', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellPadding:tableCell', ( evt, data, conversionApi ) => {
 							conversionApi.consumable.consume( data.item, evt.name );
 						}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'padding', '1px', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellPadding', '1px', tableCell ) );
 
 					assertTableCellStyle( editor, '' );
 				} );
 
-				it( 'should downcast padding (same top, right, bottom, left)', () => {
-					model.change( writer => writer.setAttribute( 'padding', {
+				it( 'should downcast tableCellPadding (same top, right, bottom, left)', () => {
+					model.change( writer => writer.setAttribute( 'tableCellPadding', {
 						top: '2px',
 						right: '2px',
 						bottom: '2px',
@@ -1104,8 +1104,8 @@ describe( 'table cell properties', () => {
 					assertTableCellStyle( editor, 'padding:2px;' );
 				} );
 
-				it( 'should downcast padding (different top, right, bottom, left)', () => {
-					model.change( writer => writer.setAttribute( 'padding', {
+				it( 'should downcast tableCellPadding (different top, right, bottom, left)', () => {
+					model.change( writer => writer.setAttribute( 'tableCellPadding', {
 						top: '2px',
 						right: '3px',
 						bottom: '4px',
@@ -1115,20 +1115,20 @@ describe( 'table cell properties', () => {
 					assertTableCellStyle( editor, 'padding:2px 3px 4px 5px;' );
 				} );
 
-				it( 'should downcast padding removal', () => {
-					model.change( writer => writer.setAttribute( 'padding', '1337px', tableCell ) );
+				it( 'should downcast tableCellPadding removal', () => {
+					model.change( writer => writer.setAttribute( 'tableCellPadding', '1337px', tableCell ) );
 
-					model.change( writer => writer.removeAttribute( 'padding', tableCell ) );
+					model.change( writer => writer.removeAttribute( 'tableCellPadding', tableCell ) );
 
 					assertTableCellStyle( editor );
 				} );
 
-				it( 'should downcast padding change', () => {
-					model.change( writer => writer.setAttribute( 'padding', '1337px', tableCell ) );
+				it( 'should downcast tableCellPadding change', () => {
+					model.change( writer => writer.setAttribute( 'tableCellPadding', '1337px', tableCell ) );
 
 					assertTableCellStyle( editor, 'padding:1337px;' );
 
-					model.change( writer => writer.setAttribute( 'padding', '1410em', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellPadding', '1410em', tableCell ) );
 
 					assertTableCellStyle( editor, 'padding:1410em;' );
 				} );
@@ -1137,7 +1137,7 @@ describe( 'table cell properties', () => {
 
 		describe( 'cell width', () => {
 			it( 'should set proper schema rules', () => {
-				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'width' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'tableCellWidth' ) ).to.be.true;
 			} );
 
 			describe( 'upcast conversion', () => {
@@ -1145,7 +1145,7 @@ describe( 'table cell properties', () => {
 					editor.setData( '<table><tr><td style="width:20px">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'width' ) ).to.equal( '20px' );
+					expect( tableCell.getAttribute( 'tableCellWidth' ) ).to.equal( '20px' );
 				} );
 			} );
 
@@ -1167,28 +1167,28 @@ describe( 'table cell properties', () => {
 					tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 				} );
 
-				it( 'should consume converted item width attribute', () => {
+				it( 'should consume converted item tableCellWidth attribute', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:width:tableCell', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellWidth:tableCell', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
 						} ) );
 
-					model.change( writer => writer.setAttribute( 'width', '40px', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellWidth', '40px', tableCell ) );
 				} );
 
 				it( 'should be overridable', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:width:tableCell', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellWidth:tableCell', ( evt, data, conversionApi ) => {
 							conversionApi.consumable.consume( data.item, evt.name );
 						}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'width', '40px', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellWidth', '40px', tableCell ) );
 
 					assertTableCellStyle( editor, '' );
 				} );
 
-				it( 'should downcast width attribute', () => {
-					model.change( writer => writer.setAttribute( 'width', '20px', tableCell ) );
+				it( 'should downcast tableCellWidth attribute', () => {
+					model.change( writer => writer.setAttribute( 'tableCellWidth', '20px', tableCell ) );
 
 					assertEqualMarkup(
 						editor.getData(),
@@ -1196,20 +1196,20 @@ describe( 'table cell properties', () => {
 					);
 				} );
 
-				it( 'should downcast width removal', () => {
-					model.change( writer => writer.setAttribute( 'width', '1337px', tableCell ) );
+				it( 'should downcast tableCellWidth removal', () => {
+					model.change( writer => writer.setAttribute( 'tableCellWidth', '1337px', tableCell ) );
 
-					model.change( writer => writer.removeAttribute( 'width', tableCell ) );
+					model.change( writer => writer.removeAttribute( 'tableCellWidth', tableCell ) );
 
 					assertTableCellStyle( editor );
 				} );
 
 				it( 'should downcast width change', () => {
-					model.change( writer => writer.setAttribute( 'width', '1337px', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellWidth', '1337px', tableCell ) );
 
 					assertTableCellStyle( editor, 'width:1337px;' );
 
-					model.change( writer => writer.setAttribute( 'width', '1410em', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellWidth', '1410em', tableCell ) );
 
 					assertTableCellStyle( editor, 'width:1410em;' );
 				} );
@@ -1218,7 +1218,7 @@ describe( 'table cell properties', () => {
 
 		describe( 'cell height', () => {
 			it( 'should set proper schema rules', () => {
-				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'height' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'tableCellHeight' ) ).to.be.true;
 			} );
 
 			describe( 'upcast conversion', () => {
@@ -1226,7 +1226,7 @@ describe( 'table cell properties', () => {
 					editor.setData( '<table><tr><td style="height:20px">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'height' ) ).to.equal( '20px' );
+					expect( tableCell.getAttribute( 'tableCellHeight' ) ).to.equal( '20px' );
 				} );
 			} );
 
@@ -1248,28 +1248,28 @@ describe( 'table cell properties', () => {
 					tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 				} );
 
-				it( 'should consume converted item height attribute', () => {
+				it( 'should consume converted item tableCellHeight attribute', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:height:tableCell', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellHeight:tableCell', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
 						} ) );
 
-					model.change( writer => writer.setAttribute( 'height', '40px', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellHeight', '40px', tableCell ) );
 				} );
 
 				it( 'should be overridable', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:height:tableCell', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellHeight:tableCell', ( evt, data, conversionApi ) => {
 							conversionApi.consumable.consume( data.item, evt.name );
 						}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'height', '40px', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellHeight', '40px', tableCell ) );
 
 					assertTableCellStyle( editor, '' );
 				} );
 
-				it( 'should downcast height attribute', () => {
-					model.change( writer => writer.setAttribute( 'height', '20px', tableCell ) );
+				it( 'should downcast tableCellHeight attribute', () => {
+					model.change( writer => writer.setAttribute( 'tableCellHeight', '20px', tableCell ) );
 
 					assertEqualMarkup(
 						editor.getData(),
@@ -1277,20 +1277,20 @@ describe( 'table cell properties', () => {
 					);
 				} );
 
-				it( 'should downcast height removal', () => {
-					model.change( writer => writer.setAttribute( 'height', '1337px', tableCell ) );
+				it( 'should downcast tableCellHeight removal', () => {
+					model.change( writer => writer.setAttribute( 'tableCellHeight', '1337px', tableCell ) );
 
-					model.change( writer => writer.removeAttribute( 'height', tableCell ) );
+					model.change( writer => writer.removeAttribute( 'tableCellHeight', tableCell ) );
 
 					assertTableCellStyle( editor );
 				} );
 
-				it( 'should downcast height change', () => {
-					model.change( writer => writer.setAttribute( 'height', '1337px', tableCell ) );
+				it( 'should downcast tableCellHeight change', () => {
+					model.change( writer => writer.setAttribute( 'tableCellHeight', '1337px', tableCell ) );
 
 					assertTableCellStyle( editor, 'height:1337px;' );
 
-					model.change( writer => writer.setAttribute( 'height', '1410em', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellHeight', '1410em', tableCell ) );
 
 					assertTableCellStyle( editor, 'height:1410em;' );
 				} );

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -675,7 +675,7 @@ describe( 'table cell properties', () => {
 
 		describe( 'horizontal alignment', () => {
 			it( 'should set proper schema rules', () => {
-				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'horizontalAlignment' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'tableCellHorizontalAlignment' ) ).to.be.true;
 			} );
 
 			describe( 'upcast conversion', () => {
@@ -683,28 +683,28 @@ describe( 'table cell properties', () => {
 					editor.setData( '<table><tr><td style="text-align:left">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.be.undefined;
 				} );
 
 				it( 'should upcast text-align:right style', () => {
 					editor.setData( '<table><tr><td style="text-align:right">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.equal( 'right' );
+					expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'right' );
 				} );
 
 				it( 'should not upcast text-align:center style', () => {
 					editor.setData( '<table><tr><td style="text-align:center">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.equal( 'center' );
+					expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'center' );
 				} );
 
 				it( 'should upcast text-align:justify style', () => {
 					editor.setData( '<table><tr><td style="text-align:justify">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.equal( 'justify' );
+					expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'justify' );
 				} );
 
 				describe( 'the [align] attribute', () => {
@@ -712,28 +712,28 @@ describe( 'table cell properties', () => {
 						editor.setData( '<table><tr><td align="left">foo</td></tr></table>' );
 						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-						expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.be.undefined;
+						expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.be.undefined;
 					} );
 
 					it( 'should upcast the align=right attribute', () => {
 						editor.setData( '<table><tr><td align="right">foo</td></tr></table>' );
 						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-						expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.equal( 'right' );
+						expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'right' );
 					} );
 
 					it( 'should upcast the align=center attribute', () => {
 						editor.setData( '<table><tr><td align="center">foo</td></tr></table>' );
 						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-						expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.equal( 'center' );
+						expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'center' );
 					} );
 
 					it( 'should upcast the align=justify attribute', () => {
 						editor.setData( '<table><tr><td align="justify">foo</td></tr></table>' );
 						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-						expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.equal( 'justify' );
+						expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'justify' );
 					} );
 				} );
 
@@ -757,28 +757,28 @@ describe( 'table cell properties', () => {
 						editor.setData( '<table><tr><td style="text-align:right">foo</td></tr></table>' );
 						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-						expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.be.undefined;
+						expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.be.undefined;
 					} );
 
 					it( 'should upcast text-align:left style', () => {
 						editor.setData( '<table><tr><td style="text-align:left">foo</td></tr></table>' );
 						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-						expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.equal( 'left' );
+						expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'left' );
 					} );
 
 					it( 'should not upcast text-align:center style', () => {
 						editor.setData( '<table><tr><td style="text-align:center">foo</td></tr></table>' );
 						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-						expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.equal( 'center' );
+						expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'center' );
 					} );
 
 					it( 'should upcast text-align:justify style', () => {
 						editor.setData( '<table><tr><td style="text-align:justify">foo</td></tr></table>' );
 						const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-						expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.equal( 'justify' );
+						expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'justify' );
 					} );
 
 					describe( 'the [align] attribute', () => {
@@ -786,28 +786,28 @@ describe( 'table cell properties', () => {
 							editor.setData( '<table><tr><td align="left">foo</td></tr></table>' );
 							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-							expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.equal( 'left' );
+							expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'left' );
 						} );
 
 						it( 'should not upcast the align=right attribute  (due to the default value of the property)', () => {
 							editor.setData( '<table><tr><td align="right">foo</td></tr></table>' );
 							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-							expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.be.undefined;
+							expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.be.undefined;
 						} );
 
 						it( 'should upcast the align=center attribute', () => {
 							editor.setData( '<table><tr><td align="center">foo</td></tr></table>' );
 							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-							expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.equal( 'center' );
+							expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'center' );
 						} );
 
 						it( 'should upcast the align=justify attribute', () => {
 							editor.setData( '<table><tr><td align="justify">foo</td></tr></table>' );
 							const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-							expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.equal( 'justify' );
+							expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.equal( 'justify' );
 						} );
 					} );
 				} );
@@ -830,46 +830,48 @@ describe( 'table cell properties', () => {
 					tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 				} );
 
-				it( 'should consume converted item horizontalAlignment attribute', () => {
+				it( 'should consume converted item tableCellHorizontalAlignment attribute', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:horizontalAlignment:tableCell', ( evt, data, conversionApi ) => {
-							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
-						} ) );
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellHorizontalAlignment:tableCell',
+							( evt, data, conversionApi ) => {
+								expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
+							} ) );
 
-					model.change( writer => writer.setAttribute( 'horizontalAlignment', 'right', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellHorizontalAlignment', 'right', tableCell ) );
 				} );
 
 				it( 'should be overridable', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:horizontalAlignment:tableCell', ( evt, data, conversionApi ) => {
-							conversionApi.consumable.consume( data.item, evt.name );
-						}, { priority: 'high' } ) );
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellHorizontalAlignment:tableCell',
+							( evt, data, conversionApi ) => {
+								conversionApi.consumable.consume( data.item, evt.name );
+							}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'horizontalAlignment', 'right', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellHorizontalAlignment', 'right', tableCell ) );
 
 					assertTableCellStyle( editor, '' );
 				} );
 
-				it( 'should downcast horizontalAlignment=left', () => {
-					model.change( writer => writer.setAttribute( 'horizontalAlignment', 'left', tableCell ) );
+				it( 'should downcast tableCellHorizontalAlignment=left', () => {
+					model.change( writer => writer.setAttribute( 'tableCellHorizontalAlignment', 'left', tableCell ) );
 
 					assertTableCellStyle( editor, 'text-align:left;' );
 				} );
 
-				it( 'should downcast horizontalAlignment=right', () => {
-					model.change( writer => writer.setAttribute( 'horizontalAlignment', 'right', tableCell ) );
+				it( 'should downcast tableCellHorizontalAlignment=right', () => {
+					model.change( writer => writer.setAttribute( 'tableCellHorizontalAlignment', 'right', tableCell ) );
 
 					assertTableCellStyle( editor, 'text-align:right;' );
 				} );
 
-				it( 'should downcast horizontalAlignment=center', () => {
-					model.change( writer => writer.setAttribute( 'horizontalAlignment', 'center', tableCell ) );
+				it( 'should downcast tableCellHorizontalAlignment=center', () => {
+					model.change( writer => writer.setAttribute( 'tableCellHorizontalAlignment', 'center', tableCell ) );
 
 					assertTableCellStyle( editor, 'text-align:center;' );
 				} );
 
-				it( 'should downcast horizontalAlignment=justify', () => {
-					model.change( writer => writer.setAttribute( 'horizontalAlignment', 'justify', tableCell ) );
+				it( 'should downcast tableCellHorizontalAlignment=justify', () => {
+					model.change( writer => writer.setAttribute( 'tableCellHorizontalAlignment', 'justify', tableCell ) );
 
 					assertTableCellStyle( editor, 'text-align:justify;' );
 				} );
@@ -903,46 +905,48 @@ describe( 'table cell properties', () => {
 						await editor.destroy();
 					} );
 
-					it( 'should consume converted item\'s horizontalAlignment attribute', () => {
+					it( 'should consume converted item\'s tableCellHorizontalAlignment attribute', () => {
 						editor.conversion.for( 'downcast' )
-							.add( dispatcher => dispatcher.on( 'attribute:horizontalAlignment:tableCell', ( evt, data, conversionApi ) => {
-								expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
-							} ) );
+							.add( dispatcher => dispatcher.on( 'attribute:tableCellHorizontalAlignment:tableCell',
+								( evt, data, conversionApi ) => {
+									expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
+								} ) );
 
-						model.change( writer => writer.setAttribute( 'horizontalAlignment', 'center', tableCell ) );
+						model.change( writer => writer.setAttribute( 'tableCellHorizontalAlignment', 'center', tableCell ) );
 					} );
 
 					it( 'should be overridable', () => {
 						editor.conversion.for( 'downcast' )
-							.add( dispatcher => dispatcher.on( 'attribute:horizontalAlignment:tableCell', ( evt, data, conversionApi ) => {
-								conversionApi.consumable.consume( data.item, evt.name );
-							}, { priority: 'high' } ) );
+							.add( dispatcher => dispatcher.on( 'attribute:tableCellHorizontalAlignment:tableCell',
+								( evt, data, conversionApi ) => {
+									conversionApi.consumable.consume( data.item, evt.name );
+								}, { priority: 'high' } ) );
 
-						model.change( writer => writer.setAttribute( 'horizontalAlignment', 'center', tableCell ) );
+						model.change( writer => writer.setAttribute( 'tableCellHorizontalAlignment', 'center', tableCell ) );
 
 						assertTableCellStyle( editor, '' );
 					} );
 
-					it( 'should not downcast horizontalAlignment=right', () => {
-						model.change( writer => writer.setAttribute( 'horizontalAlignment', 'right', tableCell ) );
+					it( 'should downcast tableCellHorizontalAlignment=right', () => {
+						model.change( writer => writer.setAttribute( 'tableCellHorizontalAlignment', 'right', tableCell ) );
 
 						assertTableCellStyle( editor, 'text-align:right;' );
 					} );
 
-					it( 'should downcast horizontalAlignment=left', () => {
-						model.change( writer => writer.setAttribute( 'horizontalAlignment', 'left', tableCell ) );
+					it( 'should downcast tableCellHorizontalAlignment=left', () => {
+						model.change( writer => writer.setAttribute( 'tableCellHorizontalAlignment', 'left', tableCell ) );
 
 						assertTableCellStyle( editor, 'text-align:left;' );
 					} );
 
-					it( 'should downcast horizontalAlignment=center', () => {
-						model.change( writer => writer.setAttribute( 'horizontalAlignment', 'center', tableCell ) );
+					it( 'should downcast tableCellHorizontalAlignment=center', () => {
+						model.change( writer => writer.setAttribute( 'tableCellHorizontalAlignment', 'center', tableCell ) );
 
 						assertTableCellStyle( editor, 'text-align:center;' );
 					} );
 
-					it( 'should downcast horizontalAlignment=justify', () => {
-						model.change( writer => writer.setAttribute( 'horizontalAlignment', 'justify', tableCell ) );
+					it( 'should downcast tableCellHorizontalAlignment=justify', () => {
+						model.change( writer => writer.setAttribute( 'tableCellHorizontalAlignment', 'justify', tableCell ) );
 
 						assertTableCellStyle( editor, 'text-align:justify;' );
 					} );
@@ -952,7 +956,7 @@ describe( 'table cell properties', () => {
 
 		describe( 'vertical alignment', () => {
 			it( 'should set proper schema rules', () => {
-				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'verticalAlignment' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'tableCellVerticalAlignment' ) ).to.be.true;
 			} );
 
 			describe( 'upcast conversion', () => {
@@ -960,42 +964,42 @@ describe( 'table cell properties', () => {
 					editor.setData( '<table><tr><td style="vertical-align:top">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'verticalAlignment' ) ).to.equal( 'top' );
+					expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.equal( 'top' );
 				} );
 
 				it( 'should upcast "bottom" vertical-align', () => {
 					editor.setData( '<table><tr><td style="vertical-align:bottom">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'verticalAlignment' ) ).to.equal( 'bottom' );
+					expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.equal( 'bottom' );
 				} );
 
 				it( 'should not upcast "middle" vertical-align (due to the default value of the property)', () => {
 					editor.setData( '<table><tr><td style="vertical-align:middle">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'verticalAlignment' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.be.undefined;
 				} );
 
 				it( 'should upcast "top" valign attribute', () => {
 					editor.setData( '<table><tr><td valign="top">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'verticalAlignment' ) ).to.equal( 'top' );
+					expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.equal( 'top' );
 				} );
 
 				it( 'should upcast "bottom" valign attribute', () => {
 					editor.setData( '<table><tr><td valign="bottom">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'verticalAlignment' ) ).to.equal( 'bottom' );
+					expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.equal( 'bottom' );
 				} );
 
 				it( 'should not upcast "middle" valign attribute (due to the default value of the property)', () => {
 					editor.setData( '<table><tr><td valign="middle">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'verticalAlignment' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.be.undefined;
 				} );
 			} );
 
@@ -1016,28 +1020,30 @@ describe( 'table cell properties', () => {
 					tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 				} );
 
-				it( 'should consume converted item verticalAlignment attribute', () => {
+				it( 'should consume converted item tableCellVerticalAlignment attribute', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:verticalAlignment:tableCell', ( evt, data, conversionApi ) => {
-							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
-						} ) );
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellVerticalAlignment:tableCell',
+							( evt, data, conversionApi ) => {
+								expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
+							} ) );
 
-					model.change( writer => writer.setAttribute( 'verticalAlignment', 'top', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellVerticalAlignment', 'top', tableCell ) );
 				} );
 
 				it( 'should be overridable', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:verticalAlignment:tableCell', ( evt, data, conversionApi ) => {
-							conversionApi.consumable.consume( data.item, evt.name );
-						}, { priority: 'high' } ) );
+						.add( dispatcher => dispatcher.on( 'attribute:tableCellVerticalAlignment:tableCell',
+							( evt, data, conversionApi ) => {
+								conversionApi.consumable.consume( data.item, evt.name );
+							}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'verticalAlignment', 'top', tableCell ) );
+					model.change( writer => writer.setAttribute( 'tableCellVerticalAlignment', 'top', tableCell ) );
 
 					assertTableCellStyle( editor, '' );
 				} );
 
-				it( 'should downcast verticalAlignment', () => {
-					model.change( writer => writer.setAttribute( 'verticalAlignment', 'top', tableCell ) );
+				it( 'should downcast tableCellVerticalAlignment', () => {
+					model.change( writer => writer.setAttribute( 'tableCellVerticalAlignment', 'top', tableCell ) );
 
 					assertTableCellStyle( editor, 'vertical-align:top;' );
 				} );
@@ -1465,63 +1471,63 @@ describe( 'table cell properties', () => {
 				} );
 			} );
 
-			describe( 'horizontalAlignment', () => {
+			describe( 'tableCellHorizontalAlignment', () => {
 				it( 'should not upcast the default value from the style attribute (text-align:left) from <td>', () => {
 					editor.setData( '<table><tr><td style="text-align:left">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default value from the style attribute (text-align:left) from <th>', () => {
 					editor.setData( '<table><tr><th style="text-align:left">foo</th></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default value from the align attribute (left) from <td>', () => {
 					editor.setData( '<table><tr><td align="left">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default value from the align attribute (left) from <th>', () => {
 					editor.setData( '<table><tr><th align="left">foo</th></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'horizontalAlignment' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellHorizontalAlignment' ) ).to.be.undefined;
 				} );
 			} );
 
-			describe( 'verticalAlignment', () => {
+			describe( 'tableCellVerticalAlignment', () => {
 				it( 'should not upcast the default value from the style attribute (vertical-align:bottom;) from <td>', () => {
 					editor.setData( '<table><tr><td style="vertical-align:bottom;">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'verticalAlignment' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default value from the style attribute (vertical-align:bottom;) from <th>', () => {
 					editor.setData( '<table><tr><th style="vertical-align:bottom;">foo</th></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'verticalAlignment' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default value from the valign attribute (bottom) from <td>', () => {
 					editor.setData( '<table><tr><td valign="bottom">foo</td></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'verticalAlignment' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default value from the valign attribute (bottom) from <th>', () => {
 					editor.setData( '<table><tr><th valign="bottom">foo</th></tr></table>' );
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'verticalAlignment' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellVerticalAlignment' ) ).to.be.undefined;
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesui.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesui.js
@@ -200,7 +200,7 @@ describe( 'table cell properties', () => {
 					expect( getModelData( editor.model ) ).to.equal(
 						'<table>' +
 							'<tableRow>' +
-								'<tableCell backgroundColor="red" borderStyle="dotted">' +
+								'<tableCell borderStyle="dotted" tableCellBackgroundColor="red">' +
 									'<paragraph>[]foo</paragraph>' +
 								'</tableCell>' +
 							'</tableRow>' +

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesui.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesui.js
@@ -200,7 +200,7 @@ describe( 'table cell properties', () => {
 					expect( getModelData( editor.model ) ).to.equal(
 						'<table>' +
 							'<tableRow>' +
-								'<tableCell borderStyle="dotted" tableCellBackgroundColor="red">' +
+								'<tableCell tableCellBackgroundColor="red" tableCellBorderStyle="dotted">' +
 									'<paragraph>[]foo</paragraph>' +
 								'</tableCell>' +
 							'</tableRow>' +

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -3877,9 +3877,9 @@ describe( 'table clipboard', () => {
 
 			const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-			expect( tableCell.getAttribute( 'borderColor' ) ).to.equal( '#f00' );
-			expect( tableCell.getAttribute( 'borderStyle' ) ).to.equal( 'solid' );
-			expect( tableCell.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
+			expect( tableCell.getAttribute( 'tableCellBorderColor' ) ).to.equal( '#f00' );
+			expect( tableCell.getAttribute( 'tableCellBorderStyle' ) ).to.equal( 'solid' );
+			expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.equal( '1px' );
 			expect( tableCell.getAttribute( 'tableCellBackgroundColor' ) ).to.equal( '#ba7' );
 			expect( tableCell.getAttribute( 'tableCellWidth' ) ).to.equal( '1337px' );
 		} );
@@ -3973,9 +3973,9 @@ describe( 'table clipboard', () => {
 			const tableModelData = modelTable( [
 				[ {
 					contents: '<paragraph>Test</paragraph>',
-					borderColor: color,
-					borderStyle: style,
-					borderWidth: width
+					tableCellBorderColor: color,
+					tableCellBorderStyle: style,
+					tableCellBorderWidth: width
 				} ]
 			] );
 

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -3880,8 +3880,8 @@ describe( 'table clipboard', () => {
 			expect( tableCell.getAttribute( 'borderColor' ) ).to.equal( '#f00' );
 			expect( tableCell.getAttribute( 'borderStyle' ) ).to.equal( 'solid' );
 			expect( tableCell.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
-			expect( tableCell.getAttribute( 'backgroundColor' ) ).to.equal( '#ba7' );
-			expect( tableCell.getAttribute( 'width' ) ).to.equal( '1337px' );
+			expect( tableCell.getAttribute( 'tableCellBackgroundColor' ) ).to.equal( '#ba7' );
+			expect( tableCell.getAttribute( 'tableCellWidth' ) ).to.equal( '1337px' );
 		} );
 
 		it( 'discards table properties', async () => {

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tablealignmentcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tablealignmentcommand.js
@@ -59,13 +59,13 @@ describe( 'table properties', () => {
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
 					it( 'should be set if selected table has alignment property', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { alignment: 'left' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableAlignment: 'left' } ) );
 
 						expect( command.value ).to.equal( 'left' );
 					} );
 
 					it( 'should be undefined if selected table has set the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { alignment: 'center' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableAlignment: 'center' } ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
@@ -85,13 +85,13 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should be undefined if selected table has set the default value', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { alignment: 'center' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableAlignment: 'center' } ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
 					it( 'should be true is selection has table', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { alignment: 'left' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableAlignment: 'left' } ) );
 
 						expect( command.value ).to.equal( 'left' );
 					} );
@@ -118,7 +118,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should change selected table alignment to a passed value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { alignment: 'center' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableAlignment: 'center' } ) );
 
 						command.execute( { value: 'right' } );
 
@@ -126,7 +126,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should remove alignment from a selected table if no value is passed', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { alignment: 'center' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableAlignment: 'center' } ) );
 
 						command.execute();
 

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tablebackgroundcolorcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tablebackgroundcolorcommand.js
@@ -65,7 +65,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should be set if selected table has backgroundColor property', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { backgroundColor: 'blue' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBackgroundColor: 'blue' } ) );
 
 						expect( command.value ).to.equal( 'blue' );
 					} );
@@ -79,7 +79,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should be true is selection has table', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { backgroundColor: 'blue' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableBackgroundColor: 'blue' } ) );
 
 						expect( command.value ).to.equal( 'blue' );
 					} );
@@ -106,7 +106,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should change selected table backgroundColor to a passed value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { backgroundColor: 'blue' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBackgroundColor: 'blue' } ) );
 
 						command.execute( { value: '#f00' } );
 
@@ -114,7 +114,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should remove backgroundColor from a selected table if no value is passed', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { backgroundColor: 'blue' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBackgroundColor: 'blue' } ) );
 
 						command.execute();
 
@@ -169,13 +169,13 @@ describe( 'table properties', () => {
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
 					it( 'should be undefined if selected table has set the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { backgroundColor: 'red' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBackgroundColor: 'red' } ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
 					it( 'should be set if selected table has backgroundColor property other than the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { backgroundColor: 'blue' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBackgroundColor: 'blue' } ) );
 
 						expect( command.value ).to.equal( 'blue' );
 					} );
@@ -183,13 +183,13 @@ describe( 'table properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should be undefined if selected table has set the default value', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { backgroundColor: 'red' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableBackgroundColor: 'red' } ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
 					it( 'should be set if selected table has backgroundColor property other than the default value', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { backgroundColor: 'blue' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableBackgroundColor: 'blue' } ) );
 
 						expect( command.value ).to.equal( 'blue' );
 					} );
@@ -199,7 +199,7 @@ describe( 'table properties', () => {
 			describe( 'execute()', () => {
 				describe( 'collapsed selection', () => {
 					it( 'should remove backgroundColor from a selected table if passed the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { backgroundColor: 'blue' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBackgroundColor: 'blue' } ) );
 
 						command.execute( { value: 'red' } );
 
@@ -209,7 +209,7 @@ describe( 'table properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should remove backgroundColor from a selected table if passed the default value', () => {
-						setData( model, modelTable( [ [ '[foo]' ] ], { backgroundColor: 'blue' } ) );
+						setData( model, modelTable( [ [ '[foo]' ] ], { tableBackgroundColor: 'blue' } ) );
 
 						command.execute( { value: 'red' } );
 

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tablebordercolorcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tablebordercolorcommand.js
@@ -65,14 +65,14 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should be set if selected table has borderColor property (single string)', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderColor: 'blue' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderColor: 'blue' } ) );
 
 						expect( command.value ).to.equal( 'blue' );
 					} );
 
 					it( 'should be set if selected table has borderColor property object with same values', () => {
 						setTableWithObjectAttributes( model, {
-							borderColor: {
+							tableBorderColor: {
 								top: 'blue',
 								right: 'blue',
 								bottom: 'blue',
@@ -84,7 +84,7 @@ describe( 'table properties', () => {
 
 					it( 'should be undefined if selected table has borderColor property object with different values', () => {
 						setTableWithObjectAttributes( model, {
-							borderColor: {
+							tableBorderColor: {
 								top: 'blue',
 								right: 'red',
 								bottom: 'blue',
@@ -104,7 +104,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should be true is selection has table', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { borderColor: 'blue' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableBorderColor: 'blue' } ) );
 
 						expect( command.value ).to.equal( 'blue' );
 					} );
@@ -131,7 +131,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should change selected table borderColor to a passed value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderColor: 'blue' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderColor: 'blue' } ) );
 
 						command.execute( { value: '#f00' } );
 
@@ -139,7 +139,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should remove borderColor from a selected table if no value is passed', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderColor: 'blue' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderColor: 'blue' } ) );
 
 						command.execute();
 
@@ -194,13 +194,13 @@ describe( 'table properties', () => {
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
 					it( 'should be undefined if selected table has set the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderColor: 'red' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderColor: 'red' } ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
 					it( 'should be set if selected table has borderColor property other than the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderColor: 'blue' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderColor: 'blue' } ) );
 
 						expect( command.value ).to.equal( 'blue' );
 					} );
@@ -208,13 +208,13 @@ describe( 'table properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should be undefined if selected table has set the default value', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { borderColor: 'red' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableBorderColor: 'red' } ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
 					it( 'should be set if selected table has borderColor property other than the default value', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { borderColor: 'blue' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableBorderColor: 'blue' } ) );
 
 						expect( command.value ).to.equal( 'blue' );
 					} );
@@ -224,7 +224,7 @@ describe( 'table properties', () => {
 			describe( 'execute()', () => {
 				describe( 'collapsed selection', () => {
 					it( 'should remove borderColor from a selected table if passed the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderColor: 'blue' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderColor: 'blue' } ) );
 
 						command.execute( { value: 'red' } );
 
@@ -234,7 +234,7 @@ describe( 'table properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should remove borderColor from a selected table if passed the default value', () => {
-						setData( model, modelTable( [ [ '[foo]' ] ], { borderColor: 'blue' } ) );
+						setData( model, modelTable( [ [ '[foo]' ] ], { tableBorderColor: 'blue' } ) );
 
 						command.execute( { value: 'red' } );
 

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tableborderstylecommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tableborderstylecommand.js
@@ -65,14 +65,14 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should be set if selected table has borderStyle property (single string)', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderStyle: 'ridge' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderStyle: 'ridge' } ) );
 
 						expect( command.value ).to.equal( 'ridge' );
 					} );
 
 					it( 'should be set if selected table has borderStyle property object with same values', () => {
 						setTableWithObjectAttributes( model, {
-							borderStyle: {
+							tableBorderStyle: {
 								top: 'ridge',
 								right: 'ridge',
 								bottom: 'ridge',
@@ -84,7 +84,7 @@ describe( 'table properties', () => {
 
 					it( 'should be undefined if selected table has borderStyle property object with different values', () => {
 						setTableWithObjectAttributes( model, {
-							borderStyle: {
+							tableBorderStyle: {
 								top: 'ridge',
 								right: 'dashed',
 								bottom: 'ridge',
@@ -104,7 +104,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should be true is selection has table', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { borderStyle: 'ridge' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableBorderStyle: 'ridge' } ) );
 
 						expect( command.value ).to.equal( 'ridge' );
 					} );
@@ -131,7 +131,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should change selected table borderStyle to a passed value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderStyle: 'ridge' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderStyle: 'ridge' } ) );
 
 						command.execute( { value: 'solid' } );
 
@@ -139,7 +139,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should remove borderStyle from a selected table if no value is passed', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderStyle: 'ridge' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderStyle: 'ridge' } ) );
 
 						command.execute();
 
@@ -194,13 +194,13 @@ describe( 'table properties', () => {
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
 					it( 'should be undefined if selected table has set the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderStyle: 'none' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderStyle: 'none' } ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
 					it( 'should be set if selected table has borderStyle property other than the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderStyle: 'solid' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderStyle: 'solid' } ) );
 
 						expect( command.value ).to.equal( 'solid' );
 					} );
@@ -208,13 +208,13 @@ describe( 'table properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should be undefined if selected table has set the default value', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { borderStyle: 'none' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableBorderStyle: 'none' } ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
 					it( 'should be set if selected table has borderStyle property other than the default value', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { borderStyle: 'solid' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableBorderStyle: 'solid' } ) );
 
 						expect( command.value ).to.equal( 'solid' );
 					} );
@@ -224,7 +224,7 @@ describe( 'table properties', () => {
 			describe( 'execute()', () => {
 				describe( 'collapsed selection', () => {
 					it( 'should remove borderStyle from a selected table if passed the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderStyle: 'solid' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderStyle: 'solid' } ) );
 
 						command.execute( { value: 'none' } );
 
@@ -234,7 +234,7 @@ describe( 'table properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should remove borderStyle from a selected table if passed the default value', () => {
-						setData( model, modelTable( [ [ '[foo]' ] ], { borderStyle: 'solid' } ) );
+						setData( model, modelTable( [ [ '[foo]' ] ], { tableBorderStyle: 'solid' } ) );
 
 						command.execute( { value: 'none' } );
 

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tableborderwidthcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tableborderwidthcommand.js
@@ -65,14 +65,14 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should be set if selected table has borderWidth property (single string)', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderWidth: '2em' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderWidth: '2em' } ) );
 
 						expect( command.value ).to.equal( '2em' );
 					} );
 
 					it( 'should be set if selected table has borderWidth property object with same values', () => {
 						setTableWithObjectAttributes( model, {
-							borderWidth: {
+							tableBorderWidth: {
 								top: '2em',
 								right: '2em',
 								bottom: '2em',
@@ -84,7 +84,7 @@ describe( 'table properties', () => {
 
 					it( 'should be undefined if selected table has borderWidth property object with different values', () => {
 						setTableWithObjectAttributes( model, {
-							borderWidth: {
+							tableBorderWidth: {
 								top: '2em',
 								right: '333px',
 								bottom: '2em',
@@ -104,7 +104,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should be true is selection has table', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { borderWidth: '2em' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableBorderWidth: '2em' } ) );
 
 						expect( command.value ).to.equal( '2em' );
 					} );
@@ -187,7 +187,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should change selected table borderWidth to a passed value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderWidth: '2em' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderWidth: '2em' } ) );
 
 						command.execute( { value: '1px' } );
 
@@ -195,7 +195,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should remove borderWidth from a selected table if no value is passed', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderWidth: '2em' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderWidth: '2em' } ) );
 
 						command.execute();
 
@@ -250,13 +250,13 @@ describe( 'table properties', () => {
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
 					it( 'should be undefined if selected table has set the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderWidth: '3px' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderWidth: '3px' } ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
 					it( 'should be set if selected table has borderWidth property other than the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderWidth: '1px' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderWidth: '1px' } ) );
 
 						expect( command.value ).to.equal( '1px' );
 					} );
@@ -264,13 +264,13 @@ describe( 'table properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should be undefined if selected table has set the default value', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { borderWidth: '3px' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableBorderWidth: '3px' } ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
 					it( 'should be set if selected table has borderWidth property other than the default value', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { borderWidth: '1px' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableBorderWidth: '1px' } ) );
 
 						expect( command.value ).to.equal( '1px' );
 					} );
@@ -280,7 +280,7 @@ describe( 'table properties', () => {
 			describe( 'execute()', () => {
 				describe( 'collapsed selection', () => {
 					it( 'should remove borderWidth from a selected table if passed the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { borderWidth: '1px' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableBorderWidth: '1px' } ) );
 
 						command.execute( { value: '3px' } );
 
@@ -290,7 +290,7 @@ describe( 'table properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should remove borderWidth from a selected table if passed the default value', () => {
-						setData( model, modelTable( [ [ '[foo]' ] ], { borderWidth: '1px' } ) );
+						setData( model, modelTable( [ [ '[foo]' ] ], { tableBorderWidth: '1px' } ) );
 
 						command.execute( { value: '3px' } );
 

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tableheightcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tableheightcommand.js
@@ -65,7 +65,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should be set if selected table has height property', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { height: '100px' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableHeight: '100px' } ) );
 
 						expect( command.value ).to.equal( '100px' );
 					} );
@@ -79,7 +79,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should be true is selection has table', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { height: '100px' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableHeight: '100px' } ) );
 
 						expect( command.value ).to.equal( '100px' );
 					} );
@@ -162,7 +162,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should change selected table height to a passed value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { height: '100px' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableHeight: '100px' } ) );
 
 						command.execute( { value: '25px' } );
 
@@ -170,7 +170,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should remove height from a selected table if no value is passed', () => {
-						setData( model, modelTable( [ [ { height: '100px', contents: '[]foo' } ] ] ) );
+						setData( model, modelTable( [ [ { tableHeight: '100px', contents: '[]foo' } ] ] ) );
 
 						command.execute();
 
@@ -225,13 +225,13 @@ describe( 'table properties', () => {
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
 					it( 'should be undefined if selected table has set the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { height: '300px' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableHeight: '300px' } ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
 					it( 'should be set if selected table has height property other than the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { height: '100px' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableHeight: '100px' } ) );
 
 						expect( command.value ).to.equal( '100px' );
 					} );
@@ -239,13 +239,13 @@ describe( 'table properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should be undefined if selected table has set the default value', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { height: '300px' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableHeight: '300px' } ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
 					it( 'should be set if selected table has height property other than the default value', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { height: '100px' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableHeight: '100px' } ) );
 
 						expect( command.value ).to.equal( '100px' );
 					} );
@@ -255,7 +255,7 @@ describe( 'table properties', () => {
 			describe( 'execute()', () => {
 				describe( 'collapsed selection', () => {
 					it( 'should remove height from a selected table if passed the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { height: '100px' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableHeight: '100px' } ) );
 
 						command.execute( { value: '300px' } );
 
@@ -265,7 +265,7 @@ describe( 'table properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should remove height from a selected table if passed the default value', () => {
-						setData( model, modelTable( [ [ '[foo]' ] ], { height: '100px' } ) );
+						setData( model, modelTable( [ [ '[foo]' ] ], { tableHeight: '100px' } ) );
 
 						command.execute( { value: '300px' } );
 

--- a/packages/ckeditor5-table/tests/tableproperties/commands/tablewidthcommand.js
+++ b/packages/ckeditor5-table/tests/tableproperties/commands/tablewidthcommand.js
@@ -65,7 +65,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should be set if selected table has width property', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { width: '100px' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableWidth: '100px' } ) );
 
 						expect( command.value ).to.equal( '100px' );
 					} );
@@ -79,7 +79,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should be true is selection has table', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { width: '100px' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableWidth: '100px' } ) );
 
 						expect( command.value ).to.equal( '100px' );
 					} );
@@ -162,7 +162,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should change selected table width to a passed value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { width: '100px' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableWidth: '100px' } ) );
 
 						command.execute( { value: '25px' } );
 
@@ -170,7 +170,7 @@ describe( 'table properties', () => {
 					} );
 
 					it( 'should remove width from a selected table if no value is passed', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { width: '100px' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableWidth: '100px' } ) );
 
 						command.execute();
 
@@ -225,13 +225,13 @@ describe( 'table properties', () => {
 			describe( 'value', () => {
 				describe( 'collapsed selection', () => {
 					it( 'should be undefined if selected table has set the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { width: '300px' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableWidth: '300px' } ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
 					it( 'should be set if selected table has width property other than the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { width: '100px' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableWidth: '100px' } ) );
 
 						expect( command.value ).to.equal( '100px' );
 					} );
@@ -239,13 +239,13 @@ describe( 'table properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should be undefined if selected table has set the default value', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { width: '300px' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableWidth: '300px' } ) );
 
 						expect( command.value ).to.be.undefined;
 					} );
 
 					it( 'should be set if selected table has width property other than the default value', () => {
-						setData( model, modelTable( [ [ 'f[o]o' ] ], { width: '100px' } ) );
+						setData( model, modelTable( [ [ 'f[o]o' ] ], { tableWidth: '100px' } ) );
 
 						expect( command.value ).to.equal( '100px' );
 					} );
@@ -255,7 +255,7 @@ describe( 'table properties', () => {
 			describe( 'execute()', () => {
 				describe( 'collapsed selection', () => {
 					it( 'should remove width from a selected table if passed the default value', () => {
-						setData( model, modelTable( [ [ '[]foo' ] ], { width: '100px' } ) );
+						setData( model, modelTable( [ [ '[]foo' ] ], { tableWidth: '100px' } ) );
 
 						command.execute( { value: '300px' } );
 
@@ -265,7 +265,7 @@ describe( 'table properties', () => {
 
 				describe( 'non-collapsed selection', () => {
 					it( 'should remove width from a selected table if passed the default value', () => {
-						setData( model, modelTable( [ [ '[foo]' ] ], { width: '100px' } ) );
+						setData( model, modelTable( [ [ '[foo]' ] ], { tableWidth: '100px' } ) );
 
 						command.execute( { value: '300px' } );
 

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting-integration.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting-integration.js
@@ -37,7 +37,7 @@ describe( 'table properties', () => {
 			} );
 
 			it( 'should properly downcast table with Alignment plugin enabled', () => {
-				model.change( writer => writer.setAttribute( 'alignment', 'right', table ) );
+				model.change( writer => writer.setAttribute( 'tableAlignment', 'right', table ) );
 
 				assertTableStyle( editor, null, 'float:right;' );
 			} );
@@ -66,17 +66,17 @@ describe( 'table properties', () => {
 
 				editor.execute( 'tableCellBackgroundColor', { value: 'green' } );
 
-				expect( table.getAttribute( 'backgroundColor' ) ).to.equal( 'red' );
+				expect( table.getAttribute( 'tableBackgroundColor' ) ).to.equal( 'red' );
 				expect( firstCell.getAttribute( 'backgroundColor' ) ).to.equal( 'green' );
 
 				editor.execute( 'undo' );
 
-				expect( table.getAttribute( 'backgroundColor' ) ).to.equal( 'red' );
+				expect( table.getAttribute( 'tableBackgroundColor' ) ).to.equal( 'red' );
 				expect( firstCell.getAttribute( 'backgroundColor' ) ).to.be.undefined;
 
 				editor.execute( 'undo' );
 
-				expect( table.getAttribute( 'backgroundColor' ) ).to.be.undefined;
+				expect( table.getAttribute( 'tableBackgroundColor' ) ).to.be.undefined;
 				expect( firstCell.getAttribute( 'backgroundColor' ) ).to.be.undefined;
 			} );
 		} );

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting-integration.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting-integration.js
@@ -41,6 +41,14 @@ describe( 'table properties', () => {
 
 				assertTableStyle( editor, null, 'float:right;' );
 			} );
+
+			it( 'Alignment command should be disabled when table is selected', () => {
+				model.change( writer => {
+					writer.setSelection( table, 'on' );
+				} );
+
+				expect( editor.commands.get( 'alignment' ).isEnabled ).to.be.false;
+			} );
 		} );
 
 		describe( 'Undo', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting-integration.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting-integration.js
@@ -67,17 +67,17 @@ describe( 'table properties', () => {
 				editor.execute( 'tableCellBackgroundColor', { value: 'green' } );
 
 				expect( table.getAttribute( 'tableBackgroundColor' ) ).to.equal( 'red' );
-				expect( firstCell.getAttribute( 'backgroundColor' ) ).to.equal( 'green' );
+				expect( firstCell.getAttribute( 'tableCellBackgroundColor' ) ).to.equal( 'green' );
 
 				editor.execute( 'undo' );
 
 				expect( table.getAttribute( 'tableBackgroundColor' ) ).to.equal( 'red' );
-				expect( firstCell.getAttribute( 'backgroundColor' ) ).to.be.undefined;
+				expect( firstCell.getAttribute( 'tableCellBackgroundColor' ) ).to.be.undefined;
 
 				editor.execute( 'undo' );
 
 				expect( table.getAttribute( 'tableBackgroundColor' ) ).to.be.undefined;
-				expect( firstCell.getAttribute( 'backgroundColor' ) ).to.be.undefined;
+				expect( firstCell.getAttribute( 'tableCellBackgroundColor' ) ).to.be.undefined;
 			} );
 		} );
 

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -85,9 +85,9 @@ describe( 'table properties', () => {
 
 		describe( 'border', () => {
 			it( 'should set proper schema rules', () => {
-				expect( model.schema.checkAttribute( [ '$root', 'table' ], 'borderColor' ) ).to.be.true;
-				expect( model.schema.checkAttribute( [ '$root', 'table' ], 'borderStyle' ) ).to.be.true;
-				expect( model.schema.checkAttribute( [ '$root', 'table' ], 'borderWidth' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'table' ], 'tableBorderColor' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'table' ], 'tableBorderStyle' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'table' ], 'tableBorderWidth' ) ).to.be.true;
 			} );
 
 			describe( 'upcast conversion', () => {
@@ -96,9 +96,9 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'borderColor' ) ).to.equal( '#f00' );
-					expect( table.getAttribute( 'borderStyle' ) ).to.equal( 'solid' );
-					expect( table.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
+					expect( table.getAttribute( 'tableBorderColor' ) ).to.equal( '#f00' );
+					expect( table.getAttribute( 'tableBorderStyle' ) ).to.equal( 'solid' );
+					expect( table.getAttribute( 'tableBorderWidth' ) ).to.equal( '1px' );
 				} );
 
 				it( 'should upcast border-color shorthand', () => {
@@ -106,7 +106,7 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'borderColor' ) ).to.equal( '#f00' );
+					expect( table.getAttribute( 'tableBorderColor' ) ).to.equal( '#f00' );
 				} );
 
 				it( 'should upcast border-style shorthand', () => {
@@ -114,7 +114,7 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'borderStyle' ) ).to.equal( 'ridge' );
+					expect( table.getAttribute( 'tableBorderStyle' ) ).to.equal( 'ridge' );
 				} );
 
 				it( 'should upcast border-width shorthand', () => {
@@ -122,7 +122,7 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
+					expect( table.getAttribute( 'tableBorderWidth' ) ).to.equal( '1px' );
 				} );
 
 				it( 'should upcast border-top shorthand', () => {
@@ -130,9 +130,9 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					assertTRBLAttribute( table, 'borderColor', '#f00', null, null, null );
-					assertTRBLAttribute( table, 'borderStyle', 'solid', null, null, null );
-					assertTRBLAttribute( table, 'borderWidth', '1px', null, null, null );
+					assertTRBLAttribute( table, 'tableBorderColor', '#f00', null, null, null );
+					assertTRBLAttribute( table, 'tableBorderStyle', 'solid', null, null, null );
+					assertTRBLAttribute( table, 'tableBorderWidth', '1px', null, null, null );
 				} );
 
 				it( 'should upcast border-right shorthand', () => {
@@ -140,9 +140,9 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					assertTRBLAttribute( table, 'borderColor', null, '#f00', null, null );
-					assertTRBLAttribute( table, 'borderStyle', null, 'solid', null, null );
-					assertTRBLAttribute( table, 'borderWidth', null, '1px', null, null );
+					assertTRBLAttribute( table, 'tableBorderColor', null, '#f00', null, null );
+					assertTRBLAttribute( table, 'tableBorderStyle', null, 'solid', null, null );
+					assertTRBLAttribute( table, 'tableBorderWidth', null, '1px', null, null );
 				} );
 
 				it( 'should upcast border-bottom shorthand', () => {
@@ -150,9 +150,9 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					assertTRBLAttribute( table, 'borderColor', null, null, '#f00', null );
-					assertTRBLAttribute( table, 'borderStyle', null, null, 'solid', null );
-					assertTRBLAttribute( table, 'borderWidth', null, null, '1px', null );
+					assertTRBLAttribute( table, 'tableBorderColor', null, null, '#f00', null );
+					assertTRBLAttribute( table, 'tableBorderStyle', null, null, 'solid', null );
+					assertTRBLAttribute( table, 'tableBorderWidth', null, null, '1px', null );
 				} );
 
 				it( 'should upcast border-left shorthand', () => {
@@ -160,9 +160,9 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					assertTRBLAttribute( table, 'borderColor', null, null, null, '#f00' );
-					assertTRBLAttribute( table, 'borderStyle', null, null, null, 'solid' );
-					assertTRBLAttribute( table, 'borderWidth', null, null, null, '1px' );
+					assertTRBLAttribute( table, 'tableBorderColor', null, null, null, '#f00' );
+					assertTRBLAttribute( table, 'tableBorderStyle', null, null, null, 'solid' );
+					assertTRBLAttribute( table, 'tableBorderWidth', null, null, null, '1px' );
 				} );
 
 				it( 'should upcast border-top-* styles', () => {
@@ -172,9 +172,9 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					assertTRBLAttribute( table, 'borderColor', '#f00', null, null, null );
-					assertTRBLAttribute( table, 'borderStyle', 'solid', null, null, null );
-					assertTRBLAttribute( table, 'borderWidth', '1px', null, null, null );
+					assertTRBLAttribute( table, 'tableBorderColor', '#f00', null, null, null );
+					assertTRBLAttribute( table, 'tableBorderStyle', 'solid', null, null, null );
+					assertTRBLAttribute( table, 'tableBorderWidth', '1px', null, null, null );
 				} );
 
 				it( 'should upcast border-right-* styles', () => {
@@ -188,9 +188,9 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					assertTRBLAttribute( table, 'borderColor', null, '#f00', null, null );
-					assertTRBLAttribute( table, 'borderStyle', null, 'solid', null, null );
-					assertTRBLAttribute( table, 'borderWidth', null, '1px', null, null );
+					assertTRBLAttribute( table, 'tableBorderColor', null, '#f00', null, null );
+					assertTRBLAttribute( table, 'tableBorderStyle', null, 'solid', null, null );
+					assertTRBLAttribute( table, 'tableBorderWidth', null, '1px', null, null );
 				} );
 
 				it( 'should upcast border-bottom-* styles', () => {
@@ -204,9 +204,9 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					assertTRBLAttribute( table, 'borderColor', null, null, '#f00', null );
-					assertTRBLAttribute( table, 'borderStyle', null, null, 'solid', null );
-					assertTRBLAttribute( table, 'borderWidth', null, null, '1px', null );
+					assertTRBLAttribute( table, 'tableBorderColor', null, null, '#f00', null );
+					assertTRBLAttribute( table, 'tableBorderStyle', null, null, 'solid', null );
+					assertTRBLAttribute( table, 'tableBorderWidth', null, null, '1px', null );
 				} );
 
 				it( 'should upcast border-left-* styles', () => {
@@ -216,9 +216,9 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					assertTRBLAttribute( table, 'borderColor', null, null, null, '#f00' );
-					assertTRBLAttribute( table, 'borderStyle', null, null, null, 'solid' );
-					assertTRBLAttribute( table, 'borderWidth', null, null, null, '1px' );
+					assertTRBLAttribute( table, 'tableBorderColor', null, null, null, '#f00' );
+					assertTRBLAttribute( table, 'tableBorderStyle', null, null, null, 'solid' );
+					assertTRBLAttribute( table, 'tableBorderWidth', null, null, null, '1px' );
 				} );
 
 				describe( 'nested tables', () => {
@@ -237,14 +237,14 @@ describe( 'table properties', () => {
 
 						const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-						expect( table.getAttribute( 'borderColor' ) ).to.equal( 'red' );
-						expect( table.getAttribute( 'borderStyle' ) ).to.equal( 'solid' );
-						expect( table.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
+						expect( table.getAttribute( 'tableBorderColor' ) ).to.equal( 'red' );
+						expect( table.getAttribute( 'tableBorderStyle' ) ).to.equal( 'solid' );
+						expect( table.getAttribute( 'tableBorderWidth' ) ).to.equal( '1px' );
 
 						// Also check the entire structure of the model.
 						// Previously the test was too loose in that regard.
 						expect( getModelData( editor.model ) ).to.equal(
-							'[<table borderColor="red" borderStyle="solid" borderWidth="1px">' +
+							'[<table tableBorderColor="red" tableBorderStyle="solid" tableBorderWidth="1px">' +
 								'<tableRow>' +
 									'<tableCell>' +
 										'<paragraph>' +
@@ -252,7 +252,7 @@ describe( 'table properties', () => {
 										'</paragraph>' +
 									'</tableCell>' +
 									'<tableCell>' +
-										'<table borderColor="green" borderStyle="solid" borderWidth="1px">' +
+										'<table tableBorderColor="green" tableBorderStyle="solid" tableBorderWidth="1px">' +
 											'<tableRow>' +
 												'<tableCell>' +
 													'<paragraph>' +
@@ -327,9 +327,9 @@ describe( 'table properties', () => {
 								'<tableRow>' +
 									'<tableCell>' +
 										'<table ' +
-											'borderColor="{"bottom":"#fff"}" ' +
-											'borderStyle="{"bottom":"solid"}" ' +
-											'borderWidth="{"bottom":"0"}"' +
+											'tableBorderColor="{"bottom":"#fff"}" ' +
+											'tableBorderStyle="{"bottom":"solid"}" ' +
+											'tableBorderWidth="{"bottom":"0"}"' +
 										'>' +
 											'<tableRow>' +
 												'<tableCell>' +
@@ -377,7 +377,7 @@ describe( 'table properties', () => {
 										'<paragraph>parent:00</paragraph>' +
 									'</tableCell>' +
 									'<tableCell>' +
-										'<table borderColor="green" borderStyle="solid" borderWidth="1px">' +
+										'<table tableBorderColor="green" tableBorderStyle="solid" tableBorderWidth="1px">' +
 											'<tableRow>' +
 												'<tableCell>' +
 													'<paragraph>child:00</paragraph>' +
@@ -415,12 +415,12 @@ describe( 'table properties', () => {
 
 							const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-							expect( table.getAttribute( 'borderColor' ) ).to.equal( 'red' );
-							expect( table.getAttribute( 'borderStyle' ) ).to.equal( 'solid' );
-							expect( table.getAttribute( 'borderWidth' ) ).to.equal( '1px' );
+							expect( table.getAttribute( 'tableBorderColor' ) ).to.equal( 'red' );
+							expect( table.getAttribute( 'tableBorderStyle' ) ).to.equal( 'solid' );
+							expect( table.getAttribute( 'tableBorderWidth' ) ).to.equal( '1px' );
 
 							expect( getModelData( editor.model ) ).to.equal(
-								'[<table borderColor="red" borderStyle="solid" borderWidth="1px">' +
+								'[<table tableBorderColor="red" tableBorderStyle="solid" tableBorderWidth="1px">' +
 									'<tableRow>' +
 										'<tableCell>' +
 											'<paragraph>' +
@@ -1269,9 +1269,9 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'borderColor' ) ).to.be.undefined;
-					expect( table.getAttribute( 'borderStyle' ) ).to.be.undefined;
-					expect( table.getAttribute( 'borderWidth' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableBorderColor' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableBorderStyle' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableBorderWidth' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default `border-color` value', () => {
@@ -1279,7 +1279,7 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'borderColor' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableBorderColor' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default `border-style` value', () => {
@@ -1287,7 +1287,7 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'borderStyle' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableBorderStyle' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default `border-width` value', () => {
@@ -1295,7 +1295,7 @@ describe( 'table properties', () => {
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'borderWidth' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableBorderWidth' ) ).to.be.undefined;
 				} );
 			} );
 

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -548,28 +548,28 @@ describe( 'table properties', () => {
 					table = createEmptyTable();
 				} );
 
-				it( 'should consume converted item borderColor attribute', () => {
+				it( 'should consume converted item tableBorderColor attribute', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:borderColor:table', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableBorderColor:table', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
 						} ) );
 
-					model.change( writer => writer.setAttribute( 'borderColor', '#f00', table ) );
+					model.change( writer => writer.setAttribute( 'tableBorderColor', '#f00', table ) );
 				} );
 
 				it( 'should be overridable', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:borderColor:table', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableBorderColor:table', ( evt, data, conversionApi ) => {
 							conversionApi.consumable.consume( data.item, evt.name );
 						}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'borderColor', '#f00', table ) );
+					model.change( writer => writer.setAttribute( 'tableBorderColor', '#f00', table ) );
 
 					assertTableStyle( editor, '' );
 				} );
 
-				it( 'should downcast borderColor attribute (same top, right, bottom, left)', () => {
-					model.change( writer => writer.setAttribute( 'borderColor', {
+				it( 'should downcast tableBorderColor attribute (same top, right, bottom, left)', () => {
+					model.change( writer => writer.setAttribute( 'tableBorderColor', {
 						top: '#f00',
 						right: '#f00',
 						bottom: '#f00',
@@ -579,8 +579,8 @@ describe( 'table properties', () => {
 					assertTableStyle( editor, 'border-color:#f00;' );
 				} );
 
-				it( 'should downcast borderColor attribute (different top, right, bottom, left)', () => {
-					model.change( writer => writer.setAttribute( 'borderColor', {
+				it( 'should downcast tableBorderColor attribute (different top, right, bottom, left)', () => {
+					model.change( writer => writer.setAttribute( 'tableBorderColor', {
 						top: '#f00',
 						right: 'hsla(0, 100%, 50%, 0.5)',
 						bottom: 'deeppink',
@@ -595,28 +595,28 @@ describe( 'table properties', () => {
 					);
 				} );
 
-				it( 'should consume converted item borderStyle attribute', () => {
+				it( 'should consume converted item tableBorderStyle attribute', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:borderStyle:table', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableBorderStyle:table', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
 						} ) );
 
-					model.change( writer => writer.setAttribute( 'borderStyle', 'solid', table ) );
+					model.change( writer => writer.setAttribute( 'tableBorderStyle', 'solid', table ) );
 				} );
 
-				it( 'should be overridable for borderStyle', () => {
+				it( 'should be overridable for tableBorderStyle', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:borderStyle:table', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableBorderStyle:table', ( evt, data, conversionApi ) => {
 							conversionApi.consumable.consume( data.item, evt.name );
 						}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'borderStyle', 'solid', table ) );
+					model.change( writer => writer.setAttribute( 'tableBorderStyle', 'solid', table ) );
 
 					assertTableStyle( editor, '' );
 				} );
 
-				it( 'should downcast borderStyle attribute (same top, right, bottom, left)', () => {
-					model.change( writer => writer.setAttribute( 'borderStyle', {
+				it( 'should downcast tableBorderStyle attribute (same top, right, bottom, left)', () => {
+					model.change( writer => writer.setAttribute( 'tableBorderStyle', {
 						top: 'solid',
 						right: 'solid',
 						bottom: 'solid',
@@ -626,8 +626,8 @@ describe( 'table properties', () => {
 					assertTableStyle( editor, 'border-style:solid;' );
 				} );
 
-				it( 'should downcast borderStyle attribute (different top, right, bottom, left)', () => {
-					model.change( writer => writer.setAttribute( 'borderStyle', {
+				it( 'should downcast tableBorderStyle attribute (different top, right, bottom, left)', () => {
+					model.change( writer => writer.setAttribute( 'tableBorderStyle', {
 						top: 'solid',
 						right: 'ridge',
 						bottom: 'dotted',
@@ -642,28 +642,28 @@ describe( 'table properties', () => {
 					);
 				} );
 
-				it( 'should consume converted item borderWidth attribute', () => {
+				it( 'should consume converted item tableBorderWidth attribute', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:borderWidth:table', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableBorderWidth:table', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
 						} ) );
 
-					model.change( writer => writer.setAttribute( 'borderWidth', '2px', table ) );
+					model.change( writer => writer.setAttribute( 'tableBorderWidth', '2px', table ) );
 				} );
 
-				it( 'should be overridable for borderWidth', () => {
+				it( 'should be overridable for tableBorderWidth', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:borderWidth:table', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableBorderWidth:table', ( evt, data, conversionApi ) => {
 							conversionApi.consumable.consume( data.item, evt.name );
 						}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'borderWidth', '2px', table ) );
+					model.change( writer => writer.setAttribute( 'tableBorderWidth', '2px', table ) );
 
 					assertTableStyle( editor, '' );
 				} );
 
-				it( 'should downcast borderWidth attribute (same top, right, bottom, left)', () => {
-					model.change( writer => writer.setAttribute( 'borderWidth', {
+				it( 'should downcast tableBorderWidth attribute (same top, right, bottom, left)', () => {
+					model.change( writer => writer.setAttribute( 'tableBorderWidth', {
 						top: '42px',
 						right: '.1em',
 						bottom: '1337rem',
@@ -676,8 +676,8 @@ describe( 'table properties', () => {
 					);
 				} );
 
-				it( 'should downcast borderWidth attribute (different top, right, bottom, left)', () => {
-					model.change( writer => writer.setAttribute( 'borderWidth', {
+				it( 'should downcast tableBorderWidth attribute (different top, right, bottom, left)', () => {
+					model.change( writer => writer.setAttribute( 'tableBorderWidth', {
 						top: '42px',
 						right: '42px',
 						bottom: '42px',
@@ -687,23 +687,26 @@ describe( 'table properties', () => {
 					assertTableStyle( editor, 'border-width:42px;' );
 				} );
 
-				it( 'should downcast borderColor, borderStyle and borderWidth attributes together (same top, right, bottom, left)', () => {
+				it( `should downcast
+				tableBorderColor,
+				tableBorderStyle
+				and tableBorderWidth attributes together (same top, right, bottom, left)`, () => {
 					model.change( writer => {
-						writer.setAttribute( 'borderColor', {
+						writer.setAttribute( 'tableBorderColor', {
 							top: '#f00',
 							right: '#f00',
 							bottom: '#f00',
 							left: '#f00'
 						}, table );
 
-						writer.setAttribute( 'borderStyle', {
+						writer.setAttribute( 'tableBorderStyle', {
 							top: 'solid',
 							right: 'solid',
 							bottom: 'solid',
 							left: 'solid'
 						}, table );
 
-						writer.setAttribute( 'borderWidth', {
+						writer.setAttribute( 'tableBorderWidth', {
 							top: '42px',
 							right: '42px',
 							bottom: '42px',
@@ -715,24 +718,27 @@ describe( 'table properties', () => {
 				} );
 
 				it(
-					'should downcast borderColor, borderStyle and borderWidth attributes together (different top, right, bottom, left)',
+					`should downcast
+					tableBorderColor,
+					tableBorderStyle
+					and tableBorderWidth attributes together (different top, right, bottom, left)`,
 					() => {
 						model.change( writer => {
-							writer.setAttribute( 'borderColor', {
+							writer.setAttribute( 'tableBorderColor', {
 								top: '#f00',
 								right: 'hsla(0, 100%, 50%, 0.5)',
 								bottom: 'deeppink',
 								left: 'rgb(255, 0, 0)'
 							}, table );
 
-							writer.setAttribute( 'borderStyle', {
+							writer.setAttribute( 'tableBorderStyle', {
 								top: 'solid',
 								right: 'ridge',
 								bottom: 'dotted',
 								left: 'dashed'
 							}, table );
 
-							writer.setAttribute( 'borderWidth', {
+							writer.setAttribute( 'tableBorderWidth', {
 								top: '42px',
 								right: '.1em',
 								bottom: '1337rem',
@@ -752,21 +758,21 @@ describe( 'table properties', () => {
 				describe( 'change attribute', () => {
 					beforeEach( () => {
 						model.change( writer => {
-							writer.setAttribute( 'borderColor', {
+							writer.setAttribute( 'tableBorderColor', {
 								top: '#f00',
 								right: '#f00',
 								bottom: '#f00',
 								left: '#f00'
 							}, table );
 
-							writer.setAttribute( 'borderStyle', {
+							writer.setAttribute( 'tableBorderStyle', {
 								top: 'solid',
 								right: 'solid',
 								bottom: 'solid',
 								left: 'solid'
 							}, table );
 
-							writer.setAttribute( 'borderWidth', {
+							writer.setAttribute( 'tableBorderWidth', {
 								top: '42px',
 								right: '42px',
 								bottom: '42px',
@@ -775,8 +781,8 @@ describe( 'table properties', () => {
 						} );
 					} );
 
-					it( 'should downcast borderColor attribute change', () => {
-						model.change( writer => writer.setAttribute( 'borderColor', {
+					it( 'should downcast tableBorderColor attribute change', () => {
+						model.change( writer => writer.setAttribute( 'tableBorderColor', {
 							top: 'deeppink',
 							right: 'deeppink',
 							bottom: 'deeppink',
@@ -786,8 +792,8 @@ describe( 'table properties', () => {
 						assertTableStyle( editor, 'border:42px solid deeppink;' );
 					} );
 
-					it( 'should downcast borderStyle attribute change', () => {
-						model.change( writer => writer.setAttribute( 'borderStyle', {
+					it( 'should downcast tableBorderStyle attribute change', () => {
+						model.change( writer => writer.setAttribute( 'tableBorderStyle', {
 							top: 'ridge',
 							right: 'ridge',
 							bottom: 'ridge',
@@ -797,8 +803,8 @@ describe( 'table properties', () => {
 						assertTableStyle( editor, 'border:42px ridge #f00;' );
 					} );
 
-					it( 'should downcast borderWidth attribute change', () => {
-						model.change( writer => writer.setAttribute( 'borderWidth', {
+					it( 'should downcast tableBorderWidth attribute change', () => {
+						model.change( writer => writer.setAttribute( 'tableBorderWidth', {
 							top: 'thick',
 							right: 'thick',
 							bottom: 'thick',
@@ -808,8 +814,8 @@ describe( 'table properties', () => {
 						assertTableStyle( editor, 'border:thick solid #f00;' );
 					} );
 
-					it( 'should downcast borderColor attribute removal', () => {
-						model.change( writer => writer.removeAttribute( 'borderColor', table ) );
+					it( 'should downcast tableBorderColor attribute removal', () => {
+						model.change( writer => writer.removeAttribute( 'tableBorderColor', table ) );
 
 						assertTableStyle( editor,
 							'border-style:solid;' +
@@ -817,8 +823,8 @@ describe( 'table properties', () => {
 						);
 					} );
 
-					it( 'should downcast borderStyle attribute removal', () => {
-						model.change( writer => writer.removeAttribute( 'borderStyle', table ) );
+					it( 'should downcast tableBorderStyle attribute removal', () => {
+						model.change( writer => writer.removeAttribute( 'tableBorderStyle', table ) );
 
 						assertTableStyle( editor,
 							'border-color:#f00;' +
@@ -827,8 +833,8 @@ describe( 'table properties', () => {
 						);
 					} );
 
-					it( 'should downcast borderWidth attribute removal', () => {
-						model.change( writer => writer.removeAttribute( 'borderWidth', table ) );
+					it( 'should downcast tableBorderWidth attribute removal', () => {
+						model.change( writer => writer.removeAttribute( 'tableBorderWidth', table ) );
 
 						assertTableStyle( editor,
 							'border-color:#f00;' +
@@ -836,11 +842,11 @@ describe( 'table properties', () => {
 						);
 					} );
 
-					it( 'should downcast borderColor, borderStyle and borderWidth attributes removal', () => {
+					it( 'should downcast tableBorderColor, tableBorderStyle and tableBorderWidth attributes removal', () => {
 						model.change( writer => {
-							writer.removeAttribute( 'borderColor', table );
-							writer.removeAttribute( 'borderStyle', table );
-							writer.removeAttribute( 'borderWidth', table );
+							writer.removeAttribute( 'tableBorderColor', table );
+							writer.removeAttribute( 'tableBorderStyle', table );
+							writer.removeAttribute( 'tableBorderWidth', table );
 						} );
 
 						assertEqualMarkup(
@@ -854,7 +860,7 @@ describe( 'table properties', () => {
 
 		describe( 'background color', () => {
 			it( 'should set proper schema rules', () => {
-				expect( model.schema.checkAttribute( [ '$root', 'table' ], 'backgroundColor' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'table' ], 'tableBackgroundColor' ) ).to.be.true;
 			} );
 
 			describe( 'upcast conversion', () => {
@@ -862,21 +868,21 @@ describe( 'table properties', () => {
 					editor.setData( '<table style="background-color:#f00"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'backgroundColor' ) ).to.equal( '#f00' );
+					expect( table.getAttribute( 'tableBackgroundColor' ) ).to.equal( '#f00' );
 				} );
 
 				it( 'should upcast from background shorthand', () => {
 					editor.setData( '<table style="background:#f00 center center"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'backgroundColor' ) ).to.equal( '#f00' );
+					expect( table.getAttribute( 'tableBackgroundColor' ) ).to.equal( '#f00' );
 				} );
 
 				it( 'should upcast from background shorthand (rbg color value with spaces)', () => {
 					editor.setData( '<table style="background:rgb(253, 253, 119) center center"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'backgroundColor' ) ).to.equal( 'rgb(253, 253, 119)' );
+					expect( table.getAttribute( 'tableBackgroundColor' ) ).to.equal( 'rgb(253, 253, 119)' );
 				} );
 			} );
 
@@ -889,31 +895,31 @@ describe( 'table properties', () => {
 
 				it( 'should consume converted item', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:backgroundColor:table', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableBackgroundColor:table', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
 						} ) );
 
-					model.change( writer => writer.setAttribute( 'backgroundColor', '#f00', table ) );
+					model.change( writer => writer.setAttribute( 'tableBackgroundColor', '#f00', table ) );
 				} );
 
 				it( 'should be overridable', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:backgroundColor:table', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableBackgroundColor:table', ( evt, data, conversionApi ) => {
 							conversionApi.consumable.consume( data.item, evt.name );
 						}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'backgroundColor', '#f00', table ) );
+					model.change( writer => writer.setAttribute( 'tableBackgroundColor', '#f00', table ) );
 
 					assertTableStyle( editor, '' );
 				} );
 
-				it( 'should downcast backgroundColor', () => {
-					model.change( writer => writer.setAttribute( 'backgroundColor', '#f00', table ) );
+				it( 'should downcast tableBackgroundColor', () => {
+					model.change( writer => writer.setAttribute( 'tableBackgroundColor', '#f00', table ) );
 
 					assertTableStyle( editor, 'background-color:#f00;' );
 				} );
 
-				it( 'should downcast backgroundColor removal', () => {
+				it( 'should downcast tableBackgroundColor removal', () => {
 					model.change( writer => writer.setAttribute( 'backgroundColor', '#f00', table ) );
 
 					model.change( writer => writer.removeAttribute( 'backgroundColor', table ) );
@@ -921,21 +927,21 @@ describe( 'table properties', () => {
 					assertTableStyle( editor );
 				} );
 
-				it( 'should downcast backgroundColor change', () => {
-					model.change( writer => writer.setAttribute( 'backgroundColor', '#f00', table ) );
+				it( 'should downcast tableBackgroundColor change', () => {
+					model.change( writer => writer.setAttribute( 'tableBackgroundColor', '#f00', table ) );
 
 					assertTableStyle( editor, 'background-color:#f00;' );
 
-					model.change( writer => writer.setAttribute( 'backgroundColor', '#ba7', table ) );
+					model.change( writer => writer.setAttribute( 'tableBackgroundColor', '#ba7', table ) );
 
 					assertTableStyle( editor, 'background-color:#ba7;' );
 				} );
 			} );
 		} );
 
-		describe( 'width', () => {
+		describe( 'tableWidth', () => {
 			it( 'should set proper schema rules', () => {
-				expect( model.schema.checkAttribute( [ '$root', 'table' ], 'width' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'table' ], 'tableWidth' ) ).to.be.true;
 			} );
 
 			describe( 'upcast conversion', () => {
@@ -943,14 +949,14 @@ describe( 'table properties', () => {
 					editor.setData( '<table style="width:1337px"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'width' ) ).to.equal( '1337px' );
+					expect( table.getAttribute( 'tableWidth' ) ).to.equal( '1337px' );
 				} );
 
 				it( 'should upcast width from <figure>', () => {
 					editor.setData( '<figure style="width:1337px"><table><tr><td>foo</td></tr></table></figure>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'width' ) ).to.equal( '1337px' );
+					expect( table.getAttribute( 'tableWidth' ) ).to.equal( '1337px' );
 				} );
 			} );
 
@@ -963,53 +969,53 @@ describe( 'table properties', () => {
 
 				it( 'should consume converted item', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:width:table', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableWidth:table', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
 						} ) );
 
-					model.change( writer => writer.setAttribute( 'width', '400px', table ) );
+					model.change( writer => writer.setAttribute( 'tableWidth', '400px', table ) );
 				} );
 
 				it( 'should be overridable', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:width:table', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableWidth:table', ( evt, data, conversionApi ) => {
 							conversionApi.consumable.consume( data.item, evt.name );
 						}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'width', '400px', table ) );
+					model.change( writer => writer.setAttribute( 'tableWidth', '400px', table ) );
 
 					assertTableStyle( editor, '' );
 				} );
 
-				it( 'should downcast width', () => {
-					model.change( writer => writer.setAttribute( 'width', '1337px', table ) );
+				it( 'should downcast tableWidth', () => {
+					model.change( writer => writer.setAttribute( 'tableWidth', '1337px', table ) );
 
 					assertTableStyle( editor, null, 'width:1337px;' );
 				} );
 
-				it( 'should downcast width removal', () => {
-					model.change( writer => writer.setAttribute( 'width', '1337px', table ) );
+				it( 'should downcast tableWidth removal', () => {
+					model.change( writer => writer.setAttribute( 'tableWidth', '1337px', table ) );
 
-					model.change( writer => writer.removeAttribute( 'width', table ) );
+					model.change( writer => writer.removeAttribute( 'tableWidth', table ) );
 
 					assertTableStyle( editor );
 				} );
 
 				it( 'should downcast width change', () => {
-					model.change( writer => writer.setAttribute( 'width', '1337px', table ) );
+					model.change( writer => writer.setAttribute( 'tableWidth', '1337px', table ) );
 
 					assertTableStyle( editor, null, 'width:1337px;' );
 
-					model.change( writer => writer.setAttribute( 'width', '1410em', table ) );
+					model.change( writer => writer.setAttribute( 'tableWidth', '1410em', table ) );
 
 					assertTableStyle( editor, null, 'width:1410em;' );
 				} );
 			} );
 		} );
 
-		describe( 'height', () => {
+		describe( 'tableHeight', () => {
 			it( 'should set proper schema rules', () => {
-				expect( model.schema.checkAttribute( [ '$root', 'table' ], 'height' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'table' ], 'tableHeight' ) ).to.be.true;
 			} );
 
 			describe( 'upcast conversion', () => {
@@ -1017,14 +1023,14 @@ describe( 'table properties', () => {
 					editor.setData( '<table style="height:1337px"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'height' ) ).to.equal( '1337px' );
+					expect( table.getAttribute( 'tableHeight' ) ).to.equal( '1337px' );
 				} );
 
 				it( 'should upcast height from <figure>', () => {
 					editor.setData( '<figure style="height:1337px"><table><tr><td>foo</td></tr></table></figure>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'height' ) ).to.equal( '1337px' );
+					expect( table.getAttribute( 'tableHeight' ) ).to.equal( '1337px' );
 				} );
 			} );
 
@@ -1035,55 +1041,55 @@ describe( 'table properties', () => {
 					table = createEmptyTable();
 				} );
 
-				it( 'should downcast height', () => {
-					model.change( writer => writer.setAttribute( 'height', '1337px', table ) );
+				it( 'should downcast tableHeight', () => {
+					model.change( writer => writer.setAttribute( 'tableHeight', '1337px', table ) );
 
 					assertTableStyle( editor, null, 'height:1337px;' );
 				} );
 
-				it( 'should downcast height removal', () => {
-					model.change( writer => writer.setAttribute( 'height', '1337px', table ) );
+				it( 'should downcast tableHeight removal', () => {
+					model.change( writer => writer.setAttribute( 'tableHeight', '1337px', table ) );
 
-					model.change( writer => writer.removeAttribute( 'height', table ) );
+					model.change( writer => writer.removeAttribute( 'tableHeight', table ) );
 
 					assertTableStyle( editor );
 				} );
 
-				it( 'should downcast height change', () => {
-					model.change( writer => writer.setAttribute( 'height', '1337px', table ) );
+				it( 'should downcast tableHeight change', () => {
+					model.change( writer => writer.setAttribute( 'tableHeight', '1337px', table ) );
 
 					assertTableStyle( editor, null, 'height:1337px;' );
 
-					model.change( writer => writer.setAttribute( 'height', '1410em', table ) );
+					model.change( writer => writer.setAttribute( 'tableHeight', '1410em', table ) );
 
 					assertTableStyle( editor, null, 'height:1410em;' );
 				} );
 
 				it( 'should consume converted item', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:height:table', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableHeight:table', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
 						} ) );
 
-					model.change( writer => writer.setAttribute( 'height', '400px', table ) );
+					model.change( writer => writer.setAttribute( 'tableHeight', '400px', table ) );
 				} );
 
 				it( 'should be overridable', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:height:table', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableHeight:table', ( evt, data, conversionApi ) => {
 							conversionApi.consumable.consume( data.item, evt.name );
 						}, { priority: 'high' } ) );
 
-					model.change( writer => writer.setAttribute( 'height', '400px', table ) );
+					model.change( writer => writer.setAttribute( 'tableHeight', '400px', table ) );
 
 					assertTableStyle( editor, '' );
 				} );
 			} );
 		} );
 
-		describe( 'alignment', () => {
+		describe( 'tableAlignment', () => {
 			it( 'should set proper schema rules', () => {
-				expect( model.schema.checkAttribute( [ '$root', 'table' ], 'alignment' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', 'table' ], 'tableAlignment' ) ).to.be.true;
 			} );
 
 			describe( 'upcast conversion', () => {
@@ -1091,49 +1097,49 @@ describe( 'table properties', () => {
 					editor.setData( '<table style="float:right"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'alignment' ) ).to.equal( 'right' );
+					expect( table.getAttribute( 'tableAlignment' ) ).to.equal( 'right' );
 				} );
 
 				it( 'should upcast style="float:left;" to left value', () => {
 					editor.setData( '<table style="float:left;"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'alignment' ) ).to.equal( 'left' );
+					expect( table.getAttribute( 'tableAlignment' ) ).to.equal( 'left' );
 				} );
 
 				it( 'should discard the unknown float value (style="float:foo;")', () => {
 					editor.setData( '<table style="float:foo;"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'alignment' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableAlignment' ) ).to.be.undefined;
 				} );
 
 				it( 'should upcast align=right attribute', () => {
 					editor.setData( '<table align="right"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'alignment' ) ).to.equal( 'right' );
+					expect( table.getAttribute( 'tableAlignment' ) ).to.equal( 'right' );
 				} );
 
 				it( 'should upcast align=left attribute', () => {
 					editor.setData( '<table align="left"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'alignment' ) ).to.equal( 'left' );
+					expect( table.getAttribute( 'tableAlignment' ) ).to.equal( 'left' );
 				} );
 
 				it( 'should discard align=center attribute', () => {
 					editor.setData( '<table align="center"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'alignment' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableAlignment' ) ).to.be.undefined;
 				} );
 
 				it( 'should discard align=justify attribute', () => {
 					editor.setData( '<table align="justify"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.hasAttribute( 'alignment' ) ).to.be.false;
+					expect( table.hasAttribute( 'tableAlignment' ) ).to.be.false;
 				} );
 			} );
 
@@ -1146,78 +1152,78 @@ describe( 'table properties', () => {
 
 				it( 'should consume converted item', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:alignment:table', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableAlignment:table', ( evt, data, conversionApi ) => {
 							expect( conversionApi.consumable.consume( data.item, evt.name ) ).to.be.false;
 						} ) );
 
-					model.change( writer => writer.setAttribute( 'alignment', 'right', table ) );
+					model.change( writer => writer.setAttribute( 'tableAlignment', 'right', table ) );
 				} );
 
 				it( 'should be overridable', () => {
 					editor.conversion.for( 'downcast' )
-						.add( dispatcher => dispatcher.on( 'attribute:alignment:table', ( evt, data, conversionApi ) => {
+						.add( dispatcher => dispatcher.on( 'attribute:tableAlignment:table', ( evt, data, conversionApi ) => {
 							conversionApi.consumable.consume( data.item, evt.name );
 						}, { priority: 'highest' } ) );
 
-					model.change( writer => writer.setAttribute( 'alignment', 'right', table ) );
+					model.change( writer => writer.setAttribute( 'tableAlignment', 'right', table ) );
 
 					assertTableStyle( editor, '' );
 				} );
 
-				it( 'should downcast "right" alignment', () => {
-					model.change( writer => writer.setAttribute( 'alignment', 'right', table ) );
+				it( 'should downcast "right" tableAlignment', () => {
+					model.change( writer => writer.setAttribute( 'tableAlignment', 'right', table ) );
 
 					assertTableStyle( editor, null, 'float:right;' );
 				} );
 
-				it( 'should downcast "left" alignment', () => {
-					model.change( writer => writer.setAttribute( 'alignment', 'left', table ) );
+				it( 'should downcast "left" tableAlignment', () => {
+					model.change( writer => writer.setAttribute( 'tableAlignment', 'left', table ) );
 
 					assertTableStyle( editor, null, 'float:left;' );
 				} );
 
-				it( 'should downcast "center" alignment', () => {
-					model.change( writer => writer.setAttribute( 'alignment', 'center', table ) );
+				it( 'should downcast "center" tableAlignment', () => {
+					model.change( writer => writer.setAttribute( 'tableAlignment', 'center', table ) );
 
 					assertTableStyle( editor, null, 'float:none;' );
 				} );
 
-				it( 'should downcast changed alignment (left -> right)', () => {
-					model.change( writer => writer.setAttribute( 'alignment', 'left', table ) );
+				it( 'should downcast changed tableAlignment (left -> right)', () => {
+					model.change( writer => writer.setAttribute( 'tableAlignment', 'left', table ) );
 
 					assertTableStyle( editor, null, 'float:left;' );
 
-					model.change( writer => writer.setAttribute( 'alignment', 'right', table ) );
+					model.change( writer => writer.setAttribute( 'tableAlignment', 'right', table ) );
 
 					assertTableStyle( editor, null, 'float:right;' );
 				} );
 
-				it( 'should downcast changed alignment (right -> left)', () => {
-					model.change( writer => writer.setAttribute( 'alignment', 'right', table ) );
+				it( 'should downcast changed tableAlignment (right -> left)', () => {
+					model.change( writer => writer.setAttribute( 'tableAlignment', 'right', table ) );
 
 					assertTableStyle( editor, null, 'float:right;' );
 
-					model.change( writer => writer.setAttribute( 'alignment', 'left', table ) );
+					model.change( writer => writer.setAttribute( 'tableAlignment', 'left', table ) );
 
 					assertTableStyle( editor, null, 'float:left;' );
 				} );
 
-				it( 'should downcast removed alignment (from left)', () => {
-					model.change( writer => writer.setAttribute( 'alignment', 'left', table ) );
+				it( 'should downcast removed tableAlignment (from left)', () => {
+					model.change( writer => writer.setAttribute( 'tableAlignment', 'left', table ) );
 
 					assertTableStyle( editor, null, 'float:left;' );
 
-					model.change( writer => writer.removeAttribute( 'alignment', table ) );
+					model.change( writer => writer.removeAttribute( 'tableAlignment', table ) );
 
 					assertTableStyle( editor );
 				} );
 
-				it( 'should downcast removed alignment (from right)', () => {
-					model.change( writer => writer.setAttribute( 'alignment', 'right', table ) );
+				it( 'should downcast removed tableAlignment (from right)', () => {
+					model.change( writer => writer.setAttribute( 'tableAlignment', 'right', table ) );
 
 					assertTableStyle( editor, null, 'float:right;' );
 
-					model.change( writer => writer.removeAttribute( 'alignment', table ) );
+					model.change( writer => writer.removeAttribute( 'tableAlignment', table ) );
 
 					assertTableStyle( editor );
 				} );
@@ -1346,28 +1352,28 @@ describe( 'table properties', () => {
 					editor.setData( '<table style="float:left"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'alignment' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableAlignment' ) ).to.be.undefined;
 				} );
 
 				it( 'should not upcast the default value from the align attribute (left)', () => {
 					editor.setData( '<table align="left"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'alignment' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableAlignment' ) ).to.be.undefined;
 				} );
 
 				it( 'should upcast style="float:none" as "center" option', () => {
 					editor.setData( '<table style="float:none;""><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'alignment' ) ).to.equal( 'center' );
+					expect( table.getAttribute( 'tableAlignment' ) ).to.equal( 'center' );
 				} );
 
 				it( 'should upcast align=center attribute', () => {
 					editor.setData( '<table align="center"><tr><td>foo</td></tr></table>' );
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'alignment' ) ).to.equal( 'center' );
+					expect( table.getAttribute( 'tableAlignment' ) ).to.equal( 'center' );
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
@@ -199,7 +199,7 @@ describe( 'table properties', () => {
 					tablePropertiesView.backgroundColor = 'red';
 
 					expect( getModelData( editor.model ) ).to.equal(
-						'<table backgroundColor="red" borderStyle="dotted">' +
+						'<table tableBackgroundColor="red" tableBorderStyle="dotted">' +
 							'<tableRow>' +
 								'<tableCell>' +
 									'<paragraph>[]foo</paragraph>' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): Disabled alignment button on main editor toolbar for tables in order to have more unified behaviour. Closes #9369.

MINOR BREAKING CHANGE (table): Changed `TablePropertiesEditing` plugin's attributes names by prefixing them with `table` to be in line with other plugins' attributes naming. Affected attributes are: `borderStyle`, `borderColor`, `borderWidth`, `backgroundColor`, `alignment`, `width`, `height`.

MINOR BREAKING CHANGE (table): Changed `TableCellPropertiesEditing` plugin's attributes names by prefixing them with `tableCell` to be in line with other plugins' attributes naming. Affected attributes: `backgroundColor`, `padding`, `width`, `height`, `borderStyle`, `borderColor`, `borderWidth`, `verticalAlignment`, `horizontalAlignment`.

MINOR BREAKING CHANGE (table): The `upcastBorderStyles()` helper parameters were modified (added `modelAttributes` param).

---

### Additional information

Table allowed 'alignment' attribute in schema which allowed Alignment plugin's button to align the table. It was fixed by changing the attribute name to tableAlignment. Other attributes weren't prefixed so it made sense to prefix them as well in order to be more consistent in naming.