### PR TITLE
Adds all list properties to decoupled document build config

### DIFF
--- a/packages/ckeditor5-build-decoupled-document/src/ckeditor.js
+++ b/packages/ckeditor5-build-decoupled-document/src/ckeditor.js
@@ -133,6 +133,13 @@ DecoupledEditor.defaultConfig = {
 			'mergeTableCells'
 		]
 	},
+	list: {
+		properties: {
+			styles: true,
+			startIndex: true,
+			reversed: true
+		}
+	},
 	// This value must be kept in sync with the language defined in webpack.config.js.
 	language: 'en'
 };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (build-decoupled-document): Enables `startIndex` and `reversed` list properties in document build. Closes #11037.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._