### PR TITLE
Removed workspaces from `external/*/external` after extracting collaboration samples and cloud services outside CF

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,10 +194,6 @@
       "packages/*",
       "external/*",
       "external/*/packages/*",
-      "external/*/external/*",
-      "external/*/external/*/packages/*",
-      "external/*/external/*/packages/**/vendor/ckeditor5",
-      "external/*/external/*/packages/**/frontend",
       "."
     ],
     "nohoist": [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Removed workspaces from `external/*/external` after extracting collaboration samples and cloud services outside CF.

---

### Additional information

See https://github.com/cksource/collaboration-features/issues/4316.
