### PR TITLE
Markers that do not change their range will not trigger the change:data event.

### DIFF
--- a/packages/ckeditor5-engine/src/model/differ.js
+++ b/packages/ckeditor5-engine/src/model/differ.js
@@ -340,6 +340,11 @@ export default class Differ {
 	hasDataChanges() {
 		for ( const [ , change ] of this._changedMarkers ) {
 			if ( change.affectsData ) {
+				// Skip markers, which ranges have not changed.
+				if ( change.oldRange && change.newRange && change.oldRange.isEqual( change.newRange ) ) {
+					return false;
+				}
+
 				return true;
 			}
 		}

--- a/packages/ckeditor5-engine/tests/model/document.js
+++ b/packages/ckeditor5-engine/tests/model/document.js
@@ -515,6 +515,9 @@ describe( 'Document', () => {
 			sinon.assert.notCalled( changeDataSpy );
 		} );
 
+		// There are no strong preferences here.
+		// This case is a bit artificial so perhaps it's better to stay on the safe side and fire the change:data event
+		// even when the marker is empty. But if there is a problem with it, this behavior can be easily changed.
 		it( 'should be fired when the marker updates range from null to null', () => {
 			const root = doc.createRoot();
 			root._appendChild( new Text( 'foo' ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix: Markers that do not change their range will not trigger the `change:data` event. Closes #9901.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._