### PR TITLE
Extract isComment() to utils

### DIFF
--- a/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js
+++ b/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.js
@@ -7,10 +7,12 @@
  * @module engine/dataprocessor/htmldataprocessor
  */
 
-/* globals document, DOMParser, Node */
+/* globals document, DOMParser */
 
 import BasicHtmlWriter from './basichtmlwriter';
 import DomConverter from '../view/domconverter';
+
+import isComment from '@ckeditor/ckeditor5-utils/src/dom/iscomment';
 
 /**
  * The HTML data processor class.
@@ -140,7 +142,7 @@ export default class HtmlDataProcessor {
 			// node. The condition below is just to be sure we are moving only comment nodes.
 
 			/* istanbul ignore else */
-			if ( node.nodeType == Node.COMMENT_NODE ) {
+			if ( isComment( node ) ) {
 				fragment.appendChild( node );
 			}
 		}

--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -28,6 +28,7 @@ import { logWarning } from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import indexOf from '@ckeditor/ckeditor5-utils/src/dom/indexof';
 import getAncestors from '@ckeditor/ckeditor5-utils/src/dom/getancestors';
 import isText from '@ckeditor/ckeditor5-utils/src/dom/istext';
+import isComment from '@ckeditor/ckeditor5-utils/src/dom/iscomment';
 
 const BR_FILLER_REF = BR_FILLER( document ); // eslint-disable-line new-cap
 const NBSP_FILLER_REF = NBSP_FILLER( document ); // eslint-disable-line new-cap
@@ -617,7 +618,7 @@ export default class DomConverter {
 			return hostElement;
 		}
 
-		if ( this.isComment( domNode ) && options.skipComments ) {
+		if ( isComment( domNode ) && options.skipComments ) {
 			return null;
 		}
 
@@ -662,8 +663,8 @@ export default class DomConverter {
 
 				// Treat this element's content as a raw data if it was registered as such.
 				// Comment node is also treated as an element with raw data.
-				if ( this._isViewElementWithRawContent( viewElement, options ) || this.isComment( domNode ) ) {
-					const rawContent = this.isComment( domNode ) ? domNode.data : domNode.innerHTML;
+				if ( this._isViewElementWithRawContent( viewElement, options ) || isComment( domNode ) ) {
+					const rawContent = isComment( domNode ) ? domNode.data : domNode.innerHTML;
 
 					viewElement._setCustomProperty( '$rawContent', rawContent );
 
@@ -1030,16 +1031,6 @@ export default class DomConverter {
 	 */
 	isDocumentFragment( node ) {
 		return node && node.nodeType == Node.DOCUMENT_FRAGMENT_NODE;
-	}
-
-	/**
-	 * Returns `true` when `node.nodeType` equals `Node.COMMENT_NODE`.
-	 *
-	 * @param {Node} node Node to check.
-	 * @returns {Boolean}
-	 */
-	isComment( node ) {
-		return node && node.nodeType == Node.COMMENT_NODE;
 	}
 
 	/**
@@ -1526,7 +1517,7 @@ export default class DomConverter {
 	 * @returns {Element}
 	 */
 	_createViewElement( node, options ) {
-		if ( this.isComment( node ) ) {
+		if ( isComment( node ) ) {
 			return new ViewUIElement( this.document, '$comment' );
 		}
 

--- a/packages/ckeditor5-engine/src/view/renderer.js
+++ b/packages/ckeditor5-engine/src/view/renderer.js
@@ -20,6 +20,7 @@ import remove from '@ckeditor/ckeditor5-utils/src/dom/remove';
 import ObservableMixin from '@ckeditor/ckeditor5-utils/src/observablemixin';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import isText from '@ckeditor/ckeditor5-utils/src/dom/istext';
+import isComment from '@ckeditor/ckeditor5-utils/src/dom/iscomment';
 import isNode from '@ckeditor/ckeditor5-utils/src/dom/isnode';
 import fastDiff from '@ckeditor/ckeditor5-utils/src/fastdiff';
 import env from '@ckeditor/ckeditor5-utils/src/env';
@@ -989,7 +990,7 @@ function addInlineFiller( domDocument, domParentOrArray, offset ) {
 function areSimilar( node1, node2 ) {
 	return isNode( node1 ) && isNode( node2 ) &&
 		!isText( node1 ) && !isText( node2 ) &&
-		node1.nodeType !== Node.COMMENT_NODE && node2.nodeType !== Node.COMMENT_NODE &&
+		!isComment( node1 ) && !isComment( node2 ) &&
 		node1.tagName.toLowerCase() === node2.tagName.toLowerCase();
 }
 

--- a/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
@@ -177,19 +177,6 @@ describe( 'DomConverter', () => {
 				expect( converter.isDocumentFragment( {} ) ).to.be.false;
 			} );
 		} );
-
-		describe( 'isComment()', () => {
-			it( 'should return true for HTML comments', () => {
-				expect( converter.isComment( comment ) ).to.be.true;
-			} );
-
-			it( 'should return false for other arguments', () => {
-				expect( converter.isComment( text ) ).to.be.false;
-				expect( converter.isComment( element ) ).to.be.false;
-				expect( converter.isComment( documentFragment ) ).to.be.false;
-				expect( converter.isComment( {} ) ).to.be.false;
-			} );
-		} );
 	} );
 
 	describe( 'isDomSelectionCorrect()', () => {

--- a/packages/ckeditor5-utils/src/dom/iscomment.js
+++ b/packages/ckeditor5-utils/src/dom/iscomment.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+/* globals Node */
+
 /**
  * @module utils/dom/iscomment
  */
@@ -14,5 +16,5 @@
  * @returns {Boolean}
  */
 export default function isComment( obj ) {
-	return Object.prototype.toString.call( obj ) == '[object Comment]';
+	return obj && obj.nodeType === Node.COMMENT_NODE;
 }

--- a/packages/ckeditor5-utils/src/dom/iscomment.js
+++ b/packages/ckeditor5-utils/src/dom/iscomment.js
@@ -1,0 +1,18 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module utils/dom/istext
+ */
+
+/**
+ * Checks if the object is a native DOM Comment node.
+ *
+ * @param {*} obj
+ * @returns {Boolean}
+ */
+export default function isComment( obj ) {
+	return Object.prototype.toString.call( obj ) == '[object Comment]';
+}

--- a/packages/ckeditor5-utils/src/dom/iscomment.js
+++ b/packages/ckeditor5-utils/src/dom/iscomment.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module utils/dom/istext
+ * @module utils/dom/iscomment
  */
 
 /**

--- a/packages/ckeditor5-utils/tests/dom/iscomment.js
+++ b/packages/ckeditor5-utils/tests/dom/iscomment.js
@@ -1,0 +1,30 @@
+/**
+ * @license Copyright (c) 2003-2021, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global document */
+
+import isComment from '../../src/dom/iscomment';
+
+describe( 'isComment()', () => {
+	let text, element, documentFragment, comment;
+
+	before( () => {
+		text = document.createTextNode( 'test' );
+		element = document.createElement( 'div' );
+		documentFragment = document.createDocumentFragment();
+		comment = document.createComment( 'a' );
+	} );
+
+	it( 'should return true for HTML comments', () => {
+		expect( isComment( comment ) ).to.be.true;
+	} );
+
+	it( 'should return false for other arguments', () => {
+		expect( isComment( text ) ).to.be.false;
+		expect( isComment( element ) ).to.be.false;
+		expect( isComment( documentFragment ) ).to.be.false;
+		expect( isComment( {} ) ).to.be.false;
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (utils, engine): Extracted `isComment()` function from engine to utils. Closes #7428.
