### PR TITLE
Improved enter handling in document lists

### DIFF
--- a/packages/ckeditor5-list/src/documentlist/documentlistindentcommand.js
+++ b/packages/ckeditor5-list/src/documentlist/documentlistindentcommand.js
@@ -40,7 +40,7 @@ export default class DocumentListIndentCommand extends Command {
 		 *
 		 * @readonly
 		 * @private
-		 * @member {Number}
+		 * @member {'forward'|'backward'}
 		 */
 		this._direction = indentDirection;
 	}

--- a/packages/ckeditor5-list/src/documentlist/documentlistsplitcommand.js
+++ b/packages/ckeditor5-list/src/documentlist/documentlistsplitcommand.js
@@ -36,7 +36,7 @@ export default class DocumentListSplitCommand extends Command {
 		 *
 		 * @readonly
 		 * @private
-		 * @member {Number}
+		 * @member {'before'|'after'}
 		 */
 		this._direction = direction;
 	}
@@ -94,7 +94,7 @@ export default class DocumentListSplitCommand extends Command {
 		const block = this._getStartBlock();
 
 		return selection.isCollapsed &&
-			block && block.hasAttribute( 'listItemId' ) &&
+			!!block && block.hasAttribute( 'listItemId' ) &&
 			!isFirstBlockOfListItem( block );
 	}
 

