### PR TITLE
Docs: missing comma in example configuration

### DIFF
--- a/packages/ckeditor5-html-support/docs/features/general-html-support.md
+++ b/packages/ckeditor5-html-support/docs/features/general-html-support.md
@@ -87,7 +87,7 @@ By default, enabling the {@link module:html-support/generalhtmlsupport~GeneralHt
 ```js
 ClassicEditor.create( document.querySelector( '#editor' ), {
 	htmlSupport: {
-		allow: [ /* HTML features to allow */ ]
+		allow: [ /* HTML features to allow */ ],
 		disallow: [ /* HTML features to disallow */ ]
 	}
 } )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: missing comma in an example configuration. Closes #11209.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._