### PR TITLE
Revert "elementToStructure() should throw when invoked for an element that allows $text"

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.js
@@ -1703,38 +1703,6 @@ function downcastElementToStructure( config ) {
 	config.model.children = true;
 
 	return dispatcher => {
-		if ( dispatcher._conversionApi.schema.checkChild( config.model.name, '$text' ) ) {
-			/**
-			 * This error occurs when a {@link module:engine/model/element~Element model element} is downcasted
-			 * via {@link module:engine/conversion/downcasthelpers~DowncastHelpers#elementToStructure} helper but the element was
-			 * allowed to host `$text` by the {@link module:engine/model/schema~Schema model schema}.
-			 *
-			 * For instance, this may be the result of `myElement` allowing the content of
-			 * {@glink framework/guides/deep-dive/schema#generic-items `$block`} in its schema definition:
-			 *
-			 *		// Element definition in schema.
-			 *		schema.register( 'myElement', {
-			 *			allowContentOf: '$block',
-			 *
-			 *			// ...
-			 *		} );
-			 *
-			 *		// ...
-			 *
-			 *		// Conversion of myElement with the use of elementToStructure().
-			 *		editor.conversion.for( 'downcast' ).elementToStructure( {
-			 *			model: 'myElement',
-			 *			view: ( modelElement, { writer } ) => {
-			 *				// ...
-			 *			}
-			 *		} );
-			 *
-			 * @error conversion-element-to-structure-disallowed-text
-			 * @param {String} elementName The name of the element the structure is to be created for.
-			 */
-			throw new CKEditorError( 'conversion-element-to-structure-disallowed-text', dispatcher, { elementName: config.model.name } );
-		}
-
 		dispatcher.on(
 			'insert:' + config.model.name,
 			insertStructure( config.view, createConsumer( config.model ) ),

--- a/packages/ckeditor5-engine/tests/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/downcasthelpers.js
@@ -2301,25 +2301,6 @@ describe( 'DowncastHelpers', () => {
 				} );
 			}, /^conversion-slot-filter-incomplete/, controller.downcastDispatcher );
 		} );
-
-		// https://github.com/ckeditor/ckeditor5/issues/11163
-		it( 'should throw an exception when invoked for a model element that allows $text', () => {
-			model.schema.register( 'myElement', {
-				allowIn: '$root',
-
-				// This makes it accept $text.
-				allowContentOf: '$block'
-			} );
-
-			expectToThrowCKEditorError( () => {
-				downcastHelpers.elementToStructure( {
-					model: 'myElement',
-					view: ( modelElement, { writer } ) => {
-						return writer.createContainerElement( 'div' );
-					}
-				} );
-			}, /^conversion-element-to-structure-disallowed-text/, controller.downcastDispatcher, { elementName: 'myElement' } );
-		} );
 	} );
 
 	describe( 'attributeToElement()', () => {


### PR DESCRIPTION
Revert (engine): Reverted #11229 due to concerns in `Widget` tests.