### PR TITLE
Docs: integrating changes from  #11097.

### DIFF
--- a/docs/installation/advanced/dll-builds-collaboration-features.md
+++ b/docs/installation/advanced/dll-builds-collaboration-features.md
@@ -1,0 +1,176 @@
+---
+menu-title: DLL builds for CKEditor 5 Collaboration Features
+category: alternative-setups
+order: 25
+modified_at: 2022-02-22
+---
+
+# CKEditor 5 DLL builds for CKEditor 5 Collaboration Features
+
+<info-box>
+    This guide discusses using a DLL build together with CKEditor 5 Collaboration Features and is supplemental to the {@link installation/advanced/dll-builds CKEditor 5 DLL builds guide}.
+
+    Make sure to read the {@link installation/advanced/dll-builds base guide} first before proceeding.
+</info-box>
+
+## Anatomy of a DLL build with CKEditor 5 collaboration features
+
+A DLL build of the editor consists of the following parts:
+
+* **Base DLL build**. It is a single JavaScript file that combines the contents of several core CKEditor 5 packages: `utils`, `core`, `engine`, `ui`, `clipboard`, `enter`, `paragraph`, `select-all`, `typing`, `undo`, `upload`, and `widget`. These packages are either the framework core, or are features used by nearly all editor installations (`ckeditor5` on npm).
+* **Base DLL build for CKEditor 5 Collaboration Features**. It is a single JavaScript file that includes all necessary files for the collaboration features packages and extends the base DLL for CKEditor 5 (`ckeditor5-collaboration` on NPM).
+* **DLL-compatible package builds**. Every package that is not a part of the base DLL builds, is built into a DLL-compatible JavaScript file (`@ckeditor/ckeditor5-*` on NPM). The CKEditor 5 Collaboration Features DLL builds are available in this format as well.
+
+In order to create an editor, you need to use the two base DLL builds plus several DLL-compatible package builds.
+
+## Integrating CKEditor 5 Collaboration Features as DLL builds
+
+The exact way to use a DLL build will depend on your system. Presented in this guide is the simplest method that uses `<script>` tags.
+
+In order to run the editor, you need to load the necessary files (base DLL + CF base DLL + editor creator + features). These files expose their content in the `CKEditor5` global, using the following format:
+
+```
+CKEditor5.packageName.moduleName
+```
+
+<info-box>
+	This guide uses the {@link features/watchdog watchdog feature} feature. You can also integrate the collaboration features without it, but it is strongly recommended to use the watchdog when the real-time collaboration is enabled.
+</info-box>
+
+Below is an example of an integration:
+
+```html
+<div id="presence-list-container"></div>
+
+<div class="container">
+    <div id="editor"><p>Let's edit this together!</p></div>
+    <div class="sidebar" id="sidebar"></div>
+</div>
+
+<!-- Base DLL build. -->
+<!-- Note: It includes ckeditor5-paragraph too. -->
+<script src="path/to/node_modules/ckeditor5/build/ckeditor5-dll.js"></script>
+
+<!-- DLL-compatible build of ckeditor5-editor-classic. -->
+<script src="path/to/node_modules/@ckeditor/ckeditor5-editor-classic/build/editor-classic.js"></script>
+
+<!-- DLL-compatible builds of editor features. -->
+<script src="path/to/node_modules/@ckeditor/ckeditor5-autoformat/build/autoformat.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-basic-styles/build/basic-styles.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-block-quote/build/block-quote.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-essentials/build/essentials.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-heading/build/heading.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-image/build/image.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-indent/build/indent.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-link/build/link.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-list/build/list.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-media-embed/build/media-embed.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-paste-from-office/build/paste-from-office.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-table/build/table.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-cloud-services/build/cloud-services.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-watchdog/build/watchdog.js"></script>
+
+<!-- Base DLL build for Collaboration features -->
+<script src="path/to/node_modules/ckeditor5-collaboration/build/ckeditor5-collaboration-dll.js"></script>
+
+<!-- DLL-compatible builds of collaboration features. -->
+<script src="path/to/node_modules/@ckeditor/ckeditor5-comments/build/comments.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-track-changes/build/track-changes.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-real-time-collaboration/build/real-time-collaboration.js"></script>
+
+<script>
+	const watchdog = new CKEditor5.watchdog.EditorWatchdog( Editor );
+
+	watchdog.create( document.querySelector( '#editor', {
+		plugins: [
+			CKEditor5.autoformat.Autoformat,
+			CKEditor5.basicStyles.Bold,
+			CKEditor5.basicStyles.Italic,
+			CKEditor5.blockQuote.BlockQuote,
+			CKEditor5.essentials.Essentials,
+			CKEditor5.heading.Heading,
+			CKEditor5.image.Image,
+			CKEditor5.image.ImageCaption,
+			CKEditor5.image.ImageStyle,
+			CKEditor5.image.ImageToolbar,
+			CKEditor5.image.ImageUpload,
+			CKEditor5.indent.Indent,
+			CKEditor5.link.Link,
+			CKEditor5.list.List,
+			CKEditor5.mediaEmbed.MediaEmbed,
+			CKEditor5.paragraph.Paragraph,
+			CKEditor5.pasteFromOffice.PasteFromOffice,
+			CKEditor5.table.Table,
+			CKEditor5.table.TableToolbar
+			CKEditor5.cloudServices.CloudServices,
+			CKEditor5.comments.Comments,
+			CKEditor5.trackChanges.TrackChanges,
+			CKEditor5.realTimeCollaboration.RealTimeCollaborativeEditing,
+			CKEditor5.realTimeCollaboration.RealTimeCollaborativeComments,
+			CKEditor5.realTimeCollaboration.RealTimeCollaborativeTrackChanges,
+		],
+		toolbar: {
+			items: [
+				'heading',
+				'|',
+				'bold',
+				'italic',
+				'link',
+				'bulletedList',
+				'numberedList',
+				'|',
+				'outdent',
+				'indent',
+				'|',
+				'uploadImage',
+				'blockQuote',
+				'insertTable',
+				'mediaEmbed',
+				'undo',
+				'redo',
+				'-',
+				'comment',
+				'-',
+				'trackChanges'
+			]
+		},
+		image: {
+			toolbar: [
+				'imageStyle:inline',
+				'imageStyle:block',
+				'imageStyle:side',
+				'|',
+				'toggleImageCaption',
+				'imageTextAlternative'
+			]
+		},
+		table: {
+			contentToolbar: [
+				'tableColumn',
+				'tableRow',
+				'mergeTableCells'
+			]
+		},
+		comments: {
+			editorConfig: {
+				extraPlugins: [ CKEditor5.basicStyles.Bold, CKEditor5.basicStyles.Italic, CKEditor5.list.List, CKEditor5.autoformat.Autoformat ]
+			}
+		},
+		presenceList: {
+			container: document.querySelector( '#presence-list-container' )
+		},
+		sidebar: {
+			container: document.querySelector( '#sidebar' )
+		},
+		cloudServices: {
+			// PROVIDE CORRECT VALUES HERE:
+			tokenUrl: 'https://example.com/cs-token-endpoint',
+			uploadUrl: 'https://your-organization-id.cke-cs.com/easyimage/upload/',
+			webSocketUrl: 'your-organization-id.cke-cs.com/ws/'
+		},
+		collaboration: {
+			channelId: 'document-id'
+		}
+	} ) );
+</script>
+```