--- a/packages/ckeditor5-list/src/documentlist/documentlistsplitcommand.js
+++ b/packages/ckeditor5-list/src/documentlist/documentlistsplitcommand.js
@@ -23,6 +23,25 @@ import {
  */
 export default class DocumentListSplitCommand extends Command {
 	/**
+	 * Creates an instance of the command.
+	 *
+	 * @param {module:core/editor/editor~Editor} editor The editor instance.
+	 * @param {'before'|'after'} direction Whether list item should be split before or after the selected block.
+	 */
+	constructor( editor, direction ) {
+		super( editor );
+
+		/**
+		 * Whether list item should be split before or after the selected block.
+		 *
+		 * @readonly
+		 * @private
+		 * @member {Number}
+		 */
+		this._direction = direction;
+	}
+
+	/**
 	 * @inheritDoc
 	 */
 	refresh() {
@@ -39,8 +58,7 @@ export default class DocumentListSplitCommand extends Command {
 		const editor = this.editor;
 
 		editor.model.change( writer => {
-			const positionParent = editor.model.document.selection.getFirstPosition().parent;
-			const changedBlocks = splitListItemBefore( positionParent, writer );
+			const changedBlocks = splitListItemBefore( this._getStartBlock(), writer );
 
 			this._fireAfterExecute( changedBlocks );
 		} );
@@ -72,11 +90,24 @@ export default class DocumentListSplitCommand extends Command {
 	 * @returns {Boolean} Whether the command should be enabled.
 	 */
 	_checkEnabled() {
+		const selection = this.editor.model.document.selection;
+		const block = this._getStartBlock();
+
+		return selection.isCollapsed &&
+			block && block.hasAttribute( 'listItemId' ) &&
+			!isFirstBlockOfListItem( block );
+	}
+
+	/**
+	 * Returns the model element that is the main focus of the command (according to the current selection and command direction).
+	 *
+	 * @private
+	 * @returns {module:engine/model/element~Element}
+	 */
+	_getStartBlock() {
 		const doc = this.editor.model.document;
 		const positionParent = doc.selection.getFirstPosition().parent;
 
-		return doc.selection.isCollapsed &&
-			positionParent.hasAttribute( 'listItemId' ) &&
-			!isFirstBlockOfListItem( positionParent );
+		return this._direction == 'before' ? positionParent : positionParent.nextSibling;
 	}
 }

--- a/packages/ckeditor5-list/tests/documentlist/documentlistediting-integrations.js
+++ b/packages/ckeditor5-list/tests/documentlist/documentlistediting-integrations.js
@@ -516,7 +516,7 @@ describe( 'DocumentListEditing integrations', () => {
 				preventDefault: sinon.spy()
 			} );
 
-			splitCommand = editor.commands.get( 'splitListItem' );
+			splitCommand = editor.commands.get( 'splitListItemBefore' );
 			indentCommand = editor.commands.get( 'outdentList' );
 
 			splitCommandExecuteSpy = sinon.spy( splitCommand, 'execute' );

--- a/packages/ckeditor5-list/tests/documentlist/documentlistediting-integrations.js
+++ b/packages/ckeditor5-list/tests/documentlist/documentlistediting-integrations.js
@@ -508,7 +508,8 @@ describe( 'DocumentListEditing integrations', () => {
 
 	describe( 'enter key handling', () => {
 		const changedBlocks = [];
-		let domEventData, splitCommand, indentCommand, eventInfo, splitCommandExecuteSpy, outdentCommandExecuteSpy;
+		let domEventData, splitBeforeCommand, splitAfterCommand, indentCommand,
+			eventInfo, splitBeforeCommandExecuteSpy, splitAfterCommandExecuteSpy, outdentCommandExecuteSpy;
 
 		beforeEach( () => {
 			eventInfo = new EventInfo( view.document, 'enter' );
@@ -516,15 +517,21 @@ describe( 'DocumentListEditing integrations', () => {
 				preventDefault: sinon.spy()
 			} );
 
-			splitCommand = editor.commands.get( 'splitListItemBefore' );
+			splitBeforeCommand = editor.commands.get( 'splitListItemBefore' );
+			splitAfterCommand = editor.commands.get( 'splitListItemAfter' );
 			indentCommand = editor.commands.get( 'outdentList' );
 
-			splitCommandExecuteSpy = sinon.spy( splitCommand, 'execute' );
+			splitBeforeCommandExecuteSpy = sinon.spy( splitBeforeCommand, 'execute' );
+			splitAfterCommandExecuteSpy = sinon.spy( splitAfterCommand, 'execute' );
 			outdentCommandExecuteSpy = sinon.spy( indentCommand, 'execute' );
 
 			changedBlocks.length = 0;
 
-			splitCommand.on( 'afterExecute', ( evt, data ) => {
+			splitBeforeCommand.on( 'afterExecute', ( evt, data ) => {
+				changedBlocks.push( ...data );
+			} );
+
+			splitAfterCommand.on( 'afterExecute', ( evt, data ) => {
 				changedBlocks.push( ...data );
 			} );
 
@@ -551,7 +558,8 @@ describe( 'DocumentListEditing integrations', () => {
 					] );
 
 					sinon.assert.calledOnce( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.true;
@@ -575,7 +583,8 @@ describe( 'DocumentListEditing integrations', () => {
 					] );
 
 					sinon.assert.calledOnce( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.true;
@@ -598,7 +607,8 @@ describe( 'DocumentListEditing integrations', () => {
 					] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.calledOnce( splitCommandExecuteSpy );
+					sinon.assert.calledOnce( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -626,7 +636,8 @@ describe( 'DocumentListEditing integrations', () => {
 					] );
 
 					sinon.assert.calledOnce( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.true;
@@ -654,7 +665,8 @@ describe( 'DocumentListEditing integrations', () => {
 					] );
 
 					sinon.assert.calledOnce( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.true;
@@ -682,7 +694,8 @@ describe( 'DocumentListEditing integrations', () => {
 					] );
 
 					sinon.assert.calledOnce( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.true;
@@ -707,7 +720,8 @@ describe( 'DocumentListEditing integrations', () => {
 					expect( changedBlocks ).to.deep.equal( [] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -732,7 +746,8 @@ describe( 'DocumentListEditing integrations', () => {
 					expect( changedBlocks ).to.deep.equal( [] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -757,7 +772,8 @@ describe( 'DocumentListEditing integrations', () => {
 					expect( changedBlocks ).to.deep.equal( [] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -782,7 +798,8 @@ describe( 'DocumentListEditing integrations', () => {
 					expect( changedBlocks ).to.deep.equal( [] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -807,7 +824,8 @@ describe( 'DocumentListEditing integrations', () => {
 					expect( changedBlocks ).to.deep.equal( [] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -831,7 +849,8 @@ describe( 'DocumentListEditing integrations', () => {
 					] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.calledOnce( splitCommandExecuteSpy );
+					sinon.assert.calledOnce( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.true;
@@ -857,7 +876,8 @@ describe( 'DocumentListEditing integrations', () => {
 					] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.calledOnce( splitCommandExecuteSpy );
+					sinon.assert.calledOnce( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.true;
@@ -885,11 +905,96 @@ describe( 'DocumentListEditing integrations', () => {
 					] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.calledOnce( splitCommandExecuteSpy );
+					sinon.assert.calledOnce( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.true;
 				} );
+
+				it( 'should create another list item when the selection in an empty first block (followed by another block)', () => {
+					setModelData( model, modelList( [
+						'* []',
+						'  b'
+					] ) );
+
+					view.document.fire( eventInfo, domEventData );
+
+					expect( getModelData( model ) ).to.equalMarkup( modelList( [
+						'* []',
+						'* b {id:a00}'
+					] ) );
+
+					expect( changedBlocks ).to.deep.equal( [
+						modelRoot.getChild( 1 )
+					] );
+
+					sinon.assert.notCalled( outdentCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.calledOnce( splitAfterCommandExecuteSpy );
+
+					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
+					expect( eventInfo.stop.called ).to.be.true;
+				} );
+
+				it( 'should create another list item when the selection in an empty first block (followed by multiple blocks)', () => {
+					setModelData( model, modelList( [
+						'* []',
+						'  a',
+						'  b'
+					] ) );
+
+					view.document.fire( eventInfo, domEventData );
+
+					expect( getModelData( model ) ).to.equalMarkup( modelList( [
+						'* []',
+						'* a {id:a00}',
+						'  b'
+					] ) );
+
+					expect( changedBlocks ).to.deep.equal( [
+						modelRoot.getChild( 1 ),
+						modelRoot.getChild( 2 )
+					] );
+
+					sinon.assert.notCalled( outdentCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.calledOnce( splitAfterCommandExecuteSpy );
+
+					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
+					expect( eventInfo.stop.called ).to.be.true;
+				} );
+
+				it( 'should create another list item when the selection in an empty first block (followed by multiple blocks and an item)',
+					() => {
+						setModelData( model, modelList( [
+							'* []',
+							'  a',
+							'  b',
+							'* c'
+						] ) );
+
+						view.document.fire( eventInfo, domEventData );
+
+						expect( getModelData( model ) ).to.equalMarkup( modelList( [
+							'* []',
+							'* a {id:a00}',
+							'  b',
+							'* c'
+						] ) );
+
+						expect( changedBlocks ).to.deep.equal( [
+							modelRoot.getChild( 1 ),
+							modelRoot.getChild( 2 )
+						] );
+
+						sinon.assert.notCalled( outdentCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.calledOnce( splitAfterCommandExecuteSpy );
+
+						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
+						expect( eventInfo.stop.called ).to.be.true;
+					} );
 			} );
 		} );
 
@@ -912,7 +1017,8 @@ describe( 'DocumentListEditing integrations', () => {
 					] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.calledOnce( splitCommandExecuteSpy );
+					sinon.assert.calledOnce( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -935,7 +1041,8 @@ describe( 'DocumentListEditing integrations', () => {
 					] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.calledOnce( splitCommandExecuteSpy );
+					sinon.assert.calledOnce( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -955,8 +1062,9 @@ describe( 'DocumentListEditing integrations', () => {
 
 					expect( changedBlocks ).to.deep.equal( [] );
 
-					sinon.assert.notCalled( splitCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( outdentCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -977,8 +1085,9 @@ describe( 'DocumentListEditing integrations', () => {
 
 					expect( changedBlocks ).to.deep.equal( [] );
 
-					sinon.assert.notCalled( splitCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( outdentCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -1003,7 +1112,8 @@ describe( 'DocumentListEditing integrations', () => {
 					expect( changedBlocks ).to.deep.equal( [] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -1025,7 +1135,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1048,7 +1159,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1072,7 +1184,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1096,7 +1209,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1121,7 +1235,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1146,7 +1261,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1170,7 +1286,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1196,7 +1313,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1220,7 +1338,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1245,7 +1364,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1270,7 +1390,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1296,7 +1417,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1324,7 +1446,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1351,7 +1474,8 @@ describe( 'DocumentListEditing integrations', () => {
 					] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.calledOnce( splitCommandExecuteSpy );
+					sinon.assert.calledOnce( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -1374,7 +1498,8 @@ describe( 'DocumentListEditing integrations', () => {
 					expect( changedBlocks ).to.deep.equal( [] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -1398,7 +1523,8 @@ describe( 'DocumentListEditing integrations', () => {
 					expect( changedBlocks ).to.deep.equal( [] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -1431,7 +1557,8 @@ describe( 'DocumentListEditing integrations', () => {
 					] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.calledOnce( splitCommandExecuteSpy );
+					sinon.assert.calledOnce( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -1455,7 +1582,8 @@ describe( 'DocumentListEditing integrations', () => {
 					expect( changedBlocks ).to.deep.equal( [] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -1479,7 +1607,8 @@ describe( 'DocumentListEditing integrations', () => {
 					expect( changedBlocks ).to.deep.equal( [] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -1504,7 +1633,8 @@ describe( 'DocumentListEditing integrations', () => {
 					expect( changedBlocks ).to.deep.equal( [] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -1528,7 +1658,8 @@ describe( 'DocumentListEditing integrations', () => {
 					expect( changedBlocks ).to.deep.equal( [] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -1554,7 +1685,8 @@ describe( 'DocumentListEditing integrations', () => {
 					expect( changedBlocks ).to.deep.equal( [] );
 
 					sinon.assert.notCalled( outdentCommandExecuteSpy );
-					sinon.assert.notCalled( splitCommandExecuteSpy );
+					sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+					sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 					sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 					expect( eventInfo.stop.called ).to.be.undefined;
@@ -1582,7 +1714,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1609,7 +1742,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;
@@ -1636,7 +1770,8 @@ describe( 'DocumentListEditing integrations', () => {
 						expect( changedBlocks ).to.deep.equal( [] );
 
 						sinon.assert.notCalled( outdentCommandExecuteSpy );
-						sinon.assert.notCalled( splitCommandExecuteSpy );
+						sinon.assert.notCalled( splitBeforeCommandExecuteSpy );
+						sinon.assert.notCalled( splitAfterCommandExecuteSpy );
 
 						sinon.assert.calledOnce( domEventData.domEvent.preventDefault );
 						expect( eventInfo.stop.called ).to.be.undefined;

--- a/packages/ckeditor5-list/tests/documentlist/documentlistediting.js
+++ b/packages/ckeditor5-list/tests/documentlist/documentlistediting.js
@@ -118,8 +118,14 @@ describe( 'DocumentListEditing', () => {
 			expect( command ).to.be.instanceOf( DocumentListIndentCommand );
 		} );
 
-		it( 'should register the splitListItem command', () => {
-			const command = editor.commands.get( 'splitListItem' );
+		it( 'should register the splitListItemBefore command', () => {
+			const command = editor.commands.get( 'splitListItemBefore' );
+
+			expect( command ).to.be.instanceOf( DocumentListSplitCommand );
+		} );
+
+		it( 'should register the splitListItemAfter command', () => {
+			const command = editor.commands.get( 'splitListItemAfter' );
 
 			expect( command ).to.be.instanceOf( DocumentListSplitCommand );
 		} );

--- a/packages/ckeditor5-list/tests/documentlist/documentlistsplitcommand.js
+++ b/packages/ckeditor5-list/tests/documentlist/documentlistsplitcommand.js
@@ -31,12 +31,6 @@ describe( 'DocumentListSplitCommand', () => {
 		model.schema.register( 'blockQuote', { inheritAllFrom: '$container' } );
 		model.schema.extend( '$container', { allowAttributes: [ 'listType', 'listIndent', 'listItemId' ] } );
 
-		command = new DocumentListSplitCommand( editor, 'before' );
-
-		command.on( 'afterExecute', ( evt, data ) => {
-			changedBlocks = data;
-		} );
-
 		stubUid();
 	} );
 
@@ -44,221 +38,452 @@ describe( 'DocumentListSplitCommand', () => {
 		command.destroy();
 	} );
 
-	describe( 'isEnabled', () => {
-		it( 'should be false if selection is not in a list item', () => {
-			setData( model, modelList( [
-				'[]'
-			] ) );
+	describe( 'split before', () => {
+		beforeEach( () => {
+			command = new DocumentListSplitCommand( editor, 'before' );
 
-			expect( command.isEnabled ).to.be.false;
-		} );
-
-		it( 'should be false if selection is not collapsed in a list item', () => {
-			setData( model, modelList( [
-				'* a',
-				'  [b]'
-			] ) );
-
-			expect( command.isEnabled ).to.be.false;
-		} );
-
-		it( 'should be false if selection is in the first block of a list item', () => {
-			setData( model, modelList( [
-				'* a[]'
-			] ) );
-
-			expect( command.isEnabled ).to.be.false;
-		} );
-
-		it( 'should be true if selection is collapsed in a non-first block of a list item', () => {
-			setData( model, modelList( [
-				'* a',
-				'  []'
-			] ) );
-
-			expect( command.isEnabled ).to.be.true;
-
-			setData( model, modelList( [
-				'* a',
-				'  b[]'
-			] ) );
-
-			expect( command.isEnabled ).to.be.true;
-
-			setData( model, modelList( [
-				'* a',
-				'  []b'
-			] ) );
-
-			expect( command.isEnabled ).to.be.true;
-
-			setData( model, modelList( [
-				'* a',
-				'  b[]c'
-			] ) );
-
-			expect( command.isEnabled ).to.be.true;
-
-			setData( model, modelList( [
-				'* a',
-				'  b[]c',
-				'  d'
-			] ) );
-
-			expect( command.isEnabled ).to.be.true;
-		} );
-	} );
-
-	describe( 'execute()', () => {
-		it( 'should use parent batch', () => {
-			setData( model, modelList( [
-				'* a',
-				'  []'
-			] ) );
-
-			model.change( writer => {
-				expect( writer.batch.operations.length, 'before' ).to.equal( 0 );
-
-				command.execute();
-
-				expect( writer.batch.operations.length, 'after' ).to.be.above( 0 );
+			command.on( 'afterExecute', ( evt, data ) => {
+				changedBlocks = data;
 			} );
 		} );
 
-		it( 'should create another list item when the selection in an empty last block (two blocks in total)', () => {
-			setData( model, modelList( [
-				'* a',
-				'  []'
-			] ) );
+		describe( 'isEnabled', () => {
+			it( 'should be false if selection is not in a list item', () => {
+				setData( model, modelList( [
+					'[]'
+				] ) );
 
-			command.execute();
+				expect( command.isEnabled ).to.be.false;
+			} );
 
-			expect( getData( model ) ).to.equalMarkup( modelList( [
-				'* a',
-				'* [] {id:a00}'
-			] ) );
+			it( 'should be false if selection is not collapsed in a list item', () => {
+				setData( model, modelList( [
+					'* a',
+					'  [b]'
+				] ) );
 
-			expect( changedBlocks ).to.deep.equal( [
-				root.getChild( 1 )
-			] );
+				expect( command.isEnabled ).to.be.false;
+			} );
+
+			it( 'should be false if selection is in the first block of a list item', () => {
+				setData( model, modelList( [
+					'* a[]'
+				] ) );
+
+				expect( command.isEnabled ).to.be.false;
+			} );
+
+			it( 'should be true if selection is collapsed in a non-first block of a list item', () => {
+				setData( model, modelList( [
+					'* a',
+					'  []'
+				] ) );
+
+				expect( command.isEnabled ).to.be.true;
+
+				setData( model, modelList( [
+					'* a',
+					'  b[]'
+				] ) );
+
+				expect( command.isEnabled ).to.be.true;
+
+				setData( model, modelList( [
+					'* a',
+					'  []b'
+				] ) );
+
+				expect( command.isEnabled ).to.be.true;
+
+				setData( model, modelList( [
+					'* a',
+					'  b[]c'
+				] ) );
+
+				expect( command.isEnabled ).to.be.true;
+
+				setData( model, modelList( [
+					'* a',
+					'  b[]c',
+					'  d'
+				] ) );
+
+				expect( command.isEnabled ).to.be.true;
+			} );
 		} );
 
-		it( 'should create another list item when the selection in an empty last block (three blocks in total)', () => {
-			setData( model, modelList( [
-				'* a',
-				'  b',
-				'  []'
-			] ) );
+		describe( 'execute()', () => {
+			it( 'should use parent batch', () => {
+				setData( model, modelList( [
+					'* a',
+					'  []'
+				] ) );
 
-			command.execute();
+				model.change( writer => {
+					expect( writer.batch.operations.length, 'before' ).to.equal( 0 );
 
-			expect( getData( model ) ).to.equalMarkup( modelList( [
-				'* a',
-				'  b',
-				'* [] {id:a00}'
-			] ) );
+					command.execute();
 
-			expect( changedBlocks ).to.deep.equal( [
-				root.getChild( 2 )
-			] );
+					expect( writer.batch.operations.length, 'after' ).to.be.above( 0 );
+				} );
+			} );
+
+			it( 'should create another list item when the selection in an empty last block (two blocks in total)', () => {
+				setData( model, modelList( [
+					'* a',
+					'  []'
+				] ) );
+
+				command.execute();
+
+				expect( getData( model ) ).to.equalMarkup( modelList( [
+					'* a',
+					'* [] {id:a00}'
+				] ) );
+
+				expect( changedBlocks ).to.deep.equal( [
+					root.getChild( 1 )
+				] );
+			} );
+
+			it( 'should create another list item when the selection in an empty last block (three blocks in total)', () => {
+				setData( model, modelList( [
+					'* a',
+					'  b',
+					'  []'
+				] ) );
+
+				command.execute();
+
+				expect( getData( model ) ).to.equalMarkup( modelList( [
+					'* a',
+					'  b',
+					'* [] {id:a00}'
+				] ) );
+
+				expect( changedBlocks ).to.deep.equal( [
+					root.getChild( 2 )
+				] );
+			} );
+
+			it( 'should create another list item when the selection in an empty last block (followed by a list item)', () => {
+				setData( model, modelList( [
+					'* a',
+					'  b',
+					'  []',
+					'* '
+				] ) );
+
+				command.execute();
+
+				expect( getData( model ) ).to.equalMarkup( modelList( [
+					'* a',
+					'  b',
+					'* [] {id:a00}',
+					'* '
+				] ) );
+
+				expect( changedBlocks ).to.deep.equal( [
+					root.getChild( 2 )
+				] );
+			} );
+
+			it( 'should create another list item in a nested structure (last block of the list item)', () => {
+				setData( model, modelList( [
+					'* a',
+					'  b',
+					'  * c',
+					'    []'
+				] ) );
+
+				command.execute();
+
+				expect( getData( model ) ).to.equalMarkup( modelList( [
+					'* a',
+					'  b',
+					'  * c',
+					'  * [] {id:a00}'
+				] ) );
+
+				expect( changedBlocks ).to.deep.equal( [
+					root.getChild( 3 )
+				] );
+			} );
+
+			it( 'should create another list item in a nested structure (middle block of the list item)', () => {
+				setData( model, modelList( [
+					'* a',
+					'  b',
+					'  * c',
+					'    d[]',
+					'    e'
+				] ) );
+
+				command.execute();
+
+				expect( getData( model ) ).to.equalMarkup( modelList( [
+					'* a',
+					'  b',
+					'  * c',
+					'  * d[] {id:a00}',
+					'    e'
+				] ) );
+
+				expect( changedBlocks ).to.deep.equal( [
+					root.getChild( 3 ),
+					root.getChild( 4 )
+				] );
+			} );
+
+			it( 'should create another list item in a nested structure (middle block of the list item, followed by list items)', () => {
+				setData( model, modelList( [
+					'* a',
+					'  b',
+					'  * c',
+					'    d[]',
+					'    e',
+					'  * f',
+					'* g'
+				] ) );
+
+				command.execute();
+
+				expect( getData( model ) ).to.equalMarkup( modelList( [
+					'* a',
+					'  b',
+					'  * c',
+					'  * d[] {id:a00}',
+					'    e',
+					'  * f',
+					'* g'
+				] ) );
+
+				expect( changedBlocks ).to.deep.equal( [
+					root.getChild( 3 ),
+					root.getChild( 4 )
+				] );
+			} );
+		} );
+	} );
+
+	describe( 'split after', () => {
+		beforeEach( () => {
+			command = new DocumentListSplitCommand( editor, 'after' );
+
+			command.on( 'afterExecute', ( evt, data ) => {
+				changedBlocks = data;
+			} );
 		} );
 
-		it( 'should create another list item when the selection in an empty last block (followed by a list item)', () => {
-			setData( model, modelList( [
-				'* a',
-				'  b',
-				'  []',
-				'* '
-			] ) );
+		describe( 'isEnabled', () => {
+			it( 'should be false if selection is not in a list item', () => {
+				setData( model, modelList( [
+					'[]'
+				] ) );
 
-			command.execute();
+				expect( command.isEnabled ).to.be.false;
+			} );
 
-			expect( getData( model ) ).to.equalMarkup( modelList( [
-				'* a',
-				'  b',
-				'* [] {id:a00}',
-				'* '
-			] ) );
+			it( 'should be false if selection is not collapsed in a list item', () => {
+				setData( model, modelList( [
+					'* a',
+					'  [b]'
+				] ) );
 
-			expect( changedBlocks ).to.deep.equal( [
-				root.getChild( 2 )
-			] );
+				expect( command.isEnabled ).to.be.false;
+			} );
+
+			it( 'should be false if selection is in the first empty block of a list item not followed by another block', () => {
+				setData( model, modelList( [
+					'* []'
+				] ) );
+
+				expect( command.isEnabled ).to.be.false;
+			} );
+
+			it( 'should be false if selection is in the first block of a list item not followed by another block', () => {
+				setData( model, modelList( [
+					'* a[]'
+				] ) );
+
+				expect( command.isEnabled ).to.be.false;
+			} );
+
+			it( 'should be true if selection is collapsed in a block followed by another block in the same list item', () => {
+				setData( model, modelList( [
+					'* []',
+					'  a'
+				] ) );
+
+				expect( command.isEnabled ).to.be.true;
+
+				setData( model, modelList( [
+					'* a',
+					'  []',
+					'  b'
+				] ) );
+
+				expect( command.isEnabled ).to.be.true;
+
+				setData( model, modelList( [
+					'* a',
+					'  b[]c',
+					'  d'
+				] ) );
+
+				expect( command.isEnabled ).to.be.true;
+			} );
 		} );
 
-		it( 'should create another list item in a nested structure (last block of the list item)', () => {
-			setData( model, modelList( [
-				'* a',
-				'  b',
-				'  * c',
-				'    []'
-			] ) );
+		describe( 'execute()', () => {
+			it( 'should use parent batch', () => {
+				setData( model, modelList( [
+					'* []',
+					'  a'
+				] ) );
 
-			command.execute();
+				model.change( writer => {
+					expect( writer.batch.operations.length, 'before' ).to.equal( 0 );
 
-			expect( getData( model ) ).to.equalMarkup( modelList( [
-				'* a',
-				'  b',
-				'  * c',
-				'  * [] {id:a00}'
-			] ) );
+					command.execute();
 
-			expect( changedBlocks ).to.deep.equal( [
-				root.getChild( 3 )
-			] );
-		} );
+					expect( writer.batch.operations.length, 'after' ).to.be.above( 0 );
+				} );
+			} );
 
-		it( 'should create another list item in a nested structure (middle block of the list item)', () => {
-			setData( model, modelList( [
-				'* a',
-				'  b',
-				'  * c',
-				'    d[]',
-				'    e'
-			] ) );
+			it( 'should create another list item when the selection in an empty first block followed by another', () => {
+				setData( model, modelList( [
+					'* []',
+					'  a'
+				] ) );
 
-			command.execute();
+				command.execute();
 
-			expect( getData( model ) ).to.equalMarkup( modelList( [
-				'* a',
-				'  b',
-				'  * c',
-				'  * d[] {id:a00}',
-				'    e'
-			] ) );
+				expect( getData( model ) ).to.equalMarkup( modelList( [
+					'* []',
+					'* a {id:a00}'
+				] ) );
 
-			expect( changedBlocks ).to.deep.equal( [
-				root.getChild( 3 ),
-				root.getChild( 4 )
-			] );
-		} );
+				expect( changedBlocks ).to.deep.equal( [
+					root.getChild( 1 )
+				] );
+			} );
 
-		it( 'should create another list item in a nested structure (middle block of the list item, followed by list items)', () => {
-			setData( model, modelList( [
-				'* a',
-				'  b',
-				'  * c',
-				'    d[]',
-				'    e',
-				'  * f',
-				'* g'
-			] ) );
+			it( 'should create another list item when the selection in a middle block of the list item', () => {
+				setData( model, modelList( [
+					'* a',
+					'  []',
+					'  c'
+				] ) );
 
-			command.execute();
+				command.execute();
 
-			expect( getData( model ) ).to.equalMarkup( modelList( [
-				'* a',
-				'  b',
-				'  * c',
-				'  * d[] {id:a00}',
-				'    e',
-				'  * f',
-				'* g'
-			] ) );
+				expect( getData( model ) ).to.equalMarkup( modelList( [
+					'* a',
+					'  []',
+					'* c {id:a00}'
+				] ) );
 
-			expect( changedBlocks ).to.deep.equal( [
-				root.getChild( 3 ),
-				root.getChild( 4 )
-			] );
+				expect( changedBlocks ).to.deep.equal( [
+					root.getChild( 2 )
+				] );
+			} );
+
+			it( 'should create another list item when the selection in a middle block of the list item (followed by another)', () => {
+				setData( model, modelList( [
+					'* a',
+					'  []',
+					'  c',
+					'* '
+				] ) );
+
+				command.execute();
+
+				expect( getData( model ) ).to.equalMarkup( modelList( [
+					'* a',
+					'  []',
+					'* c {id:a00}',
+					'* '
+				] ) );
+
+				expect( changedBlocks ).to.deep.equal( [
+					root.getChild( 2 )
+				] );
+			} );
+
+			it( 'should create another list item in a nested structure', () => {
+				setData( model, modelList( [
+					'* a',
+					'  b',
+					'  * a[]',
+					'    b'
+				] ) );
+
+				command.execute();
+
+				expect( getData( model ) ).to.equalMarkup( modelList( [
+					'* a',
+					'  b',
+					'  * a[]',
+					'  * b {id:a00}'
+				] ) );
+
+				expect( changedBlocks ).to.deep.equal( [
+					root.getChild( 3 )
+				] );
+			} );
+
+			it( 'should create another list item in a nested structure (middle block of the list item)', () => {
+				setData( model, modelList( [
+					'* a',
+					'  b',
+					'  * c',
+					'    d[]',
+					'    e'
+				] ) );
+
+				command.execute();
+
+				expect( getData( model ) ).to.equalMarkup( modelList( [
+					'* a',
+					'  b',
+					'  * c',
+					'    d[]',
+					'  * e {id:a00}'
+				] ) );
+
+				expect( changedBlocks ).to.deep.equal( [
+					root.getChild( 4 )
+				] );
+			} );
+
+			it( 'should create another list item in a nested structure (middle block of the list item, followed by list items)', () => {
+				setData( model, modelList( [
+					'* a',
+					'  b',
+					'  * c',
+					'    d[]',
+					'    e',
+					'  * f',
+					'* g'
+				] ) );
+
+				command.execute();
+
+				expect( getData( model ) ).to.equalMarkup( modelList( [
+					'* a',
+					'  b',
+					'  * c',
+					'    d[]',
+					'  * e {id:a00}',
+					'  * f',
+					'* g'
+				] ) );
+
+				expect( changedBlocks ).to.deep.equal( [
+					root.getChild( 4 )
+				] );
+			} );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-list/tests/documentlist/documentlistsplitcommand.js
+++ b/packages/ckeditor5-list/tests/documentlist/documentlistsplitcommand.js
@@ -31,7 +31,7 @@ describe( 'DocumentListSplitCommand', () => {
 		model.schema.register( 'blockQuote', { inheritAllFrom: '$container' } );
 		model.schema.extend( '$container', { allowAttributes: [ 'listType', 'listIndent', 'listItemId' ] } );
 
-		command = new DocumentListSplitCommand( editor );
+		command = new DocumentListSplitCommand( editor, 'before' );
 
 		command.on( 'afterExecute', ( evt, data ) => {
 			changedBlocks = data;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (list): Improved enter handling in document lists by allowing to split the list item when the collapsed selection is anchored in the first (but not only) empty block of a list item (see [#10879](https://github.com/ckeditor/ckeditor5/issues/10879), [#10976](https://github.com/ckeditor/ckeditor5/issues/10976)).