### PR TITLE
WIP: Travis coverage fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,6 @@
   "resolutions": {
     "eslint-config-ckeditor5": "^3.0.0",
     "postcss-loader": "^4.0.0",
-    "colors": "1.4.0",
     "karma-coverage": "2.1.0"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -175,7 +175,6 @@
     "eslint-config-ckeditor5": "^3.0.0",
     "postcss-loader": "^4.0.0",
     "colors": "1.4.0",
-    "mini-css-extract-plugin": "2.4.2",
     "karma-coverage": "2.1.0"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -175,7 +175,8 @@
     "eslint-config-ckeditor5": "^3.0.0",
     "postcss-loader": "^4.0.0",
     "colors": "1.4.0",
-    "mini-css-extract-plugin": "2.4.2"
+    "mini-css-extract-plugin": "2.4.2",
+    "karma-coverage": "2.1.0"
   },
   "lint-staged": {
     "**/*.js": [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Specified an exact version to the `karma-coverage` package due to [karma-coverage@v2.1.1](https://github.com/karma-runner/karma-coverage/releases/tag/v2.1.1) which breaks the testing environment. Closes #11221.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
