### PR TITLE
Refactor createBlockImageViewElement() helper function.

### DIFF
--- a/packages/ckeditor5-image/src/image/imageblockediting.js
+++ b/packages/ckeditor5-image/src/image/imageblockediting.js
@@ -92,14 +92,14 @@ export default class ImageBlockEditing extends Plugin {
 		conversion.for( 'dataDowncast' )
 			.elementToStructure( {
 				model: 'imageBlock',
-				view: ( modelElement, { writer } ) => createBlockImageViewElement( writer, writer.createSlot() )
+				view: ( modelElement, { writer } ) => createBlockImageViewElement( writer )
 			} );
 
 		conversion.for( 'editingDowncast' )
 			.elementToStructure( {
 				model: 'imageBlock',
 				view: ( modelElement, { writer } ) => imageUtils.toImageWidget(
-					createBlockImageViewElement( writer, writer.createSlot() ), writer, t( 'image widget' )
+					createBlockImageViewElement( writer ), writer, t( 'image widget' )
 				)
 			} );
 

--- a/packages/ckeditor5-image/src/image/utils.js
+++ b/packages/ckeditor5-image/src/image/utils.js
@@ -36,7 +36,6 @@ export function createInlineImageViewElement( writer ) {
  *
  * @protected
  * @param {module:engine/view/downcastwriter~DowncastWriter} writer
- * @param {module:engine/view/element~Element} slotElement
  * @returns {module:engine/view/containerelement~ContainerElement}
  */
 export function createBlockImageViewElement( writer ) {

--- a/packages/ckeditor5-image/src/image/utils.js
+++ b/packages/ckeditor5-image/src/image/utils.js
@@ -39,10 +39,10 @@ export function createInlineImageViewElement( writer ) {
  * @param {module:engine/view/element~Element} slotElement
  * @returns {module:engine/view/containerelement~ContainerElement}
  */
-export function createBlockImageViewElement( writer, slotElement ) {
+export function createBlockImageViewElement( writer ) {
 	return writer.createContainerElement( 'figure', { class: 'image' }, [
 		writer.createEmptyElement( 'img' ),
-		slotElement
+		writer.createSlot()
 	] );
 }
 

--- a/packages/ckeditor5-image/tests/image/converters.js
+++ b/packages/ckeditor5-image/tests/image/converters.js
@@ -50,7 +50,7 @@ describe( 'Image converters', () => {
 			} );
 
 			const imageEditingElementCreator = ( modelElement, { writer } ) =>
-				imageUtils.toImageWidget( createBlockImageViewElement( writer, writer.createSlot() ), writer, '' );
+				imageUtils.toImageWidget( createBlockImageViewElement( writer ), writer, '' );
 
 			const imageInlineEditingElementCreator = ( modelElement, { writer } ) =>
 				imageUtils.toImageWidget( createInlineImageViewElement( writer ), writer, '' );

--- a/packages/ckeditor5-image/tests/image/utils.js
+++ b/packages/ckeditor5-image/tests/image/utils.js
@@ -290,8 +290,11 @@ describe( 'image utils', () => {
 		} );
 
 		it( 'should create a figure element for "image" type', () => {
-			const slotElement = writer.createEmptyElement( '$slot' );
-			const element = createBlockImageViewElement( writer, slotElement );
+			sinon.stub( writer, 'createSlot' ).callsFake( function createSlot() {
+				return writer.createEmptyElement( '$slot' );
+			} );
+
+			const element = createBlockImageViewElement( writer );
 
 			expect( element.is( 'element', 'figure' ) ).to.be.true;
 			expect( element.hasClass( 'image' ) ).to.be.true;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (image): Refactor `createBlockImageViewElement()` helper function.

________________

Why: Recently we changed the `slotFor()` API by moving it into the writer and renaming the function. This PR aims to do a small refactoring by removing second parameter `slotElement` which is created using `writer` since we already pass the whole `writer` into the `createBlockImageViewElement()`.

It's documented in another PR review and acts as a follow up to it: https://github.com/ckeditor/ckeditor5/pull/11211#pullrequestreview-875583814