### PR TITLE
Updated the guide that was using outdated API.

### DIFF
--- a/docs/builds/guides/frameworks/react.md
+++ b/docs/builds/guides/frameworks/react.md
@@ -481,18 +481,18 @@ Finally, exclude CKEditor 5 SVG and CSS files from `file-loader`. Find the last 
 ```js
 {
 	loader: require.resolve( 'file-loader' ),
-	// Exclude `js` files to keep the "css" loader working as it injects
-	// its runtime that would otherwise be processed through the "file" loader.
-	// Also exclude `html` and `json` extensions so they get processed
-	// by webpack's internal loaders.
-	exclude: [
-		/\.(js|mjs|jsx|ts|tsx)$/,
-		/\.html$/,
-		/\.json$/,
-		/ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
-		/ckeditor5-[^/\\]+[/\\]theme[/\\].+\.css$/
-	],
 	options: {
+		// Exclude `js` files to keep the "css" loader working as it injects
+		// its runtime that would otherwise be processed through the "file" loader.
+		// Also exclude `html` and `json` extensions so they get processed
+		// by webpack's internal loaders.
+		exclude: [
+			/\.(js|mjs|jsx|ts|tsx)$/,
+			/\.html$/,
+			/\.json$/,
+			/ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
+			/ckeditor5-[^/\\]+[/\\]theme[/\\].+\.css$/
+		],
 		name: 'static/media/[name].[hash:8].[ext]',
 	}
 }


### PR DESCRIPTION
Docs: Updated the React component guide. Closes #11160.