--- a/docs/installation/advanced/dll-builds-collaboration-features.md
+++ b/docs/installation/advanced/dll-builds-collaboration-features.md
@@ -17,11 +17,11 @@ modified_at: 2022-02-22
 
 A DLL build of the editor consists of the following parts:
 
-* **Base DLL build**. It is a single JavaScript file that combines the contents of several core CKEditor 5 packages: `utils`, `core`, `engine`, `ui`, `clipboard`, `enter`, `paragraph`, `select-all`, `typing`, `undo`, `upload`, and `widget`. These packages are either the framework core, or are features used by nearly all editor installations (`ckeditor5` on npm).
-* **Base DLL build for CKEditor 5 Collaboration Features**. It is a single JavaScript file that includes all necessary files for the collaboration features packages and extends the base DLL for CKEditor 5 (`ckeditor5-collaboration` on NPM).
-* **DLL-compatible package builds**. Every package that is not a part of the base DLL builds, is built into a DLL-compatible JavaScript file (`@ckeditor/ckeditor5-*` on NPM). The CKEditor 5 Collaboration Features DLL builds are available in this format as well.
+* **Base DLL build**. It is a single JavaScript file that combines the contents of several core CKEditor 5 packages: `utils`, `core`, `engine`, `ui`, `clipboard`, `enter`, `paragraph`, `select-all`, `typing`, `undo`, `upload`, and `widget`. These packages are either the framework core, or are features used by nearly all editor installations. The build is available on NPM in `ckeditor5` package.
+* **Base DLL build for CKEditor 5 Collaboration Features**. It is a single JavaScript file that includes all necessary files for the collaboration features packages and extends the base DLL for CKEditor 5. The build is available on NPM in `ckeditor5-collaboration` package.
+* **DLL-compatible package builds**. Every package that is not a part of the base DLL builds, is built into a DLL-compatible JavaScript file. The CKEditor 5 Collaboration Features DLL builds are available in this format as well. These DLLs are available on NPM in `@ckeditor/ckeditor5-[FEATURE_NAME]` packages.
 
