### PR TITLE
Ck/11167 document list properties post fixer

### DIFF
--- a/packages/ckeditor5-list/src/documentlist/documentlistediting.js
+++ b/packages/ckeditor5-list/src/documentlist/documentlistediting.js
@@ -448,12 +448,7 @@ function modelChangePostFixer( model, writer, emitter ) {
 			findAndAddListHeadToMap( entry.position, itemToListHead );
 		}
 		// Changed list item indent or type.
-		else if (
-			entry.type == 'attribute' && (
-				entry.attributeKey == 'listIndent' ||
-				emitter._sameListDefiningAttributes.includes( entry.attributeKey )
-			)
-		) {
+		else if ( entry.type == 'attribute' && entry.attributeKey.startsWith( 'list' ) ) {
 			findAndAddListHeadToMap( entry.range.start, itemToListHead );
 
 			if ( entry.attributeNewValue === null ) {

--- a/packages/ckeditor5-list/src/documentlist/documentlistediting.js
+++ b/packages/ckeditor5-list/src/documentlist/documentlistediting.js
@@ -375,12 +375,12 @@ export default class DocumentListEditing extends Plugin {
 		// Then the callbacks for the specific lists.
 		// The indentation fixing must be the first one...
 		this.on( 'postFixer', ( evt, { listHead, writer } ) => {
-			evt.return = fixListIndents( listHead, writer );
+			evt.return = fixListIndents( listHead, writer ) || evt.return;
 		}, { priority: 'high' } );
 
 		// ...then the item ids... and after that other fixers that rely on the correct indentation and ids.
 		this.on( 'postFixer', ( evt, { listHead, writer, seenIds } ) => {
-			evt.return = fixListItemIds( listHead, seenIds, writer );
+			evt.return = fixListItemIds( listHead, seenIds, writer ) || evt.return;
 		}, { priority: 'high' } );
 	}
 }
@@ -448,7 +448,12 @@ function modelChangePostFixer( model, writer, emitter ) {
 			findAndAddListHeadToMap( entry.position, itemToListHead );
 		}
 		// Changed list item indent or type.
-		else if ( entry.type == 'attribute' && [ 'listIndent', 'listType' ].includes( entry.attributeKey ) ) {
+		else if (
+			entry.type == 'attribute' && (
+				entry.attributeKey == 'listIndent' ||
+				emitter._sameListDefiningAttributes.includes( entry.attributeKey )
+			)
+		) {
 			findAndAddListHeadToMap( entry.range.start, itemToListHead );
 
 			if ( entry.attributeNewValue === null ) {

--- a/packages/ckeditor5-list/src/documentlist/documentlistediting.js
+++ b/packages/ckeditor5-list/src/documentlist/documentlistediting.js
@@ -443,8 +443,8 @@ function modelChangePostFixer( model, writer, emitter ) {
 				}
 			}
 		}
-		// Removed list item.
-		else if ( entry.type == 'remove' && entry.attributes.has( 'listItemId' ) ) {
+		// Removed list item or block adjacent to a list.
+		else if ( entry.type == 'remove' ) {
 			findAndAddListHeadToMap( entry.position, itemToListHead );
 		}
 		// Changed list item indent or type.

--- a/packages/ckeditor5-list/src/documentlist/utils/model.js
+++ b/packages/ckeditor5-list/src/documentlist/utils/model.js
@@ -200,6 +200,28 @@ export function expandListBlocksToCompleteItems( blocks, options = {} ) {
 }
 
 /**
+ * Expands the given list of selected blocks to include the leading and tailing blocks of partially selected list items.
+ *
+ * @protected
+ * @param {module:engine/model/element~Element|Array.<module:engine/model/element~Element>} blocks The list of selected blocks.
+ * @param {Array.<String>} sameListDefiningAttributes The list of attributes that must be consistent among all items in the same list.
+ * @returns {Array.<module:engine/model/element~Element>}
+ */
+export function expandListBlocksToCompleteList( blocks, sameListDefiningAttributes ) {
+	blocks = toArray( blocks );
+
+	const allBlocks = new Set();
+
+	for ( const block of blocks ) {
+		for ( const itemBlock of getListItems( block, sameListDefiningAttributes ) ) {
+			allBlocks.add( itemBlock );
+		}
+	}
+
+	return sortBlocks( allBlocks );
+}
+
+/**
  * Splits the list item just before the provided list block.
  *
  * @protected

--- a/packages/ckeditor5-list/src/documentlist/utils/model.js
+++ b/packages/ckeditor5-list/src/documentlist/utils/model.js
@@ -200,7 +200,7 @@ export function expandListBlocksToCompleteItems( blocks, options = {} ) {
 }
 
 /**
- * Expands the given list of selected blocks to include the leading and tailing blocks of partially selected list items.
+ * Expands the given list of selected blocks to include all the items of the lists they're in.
  *
  * @protected
  * @param {module:engine/model/element~Element|Array.<module:engine/model/element~Element>} blocks The list of selected blocks.

--- a/packages/ckeditor5-list/src/documentlistproperties/documentlistpropertiesediting.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/documentlistpropertiesediting.js
@@ -105,7 +105,7 @@ export default class DocumentListPropertiesEditing extends Plugin {
 			}
 		} );
 
-		// Add or remove list properties attributes depending of the list type.
+		// Add or remove list properties attributes depending on the list type.
 		documentListEditing.on( 'postFixer', ( evt, { listHead, writer } ) => {
 			for ( const { node } of iterateSiblingListBlocks( listHead, 'forward' ) ) {
 				for ( const strategy of strategies ) {

--- a/packages/ckeditor5-list/src/documentlistproperties/documentlistpropertiesediting.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/documentlistpropertiesediting.js
@@ -74,7 +74,6 @@ export default class DocumentListPropertiesEditing extends Plugin {
 
 		for ( const strategy of strategies ) {
 			strategy.addCommand( editor );
-			documentListEditing.registerSameListDefiningAttributes( strategy.attributeName );
 			model.schema.extend( '$container', { allowAttributes: strategy.attributeName } );
 			model.schema.extend( '$block', { allowAttributes: strategy.attributeName } );
 			model.schema.extend( '$blockObject', { allowAttributes: strategy.attributeName } );

--- a/packages/ckeditor5-list/src/documentlistproperties/documentlistpropertiesediting.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/documentlistpropertiesediting.js
@@ -109,19 +109,21 @@ export default class DocumentListPropertiesEditing extends Plugin {
 		documentListEditing.on( 'postFixer', ( evt, { listHead, writer } ) => {
 			for ( const { node } of iterateSiblingListBlocks( listHead, 'forward' ) ) {
 				for ( const strategy of strategies ) {
-					if ( strategy.appliesToListItem( node ) ) {
-						// Add missing default property attributes.
-						if ( !strategy.hasValidAttribute( node ) ) {
-							writer.setAttribute( strategy.attributeName, strategy.defaultValue, node );
-							evt.return = true;
-						}
-					} else {
-						// Remove invalid property attributes.
-						if ( node.hasAttribute( strategy.attributeName ) ) {
-							writer.removeAttribute( strategy.attributeName, node );
-							evt.return = true;
-						}
+					// Check if attribute is valid.
+					if ( strategy.hasValidAttribute( node ) ) {
+						continue;
 					}
+
+					// Add missing default property attributes...
+					if ( strategy.appliesToListItem( node ) ) {
+						writer.setAttribute( strategy.attributeName, strategy.defaultValue, node );
+					}
+					// ...or remove invalid property attributes.
+					else {
+						writer.removeAttribute( strategy.attributeName, node );
+					}
+
+					evt.return = true;
 				}
 			}
 		} );
@@ -263,7 +265,7 @@ function createAttributeStrategies( enabledProperties ) {
 			},
 
 			hasValidAttribute( item ) {
-				return item.hasAttribute( 'listReversed' );
+				return this.appliesToListItem( item ) == item.hasAttribute( 'listReversed' );
 			},
 
 			setAttributeOnDowncast( writer, listReversed, element ) {
@@ -295,7 +297,7 @@ function createAttributeStrategies( enabledProperties ) {
 			},
 
 			hasValidAttribute( item ) {
-				return item.hasAttribute( 'listStart' );
+				return this.appliesToListItem( item ) == item.hasAttribute( 'listStart' );
 			},
 
 			setAttributeOnDowncast( writer, listStart, element ) {

--- a/packages/ckeditor5-list/src/documentlistproperties/documentlistreversedcommand.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/documentlistreversedcommand.js
@@ -10,8 +10,7 @@
 import { Command } from 'ckeditor5/src/core';
 import { first } from 'ckeditor5/src/utils';
 import {
-	getListItems,
-	getSelectedBlockObject,
+	expandListBlocksToCompleteList,
 	isListItemBlock
 } from '../documentlist/utils/model';
 
@@ -43,14 +42,13 @@ export default class DocumentListReversedCommand extends Command {
 	execute( options = {} ) {
 		const model = this.editor.model;
 		const document = model.document;
-		const selectedBlockObject = getSelectedBlockObject( model );
 
 		let blocks = Array.from( document.selection.getSelectedBlocks() )
 			.filter( block => isListItemBlock( block ) && block.getAttribute( 'listType' ) == 'numbered' );
 
 		const documentListEditingPlugin = this.editor.plugins.get( 'DocumentListEditing' );
 
-		blocks = getListItems( selectedBlockObject || blocks[ 0 ], documentListEditingPlugin.getSameListDefiningAttributes() );
+		blocks = expandListBlocksToCompleteList( blocks, documentListEditingPlugin.getSameListDefiningAttributes() );
 
 		model.change( writer => {
 			for ( const block of blocks ) {

--- a/packages/ckeditor5-list/src/documentlistproperties/documentlistreversedcommand.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/documentlistreversedcommand.js
@@ -10,7 +10,6 @@
 import { Command } from 'ckeditor5/src/core';
 import { first } from 'ckeditor5/src/utils';
 import {
-	expandListBlocksToCompleteItems,
 	getListItems,
 	getSelectedBlockObject,
 	isListItemBlock
@@ -49,13 +48,9 @@ export default class DocumentListReversedCommand extends Command {
 		let blocks = Array.from( document.selection.getSelectedBlocks() )
 			.filter( block => isListItemBlock( block ) && block.getAttribute( 'listType' ) == 'numbered' );
 
-		if ( document.selection.isCollapsed || selectedBlockObject ) {
-			const documentListEditingPlugin = this.editor.plugins.get( 'DocumentListEditing' );
+		const documentListEditingPlugin = this.editor.plugins.get( 'DocumentListEditing' );
 
-			blocks = getListItems( selectedBlockObject || blocks[ 0 ], documentListEditingPlugin.getSameListDefiningAttributes() );
-		} else {
-			blocks = expandListBlocksToCompleteItems( blocks, { withNested: false } );
-		}
+		blocks = getListItems( selectedBlockObject || blocks[ 0 ], documentListEditingPlugin.getSameListDefiningAttributes() );
 
 		model.change( writer => {
 			for ( const block of blocks ) {

--- a/packages/ckeditor5-list/src/documentlistproperties/documentliststartcommand.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/documentliststartcommand.js
@@ -10,8 +10,7 @@
 import { Command } from 'ckeditor5/src/core';
 import { first } from 'ckeditor5/src/utils';
 import {
-	getListItems,
-	getSelectedBlockObject,
+	expandListBlocksToCompleteList,
 	isListItemBlock
 } from '../documentlist/utils/model';
 
@@ -43,14 +42,13 @@ export default class DocumentListStartCommand extends Command {
 	execute( options = {} ) {
 		const model = this.editor.model;
 		const document = model.document;
-		const selectedBlockObject = getSelectedBlockObject( model );
 
 		let blocks = Array.from( document.selection.getSelectedBlocks() )
 			.filter( block => isListItemBlock( block ) && block.getAttribute( 'listType' ) == 'numbered' );
 
 		const documentListEditingPlugin = this.editor.plugins.get( 'DocumentListEditing' );
 
-		blocks = getListItems( selectedBlockObject || blocks[ 0 ], documentListEditingPlugin.getSameListDefiningAttributes() );
+		blocks = expandListBlocksToCompleteList( blocks, documentListEditingPlugin.getSameListDefiningAttributes() );
 
 		model.change( writer => {
 			for ( const block of blocks ) {

--- a/packages/ckeditor5-list/src/documentlistproperties/documentliststartcommand.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/documentliststartcommand.js
@@ -10,7 +10,6 @@
 import { Command } from 'ckeditor5/src/core';
 import { first } from 'ckeditor5/src/utils';
 import {
-	expandListBlocksToCompleteItems,
 	getListItems,
 	getSelectedBlockObject,
 	isListItemBlock
@@ -49,13 +48,9 @@ export default class DocumentListStartCommand extends Command {
 		let blocks = Array.from( document.selection.getSelectedBlocks() )
 			.filter( block => isListItemBlock( block ) && block.getAttribute( 'listType' ) == 'numbered' );
 
-		if ( document.selection.isCollapsed || selectedBlockObject ) {
-			const documentListEditingPlugin = this.editor.plugins.get( 'DocumentListEditing' );
+		const documentListEditingPlugin = this.editor.plugins.get( 'DocumentListEditing' );
 
-			blocks = getListItems( selectedBlockObject || blocks[ 0 ], documentListEditingPlugin.getSameListDefiningAttributes() );
-		} else {
-			blocks = expandListBlocksToCompleteItems( blocks, { withNested: false } );
-		}
+		blocks = getListItems( selectedBlockObject || blocks[ 0 ], documentListEditingPlugin.getSameListDefiningAttributes() );
 
 		model.change( writer => {
 			for ( const block of blocks ) {

--- a/packages/ckeditor5-list/src/documentlistproperties/documentliststylecommand.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/documentliststylecommand.js
@@ -10,8 +10,7 @@
 import { Command } from 'ckeditor5/src/core';
 import { first } from 'ckeditor5/src/utils';
 import {
-	getListItems,
-	getSelectedBlockObject,
+	expandListBlocksToCompleteList,
 	isListItemBlock
 } from '../documentlist/utils/model';
 import { getListTypeFromListStyleType } from './utils/style';
@@ -66,8 +65,6 @@ export default class DocumentListStyleCommand extends Command {
 		model.change( writer => {
 			this._tryToConvertItemsToList( options );
 
-			const selectedBlockObject = getSelectedBlockObject( model );
-
 			let blocks = Array.from( document.selection.getSelectedBlocks() )
 				.filter( block => block.hasAttribute( 'listType' ) );
 
@@ -77,7 +74,7 @@ export default class DocumentListStyleCommand extends Command {
 
 			const documentListEditingPlugin = this.editor.plugins.get( 'DocumentListEditing' );
 
-			blocks = getListItems( selectedBlockObject || blocks[ 0 ], documentListEditingPlugin.getSameListDefiningAttributes() );
+			blocks = expandListBlocksToCompleteList( blocks, documentListEditingPlugin.getSameListDefiningAttributes() );
 
 			for ( const block of blocks ) {
 				writer.setAttribute( 'listStyle', options.type || this._defaultType, block );

--- a/packages/ckeditor5-list/src/documentlistproperties/documentliststylecommand.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/documentliststylecommand.js
@@ -10,7 +10,6 @@
 import { Command } from 'ckeditor5/src/core';
 import { first } from 'ckeditor5/src/utils';
 import {
-	expandListBlocksToCompleteItems,
 	getListItems,
 	getSelectedBlockObject,
 	isListItemBlock
@@ -76,13 +75,9 @@ export default class DocumentListStyleCommand extends Command {
 				return;
 			}
 
-			if ( document.selection.isCollapsed || selectedBlockObject ) {
-				const documentListEditingPlugin = this.editor.plugins.get( 'DocumentListEditing' );
+			const documentListEditingPlugin = this.editor.plugins.get( 'DocumentListEditing' );
 
-				blocks = getListItems( selectedBlockObject || blocks[ 0 ], documentListEditingPlugin.getSameListDefiningAttributes() );
-			} else {
-				blocks = expandListBlocksToCompleteItems( blocks, { withNested: false } );
-			}
+			blocks = getListItems( selectedBlockObject || blocks[ 0 ], documentListEditingPlugin.getSameListDefiningAttributes() );
 
 			for ( const block of blocks ) {
 				writer.setAttribute( 'listStyle', options.type || this._defaultType, block );

--- a/packages/ckeditor5-list/src/documentlistproperties/utils/style.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/utils/style.js
@@ -17,7 +17,9 @@ const NUMBERED_LIST_STYLE_TYPES = [
 	'lower-roman',
 	'upper-roman',
 	'lower-latin',
-	'upper-latin'
+	'upper-latin',
+	'lower-alpha',
+	'upper-alpha'
 ];
 
 /**

--- a/packages/ckeditor5-list/tests/documentlist/documentlistediting.js
+++ b/packages/ckeditor5-list/tests/documentlist/documentlistediting.js
@@ -105,6 +105,28 @@ describe( 'DocumentListEditing', () => {
 		expect( model.schema.checkAttribute( [ '$root', 'tableCell' ], 'listType' ) ).to.be.false;
 	} );
 
+	describe( 'same list-defining attributes', () => {
+		let plugin;
+
+		beforeEach( () => {
+			plugin = editor.plugins.get( DocumentListEditing );
+		} );
+
+		it( '`listType` should define list', () => {
+			expect( plugin.getSameListDefiningAttributes() ).to.include( 'listType' );
+		} );
+
+		it( 'should allow registering custom list-defining attributes', () => {
+			plugin.registerSameListDefiningAttributes( 'attr1' );
+			plugin.registerSameListDefiningAttributes( 'attr2' );
+			plugin.registerSameListDefiningAttributes( 'attr3' );
+
+			expect( plugin.getSameListDefiningAttributes() ).to.include( 'attr1' );
+			expect( plugin.getSameListDefiningAttributes() ).to.include( 'attr2' );
+			expect( plugin.getSameListDefiningAttributes() ).to.include( 'attr3' );
+		} );
+	} );
+
 	describe( 'commands', () => {
 		it( 'should register indent list command', () => {
 			const command = editor.commands.get( 'indentList' );

--- a/packages/ckeditor5-list/tests/documentlist/utils/model.js
+++ b/packages/ckeditor5-list/tests/documentlist/utils/model.js
@@ -5,6 +5,7 @@
 
 import {
 	expandListBlocksToCompleteItems,
+	expandListBlocksToCompleteList,
 	getAllListItemBlocks,
 	getListItemBlocks,
 	getListItems,
@@ -903,6 +904,141 @@ describe( 'DocumentList - utils - model', () => {
 			expect( blocks[ 3 ] ).to.equal( fragment.getChild( 4 ) );
 			expect( blocks[ 4 ] ).to.equal( fragment.getChild( 5 ) );
 			expect( blocks[ 5 ] ).to.equal( fragment.getChild( 6 ) );
+		} );
+	} );
+
+	describe( 'expandListBlocksToCompleteList()', () => {
+		it( 'should not include anything (no blocks given)', () => {
+			let blocks = [];
+
+			blocks = expandListBlocksToCompleteList( blocks );
+
+			expect( blocks.length ).to.equal( 0 );
+		} );
+
+		it( 'should include all list item (single item given)', () => {
+			const input = modelList( [
+				'* a',
+				'* b', // this one
+				'* c',
+				'* d'
+			] );
+
+			const fragment = parseModel( input, schema );
+			let blocks = [
+				fragment.getChild( 1 )
+			];
+
+			blocks = expandListBlocksToCompleteList( blocks );
+
+			expect( blocks.length ).to.equal( 4 );
+			expect( blocks[ 0 ] ).to.equal( fragment.getChild( 0 ) );
+			expect( blocks[ 1 ] ).to.equal( fragment.getChild( 1 ) );
+			expect( blocks[ 2 ] ).to.equal( fragment.getChild( 2 ) );
+			expect( blocks[ 3 ] ).to.equal( fragment.getChild( 3 ) );
+		} );
+
+		it( 'should include all list item (two items given)', () => {
+			const input = modelList( [
+				'* a',
+				'* b', // this
+				'* c',
+				'* d' // and this
+			] );
+
+			const fragment = parseModel( input, schema );
+			let blocks = [
+				fragment.getChild( 1 ),
+				fragment.getChild( 3 )
+			];
+
+			blocks = expandListBlocksToCompleteList( blocks );
+
+			expect( blocks.length ).to.equal( 4 );
+			expect( blocks[ 0 ] ).to.equal( fragment.getChild( 0 ) );
+			expect( blocks[ 1 ] ).to.equal( fragment.getChild( 1 ) );
+			expect( blocks[ 2 ] ).to.equal( fragment.getChild( 2 ) );
+			expect( blocks[ 3 ] ).to.equal( fragment.getChild( 3 ) );
+		} );
+
+		it( 'should include all list item (part of list item given)', () => {
+			const input = modelList( [
+				'* a',
+				'* b',
+				'  c', // this one
+				'* d',
+				'  e'
+			] );
+
+			const fragment = parseModel( input, schema );
+			let blocks = [
+				fragment.getChild( 2 )
+			];
+
+			blocks = expandListBlocksToCompleteList( blocks );
+
+			expect( blocks.length ).to.equal( 5 );
+			expect( blocks[ 0 ] ).to.equal( fragment.getChild( 0 ) );
+			expect( blocks[ 1 ] ).to.equal( fragment.getChild( 1 ) );
+			expect( blocks[ 2 ] ).to.equal( fragment.getChild( 2 ) );
+			expect( blocks[ 3 ] ).to.equal( fragment.getChild( 3 ) );
+			expect( blocks[ 4 ] ).to.equal( fragment.getChild( 4 ) );
+		} );
+
+		it( 'should include all list item of nested list', () => {
+			const input = modelList( [
+				'* a',
+				'* b',
+				'  # b1',
+				'  # b2', // this one
+				'  # b3',
+				'* c',
+				'* d'
+			] );
+
+			const fragment = parseModel( input, schema );
+			let blocks = [
+				fragment.getChild( 3 )
+			];
+
+			blocks = expandListBlocksToCompleteList( blocks );
+
+			expect( blocks.length ).to.equal( 3 );
+			expect( blocks[ 0 ] ).to.equal( fragment.getChild( 2 ) );
+			expect( blocks[ 1 ] ).to.equal( fragment.getChild( 3 ) );
+			expect( blocks[ 2 ] ).to.equal( fragment.getChild( 4 ) );
+		} );
+
+		it( 'should include all list item from many lists', () => {
+			const input = modelList( [
+				'* a',
+				'* b',
+				'  # b1', // this
+				'    * b1a', // and this
+				'    * b1b',
+				'      # b1b1',
+				'    * b1c',
+				'  # b2',
+				'  # b3',
+				'* c',
+				'* d'
+			] );
+
+			const fragment = parseModel( input, schema );
+			let blocks = [
+				fragment.getChild( 2 ),
+				fragment.getChild( 3 )
+			];
+
+			blocks = expandListBlocksToCompleteList( blocks );
+
+			expect( blocks.length ).to.equal( 6 );
+			expect( blocks[ 0 ] ).to.equal( fragment.getChild( 2 ) );
+			expect( blocks[ 1 ] ).to.equal( fragment.getChild( 3 ) );
+			expect( blocks[ 2 ] ).to.equal( fragment.getChild( 4 ) );
+			expect( blocks[ 3 ] ).to.equal( fragment.getChild( 6 ) );
+			expect( blocks[ 4 ] ).to.equal( fragment.getChild( 7 ) );
+			expect( blocks[ 5 ] ).to.equal( fragment.getChild( 8 ) );
 		} );
 	} );
 

--- a/packages/ckeditor5-list/tests/documentlist/utils/model.js
+++ b/packages/ckeditor5-list/tests/documentlist/utils/model.js
@@ -916,10 +916,10 @@ describe( 'DocumentList - utils - model', () => {
 			expect( blocks.length ).to.equal( 0 );
 		} );
 
-		it( 'should include all list item (single item given)', () => {
+		it( 'should include all list items (single item given)', () => {
 			const input = modelList( [
 				'* a',
-				'* b', // this one
+				'* b', // <-- This one.
 				'* c',
 				'* d'
 			] );

--- a/packages/ckeditor5-list/tests/documentlistproperties/converters.js
+++ b/packages/ckeditor5-list/tests/documentlistproperties/converters.js
@@ -386,9 +386,9 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 				it( 'should be able to downcast part of a nested list', () => {
 					setModelData( model, modelList( `
 						* A
-						  * [B1 {style:foo}
+						  * [B1 {style:circle}
 						    B2
-						    * C1] {style:bar}
+						    * C1] {style:square}
 						      C2
 					` ) );
 
@@ -397,11 +397,11 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 					const data = editor.data.htmlProcessor.toData( viewFragment );
 
 					expect( data ).to.equal(
-						'<ul style="list-style-type:foo;">' +
+						'<ul style="list-style-type:circle;">' +
 							'<li>' +
 								'<p>B1</p>' +
 								'<p>B2</p>' +
-								'<ul style="list-style-type:bar;">' +
+								'<ul style="list-style-type:square;">' +
 									'<li>C1</li>' +
 								'</ul>' +
 							'</li>' +
@@ -412,9 +412,9 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 				it( 'should be able to downcast part of a deep nested list', () => {
 					setModelData( model, modelList( `
 						* A
-						  * B1 {style:foo}
+						  * B1 {style:circle}
 						    B2
-						    * [C1 {style:bar}
+						    * [C1 {style:square}
 						      C2]
 					` ) );
 
@@ -423,7 +423,7 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 					const data = editor.data.htmlProcessor.toData( viewFragment );
 
 					expect( data ).to.equal(
-						'<ul style="list-style-type:bar;">' +
+						'<ul style="list-style-type:square;">' +
 							'<li>' +
 								'<p>C1</p>' +
 								'<p>C2</p>' +
@@ -629,8 +629,8 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 
 				it( 'on a list with nested lists', () => {
 					const input = modelList( `
-						* [<paragraph>a</paragraph> {style:foo}
-						  * <paragraph>b</paragraph> {style:bar}
+						* [<paragraph>a</paragraph> {style:square}
+						  * <paragraph>b</paragraph> {style:disc}
 						* <paragraph>c</paragraph>]
 					` );
 
@@ -638,7 +638,7 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 						'<ul>' +
 							'<li>' +
 								'<span class="ck-list-bogus-paragraph">a</span>' +
-								'<ul style="list-style-type:bar">' +
+								'<ul style="list-style-type:disc">' +
 									'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 								'</ul>' +
 							'</li>' +
@@ -680,35 +680,35 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 			describe( 'change list style', () => {
 				it( 'on a flat list', () => {
 					const input = modelList( `
-						* [<paragraph>a</paragraph> {style:foo}
+						* [<paragraph>a</paragraph> {style:disc}
 						* <paragraph>b</paragraph>]
 					` );
 
 					const output =
-						'<ul style="list-style-type:bar">' +
+						'<ul style="list-style-type:circle">' +
 							'<li><span class="ck-list-bogus-paragraph">a</span></li>' +
 							'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 						'</ul>';
 
 					test.test( input, output, selection => {
 						model.change( writer => {
-							writer.setAttribute( 'listStyle', 'bar', selection.getFirstRange() );
+							writer.setAttribute( 'listStyle', 'circle', selection.getFirstRange() );
 						} );
 					} );
 				} );
 
 				it( 'on a list with nested lists', () => {
 					const input = modelList( `
-						* [<paragraph>a</paragraph> {style:foo}
-						  * <paragraph>b</paragraph> {style:bar}
+						* [<paragraph>a</paragraph> {style:square}
+						  * <paragraph>b</paragraph> {style:disc}
 						* <paragraph>c</paragraph>]
 					` );
 
 					const output =
-						'<ul style="list-style-type:bar">' +
+						'<ul style="list-style-type:circle">' +
 							'<li>' +
 								'<span class="ck-list-bogus-paragraph">a</span>' +
-								'<ul style="list-style-type:bar">' +
+								'<ul style="list-style-type:disc">' +
 									'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 								'</ul>' +
 							'</li>' +
@@ -719,7 +719,7 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 						model.change( writer => {
 							for ( const item of selection.getFirstRange().getItems( { shallow: true } ) ) {
 								if ( item.getAttribute( 'listIndent' ) == 0 ) {
-									writer.setAttribute( 'listStyle', 'bar', item );
+									writer.setAttribute( 'listStyle', 'circle', item );
 								}
 							}
 						} );
@@ -730,12 +730,12 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 			describe( 'change list type', () => {
 				it( 'on a flat list', () => {
 					const input = modelList( `
-						* [<paragraph>a</paragraph> {style:foo}
+						* [<paragraph>a</paragraph> {style:circle}
 						* <paragraph>b</paragraph>]
 					` );
 
 					const output =
-						'<ol style="list-style-type:foo">' +
+						'<ol>' +
 							'<li><span class="ck-list-bogus-paragraph">a</span></li>' +
 							'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 						'</ol>';
@@ -749,16 +749,16 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 
 				it( 'on a list with nested lists', () => {
 					const input = modelList( `
-						* [<paragraph>a</paragraph> {style:foo}
-						  * <paragraph>b</paragraph> {style:bar}
+						* [<paragraph>a</paragraph> {style:circle}
+						  * <paragraph>b</paragraph> {style:disc}
 						* <paragraph>c</paragraph>]
 					` );
 
 					const output =
-						'<ol style="list-style-type:foo">' +
+						'<ol>' +
 							'<li>' +
 								'<span class="ck-list-bogus-paragraph">a</span>' +
-								'<ul style="list-style-type:bar">' +
+								'<ul style="list-style-type:disc">' +
 									'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 								'</ul>' +
 							'</li>' +
@@ -782,7 +782,7 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 					const input = modelList( [
 						'* <paragraph>a</paragraph>',
 						'* [<paragraph>b</paragraph>',
-						'  # <paragraph>c</paragraph>] {style:roman}'
+						'  # <paragraph>c</paragraph>] {style:upper-roman}'
 					] );
 
 					const output =
@@ -792,7 +792,7 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 								'<ul>' +
 									'<li>' +
 										'<span class="ck-list-bogus-paragraph">b</span>' +
-										'<ol style="list-style-type:roman">' +
+										'<ol style="list-style-type:upper-roman">' +
 											'<li><span class="ck-list-bogus-paragraph">c</span></li>' +
 										'</ol>' +
 									'</li>' +
@@ -1381,12 +1381,12 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 			describe( 'change list type', () => {
 				it( 'on a flat list', () => {
 					const input = modelList( `
-						* [<paragraph>a</paragraph> {reversed:true}
+						* [<paragraph>a</paragraph>
 						* <paragraph>b</paragraph>]
 					` );
 
 					const output =
-						'<ol reversed="reversed">' +
+						'<ol>' +
 							'<li><span class="ck-list-bogus-paragraph">a</span></li>' +
 							'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 						'</ol>';
@@ -1400,18 +1400,18 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 
 				it( 'on a list with nested lists', () => {
 					const input = modelList( `
-						* [<paragraph>a</paragraph> {reversed:true}
-						  * <paragraph>b</paragraph> {reversed:true}
+						* [<paragraph>a</paragraph>
+						  # <paragraph>b</paragraph> {reversed:true}
 						* <paragraph>c</paragraph>]
 					` );
 
 					const output =
-						'<ol reversed="reversed">' +
+						'<ol>' +
 							'<li>' +
 								'<span class="ck-list-bogus-paragraph">a</span>' +
-								'<ul>' +
+								'<ol reversed="reversed">' +
 									'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
-								'</ul>' +
+								'</ol>' +
 							'</li>' +
 							'<li><span class="ck-list-bogus-paragraph">c</span></li>' +
 						'</ol>';
@@ -2025,46 +2025,46 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 			describe( 'change list type', () => {
 				it( 'on a flat list', () => {
 					const input = modelList( `
-						* [<paragraph>a</paragraph> {start:2}
-						* <paragraph>b</paragraph>]
+						# [<paragraph>a</paragraph> {start:2}
+						# <paragraph>b</paragraph>]
 					` );
 
 					const output =
-						'<ol start="2">' +
+						'<ul>' +
 							'<li><span class="ck-list-bogus-paragraph">a</span></li>' +
 							'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
-						'</ol>';
+						'</ul>';
 
 					test.test( input, output, selection => {
 						model.change( writer => {
-							writer.setAttribute( 'listType', 'numbered', selection.getFirstRange() );
+							writer.setAttribute( 'listType', 'bulleted', selection.getFirstRange() );
 						} );
 					} );
 				} );
 
 				it( 'on a list with nested lists', () => {
 					const input = modelList( `
-						* [<paragraph>a</paragraph> {start:2}
-						  * <paragraph>b</paragraph> {start:5}
-						* <paragraph>c</paragraph>]
+						# [<paragraph>a</paragraph> {start:2}
+						  # <paragraph>b</paragraph> {start:5}
+						# <paragraph>c</paragraph>]
 					` );
 
 					const output =
-						'<ol start="2">' +
+						'<ul>' +
 							'<li>' +
 								'<span class="ck-list-bogus-paragraph">a</span>' +
-								'<ul>' +
+								'<ol start="5">' +
 									'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
-								'</ul>' +
+								'</ol>' +
 							'</li>' +
 							'<li><span class="ck-list-bogus-paragraph">c</span></li>' +
-						'</ol>';
+						'</ul>';
 
 					test.test( input, output, selection => {
 						model.change( writer => {
 							for ( const item of selection.getFirstRange().getItems( { shallow: true } ) ) {
 								if ( item.getAttribute( 'listIndent' ) == 0 ) {
-									writer.setAttribute( 'listType', 'numbered', item );
+									writer.setAttribute( 'listType', 'bulleted', item );
 								}
 							}
 						} );
@@ -2497,12 +2497,12 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 			describe( 'change list type', () => {
 				it( 'to numbered', () => {
 					const input = modelList( `
-						* [<paragraph>a</paragraph> {start:2} {style:lower-alpha} {reversed:true}
+						* [<paragraph>a</paragraph> {style:default}
 						* <paragraph>b</paragraph>]
 					` );
 
 					const output =
-						'<ol reversed="reversed" start="2" style="list-style-type:lower-alpha">' +
+						'<ol>' +
 							'<li><span class="ck-list-bogus-paragraph">a</span></li>' +
 							'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 						'</ol>';
@@ -2521,7 +2521,7 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 					` );
 
 					const output =
-						'<ul style="list-style-type:lower-alpha">' +
+						'<ul>' +
 							'<li><span class="ck-list-bogus-paragraph">a</span></li>' +
 							'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 						'</ul>';

--- a/packages/ckeditor5-list/tests/documentlistproperties/documentlistpropertiesediting.js
+++ b/packages/ckeditor5-list/tests/documentlistproperties/documentlistpropertiesediting.js
@@ -122,6 +122,42 @@ describe( 'DocumentListPropertiesEditing', () => {
 					'<paragraph listItemId="04" listStyle="circle" listType="bulleted">4.</paragraph>'
 				);
 			} );
+
+			it( 'should restore `listStyle` attribute after it\'s changed in one of the following items', () => {
+				setData( model, modelList( `
+					# 1. {style:upper-roman}
+					# 2.
+					# 3.
+				` ) );
+
+				model.change( writer => {
+					writer.setAttribute( 'listStyle', 'decimal', model.document.getRoot().getChild( 2 ) );
+				} );
+
+				expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+					# 1. {style:upper-roman}
+					# 2.
+					# 3.
+				` ) );
+			} );
+
+			it( 'should change `listStyle` attribute for all the following items after the first one is changed', () => {
+				setData( model, modelList( `
+					# 1. {style:upper-roman}
+					# 2.
+					# 3.
+				` ) );
+
+				model.change( writer => {
+					writer.setAttribute( 'listStyle', 'decimal', model.document.getRoot().getChild( 0 ) );
+				} );
+
+				expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+					# 1. {style:decimal}
+					# 2.
+					# 3.
+				` ) );
+			} );
 		} );
 	} );
 
@@ -204,6 +240,42 @@ describe( 'DocumentListPropertiesEditing', () => {
 					'<paragraph listItemId="04" listReversed="true" listType="numbered">4.</paragraph>'
 				);
 			} );
+
+			it( 'should restore `listReversed` attribute after it\'s changed in one of the following items', () => {
+				setData( model, modelList( `
+					# 1. {reversed:true}
+					# 2.
+					# 3.
+				` ) );
+
+				model.change( writer => {
+					writer.setAttribute( 'listReversed', false, model.document.getRoot().getChild( 2 ) );
+				} );
+
+				expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+					# 1. {reversed:true}
+					# 2.
+					# 3.
+				` ) );
+			} );
+
+			it( 'should change `listReversed` attribute for all the following items after the first one is changed', () => {
+				setData( model, modelList( `
+					# 1. {reversed:false}
+					# 2.
+					# 3.
+				` ) );
+
+				model.change( writer => {
+					writer.setAttribute( 'listReversed', true, model.document.getRoot().getChild( 0 ) );
+				} );
+
+				expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+					# 1. {reversed:true}
+					# 2.
+					# 3.
+				` ) );
+			} );
 		} );
 	} );
 
@@ -285,6 +357,42 @@ describe( 'DocumentListPropertiesEditing', () => {
 					'<paragraph listItemId="03" listStart="2" listType="numbered">3.</paragraph>' +
 					'<paragraph listItemId="04" listStart="2" listType="numbered">4.</paragraph>'
 				);
+			} );
+
+			it( 'should restore `listStart` attribute after it\'s changed in one of the following items', () => {
+				setData( model, modelList( `
+					# 1. {start:2}
+					# 2.
+					# 3.
+				` ) );
+
+				model.change( writer => {
+					writer.setAttribute( 'listStart', 5, model.document.getRoot().getChild( 2 ) );
+				} );
+
+				expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+					# 1. {start:2}
+					# 2.
+					# 3.
+				` ) );
+			} );
+
+			it( 'should change `listStart` attribute for all the following items after the first one is changed', () => {
+				setData( model, modelList( `
+					# 1. {start:2}
+					# 2.
+					# 3.
+				` ) );
+
+				model.change( writer => {
+					writer.setAttribute( 'listStart', 5, model.document.getRoot().getChild( 0 ) );
+				} );
+
+				expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+					# 1. {start:5}
+					# 2.
+					# 3.
+				` ) );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-list/tests/documentlistproperties/documentlistpropertiesediting.js
+++ b/packages/ckeditor5-list/tests/documentlistproperties/documentlistpropertiesediting.js
@@ -6,7 +6,9 @@
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
+import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import DocumentListPropertiesEditing from '../../src/documentlistproperties/documentlistpropertiesediting';
+import { modelList } from '../documentlist/_utils/utils';
 
 describe( 'DocumentListPropertiesEditing', () => {
 	let editor, model;
@@ -70,6 +72,34 @@ describe( 'DocumentListPropertiesEditing', () => {
 				expect( model.schema.checkAttribute( [ '$root', 'paragraph' ], 'listStart' ) ).to.be.false;
 			} );
 		} );
+
+		it( 'should ensure that all item in a single list have the same `listStyle` attribute', () => {
+			setData( model, modelList( `
+				* 1. {style:circle}
+				* 2.
+				* 3. {style:square}
+				* 4.
+				  # 4.1. {style:default}
+				  # 4.2. {style:upper-roman}
+				  # 4.3. {style:decimal}
+				    # 4.3.1. {style:decimal}
+					# 4.3.2. {style:upper-roman}
+				* 5. {style:disc}
+			` ) );
+
+			expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+				* 1. {style:circle}
+				* 2.
+				* 3.
+				* 4.
+				  # 4.1. {style:default}
+				  # 4.2.
+				  # 4.3.
+				    # 4.3.1. {style:decimal}
+				    # 4.3.2.
+				* 5.
+			` ) );
+		} );
 	} );
 
 	describe( 'listReversed', () => {
@@ -101,6 +131,34 @@ describe( 'DocumentListPropertiesEditing', () => {
 				expect( model.schema.checkAttribute( [ '$root', 'paragraph' ], 'listStart' ) ).to.be.false;
 			} );
 		} );
+
+		it( 'should ensure that all item in a single list have the same `listReversed` attribute', () => {
+			setData( model, modelList( `
+				# 1. {reversed:true}
+				# 2.
+				# 3. {reversed:false}
+				# 4.
+				  # 4.1. {reversed:false}
+				  # 4.2. {reversed:true}
+				  # 4.3. {reversed:false}
+				    # 4.3.1. {reversed:true}
+					# 4.3.2. {reversed:false}
+				# 5. {reversed:true}
+			` ) );
+
+			expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+				# 1. {reversed:true}
+				# 2.
+				# 3.
+				# 4.
+				  # 4.1. {reversed:false}
+				  # 4.2.
+				  # 4.3.
+				    # 4.3.1. {reversed:true}
+				    # 4.3.2.
+				# 5.
+			` ) );
+		} );
 	} );
 
 	describe( 'listStart', () => {
@@ -131,6 +189,34 @@ describe( 'DocumentListPropertiesEditing', () => {
 			it( 'should not allow set `listStart` on the `paragraph`', () => {
 				expect( model.schema.checkAttribute( [ '$root', 'paragraph' ], 'listStart' ) ).to.be.true;
 			} );
+		} );
+
+		it( 'should ensure that all item in a single list have the same `listStart` attribute', () => {
+			setData( model, modelList( `
+				# 1. {start:2}
+				# 2.
+				# 3. {start:5}
+				# 4.
+				  # 4.1. {start:3}
+				  # 4.2. {start:7}
+				  # 4.3. {start:1}
+				    # 4.3.1. {start:42}
+					# 4.3.2. {start:1}
+				# 5. {start:8}
+			` ) );
+
+			expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+				# 1. {start:2}
+				# 2.
+				# 3.
+				# 4.
+				  # 4.1. {start:3}
+				  # 4.2.
+				  # 4.3.
+				    # 4.3.1. {start:42}
+				    # 4.3.2.
+				# 5.
+			` ) );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-list/tests/documentlistproperties/documentlistpropertiesediting.js
+++ b/packages/ckeditor5-list/tests/documentlistproperties/documentlistpropertiesediting.js
@@ -73,32 +73,55 @@ describe( 'DocumentListPropertiesEditing', () => {
 			} );
 		} );
 
-		it( 'should ensure that all item in a single list have the same `listStyle` attribute', () => {
-			setData( model, modelList( `
-				* 1. {style:circle}
-				* 2.
-				* 3. {style:square}
-				* 4.
-				  # 4.1. {style:default}
-				  # 4.2. {style:upper-roman}
-				  # 4.3. {style:decimal}
-				    # 4.3.1. {style:decimal}
-					# 4.3.2. {style:upper-roman}
-				* 5. {style:disc}
-			` ) );
+		describe( 'post-fixer', () => {
+			it( 'should ensure that all item in a single list have the same `listStyle` attribute', () => {
+				setData( model, modelList( `
+					* 1. {style:circle}
+					* 2.
+					* 3. {style:square}
+					* 4.
+					  # 4.1. {style:default}
+					  # 4.2. {style:upper-roman}
+					  # 4.3. {style:decimal}
+					    # 4.3.1. {style:decimal}
+					    # 4.3.2. {style:upper-roman}
+					* 5. {style:disc}
+				` ) );
 
-			expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
-				* 1. {style:circle}
-				* 2.
-				* 3.
-				* 4.
-				  # 4.1. {style:default}
-				  # 4.2.
-				  # 4.3.
-				    # 4.3.1. {style:decimal}
-				    # 4.3.2.
-				* 5.
-			` ) );
+				expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+					* 1. {style:circle}
+					* 2.
+					* 3.
+					* 4.
+					  # 4.1. {style:default}
+					  # 4.2.
+					  # 4.3.
+					    # 4.3.1. {style:decimal}
+					    # 4.3.2.
+					* 5.
+				` ) );
+			} );
+
+			it( 'should ensure that all list item have the same `listStyle` after removing a block between them', () => {
+				setData( model,
+					'<paragraph listItemId="01" listStyle="circle" listType="bulleted">1.</paragraph>' +
+					'<paragraph listItemId="02" listStyle="circle" listType="bulleted">2.</paragraph>' +
+					'<paragraph>Foo</paragraph>' +
+					'<paragraph listItemId="03" listStyle="square" listType="bulleted">3.</paragraph>' +
+					'<paragraph listItemId="04" listStyle="square" listType="bulleted">4.</paragraph>'
+				);
+
+				model.change( writer => {
+					writer.remove( model.document.getRoot().getChild( 2 ) );
+				} );
+
+				expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup(
+					'<paragraph listItemId="01" listStyle="circle" listType="bulleted">1.</paragraph>' +
+					'<paragraph listItemId="02" listStyle="circle" listType="bulleted">2.</paragraph>' +
+					'<paragraph listItemId="03" listStyle="circle" listType="bulleted">3.</paragraph>' +
+					'<paragraph listItemId="04" listStyle="circle" listType="bulleted">4.</paragraph>'
+				);
+			} );
 		} );
 	} );
 
@@ -132,32 +155,55 @@ describe( 'DocumentListPropertiesEditing', () => {
 			} );
 		} );
 
-		it( 'should ensure that all item in a single list have the same `listReversed` attribute', () => {
-			setData( model, modelList( `
-				# 1. {reversed:true}
-				# 2.
-				# 3. {reversed:false}
-				# 4.
-				  # 4.1. {reversed:false}
-				  # 4.2. {reversed:true}
-				  # 4.3. {reversed:false}
-				    # 4.3.1. {reversed:true}
-					# 4.3.2. {reversed:false}
-				# 5. {reversed:true}
-			` ) );
+		describe( 'post-fixer', () => {
+			it( 'should ensure that all item in a single list have the same `listReversed` attribute', () => {
+				setData( model, modelList( `
+					# 1. {reversed:true}
+					# 2.
+					# 3. {reversed:false}
+					# 4.
+					  # 4.1. {reversed:false}
+					  # 4.2. {reversed:true}
+					  # 4.3. {reversed:false}
+					    # 4.3.1. {reversed:true}
+						# 4.3.2. {reversed:false}
+					# 5. {reversed:true}
+				` ) );
 
-			expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
-				# 1. {reversed:true}
-				# 2.
-				# 3.
-				# 4.
-				  # 4.1. {reversed:false}
-				  # 4.2.
-				  # 4.3.
-				    # 4.3.1. {reversed:true}
-				    # 4.3.2.
-				# 5.
-			` ) );
+				expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+					# 1. {reversed:true}
+					# 2.
+					# 3.
+					# 4.
+					  # 4.1. {reversed:false}
+					  # 4.2.
+					  # 4.3.
+					    # 4.3.1. {reversed:true}
+					    # 4.3.2.
+					# 5.
+				` ) );
+			} );
+
+			it( 'should ensure that all list item have the same `listReversed` after removing a block between them', () => {
+				setData( model,
+					'<paragraph listItemId="01" listReversed="true" listType="numbered">1.</paragraph>' +
+					'<paragraph listItemId="02" listReversed="true" listType="numbered">2.</paragraph>' +
+					'<paragraph>Foo</paragraph>' +
+					'<paragraph listItemId="03" listReversed="false" listType="numbered">3.</paragraph>' +
+					'<paragraph listItemId="04" listReversed="false" listType="numbered">4.</paragraph>'
+				);
+
+				model.change( writer => {
+					writer.remove( model.document.getRoot().getChild( 2 ) );
+				} );
+
+				expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup(
+					'<paragraph listItemId="01" listReversed="true" listType="numbered">1.</paragraph>' +
+					'<paragraph listItemId="02" listReversed="true" listType="numbered">2.</paragraph>' +
+					'<paragraph listItemId="03" listReversed="true" listType="numbered">3.</paragraph>' +
+					'<paragraph listItemId="04" listReversed="true" listType="numbered">4.</paragraph>'
+				);
+			} );
 		} );
 	} );
 
@@ -191,32 +237,55 @@ describe( 'DocumentListPropertiesEditing', () => {
 			} );
 		} );
 
-		it( 'should ensure that all item in a single list have the same `listStart` attribute', () => {
-			setData( model, modelList( `
-				# 1. {start:2}
-				# 2.
-				# 3. {start:5}
-				# 4.
-				  # 4.1. {start:3}
-				  # 4.2. {start:7}
-				  # 4.3. {start:1}
-				    # 4.3.1. {start:42}
-					# 4.3.2. {start:1}
-				# 5. {start:8}
-			` ) );
+		describe( 'post-fixer', () => {
+			it( 'should ensure that all item in a single list have the same `listStart` attribute', () => {
+				setData( model, modelList( `
+					# 1. {start:2}
+					# 2.
+					# 3. {start:5}
+					# 4.
+					  # 4.1. {start:3}
+					  # 4.2. {start:7}
+					  # 4.3. {start:1}
+					    # 4.3.1. {start:42}
+					    # 4.3.2. {start:1}
+					# 5. {start:8}
+				` ) );
 
-			expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
-				# 1. {start:2}
-				# 2.
-				# 3.
-				# 4.
-				  # 4.1. {start:3}
-				  # 4.2.
-				  # 4.3.
-				    # 4.3.1. {start:42}
-				    # 4.3.2.
-				# 5.
-			` ) );
+				expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+					# 1. {start:2}
+					# 2.
+					# 3.
+					# 4.
+					  # 4.1. {start:3}
+					  # 4.2.
+					  # 4.3.
+					    # 4.3.1. {start:42}
+					    # 4.3.2.
+					# 5.
+				` ) );
+			} );
+
+			it( 'should ensure that all list item have the same `listStart` after removing a block between them', () => {
+				setData( model,
+					'<paragraph listItemId="01" listStart="2" listType="numbered">1.</paragraph>' +
+					'<paragraph listItemId="02" listStart="2" listType="numbered">2.</paragraph>' +
+					'<paragraph>Foo</paragraph>' +
+					'<paragraph listItemId="03" listStart="7" listType="numbered">3.</paragraph>' +
+					'<paragraph listItemId="04" listStart="7" listType="numbered">4.</paragraph>'
+				);
+
+				model.change( writer => {
+					writer.remove( model.document.getRoot().getChild( 2 ) );
+				} );
+
+				expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup(
+					'<paragraph listItemId="01" listStart="2" listType="numbered">1.</paragraph>' +
+					'<paragraph listItemId="02" listStart="2" listType="numbered">2.</paragraph>' +
+					'<paragraph listItemId="03" listStart="2" listType="numbered">3.</paragraph>' +
+					'<paragraph listItemId="04" listStart="2" listType="numbered">4.</paragraph>'
+				);
+			} );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-list/tests/documentlistproperties/documentlistreversedcommand.js
+++ b/packages/ckeditor5-list/tests/documentlistproperties/documentlistreversedcommand.js
@@ -313,7 +313,7 @@ describe( 'DocumentListReversedCommand', () => {
 			` ) );
 		} );
 
-		it( 'should only set the `listReversed` attribute for selected items (non-collapsed selection)', () => {
+		it( 'should set the `listReversed` attribute for selected items (non-collapsed selection)', () => {
 			setData( model, modelList( `
 				# 1. {reversed:false}
 				# 2a.
@@ -327,17 +327,17 @@ describe( 'DocumentListReversedCommand', () => {
 			listReversedCommand.execute( { reversed: true } );
 
 			expect( getData( model ) ).to.equalMarkup( modelList( `
-				# 1. {reversed:false}
-				# 2a. {reversed:true}
+				# 1. {reversed:true}
+				# 2a.
 				  [2b.
 				  2c.
 				# 3a].
 				  3b.
-				# 4. {reversed:false}
+				# 4.
 			` ) );
 		} );
 
-		it( 'should only set the `listReversed` attribute for all blocks in the list item (non-collapsed selection)', () => {
+		it( 'should set the `listReversed` attribute for all blocks in the list item (non-collapsed selection)', () => {
 			setData( model, modelList( `
 				# 1. {reversed:true}
 				# 2.
@@ -348,10 +348,10 @@ describe( 'DocumentListReversedCommand', () => {
 			listReversedCommand.execute( { reversed: false } );
 
 			expect( getData( model ) ).to.equalMarkup( modelList( `
-				# 1. {reversed:true}
-				# 2. {reversed:false}
+				# 1. {reversed:false}
+				# 2.
 				  [3].
-				# 4. {reversed:true}
+				# 4.
 			` ) );
 		} );
 
@@ -362,13 +362,13 @@ describe( 'DocumentListReversedCommand', () => {
 			// "2.1" a child list of the "2." element (listIndent=1)
 			// "2.1.1" a child list of the "2.1" element (listIndent=2)
 			//
-			// [ ] ■ 1.
+			// [x] ■ 1.
 			// [x] ■ [2.
 			// [x]     ○ 2.1.
 			// [X]         ▶ 2.1.1.]
-			// [ ]         ▶ 2.1.2.
-			// [ ]     ○ 2.2.
-			// [ ] ■ 3.
+			// [x]         ▶ 2.1.2.
+			// [x]     ○ 2.2.
+			// [x] ■ 3.
 			// [ ]     ○ 3.1.
 			// [ ]         ▶ 3.1.1.
 			//
@@ -381,21 +381,21 @@ describe( 'DocumentListReversedCommand', () => {
 					# 2.1.2.
 				  # 2.2.
 				# 3.
-				  # 3.1. {reversed:true}
+				  # 3.1. {reversed:false}
 				    # 3.1.1. {reversed:false}
 			` ) );
 
 			listReversedCommand.execute( { reversed: true } );
 
 			expect( getData( model ) ).to.equalMarkup( modelList( `
-				# 1. {reversed:false}
-				# [2. {reversed:true}
+				# 1. {reversed:true}
+				# [2.
 				  # 2.1. {reversed:true}
 				    # 2.1.1.] {reversed:true}
-				    # 2.1.2. {reversed:false}
-				  # 2.2. {reversed:false}
-				# 3. {reversed:false}
-				  # 3.1. {reversed:true}
+				    # 2.1.2.
+				  # 2.2.
+				# 3.
+				  # 3.1. {reversed:false}
 				    # 3.1.1. {reversed:false}
 			` ) );
 		} );

--- a/packages/ckeditor5-list/tests/documentlistproperties/documentliststartcommand.js
+++ b/packages/ckeditor5-list/tests/documentlistproperties/documentliststartcommand.js
@@ -311,7 +311,7 @@ describe( 'DocumentListStartCommand', () => {
 			` ) );
 		} );
 
-		it( 'should only set the `listStart` attribute for selected items (non-collapsed selection)', () => {
+		it( 'should set the `listStart` attribute for selected items (non-collapsed selection)', () => {
 			setData( model, modelList( `
 				# 1. {start:7}
 				# 2a.
@@ -325,17 +325,17 @@ describe( 'DocumentListStartCommand', () => {
 			listStartCommand.execute( { startIndex: 5 } );
 
 			expect( getData( model ) ).to.equalMarkup( modelList( `
-				# 1. {start:7}
-				# 2a. {start:5}
+				# 1. {start:5}
+				# 2a.
 				  [2b.
 				  2c.
 				# 3a].
 				  3b.
-				# 4. {start:7}
+				# 4.
 			` ) );
 		} );
 
-		it( 'should only set the `listStart` attribute for all blocks in the list item (non-collapsed selection)', () => {
+		it( 'should set the `listStart` attribute for all blocks in the list item (non-collapsed selection)', () => {
 			setData( model, modelList( `
 				# 1. {start:2}
 				# 2.
@@ -346,10 +346,10 @@ describe( 'DocumentListStartCommand', () => {
 			listStartCommand.execute( { startIndex: 5 } );
 
 			expect( getData( model ) ).to.equalMarkup( modelList( `
-				# 1. {start:2}
-				# 2. {start:5}
+				# 1. {start:5}
+				# 2.
 				  [3].
-				# 4. {start:2}
+				# 4.
 			` ) );
 		} );
 
@@ -360,13 +360,13 @@ describe( 'DocumentListStartCommand', () => {
 			// "2.1" a child list of the "2." element (listIndent=1)
 			// "2.1.1" a child list of the "2.1" element (listIndent=2)
 			//
-			// [ ] ■ 1.
+			// [x] ■ 1.
 			// [x] ■ [2.
 			// [x]     ○ 2.1.
 			// [X]         ▶ 2.1.1.]
-			// [ ]         ▶ 2.1.2.
-			// [ ]     ○ 2.2.
-			// [ ] ■ 3.
+			// [x]         ▶ 2.1.2.
+			// [x]     ○ 2.2.
+			// [x] ■ 3.
 			// [ ]     ○ 3.1.
 			// [ ]         ▶ 3.1.1.
 			//
@@ -386,13 +386,13 @@ describe( 'DocumentListStartCommand', () => {
 			listStartCommand.execute( { startIndex: 7 } );
 
 			expect( getData( model ) ).to.equalMarkup( modelList( `
-				# 1. {start:1}
-				# [2. {start:7}
+				# 1. {start:7}
+				# [2.
 				  # 2.1. {start:7}
 				    # 2.1.1.] {start:7}
-				    # 2.1.2. {start:3}
-				  # 2.2. {start:2}
-				# 3. {start:1}
+				    # 2.1.2.
+				  # 2.2.
+				# 3.
 				  # 3.1. {start:4}
 				    # 3.1.1. {start:5}
 			` ) );

--- a/packages/ckeditor5-list/tests/documentlistproperties/documentliststylecommand.js
+++ b/packages/ckeditor5-list/tests/documentlistproperties/documentliststylecommand.js
@@ -296,7 +296,7 @@ describe( 'DocumentListStyleCommand', () => {
 			` ) );
 		} );
 
-		it( 'should only set the `listStyle` attribute for selected items (non-collapsed selection)', () => {
+		it( 'should set the `listStyle` attribute for selected items (non-collapsed selection)', () => {
 			setData( model, modelList( `
 				* 1. {style:disc}
 				* 2a.
@@ -310,17 +310,17 @@ describe( 'DocumentListStyleCommand', () => {
 			listStyleCommand.execute( { type: 'circle' } );
 
 			expect( getData( model ) ).to.equalMarkup( modelList( `
-				* 1. {style:disc}
-				* 2a. {style:circle}
+				* 1. {style:circle}
+				* 2a.
 				  [2b.
 				  2c.
 				* 3a].
 				  3b.
-				* 4. {style:disc}
+				* 4.
 			` ) );
 		} );
 
-		it( 'should only set the `listStyle` attribute for all blocks in the list item (non-collapsed selection)', () => {
+		it( 'should set the `listStyle` attribute for all blocks in the list item (non-collapsed selection)', () => {
 			setData( model, modelList( `
 				* 1. {style:disc}
 				* [2.
@@ -331,10 +331,10 @@ describe( 'DocumentListStyleCommand', () => {
 			listStyleCommand.execute( { type: 'circle' } );
 
 			expect( getData( model ) ).to.equalMarkup( modelList( `
-				* 1. {style:disc}
-				* [2. {style:circle}
+				* 1. {style:circle}
+				* [2.
 				* 3].
-				* 4. {style:disc}
+				* 4.
 			` ) );
 		} );
 
@@ -345,13 +345,13 @@ describe( 'DocumentListStyleCommand', () => {
 			// "2.1" a child list of the "2." element (listIndent=1)
 			// "2.1.1" a child list of the "2.1" element (listIndent=2)
 			//
-			// [ ] ■ 1.
+			// [x] ■ 1.
 			// [x] ■ [2.
 			// [x]     ○ 2.1.
 			// [X]         ▶ 2.1.1.]
-			// [ ]         ▶ 2.1.2.
-			// [ ]     ○ 2.2.
-			// [ ] ■ 3.
+			// [x]         ▶ 2.1.2.
+			// [x]     ○ 2.2.
+			// [x] ■ 3.
 			// [ ]     ○ 3.1.
 			// [ ]         ▶ 3.1.1.
 			//
@@ -371,13 +371,13 @@ describe( 'DocumentListStyleCommand', () => {
 			listStyleCommand.execute( { type: 'disc' } );
 
 			expect( getData( model ) ).to.equalMarkup( modelList( `
-				* 1. {style:square}
-				* [2. {style:disc}
+				* 1. {style:disc}
+				* [2.
 				  * 2.1. {style:disc}
 				    * 2.1.1.] {style:disc}
-				    * 2.1.2. {style:square}
-				  * 2.2. {style:circle}
-				* 3. {style:square}
+				    * 2.1.2.
+				  * 2.2.
+				* 3.
 				  * 3.1. {style:square}
 				    * 3.1.1. {style:square}
 			` ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (list): Adds postfixer that makes sure that all items in a single list have the same start, reversed and style properties. Closes #11167.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._