### PR TITLE
Introduced batch sub-types

### DIFF
--- a/packages/ckeditor5-autoformat/src/blockautoformatediting.js
+++ b/packages/ckeditor5-autoformat/src/blockautoformatediting.js
@@ -77,7 +77,7 @@ export default function blockAutoformatEditing( editor, plugin, pattern, callbac
 			return;
 		}
 
-		if ( batch.type == 'transparent' ) {
+		if ( batch.isUndo || !batch.isLocal ) {
 			return;
 		}
 

--- a/packages/ckeditor5-autoformat/src/inlineautoformatediting.js
+++ b/packages/ckeditor5-autoformat/src/inlineautoformatediting.js
@@ -125,7 +125,7 @@ export default function inlineAutoformatEditing( editor, plugin, testRegexpOrCal
 	} );
 
 	editor.model.document.on( 'change:data', ( evt, batch ) => {
-		if ( batch.type == 'transparent' || !plugin.isEnabled ) {
+		if ( batch.isUndo || !batch.isLocal || !plugin.isEnabled ) {
 			return;
 		}
 

--- a/packages/ckeditor5-autoformat/tests/blockautoformatediting.js
+++ b/packages/ckeditor5-autoformat/tests/blockautoformatediting.js
@@ -234,12 +234,24 @@ describe( 'blockAutoformatEditing', () => {
 		} );
 	} );
 
-	it( 'should ignore transparent batches', () => {
+	it( 'should ignore non-local batches', () => {
 		const spy = testUtils.sinon.spy();
 		blockAutoformatEditing( editor, plugin, /^[*]\s$/, spy );
 
 		setData( model, '<paragraph>*[]</paragraph>' );
-		model.enqueueChange( 'transparent', writer => {
+		model.enqueueChange( { isLocal: false }, writer => {
+			writer.insertText( ' ', doc.selection.getFirstPosition() );
+		} );
+
+		sinon.assert.notCalled( spy );
+	} );
+
+	it( 'should ignore undo batches', () => {
+		const spy = testUtils.sinon.spy();
+		blockAutoformatEditing( editor, plugin, /^[*]\s$/, spy );
+
+		setData( model, '<paragraph>*[]</paragraph>' );
+		model.enqueueChange( { isUndo: true }, writer => {
 			writer.insertText( ' ', doc.selection.getFirstPosition() );
 		} );
 

--- a/packages/ckeditor5-autoformat/tests/inlineautoformatediting.js
+++ b/packages/ckeditor5-autoformat/tests/inlineautoformatediting.js
@@ -152,11 +152,23 @@ describe( 'inlineAutoformatEditing', () => {
 		} );
 	} );
 
-	it( 'should ignore transparent batches', () => {
+	it( 'should ignore non-local batches', () => {
 		inlineAutoformatEditing( editor, plugin, /(\*)(.+?)(\*)/g, formatSpy );
 
 		setData( model, '<paragraph>*foobar[]</paragraph>' );
-		model.enqueueChange( 'transparent', writer => {
+		model.enqueueChange( { isLocal: false }, writer => {
+			writer.insertText( '*', doc.selection.getFirstPosition() );
+		} );
+
+		sinon.assert.notCalled( formatSpy );
+		expect( getData( model ) ).to.equal( '<paragraph>*foobar*[]</paragraph>' );
+	} );
+
+	it( 'should ignore undo batches', () => {
+		inlineAutoformatEditing( editor, plugin, /(\*)(.+?)(\*)/g, formatSpy );
+
+		setData( model, '<paragraph>*foobar[]</paragraph>' );
+		model.enqueueChange( { isUndo: true }, writer => {
 			writer.insertText( '*', doc.selection.getFirstPosition() );
 		} );
 

--- a/packages/ckeditor5-ckfinder/tests/ckfindercommand.js
+++ b/packages/ckeditor5-ckfinder/tests/ckfindercommand.js
@@ -44,7 +44,7 @@ describe( 'CKFinderCommand', () => {
 
 	describe( 'isEnabled', () => {
 		it( 'should be true when the selection directly in the root', () => {
-			model.enqueueChange( 'transparent', () => {
+			model.enqueueChange( { isUndoable: false }, () => {
 				setModelData( model, '[]' );
 
 				command.refresh();

--- a/packages/ckeditor5-engine/src/dev-utils/model.js
+++ b/packages/ckeditor5-engine/src/dev-utils/model.js
@@ -102,7 +102,7 @@ getData._stringify = stringify;
  * name will be used.
  * @param {Array<Object>} [options.selectionAttributes] A list of attributes which will be passed to the selection.
  * @param {Boolean} [options.lastRangeBackward=false] If set to `true`, the last range will be added as backward.
- * @param {String} [options.batchType='default'] Batch type used for inserting elements.
+ * @param {Object} [options.batchType] Batch type used for inserting elements. See {@link module:engine/model/batch~Batch#constructor}.
  * See {@link module:engine/model/batch~Batch#type}.
  */
 export function setData( model, data, options = {} ) {
@@ -128,7 +128,7 @@ export function setData( model, data, options = {} ) {
 		modelDocumentFragment = parsedResult;
 	}
 
-	if ( typeof options.batchType === 'string' ) {
+	if ( options.batchType !== undefined ) {
 		model.enqueueChange( options.batchType, writeToModel );
 	} else {
 		model.change( writeToModel );

--- a/packages/ckeditor5-engine/src/model/batch.js
+++ b/packages/ckeditor5-engine/src/model/batch.js
@@ -40,8 +40,9 @@ export default class Batch {
 			type = type === 'transparent' ? { isUndoable: false } : {};
 
 			/**
-			 * The string value for {@link module:engine/model/batch~Batch#type `type`} constructor property has been
-			 * deprecated and will be removed in the near future. Please refer to the API documentation for more information.
+			 * The string value for `type` property of the `Batch` constructor has been deprecated and will be removed in the near future.
+			 * Please refer to the {@link module:engine/model/batch~Batch#constructor `Batch` constructor API documentation} for more
+			 * information.
 			 *
 			 * @error batch-constructor-deprecated-string-type
 			 */
@@ -89,6 +90,31 @@ export default class Batch {
 		 * @type {Boolean}
 		 */
 		this.isTyping = isTyping;
+	}
+
+	/**
+	 * The type of the batch.
+	 *
+	 * **This property has been deprecated and is always set to `'default'` value.**
+	 *
+	 * It can be one of the following values:
+	 * * `'default'` &ndash; All "normal" batches. This is the most commonly used type.
+	 * * `'transparent'` &ndash; A batch that should be ignored by other features, i.e. an initial batch or collaborative editing
+	 * changes.
+	 *
+	 * @deprecated
+	 * @type {'default'}
+	 */
+	get type() {
+		/**
+		 * The {@link module:engine/model/batch~Batch#type `Batch#type` } property has been deprecated and will be removed in the near
+		 * future. Use `Batch#isLocal`, `Batch#isUndoable`, `Batch#isUndo` and `Batch#isTyping` instead.
+		 *
+		 * @error batch-type-deprecated
+		 */
+		logWarning( 'batch-type-deprecated' );
+
+		return 'default';
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/model/batch.js
+++ b/packages/ckeditor5-engine/src/model/batch.js
@@ -7,6 +7,8 @@
  * @module engine/model/batch
  */
 
+/* global console */
+
 /**
  * A batch instance groups model changes ({@link module:engine/model/operation/operation~Operation operations}). All operations
  * grouped in a single batch can be reverted together, so you can also think about a batch as of a single undo step. If you want
@@ -25,9 +27,32 @@ export default class Batch {
 	 *
 	 * @see module:engine/model/model~Model#enqueueChange
 	 * @see module:engine/model/model~Model#change
-	 * @param {'transparent'|'default'} [type='default'] The type of the batch.
+	 * @param {Object} [type] Set of flags that specifies the type of the batch. Batch type can alter how some of the features work when
+	 * encountering given `Batch` instance (for example, when a feature listens to applied operations).
+	 * @param {Boolean} [type.isUndoable=true] Whether batch can be undone through undo feature.
+	 * @param {Boolean} [type.isLocal=true] Whether batch includes operations created locally (`true`) or operations created on
+	 * other, remote editors (`false`).
+	 * @param {Boolean} [type.isUndo=false] Whether batch was created by the undo feature and undoes other operations.
+	 * @param {Boolean} [type.isTyping=false] Whether batch includes operations connected with typing action.
 	 */
-	constructor( type = 'default' ) {
+	constructor( type = {} ) {
+		if ( typeof type === 'string' ) {
+			type = type === 'transparent' ? { isUndoable: false } : {};
+
+			/**
+			 * The string value for {@link module:engine/model/batch~Batch#type `type`} constructor property has been
+			 * deprecated and will be removed in the near future. Please refer to the API documentation for more information.
+			 *
+			 * @error batch-constructor-deprecated-string-type
+			 */
+			console.warn(
+				'batch-constructor-deprecated-string-type: ' +
+				'The string value for Batch type constructor property has been deprecated and will be removed in the near future.'
+			);
+		}
+
+		const { isUndoable = true, isLocal = true, isUndo = false, isTyping = false } = type;
+
 		/**
 		 * An array of operations that compose this batch.
 		 *
@@ -37,17 +62,32 @@ export default class Batch {
 		this.operations = [];
 
 		/**
-		 * The type of the batch.
+		 * Whether batch can be undone through the undo feature.
 		 *
-		 * It can be one of the following values:
-		 * * `'default'` &ndash; All "normal" batches. This is the most commonly used type.
-		 * * `'transparent'` &ndash; A batch that should be ignored by other features, i.e. an initial batch or collaborative editing
-		 * changes.
-		 *
-		 * @readonly
-		 * @type {'transparent'|'default'}
+		 * @type {Boolean}
 		 */
-		this.type = type;
+		this.isUndoable = isUndoable;
+
+		/**
+		 * Whether batch includes operations created locally (`true`) or operations created on other, remote editors (`false`).
+		 *
+		 * @type {Boolean}
+		 */
+		this.isLocal = isLocal;
+
+		/**
+		 * Whether batch was created by the undo feature and undoes other operations.
+		 *
+		 * @type {Boolean}
+		 */
+		this.isUndo = isUndo;
+
+		/**
+		 * Whether batch includes operations connected with typing.
+		 *
+		 * @type {Boolean}
+		 */
+		this.isTyping = isTyping;
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/model/batch.js
+++ b/packages/ckeditor5-engine/src/model/batch.js
@@ -64,6 +64,7 @@ export default class Batch {
 		/**
 		 * Whether batch can be undone through the undo feature.
 		 *
+		 * @readonly
 		 * @type {Boolean}
 		 */
 		this.isUndoable = isUndoable;
@@ -71,6 +72,7 @@ export default class Batch {
 		/**
 		 * Whether batch includes operations created locally (`true`) or operations created on other, remote editors (`false`).
 		 *
+		 * @readonly
 		 * @type {Boolean}
 		 */
 		this.isLocal = isLocal;
@@ -78,6 +80,7 @@ export default class Batch {
 		/**
 		 * Whether batch was created by the undo feature and undoes other operations.
 		 *
+		 * @readonly
 		 * @type {Boolean}
 		 */
 		this.isUndo = isUndo;
@@ -85,6 +88,7 @@ export default class Batch {
 		/**
 		 * Whether batch includes operations connected with typing.
 		 *
+		 * @readonly
 		 * @type {Boolean}
 		 */
 		this.isTyping = isTyping;

--- a/packages/ckeditor5-engine/src/model/batch.js
+++ b/packages/ckeditor5-engine/src/model/batch.js
@@ -7,7 +7,7 @@
  * @module engine/model/batch
  */
 
-/* global console */
+import { logWarning } from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 /**
  * A batch instance groups model changes ({@link module:engine/model/operation/operation~Operation operations}). All operations
@@ -45,10 +45,7 @@ export default class Batch {
 			 *
 			 * @error batch-constructor-deprecated-string-type
 			 */
-			console.warn(
-				'batch-constructor-deprecated-string-type: ' +
-				'The string value for Batch type constructor property has been deprecated and will be removed in the near future.'
-			);
+			logWarning( 'batch-constructor-deprecated-string-type' );
 		}
 
 		const { isUndoable = true, isLocal = true, isUndo = false, isTyping = false } = type;

--- a/packages/ckeditor5-engine/src/model/model.js
+++ b/packages/ckeditor5-engine/src/model/model.js
@@ -214,8 +214,13 @@ export default class Model {
 	 * done in the outer `change()` block.
 	 *
 	 * Second, it lets you define the {@link module:engine/model/batch~Batch} into which you want to add your changes.
-	 * By default, a new batch is created. In the sample above, `change` and `enqueueChange` blocks use a different
-	 * batch (and different {@link module:engine/model/writer~Writer} since each of them operates on the separate batch).
+	 * By default, a new batch with the default {@link module:engine/model/batch~Batch#constructor batch type} is created.
+	 * In the sample above, `change` and `enqueueChange` blocks will use a different batch (and a different
+	 * {@link module:engine/model/writer~Writer} instance since each of them operates on a separate batch).
+	 *
+	 *		model.enqueueChange( { isUndoable: false }, writer => {
+	 *			writer.insertText( 'foo', paragraph, 'end' );
+	 *		} );
 	 *
 	 * When using the `enqueueChange()` block you can also add some changes to the batch you used before.
 	 *
@@ -226,17 +231,20 @@ export default class Model {
 	 * In order to make a nested `enqueueChange()` create a single undo step together with the changes done in the outer `change()`
 	 * block, you can obtain the batch instance from the  {@link module:engine/model/writer~Writer#batch writer} of the outer block.
 	 *
-	 * @param {module:engine/model/batch~Batch|'transparent'|'default'} batchOrType Batch or batch type should be used in the callback.
-	 * If not defined, a new batch will be created.
+	 * @param {module:engine/model/batch~Batch|Object} [batchOrType] A batch or a
+	 * {@link module:engine/model/batch~Batch#constructor batch type} that should be used in the callback. If not defined, a new batch with
+	 * the default type will be created.
 	 * @param {Function} callback Callback function which may modify the model.
 	 */
 	enqueueChange( batchOrType, callback ) {
 		try {
-			if ( typeof batchOrType === 'string' ) {
-				batchOrType = new Batch( batchOrType );
-			} else if ( typeof batchOrType == 'function' ) {
+			if ( !batchOrType ) {
+				batchOrType = new Batch();
+			} else if ( typeof batchOrType === 'function' ) {
 				callback = batchOrType;
 				batchOrType = new Batch();
+			} else if ( !( batchOrType instanceof Batch ) ) {
+				batchOrType = new Batch( batchOrType );
 			}
 
 			this._pendingChanges.push( { batch: batchOrType, callback } );
@@ -791,7 +799,7 @@ export default class Model {
 	 * * {@link #change `change()`},
 	 * * {@link #enqueueChange `enqueueChange()`}.
 	 *
-	 * @param {'transparent'|'default'} [type='default'] The type of the batch.
+	 * @param {Object} [type] {@link module:engine/model/batch~Batch#constructor The type} of the batch.
 	 * @returns {module:engine/model/batch~Batch}
 	 */
 	createBatch( type ) {

--- a/packages/ckeditor5-engine/tests/controller/datacontroller.js
+++ b/packages/ckeditor5-engine/tests/controller/datacontroller.js
@@ -291,22 +291,26 @@ describe( 'DataController', () => {
 			expect( modelDocument.history.getOperations().length ).to.equal( 1 );
 		} );
 
-		it( 'should create a `default` batch by default', () => {
+		it( 'should create a batch with default type if `batchType` option is not given', () => {
 			schema.extend( '$text', { allowIn: '$root' } );
 			data.set( 'foo' );
 
 			const operation = modelDocument.history.getOperations()[ 0 ];
+			const batch = operation.batch;
 
-			expect( operation.batch.type ).to.equal( 'default' );
+			expect( batch.isUndoable ).to.be.true;
+			expect( batch.isLocal ).to.be.true;
+			expect( batch.isUndo ).to.be.false;
+			expect( batch.isTyping ).to.be.false;
 		} );
 
 		it( 'should create a batch specified by the `options.batch` option when provided', () => {
 			schema.extend( '$text', { allowIn: '$root' } );
-			data.set( 'foo', { batchType: 'transparent' } );
+			data.set( 'foo', { batchType: { isUndoable: true } } );
 
 			const operation = modelDocument.history.getOperations()[ 0 ];
 
-			expect( operation.batch.type ).to.equal( 'transparent' );
+			expect( operation.batch.isUndoable ).to.be.true;
 		} );
 
 		it( 'should cause firing change event', () => {

--- a/packages/ckeditor5-engine/tests/dev-utils/model.js
+++ b/packages/ckeditor5-engine/tests/dev-utils/model.js
@@ -132,7 +132,7 @@ describe( 'model test utils', () => {
 
 		it( 'should use model#enqueueChange method if the batchType option was provided', () => {
 			const changeSpy = sinon.spy( model, 'enqueueChange' );
-			const batchType = 'default';
+			const batchType = { isUndoable: true };
 			setData( model, 'text', { batchType } );
 
 			sinon.assert.calledTwice( changeSpy );

--- a/packages/ckeditor5-engine/tests/model/batch.js
+++ b/packages/ckeditor5-engine/tests/model/batch.js
@@ -5,6 +5,9 @@
 
 import Batch from '../../src/model/batch';
 import Operation from '../../src/model/operation/operation';
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
+
+/* globals console */
 
 describe( 'Batch', () => {
 	describe( 'type', () => {
@@ -37,22 +40,34 @@ describe( 'Batch', () => {
 	} );
 
 	describe( 'deprecated string type', () => {
-		it( 'when set to "default" should set default properties', () => {
+		let stub;
+
+		testUtils.createSinonSandbox();
+
+		beforeEach( () => {
+			stub = testUtils.sinon.stub( console, 'warn' );
+		} );
+
+		it( 'when set to "default" should set default properties and log warning on console', () => {
 			const batch = new Batch( 'default' );
 
 			expect( batch.isUndoable ).to.be.true;
 			expect( batch.isLocal ).to.be.true;
 			expect( batch.isUndo ).to.be.false;
 			expect( batch.isTyping ).to.be.false;
+
+			sinon.assert.calledWithMatch( stub, 'batch-constructor-deprecated-string-type' );
 		} );
 
-		it( 'when set to "transparent" should set isUndoable to false', () => {
+		it( 'when set to "transparent" should set isUndoable to false and log warning on console', () => {
 			const batch = new Batch( 'transparent' );
 
 			expect( batch.isUndoable ).to.be.false;
 			expect( batch.isLocal ).to.be.true;
 			expect( batch.isUndo ).to.be.false;
 			expect( batch.isTyping ).to.be.false;
+
+			sinon.assert.calledWithMatch( stub, 'batch-constructor-deprecated-string-type' );
 		} );
 	} );
 

--- a/packages/ckeditor5-engine/tests/model/batch.js
+++ b/packages/ckeditor5-engine/tests/model/batch.js
@@ -10,8 +10,8 @@ import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 /* globals console */
 
 describe( 'Batch', () => {
-	describe( 'type', () => {
-		it( 'should have default value', () => {
+	describe( 'constructor', () => {
+		it( 'should set default types', () => {
 			const batch = new Batch();
 
 			expect( batch.isUndoable ).to.be.true;
@@ -20,7 +20,7 @@ describe( 'Batch', () => {
 			expect( batch.isTyping ).to.be.false;
 		} );
 
-		it( 'should set batch properties accordingly', () => {
+		it( 'should set batch types accordingly', () => {
 			const batch = new Batch( { isUndoable: false, isLocal: false, isUndo: true, isTyping: true } );
 
 			expect( batch.isUndoable ).to.be.false;
@@ -29,7 +29,7 @@ describe( 'Batch', () => {
 			expect( batch.isTyping ).to.be.true;
 		} );
 
-		it( 'can be set partially', () => {
+		it( 'should allow setting only some of the batch types', () => {
 			const batch = new Batch( { isUndoable: false, isLocal: false } );
 
 			expect( batch.isUndoable ).to.be.false;
@@ -37,37 +37,50 @@ describe( 'Batch', () => {
 			expect( batch.isUndo ).to.be.false;
 			expect( batch.isTyping ).to.be.false;
 		} );
+
+		describe( 'deprecated string type', () => {
+			let stub;
+
+			testUtils.createSinonSandbox();
+
+			beforeEach( () => {
+				stub = testUtils.sinon.stub( console, 'warn' );
+			} );
+
+			it( 'when set to "default" should set default properties and log warning on console', () => {
+				const batch = new Batch( 'default' );
+
+				expect( batch.isUndoable ).to.be.true;
+				expect( batch.isLocal ).to.be.true;
+				expect( batch.isUndo ).to.be.false;
+				expect( batch.isTyping ).to.be.false;
+
+				sinon.assert.calledWithMatch( stub, 'batch-constructor-deprecated-string-type' );
+			} );
+
+			it( 'when set to "transparent" should set isUndoable to false and log warning on console', () => {
+				const batch = new Batch( 'transparent' );
+
+				expect( batch.isUndoable ).to.be.false;
+				expect( batch.isLocal ).to.be.true;
+				expect( batch.isUndo ).to.be.false;
+				expect( batch.isTyping ).to.be.false;
+
+				sinon.assert.calledWithMatch( stub, 'batch-constructor-deprecated-string-type' );
+			} );
+		} );
 	} );
 
-	describe( 'deprecated string type', () => {
-		let stub;
+	describe( 'type', () => {
+		it( 'should return "default" and log warning on console', () => {
+			testUtils.createSinonSandbox();
 
-		testUtils.createSinonSandbox();
+			const stub = testUtils.sinon.stub( console, 'warn' );
+			const batch = new Batch();
 
-		beforeEach( () => {
-			stub = testUtils.sinon.stub( console, 'warn' );
-		} );
+			batch.type;
 
-		it( 'when set to "default" should set default properties and log warning on console', () => {
-			const batch = new Batch( 'default' );
-
-			expect( batch.isUndoable ).to.be.true;
-			expect( batch.isLocal ).to.be.true;
-			expect( batch.isUndo ).to.be.false;
-			expect( batch.isTyping ).to.be.false;
-
-			sinon.assert.calledWithMatch( stub, 'batch-constructor-deprecated-string-type' );
-		} );
-
-		it( 'when set to "transparent" should set isUndoable to false and log warning on console', () => {
-			const batch = new Batch( 'transparent' );
-
-			expect( batch.isUndoable ).to.be.false;
-			expect( batch.isLocal ).to.be.true;
-			expect( batch.isUndo ).to.be.false;
-			expect( batch.isTyping ).to.be.false;
-
-			sinon.assert.calledWithMatch( stub, 'batch-constructor-deprecated-string-type' );
+			sinon.assert.calledWithMatch( stub, 'batch-type-deprecated' );
 		} );
 	} );
 

--- a/packages/ckeditor5-engine/tests/model/batch.js
+++ b/packages/ckeditor5-engine/tests/model/batch.js
@@ -8,16 +8,51 @@ import Operation from '../../src/model/operation/operation';
 
 describe( 'Batch', () => {
 	describe( 'type', () => {
-		it( 'should default to "default"', () => {
+		it( 'should have default value', () => {
 			const batch = new Batch();
 
-			expect( batch.type ).to.equal( 'default' );
+			expect( batch.isUndoable ).to.be.true;
+			expect( batch.isLocal ).to.be.true;
+			expect( batch.isUndo ).to.be.false;
+			expect( batch.isTyping ).to.be.false;
 		} );
 
-		it( 'should be set to the value set in constructor', () => {
+		it( 'should set batch properties accordingly', () => {
+			const batch = new Batch( { isUndoable: false, isLocal: false, isUndo: true, isTyping: true } );
+
+			expect( batch.isUndoable ).to.be.false;
+			expect( batch.isLocal ).to.be.false;
+			expect( batch.isUndo ).to.be.true;
+			expect( batch.isTyping ).to.be.true;
+		} );
+
+		it( 'can be set partially', () => {
+			const batch = new Batch( { isUndoable: false, isLocal: false } );
+
+			expect( batch.isUndoable ).to.be.false;
+			expect( batch.isLocal ).to.be.false;
+			expect( batch.isUndo ).to.be.false;
+			expect( batch.isTyping ).to.be.false;
+		} );
+	} );
+
+	describe( 'deprecated string type', () => {
+		it( 'when set to "default" should set default properties', () => {
+			const batch = new Batch( 'default' );
+
+			expect( batch.isUndoable ).to.be.true;
+			expect( batch.isLocal ).to.be.true;
+			expect( batch.isUndo ).to.be.false;
+			expect( batch.isTyping ).to.be.false;
+		} );
+
+		it( 'when set to "transparent" should set isUndoable to false', () => {
 			const batch = new Batch( 'transparent' );
 
-			expect( batch.type ).to.equal( 'transparent' );
+			expect( batch.isUndoable ).to.be.false;
+			expect( batch.isLocal ).to.be.true;
+			expect( batch.isUndo ).to.be.false;
+			expect( batch.isTyping ).to.be.false;
 		} );
 	} );
 

--- a/packages/ckeditor5-engine/tests/model/documentselection.js
+++ b/packages/ckeditor5-engine/tests/model/documentselection.js
@@ -1252,13 +1252,11 @@ describe( 'DocumentSelection', () => {
 
 		describe( 'parent element\'s attributes', () => {
 			it( 'are set using a normal batch', () => {
-				const batchTypes = [];
+				let batch;
 
-				model.on( 'applyOperation', ( event, args ) => {
+				model.once( 'applyOperation', ( event, args ) => {
 					const operation = args[ 0 ];
-					const batch = operation.batch;
-
-					batchTypes.push( batch.type );
+					batch = operation.batch;
 				} );
 
 				selection._setTo( [ rangeInEmptyP ] );
@@ -1267,13 +1265,13 @@ describe( 'DocumentSelection', () => {
 					writer.setSelectionAttribute( 'foo', 'bar' );
 				} );
 
-				expect( batchTypes ).to.deep.equal( [ 'default' ] );
+				expect( batch.isUndoable ).to.be.true;
+
 				expect( emptyP.getAttribute( fooStoreAttrKey ) ).to.equal( 'bar' );
 			} );
 
 			it( 'are removed when any content is inserted (reuses the same batch)', () => {
-				// Dedupe batches by using a map (multiple change events will be fired).
-				const batchTypes = new Map();
+				const batches = new Set();
 
 				selection._setTo( rangeInEmptyP );
 				selection._setAttribute( 'foo', 'bar' );
@@ -1283,7 +1281,7 @@ describe( 'DocumentSelection', () => {
 					const operation = args[ 0 ];
 					const batch = operation.batch;
 
-					batchTypes.set( batch, batch.type );
+					batches.add( batch );
 				} );
 
 				model.change( writer => {
@@ -1293,7 +1291,11 @@ describe( 'DocumentSelection', () => {
 				expect( emptyP.hasAttribute( fooStoreAttrKey ) ).to.be.false;
 				expect( emptyP.hasAttribute( abcStoreAttrKey ) ).to.be.false;
 
-				expect( Array.from( batchTypes.values() ) ).to.deep.equal( [ 'default' ] );
+				expect( batches.size ).to.equal( 1 );
+
+				const batch = Array.from( batches )[ 0 ];
+
+				expect( batch.isUndoable ).to.be.true;
 			} );
 
 			it( 'are removed when any content is moved into', () => {

--- a/packages/ckeditor5-engine/tests/model/model.js
+++ b/packages/ckeditor5-engine/tests/model/model.js
@@ -334,6 +334,22 @@ describe( 'Model', () => {
 			} );
 		} );
 
+		it( 'should create a batch with the default type if empty value is passed', () => {
+			model.enqueueChange( null, writer => {
+				expect( writer.batch.isUndoable ).to.be.true;
+				expect( writer.batch.isLocal ).to.be.true;
+				expect( writer.batch.isTyping ).to.be.false;
+				expect( writer.batch.isUndo ).to.be.false;
+			} );
+
+			model.enqueueChange( undefined, writer => {
+				expect( writer.batch.isUndoable ).to.be.true;
+				expect( writer.batch.isLocal ).to.be.true;
+				expect( writer.batch.isTyping ).to.be.false;
+				expect( writer.batch.isUndo ).to.be.false;
+			} );
+		} );
+
 		it( 'should rethrow native errors as they are in the dubug=true mode in the model.change() block', () => {
 			const error = new TypeError( 'foo' );
 

--- a/packages/ckeditor5-engine/tests/model/model.js
+++ b/packages/ckeditor5-engine/tests/model/model.js
@@ -327,9 +327,10 @@ describe( 'Model', () => {
 			} );
 		} );
 
-		it( 'should let you create transparent batch', () => {
-			model.enqueueChange( 'transparent', writer => {
-				expect( writer.batch.type ).to.equal( 'transparent' );
+		it( 'should let you create batch of given type', () => {
+			model.enqueueChange( { isUndoable: false, isLocal: false }, writer => {
+				expect( writer.batch.isUndoable ).to.be.false;
+				expect( writer.batch.isLocal ).to.be.false;
 			} );
 		} );
 
@@ -591,7 +592,7 @@ describe( 'Model', () => {
 		it( 'should return true if given element has text node containing spaces only', () => {
 			const pEmpty = root.getChild( 0 ).getChild( 0 );
 
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				// Model `setData()` method trims whitespaces so use writer here to insert whitespace only text.
 				writer.insertText( '    ', pEmpty, 'end' );
 			} );
@@ -602,7 +603,7 @@ describe( 'Model', () => {
 		it( 'should false true if given element has text node containing spaces only (ignoreWhitespaces)', () => {
 			const pEmpty = root.getChild( 0 ).getChild( 0 );
 
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				// Model `setData()` method trims whitespaces so use writer here to insert whitespace only text.
 				writer.insertText( '    ', pEmpty, 'end' );
 			} );
@@ -669,7 +670,7 @@ describe( 'Model', () => {
 		it( 'should return false for empty element with marker (usingOperation=false, affectsData=false)', () => {
 			const pEmpty = root.getChild( 0 ).getChild( 0 );
 
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				// Insert marker.
 				const range = ModelRange._createIn( pEmpty );
 				writer.addMarker( 'comment1', { range, usingOperation: false, affectsData: false } );
@@ -684,7 +685,7 @@ describe( 'Model', () => {
 		it( 'should return false for empty element with marker (usingOperation=true, affectsData=false)', () => {
 			const pEmpty = root.getChild( 0 ).getChild( 0 );
 
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				// Insert marker.
 				const range = ModelRange._createIn( pEmpty );
 				writer.addMarker( 'comment1', { range, usingOperation: true, affectsData: false } );
@@ -699,7 +700,7 @@ describe( 'Model', () => {
 		it( 'should return false (ignoreWhitespaces) for empty text with marker (usingOperation=false, affectsData=false)', () => {
 			const pEmpty = root.getChild( 0 ).getChild( 0 );
 
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				// Insert empty text.
 				const text = writer.createText( '    ', { bold: true } );
 				writer.append( text, pEmpty );
@@ -716,7 +717,7 @@ describe( 'Model', () => {
 		it( 'should return true for empty text with marker (usingOperation=false, affectsData=false)', () => {
 			const pEmpty = root.getChild( 0 ).getChild( 0 );
 
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				// Insert empty text.
 				const text = writer.createText( '    ', { bold: true } );
 				writer.append( text, pEmpty );
@@ -734,7 +735,7 @@ describe( 'Model', () => {
 		it( 'should return false for empty element with marker (usingOperation=false, affectsData=true)', () => {
 			const pEmpty = root.getChild( 0 ).getChild( 0 );
 
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				// Insert marker.
 				const range = ModelRange._createIn( pEmpty );
 				writer.addMarker( 'comment1', { range, usingOperation: false, affectsData: true } );
@@ -749,7 +750,7 @@ describe( 'Model', () => {
 		it( 'should return false for empty element with marker (usingOperation=true, affectsData=true)', () => {
 			const pEmpty = root.getChild( 0 ).getChild( 0 );
 
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				// Insert marker.
 				const range = ModelRange._createIn( pEmpty );
 				writer.addMarker( 'comment1', { range, usingOperation: true, affectsData: true } );
@@ -764,7 +765,7 @@ describe( 'Model', () => {
 		it( 'should return true (ignoreWhitespaces) for empty text with marker (usingOperation=false, affectsData=true)', () => {
 			const pEmpty = root.getChild( 0 ).getChild( 0 );
 
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				// Insert empty text.
 				const text = writer.createText( '    ', { bold: true } );
 				writer.append( text, pEmpty );
@@ -861,13 +862,13 @@ describe( 'Model', () => {
 		it( 'should return instance of Batch', () => {
 			const batch = model.createBatch();
 			expect( batch ).to.be.instanceof( Batch );
-			expect( batch.type ).to.equal( 'default' );
 		} );
 
 		it( 'should allow to define type of Batch', () => {
-			const batch = model.createBatch( 'transparent' );
+			const batch = model.createBatch( { isUndo: true, isUndoable: true } );
 			expect( batch ).to.be.instanceof( Batch );
-			expect( batch.type ).to.equal( 'transparent' );
+			expect( batch.isUndo ).to.be.true;
+			expect( batch.isUndoable ).to.be.true;
 		} );
 	} );
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/utils.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/utils.js
@@ -335,7 +335,7 @@ export function syncClients() {
 				remoteOperationsTransformed = transformSets( remoteOperations, localOperations, options ).operationsA;
 			}
 
-			localClient.editor.model.enqueueChange( 'transparent', writer => {
+			localClient.editor.model.enqueueChange( { isUndoable: false }, writer => {
 				for ( const operation of remoteOperationsTransformed ) {
 					writer.batch.addOperation( operation );
 					localClient.editor.model.applyOperation( operation );

--- a/packages/ckeditor5-engine/tests/model/schema.js
+++ b/packages/ckeditor5-engine/tests/model/schema.js
@@ -1105,7 +1105,7 @@ describe( 'Schema', () => {
 			schema.extend( 'article', { isLimit: true } );
 			schema.extend( 'section', { isLimit: true } );
 
-			model.enqueueChange( 'transparent', () => {
+			model.enqueueChange( { isUndoable: false }, () => {
 				setData( model, '<div><section><article>[foo</article><article>bar]</article></section></div>' );
 
 				const section = root.getNodeByPath( [ 0, 0 ] );
@@ -1794,7 +1794,7 @@ describe( 'Schema', () => {
 			it( testName, () => {
 				let range;
 
-				model.enqueueChange( 'transparent', () => {
+				model.enqueueChange( { isUndoable: false }, () => {
 					setData( model, data );
 					range = schema.getNearestSelectionRange( selection.anchor, direction );
 				} );

--- a/packages/ckeditor5-engine/tests/model/utils/deletecontent.js
+++ b/packages/ckeditor5-engine/tests/model/utils/deletecontent.js
@@ -689,7 +689,7 @@ describe( 'DataController utils', () => {
 				it( 'should merge left if the first element is not empty', () => {
 					setData( model, '<heading1>foo[</heading1><paragraph>]bar</paragraph>' );
 
-					model.enqueueChange( 'transparent', writer => {
+					model.enqueueChange( { isUndoable: false }, writer => {
 						const root = doc.getRoot( );
 						const range = writer.createRange(
 							writer.createPositionFromPath( root, [ 0, 3 ] ),
@@ -706,7 +706,7 @@ describe( 'DataController utils', () => {
 				it( 'should merge right if the first element is empty', () => {
 					setData( model, '<heading1>[</heading1><paragraph>]bar</paragraph>' );
 
-					model.enqueueChange( 'transparent', writer => {
+					model.enqueueChange( { isUndoable: false }, writer => {
 						const root = doc.getRoot( );
 						const range = writer.createRange(
 							writer.createPositionFromPath( root, [ 0, 0 ] ),
@@ -723,7 +723,7 @@ describe( 'DataController utils', () => {
 				it( 'should merge left if the last element is empty', () => {
 					setData( model, '<heading1>foo[</heading1><paragraph>]</paragraph>' );
 
-					model.enqueueChange( 'transparent', writer => {
+					model.enqueueChange( { isUndoable: false }, writer => {
 						const root = doc.getRoot( );
 						const range = writer.createRange(
 							writer.createPositionFromPath( root, [ 0, 3 ] ),
@@ -1245,7 +1245,7 @@ describe( 'DataController utils', () => {
 
 		function test( title, input, output, options ) {
 			it( title, () => {
-				model.enqueueChange( 'transparent', () => {
+				model.enqueueChange( { isUndoable: false }, () => {
 					setData( model, input );
 
 					deleteContent( model, doc.selection, options );

--- a/packages/ckeditor5-engine/tests/model/utils/insertcontent.js
+++ b/packages/ckeditor5-engine/tests/model/utils/insertcontent.js
@@ -1339,7 +1339,7 @@ describe( 'DataController utils', () => {
 		it( 'should insert text into limit element when selection spans over many limit elements', () => {
 			let affectedRange;
 
-			model.enqueueChange( 'transparent', () => {
+			model.enqueueChange( { isUndoable: false }, () => {
 				setData( model, '<limit>foo[</limit><limit>]bar</limit>' );
 				affectedRange = insertHelper( 'baz' );
 			} );

--- a/packages/ckeditor5-engine/tests/tickets/1267.js
+++ b/packages/ckeditor5-engine/tests/tickets/1267.js
@@ -40,7 +40,7 @@ describe( 'Bug ckeditor5-engine#1267', () => {
 		);
 
 		// Remove second paragraph where selection is placed.
-		model.enqueueChange( 'transparent', writer => {
+		model.enqueueChange( { isUndoable: false }, writer => {
 			writer.remove( Range._createFromPositionAndShift( new Position( model.document.getRoot(), [ 1 ] ), 1 ) );
 		} );
 
@@ -63,7 +63,7 @@ describe( 'Bug ckeditor5-engine#1267', () => {
 		);
 
 		// Remove second paragraph.
-		model.enqueueChange( 'transparent', writer => {
+		model.enqueueChange( { isUndoable: false }, writer => {
 			writer.remove( Range._createFromPositionAndShift( new Position( model.document.getRoot(), [ 1 ] ), 1 ) );
 		} );
 

--- a/packages/ckeditor5-find-and-replace/tests/replacecommand.js
+++ b/packages/ckeditor5-find-and-replace/tests/replacecommand.js
@@ -188,7 +188,7 @@ describe( 'ReplaceCommand', () => {
 			// Wrap this call in the transparent batch to make it easier to undo the above deletion only.
 			// In real life scenario the above deletion would be a transparent batch from the remote user,
 			// and undo would also be triggered by the remote user.
-			model.enqueueChange( 'transparent', () => {
+			model.enqueueChange( { isUndoable: false }, () => {
 				editor.execute( 'replaceAll', 'aa', results );
 			} );
 

--- a/packages/ckeditor5-heading/tests/integration.js
+++ b/packages/ckeditor5-heading/tests/integration.js
@@ -93,7 +93,7 @@ describe( 'Heading integration', () => {
 	describe( 'with the undo feature', () => {
 		it( 'does not create undo steps when applied to an existing heading (collapsed selection)', () => {
 			// Ensure no undo step by using a transparent batch.
-			model.enqueueChange( 'transparent', () => {
+			model.enqueueChange( { isUndoable: false }, () => {
 				setModelData( model, '<heading1>foo[]bar</heading1>' );
 			} );
 
@@ -105,7 +105,7 @@ describe( 'Heading integration', () => {
 
 		it( 'does not create undo steps when applied to an existing heading (non–collapsed selection)', () => {
 			// Ensure no undo step by using a transparent batch.
-			model.enqueueChange( 'transparent', () => {
+			model.enqueueChange( { isUndoable: false }, () => {
 				setModelData( model, '<heading1>[foo</heading1><heading1>bar]</heading1>' );
 			} );
 

--- a/packages/ckeditor5-horizontal-line/tests/horizontallinecommand.js
+++ b/packages/ckeditor5-horizontal-line/tests/horizontallinecommand.js
@@ -40,7 +40,7 @@ describe( 'HorizontalLineCommand', () => {
 
 	describe( 'isEnabled', () => {
 		it( 'should be true when the selection directly in the root', () => {
-			model.enqueueChange( 'transparent', () => {
+			model.enqueueChange( { isUndoable: false }, () => {
 				setModelData( model, '[]' );
 
 				command.refresh();

--- a/packages/ckeditor5-html-embed/tests/htmlembedcommand.js
+++ b/packages/ckeditor5-html-embed/tests/htmlembedcommand.js
@@ -40,7 +40,7 @@ describe( 'HtmlEmbedCommand', () => {
 
 	describe( 'isEnabled', () => {
 		it( 'should be true when the selection directly in the root', () => {
-			model.enqueueChange( 'transparent', () => {
+			model.enqueueChange( { isUndoable: false }, () => {
 				setModelData( model, '[]' );
 
 				command.refresh();

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.js
@@ -129,7 +129,7 @@ export default class ImageUploadEditing extends Plugin {
 				}
 
 				// Upload images after the selection has changed in order to ensure the command's state is refreshed.
-				editor.model.enqueueChange( 'default', () => {
+				editor.model.enqueueChange( () => {
 					editor.execute( 'uploadImage', { file: images } );
 				} );
 			} );
@@ -277,7 +277,7 @@ export default class ImageUploadEditing extends Plugin {
 		const imageUtils = editor.plugins.get( 'ImageUtils' );
 		const imageUploadElements = this._uploadImageElements;
 
-		model.enqueueChange( 'transparent', writer => {
+		model.enqueueChange( { isUndoable: false }, writer => {
 			writer.setAttribute( 'uploadStatus', 'reading', imageUploadElements.get( loader.id ) );
 		} );
 
@@ -317,14 +317,14 @@ export default class ImageUploadEditing extends Plugin {
 					} );
 				}
 
-				model.enqueueChange( 'transparent', writer => {
+				model.enqueueChange( { isUndoable: false }, writer => {
 					writer.setAttribute( 'uploadStatus', 'uploading', imageElement );
 				} );
 
 				return promise;
 			} )
 			.then( data => {
-				model.enqueueChange( 'transparent', writer => {
+				model.enqueueChange( { isUndoable: false }, writer => {
 					const imageElement = imageUploadElements.get( loader.id );
 
 					writer.setAttribute( 'uploadStatus', 'complete', imageElement );
@@ -378,7 +378,7 @@ export default class ImageUploadEditing extends Plugin {
 				}
 
 				// Permanently remove image from insertion batch.
-				model.enqueueChange( 'transparent', writer => {
+				model.enqueueChange( { isUndoable: false }, writer => {
 					writer.remove( imageUploadElements.get( loader.id ) );
 				} );
 
@@ -386,7 +386,7 @@ export default class ImageUploadEditing extends Plugin {
 			} );
 
 		function clean() {
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				const imageElement = imageUploadElements.get( loader.id );
 
 				writer.removeAttribute( 'uploadId', imageElement );

--- a/packages/ckeditor5-image/tests/autoimage.js
+++ b/packages/ckeditor5-image/tests/autoimage.js
@@ -436,7 +436,7 @@ describe( 'AutoImage - integration', () => {
 				const rootEl = editor.model.document.getRoot();
 
 				setTimeout( () => {
-					editor.model.enqueueChange( 'transparent', writer => {
+					editor.model.enqueueChange( { isUndoable: false }, writer => {
 						writer.insertText( characters[ i ], writer.createPositionFromPath( rootEl, [ 0, i ] ) );
 					} );
 				}, i * 5 );
@@ -458,7 +458,7 @@ describe( 'AutoImage - integration', () => {
 
 			for ( let i = 0; i < 10; ++i ) {
 				setTimeout( () => {
-					editor.model.enqueueChange( 'transparent', writer => {
+					editor.model.enqueueChange( { isUndoable: false }, writer => {
 						writer.insertText( characters[ i ], editor.model.document.selection.getFirstPosition() );
 					} );
 				}, i * 5 );
@@ -478,7 +478,7 @@ describe( 'AutoImage - integration', () => {
 
 			pasteHtml( editor, 'http://example.com/image.png' );
 
-			editor.model.enqueueChange( 'transparent', writer => {
+			editor.model.enqueueChange( { isUndoable: false }, writer => {
 				writer.remove( writer.createRangeOn( editor.model.document.getRoot().getChild( 1 ) ) );
 			} );
 
@@ -496,7 +496,7 @@ describe( 'AutoImage - integration', () => {
 
 			pasteHtml( editor, 'http://example.com/image.png' );
 
-			editor.model.enqueueChange( 'transparent', writer => {
+			editor.model.enqueueChange( { isUndoable: false }, writer => {
 				const paragraph = writer.createElement( 'paragraph' );
 				writer.insert( paragraph, writer.createPositionAfter( editor.model.document.getRoot().getChild( 0 ) ) );
 				writer.setSelection( paragraph, 'in' );
@@ -504,7 +504,7 @@ describe( 'AutoImage - integration', () => {
 
 			for ( let i = 0; i < 10; ++i ) {
 				setTimeout( () => {
-					editor.model.enqueueChange( 'transparent', writer => {
+					editor.model.enqueueChange( { isUndoable: false }, writer => {
 						writer.insertText( characters[ i ], editor.model.document.selection.getFirstPosition() );
 					} );
 				}, i * 5 );
@@ -528,7 +528,7 @@ describe( 'AutoImage - integration', () => {
 
 			pasteHtml( editor, 'http://example.com/image.png' );
 
-			editor.model.enqueueChange( 'transparent', writer => {
+			editor.model.enqueueChange( { isUndoable: false }, writer => {
 				const paragraph = writer.createElement( 'paragraph' );
 				writer.insert( paragraph, writer.createPositionAfter( editor.model.document.getRoot().getChild( 1 ) ) );
 				writer.setSelection( paragraph, 'in' );
@@ -536,7 +536,7 @@ describe( 'AutoImage - integration', () => {
 
 			for ( let i = 0; i < 10; ++i ) {
 				setTimeout( () => {
-					editor.model.enqueueChange( 'transparent', writer => {
+					editor.model.enqueueChange( { isUndoable: false }, writer => {
 						writer.insertText( characters[ i ], editor.model.document.selection.getFirstPosition() );
 					} );
 				}, i * 5 );

--- a/packages/ckeditor5-image/tests/image/imagetypecommand.js
+++ b/packages/ckeditor5-image/tests/image/imagetypecommand.js
@@ -36,7 +36,7 @@ describe( 'ImageTypeCommand', () => {
 	describe( 'isEnabled', () => {
 		describe( 'block command', () => {
 			it( 'should be false when the selection directly in the root', () => {
-				model.enqueueChange( 'transparent', () => {
+				model.enqueueChange( { isUndoable: false }, () => {
 					setModelData( model, '[]' );
 
 					blockCommand.refresh();
@@ -90,7 +90,7 @@ describe( 'ImageTypeCommand', () => {
 
 		describe( 'inline command', () => {
 			it( 'should be false when the selection directly in the root', () => {
-				model.enqueueChange( 'transparent', () => {
+				model.enqueueChange( { isUndoable: false }, () => {
 					setModelData( model, '[]' );
 
 					inlineCommand.refresh();

--- a/packages/ckeditor5-image/tests/image/insertimagecommand.js
+++ b/packages/ckeditor5-image/tests/image/insertimagecommand.js
@@ -36,7 +36,7 @@ describe( 'InsertImageCommand', () => {
 
 	describe( 'isEnabled', () => {
 		it( 'should be true when the selection directly in the root', () => {
-			model.enqueueChange( 'transparent', () => {
+			model.enqueueChange( { isUndoable: false }, () => {
 				setModelData( model, '[]' );
 
 				command.refresh();

--- a/packages/ckeditor5-image/tests/imagetextalternative/imagetextalternativeui.js
+++ b/packages/ckeditor5-image/tests/imagetextalternative/imagetextalternativeui.js
@@ -247,7 +247,7 @@ describe( 'ImageTextAlternativeUI', () => {
 				const removeSpy = sinon.spy( balloon, 'remove' );
 				const focusSpy = sinon.spy( editor.editing.view, 'focus' );
 
-				model.enqueueChange( 'transparent', writer => {
+				model.enqueueChange( { isUndoable: false }, writer => {
 					writer.remove( doc.selection.getFirstRange() );
 				} );
 

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
@@ -868,8 +868,8 @@ describe( 'ImageUploadEditing', () => {
 				loader.file.then( () => adapterMocks[ 0 ].mockSuccess( { originalUrl: 'original.jpg', default: 'image.jpg' } ) );
 			} );
 
-			// Make sure the custom attribute was set in the same transparent batch as the default handling (setting src and status).
-			expect( batch.type ).to.equal( 'transparent' );
+			// Make sure the custom attribute was set in the same non-undoable batch as the default handling (setting src and status).
+			expect( batch.isUndoable ).to.be.false;
 			expect( batch.operations.length ).to.equal( 3 );
 
 			expect( batch.operations[ 0 ].type ).to.equal( 'changeAttribute' );
@@ -923,8 +923,8 @@ describe( 'ImageUploadEditing', () => {
 				) );
 			} );
 
-			// Make sure the custom attribute was set in the same transparent batch as the default handling (setting src and status).
-			expect( batch.type ).to.equal( 'transparent' );
+			// Make sure the custom attribute was set in the non-undoable batch as the default handling (setting src and status).
+			expect( batch.isUndoable ).to.be.false;
 			expect( batch.operations.length ).to.equal( 2 );
 
 			expect( batch.operations[ 0 ].type ).to.equal( 'changeAttribute' );

--- a/packages/ckeditor5-image/tests/imageupload/uploadimagecommand.js
+++ b/packages/ckeditor5-image/tests/imageupload/uploadimagecommand.js
@@ -55,7 +55,7 @@ describe( 'UploadImageCommand', () => {
 
 	describe( 'isEnabled', () => {
 		it( 'should be true when the selection directly in the root', () => {
-			model.enqueueChange( 'transparent', () => {
+			model.enqueueChange( { isUndoable: false }, () => {
 				setModelData( model, '[]' );
 
 				command.refresh();

--- a/packages/ckeditor5-image/tests/imageutils.js
+++ b/packages/ckeditor5-image/tests/imageutils.js
@@ -381,7 +381,7 @@ describe( 'ImageUtils plugin', () => {
 		} );
 
 		it( 'should return true when the selection directly in the root', () => {
-			model.enqueueChange( 'transparent', () => {
+			model.enqueueChange( { isUndoable: false }, () => {
 				setModelData( model, '[]' );
 
 				expect( imageUtils.isImageAllowed() ).to.be.true;

--- a/packages/ckeditor5-image/tests/manual/tickets/106/1.js
+++ b/packages/ckeditor5-image/tests/manual/tickets/106/1.js
@@ -56,7 +56,7 @@ function startExternalInsert( editor ) {
 
 			function typing() {
 				wait( 40 ).then( () => {
-					model.enqueueChange( 'transparent', writer => {
+					model.enqueueChange( { isUndoable: false }, writer => {
 						writer.insertText( text[ index ], position );
 						position = position.getShiftedBy( 1 );
 
@@ -78,7 +78,7 @@ function startExternalInsert( editor ) {
 
 	function insertNewLine( path ) {
 		return wait( 200 ).then( () => {
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				writer.insertElement( 'paragraph', writer.createPositionFromPath( model.document.getRoot(), path ) );
 			} );
 
@@ -102,7 +102,7 @@ function startExternalDelete( editor ) {
 	const model = editor.model;
 
 	function removeSecondBlock() {
-		model.enqueueChange( 'transparent', writer => {
+		model.enqueueChange( { isUndoable: false }, writer => {
 			const start = writer.createPositionFromPath( model.document.getRoot(), [ 1 ] );
 			writer.remove( writer.createRange( start, start.getShiftedBy( 1 ) ) );
 		} );

--- a/packages/ckeditor5-link/src/autolink.js
+++ b/packages/ckeditor5-link/src/autolink.js
@@ -128,12 +128,10 @@ export default class AutoLink extends Plugin {
 			}
 		} );
 
-		const input = editor.plugins.get( 'Input' );
-
 		watcher.on( 'matched:data', ( evt, data ) => {
 			const { batch, range, url } = data;
 
-			if ( !input.isInput( batch ) ) {
+			if ( !batch.isTyping ) {
 				return;
 			}
 

--- a/packages/ckeditor5-link/src/linkediting.js
+++ b/packages/ckeditor5-link/src/linkediting.js
@@ -642,9 +642,9 @@ function shouldCopyAttributes( model ) {
 // @params {module:core/editor/editor~Editor} editor
 // @returns {Boolean}
 function isTyping( editor ) {
-	const input = editor.plugins.get( 'Input' );
+	const currentBatch = editor.model.change( writer => writer.batch );
 
-	return input.isInput( editor.model.change( writer => writer.batch ) );
+	return currentBatch.isTyping;
 }
 
 // Returns an array containing names of the attributes allowed on `$text` that describes the link item.

--- a/packages/ckeditor5-link/tests/manual/tickets/113/1.js
+++ b/packages/ckeditor5-link/tests/manual/tickets/113/1.js
@@ -58,7 +58,7 @@ function startExternalInsert( editor ) {
 
 			function typing() {
 				wait( 40 ).then( () => {
-					model.enqueueChange( 'transparent', writer => {
+					model.enqueueChange( { isUndoable: false }, writer => {
 						writer.insertText( text[ index ], position );
 						position = position.getShiftedBy( 1 );
 
@@ -80,7 +80,7 @@ function startExternalInsert( editor ) {
 
 	function insertNewLine( path ) {
 		return wait( 200 ).then( () => {
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				writer.insertElement( 'paragraph', writer.createPositionFromPath( model.document.getRoot(), path ) );
 			} );
 
@@ -104,7 +104,7 @@ function startExternalDelete( editor ) {
 	const model = editor.model;
 
 	wait( 3000 ).then( () => {
-		model.enqueueChange( 'transparent', writer => {
+		model.enqueueChange( { isUndoable: false }, writer => {
 			const start = writer.createPositionFromPath( model.document.getRoot(), [ 1 ] );
 			writer.remove( writer.createRange( start, start.getShiftedBy( 1 ) ) );
 		} );

--- a/packages/ckeditor5-list/tests/listediting.js
+++ b/packages/ckeditor5-list/tests/listediting.js
@@ -4823,7 +4823,7 @@ describe( 'ListEditing', () => {
 			const selection = parsedResult.selection;
 
 			// Ensure no undo step is generated.
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				// Replace existing model in document by new one.
 				writer.remove( writer.createRangeIn( modelRoot ) );
 				writer.insert( modelDocumentFragment, modelRoot );

--- a/packages/ckeditor5-media-embed/tests/automediaembed.js
+++ b/packages/ckeditor5-media-embed/tests/automediaembed.js
@@ -504,7 +504,7 @@ describe( 'AutoMediaEmbed - integration', () => {
 				const rootEl = editor.model.document.getRoot();
 
 				setTimeout( () => {
-					editor.model.enqueueChange( 'transparent', writer => {
+					editor.model.enqueueChange( { isUndoable: false }, writer => {
 						writer.insertText( characters[ i ], writer.createPositionFromPath( rootEl, [ 0, i ] ) );
 					} );
 				}, i * 5 );
@@ -526,7 +526,7 @@ describe( 'AutoMediaEmbed - integration', () => {
 
 			for ( let i = 0; i < 10; ++i ) {
 				setTimeout( () => {
-					editor.model.enqueueChange( 'transparent', writer => {
+					editor.model.enqueueChange( { isUndoable: false }, writer => {
 						writer.insertText( characters[ i ], editor.model.document.selection.getFirstPosition() );
 					} );
 				}, i * 5 );
@@ -546,7 +546,7 @@ describe( 'AutoMediaEmbed - integration', () => {
 
 			pasteHtml( editor, 'https://www.youtube.com/watch?v=H08tGjXNHO4' );
 
-			editor.model.enqueueChange( 'transparent', writer => {
+			editor.model.enqueueChange( { isUndoable: false }, writer => {
 				writer.remove( writer.createRangeOn( editor.model.document.getRoot().getChild( 1 ) ) );
 			} );
 
@@ -564,7 +564,7 @@ describe( 'AutoMediaEmbed - integration', () => {
 
 			pasteHtml( editor, 'https://www.youtube.com/watch?v=H08tGjXNHO4' );
 
-			editor.model.enqueueChange( 'transparent', writer => {
+			editor.model.enqueueChange( { isUndoable: false }, writer => {
 				const paragraph = writer.createElement( 'paragraph' );
 				writer.insert( paragraph, writer.createPositionAfter( editor.model.document.getRoot().getChild( 0 ) ) );
 				writer.setSelection( paragraph, 'in' );
@@ -572,7 +572,7 @@ describe( 'AutoMediaEmbed - integration', () => {
 
 			for ( let i = 0; i < 10; ++i ) {
 				setTimeout( () => {
-					editor.model.enqueueChange( 'transparent', writer => {
+					editor.model.enqueueChange( { isUndoable: false }, writer => {
 						writer.insertText( characters[ i ], editor.model.document.selection.getFirstPosition() );
 					} );
 				}, i * 5 );
@@ -595,7 +595,7 @@ describe( 'AutoMediaEmbed - integration', () => {
 
 			pasteHtml( editor, 'https://www.youtube.com/watch?v=H08tGjXNHO4' );
 
-			editor.model.enqueueChange( 'transparent', writer => {
+			editor.model.enqueueChange( { isUndoable: false }, writer => {
 				const paragraph = writer.createElement( 'paragraph' );
 				writer.insert( paragraph, writer.createPositionAfter( editor.model.document.getRoot().getChild( 1 ) ) );
 				writer.setSelection( paragraph, 'in' );
@@ -603,7 +603,7 @@ describe( 'AutoMediaEmbed - integration', () => {
 
 			for ( let i = 0; i < 10; ++i ) {
 				setTimeout( () => {
-					editor.model.enqueueChange( 'transparent', writer => {
+					editor.model.enqueueChange( { isUndoable: false }, writer => {
 						writer.insertText( characters[ i ], editor.model.document.selection.getFirstPosition() );
 					} );
 				}, i * 5 );

--- a/packages/ckeditor5-page-break/tests/pagebreakcommand.js
+++ b/packages/ckeditor5-page-break/tests/pagebreakcommand.js
@@ -40,7 +40,7 @@ describe( 'PageBreakCommand', () => {
 
 	describe( 'isEnabled', () => {
 		it( 'should be true when the selection directly in the root', () => {
-			model.enqueueChange( 'transparent', () => {
+			model.enqueueChange( { isUndoable: false }, () => {
 				setModelData( model, '[]' );
 
 				command.refresh();

--- a/packages/ckeditor5-source-editing/src/sourceediting.js
+++ b/packages/ckeditor5-source-editing/src/sourceediting.js
@@ -305,7 +305,7 @@ export default class SourceEditing extends Plugin {
 		}
 
 		if ( Object.keys( data ).length ) {
-			editor.data.set( data, { batchType: 'default' } );
+			editor.data.set( data, { batchType: { isUndoable: true } } );
 		}
 	}
 

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -428,7 +428,7 @@ describe( 'SourceEditing', () => {
 			expect( setDataSpy.calledOnce ).to.be.true;
 			expect( setDataSpy.firstCall.args[ 1 ] ).to.deep.equal( [
 				{ main: '<p>Foo</p><p>bar</p>' },
-				{ batchType: 'default' }
+				{ batchType: { isUndoable: true } }
 			] );
 			expect( editor.data.get() ).to.equal( '<p>Foo</p><p>bar</p>' );
 		} );
@@ -478,11 +478,11 @@ describe( 'SourceEditing', () => {
 			expect( setDataSpy.calledTwice ).to.be.true;
 			expect( setDataSpy.firstCall.args[ 1 ] ).to.deep.equal( [
 				{ main: 'foo' },
-				{ batchType: 'default' }
+				{ batchType: { isUndoable: true } }
 			] );
 			expect( setDataSpy.secondCall.args[ 1 ] ).to.deep.equal( [
 				{ main: 'bar' },
-				{ batchType: 'default' }
+				{ batchType: { isUndoable: true } }
 			] );
 			expect( editor.data.get() ).to.equal( '<p>bar</p>' );
 		} );

--- a/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellpropertycommand.js
+++ b/packages/ckeditor5-table/src/tablecellproperties/commands/tablecellpropertycommand.js
@@ -73,7 +73,7 @@ export default class TableCellPropertyCommand extends Command {
 		const tableCells = getSelectionAffectedTableCells( model.document.selection );
 		const valueToSet = this._getValueToSet( value );
 
-		model.enqueueChange( batch || 'default', writer => {
+		model.enqueueChange( batch, writer => {
 			if ( valueToSet ) {
 				tableCells.forEach( tableCell => writer.setAttribute( this.attributeName, valueToSet, tableCell ) );
 			} else {

--- a/packages/ckeditor5-table/src/tableproperties/commands/tablepropertycommand.js
+++ b/packages/ckeditor5-table/src/tableproperties/commands/tablepropertycommand.js
@@ -77,7 +77,7 @@ export default class TablePropertyCommand extends Command {
 		const table = selection.getFirstPosition().findAncestor( 'table' );
 		const valueToSet = this._getValueToSet( value );
 
-		model.enqueueChange( batch || 'default', writer => {
+		model.enqueueChange( batch, writer => {
 			if ( valueToSet ) {
 				writer.setAttribute( this.attributeName, valueToSet, table );
 			} else {

--- a/packages/ckeditor5-table/tests/converters/table-layout-post-fixer.js
+++ b/packages/ckeditor5-table/tests/converters/table-layout-post-fixer.js
@@ -393,7 +393,7 @@ describe( 'Table layout post-fixer', () => {
 
 			model.change( localCallback );
 
-			model.enqueueChange( 'transparent', externalCallback );
+			model.enqueueChange( { isUndoable: false }, externalCallback );
 
 			expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup( modelAfter );
 

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesui.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesui.js
@@ -280,8 +280,12 @@ describe( 'table cell properties', () => {
 			} );
 
 			describe( 'property changes', () => {
+				let batch;
+
 				beforeEach( () => {
-					tableCellPropertiesUI._undoStepBatch = 'foo';
+					batch = editor.model.createBatch();
+
+					tableCellPropertiesUI._undoStepBatch = batch;
 				} );
 
 				describe( '#borderStyle', () => {
@@ -291,7 +295,7 @@ describe( 'table cell properties', () => {
 						tableCellPropertiesView.borderStyle = 'dotted';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableCellBorderStyle', { value: 'dotted', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellBorderStyle', { value: 'dotted', batch } );
 					} );
 				} );
 
@@ -302,7 +306,7 @@ describe( 'table cell properties', () => {
 						tableCellPropertiesView.borderColor = '#FFAAFF';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableCellBorderColor', { value: '#FFAAFF', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellBorderColor', { value: '#FFAAFF', batch } );
 					} );
 
 					it( 'should display an error message if value is invalid', () => {
@@ -322,7 +326,7 @@ describe( 'table cell properties', () => {
 						clock.tick( 500 );
 
 						expect( tableCellPropertiesView.borderColorInput.errorText ).to.be.null;
-						sinon.assert.calledWithExactly( spy, 'tableCellBorderColor', { value: '#AAA', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellBorderColor', { value: '#AAA', batch } );
 					} );
 				} );
 
@@ -333,7 +337,7 @@ describe( 'table cell properties', () => {
 						tableCellPropertiesView.borderWidth = '12px';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableCellBorderWidth', { value: '12px', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellBorderWidth', { value: '12px', batch } );
 					} );
 
 					it( 'should display an error message if value is invalid', () => {
@@ -353,7 +357,7 @@ describe( 'table cell properties', () => {
 						clock.tick( 500 );
 
 						expect( tableCellPropertiesView.backgroundInput.errorText ).to.be.null;
-						sinon.assert.calledWithExactly( spy, 'tableCellBorderWidth', { value: '3em', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellBorderWidth', { value: '3em', batch } );
 					} );
 				} );
 
@@ -364,7 +368,7 @@ describe( 'table cell properties', () => {
 						tableCellPropertiesView.width = '12px';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableCellWidth', { value: '12px', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellWidth', { value: '12px', batch } );
 					} );
 
 					it( 'should display an error message if value is invalid', () => {
@@ -384,7 +388,7 @@ describe( 'table cell properties', () => {
 						clock.tick( 500 );
 
 						expect( tableCellPropertiesView.backgroundInput.errorText ).to.be.null;
-						sinon.assert.calledWithExactly( spy, 'tableCellWidth', { value: '3em', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellWidth', { value: '3em', batch } );
 					} );
 				} );
 
@@ -395,7 +399,7 @@ describe( 'table cell properties', () => {
 						tableCellPropertiesView.height = '12px';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableCellHeight', { value: '12px', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellHeight', { value: '12px', batch } );
 					} );
 
 					it( 'should display an error message if value is invalid', () => {
@@ -415,7 +419,7 @@ describe( 'table cell properties', () => {
 						clock.tick( 500 );
 
 						expect( tableCellPropertiesView.backgroundInput.errorText ).to.be.null;
-						sinon.assert.calledWithExactly( spy, 'tableCellHeight', { value: '3em', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellHeight', { value: '3em', batch } );
 					} );
 				} );
 
@@ -426,7 +430,7 @@ describe( 'table cell properties', () => {
 						tableCellPropertiesView.padding = '12px';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableCellPadding', { value: '12px', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellPadding', { value: '12px', batch } );
 					} );
 
 					it( 'should display an error message if value is invalid', () => {
@@ -446,7 +450,7 @@ describe( 'table cell properties', () => {
 						clock.tick( 500 );
 
 						expect( tableCellPropertiesView.backgroundInput.errorText ).to.be.null;
-						sinon.assert.calledWithExactly( spy, 'tableCellPadding', { value: '3em', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellPadding', { value: '3em', batch } );
 					} );
 				} );
 
@@ -457,7 +461,7 @@ describe( 'table cell properties', () => {
 						tableCellPropertiesView.backgroundColor = '#FFAAFF';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableCellBackgroundColor', { value: '#FFAAFF', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellBackgroundColor', { value: '#FFAAFF', batch } );
 					} );
 
 					it( 'should display an error message if value is invalid', () => {
@@ -477,7 +481,7 @@ describe( 'table cell properties', () => {
 						clock.tick( 500 );
 
 						expect( tableCellPropertiesView.backgroundInput.errorText ).to.be.null;
-						sinon.assert.calledWithExactly( spy, 'tableCellBackgroundColor', { value: '#AAA', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellBackgroundColor', { value: '#AAA', batch } );
 					} );
 				} );
 
@@ -488,7 +492,7 @@ describe( 'table cell properties', () => {
 						tableCellPropertiesView.horizontalAlignment = 'right';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableCellHorizontalAlignment', { value: 'right', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellHorizontalAlignment', { value: 'right', batch } );
 					} );
 				} );
 
@@ -499,7 +503,7 @@ describe( 'table cell properties', () => {
 						tableCellPropertiesView.verticalAlignment = 'right';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableCellVerticalAlignment', { value: 'right', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableCellVerticalAlignment', { value: 'right', batch } );
 					} );
 				} );
 

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
@@ -281,8 +281,12 @@ describe( 'table properties', () => {
 			} );
 
 			describe( 'property changes', () => {
+				let batch;
+
 				beforeEach( () => {
-					tablePropertiesUI._undoStepBatch = 'foo';
+					batch = editor.model.createBatch();
+
+					tablePropertiesUI._undoStepBatch = batch;
 				} );
 
 				describe( '#borderStyle', () => {
@@ -292,7 +296,7 @@ describe( 'table properties', () => {
 						tablePropertiesView.borderStyle = 'dotted';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableBorderStyle', { value: 'dotted', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableBorderStyle', { value: 'dotted', batch } );
 					} );
 				} );
 
@@ -303,7 +307,7 @@ describe( 'table properties', () => {
 						tablePropertiesView.borderColor = '#FFAAFF';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableBorderColor', { value: '#FFAAFF', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableBorderColor', { value: '#FFAAFF', batch } );
 					} );
 
 					it( 'should display an error message if value is invalid', () => {
@@ -323,7 +327,7 @@ describe( 'table properties', () => {
 						clock.tick( 500 );
 
 						expect( tablePropertiesView.borderColorInput.errorText ).to.be.null;
-						sinon.assert.calledWithExactly( spy, 'tableBorderColor', { value: '#AAA', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableBorderColor', { value: '#AAA', batch } );
 					} );
 				} );
 
@@ -334,7 +338,7 @@ describe( 'table properties', () => {
 						tablePropertiesView.borderWidth = '12px';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableBorderWidth', { value: '12px', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableBorderWidth', { value: '12px', batch } );
 					} );
 
 					it( 'should display an error message if value is invalid', () => {
@@ -354,7 +358,7 @@ describe( 'table properties', () => {
 						clock.tick( 500 );
 
 						expect( tablePropertiesView.backgroundInput.errorText ).to.be.null;
-						sinon.assert.calledWithExactly( spy, 'tableBorderWidth', { value: '3em', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableBorderWidth', { value: '3em', batch } );
 					} );
 				} );
 
@@ -365,7 +369,7 @@ describe( 'table properties', () => {
 						tablePropertiesView.backgroundColor = '#FFAAFF';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableBackgroundColor', { value: '#FFAAFF', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableBackgroundColor', { value: '#FFAAFF', batch } );
 					} );
 
 					it( 'should display an error message if value is invalid', () => {
@@ -385,7 +389,7 @@ describe( 'table properties', () => {
 						clock.tick( 500 );
 
 						expect( tablePropertiesView.backgroundInput.errorText ).to.be.null;
-						sinon.assert.calledWithExactly( spy, 'tableBackgroundColor', { value: '#AAA', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableBackgroundColor', { value: '#AAA', batch } );
 					} );
 				} );
 
@@ -396,7 +400,7 @@ describe( 'table properties', () => {
 						tablePropertiesView.width = '12px';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableWidth', { value: '12px', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableWidth', { value: '12px', batch } );
 					} );
 
 					it( 'should display an error message if value is invalid', () => {
@@ -416,7 +420,7 @@ describe( 'table properties', () => {
 						clock.tick( 500 );
 
 						expect( tablePropertiesView.backgroundInput.errorText ).to.be.null;
-						sinon.assert.calledWithExactly( spy, 'tableWidth', { value: '3em', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableWidth', { value: '3em', batch } );
 					} );
 				} );
 
@@ -427,7 +431,7 @@ describe( 'table properties', () => {
 						tablePropertiesView.height = '12px';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableHeight', { value: '12px', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableHeight', { value: '12px', batch } );
 					} );
 
 					it( 'should display an error message if value is invalid', () => {
@@ -447,7 +451,7 @@ describe( 'table properties', () => {
 						clock.tick( 500 );
 
 						expect( tablePropertiesView.backgroundInput.errorText ).to.be.null;
-						sinon.assert.calledWithExactly( spy, 'tableHeight', { value: '3em', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableHeight', { value: '3em', batch } );
 					} );
 				} );
 
@@ -458,7 +462,7 @@ describe( 'table properties', () => {
 						tablePropertiesView.alignment = 'right';
 
 						sinon.assert.calledOnce( spy );
-						sinon.assert.calledWithExactly( spy, 'tableAlignment', { value: 'right', batch: 'foo' } );
+						sinon.assert.calledWithExactly( spy, 'tableAlignment', { value: 'right', batch } );
 					} );
 				} );
 

--- a/packages/ckeditor5-typing/src/input.js
+++ b/packages/ckeditor5-typing/src/input.js
@@ -40,27 +40,4 @@ export default class Input extends Plugin {
 		injectUnsafeKeystrokesHandling( editor );
 		injectTypingMutationsHandling( editor );
 	}
-
-	/**
-	 * Checks batch if it is a result of user input - e.g. typing.
-	 *
-	 *		const input = editor.plugins.get( 'Input' );
-	 *
-	 *		editor.model.document.on( 'change:data', ( evt, batch ) => {
-	 *			if ( input.isInput( batch ) ) {
-	 *				console.log( 'The user typed something...' );
-	 *			}
-	 *		} );
-	 *
-	 * **Note:** This method checks if the batch was created using {@link module:typing/inputcommand~InputCommand 'input'}
-	 * command as typing changes coming from user input are inserted to the document using that command.
-	 *
-	 * @param {module:engine/model/batch~Batch} batch A batch to check.
-	 * @returns {Boolean}
-	 */
-	isInput( batch ) {
-		const inputCommand = this.editor.commands.get( 'input' );
-
-		return inputCommand._batches.has( batch );
-	}
 }

--- a/packages/ckeditor5-typing/src/inputcommand.js
+++ b/packages/ckeditor5-typing/src/inputcommand.js
@@ -35,15 +35,6 @@ export default class InputCommand extends Command {
 		 * @member {module:typing/utils/changebuffer~ChangeBuffer} #_buffer
 		 */
 		this._buffer = new ChangeBuffer( editor.model, undoStepSize );
-
-		/**
-		 * Stores batches created by the input command. The batches are used to differentiate input batches from other batches using
-		 * {@link module:typing/input~Input#isInput} method.
-		 *
-		 * @type {WeakSet<module:engine/model/batch~Batch>}
-		 * @protected
-		 */
-		this._batches = new WeakSet();
 	}
 
 	/**
@@ -88,9 +79,6 @@ export default class InputCommand extends Command {
 
 		model.enqueueChange( this._buffer.batch, writer => {
 			this._buffer.lock();
-
-			// Store the batch as an 'input' batch for the Input.isInput( batch ) check.
-			this._batches.add( this._buffer.batch );
 
 			model.deleteContent( selection );
 

--- a/packages/ckeditor5-typing/src/texttransformation.js
+++ b/packages/ckeditor5-typing/src/texttransformation.js
@@ -124,7 +124,6 @@ export default class TextTransformation extends Plugin {
 	_enableTransformationWatchers() {
 		const editor = this.editor;
 		const model = editor.model;
-		const inputPlugin = editor.plugins.get( 'Input' );
 		const deletePlugin = editor.plugins.get( 'Delete' );
 		const normalizedTransformations = normalizeTransformations( editor.config.get( 'typing.transformations' ) );
 
@@ -140,7 +139,7 @@ export default class TextTransformation extends Plugin {
 		};
 
 		const watcherCallback = ( evt, data ) => {
-			if ( !inputPlugin.isInput( data.batch ) ) {
+			if ( !data.batch.isTyping ) {
 				return;
 			}
 
@@ -249,8 +248,9 @@ function normalizeTransformations( config ) {
 	const configured = config.include.concat( extra ).filter( isNotRemoved );
 
 	return expandGroupsAndRemoveDuplicates( configured )
-		.filter( isNotRemoved ) // Filter out 'remove' transformations as they might be set in group
+		.filter( isNotRemoved ) // Filter out 'remove' transformations as they might be set in group.
 		.map( transformation => TRANSFORMATIONS[ transformation ] || transformation )
+		.filter( transformation => typeof transformation === 'object' ) // Filter out transformations set as string that has not been found.
 		.map( transformation => ( {
 			from: normalizeFrom( transformation.from ),
 			to: normalizeTo( transformation.to )

--- a/packages/ckeditor5-typing/src/textwatcher.js
+++ b/packages/ckeditor5-typing/src/textwatcher.js
@@ -117,7 +117,7 @@ export default class TextWatcher {
 		} );
 
 		this.listenTo( document, 'change:data', ( evt, batch ) => {
-			if ( batch.type == 'transparent' ) {
+			if ( batch.isUndo || !batch.isLocal ) {
 				return;
 			}
 

--- a/packages/ckeditor5-typing/src/utils/changebuffer.js
+++ b/packages/ckeditor5-typing/src/utils/changebuffer.js
@@ -70,10 +70,10 @@ export default class ChangeBuffer {
 		// The callback will check whether it is a new batch and in that case the buffer will be flushed.
 		//
 		// The reason why the buffer needs to be flushed whenever a new batch appears is that the changes added afterwards
-		// should be added to a new batch. For instance, when the  user types, then inserts an image, and then types again,
+		// should be added to a new batch. For instance, when the user types, then inserts an image, and then types again,
 		// the characters typed after inserting the image should be added to a different batch than the characters typed before.
 		this._changeCallback = ( evt, batch ) => {
-			if ( batch.type != 'transparent' && batch !== this._batch ) {
+			if ( batch.isLocal && batch.isUndoable && batch !== this._batch ) {
 				this._reset( true );
 			}
 		};
@@ -117,7 +117,7 @@ export default class ChangeBuffer {
 	 */
 	get batch() {
 		if ( !this._batch ) {
-			this._batch = this.model.createBatch();
+			this._batch = this.model.createBatch( { isTyping: true } );
 		}
 
 		return this._batch;

--- a/packages/ckeditor5-typing/src/utils/injectunsafekeystrokeshandling.js
+++ b/packages/ckeditor5-typing/src/utils/injectunsafekeystrokeshandling.js
@@ -121,7 +121,6 @@ export default function injectUnsafeKeystrokesHandling( editor ) {
 		buffer.lock();
 
 		const batch = buffer.batch;
-		inputCommand._batches.add( batch );
 
 		model.enqueueChange( batch, () => {
 			model.deleteContent( model.document.selection );

--- a/packages/ckeditor5-typing/tests/input.js
+++ b/packages/ckeditor5-typing/tests/input.js
@@ -82,29 +82,6 @@ describe( 'Input feature', () => {
 		return editor.destroy();
 	} );
 
-	describe( 'isInput()', () => {
-		let input;
-
-		beforeEach( () => {
-			input = editor.plugins.get( 'Input' );
-		} );
-
-		it( 'returns true for batch created using "input" command', done => {
-			model.document.once( 'change:data', ( evt, batch ) => {
-				expect( input.isInput( batch ) ).to.be.true;
-				done();
-			} );
-
-			editor.execute( 'input', { text: 'foo' } );
-		} );
-
-		it( 'returns false for batch not created using "input" command', () => {
-			const batch = model.createBatch();
-
-			expect( input.isInput( batch ) ).to.be.false;
-		} );
-	} );
-
 	describe( 'mutations handling', () => {
 		it( 'should handle text mutation', () => {
 			viewDocument.fire( 'mutations', [

--- a/packages/ckeditor5-typing/tests/inputcommand.js
+++ b/packages/ckeditor5-typing/tests/inputcommand.js
@@ -283,14 +283,20 @@ describe( 'InputCommand', () => {
 		} );
 
 		it( 'uses typing batch while removing and inserting the content', () => {
-			expect( inputCommand._batches.has( getCurrentBatch() ), 'batch before typing' ).to.equal( false );
+			let currentBatch = getCurrentBatch();
+
+			expect( currentBatch.isTyping, 'batch before typing' ).to.equal( false );
 
 			model.on( 'deleteContent', () => {
-				expect( inputCommand._batches.has( getCurrentBatch() ), 'batch when deleting content' ).to.equal( true );
+				currentBatch = getCurrentBatch();
+
+				expect( currentBatch.isTyping, 'batch when deleting content' ).to.equal( true );
 			}, { priority: 'highest' } );
 
 			model.on( 'insertContent', () => {
-				expect( inputCommand._batches.has( getCurrentBatch() ), 'batch when inserting content' ).to.equal( true );
+				currentBatch = getCurrentBatch();
+
+				expect( currentBatch.isTyping, 'batch when inserting content' ).to.equal( true );
 			}, { priority: 'lowest' } );
 
 			setData( model, '<paragraph>[foo]</paragraph>' );

--- a/packages/ckeditor5-typing/tests/textwatcher.js
+++ b/packages/ckeditor5-typing/tests/textwatcher.js
@@ -102,8 +102,16 @@ describe( 'TextWatcher', () => {
 			sinon.assert.calledWithExactly( testCallbackStub, '@' );
 		} );
 
-		it( 'should not evaluate text for transparent batches', () => {
-			model.enqueueChange( 'transparent', writer => {
+		it( 'should not evaluate text for undo batches', () => {
+			model.enqueueChange( { isUndo: true }, writer => {
+				writer.insertText( '@', doc.selection.getFirstPosition() );
+			} );
+
+			sinon.assert.notCalled( testCallbackStub );
+		} );
+
+		it( 'should not evaluate text for non-local batches', () => {
+			model.enqueueChange( { isLocal: false }, writer => {
 				writer.insertText( '@', doc.selection.getFirstPosition() );
 			} );
 
@@ -192,7 +200,7 @@ describe( 'TextWatcher', () => {
 		it( 'should fire "matched:selection" event when test callback returns true for model data changes', () => {
 			testCallbackStub.returns( true );
 
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isLocal: false }, writer => {
 				writer.insertText( '@', doc.selection.getFirstPosition() );
 			} );
 
@@ -212,7 +220,7 @@ describe( 'TextWatcher', () => {
 
 			testCallbackStub.returns( true );
 
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				writer.insertText( '@', doc.selection.getFirstPosition() );
 			} );
 

--- a/packages/ckeditor5-typing/tests/twostepcaretmovement.js
+++ b/packages/ckeditor5-typing/tests/twostepcaretmovement.js
@@ -820,7 +820,7 @@ describe( 'TwoStepCaretMovement()', () => {
 		] );
 
 		// Simulate an external text insertion BEFORE the user selection to trigger #change:range.
-		model.enqueueChange( 'transparent', writer => {
+		model.enqueueChange( { isUndoable: false }, writer => {
 			writer.insertText( 'x', selection.getFirstPosition().getShiftedBy( -2 ) );
 		} );
 

--- a/packages/ckeditor5-typing/tests/utils/changebuffer.js
+++ b/packages/ckeditor5-typing/tests/utils/changebuffer.js
@@ -141,7 +141,7 @@ describe( 'ChangeBuffer', () => {
 		it( 'is not reset when changes are applied in transparent batch', () => {
 			const bufferBatch = buffer.batch;
 
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				writer.insert( 'a', root );
 			} );
 

--- a/packages/ckeditor5-typing/tests/utils/injectunsafekeystrokeshandling.js
+++ b/packages/ckeditor5-typing/tests/utils/injectunsafekeystrokeshandling.js
@@ -109,12 +109,14 @@ describe( 'unsafe keystroke handling utils', () => {
 		} );
 
 		it( 'uses typing batch while removing the content', () => {
-			const inputCommand = editor.commands.get( 'input' );
+			let currentBatch = getCurrentBatch();
 
-			expect( inputCommand._batches.has( getCurrentBatch() ), 'batch before typing' ).to.equal( false );
+			expect( currentBatch.isTyping, 'batch before typing' ).to.equal( false );
 
 			model.on( 'deleteContent', () => {
-				expect( inputCommand._batches.has( getCurrentBatch() ), 'batch when deleting content' ).to.equal( true );
+				currentBatch = getCurrentBatch();
+
+				expect( currentBatch.isTyping, 'batch when deleting content' ).to.equal( true );
 			}, { priority: 'highest' } );
 
 			setData( model, '<paragraph>[foo]</paragraph>' );

--- a/packages/ckeditor5-ui/tests/manual/blocktoolbar/blocktoolbar.js
+++ b/packages/ckeditor5-ui/tests/manual/blocktoolbar/blocktoolbar.js
@@ -59,7 +59,7 @@ function createExternalChangesSimulator( editor ) {
 	}
 
 	function insertNewLine( path ) {
-		model.enqueueChange( 'transparent', writer => {
+		model.enqueueChange( { isUndoable: false }, writer => {
 			writer.insertElement( 'paragraph', writer.createPositionFromPath( model.document.getRoot(), path ) );
 		} );
 
@@ -73,7 +73,7 @@ function createExternalChangesSimulator( editor ) {
 
 			function typing() {
 				wait( 40 ).then( () => {
-					model.enqueueChange( 'transparent', writer => {
+					model.enqueueChange( { isUndoable: false }, writer => {
 						writer.insertText( text[ index ], position );
 						position = position.getShiftedBy( 1 );
 
@@ -94,7 +94,7 @@ function createExternalChangesSimulator( editor ) {
 	}
 
 	function removeElement( path ) {
-		model.enqueueChange( 'transparent', writer => {
+		model.enqueueChange( { isUndoable: false }, writer => {
 			const start = writer.createPositionFromPath( model.document.getRoot(), path );
 
 			writer.remove( writer.createRange( start, start.getShiftedBy( 1 ) ) );

--- a/packages/ckeditor5-ui/tests/manual/contextualballoon/externalchanges.js
+++ b/packages/ckeditor5-ui/tests/manual/contextualballoon/externalchanges.js
@@ -61,7 +61,7 @@ function startExternalInsert( editor ) {
 
 			function typing() {
 				wait( 40 ).then( () => {
-					model.enqueueChange( 'transparent', writer => {
+					model.enqueueChange( { isUndoable: false }, writer => {
 						writer.insertText( text[ index ], position );
 						position = position.getShiftedBy( 1 );
 
@@ -83,7 +83,7 @@ function startExternalInsert( editor ) {
 
 	function insertNewLine( path ) {
 		return wait( 200 ).then( () => {
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				writer.insertElement( 'paragraph', writer.createPositionFromPath( model.document.getRoot(), path ) );
 			} );
 
@@ -107,7 +107,7 @@ function startExternalDelete( editor ) {
 	const model = editor.model;
 
 	wait( 3000 ).then( () => {
-		model.enqueueChange( 'transparent', writer => {
+		model.enqueueChange( { isUndoable: false }, writer => {
 			const start = writer.createPositionFromPath( model.document.getRoot(), [ 1 ] );
 
 			writer.remove( writer.createRange( start, start.getShiftedBy( 1 ) ) );

--- a/packages/ckeditor5-ui/tests/manual/tickets/198/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/198/1.js
@@ -61,7 +61,7 @@ function startExternalInsert( editor ) {
 
 			function typing() {
 				wait( 40 ).then( () => {
-					model.enqueueChange( 'transparent', writer => {
+					model.enqueueChange( { isUndoable: false }, writer => {
 						writer.insertText( text[ index ], position );
 						position = position.getShiftedBy( 1 );
 
@@ -83,7 +83,7 @@ function startExternalInsert( editor ) {
 
 	function insertNewLine( path ) {
 		return wait( 200 ).then( () => {
-			model.enqueueChange( 'transparent', writer => {
+			model.enqueueChange( { isUndoable: false }, writer => {
 				writer.insertElement( 'paragraph', writer.createPositionFromPath( model.document.getRoot(), path ) );
 			} );
 
@@ -107,7 +107,7 @@ function startExternalDelete( editor ) {
 	const model = editor.model;
 
 	wait( 3000 ).then( () => {
-		model.enqueueChange( 'transparent', writer => {
+		model.enqueueChange( { isUndoable: false }, writer => {
 			const start = writer.createPositionFromPath( model.document.getRoot(), [ 1 ] );
 
 			writer.remove( writer.createRange( start, start.getShiftedBy( 1 ) ) );

--- a/packages/ckeditor5-undo/src/basecommand.js
+++ b/packages/ckeditor5-undo/src/basecommand.js
@@ -51,20 +51,19 @@ export default class BaseCommand extends Command {
 
 			const options = data[ 1 ];
 
-			if ( options.batchType ) {
-				return;
+			// If batch type is not set, default to non-undoable batch.
+			if ( !options.batchType ) {
+				options.batchType = { isUndoable: false };
 			}
-
-			options.batchType = 'transparent';
 		}, { priority: 'high' } );
 
 		// Clear the stack for the `transparent` batches.
 		this.listenTo( editor.data, 'set', ( evt, data ) => {
-			// We can assume that the object exists - it was ensured
-			// with the high priority listener before.
+			// We can assume that the object exists and it has `batchType` property.
+			// It was ensured with a higher priority listener before.
 			const options = data[ 1 ];
 
-			if ( options.batchType === 'transparent' ) {
+			if ( !options.batchType.isUndoable ) {
 				this.clearStack();
 			}
 		} );

--- a/packages/ckeditor5-undo/src/redocommand.js
+++ b/packages/ckeditor5-undo/src/redocommand.js
@@ -30,7 +30,7 @@ export default class RedoCommand extends BaseCommand {
 	 */
 	execute() {
 		const item = this._stack.pop();
-		const redoingBatch = this.editor.model.createBatch( 'transparent' );
+		const redoingBatch = this.editor.model.createBatch( { isUndo: true } );
 
 		// All changes have to be done in one `enqueueChange` callback so other listeners will not step between consecutive
 		// operations, or won't do changes to the document before selection is properly restored.

--- a/packages/ckeditor5-undo/src/undocommand.js
+++ b/packages/ckeditor5-undo/src/undocommand.js
@@ -33,7 +33,7 @@ export default class UndoCommand extends BaseCommand {
 		const batchIndex = batch ? this._stack.findIndex( a => a.batch == batch ) : this._stack.length - 1;
 
 		const item = this._stack.splice( batchIndex, 1 )[ 0 ];
-		const undoingBatch = this.editor.model.createBatch( 'transparent' );
+		const undoingBatch = this.editor.model.createBatch( { isUndo: true } );
 
 		// All changes has to be done in one `enqueueChange` callback so other listeners will not
 		// step between consecutive operations, or won't do changes to the document before selection is properly restored.

--- a/packages/ckeditor5-undo/src/undoediting.js
+++ b/packages/ckeditor5-undo/src/undoediting.js
@@ -87,25 +87,29 @@ export default class UndoEditing extends Plugin {
 
 			const isRedoBatch = this._redoCommand._createdBatches.has( batch );
 			const isUndoBatch = this._undoCommand._createdBatches.has( batch );
-			const isRegisteredBatch = this._batchRegistry.has( batch );
+			const wasProcessed = this._batchRegistry.has( batch );
 
-			// If changes are not a part of a batch or this is not a new batch, omit those changes.
-			if ( isRegisteredBatch || ( batch.type == 'transparent' && !isRedoBatch && !isUndoBatch ) ) {
+			// Skip the batch if it was already processed.
+			if ( wasProcessed ) {
 				return;
-			} else {
-				if ( isRedoBatch ) {
-					// If this batch comes from `redoCommand`, add it to `undoCommand` stack.
-					this._undoCommand.addBatch( batch );
-				} else if ( !isUndoBatch ) {
-					// A default batch - these are new changes in the document, not introduced by undo feature.
-					// Add them to `undoCommand` stack and clear `redoCommand` stack.
-					this._undoCommand.addBatch( batch );
-					this._redoCommand.clearStack();
-				}
 			}
 
 			// Add the batch to the registry so it will not be processed again.
 			this._batchRegistry.add( batch );
+
+			if ( !batch.isUndoable ) {
+				return;
+			}
+
+			if ( isRedoBatch ) {
+				// If this batch comes from `redoCommand`, add it to `undoCommand` stack.
+				this._undoCommand.addBatch( batch );
+			} else if ( !isUndoBatch ) {
+				// If the batch neither comes from `redoCommand` or `undoCommand` then this is a new, regular batch.
+				// Add the batch to the `undoCommand` stack and clear `redoCommand` stack.
+				this._undoCommand.addBatch( batch );
+				this._redoCommand.clearStack();
+			}
 		}, { priority: 'highest' } );
 
 		this.listenTo( this._undoCommand, 'revert', ( evt, undoneBatch, undoingBatch ) => {

--- a/packages/ckeditor5-undo/tests/redocommand.js
+++ b/packages/ckeditor5-undo/tests/redocommand.js
@@ -298,18 +298,18 @@ describe( 'RedoCommand', () => {
 			sinon.assert.called( spy );
 		} );
 
-		it( 'should clear stack on DataController set() when the `batchType` is set to `transparent`', () => {
+		it( 'should clear stack on DataController set() when the batch is set as not undoable', () => {
 			const spy = sinon.stub( redo, 'clearStack' );
 
-			editor.setData( 'foo' );
+			editor.data.set( 'foo', { batchType: { isUndoable: false } } );
 
 			sinon.assert.called( spy );
 		} );
 
-		it( 'should not clear stack on DataController#set() when the `batchType` is set to `default`', () => {
+		it( 'should not clear stack on DataController#set() when the batch is set as undoable', () => {
 			const spy = sinon.spy( redo, 'clearStack' );
 
-			editor.data.set( 'foo', { batchType: 'default' } );
+			editor.data.set( 'foo', { batchType: { isUndoable: true } } );
 
 			sinon.assert.notCalled( spy );
 		} );
@@ -325,7 +325,7 @@ describe( 'RedoCommand', () => {
 			const data = firstCall.args[ 1 ];
 
 			expect( data[ 1 ] ).to.be.an( 'object' );
-			expect( data[ 1 ] ).to.have.property( 'batchType', 'transparent' );
+			expect( data[ 1 ].batchType ).to.deep.equal( { isUndoable: false } );
 		} );
 
 		it( 'should not override the batch type in editor.data.set() when the batch type is set', () => {
@@ -333,13 +333,13 @@ describe( 'RedoCommand', () => {
 
 			editor.data.on( 'set', dataSetSpy, { priority: 'lowest' } );
 
-			editor.data.set( 'foo', { batchType: 'default' } );
+			editor.data.set( 'foo', { batchType: { isUndoable: true } } );
 
 			const firstCall = dataSetSpy.firstCall;
 			const data = firstCall.args[ 1 ];
 
 			expect( data[ 1 ] ).to.be.an( 'object' );
-			expect( data[ 1 ] ).to.have.property( 'batchType', 'default' );
+			expect( data[ 1 ].batchType ).to.deep.equal( { isUndoable: true } );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-undo/tests/undocommand.js
+++ b/packages/ckeditor5-undo/tests/undocommand.js
@@ -357,18 +357,18 @@ describe( 'UndoCommand', () => {
 			sinon.assert.called( spy );
 		} );
 
-		it( 'should clear stack on DataController set() when the `batchType` is set to `transparent`', () => {
+		it( 'should clear stack on DataController set() when the batch is set as not undoable', () => {
 			const spy = sinon.stub( undo, 'clearStack' );
 
-			editor.setData( 'foo' );
+			editor.data.set( 'foo', { batchType: { isUndoable: false } } );
 
 			sinon.assert.called( spy );
 		} );
 
-		it( 'should not clear stack on DataController#set() when the `batchType` is set to `default`', () => {
+		it( 'should not clear stack on DataController#set() when the batch is set as undoable', () => {
 			const spy = sinon.spy( undo, 'clearStack' );
 
-			editor.data.set( 'foo', { batchType: 'default' } );
+			editor.data.set( 'foo', { batchType: { isUndoable: true } } );
 
 			sinon.assert.notCalled( spy );
 		} );
@@ -384,7 +384,7 @@ describe( 'UndoCommand', () => {
 			const data = firstCall.args[ 1 ];
 
 			expect( data[ 1 ] ).to.be.an( 'object' );
-			expect( data[ 1 ] ).to.have.property( 'batchType', 'transparent' );
+			expect( data[ 1 ].batchType ).to.deep.equal( { isUndoable: false } );
 		} );
 
 		it( 'should not override the batch type in editor.data.set() when the batch type is set', () => {
@@ -392,13 +392,13 @@ describe( 'UndoCommand', () => {
 
 			editor.data.on( 'set', dataSetSpy, { priority: 'lowest' } );
 
-			editor.data.set( 'foo', { batchType: 'default' } );
+			editor.data.set( 'foo', { batchType: { isUndoable: true } } );
 
 			const firstCall = dataSetSpy.firstCall;
 			const data = firstCall.args[ 1 ];
 
 			expect( data[ 1 ] ).to.be.an( 'object' );
-			expect( data[ 1 ] ).to.have.property( 'batchType', 'default' );
+			expect( data[ 1 ].batchType ).to.deep.equal( { isUndoable: true } );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-undo/tests/undoediting-integration.js
+++ b/packages/ckeditor5-undo/tests/undoediting-integration.js
@@ -53,7 +53,7 @@ describe( 'UndoEditing integration', () => {
 	}
 
 	function input( input ) {
-		model.enqueueChange( 'transparent', () => {
+		model.enqueueChange( { isUndoable: false }, () => {
 			setData( model, input );
 		} );
 	}

--- a/packages/ckeditor5-undo/tests/undoediting.js
+++ b/packages/ckeditor5-undo/tests/undoediting.js
@@ -120,7 +120,7 @@ describe( 'UndoEditing', () => {
 	it( 'should not add a transparent batch', () => {
 		sinon.spy( undo._undoCommand, 'addBatch' );
 
-		model.enqueueChange( 'transparent', writer => {
+		model.enqueueChange( { isUndoable: false }, writer => {
 			writer.insertText( 'foobar', root );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature: Replaced `Batch#type` with a set of flags: `isUndoable`, `isLocal`, `isUndo`, `isTyping` which better represent the batch type. `Batch` constructor and `Model#enqueueChange()` now expect an object. Closes #10967.

Fix (typing): Fixed editor crash when an unrecognized transformation was given in configuration (as a string).

Other (typing): Typing feature will now create batches with `isTyping` set to `true`.

Other (undo): Undo feature will now create batches with `isUndo` set to `true`.

BREAKING CHANGE (engine): `Batch#type` has been removed. Use `Batch#isUndoable`, `#isLocal`, `#isUndo` and `#isTyping` instead.

BREAKING CHANGE (typing): `Input#isInput()` has been removed. Use `Batch#isTyping` instead.

MINOR BREAKING CHANGE (engine): String value for `Batch` type and `Model#enqueueChange()` is now deprecated. Using string value will log a warning in the console. Use an object value instead. For more information, refer to the API documentation.