### PR TITLE
Changed slotFor() API into writer.createSlot()

### DIFF
--- a/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-structure.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector-structure.js
@@ -15,10 +15,10 @@ function Structure( editor ) {
 
 	editor.conversion.for( 'downcast' ).elementToStructure( {
 		model: 'myElement',
-		view: ( modelElement, { writer, slotFor } ) => {
+		view: ( modelElement, { writer } ) => {
 			return writer.createContainerElement( 'div', { class: 'wrapper' }, [
 				writer.createContainerElement( 'div', { class: 'inner-wrapper' }, [
-					slotFor( 'children' )
+					writer.createSlot()
 				] )
 			] );
 		}

--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/conversion/downcast.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/conversion/downcast.md
@@ -178,10 +178,10 @@ You can use `elementToStructure()` conversion helper for this purpose:
 editor.conversion
 	.for( 'downcast' ).elementToStructure( {
 		model: 'myElement',
-		view: ( modelElement, { writer, slotFor } ) => {
+		view: ( modelElement, { writer } ) => {
 			return writer.createContainerElement( 'div', { class: 'wrapper' }, [
 				writer.createContainerElement( 'div', { class: 'inner-wrapper' }, [
-					slotFor( 'children' )
+					writer.createSlot()
 				] )
 			] );
 		}

--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/conversion/helpers/downcast.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/conversion/helpers/downcast.md
@@ -149,7 +149,7 @@ Another thing to remember is that in the real life scenario it would be recommen
 
 ### Handling model element’s children
 
-The example above uses an empty model element. If your model element may contain children you need to specify in the view where these children should be placed. To do that use `slotFor( 'children' )`
+The example above uses an empty model element. If your model element may contain children you need to specify in the view where these children should be placed. To do that use `writer.createSlot()`
 
 ```js
 editor.conversion
@@ -157,9 +157,9 @@ editor.conversion
 	.elementToStructure( {
 		model: 'wrappedParagraph',
 		view: ( modelElement, conversionApi ) => {
-			const { writer, slotFor } = conversionApi;
+			const { writer } = conversionApi;
 			const paragraphViewElement = writer.createContainerElement( 'p', {}, [
-				slotFor( 'children' )
+				writer.createSlot()
 			] );
 
 			return writer.createContainerElement( 'div', { class: 'wrapper' }, [

--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
@@ -1084,11 +1084,12 @@ export function insertStructure( elementCreator, consumer ) {
 
 		const slotsMap = new Map();
 
+		conversionApi.writer._registerSlotFactory( createSlotFactory( data.item, slotsMap, conversionApi ) );
+
 		// View creation.
-		const viewElement = elementCreator( data.item, {
-			...conversionApi,
-			slotFor: createSlotFactory( data.item, slotsMap, conversionApi )
-		} );
+		const viewElement = elementCreator( data.item, conversionApi );
+
+		conversionApi.writer._clearSlotFactory();
 
 		if ( !viewElement ) {
 			return;
@@ -2152,8 +2153,8 @@ function validateChildren( viewElement ) {
 // @param {module:engine/conversion/downcastdispatcher~DowncastConversionApi} conversionApi
 // @returns {Function} Exposed by conversionApi as {@link module:engine/conversion/downcasthelpers~DowncastConversionWithSlotsApi#slotFor}.
 function createSlotFactory( element, slotsMap, conversionApi ) {
-	return modeOrFilter => {
-		const slot = conversionApi.writer.createContainerElement( '$slot' );
+	return ( writer, modeOrFilter = 'children' ) => {
+		const slot = writer.createContainerElement( '$slot' );
 
 		let children = null;
 

--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
@@ -189,13 +189,13 @@ export default class DowncastHelpers extends ConversionHelpers {
 	 *		editor.conversion.for( 'downcast' ).elementToStructure( {
 	 *			model: 'wrappedParagraph',
 	 *			view: ( modelElement, conversionApi ) => {
-	 *				const { writer, slotFor } = conversionApi;
+	 *				const { writer } = conversionApi;
 	 *
 	 *				const wrapperViewElement = writer.createContainerElement( 'div', { class: 'wrapper' } );
 	 *				const paragraphViewElement = writer.createContainerElement( 'p' );
 	 *
 	 *				writer.insert( writer.createPositionAt( wrapperViewElement, 0 ), paragraphViewElement );
-	 *				writer.insert( writer.createPositionAt( paragraphViewElement, 0 ), slotFor( 'children' ) );
+	 *				writer.insert( writer.createPositionAt( paragraphViewElement, 0 ), writer.createSlot() );
 	 *
 	 *				return wrapperViewElement;
 	 *			}
@@ -242,7 +242,7 @@ export default class DowncastHelpers extends ConversionHelpers {
 	 *				attributes: [ 'headingRows' ]
 	 *			},
 	 *			view: ( modelElement, conversionApi ) => {
-	 *				const { writer, slotFor } = conversionApi;
+	 *				const { writer } = conversionApi;
 	 *
 	 *				const figureElement = writer.createContainerElement( 'figure', { class: 'table' } );
 	 *				const tableElement = writer.createContainerElement( 'table' );
@@ -254,7 +254,7 @@ export default class DowncastHelpers extends ConversionHelpers {
 	 *				if ( headingRows > 0 ) {
 	 *					const tableHead = writer.createContainerElement( 'thead' );
 	 *
-	 *					const headSlot = slotFor( element => element.is( 'element', 'tableRow' ) && element.index < headingRows );
+	 *					const headSlot = writer.createSlot( node => node.is( 'element', 'tableRow' ) && node.index < headingRows );
 	 *
 	 *					writer.insert( writer.createPositionAt( tableElement, 'end' ), tableHead );
 	 *					writer.insert( writer.createPositionAt( tableHead, 0 ), headSlot );
@@ -263,13 +263,13 @@ export default class DowncastHelpers extends ConversionHelpers {
 	 *				if ( headingRows < tableUtils.getRows( table ) ) {
 	 *					const tableBody = writer.createContainerElement( 'tbody' );
 	 *
-	 *					const bodySlot = slotFor( element => element.is( 'element', 'tableRow' ) && element.index >= headingRows );
+	 *					const bodySlot = writer.createSlot( node => node.is( 'element', 'tableRow' ) && node.index >= headingRows );
 	 *
 	 *					writer.insert( writer.createPositionAt( tableElement, 'end' ), tableBody );
 	 *					writer.insert( writer.createPositionAt( tableBody, 0 ), bodySlot );
 	 *				}
 	 *
-	 *				const restSlot = slotFor( element => !element.is( 'element', 'tableRow' ) );
+	 *				const restSlot = writer.createSlot( node => !node.is( 'element', 'tableRow' ) );
 	 *
 	 *				writer.insert( writer.createPositionAt( figureElement, 'end' ), restSlot );
 	 *
@@ -290,7 +290,7 @@ export default class DowncastHelpers extends ConversionHelpers {
  	 * @param {String|Array.<String>} [config.model.attributes] The list of attribute names that should be consumed while creating
 	 * the view structure. Note that the view will be reconverted if any of the listed attributes will change.
 	 * @param {module:engine/conversion/downcasthelpers~StructureCreatorFunction} config.view A function
-	 * that takes the model element and {@link module:engine/conversion/downcasthelpers~DowncastConversionWithSlotsApi downcast
+	 * that takes the model element and {@link module:engine/conversion/downcastdispatcher~DowncastConversionApi downcast
 	 * conversion API} as parameters and returns a view container element with slots for model child nodes to be converted into.
 	 * @returns {module:engine/conversion/downcasthelpers~DowncastHelpers}
 	 */
@@ -1065,7 +1065,7 @@ export function insertElement( elementCreator, consumer = defaultConsumer ) {
  * Function factory that creates a converter which converts a single model node insertion to a view structure.
  *
  * It is expected that the passed element creator function returns an {@link module:engine/view/element~Element} with attached slots
- * created with `conversionApi.slotFor()` to indicate where child nodes should be converted.
+ * created with `writer.createSlot()` to indicate where child nodes should be converted.
  *
  * @see module:engine/conversion/downcasthelpers~DowncastHelpers#elementToStructure
  *
@@ -2151,7 +2151,7 @@ function validateChildren( viewElement ) {
 // @param {module:engine/model/element~Element} element
 // @param {Map.<module:engine/view/element~Element,Array.<module:engine/model/node~Node>>} slotsMap
 // @param {module:engine/conversion/downcastdispatcher~DowncastConversionApi} conversionApi
-// @returns {Function} Exposed by conversionApi as {@link module:engine/conversion/downcasthelpers~DowncastConversionWithSlotsApi#slotFor}.
+// @returns {Function} Exposed by writer as createSlot().
 function createSlotFactory( element, slotsMap, conversionApi ) {
 	return ( writer, modeOrFilter = 'children' ) => {
 		const slot = writer.createContainerElement( '$slot' );
@@ -2164,7 +2164,7 @@ function createSlotFactory( element, slotsMap, conversionApi ) {
 			children = Array.from( element.getChildren() ).filter( element => modeOrFilter( element ) );
 		} else {
 			/**
-			 * Unknown slot mode was provided to `conversionApi.slotFor()` in downcast converter.
+			 * Unknown slot mode was provided to `writer.createSlot()` in downcast converter.
 			 *
 			 * @error conversion-slot-mode-unknown
 			 */
@@ -2188,7 +2188,7 @@ function validateSlotsChildren( element, slotsMap, conversionApi ) {
 
 	if ( uniqueChildrenInSlots.size != childrenInSlots.length ) {
 		/**
-		 * Filters provided to `conversionApi.slotFor()` overlap (at least two filters accept the same child element).
+		 * Filters provided to `writer.createSlot()` overlap (at least two filters accept the same child element).
 		 *
 		 * @error conversion-slot-filter-overlap
 		 * @param {module:engine/model/element~Element} element The element of which children would not be properly
@@ -2199,7 +2199,7 @@ function validateSlotsChildren( element, slotsMap, conversionApi ) {
 
 	if ( uniqueChildrenInSlots.size != element.childCount ) {
 		/**
-		 * Filters provided to `conversionApi.slotFor()` are incomplete and exclude at least one children element (one of
+		 * Filters provided to `writer.createSlot()` are incomplete and exclude at least one children element (one of
 		 * the children elements would not be assigned to any of the slots).
 		 *
 		 * @error conversion-slot-filter-incomplete
@@ -2358,7 +2358,7 @@ function defaultConsumer( item, consumable, { preflight } = {} ) {
 
 /**
  * A filtering function used to choose model child nodes to be downcasted into the specific view
- * {@link module:engine/conversion/downcasthelpers~DowncastConversionWithSlotsApi#slotFor "slot"} while executing the
+ * {@link module:engine/view/downcastwriter~DowncastWriter#createSlot "slot"} while executing the
  * {@link module:engine/conversion/downcasthelpers~DowncastHelpers#elementToStructure `elementToStructure()`} converter.
  *
  * @callback module:engine/conversion/downcasthelpers~SlotFilter
@@ -2366,57 +2366,18 @@ function defaultConsumer( item, consumable, { preflight } = {} ) {
  * @param {module:engine/model/node~Node} node A model node.
  * @returns {Boolean} Whether provided model node should be downcasted into this slot.
  *
- * @see module:engine/conversion/downcasthelpers~DowncastConversionWithSlotsApi#slotFor
+ * @see module:engine/view/downcastwriter~DowncastWriter#createSlot
  * @see module:engine/conversion/downcasthelpers~DowncastHelpers#elementToStructure
  * @see module:engine/conversion/downcasthelpers~insertStructure
  */
 
 /**
- * An extended {@link module:engine/conversion/downcastdispatcher~DowncastConversionApi `DowncastConversionApi`} that adds a
- * {@link module:engine/conversion/downcasthelpers~DowncastConversionWithSlotsApi#slotFor `slotFor()`} helper to create placeholders for
- * child elements converion.
- *
- * @interface module:engine/conversion/downcasthelpers~DowncastConversionWithSlotsApi
- * @extends module:engine/conversion/downcastdispatcher~DowncastConversionApi
- *
- * @see module:engine/conversion/downcasthelpers~DowncastHelpers#elementToStructure
- * @see module:engine/conversion/downcasthelpers~insertStructure
- */
-
-/**
- * A helper that creates placeholders for child elements.
- *
- *		const viewSlot = conversionApi.slotFor( 'children' );
- *		const viewPosition = conversionApi.writer.createPositionAt( viewElement, 0 );
- *
- *		conversionApi.writer.insert( viewPosition, viewSlot );
- *
- * It could be filtered to a specific subset of children (only `<foo>` model elements in this case):
- *
- *		const viewSlot = conversionApi.slotFor( node => node.is( 'element', 'foo' ) );
- *		const viewPosition = conversionApi.writer.createPositionAt( viewElement, 0 );
- *
- *		conversionApi.writer.insert( viewPosition, viewSlot );
- *
- * While providing a filtered slot make sure to provide slots for all child nodes. A single node can not be downcasted into
- * multiple slots.
- *
- * **Note**: You should not change the order of nodes. View elements should be in the same order as model nodes.
- *
- * @method #slotFor
- * @param {'children'|module:engine/conversion/downcasthelpers~SlotFilter} modeOrFilter The filter for child nodes.
- * @returns {module:engine/view/element~Element} The slot element to be placed in to the view structure while processing
- * {@link module:engine/conversion/downcasthelpers~DowncastHelpers#elementToStructure `elementToStructure()`}.
- */
-
-/**
- * A function that takes the model element and {@link module:engine/conversion/downcasthelpers~DowncastConversionWithSlotsApi downcast
+ * A function that takes the model element and {@link module:engine/conversion/downcastdispatcher~DowncastConversionApi downcast
  * conversion API} as parameters and returns a view container element with slots for model child nodes to be converted into.
  *
  * @callback module:engine/conversion/downcasthelpers~StructureCreatorFunction
  * @param {module:engine/model/element~Element} element The model element to be converted to the view structure.
- * @param {module:engine/conversion/downcasthelpers~DowncastConversionWithSlotsApi} conversionApi The conversion interface with
- * {@link module:engine/conversion/downcasthelpers~DowncastConversionWithSlotsApi#slotFor `slotFor()`} factory.
+ * @param {module:engine/conversion/downcastdispatcher~DowncastConversionApi} conversionApi The conversion interface.
  * @returns {module:engine/view/element~Element} The view structure with slots for model child nodes.
  *
  * @see module:engine/conversion/downcasthelpers~DowncastHelpers#elementToStructure

--- a/packages/ckeditor5-engine/src/view/downcastwriter.js
+++ b/packages/ckeditor5-engine/src/view/downcastwriter.js
@@ -1286,7 +1286,7 @@ export default class DowncastWriter {
 	createSlot( modeOrFilter ) {
 		if ( !this._slotFactory ) {
 			/**
-			 * The `createSlot()` method is allowed only inside the `elementToStructure` downcast helper.
+			 * The `createSlot()` method is allowed only inside the `elementToStructure` downcast helper callback.
 			 *
 			 * @error view-writer-invalid-create-slot-context
 			 */

--- a/packages/ckeditor5-engine/src/view/downcastwriter.js
+++ b/packages/ckeditor5-engine/src/view/downcastwriter.js
@@ -1195,7 +1195,7 @@ export default class DowncastWriter {
 	}
 
 	/**
-	 Creates new {@link module:engine/view/selection~Selection} instance.
+	 * Creates new {@link module:engine/view/selection~Selection} instance.
 	 *
 	 * 		// Creates empty selection without ranges.
 	 *		const selection = writer.createSelection();
@@ -1259,10 +1259,29 @@ export default class DowncastWriter {
 	}
 
 	/**
-	 * TODO
+	 * Creates placeholders for child elements of {@link module:engine/conversion/downcasthelpers~DowncastHelpers#elementToStructure
+	 * `elementToStructure()`} conversion helper.
 	 *
-	 * @param [modeOrFilter]
-	 * @returns {*}
+	 *		const viewSlot = conversionApi.writer.createSlot();
+	 *		const viewPosition = conversionApi.writer.createPositionAt( viewElement, 0 );
+	 *
+	 *		conversionApi.writer.insert( viewPosition, viewSlot );
+	 *
+	 * It could be filtered to a specific subset of children (only `<foo>` model elements in this case):
+	 *
+	 *		const viewSlot = conversionApi.writer.createSlot( node => node.is( 'element', 'foo' ) );
+	 *		const viewPosition = conversionApi.writer.createPositionAt( viewElement, 0 );
+	 *
+	 *		conversionApi.writer.insert( viewPosition, viewSlot );
+	 *
+	 * While providing a filtered slot make sure to provide slots for all child nodes. A single node can not be downcasted into
+	 * multiple slots.
+	 *
+	 * **Note**: You should not change the order of nodes. View elements should be in the same order as model nodes.
+	 *
+	 * @param {'children'|module:engine/conversion/downcasthelpers~SlotFilter} [modeOrFilter='children'] The filter for child nodes.
+	 * @returns {module:engine/view/element~Element} The slot element to be placed in to the view structure while processing
+	 * {@link module:engine/conversion/downcasthelpers~DowncastHelpers#elementToStructure `elementToStructure()`}.
 	 */
 	createSlot( modeOrFilter ) {
 		if ( !this._slotFactory ) {

--- a/packages/ckeditor5-engine/src/view/downcastwriter.js
+++ b/packages/ckeditor5-engine/src/view/downcastwriter.js
@@ -58,6 +58,14 @@ export default class DowncastWriter {
 		 * @type {Map.<String,Set>}
 		 */
 		this._cloneGroups = new Map();
+
+		/**
+		 * The slot factory used by the `elementToStructure` downcast helper.
+		 *
+		 * @private
+		 * @type {Function|null}
+		 */
+		this._slotFactory = null;
 	}
 
 	/**
@@ -1248,6 +1256,44 @@ export default class DowncastWriter {
 	 */
 	createSelection( selectable, placeOrOffset, options ) {
 		return new Selection( selectable, placeOrOffset, options );
+	}
+
+	/**
+	 * TODO
+	 *
+	 * @param [modeOrFilter]
+	 * @returns {*}
+	 */
+	createSlot( modeOrFilter ) {
+		if ( !this._slotFactory ) {
+			/**
+			 * The `createSlot()` method is allowed only inside the `elementToStructure` downcast helper.
+			 *
+			 * @error view-writer-invalid-create-slot-context
+			 */
+			throw new CKEditorError( 'view-writer-invalid-create-slot-context', this.document );
+		}
+
+		return this._slotFactory( this, modeOrFilter );
+	}
+
+	/**
+	 * Registers a slot factory.
+	 *
+	 * @protected
+	 * @param {Function} slotFactory The slot factory.
+	 */
+	_registerSlotFactory( slotFactory ) {
+		this._slotFactory = slotFactory;
+	}
+
+	/**
+	 * Clears the registered slot factory.
+	 *
+	 * @protected
+	 */
+	_clearSlotFactory() {
+		this._slotFactory = null;
 	}
 
 	/**

--- a/packages/ckeditor5-engine/tests/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/downcasthelpers.js
@@ -1174,10 +1174,10 @@ describe( 'DowncastHelpers', () => {
 						name: 'simpleBlock',
 						attributes: [ 'toStyle', 'toClass' ]
 					},
-					view: ( modelElement, { writer, slotFor } ) => {
+					view: ( modelElement, { writer } ) => {
 						const viewElement = writer.createContainerElement( 'div', getViewAttributes( modelElement ) );
 
-						writer.insert( writer.createPositionAt( viewElement, 0 ), slotFor( 'children' ) );
+						writer.insert( writer.createPositionAt( viewElement, 0 ), writer.createSlot() );
 
 						return viewElement;
 					}
@@ -1335,10 +1335,10 @@ describe( 'DowncastHelpers', () => {
 
 				downcastHelpers.elementToStructure( {
 					model: 'simpleBlock',
-					view: ( modelElement, { writer, slotFor } ) => {
+					view: ( modelElement, { writer } ) => {
 						const viewElement = writer.createContainerElement( 'div', getViewAttributes( modelElement ) );
 
-						writer.insert( writer.createPositionAt( viewElement, 0 ), slotFor( 'children' ) );
+						writer.insert( writer.createPositionAt( viewElement, 0 ), writer.createSlot() );
 
 						return viewElement;
 					}
@@ -1510,10 +1510,10 @@ describe( 'DowncastHelpers', () => {
 						name: 'simpleBlock2',
 						children: true
 					},
-					view: ( modelElement, { writer, slotFor } ) => {
+					view: ( modelElement, { writer } ) => {
 						const viewElement = writer.createContainerElement( 'div', { class: 'second' } );
 
-						writer.insert( writer.createPositionAt( viewElement, 0 ), slotFor( 'children' ) );
+						writer.insert( writer.createPositionAt( viewElement, 0 ), writer.createSlot() );
 
 						return viewElement;
 					}
@@ -1617,12 +1617,12 @@ describe( 'DowncastHelpers', () => {
 						attributes: [ 'toStyle', 'toClass' ],
 						children: true
 					},
-					view: ( modelElement, { writer, slotFor } ) => {
+					view: ( modelElement, { writer } ) => {
 						const outer = writer.createContainerElement( 'div', { class: 'complex-outer' } );
 						const inner = writer.createContainerElement( 'div', getViewAttributes( modelElement ) );
 
 						writer.insert( writer.createPositionAt( outer, 0 ), inner );
-						writer.insert( writer.createPositionAt( inner, 0 ), slotFor( 'children' ) );
+						writer.insert( writer.createPositionAt( inner, 0 ), writer.createSlot() );
 
 						return outer;
 					}
@@ -1932,7 +1932,7 @@ describe( 'DowncastHelpers', () => {
 						name: 'complex',
 						children: true
 					},
-					view: ( modelElement, { writer, slotFor } ) => {
+					view: ( modelElement, { writer } ) => {
 						const outer = writer.createContainerElement( 'div', { class: 'complex-outer' } );
 						const inner1 = writer.createContainerElement( 'div', { class: 'inner-first' } );
 						const inner2 = writer.createContainerElement( 'div', { class: 'inner-second' } );
@@ -1940,8 +1940,8 @@ describe( 'DowncastHelpers', () => {
 						writer.insert( writer.createPositionAt( outer, 'end' ), inner1 );
 						writer.insert( writer.createPositionAt( outer, 'end' ), inner2 );
 
-						writer.insert( writer.createPositionAt( inner1, 0 ), slotFor( element => element.index < 2 ) );
-						writer.insert( writer.createPositionAt( inner2, 0 ), slotFor( element => element.index >= 2 ) );
+						writer.insert( writer.createPositionAt( inner1, 0 ), writer.createSlot( element => element.index < 2 ) );
+						writer.insert( writer.createPositionAt( inner2, 0 ), writer.createSlot( element => element.index >= 2 ) );
 
 						return outer;
 					}
@@ -2178,10 +2178,10 @@ describe( 'DowncastHelpers', () => {
 					name: 'simple',
 					children: true
 				},
-				view: ( modelElement, { writer, slotFor } ) => {
+				view: ( modelElement, { writer } ) => {
 					const element = writer.createContainerElement( 'div' );
 
-					writer.insert( writer.createPositionAt( element, 0 ), slotFor( 'foo' ) );
+					writer.insert( writer.createPositionAt( element, 0 ), writer.createSlot( 'foo' ) );
 
 					return element;
 				}
@@ -2218,7 +2218,7 @@ describe( 'DowncastHelpers', () => {
 					name: 'complex',
 					children: true
 				},
-				view: ( modelElement, { writer, slotFor } ) => {
+				view: ( modelElement, { writer } ) => {
 					const outer = writer.createContainerElement( 'div' );
 					const inner1 = writer.createContainerElement( 'div', { class: 'inner-first' } );
 					const inner2 = writer.createContainerElement( 'div', { class: 'inner-second' } );
@@ -2226,8 +2226,8 @@ describe( 'DowncastHelpers', () => {
 					writer.insert( writer.createPositionAt( outer, 'end' ), inner1 );
 					writer.insert( writer.createPositionAt( outer, 'end' ), inner2 );
 
-					writer.insert( writer.createPositionAt( inner1, 0 ), slotFor( element => element.index <= 1 ) );
-					writer.insert( writer.createPositionAt( inner2, 0 ), slotFor( element => element.index >= 1 ) );
+					writer.insert( writer.createPositionAt( inner1, 0 ), writer.createSlot( element => element.index <= 1 ) );
+					writer.insert( writer.createPositionAt( inner2, 0 ), writer.createSlot( element => element.index >= 1 ) );
 
 					return outer;
 				}
@@ -2265,7 +2265,7 @@ describe( 'DowncastHelpers', () => {
 					name: 'complex',
 					children: true
 				},
-				view: ( modelElement, { writer, slotFor } ) => {
+				view: ( modelElement, { writer } ) => {
 					const outer = writer.createContainerElement( 'div' );
 					const inner1 = writer.createContainerElement( 'div', { class: 'inner-first' } );
 					const inner2 = writer.createContainerElement( 'div', { class: 'inner-second' } );
@@ -2273,8 +2273,8 @@ describe( 'DowncastHelpers', () => {
 					writer.insert( writer.createPositionAt( outer, 'end' ), inner1 );
 					writer.insert( writer.createPositionAt( outer, 'end' ), inner2 );
 
-					writer.insert( writer.createPositionAt( inner1, 0 ), slotFor( element => element.index < 1 ) );
-					writer.insert( writer.createPositionAt( inner2, 0 ), slotFor( element => element.index > 1 ) );
+					writer.insert( writer.createPositionAt( inner1, 0 ), writer.createSlot( element => element.index < 1 ) );
+					writer.insert( writer.createPositionAt( inner2, 0 ), writer.createSlot( element => element.index > 1 ) );
 
 					return outer;
 				}

--- a/packages/ckeditor5-engine/tests/manual/slot-conversion.js
+++ b/packages/ckeditor5-engine/tests/manual/slot-conversion.js
@@ -86,7 +86,7 @@ function getBoxUpcastConverter( editor ) {
 
 function getBoxDowncastCreator( multiSlot ) {
 	return ( modelElement, conversionApi ) => {
-		const { writer, slotFor } = conversionApi;
+		const { writer } = conversionApi;
 
 		const viewBox = writer.createContainerElement( 'div', { class: 'box' } );
 		const contentWrap = writer.createContainerElement( 'div', { class: 'box-content' } );
@@ -116,14 +116,14 @@ function getBoxDowncastCreator( multiSlot ) {
 		}
 
 		if ( !multiSlot ) {
-			writer.insert( writer.createPositionAt( contentWrap, 0 ), slotFor( 'children' ) );
+			writer.insert( writer.createPositionAt( contentWrap, 0 ), writer.createSlot() );
 		} else {
-			writer.insert( writer.createPositionAt( contentWrap, 0 ), slotFor( element => element.index < 2 ) );
+			writer.insert( writer.createPositionAt( contentWrap, 0 ), writer.createSlot( element => element.index < 2 ) );
 
 			const contentWrap2 = writer.createContainerElement( 'div', { class: 'box-content' } );
 
 			writer.insert( writer.createPositionAt( viewBox, 'end' ), contentWrap2 );
-			writer.insert( writer.createPositionAt( contentWrap2, 0 ), slotFor( element => element.index >= 2 ) );
+			writer.insert( writer.createPositionAt( contentWrap2, 0 ), writer.createSlot( element => element.index >= 2 ) );
 
 			const footer = writer.createRawElement( 'div', { class: 'box-footer' }, domElement => {
 				domElement.innerHTML = 'Footer';

--- a/packages/ckeditor5-engine/tests/view/downcastwriter/writer.js
+++ b/packages/ckeditor5-engine/tests/view/downcastwriter/writer.js
@@ -15,8 +15,13 @@ import { StylesProcessor } from '../../../src/view/stylesmap';
 import DocumentFragment from '../../../src/view/documentfragment';
 import HtmlDataProcessor from '../../../src/dataprocessor/htmldataprocessor';
 
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
+
 describe( 'DowncastWriter', () => {
 	let writer, attributes, root, doc;
+
+	testUtils.createSinonSandbox();
 
 	beforeEach( () => {
 		attributes = { foo: 'bar', baz: 'quz' };
@@ -506,6 +511,36 @@ describe( 'DowncastWriter', () => {
 			doc.getRoot()._appendChild( new ViewElement( 'p' ) );
 
 			expect( writer.createSelection() ).to.be.instanceof( ViewSelection );
+		} );
+	} );
+
+	describe( 'createSlot()', () => {
+		it( 'should throw if called before slot factory is initialized', () => {
+			expect( () => {
+				writer.createSlot();
+			} ).to.throw( CKEditorError, 'view-writer-invalid-create-slot-context' );
+		} );
+
+		it( 'should call slot factory and pass the parameter', () => {
+			const spy = sinon.spy();
+
+			writer._registerSlotFactory( spy );
+			writer.createSlot( 'foo' );
+
+			sinon.assert.calledWithExactly( spy, writer, 'foo' );
+		} );
+
+		it( 'should throw if called after slot factory is cleared', () => {
+			const spy = sinon.spy();
+
+			writer._registerSlotFactory( spy );
+			writer._clearSlotFactory();
+
+			expect( () => {
+				writer.createSlot( 'foo' );
+			} ).to.throw( CKEditorError, 'view-writer-invalid-create-slot-context' );
+
+			sinon.assert.notCalled( spy );
 		} );
 	} );
 

--- a/packages/ckeditor5-image/src/image/imageblockediting.js
+++ b/packages/ckeditor5-image/src/image/imageblockediting.js
@@ -92,14 +92,14 @@ export default class ImageBlockEditing extends Plugin {
 		conversion.for( 'dataDowncast' )
 			.elementToStructure( {
 				model: 'imageBlock',
-				view: ( modelElement, { writer, slotFor } ) => createBlockImageViewElement( writer, slotFor( 'children' ) )
+				view: ( modelElement, { writer } ) => createBlockImageViewElement( writer, writer.createSlot() )
 			} );
 
 		conversion.for( 'editingDowncast' )
 			.elementToStructure( {
 				model: 'imageBlock',
-				view: ( modelElement, { writer, slotFor } ) => imageUtils.toImageWidget(
-					createBlockImageViewElement( writer, slotFor( 'children' ) ), writer, t( 'image widget' )
+				view: ( modelElement, { writer } ) => imageUtils.toImageWidget(
+					createBlockImageViewElement( writer, writer.createSlot() ), writer, t( 'image widget' )
 				)
 			} );
 

--- a/packages/ckeditor5-image/tests/image/converters.js
+++ b/packages/ckeditor5-image/tests/image/converters.js
@@ -49,8 +49,8 @@ describe( 'Image converters', () => {
 				isInline: true
 			} );
 
-			const imageEditingElementCreator = ( modelElement, { writer, slotFor } ) =>
-				imageUtils.toImageWidget( createBlockImageViewElement( writer, slotFor( 'children' ) ), writer, '' );
+			const imageEditingElementCreator = ( modelElement, { writer } ) =>
+				imageUtils.toImageWidget( createBlockImageViewElement( writer, writer.createSlot() ), writer, '' );
 
 			const imageInlineEditingElementCreator = ( modelElement, { writer } ) =>
 				imageUtils.toImageWidget( createInlineImageViewElement( writer ), writer, '' );

--- a/packages/ckeditor5-media-embed/src/utils.js
+++ b/packages/ckeditor5-media-embed/src/utils.js
@@ -73,10 +73,10 @@ export function isMediaWidget( viewElement ) {
  * @param {Boolean} [options.renderForEditingView]
  * @returns {module:engine/view/containerelement~ContainerElement}
  */
-export function createMediaFigureElement( { writer, slotFor }, registry, url, options ) {
+export function createMediaFigureElement( { writer }, registry, url, options ) {
 	return writer.createContainerElement( 'figure', { class: 'media' }, [
 		registry.getMediaViewElement( writer, url, options ),
-		slotFor( 'children' )
+		writer.createSlot()
 	] );
 }
 

--- a/packages/ckeditor5-table/src/converters/downcast.js
+++ b/packages/ckeditor5-table/src/converters/downcast.js
@@ -19,7 +19,7 @@ import { toWidget, toWidgetEditable } from 'ckeditor5/src/widget';
  * @returns {Function} Element creator.
  */
 export function downcastTable( tableUtils, options = {} ) {
-	return ( table, { writer, slotFor } ) => {
+	return ( table, { writer } ) => {
 		const headingRows = table.getAttribute( 'headingRows' ) || 0;
 		const tableSections = [];
 
@@ -27,7 +27,7 @@ export function downcastTable( tableUtils, options = {} ) {
 		if ( headingRows > 0 ) {
 			tableSections.push(
 				writer.createContainerElement( 'thead', null,
-					slotFor( element => element.is( 'element', 'tableRow' ) && element.index < headingRows )
+					writer.createSlot( element => element.is( 'element', 'tableRow' ) && element.index < headingRows )
 				)
 			);
 		}
@@ -36,7 +36,7 @@ export function downcastTable( tableUtils, options = {} ) {
 		if ( headingRows < tableUtils.getRows( table ) ) {
 			tableSections.push(
 				writer.createContainerElement( 'tbody', null,
-					slotFor( element => element.is( 'element', 'tableRow' ) && element.index >= headingRows )
+					writer.createSlot( element => element.is( 'element', 'tableRow' ) && element.index >= headingRows )
 				)
 			);
 		}
@@ -46,7 +46,7 @@ export function downcastTable( tableUtils, options = {} ) {
 			writer.createContainerElement( 'table', null, tableSections ),
 
 			// Slot for the rest (for example caption).
-			slotFor( element => !element.is( 'element', 'tableRow' ) )
+			writer.createSlot( element => !element.is( 'element', 'tableRow' ) )
 		] );
 
 		return options.asWidget ? toTableWidget( figureElement, writer ) : figureElement;

--- a/packages/ckeditor5-widget/tests/widget.js
+++ b/packages/ckeditor5-widget/tests/widget.js
@@ -98,11 +98,11 @@ describe( 'Widget', () => {
 					.elementToElement( { model: 'div', view: 'div' } )
 					.elementToStructure( {
 						model: 'widget',
-						view: ( modelItem, { writer, slotFor } ) => {
+						view: ( modelItem, { writer } ) => {
 							const b = writer.createAttributeElement( 'b' );
 							const div = writer.createContainerElement( 'div' );
 							writer.insert( writer.createPositionAt( div, 0 ), b );
-							writer.insert( writer.createPositionAt( div, 0 ), slotFor( 'children' ) );
+							writer.insert( writer.createPositionAt( div, 0 ), writer.createSlot() );
 
 							return toWidget( div, writer, { label: 'element label' } );
 						}

--- a/packages/ckeditor5-widget/tests/widgettypearound/widgettypearound.js
+++ b/packages/ckeditor5-widget/tests/widgettypearound/widgettypearound.js
@@ -1874,12 +1874,12 @@ describe( 'WidgetTypeAround', () => {
 		editor.conversion.for( 'downcast' )
 			.elementToStructure( {
 				model: 'blockWidget',
-				view: ( modelItem, { writer, slotFor } ) => {
+				view: ( modelItem, { writer } ) => {
 					const container = writer.createContainerElement( 'div' );
 					const viewText = writer.createText( 'block-widget' );
 
 					writer.insert( writer.createPositionAt( container, 0 ), viewText );
-					writer.insert( writer.createPositionAt( container, 0 ), slotFor( 'children' ) );
+					writer.insert( writer.createPositionAt( container, 0 ), writer.createSlot() );
 
 					return toWidget( container, writer, {
 						label: 'block widget'
@@ -1902,12 +1902,12 @@ describe( 'WidgetTypeAround', () => {
 		editor.conversion.for( 'downcast' )
 			.elementToStructure( {
 				model: 'inlineWidget',
-				view: ( modelItem, { writer, slotFor } ) => {
+				view: ( modelItem, { writer } ) => {
 					const container = writer.createContainerElement( 'inlineWidget' );
 					const viewText = writer.createText( 'inline-widget' );
 
 					writer.insert( writer.createPositionAt( container, 0 ), viewText );
-					writer.insert( writer.createPositionAt( container, 0 ), slotFor( 'children' ) );
+					writer.insert( writer.createPositionAt( container, 0 ), writer.createSlot() );
 
 					return toWidget( container, writer, {
 						label: 'inline widget'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (engine): The `elementToStructure` `conversionApi.slotFor()` replaced with `writer.createSlot()`. Closes #11179.

---

### Additional information