### PR TITLE
Docs: Added information about full MathML mode to MathType guide

### DIFF
--- a/docs/features/math-equations.md
+++ b/docs/features/math-equations.md
@@ -210,7 +210,7 @@ To install the Ruby on Rails service, follow the steps below:
 
 ## Displaying equations on your website
 
-By default MathType returns equations in MathML, which is [not supported by all browsers](https://developer.mozilla.org/en-US/docs/Web/MathML#browser_compatibility). In order to display equations on a page, you'll need to use some engine that will handle the rendering process.
+By default, MathType returns equations in MathML which is [not supported by all browsers](https://developer.mozilla.org/en-US/docs/Web/MathML#browser_compatibility). In order to display equations on a page, you will need to use some engine that will handle the rendering process.
 
-Fortunately, MathType introduces the full MathML mode that handles the unsupported markup and converts it to a form that could be properly recognized by browsers. You can read more about the full MathML mode [in the documentation](https://docs.wiris.com/en/mathtype/mathtype_web/integrations/mathml-mode).
+Fortunately, MathType introduces the full MathML mode that handles the unsupported markup and converts it into a form that could be properly recognized by browsers. You can read more about the full MathML mode [in the documentation](https://docs.wiris.com/en/mathtype/mathtype_web/integrations/mathml-mode).
 

--- a/docs/features/math-equations.md
+++ b/docs/features/math-equations.md
@@ -207,3 +207,10 @@ To install the Ruby on Rails service, follow the steps below:
             }
     }
     ```
+
+## Displaying equations on your website
+
+By default MathType returns equations in MathML, which is [not supported by all browsers](https://developer.mozilla.org/en-US/docs/Web/MathML#browser_compatibility). In order to display equations on a page, you'll need to use some engine that will handle the rendering process.
+
+Fortunately, MathType introduces the full MathML mode that handles the unsupported markup and converts it to a form that could be properly recognized by browsers. You can read more about the full MathML mode [in the documentation](https://docs.wiris.com/en/mathtype/mathtype_web/integrations/mathml-mode).
+


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Added information about full MathML mode to MathType guide. Closes #10831.