### PR TITLE
Replaced bump-year logic with execution of an external function

### DIFF
--- a/packages/ckeditor5-find-and-replace/tests/findandreplaceediting.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplaceediting.js
@@ -1,3 +1,7 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
 
 import FindAndReplaceEditing from '../src/findandreplaceediting';
 

--- a/packages/ckeditor5-html-support/tests/integrations/image.js
+++ b/packages/ckeditor5-html-support/tests/integrations/image.js
@@ -1,7 +1,7 @@
 /**
  * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
-*/
+ */
 
 import { range } from 'lodash-es';
 

--- a/packages/ckeditor5-html-support/tests/integrations/mediaembed.js
+++ b/packages/ckeditor5-html-support/tests/integrations/mediaembed.js
@@ -1,7 +1,7 @@
 /**
  * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
-*/
+ */
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';

--- a/packages/ckeditor5-html-support/tests/integrations/table.js
+++ b/packages/ckeditor5-html-support/tests/integrations/table.js
@@ -1,7 +1,7 @@
 /**
  * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
-*/
+ */
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';

--- a/packages/ckeditor5-html-support/tests/manual/htmlcomment.js
+++ b/packages/ckeditor5-html-support/tests/manual/htmlcomment.js
@@ -1,5 +1,10 @@
 /* global document, window, console */
 
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices';

--- a/packages/ckeditor5-html-support/tests/manual/mediaembed.js
+++ b/packages/ckeditor5-html-support/tests/manual/mediaembed.js
@@ -1,5 +1,5 @@
 /**
- * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 

--- a/packages/ckeditor5-table/src/tablecaption/tablecaptionui.js
+++ b/packages/ckeditor5-table/src/tablecaption/tablecaptionui.js
@@ -1,7 +1,7 @@
 /**
-* @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
-* For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
-*/
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
 
 /**
 * @module table/tablecaption/tablecaptionui

--- a/packages/ckeditor5-table/src/tablecaption/toggletablecaptioncommand.js
+++ b/packages/ckeditor5-table/src/tablecaption/toggletablecaptioncommand.js
@@ -1,7 +1,7 @@
 /**
-* @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
-* For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
-*/
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
 
 /**
 * @module table/tablecaption/toggletablecaptioncommand

--- a/packages/ckeditor5-typing/tests/spellchecking.js
+++ b/packages/ckeditor5-typing/tests/spellchecking.js
@@ -1,4 +1,4 @@
-/*
+/**
  * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */

--- a/scripts/bump-year.js
+++ b/scripts/bump-year.js
@@ -23,7 +23,6 @@ git commit -am "Internal: Bumped the year." && git push
 require( '@ckeditor/ckeditor5-dev-env' )
 	.bumpYear( {
 		cwd: process.cwd(),
-		initialYear: '2003',
 		globPatterns: [
 			{ // LICENSE.md, .eslintrc.js, etc.
 				pattern: '*',

--- a/scripts/bump-year.js
+++ b/scripts/bump-year.js
@@ -31,11 +31,10 @@ require( '@ckeditor/ckeditor5-dev-env' )
 				}
 			},
 			{
-				pattern: '!(build|coverage|node_modules|external)/**',
+				pattern: '!(build|coverage|external)/**',
 				options: {
 					ignore: [
-						'**/ckeditor5-build-*/**',
-						'**/src/lib/**'
+						'**/ckeditor5-build-*/build/**'
 					]
 				}
 			}

--- a/scripts/bump-year.js
+++ b/scripts/bump-year.js
@@ -22,11 +22,23 @@ git commit -am "Internal: Bumped the year." && git push
 
 require( '@ckeditor/ckeditor5-dev-env' )
 	.bumpYear( {
+		cwd: process.cwd(),
 		initialYear: '2003',
 		globPatterns: [
-			{ pattern: '*', options: { dot: true } }, // LICENSE.md, .eslintrc.js, etc.
-			{ pattern: '!(build|coverage|node_modules|external)/**' }
-		],
-		cwd: process.cwd(),
-		callback: string => string.replace( /CKSource - Frederico Knabben./, 'CKSource Holding sp. z o.o.' )
+			{ // LICENSE.md, .eslintrc.js, etc.
+				pattern: '*',
+				options: {
+					dot: true
+				}
+			},
+			{
+				pattern: '!(build|coverage|node_modules|external)/**',
+				options: {
+					ignore: [
+						'**/ckeditor5-build-*/**',
+						'**/src/lib/**'
+					]
+				}
+			}
+		]
 	} );

--- a/scripts/bump-year.js
+++ b/scripts/bump-year.js
@@ -34,7 +34,7 @@ require( '@ckeditor/ckeditor5-dev-env' )
 				pattern: '!(build|coverage|external)/**',
 				options: {
 					ignore: [
-						'**/ckeditor5-build-*/build/**'
+						'**/ckeditor5-*/build/**'
 					]
 				}
 			}

