### PR TITLE
Handle spaces in feeds for mention plugin

### DIFF
--- a/packages/ckeditor5-mention/src/mentionui.js
+++ b/packages/ckeditor5-mention/src/mentionui.js
@@ -703,7 +703,7 @@ function _getLastValidMarkerInText( feedsWithRegexp, text ) {
 //
 // @param {String} marker
 // @param {Number} minimumCharacters
-// @returns {Object}
+// @returns {RegExp}
 export function createRegExp( marker, minimumCharacters ) {
 	const numberOfCharacters = minimumCharacters == 0 ? '*' : `{${ minimumCharacters },}`;
 

--- a/packages/ckeditor5-mention/src/mentionui.js
+++ b/packages/ckeditor5-mention/src/mentionui.js
@@ -679,7 +679,7 @@ function getLastValidMarkerInText( feedsWithPattern, text ) {
 		const currentMarkerLastIndex = text.lastIndexOf( feed.marker );
 
 		if ( currentMarkerLastIndex > 0 && !text.substring( currentMarkerLastIndex - 1 ).match( feed.pattern ) ) {
-			return;
+			continue;
 		}
 
 		if ( !lastValidMarker || currentMarkerLastIndex >= lastValidMarker.position ) {
@@ -737,11 +737,9 @@ function createTestCallback( feedsWithPattern ) {
 			splitStringFrom = markerDefinition.position - 1;
 		}
 
-		const minimumCharacters = markerDefinition.minimumCharacters || 0;
-		const regExp = createRegExp( markerDefinition.marker, minimumCharacters );
-		const textToTest = text.substr( splitStringFrom );
+		const textToTest = text.substring( splitStringFrom );
 
-		return regExp.test( textToTest );
+		return markerDefinition.pattern.test( textToTest );
 	};
 
 	return textMatcher;

--- a/packages/ckeditor5-mention/tests/manual/mention.html
+++ b/packages/ckeditor5-mention/tests/manual/mention.html
@@ -1,6 +1,6 @@
 <div id="editor">
-	<p>Hello <span class="mention" data-mention="@Ted">@Ted</span>.</p>
-	<p>Hello <span class="mention" data-mention="@Ted">@Ted</span><span class="mention" data-mention="@Ted">@Ted</span>.</p>
+	<p>Hello <span class="mention" data-mention="@Ted Mosby">@Ted Mosby</span>.</p>
+	<p>Hello <span class="mention" data-mention="@Ted Mosby">@Ted Mosby</span><span class="mention" data-mention="@Ted Mosby">@Ted Mosby</span>.</p>
 
 	<figure class="image">
 		<img src="sample.jpg" />

--- a/packages/ckeditor5-mention/tests/manual/mention.js
+++ b/packages/ckeditor5-mention/tests/manual/mention.js
@@ -157,7 +157,7 @@ ClassicEditor
 			feeds: [
 				{
 					marker: '@',
-					feed: [ '@Barney', '@Lily', '@Marshall', '@Robin', '@Ted', '@Thomas Reeves' ]
+					feed: [ '@Barney Stinson', '@Lily Aldrin', '@Marshall Eriksen', '@Robin Sherbatsky', '@Ted Mosby' ]
 				},
 				{
 					marker: '#',

--- a/packages/ckeditor5-mention/tests/manual/mention.js
+++ b/packages/ckeditor5-mention/tests/manual/mention.js
@@ -157,7 +157,7 @@ ClassicEditor
 			feeds: [
 				{
 					marker: '@',
-					feed: [ '@Barney', '@Lily', '@Marshall', '@Robin', '@Ted' ]
+					feed: [ '@Barney', '@Lily', '@Marshall', '@Robin', '@Ted', '@Thomas Reeves' ]
 				},
 				{
 					marker: '#',

--- a/packages/ckeditor5-mention/tests/manual/mention.md
+++ b/packages/ckeditor5-mention/tests/manual/mention.md
@@ -8,12 +8,11 @@ The feeds:
 
 1. Static list with `@` marker:
 
-    - Barney
-    - Lily
-    - Marshall
-    - Robin
-    - Ted
-    - Thomas Reeves
+    - Barney Stinson
+    - Lily Aldrin
+    - Marshall Eriksen
+    - Robin Sherbatsky
+    - Ted Mosby
 
 2. Static list of 20 items (`#` marker)
 

--- a/packages/ckeditor5-mention/tests/manual/mention.md
+++ b/packages/ckeditor5-mention/tests/manual/mention.md
@@ -13,6 +13,7 @@ The feeds:
     - Marshall
     - Robin
     - Ted
+    - Thomas Reeves
 
 2. Static list of 20 items (`#` marker)
 

--- a/packages/ckeditor5-mention/tests/mentionui.js
+++ b/packages/ckeditor5-mention/tests/mentionui.js
@@ -525,14 +525,14 @@ describe( 'MentionUI', () => {
 				env.features.isRegExpUnicodePropertySupported = false;
 				createRegExp( '@', 2 );
 				sinon.assert.calledOnce( regExpStub );
-				sinon.assert.calledWithExactly( regExpStub, '(?:^|[ \\(\\[{"\'])([@])([\\S]{2,})$', 'u' );
+				sinon.assert.calledWithExactly( regExpStub, '(?:^|[ \\(\\[{"\'])([@])(.{2,})$', 'u' );
 			} );
 
 			it( 'returns a ES2018 RegExp for browsers supporting Unicode punctuation groups', () => {
 				env.features.isRegExpUnicodePropertySupported = true;
 				createRegExp( '@', 2 );
 				sinon.assert.calledOnce( regExpStub );
-				sinon.assert.calledWithExactly( regExpStub, '(?:^|[ \\p{Ps}\\p{Pi}"\'])([@])([\\S]{2,})$', 'u' );
+				sinon.assert.calledWithExactly( regExpStub, '(?:^|[ \\p{Ps}\\p{Pi}"\'])([@])(.{2,})$', 'u' );
 			} );
 		} );
 
@@ -1942,7 +1942,7 @@ describe( 'MentionUI', () => {
 					feeds: [
 						{
 							marker: '@',
-							feed: [ '@a1', '@a2', '@a3' ]
+							feed: [ '@a1', '@a2', '@a3', '@a4 xyz', '@a5 x y z', '@a6 x$z' ]
 						},
 						{
 							marker: '$',
@@ -1967,7 +1967,7 @@ describe( 'MentionUI', () => {
 					.then( () => {
 						expect( panelView.isVisible ).to.be.true;
 						expect( editor.model.markers.has( 'mention' ) ).to.be.true;
-						expect( mentionsView.items ).to.have.length( 3 );
+						expect( mentionsView.items ).to.have.length( 6 );
 
 						mentionsView.items.get( 0 ).children.get( 0 ).fire( 'execute' );
 					} )
@@ -2002,7 +2002,7 @@ describe( 'MentionUI', () => {
 						expect( panelView.isVisible ).to.be.true;
 						expect( editor.model.markers.has( 'mention' ) ).to.be.true;
 
-						expect( mentionsView.items ).to.have.length( 3 );
+						expect( mentionsView.items ).to.have.length( 6 );
 					} );
 			} );
 
@@ -2017,7 +2017,7 @@ describe( 'MentionUI', () => {
 					.then( () => {
 						expect( panelView.isVisible ).to.be.true;
 						expect( editor.model.markers.has( 'mention' ) ).to.be.true;
-						expect( mentionsView.items ).to.have.length( 3 );
+						expect( mentionsView.items ).to.have.length( 6 );
 
 						mentionsView.items.get( 0 ).children.get( 0 ).fire( 'execute' );
 					} )
@@ -2040,6 +2040,66 @@ describe( 'MentionUI', () => {
 					.then( () => {
 						expect( panelView.isVisible ).to.be.true;
 						expect( editor.model.markers.has( 'mention' ) ).to.be.true;
+					} );
+			} );
+
+			it( 'should match a feed', () => {
+				setData( model, '<paragraph>foo []</paragraph>' );
+
+				model.change( writer => {
+					writer.insertText( '@a3', doc.selection.getFirstPosition() );
+				} );
+
+				return waitForDebounce()
+					.then( () => {
+						expect( panelView.isVisible ).to.be.true;
+						expect( editor.model.markers.has( 'mention' ) ).to.be.true;
+						expect( mentionsView.items ).to.have.length( 1 );
+					} );
+			} );
+
+			it( 'should match a feed with space', () => {
+				setData( model, '<paragraph>foo []</paragraph>' );
+
+				model.change( writer => {
+					writer.insertText( '@a4 xyz', doc.selection.getFirstPosition() );
+				} );
+
+				return waitForDebounce()
+					.then( () => {
+						expect( panelView.isVisible ).to.be.true;
+						expect( editor.model.markers.has( 'mention' ) ).to.be.true;
+						expect( mentionsView.items ).to.have.length( 1 );
+					} );
+			} );
+
+			it( 'should match a feed with multiple spaces', () => {
+				setData( model, '<paragraph>foo []</paragraph>' );
+
+				model.change( writer => {
+					writer.insertText( '@a5 x y z', doc.selection.getFirstPosition() );
+				} );
+
+				return waitForDebounce()
+					.then( () => {
+						expect( panelView.isVisible ).to.be.true;
+						expect( editor.model.markers.has( 'mention' ) ).to.be.true;
+						expect( mentionsView.items ).to.have.length( 1 );
+					} );
+			} );
+
+			it( 'should match a feed with spaces and other mention character', () => {
+				setData( model, '<paragraph>foo []</paragraph>' );
+
+				model.change( writer => {
+					writer.insertText( '@a6 x$z', doc.selection.getFirstPosition() );
+				} );
+
+				return waitForDebounce()
+					.then( () => {
+						expect( panelView.isVisible ).to.be.true;
+						expect( editor.model.markers.has( 'mention' ) ).to.be.true;
+						expect( mentionsView.items ).to.have.length( 1 );
 					} );
 			} );
 		} );
@@ -2308,9 +2368,10 @@ describe( 'MentionUI', () => {
 			return waitForDebounce()
 				.then( () => {
 					mentionsView.items.get( 0 ).children.get( 0 ).fire( 'execute' );
-
-					expect( panelView.isVisible ).to.be.false;
-					expect( editor.model.markers.has( 'mention' ) ).to.be.false;
+					return waitForDebounce().then( () => {
+						expect( panelView.isVisible ).to.be.false;
+						expect( editor.model.markers.has( 'mention' ) ).to.be.false;
+					} );
 				} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (mention): Mention plugin now allows searching mentions that include space character. Closes #9741.

---

### Additional information

Mention plugin allowed user to search for feeds only using single words and as soon as it encountered a space it closed items list with results even if there were matches including a space e.g. 'Barry Thompson'. It happened because of regexp for matching mentions in currently edited text that only allowed visible characters to occur after a mention mark.
At first it seemed as an easy improvement of regexp to just allow a space but a scenario with multiple registered markes complicated it a lot.

Take this case:

> aaa @fooo #bar

Regexp allowing space would match @foo as well as #bar. After playing a little bit with regexp to handle that case it quickly got overcomplicated and still had some other edge cases so I had to withdraw from this approach.

Previously regexp to match mention tested entire text node till caret but what we really needed to test is just a text since last valid marker in text. But yet again, case with multiple markers complicated it a little bit. Previously there was a `TextWatcher` for each marker that tried to match a mention for it's own marker. It run outside of state of mention plugin and executed `matched` or `umatched` events without knowledge of matches for other markers. It could find a match for one marker and tried to show UI, but the other marker fired `unmatched` event and immediately hid UI. Before going with solution for spaces it had to be fixed. When initializing plugin I've merged watchers to a single one who knows about each marker and runs only one on each text change. Having that in place, I could pass a test function to `TextWatcher` and find last valid marker in text, trim text since last marker (+1 a character behind to test if marker is in correct place) till caret. Having only that part the rest of the code could stay as usual with just a little change to regexp that now allows any character after marker character instead of just visible characters.
