### PR TITLE
GHS: Prevent <script> and <style> tags removal

### DIFF
--- a/packages/ckeditor5-html-support/src/integrations/script.js
+++ b/packages/ckeditor5-html-support/src/integrations/script.js
@@ -44,7 +44,8 @@ export default class ScriptElementSupport extends Plugin {
 			schema.register( 'htmlScript', definition.modelSchema );
 
 			schema.extend( 'htmlScript', {
-				allowAttributes: [ 'htmlAttributes', 'htmlContent' ]
+				allowAttributes: [ 'htmlAttributes', 'htmlContent' ],
+				isContent: true
 			} );
 
 			editor.data.registerRawContentMatcher( {

--- a/packages/ckeditor5-html-support/src/integrations/style.js
+++ b/packages/ckeditor5-html-support/src/integrations/style.js
@@ -44,7 +44,8 @@ export default class StyleElementSupport extends Plugin {
 			schema.register( 'htmlStyle', definition.modelSchema );
 
 			schema.extend( 'htmlStyle', {
-				allowAttributes: [ 'htmlAttributes', 'htmlContent' ]
+				allowAttributes: [ 'htmlAttributes', 'htmlContent' ],
+				isContent: true
 			} );
 
 			editor.data.registerRawContentMatcher( {

--- a/packages/ckeditor5-html-support/tests/integrations/script.js
+++ b/packages/ckeditor5-html-support/tests/integrations/script.js
@@ -91,6 +91,16 @@ describe( 'ScriptElementSupport', () => {
 		expect( editor.getData() ).to.equal( `<p>Foo</p><script type="c++">${ CODE_CPP }</script>` );
 	} );
 
+	it( 'should allow element in the empty editor', () => {
+		editor.setData( `<script>${ CODE }</script>` );
+
+		expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+			`<htmlScript htmlContent="${ CODE }"></htmlScript>`
+		);
+
+		expect( editor.getData() ).to.equal( `<script>${ CODE }</script>` );
+	} );
+
 	describe( 'element position', () => {
 		const testCases = [ {
 			name: 'paragraph',

--- a/packages/ckeditor5-html-support/tests/integrations/script.js
+++ b/packages/ckeditor5-html-support/tests/integrations/script.js
@@ -91,6 +91,7 @@ describe( 'ScriptElementSupport', () => {
 		expect( editor.getData() ).to.equal( `<p>Foo</p><script type="c++">${ CODE_CPP }</script>` );
 	} );
 
+	// See: https://github.com/ckeditor/ckeditor5/issues/11247
 	it( 'should allow element in the empty editor', () => {
 		editor.setData( `<script>${ CODE }</script>` );
 

--- a/packages/ckeditor5-html-support/tests/integrations/style.js
+++ b/packages/ckeditor5-html-support/tests/integrations/style.js
@@ -90,6 +90,7 @@ describe( 'StyleElementSupport', () => {
 		expect( editor.getData() ).to.equal( `<p>Foo</p><style type="c++">${ STYLE }</style>` );
 	} );
 
+	// See: https://github.com/ckeditor/ckeditor5/issues/11247
 	it( 'should allow element in the empty editor', () => {
 		editor.setData( `<style>${ STYLE }</style>` );
 

--- a/packages/ckeditor5-html-support/tests/integrations/style.js
+++ b/packages/ckeditor5-html-support/tests/integrations/style.js
@@ -90,6 +90,16 @@ describe( 'StyleElementSupport', () => {
 		expect( editor.getData() ).to.equal( `<p>Foo</p><style type="c++">${ STYLE }</style>` );
 	} );
 
+	it( 'should allow element in the empty editor', () => {
+		editor.setData( `<style>${ STYLE }</style>` );
+
+		expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+			`<htmlStyle htmlContent="${ STYLE }"></htmlStyle>`
+		);
+
+		expect( editor.getData() ).to.equal( `<style>${ STYLE }</style>` );
+	} );
+
 	describe( 'element position', () => {
 		const testCases = [ {
 			name: 'paragraph',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (html-support): Prevent `<script>` and `<style>` tags removal if they are the only content in the editor. Closes #11247.