--- a/scripts/bump-year.js
+++ b/scripts/bump-year.js
@@ -20,65 +20,12 @@ git commit -am "Internal: Bumped the year." && git push
 
 */
 
-const glob = require( 'glob' );
-const minimatch = require( 'minimatch' );
-const fs = require( 'fs' );
-
-const includeDotFiles = {
-	dot: true
-};
-
-glob( '!(build|coverage|node_modules|external)/**', updateYear );
-
-// LICENSE.md, .eslintrc.js, etc.
-glob( '*', includeDotFiles, updateYear );
-
-function updateYear( err, fileNames ) {
-	const filteredFileNames = fileNames.filter( fileName => {
-		// Filter out nested `node_modules`.
-		if ( minimatch( fileName, '**/node_modules/**' ) ) {
-			return false;
-		}
-
-		// Filter out stuff from `src/lib/`.
-		if ( minimatch( fileName, '**/src/lib/**' ) ) {
-			return false;
-		}
-
-		// Filter out builds.
-		if ( minimatch( fileName, '**/ckeditor5-build-*/build/**' ) ) {
-			return false;
-		}
-
-		// Filter out directories.
-		if ( fs.statSync( fileName ).isDirectory() ) {
-			return false;
-		}
-
-		return true;
+require( '@ckeditor/ckeditor5-dev-env' )
+	.bumpYear( {
+		initialYear: '2003',
+		globPatterns: [
+			{ pattern: '*', options: { dot: true } }, // LICENSE.md, .eslintrc.js, etc.
+			{ pattern: '!(build|coverage|node_modules|external)/**' }
+		],
+		cwd: process.cwd()
 	} );
-
-	filteredFileNames.forEach( fileName => {
-		fs.readFile( fileName, ( err, data ) => {
-			data = data.toString();
-
-			const year = new Date().getFullYear();
-			const regexp = /Copyright \(c\) 2003-\d{4}/g;
-			const updatedData = data.replace( regexp, 'Copyright (c) 2003-' + year );
-
-			if ( data == updatedData ) {
-				// License headers are only required in JS files.
-				// Also, the file might have already been updated.
-				if ( fileName.endsWith( '.js' ) && !data.match( regexp ) ) {
-					console.warn( `The file "${ process.cwd() }/${ fileName }" misses a license header.` );
-				}
-			} else {
-				fs.writeFile( fileName, updatedData, err => {
-					if ( err ) {
-						throw err;
-					}
-				} );
-			}
-		} );
-	} );
-}

--- a/scripts/bump-year.js
+++ b/scripts/bump-year.js
@@ -27,5 +27,6 @@ require( '@ckeditor/ckeditor5-dev-env' )
 			{ pattern: '*', options: { dot: true } }, // LICENSE.md, .eslintrc.js, etc.
 			{ pattern: '!(build|coverage|node_modules|external)/**' }
 		],
-		cwd: process.cwd()
+		cwd: process.cwd(),
+		callback: string => string.replace( /CKSource - Frederico Knabben./, 'CKSource Holding sp. z o.o.' )
 	} );


### PR DESCRIPTION
Internal: Replaced the existing script for bumping a year in license headers with the common one from the `ckeditor5-dev`. Closes #10909.