### PR TITLE
DataFilter should hook into DataController#init before anything else

### DIFF
--- a/packages/ckeditor5-html-support/src/datafilter.js
+++ b/packages/ckeditor5-html-support/src/datafilter.js
@@ -240,10 +240,14 @@ export default class DataFilter extends Plugin {
 				this._fireRegisterEvent( definition );
 			}
 		}, {
-			// With high priority listener we are able to register elements right before
-			// running data conversion. Make also sure that priority is higher than the one
-			// used by `RealTimeCollaborationClient`, as RTC is stopping event propagation.
-			priority: priorities.get( 'high' ) + 1
+			// With highest priority listener we are able to register elements right before
+			// running data conversion. Also:
+			// * Make sure that priority is higher than the one used by `RealTimeCollaborationClient`,
+			// as RTC is stopping event propagation.
+			// * Make sure no other features hook into this event before GHS because otherwise the
+			// downcast conversion (for these features) could run before GHS registered its converters
+			// (https://github.com/ckeditor/ckeditor5/issues/11356).
+			priority: priorities.get( 'highest' ) + 1
 		} );
 	}
 

--- a/packages/ckeditor5-html-support/tests/datafilter.js
+++ b/packages/ckeditor5-html-support/tests/datafilter.js
@@ -117,7 +117,12 @@ describe( 'DataFilter', () => {
 				// register it before DataFilter listener.
 				this.editor.data.on( 'init', evt => {
 					evt.stop();
-				}, { priority: 'high' } );
+				}, {
+					// The actual RTC client listens on 'high' but in these tests we're making a point
+					// of GHS registering its converters before anything else triggers the downcast conversion.
+					// See https://github.com/ckeditor/ckeditor5/issues/11356.
+					priority: 'highest'
+				} );
 			}
 		}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (html-support): `DataFilter` should hook into `DataController#init` before anything else to prevent errors if other features start downcasting the model. Closes #11356.