### PR TITLE
Fix (build-decoupled-document): Fix image caption being stretched down. Closes: #10940

### DIFF
--- a/packages/ckeditor5-build-decoupled-document/sample/index.html
+++ b/packages/ckeditor5-build-decoupled-document/sample/index.html
@@ -38,7 +38,7 @@
 		max-height: 500px;
 	}
 
-	.editable-container .ck-editor__editable {
+	.editable-container .ck-content {
 		min-height: 21cm;
 		padding: 2em;
 		border: 1px #D3D3D3 solid;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (build-decoupled-document): Fix image caption being stretched down. Closes: #10940