### PR TITLE
#10712 Skip executing replace command when search input is dirty

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.js
+++ b/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.js
@@ -735,7 +735,7 @@ export default class FindAndReplaceFormView extends View {
 					this._findButtonView.fire( 'execute' );
 				}
 				stopPropagationAndPreventDefault( event );
-			} else if ( target === this._replaceInputView.fieldView.element ) {
+			} else if ( target === this._replaceInputView.fieldView.element && !this.isDirty ) {
 				this._replaceButtonView.fire( 'execute' );
 				stopPropagationAndPreventDefault( event );
 			}

--- a/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
+++ b/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
@@ -654,6 +654,20 @@ describe( 'FindAndReplaceFormView', () => {
 				sinon.assert.notCalled( spy );
 			} );
 
+			it( 'skips command execution on "enter" when search phrase input is dirty', () => {
+				const keyEvtData = {
+					keyCode: keyCodes.enter,
+					target: view._replaceInputView.fieldView.element
+				};
+
+				const spy = sinon.spy( view._replaceButtonView, 'fire' );
+
+				view.isDirty = true;
+				view._keystrokes.press( keyEvtData );
+
+				sinon.assert.notCalled( spy );
+			} );
+
 			it( 'ignores "shift+enter" when pressed somewhere else', () => {
 				const keyEvtData = {
 					keyCode: keyCodes.enter,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (find-and-replace): Replace functionality no longer replaces text when 'Replace with...' input is focused and user hits enter but search criteria changed. Closes #10712.
