### PR TITLE
Docs: Allows to add/remove bold to H3 heading in editors. Closes #9761

### DIFF
--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -280,7 +280,6 @@ https://github.com/ckeditor/ckeditor5/issues/1545 */
 
 #snippet-inline-editor header.ck-content h3 {
 	color: hsla(212, 79%, 9%, 0.59);
-	font-weight: 600;
 	font-size: 1.6rem;
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Allows to add/remove bold to H3 heading in editors. Closes #9761