### PR TITLE
Docs: adding source editing to Markdown demo

### DIFF
--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.js
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.js
@@ -8,6 +8,7 @@
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
 import EasyImage from '@ckeditor/ckeditor5-easy-image/src/easyimage';
 import ImageUpload from '@ckeditor/ckeditor5-image/src/imageupload';
 import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices';
@@ -23,34 +24,39 @@ import Markdown from '@ckeditor/ckeditor5-markdown-gfm/src/markdown';
 ClassicEditor
 	.create( document.querySelector( '#snippet-markdown' ), {
 		plugins: [
-			ArticlePluginSet, EasyImage, ImageUpload, CloudServices, Markdown,
+			ArticlePluginSet, SourceEditing, EasyImage, ImageUpload, CloudServices, Markdown,
 			Code, CodeBlock, TodoList, Strikethrough, HorizontalLine
 		],
-		toolbar: [
-			'heading',
-			'|',
-			'bold',
-			'italic',
-			'strikethrough',
-			'link',
-			'|',
-			'bulletedList',
-			'numberedList',
-			'todoList',
-			'|',
-			'code',
-			'codeBlock',
-			'|',
-			'outdent',
-			'indent',
-			'|',
-			'uploadImage',
-			'blockQuote',
-			'horizontalLine',
-			'|',
-			'undo',
-			'redo'
-		],
+		toolbar: {
+			items: [
+				'heading',
+				'|',
+				'bold',
+				'italic',
+				'strikethrough',
+				'link',
+				'|',
+				'bulletedList',
+				'numberedList',
+				'todoList',
+				'|',
+				'code',
+				'codeBlock',
+				'|',
+				'uploadImage',
+				'blockQuote',
+				'horizontalLine',
+				'-',
+				'sourceEditing',
+				'|',
+				'outdent',
+				'indent',
+				'|',
+				'undo',
+				'redo'
+			],
+			shouldNotGroupWhenFull: true
+		},
 		image: {
 			toolbar: [ 'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|', 'toggleImageCaption', 'imageTextAlternative' ]
 		},

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -16,16 +16,20 @@ Please remember that Markdown syntax is very simple and it does not cover all th
 
 The CKEditor 5 instance below is configured to output GitHub Flavored Markdown. Use the editor to create your content and see the Markdown output displayed as you type below the editor.
 
+<info-box info>
+	Please observe that the {@link features/source-editing source editing} in the demo below is a separate feature. If you would like to use it in your integration, it needs to be installed separately.
+</info-box>
+
 {@snippet features/markdown}
 
 ## Related features
 
 Some other ways to output the edited content include:
 
+* {@link features/source-editing#markdown-source-view Source editing} &ndash; Allows for Markdown source edition if configured accordingly.
 * {@link features/export-word Export to Word} &ndash; Generate editable `.docx` files out of your editor-created content.
 * {@link features/export-pdf Export to PDF} &ndash; Generate portable PDF files out of your editor-created content.
 * {@link features/autoformat Autoformatting} &ndash; Use Markdown syntax shortcodes to automatically format your content as you type!
-* {@link features/source-editing#markdown-source-view Source editing} &ndash; Allows for Markdown source edition if configured accordingly.
 
 ## The Markdown data processor
 
@@ -83,6 +87,10 @@ ClassicEditor
 	.catch( ... );
 
 ```
+
+<info-box info>
+	Read more about {@link builds/guides/integration/installing-plugins installing plugins}.
+</info-box>
 
 ## Known issues
 

--- a/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
+++ b/packages/ckeditor5-markdown-gfm/docs/features/markdown.md
@@ -22,6 +22,10 @@ The CKEditor 5 instance below is configured to output GitHub Flavored Markdown. 
 
 {@snippet features/markdown}
 
+
+## Extending formatting support
+If you need a more extensive Markdown support for formatting elements (for example, having the `title` attribute on links represented as `[Foo Bar](https://foo.bar "My link title")`), you can also install {@link features/general-html-support General HTML Support}. This advanced feature allows the integrators to provide additional tags, elements and attributes, not yet supported by other CKEditor 5 plugins and extend the the formatting capabilities.
+
 ## Related features
 
 Some other ways to output the edited content include:


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: adding source editing to Markdown demo. Closes #11231.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._