### PR TITLE
Editor.create() will set config.initialData

### DIFF
--- a/docs/_snippets/examples/multi-root-editor.js
+++ b/docs/_snippets/examples/multi-root-editor.js
@@ -67,6 +67,17 @@ class MultirootEditor extends Editor {
 	constructor( sourceElements, config ) {
 		super( config );
 
+		if ( this.config.get( 'initialData' ) === undefined ) {
+			// Create initial data object containing data from all roots.
+			const initialData = {};
+
+			for ( const rootName of Object.keys( sourceElements ) ) {
+				initialData[ rootName ] = getDataFromElement( sourceElements[ rootName ] );
+			}
+
+			this.config.set( 'initialData', initialData );
+		}
+
 		// Create root and UIView element for each editable container.
 		for ( const rootName of Object.keys( sourceElements ) ) {
 			this.model.document.createRoot( '$root', rootName );
@@ -116,16 +127,7 @@ class MultirootEditor extends Editor {
 			resolve(
 				editor.initPlugins()
 					.then( () => editor.ui.init() )
-					.then( () => {
-						const initialData = {};
-
-						// Create initial data object containing data from all roots.
-						for ( const rootName of Object.keys( sourceElements ) ) {
-							initialData[ rootName ] = getDataFromElement( sourceElements[ rootName ] );
-						}
-
-						return editor.data.init( initialData );
-					} )
+					.then( () => editor.data.init( editor.config.get( 'initialData' ) ) )
 					.then( () => editor.fire( 'ready' ) )
 					.then( () => editor )
 			);

--- a/docs/framework/guides/custom-editor-creator.md
+++ b/docs/framework/guides/custom-editor-creator.md
@@ -47,6 +47,17 @@ class MultirootEditor extends Editor {
 	constructor( sourceElements, config ) {
 		super( config );
 
+		if ( this.config.get( 'initialData' ) === undefined ) {
+			// Create initial data object containing data from all roots.
+			const initialData = {};
+
+			for ( const rootName of Object.keys( sourceElements ) ) {
+				initialData[ rootName ] = getDataFromElement( sourceElements[ rootName ] );
+			}
+
+			this.editor.config.set( 'initialData', initialData );
+		}
+
 		// Create root and UIView element for each editable container.
 		for ( const rootName of Object.keys( sourceElements ) ) {
 			this.model.document.createRoot( '$root', rootName );
@@ -96,16 +107,7 @@ class MultirootEditor extends Editor {
 			resolve(
 				editor.initPlugins()
 					.then( () => editor.ui.init() )
-					.then( () => {
-						const initialData = {};
-
-						// Create initial data object containing data from all roots.
-						for ( const rootName of Object.keys( sourceElements ) ) {
-							initialData[ rootName ] = getDataFromElement( sourceElements[ rootName ] );
-						}
-
-						return editor.data.init( initialData );
-					} )
+					.then( () => editor.data.init( editor.config.get( 'initialData' ) ) )
 					.then( () => editor.fire( 'ready' ) )
 					.then( () => editor )
 			);

--- a/packages/ckeditor5-core/src/editor/editorconfig.jsdoc
+++ b/packages/ckeditor5-core/src/editor/editorconfig.jsdoc
@@ -41,13 +41,17 @@
  *			.catch( ... );
  *
  * By default, the editor is initialized with the content of the element on which this editor is initialized.
- * See {@link module:core/editor/editor~Editor.create Editor.create()}.
- *
- * This configuration option lets you override initial data if an element is passed to `Editor.create()`.
+ * This configuration option lets you override this behavior and pass different initial data.
  * It is especially useful if it is difficult for your integration to put the data inside the HTML element.
  *
- * **Note:** If initial data is passed to `Editor.create()` as a parameter and, at the same time, via this configuration option,
- * an error will be thrown as those two options exclude themselves.
+ * See also {@link module:core/editor/editor~Editor.create Editor.create()}.
+ *
+ * **Note:** If initial data is passed to `Editor.create()` in the first parameter (instead of a DOM element), and,
+ * at the same time, `config.initialData` is set, an error will be thrown as those two options exclude themselves.
+ *
+ * If `config.initialData` is not set when the editor is initialized, the data received in `Editor.create()` call
+ * will be used to set `config.initialData`. As a result, `initialData` is always set in the editor's config and
+ * plugins can read and/or modify it during initialization.
  *
  * @member {String} module:core/editor/editorconfig~EditorConfig#initialData
  */

--- a/packages/ckeditor5-editor-balloon/src/ballooneditor.js
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditor.js
@@ -199,24 +199,24 @@ export default class BalloonEditor extends Editor {
 				throw new CKEditorError( 'editor-wrong-element', null );
 			}
 
+			// If both `config.initialData` and initial data parameter in `create()` are set, then throw.
+			if ( !isHTMLElement && config.initialData !== undefined ) {
+				// Documented in core/editor/editorconfig.jsdoc.
+				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
+				throw new CKEditorError( 'editor-create-initial-data', null );
+			}
+
+			// If `config.initialData` is not set, use DOM element or initial data set in `create()` parameter.
+			if ( config.initialData === undefined ) {
+				config.initialData = getInitialData( sourceElementOrData );
+			}
+
 			const editor = new this( sourceElementOrData, config );
 
 			resolve(
 				editor.initPlugins()
-					.then( () => {
-						editor.ui.init();
-					} )
-					.then( () => {
-						if ( !isHTMLElement && config.initialData ) {
-							// Documented in core/editor/editorconfig.jdoc.
-							// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
-							throw new CKEditorError( 'editor-create-initial-data', null );
-						}
-
-						const initialData = config.initialData !== undefined ? config.initialData : getInitialData( sourceElementOrData );
-
-						return editor.data.init( initialData );
-					} )
+					.then( () => editor.ui.init() )
+					.then( () => editor.data.init( editor.config.get( 'initialData' ) ) )
 					.then( () => editor.fire( 'ready' ) )
 					.then( () => editor )
 			);

--- a/packages/ckeditor5-editor-balloon/src/ballooneditor.js
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditor.js
@@ -59,6 +59,10 @@ export default class BalloonEditor extends Editor {
 	constructor( sourceElementOrData, config ) {
 		super( config );
 
+		if ( this.config.get( 'initialData' ) === undefined ) {
+			this.config.set( 'initialData', getInitialData( sourceElementOrData ) );
+		}
+
 		if ( isElement( sourceElementOrData ) ) {
 			this.sourceElement = sourceElementOrData;
 			secureSourceElement( this );
@@ -204,11 +208,6 @@ export default class BalloonEditor extends Editor {
 				// Documented in core/editor/editorconfig.jsdoc.
 				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
 				throw new CKEditorError( 'editor-create-initial-data', null );
-			}
-
-			// If `config.initialData` is not set, use DOM element or initial data set in `create()` parameter.
-			if ( config.initialData === undefined ) {
-				config.initialData = getInitialData( sourceElementOrData );
 			}
 
 			const editor = new this( sourceElementOrData, config );

--- a/packages/ckeditor5-editor-balloon/src/ballooneditor.js
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditor.js
@@ -54,7 +54,7 @@ export default class BalloonEditor extends Editor {
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * (on which the editor will be initialized) or initial data for the editor. For more information see
 	 * {@link module:editor-balloon/ballooneditor~BalloonEditor.create `BalloonEditor.create()`}.
-	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
+	 * @param {module:core/editor/editorconfig~EditorConfig} [config] The editor configuration.
 	 */
 	constructor( sourceElementOrData, config = {} ) {
 		// If both `config.initialData` is set and initial data is passed as the constructor parameter, then throw.

--- a/packages/ckeditor5-editor-balloon/src/ballooneditor.js
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditor.js
@@ -56,7 +56,14 @@ export default class BalloonEditor extends Editor {
 	 * {@link module:editor-balloon/ballooneditor~BalloonEditor.create `BalloonEditor.create()`}.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 */
-	constructor( sourceElementOrData, config ) {
+	constructor( sourceElementOrData, config = {} ) {
+		// If both `config.initialData` is set and initial data is passed as the constructor parameter, then throw.
+		if ( !isElement( sourceElementOrData ) && config.initialData !== undefined ) {
+			// Documented in core/editor/editorconfig.jsdoc.
+			// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
+			throw new CKEditorError( 'editor-create-initial-data', null );
+		}
+
 		super( config );
 
 		if ( this.config.get( 'initialData' ) === undefined ) {
@@ -195,19 +202,10 @@ export default class BalloonEditor extends Editor {
 	 */
 	static create( sourceElementOrData, config = {} ) {
 		return new Promise( resolve => {
-			const isHTMLElement = isElement( sourceElementOrData );
-
-			if ( isHTMLElement && sourceElementOrData.tagName === 'TEXTAREA' ) {
+			if ( isElement( sourceElementOrData ) && sourceElementOrData.tagName === 'TEXTAREA' ) {
 				// Documented in core/editor/editor.js
 				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
 				throw new CKEditorError( 'editor-wrong-element', null );
-			}
-
-			// If both `config.initialData` and initial data parameter in `create()` are set, then throw.
-			if ( !isHTMLElement && config.initialData !== undefined ) {
-				// Documented in core/editor/editorconfig.jsdoc.
-				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
-				throw new CKEditorError( 'editor-create-initial-data', null );
 			}
 
 			const editor = new this( sourceElementOrData, config );

--- a/packages/ckeditor5-editor-classic/src/classiceditor.js
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.js
@@ -58,6 +58,10 @@ export default class ClassicEditor extends Editor {
 	constructor( sourceElementOrData, config ) {
 		super( config );
 
+		if ( this.config.get( 'initialData' ) === undefined ) {
+			this.config.set( 'initialData', getInitialData( sourceElementOrData ) );
+		}
+
 		if ( isElement( sourceElementOrData ) ) {
 			this.sourceElement = sourceElementOrData;
 		}
@@ -191,11 +195,6 @@ export default class ClassicEditor extends Editor {
 				// Documented in core/editor/editorconfig.jsdoc.
 				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
 				throw new CKEditorError( 'editor-create-initial-data', null );
-			}
-
-			// If `config.initialData` is not set, use DOM element or initial data set in `create()` parameter.
-			if ( config.initialData === undefined ) {
-				config.initialData = getInitialData( sourceElementOrData );
 			}
 
 			const editor = new this( sourceElementOrData, config );

--- a/packages/ckeditor5-editor-classic/src/classiceditor.js
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.js
@@ -186,22 +186,24 @@ export default class ClassicEditor extends Editor {
 	 */
 	static create( sourceElementOrData, config = {} ) {
 		return new Promise( resolve => {
+			// If both `config.initialData` and initial data parameter in `create()` are set, then throw.
+			if ( !isElement( sourceElementOrData ) && config.initialData !== undefined ) {
+				// Documented in core/editor/editorconfig.jsdoc.
+				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
+				throw new CKEditorError( 'editor-create-initial-data', null );
+			}
+
+			// If `config.initialData` is not set, use DOM element or initial data set in `create()` parameter.
+			if ( config.initialData === undefined ) {
+				config.initialData = getInitialData( sourceElementOrData );
+			}
+
 			const editor = new this( sourceElementOrData, config );
 
 			resolve(
 				editor.initPlugins()
 					.then( () => editor.ui.init( isElement( sourceElementOrData ) ? sourceElementOrData : null ) )
-					.then( () => {
-						if ( !isElement( sourceElementOrData ) && config.initialData ) {
-							// Documented in core/editor/editorconfig.jdoc.
-							// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
-							throw new CKEditorError( 'editor-create-initial-data', null );
-						}
-
-						const initialData = config.initialData !== undefined ? config.initialData : getInitialData( sourceElementOrData );
-
-						return editor.data.init( initialData );
-					} )
+					.then( () => editor.data.init( editor.config.get( 'initialData' ) ) )
 					.then( () => editor.fire( 'ready' ) )
 					.then( () => editor )
 			);

--- a/packages/ckeditor5-editor-classic/src/classiceditor.js
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.js
@@ -53,9 +53,16 @@ export default class ClassicEditor extends Editor {
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * or the editor's initial data. For more information see
 	 * {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`}.
-	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
+	 * @param {module:core/editor/editorconfig~EditorConfig} [config] The editor configuration.
 	 */
-	constructor( sourceElementOrData, config ) {
+	constructor( sourceElementOrData, config = {} ) {
+		// If both `config.initialData` is set and initial data is passed as the constructor parameter, then throw.
+		if ( !isElement( sourceElementOrData ) && config.initialData !== undefined ) {
+			// Documented in core/editor/editorconfig.jsdoc.
+			// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
+			throw new CKEditorError( 'editor-create-initial-data', null );
+		}
+
 		super( config );
 
 		if ( this.config.get( 'initialData' ) === undefined ) {
@@ -190,13 +197,6 @@ export default class ClassicEditor extends Editor {
 	 */
 	static create( sourceElementOrData, config = {} ) {
 		return new Promise( resolve => {
-			// If both `config.initialData` and initial data parameter in `create()` are set, then throw.
-			if ( !isElement( sourceElementOrData ) && config.initialData !== undefined ) {
-				// Documented in core/editor/editorconfig.jsdoc.
-				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
-				throw new CKEditorError( 'editor-create-initial-data', null );
-			}
-
 			const editor = new this( sourceElementOrData, config );
 
 			resolve(

--- a/packages/ckeditor5-editor-classic/tests/classiceditor.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditor.js
@@ -17,12 +17,12 @@ import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import DataApiMixin from '@ckeditor/ckeditor5-core/src/editor/utils/dataapimixin';
 import ElementApiMixin from '@ckeditor/ckeditor5-core/src/editor/utils/elementapimixin';
 import RootElement from '@ckeditor/ckeditor5-engine/src/model/rootelement';
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 import { describeMemoryUsage, testMemoryUsage } from '@ckeditor/ckeditor5-core/tests/_utils/memory';
-import { removeEditorBodyOrphans } from '@ckeditor/ckeditor5-core/tests/_utils/cleanup';
 
 describe( 'ClassicEditor', () => {
 	let editor, editorElement;
@@ -128,6 +128,39 @@ describe( 'ClassicEditor', () => {
 				} );
 			} );
 		} );
+
+		describe( 'config.initialData', () => {
+			it( 'if not set, is set using DOM element data', () => {
+				const editorElement = document.createElement( 'div' );
+				editorElement.innerHTML = '<p>Foo</p>';
+
+				const editor = new ClassicEditor( editorElement );
+
+				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Foo</p>' );
+			} );
+
+			it( 'if not set, is set using data passed in constructor', () => {
+				const editor = new ClassicEditor( '<p>Foo</p>' );
+
+				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Foo</p>' );
+			} );
+
+			it( 'if set, is not overwritten with DOM element data', () => {
+				const editorElement = document.createElement( 'div' );
+				editorElement.innerHTML = '<p>Foo</p>';
+
+				const editor = new ClassicEditor( editorElement, { initialData: '<p>Bar</p>' } );
+
+				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Bar</p>' );
+			} );
+
+			it( 'it should throw if config.initialData is set and initial data is passed in constructor', () => {
+				expect( () => {
+					// eslint-disable-next-line no-new
+					new ClassicEditor( '<p>Foo</p>', { initialData: '<p>Bar</p>' } );
+				} ).to.throw( CKEditorError, 'editor-create-initial-data' );
+			} );
+		} );
 	} );
 
 	describe( 'create()', () => {
@@ -214,16 +247,6 @@ describe( 'ClassicEditor', () => {
 				expect( editor.getData() ).to.equal( '' );
 
 				editor.destroy();
-			} );
-		} );
-
-		it( 'throws if initial data is passed in Editor#create and config.initialData is also used', done => {
-			ClassicEditor.create( '<p>Hello world!</p>', {
-				initialData: '<p>I am evil!</p>',
-				plugins: [ Paragraph ]
-			} ).catch( () => {
-				removeEditorBodyOrphans();
-				done();
 			} );
 		} );
 

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitor.js
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitor.js
@@ -63,6 +63,10 @@ export default class DecoupledEditor extends Editor {
 	constructor( sourceElementOrData, config ) {
 		super( config );
 
+		if ( this.config.get( 'initialData' ) === undefined ) {
+			this.config.set( 'initialData', getInitialData( sourceElementOrData ) );
+		}
+
 		if ( isElement( sourceElementOrData ) ) {
 			this.sourceElement = sourceElementOrData;
 			secureSourceElement( this );
@@ -229,11 +233,6 @@ export default class DecoupledEditor extends Editor {
 				// Documented in core/editor/editorconfig.jsdoc.
 				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
 				throw new CKEditorError( 'editor-create-initial-data', null );
-			}
-
-			// If `config.initialData` is not set, use DOM element or initial data set in `create()` parameter.
-			if ( config.initialData === undefined ) {
-				config.initialData = getInitialData( sourceElementOrData );
 			}
 
 			const editor = new this( sourceElementOrData, config );

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitor.js
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitor.js
@@ -58,7 +58,7 @@ export default class DecoupledEditor extends Editor {
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * (on which the editor will be initialized) or initial data for the editor. For more information see
 	 * {@link module:editor-balloon/ballooneditor~BalloonEditor.create `BalloonEditor.create()`}.
-	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
+	 * @param {module:core/editor/editorconfig~EditorConfig} [config] The editor configuration.
 	 */
 	constructor( sourceElementOrData, config = {} ) {
 		// If both `config.initialData` is set and initial data is passed as the constructor parameter, then throw.

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitor.js
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitor.js
@@ -224,24 +224,24 @@ export default class DecoupledEditor extends Editor {
 				throw new CKEditorError( 'editor-wrong-element', null );
 			}
 
+			// If both `config.initialData` and initial data parameter in `create()` are set, then throw.
+			if ( !isHTMLElement && config.initialData !== undefined ) {
+				// Documented in core/editor/editorconfig.jsdoc.
+				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
+				throw new CKEditorError( 'editor-create-initial-data', null );
+			}
+
+			// If `config.initialData` is not set, use DOM element or initial data set in `create()` parameter.
+			if ( config.initialData === undefined ) {
+				config.initialData = getInitialData( sourceElementOrData );
+			}
+
 			const editor = new this( sourceElementOrData, config );
 
 			resolve(
 				editor.initPlugins()
-					.then( () => {
-						editor.ui.init();
-					} )
-					.then( () => {
-						if ( !isHTMLElement && config.initialData ) {
-							// Documented in core/editor/editorconfig.jdoc.
-							// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
-							throw new CKEditorError( 'editor-create-initial-data', null );
-						}
-
-						const initialData = config.initialData !== undefined ? config.initialData : getInitialData( sourceElementOrData );
-
-						return editor.data.init( initialData );
-					} )
+					.then( () => editor.ui.init() )
+					.then( () => editor.data.init( editor.config.get( 'initialData' ) ) )
 					.then( () => editor.fire( 'ready' ) )
 					.then( () => editor )
 			);

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitor.js
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitor.js
@@ -60,7 +60,14 @@ export default class DecoupledEditor extends Editor {
 	 * {@link module:editor-balloon/ballooneditor~BalloonEditor.create `BalloonEditor.create()`}.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 */
-	constructor( sourceElementOrData, config ) {
+	constructor( sourceElementOrData, config = {} ) {
+		// If both `config.initialData` is set and initial data is passed as the constructor parameter, then throw.
+		if ( !isElement( sourceElementOrData ) && config.initialData !== undefined ) {
+			// Documented in core/editor/editorconfig.jsdoc.
+			// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
+			throw new CKEditorError( 'editor-create-initial-data', null );
+		}
+
 		super( config );
 
 		if ( this.config.get( 'initialData' ) === undefined ) {
@@ -220,19 +227,10 @@ export default class DecoupledEditor extends Editor {
 	 */
 	static create( sourceElementOrData, config = {} ) {
 		return new Promise( resolve => {
-			const isHTMLElement = isElement( sourceElementOrData );
-
-			if ( isHTMLElement && sourceElementOrData.tagName === 'TEXTAREA' ) {
+			if ( isElement( sourceElementOrData ) && sourceElementOrData.tagName === 'TEXTAREA' ) {
 				// Documented in core/editor/editor.js
 				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
 				throw new CKEditorError( 'editor-wrong-element', null );
-			}
-
-			// If both `config.initialData` and initial data parameter in `create()` are set, then throw.
-			if ( !isHTMLElement && config.initialData !== undefined ) {
-				// Documented in core/editor/editorconfig.jsdoc.
-				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
-				throw new CKEditorError( 'editor-create-initial-data', null );
 			}
 
 			const editor = new this( sourceElementOrData, config );

--- a/packages/ckeditor5-editor-inline/src/inlineeditor.js
+++ b/packages/ckeditor5-editor-inline/src/inlineeditor.js
@@ -58,6 +58,10 @@ export default class InlineEditor extends Editor {
 	constructor( sourceElementOrData, config ) {
 		super( config );
 
+		if ( this.config.get( 'initialData' ) === undefined ) {
+			this.config.set( 'initialData', getInitialData( sourceElementOrData ) );
+		}
+
 		this.model.document.createRoot();
 
 		if ( isElement( sourceElementOrData ) ) {
@@ -200,11 +204,6 @@ export default class InlineEditor extends Editor {
 				// Documented in core/editor/editorconfig.jsdoc.
 				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
 				throw new CKEditorError( 'editor-create-initial-data', null );
-			}
-
-			// If `config.initialData` is not set, use DOM element or initial data set in `create()` parameter.
-			if ( config.initialData === undefined ) {
-				config.initialData = getInitialData( sourceElementOrData );
 			}
 
 			const editor = new this( sourceElementOrData, config );

--- a/packages/ckeditor5-editor-inline/src/inlineeditor.js
+++ b/packages/ckeditor5-editor-inline/src/inlineeditor.js
@@ -55,7 +55,14 @@ export default class InlineEditor extends Editor {
 	 * {@link module:editor-inline/inlineeditor~InlineEditor.create `InlineEditor.create()`}.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 */
-	constructor( sourceElementOrData, config ) {
+	constructor( sourceElementOrData, config = {} ) {
+		// If both `config.initialData` and initial data parameter in `create()` are set, then throw.
+		if ( !isElement( sourceElementOrData ) && config.initialData !== undefined ) {
+			// Documented in core/editor/editorconfig.jsdoc.
+			// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
+			throw new CKEditorError( 'editor-create-initial-data', null );
+		}
+
 		super( config );
 
 		if ( this.config.get( 'initialData' ) === undefined ) {
@@ -191,19 +198,10 @@ export default class InlineEditor extends Editor {
 	 */
 	static create( sourceElementOrData, config = {} ) {
 		return new Promise( resolve => {
-			const isHTMLElement = isElement( sourceElementOrData );
-
-			if ( isHTMLElement && sourceElementOrData.tagName === 'TEXTAREA' ) {
+			if ( isElement( sourceElementOrData ) && sourceElementOrData.tagName === 'TEXTAREA' ) {
 				// Documented in core/editor/editor.js
 				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
 				throw new CKEditorError( 'editor-wrong-element', null );
-			}
-
-			// If both `config.initialData` and initial data parameter in `create()` are set, then throw.
-			if ( !isHTMLElement && config.initialData !== undefined ) {
-				// Documented in core/editor/editorconfig.jsdoc.
-				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
-				throw new CKEditorError( 'editor-create-initial-data', null );
 			}
 
 			const editor = new this( sourceElementOrData, config );

--- a/packages/ckeditor5-editor-inline/src/inlineeditor.js
+++ b/packages/ckeditor5-editor-inline/src/inlineeditor.js
@@ -195,24 +195,24 @@ export default class InlineEditor extends Editor {
 				throw new CKEditorError( 'editor-wrong-element', null );
 			}
 
+			// If both `config.initialData` and initial data parameter in `create()` are set, then throw.
+			if ( !isHTMLElement && config.initialData !== undefined ) {
+				// Documented in core/editor/editorconfig.jsdoc.
+				// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
+				throw new CKEditorError( 'editor-create-initial-data', null );
+			}
+
+			// If `config.initialData` is not set, use DOM element or initial data set in `create()` parameter.
+			if ( config.initialData === undefined ) {
+				config.initialData = getInitialData( sourceElementOrData );
+			}
+
 			const editor = new this( sourceElementOrData, config );
 
 			resolve(
 				editor.initPlugins()
-					.then( () => {
-						editor.ui.init();
-					} )
-					.then( () => {
-						if ( !isHTMLElement && config.initialData ) {
-							// Documented in core/editor/editorconfig.jdoc.
-							// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
-							throw new CKEditorError( 'editor-create-initial-data', null );
-						}
-
-						const initialData = config.initialData !== undefined ? config.initialData : getInitialData( sourceElementOrData );
-
-						return editor.data.init( initialData );
-					} )
+					.then( () => editor.ui.init() )
+					.then( () => editor.data.init( editor.config.get( 'initialData' ) ) )
 					.then( () => editor.fire( 'ready' ) )
 					.then( () => editor )
 			);

--- a/packages/ckeditor5-editor-inline/src/inlineeditor.js
+++ b/packages/ckeditor5-editor-inline/src/inlineeditor.js
@@ -53,7 +53,7 @@ export default class InlineEditor extends Editor {
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * (on which the editor will be initialized) or initial data for the editor. For more information see
 	 * {@link module:editor-inline/inlineeditor~InlineEditor.create `InlineEditor.create()`}.
-	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
+	 * @param {module:core/editor/editorconfig~EditorConfig} [config] The editor configuration.
 	 */
 	constructor( sourceElementOrData, config = {} ) {
 		// If both `config.initialData` and initial data parameter in `create()` are set, then throw.

--- a/packages/ckeditor5-editor-inline/tests/inlineeditor.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditor.js
@@ -23,7 +23,7 @@ import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 import { describeMemoryUsage, testMemoryUsage } from '@ckeditor/ckeditor5-core/tests/_utils/memory';
 import { assertCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
-import { removeEditorBodyOrphans } from '@ckeditor/ckeditor5-core/tests/_utils/cleanup';
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 describe( 'InlineEditor', () => {
 	let editor, editorElement;
@@ -102,6 +102,39 @@ describe( 'InlineEditor', () => {
 				)
 				.then( done )
 				.catch( done );
+		} );
+
+		describe( 'config.initialData', () => {
+			it( 'if not set, is set using DOM element data', () => {
+				const editorElement = document.createElement( 'div' );
+				editorElement.innerHTML = '<p>Foo</p>';
+
+				const editor = new InlineEditor( editorElement );
+
+				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Foo</p>' );
+			} );
+
+			it( 'if not set, is set using data passed in constructor', () => {
+				const editor = new InlineEditor( '<p>Foo</p>' );
+
+				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Foo</p>' );
+			} );
+
+			it( 'if set, is not overwritten with DOM element data', () => {
+				const editorElement = document.createElement( 'div' );
+				editorElement.innerHTML = '<p>Foo</p>';
+
+				const editor = new InlineEditor( editorElement, { initialData: '<p>Bar</p>' } );
+
+				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Bar</p>' );
+			} );
+
+			it( 'it should throw if config.initialData is set and initial data is passed in constructor', () => {
+				expect( () => {
+					// eslint-disable-next-line no-new
+					new InlineEditor( '<p>Foo</p>', { initialData: '<p>Bar</p>' } );
+				} ).to.throw( CKEditorError, 'editor-create-initial-data' );
+			} );
 		} );
 	} );
 
@@ -212,26 +245,6 @@ describe( 'InlineEditor', () => {
 			} ).then( () => {
 				editorElement.remove();
 			} );
-		} );
-
-		it( 'throws if initial data is passed in Editor#create and config.initialData is also used', done => {
-			InlineEditor.create( '<p>Hello world!</p>', {
-				initialData: '<p>I am evil!</p>',
-				plugins: [ Paragraph ]
-			} )
-				.then(
-					() => {
-						expect.fail( 'Inline editor should throw an error when both initial data are passed' );
-					},
-					err => {
-						assertCKEditorError( err, 'editor-create-initial-data', null );
-					}
-				)
-				.then( () => {
-					removeEditorBodyOrphans();
-				} )
-				.then( done )
-				.catch( done );
 		} );
 
 		// #25


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other: `Editor.create()` will now set `config.initialData` value based on the first parameter, if `initialData` has not been set in the editor config. As a result, plugins can now easily read and modify the editor initial data.

MINOR BREAKING CHANGE: `config.initialData` now will be always set, even if it was not passed in the editor config.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._