-In order to create an editor, you need to use the two base DLL builds plus several DLL-compatible package builds.
+In order to create an editor with collaboration features, you need to use the two base DLL builds plus a DLL-compatible package build for each plugin you would like to include.
 
 ## Integrating CKEditor 5 Collaboration Features as DLL builds
 
@@ -80,7 +80,6 @@ Below is an example of an integration:
 
 <script>
 	const watchdog = new CKEditor5.watchdog.EditorWatchdog( Editor );
-
 	watchdog.create( document.querySelector( '#editor', {
 		plugins: [
 			CKEditor5.autoformat.Autoformat,

--- a/docs/installation/advanced/dll-builds.md
+++ b/docs/installation/advanced/dll-builds.md
@@ -2,7 +2,7 @@
 menu-title: DLL builds
 category: alternative-setups
 order: 20
-modified_at: 2021-08-31
+modified_at: 2022-02-22
 ---
 
 # CKEditor 5 DLL builds
@@ -20,16 +20,18 @@ This is where the DLL builds come to the rescue.
 
 DLL builds are based on the [DLL webpack](https://webpack.js.org/plugins/dll-plugin/) plugin that provides a CKEditor 5 **base DLL** and a set of **[DLL consumer plugins](https://webpack.js.org/plugins/dll-plugin/#dllreferenceplugin)**.
 
-Currently, CKEditor 5 does not come with a ready-to-use DLL build. Using this integration method requires creating it on your own, based on the tools available in the {@link framework/guides/contributing/development-environment CKEditor 5 development environment}.
+CKEditor 5 comes with ready-to-use DLL builds. These builds are added to the NPM packages and they are available inside the `/build` directory of each package.
 
-Follow the [Ship CKEditor 5 DLLs](https://github.com/ckeditor/ckeditor5/issues/9145) issue for updates (and add 👍&nbsp; if you are interested in this functionality).
+<info-box>
+	For simplicity reasons, this guide does not include any collaboration features. If you are interested in adding these features, please check the {@link installation/advanced/dll-builds-collaboration-features DLL builds for CKEditor 5 Collaboration Features} guide after reading this one.
+</info-box>
 
 ## Anatomy of a DLL build
 
 A DLL build of the editor consists of two parts:
 
-* **Base DLL build**. It is a single JavaScript file that combines the contents of several core CKEditor 5 packages: `utils`, `core`, `engine`, `ui`, `clipboard`, `enter`, `paragraph`, `select-all`, `typing`, `undo`, `upload`, and `widget`. These packages are either the framework core, or are features used by nearly all editor installations.
-* **DLL-compatible package builds**. Every package that is not part of the base DLL build is built into a DLL-compatible JavaScript file.
+* **Base DLL build**. It is a single JavaScript file that combines the contents of several core CKEditor 5 packages: `utils`, `core`, `engine`, `ui`, `clipboard`, `enter`, `paragraph`, `select-all`, `typing`, `undo`, `upload`, and `widget`. These packages are either the framework core, or are features used by nearly all editor installations (`ckeditor5`).
+* **DLL-compatible package builds**. Every package that is not part of the base DLL build is built into a DLL-compatible JavaScript file (`@ckeditor/ckeditor5-*`).
 
 In order to load an editor, you need to use the base DLL build plus several DLL-compatible package builds. You will see how to do that later on.
 
@@ -37,12 +39,8 @@ In order to load an editor, you need to use the base DLL build plus several DLL-
 
 In order to create your own base DLL build and DLL-compatible packages builds, all you need to do is:
 
-1. Set up the {@link framework/guides/contributing/development-environment CKEditor 5 development environment} locally.
-2. Run `npm run dll:build`.
-
-The base DLL build can be found in `./build/ckeditor5-dll.js`.
-
-The DLL-compatible builds of other packages can be found in `./packages/ckeditor5-*/build/<pkg-name>.js`. For example: `./packages/ckeditor5-image/build/image.js`.
+1. Install `ckeditor5` package from NPM.
+1. Install `@ckeditor/ckeditor5-*` packages for all plugins that you want to include in the build.
 
 This is it.
 
@@ -61,31 +59,31 @@ For example:
 ```html
 <!-- Base DLL build. -->
 <!-- Note: It includes ckeditor5-paragraph too. -->
-<script src="path/to/ckeditor5/build/ckeditor5-dll.js"></script>
+<script src="path/to/node_modules/ckeditor5/build/ckeditor5-dll.js"></script>
 
 <!-- DLL-compatible build of ckeditor5-editor-classic. -->
-<script src="path/to/ckeditor5/packages/ckeditor5-editor-classic/build/editor-classic.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-editor-classic/build/editor-classic.js"></script>
 
 <!-- DLL-compatible builds of editor features. -->
-<script src="path/to/ckeditor5/packages/ckeditor5-autoformat/build/autoformat.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-basic-styles/build/basic-styles.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-block-quote/build/block-quote.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-essentials/build/essentials.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-heading/build/heading.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-image/build/image.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-indent/build/indent.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-link/build/link.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-list/build/list.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-media-embed/build/media-embed.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-paste-from-office/build/paste-from-office.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-table/build/table.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-autoformat/build/autoformat.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-basic-styles/build/basic-styles.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-block-quote/build/block-quote.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-essentials/build/essentials.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-heading/build/heading.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-image/build/image.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-indent/build/indent.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-link/build/link.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-list/build/list.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-media-embed/build/media-embed.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-paste-from-office/build/paste-from-office.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-table/build/table.js"></script>
 
 <script>
 	const config = {
 		plugins: [
+			CKEditor5.autoformat.Autoformat,
 			CKEditor5.basicStyles.Bold,
 			CKEditor5.basicStyles.Italic,
-			CKEditor5.autoformat.Autoformat,
 			CKEditor5.blockQuote.BlockQuote,
 			CKEditor5.essentials.Essentials,
 			CKEditor5.heading.Heading,
@@ -173,36 +171,36 @@ For example:
 
 ```html
 <!-- Base DLL build. -->
-<script src="path/to/ckeditor5/build/ckeditor5-dll.js"></script>
+<script src="path/to/node_modules/ckeditor5/build/ckeditor5-dll.js"></script>
 
 <!-- DLL-compatible build of ckeditor5-editor-classic. -->
-<script src="path/to/ckeditor5/packages/ckeditor5-editor-classic/build/editor-classic.js"></script>
+<script src="path/to/node_modules/ckeditor5/packages/ckeditor5-editor-classic/build/editor-classic.js"></script>
 
 <!-- DLL-compatible builds of editor features. -->
-<script src="path/to/ckeditor5/packages/ckeditor5-autoformat/build/autoformat.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-basic-styles/build/basic-styles.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-block-quote/build/block-quote.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-essentials/build/essentials.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-heading/build/heading.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-image/build/image.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-indent/build/indent.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-link/build/link.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-list/build/list.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-media-embed/build/media-embed.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-paste-from-office/build/paste-from-office.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-table/build/table.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-autoformat/build/autoformat.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-basic-styles/build/basic-styles.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-block-quote/build/block-quote.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-essentials/build/essentials.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-heading/build/heading.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-image/build/image.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-indent/build/indent.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-link/build/link.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-list/build/list.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-media-embed/build/media-embed.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-paste-from-office/build/paste-from-office.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-table/build/table.js"></script>
 
 <!-- Spanish translation files. -->
-<script src="path/to/ckeditor5/build/translations/es.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-basic-styles/build/translations/es.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-block-quote/build/translations/es.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-heading/build/translations/es.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-image/build/translations/es.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-indent/build/translations/es.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-link/build/translations/es.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-list/build/translations/es.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-media-embed/build/translations/es.js"></script>
-<script src="path/to/ckeditor5/packages/ckeditor5-table/build/translations/es.js"></script>
+<script src="path/to/node_modules/ckeditor5/build/translations/es.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-basic-styles/build/translations/es.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-block-quote/build/translations/es.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-heading/build/translations/es.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-image/build/translations/es.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-indent/build/translations/es.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-link/build/translations/es.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-list/build/translations/es.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-media-embed/build/translations/es.js"></script>
+<script src="path/to/node_modules/@ckeditor/ckeditor5-table/build/translations/es.js"></script>
 
 <script>
 	const config = {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Integrating changes from https://github.com/ckeditor/ckeditor5/pull/11097/files. Closes cksource/ckeditor5-internal#1495.

---

### Additional information

DO NOT merge if revamp is dropped on production before 33.x release.