### PR TITLE
Improved the EditorWatchdog's editor destruction phase by removing a `change:data` listener before destroying the editor

### DIFF
--- a/packages/ckeditor5-watchdog/src/editorwatchdog.js
+++ b/packages/ckeditor5-watchdog/src/editorwatchdog.js
@@ -235,6 +235,11 @@ export default class EditorWatchdog extends Watchdog {
 
 				this._editor = null;
 
+				// Remove the `change:data` listener before destroying the editor.
+				// Incorrectly written plugins may trigger firing `change:data` events during the editor destruction phase
+				// causing the watchdog to call `editor.getData()` when some parts of editor are already destroyed.
+				editor.model.document.off( 'change:data', this._throttledSave );
+
 				return this._destructor( editor );
 			} );
 	}

--- a/packages/ckeditor5-watchdog/tests/editorwatchdog.js
+++ b/packages/ckeditor5-watchdog/tests/editorwatchdog.js
@@ -755,9 +755,9 @@ describe( 'EditorWatchdog', () => {
 		} );
 	} );
 
-	describe( 'destroy()', () => {
-		// See #19.
-		it( 'should clean internal stuff', () => {
+	describe( 'destroying', () => {
+		// See https://github.com/ckeditor/ckeditor5/issues/4706.
+		it( 'destroy() should clean internal stuff', () => {
 			// 30ms should be enough to make the two data changes split into two data save actions.
 			// This will ensure that the second data save action will be put off in time.
 			const SAVE_INTERVAL = 30;
@@ -790,6 +790,44 @@ describe( 'EditorWatchdog', () => {
 				expect( watchdog.state ).to.equal( 'destroyed' );
 				expect( watchdog.crashes ).to.deep.equal( [] );
 			} );
+		} );
+
+		// See https://github.com/ckeditor/ckeditor5/issues/10643.
+		it( 'watchdog should remove the listener for `change:data` event before destroying the editor', async () => {
+			const watchdog = new EditorWatchdog( ClassicTestEditor );
+
+			const spy = sinon.spy();
+
+			// A plugin that modifies the editor data during the destruction phase.
+			class InvalidPlugin {
+				constructor( editor ) {
+					this.editor = editor;
+				}
+
+				destroy() {
+					const doc = this.editor.model.document;
+
+					this.editor.model.change( writer => {
+						writer.insertText( 'bar', writer.createPositionAt( doc.getRoot(), 1 ) );
+						spy();
+					} );
+				}
+			}
+
+			await watchdog.create( element, {
+				initialData: '<p>foo</p>',
+				plugins: [ InvalidPlugin, Paragraph ]
+			} );
+
+			await watchdog._restart();
+
+			// The watchdog during destroying the editor should not listen to the data changes.
+			sinon.assert.calledOnce( spy );
+			expect( watchdog.editor.getData() ).to.equal( '<p>foo</p>' );
+
+			await watchdog.destroy();
+
+			sinon.assert.calledTwice( spy );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (watchdog): Prevented `EditorWatchdog` from crashing during the editor destruction process when one of the plugins tries to change data at this moment. Closes #10643.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._