### PR TITLE
The default configuration options for `ImageStyle` plugin are not properly cloned

### DIFF
--- a/packages/ckeditor5-image/package.json
+++ b/packages/ckeditor5-image/package.json
@@ -44,6 +44,7 @@
     "@ckeditor/ckeditor5-undo": "^32.0.0",
     "@ckeditor/ckeditor5-upload": "^32.0.0",
     "@ckeditor/ckeditor5-utils": "^32.0.0",
+    "@ckeditor/ckeditor5-watchdog": "^32.0.0",
     "@ckeditor/ckeditor5-widget": "^32.0.0",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"

--- a/packages/ckeditor5-image/src/imagestyle/utils.js
+++ b/packages/ckeditor5-image/src/imagestyle/utils.js
@@ -40,75 +40,91 @@ const {
  */
 const DEFAULT_OPTIONS = {
 	// This style represents an image placed in the line of text.
-	inline: {
-		name: 'inline',
-		title: 'In line',
-		icon: objectInline,
-		modelElements: [ 'imageInline' ],
-		isDefault: true
+	get inline() {
+		return {
+			name: 'inline',
+			title: 'In line',
+			icon: objectInline,
+			modelElements: [ 'imageInline' ],
+			isDefault: true
+		};
 	},
 
 	// This style represents an image aligned to the left and wrapped with text.
-	alignLeft: {
-		name: 'alignLeft',
-		title: 'Left aligned image',
-		icon: objectLeft,
-		modelElements: [ 'imageBlock', 'imageInline' ],
-		className: 'image-style-align-left'
+	get alignLeft() {
+		return {
+			name: 'alignLeft',
+			title: 'Left aligned image',
+			icon: objectLeft,
+			modelElements: [ 'imageBlock', 'imageInline' ],
+			className: 'image-style-align-left'
+		};
 	},
 
 	// This style represents an image aligned to the left.
-	alignBlockLeft: {
-		name: 'alignBlockLeft',
-		title: 'Left aligned image',
-		icon: objectBlockLeft,
-		modelElements: [ 'imageBlock' ],
-		className: 'image-style-block-align-left'
+	get alignBlockLeft() {
+		return {
+			name: 'alignBlockLeft',
+			title: 'Left aligned image',
+			icon: objectBlockLeft,
+			modelElements: [ 'imageBlock' ],
+			className: 'image-style-block-align-left'
+		};
 	},
 
 	// This style represents a centered image.
-	alignCenter: {
-		name: 'alignCenter',
-		title: 'Centered image',
-		icon: objectCenter,
-		modelElements: [ 'imageBlock' ],
-		className: 'image-style-align-center'
+	get alignCenter() {
+		return {
+			name: 'alignCenter',
+			title: 'Centered image',
+			icon: objectCenter,
+			modelElements: [ 'imageBlock' ],
+			className: 'image-style-align-center'
+		};
 	},
 
 	// This style represents an image aligned to the right and wrapped with text.
-	alignRight: {
-		name: 'alignRight',
-		title: 'Right aligned image',
-		icon: objectRight,
-		modelElements: [ 'imageBlock', 'imageInline' ],
-		className: 'image-style-align-right'
+	get alignRight() {
+		return {
+			name: 'alignRight',
+			title: 'Right aligned image',
+			icon: objectRight,
+			modelElements: [ 'imageBlock', 'imageInline' ],
+			className: 'image-style-align-right'
+		};
 	},
 
 	// This style represents an image aligned to the right.
-	alignBlockRight: {
-		name: 'alignBlockRight',
-		title: 'Right aligned image',
-		icon: objectBlockRight,
-		modelElements: [ 'imageBlock' ],
-		className: 'image-style-block-align-right'
+	get alignBlockRight() {
+		return {
+			name: 'alignBlockRight',
+			title: 'Right aligned image',
+			icon: objectBlockRight,
+			modelElements: [ 'imageBlock' ],
+			className: 'image-style-block-align-right'
+		};
 	},
 
 	// This option is equal to the situation when no style is applied.
-	block: {
-		name: 'block',
-		title: 'Centered image',
-		icon: objectCenter,
-		modelElements: [ 'imageBlock' ],
-		isDefault: true
+	get block() {
+		return {
+			name: 'block',
+			title: 'Centered image',
+			icon: objectCenter,
+			modelElements: [ 'imageBlock' ],
+			isDefault: true
+		};
 	},
 
 	// This represents a side image.
-	side: {
-		name: 'side',
-		title: 'Side image',
-		icon: objectRight,
-		modelElements: [ 'imageBlock' ],
-		className: 'image-style-side'
+	get side() {
+		return {
+			name: 'side',
+			title: 'Side image',
+			icon: objectRight,
+			modelElements: [ 'imageBlock' ],
+			className: 'image-style-side'
+		};
 	}
 };
 

--- a/packages/ckeditor5-image/tests/imagestyle/imagestyle-integration.js
+++ b/packages/ckeditor5-image/tests/imagestyle/imagestyle-integration.js
@@ -1,0 +1,118 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals document, window, setTimeout */
+
+import Image from '../../src/image';
+import ImageStyle from '../../src/imagestyle';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import ContextWatchdog from '@ckeditor/ckeditor5-watchdog/src/contextwatchdog';
+import Context from '@ckeditor/ckeditor5-core/src/context';
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+
+describe( 'ImageStyle integration', () => {
+	describe( 'with Watchdog plugin', () => {
+		let editorElement1, editorElement2, editorConfig;
+		let watchdog;
+		let originalErrorHandler;
+
+		beforeEach( async () => {
+			watchdog = new ContextWatchdog( Context );
+			await watchdog.create();
+
+			editorConfig = {
+				plugins: [
+					Paragraph, Image, ImageStyle
+				],
+				image: {
+					toolbar: [
+						'imageStyle:inline',
+						'imageStyle:wrapText',
+						'imageStyle:breakText',
+						'|',
+						'toggleImageCaption',
+						'imageTextAlternative'
+					]
+				}
+			};
+
+			editorElement1 = document.createElement( 'div' );
+			editorElement2 = document.createElement( 'div' );
+
+			document.body.appendChild( editorElement1 );
+			document.body.appendChild( editorElement2 );
+
+			originalErrorHandler = window.onerror;
+			window.onerror = sinon.spy();
+		} );
+
+		afterEach( async () => {
+			await watchdog.destroy();
+
+			window.onerror = originalErrorHandler;
+
+			editorElement1.remove();
+			editorElement2.remove();
+
+			sinon.restore();
+		} );
+
+		it( 'should only restart the editor in which the error occurred', async () => {
+			await watchdog.add( [ {
+				id: 'editor1',
+				type: 'editor',
+				creator: ( element, config ) => ClassicTestEditor.create( element, config ),
+				sourceElementOrData: editorElement1,
+				config: editorConfig
+			}, {
+				id: 'editor2',
+				type: 'editor',
+				creator: ( element, config ) => ClassicTestEditor.create( element, config ),
+				sourceElementOrData: editorElement2,
+				config: editorConfig
+			} ] );
+
+			const oldContext = watchdog.context;
+
+			const editorWatchdog1 = watchdog._getWatchdog( 'editor1' );
+			const editorWatchdog2 = watchdog._getWatchdog( 'editor2' );
+
+			const oldEditor1 = watchdog.getItem( 'editor1' );
+			const oldEditor2 = watchdog.getItem( 'editor2' );
+
+			const mainWatchdogRestartSpy = sinon.spy();
+			const editorWatchdog1RestartSpy = sinon.spy();
+			const editorWatchdog2RestartSpy = sinon.spy();
+
+			watchdog.on( 'restart', mainWatchdogRestartSpy );
+			editorWatchdog1.on( 'restart', editorWatchdog1RestartSpy );
+			editorWatchdog2.on( 'restart', editorWatchdog2RestartSpy );
+
+			// Throw an error from editor1.
+			setTimeout( () => throwCKEditorError( 'foo', editorWatchdog1.editor ) );
+
+			await waitCycle();
+
+			// Only editor1 should be restarted.
+			expect( editorWatchdog1RestartSpy.callCount ).to.equal( 1 );
+			expect( editorWatchdog2RestartSpy.callCount ).to.equal( 0 );
+			expect( mainWatchdogRestartSpy.callCount ).to.equal( 0 );
+
+			expect( oldEditor1 ).to.not.equal( editorWatchdog1.editor );
+			expect( oldEditor2 ).to.equal( editorWatchdog2.editor );
+
+			expect( watchdog.context ).to.equal( oldContext );
+		} );
+	} );
+} );
+
+function throwCKEditorError( name, context ) {
+	throw new CKEditorError( name, context );
+}
+
+function waitCycle() {
+	return new Promise( resolve => setTimeout( resolve ) );
+}

--- a/packages/ckeditor5-image/tests/imagestyle/utils.js
+++ b/packages/ckeditor5-image/tests/imagestyle/utils.js
@@ -11,6 +11,7 @@ import utils from '../../src/imagestyle/utils';
 describe( 'ImageStyle utils', () => {
 	const { getDefaultStylesConfiguration, DEFAULT_OPTIONS, DEFAULT_ICONS } = utils;
 	const allStyles = Object.values( DEFAULT_OPTIONS );
+	const allStyleNames = Object.keys( DEFAULT_OPTIONS );
 
 	describe( 'default styles', () => {
 		describe( 'styles', () => {
@@ -59,6 +60,13 @@ describe( 'ImageStyle utils', () => {
 					expect( style ).to.equal( DEFAULT_OPTIONS[ style ].name );
 					expect( DEFAULT_OPTIONS[ style ].icon ).to.be.a( 'string' );
 				}
+			} );
+
+			it( 'should always return new configuration object for each style', () => {
+				allStyleNames.forEach( styleName => {
+					expect( DEFAULT_OPTIONS[ styleName ] ).to.not.equal( DEFAULT_OPTIONS[ styleName ] );
+					expect( DEFAULT_OPTIONS[ styleName ].modelElements ).to.not.equal( DEFAULT_OPTIONS[ styleName ].modelElements );
+				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (image): Always create new instances of the default options for the `ImageStyle` plugin. Closes #11328.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
