### PR TITLE
Pasting from office: startIndex support

### DIFF
--- a/packages/ckeditor5-paste-from-office/src/filters/list.js
+++ b/packages/ckeditor5-paste-from-office/src/filters/list.js
@@ -155,17 +155,20 @@ function findAllItemLikeElements( documentFragment, writer ) {
 // @param {String} stylesString CSS stylesheet.
 // @returns {Object} result
 // @returns {String} result.type List type, could be `ul` or `ol`.
+// @returns {Number} result.startIndex List start index, valid only for ordered lists.
 // @returns {String|null} result.style List style, for example: `decimal`, `lower-roman`, etc. It is extracted
 // directly from Word stylesheet and adjusted to represent proper values for the CSS `list-style-type` property.
 // If it cannot be adjusted, the `null` value is returned.
 function detectListStyle( listLikeItem, stylesString ) {
 	const listStyleRegexp = new RegExp( `@list l${ listLikeItem.id }:level${ listLikeItem.indent }\\s*({[^}]*)`, 'gi' );
 	const listStyleTypeRegex = /mso-level-number-format:([^;]{0,100});/gi;
+	const listStartIndexRegex = /mso-level-start-at:\s{0,100}([0-9]{0,10})\s{0,100};/gi;
 
 	const listStyleMatch = listStyleRegexp.exec( stylesString );
 
 	let listStyleType = 'decimal'; // Decimal is default one.
 	let type = 'ol'; // <ol> is default list.
+	let startIndex = null;
 
 	if ( listStyleMatch && listStyleMatch[ 1 ] ) {
 		const listStyleTypeMatch = listStyleTypeRegex.exec( listStyleMatch[ 1 ] );
@@ -185,11 +188,18 @@ function detectListStyle( listLikeItem, stylesString ) {
 			if ( bulletedStyle ) {
 				listStyleType = bulletedStyle;
 			}
+		} else {
+			const listStartIndexMatch = listStartIndexRegex.exec( listStyleMatch[ 1 ] );
+
+			if ( listStartIndexMatch && listStartIndexMatch[ 1 ] ) {
+				startIndex = parseInt( listStartIndexMatch[ 1 ] );
+			}
 		}
 	}
 
 	return {
 		type,
+		startIndex,
 		style: mapListStyleDefinition( listStyleType )
 	};
 }
@@ -197,7 +207,7 @@ function detectListStyle( listLikeItem, stylesString ) {
 // Tries to extract the `list-style-type` value based on the marker element for bulleted list.
 //
 // @param {module:engine/view/element~Element} element
-// @returns {module:engine/view/element~Element|null}
+// @returns {String|null}
 function findBulletedListStyle( element ) {
 	const listMarkerElement = findListMarkerNode( element );
 
@@ -254,9 +264,11 @@ function findListMarkerNode( element ) {
 // @param {String|null} value
 // @returns {String|null}
 function mapListStyleDefinition( value ) {
+	if ( value.startsWith( 'arabic-leading-zero' ) ) {
+		return 'decimal-leading-zero';
+	}
+
 	switch ( value ) {
-		case 'arabic-leading-zero':
-			return 'decimal-leading-zero';
 		case 'alpha-upper':
 			return 'upper-alpha';
 		case 'alpha-lower':
@@ -293,6 +305,10 @@ function insertNewEmptyList( listStyle, element, writer ) {
 	// Set the value for the `list-style-type` property directly to the list container.
 	if ( listStyle.style ) {
 		writer.setStyle( 'list-style-type', listStyle.style, list );
+	}
+
+	if ( listStyle.startIndex && listStyle.startIndex > 1 ) {
+		writer.setAttribute( 'start', listStyle.startIndex, list );
 	}
 
 	return list;

--- a/packages/ckeditor5-paste-from-office/tests/filters/list.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/list.js
@@ -299,6 +299,20 @@ describe( 'PasteFromOffice - filters', () => {
 							`<ol style="list-style-type:decimal-leading-zero"><li ${ level1 }>Foo</li></ol>`
 						);
 					} );
+
+					it( 'converts "arabic-leading-zero2" style to proper CSS attribute', () => {
+						const styles = '@list l0:level1\n' +
+							'{mso-level-number-format:arabic-leading-zero3;}';
+
+						const html = `<p ${ level1 }>Foo</p>`;
+						const view = htmlDataProcessor.toView( html );
+
+						transformListItemLikeElementsIntoLists( view, styles );
+
+						expect( stringify( view ) ).to.equal(
+							`<ol style="list-style-type:decimal-leading-zero"><li ${ level1 }>Foo</li></ol>`
+						);
+					} );
 				} );
 
 				describe( 'unordered list', () => {
@@ -390,6 +404,56 @@ describe( 'PasteFromOffice - filters', () => {
 						);
 					} );
 				} );
+			} );
+
+			describe( 'start index', () => {
+				const testData = [
+					{
+						style: 'roman-upper',
+						cssStyle: 'upper-roman',
+						marker: 'IV.',
+						start: 4
+					},
+					{
+						style: 'alpha-lower',
+						cssStyle: 'lower-alpha',
+						marker: 'e)',
+						start: 5
+					},
+					{
+						style: 'arabic-leading-zero3',
+						cssStyle: 'decimal-leading-zero',
+						marker: '0042.',
+						start: 42
+					}
+				];
+
+				for ( const { style, cssStyle, marker, start } of testData ) {
+					it( `should handle start index in "${ style }" ordered list`, () => {
+						const styles = '@list l0:level1\n{' +
+							`mso-level-start-at:${ start };` +
+							`mso-level-number-format:${ style };` +
+							'}';
+
+						const html =
+							'<p class="MsoListParagraphCxSpFirst" style="mso-list:l0 level1 lfo0">' +
+								`<span><span style='mso-list:Ignore'>${ marker }</span>` +
+								'Foo' +
+							'</p>';
+
+						const view = htmlDataProcessor.toView( html );
+
+						transformListItemLikeElementsIntoLists( view, styles );
+
+						expect( stringify( view ) ).to.equal(
+							`<ol start="${ start }" style="list-style-type:${ cssStyle }">` +
+								'<li class="MsoListParagraphCxSpFirst" style="mso-list:l0 level1 lfo0">' +
+									'<span>Foo</span>' +
+								'</li>' +
+							'</ol>'
+						);
+					} );
+				}
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-paste-from-office/tests/filters/list.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/list.js
@@ -302,7 +302,7 @@ describe( 'PasteFromOffice - filters', () => {
 
 					it( 'converts "arabic-leading-zero2" style to proper CSS attribute', () => {
 						const styles = '@list l0:level1\n' +
-							'{mso-level-number-format:arabic-leading-zero3;}';
+							'{mso-level-number-format:arabic-leading-zero2;}';
 
 						const html = `<p ${ level1 }>Foo</p>`;
 						const view = htmlDataProcessor.toView( html );

--- a/packages/ckeditor5-paste-from-office/tests/manual/integration.js
+++ b/packages/ckeditor5-paste-from-office/tests/manual/integration.js
@@ -8,6 +8,7 @@
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 
+import ListProperties from '@ckeditor/ckeditor5-list/src/listproperties';
 import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
 import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
 import Table from '@ckeditor/ckeditor5-table/src/table';
@@ -48,8 +49,10 @@ ClassicEditor
 			EasyImage,
 			PasteFromOffice,
 			FontColor,
-			FontBackgroundColor
+			FontBackgroundColor,
+			ListProperties
 		],
+		list: { properties: { styles: true, startIndex: true } },
 		toolbar: [ 'heading', '|', 'bold', 'italic', 'strikethrough', 'underline', 'link',
 			'bulletedList', 'numberedList', 'blockQuote', 'insertTable', 'pageBreak', 'undo', 'redo' ],
 		table: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (paste-from-office): Adds support for start index in ordered lists. Closes #11043.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
