### PR TITLE
Reset document list properties after indent

### DIFF
--- a/packages/ckeditor5-engine/src/model/differ.js
+++ b/packages/ckeditor5-engine/src/model/differ.js
@@ -354,7 +354,7 @@ export default class Differ {
 	 *
 	 * The diff set is returned as an array of {@link module:engine/model/differ~DiffItem diff items}, each describing a change done
 	 * on the model. The items are sorted by the position on which the change happened. If a position
-	 * {@link module:engine/model/position~Position#isBefore is before} another one, it will be on an earlier index in the diff set.
+	 * {@link module:engine/model/position~Position#isBefore} is before another one, it will be on an earlier index in the diff set.
 	 *
 	 * **Note**: Elements inside inserted element will not have a separate diff item, only the top most element change will be reported.
 	 *

--- a/packages/ckeditor5-engine/src/model/differ.js
+++ b/packages/ckeditor5-engine/src/model/differ.js
@@ -354,7 +354,7 @@ export default class Differ {
 	 *
 	 * The diff set is returned as an array of {@link module:engine/model/differ~DiffItem diff items}, each describing a change done
 	 * on the model. The items are sorted by the position on which the change happened. If a position
-	 * {@link module:engine/model/position~Position#isBefore} is before another one, it will be on an earlier index in the diff set.
+	 * {@link module:engine/model/position~Position#isBefore is before} another one, it will be on an earlier index in the diff set.
 	 *
 	 * **Note**: Elements inside inserted element will not have a separate diff item, only the top most element change will be reported.
 	 *

--- a/packages/ckeditor5-list/src/documentlistproperties/documentlistpropertiesediting.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/documentlistpropertiesediting.js
@@ -105,6 +105,22 @@ export default class DocumentListPropertiesEditing extends Plugin {
 			}
 		} );
 
+		// Reset list properties after indenting list items.
+		this.listenTo( editor.commands.get( 'indentList' ), 'afterExecute', ( evt, changedBlocks ) => {
+			model.change( writer => {
+				for ( const node of changedBlocks ) {
+					for ( const strategy of strategies ) {
+						if ( strategy.appliesToListItem( node ) ) {
+							// Just reset the attribute.
+							// If there is a previous indented list that this node should be merged into,
+							// the postfixer will unify all the attributes of both sub-lists.
+							writer.setAttribute( strategy.attributeName, strategy.defaultValue, node );
+						}
+					}
+				}
+			} );
+		} );
+
 		// Add or remove list properties attributes depending on the list type.
 		documentListEditing.on( 'postFixer', ( evt, { listHead, writer } ) => {
 			for ( const { node } of iterateSiblingListBlocks( listHead, 'forward' ) ) {

--- a/packages/ckeditor5-list/tests/documentlistproperties/documentlistpropertiesediting.js
+++ b/packages/ckeditor5-list/tests/documentlistproperties/documentlistpropertiesediting.js
@@ -159,6 +159,86 @@ describe( 'DocumentListPropertiesEditing', () => {
 				` ) );
 			} );
 		} );
+
+		describe( 'indenting lists', () => {
+			it( 'should reset `listStyle` attribute after indenting a single item', () => {
+				setData( model, modelList( `
+					* 1. {style:circle}
+					  * 1a. {style:square}
+					* 2.
+					* 3.[]
+					* 4.
+				` ) );
+
+				editor.execute( 'indentList' );
+
+				expect( getData( model ) ).to.equalMarkup( modelList( `
+					* 1. {style:circle}
+					  * 1a. {style:square}
+					* 2.
+					  * 3.[] {style:default}
+					* 4.
+				` ) );
+			} );
+
+			it( 'should reset `listStyle` attribute after indenting a few items', () => {
+				setData( model, modelList( `
+					# 1. {style:decimal}
+					# [2.
+					# 3.]
+				` ) );
+
+				editor.execute( 'indentList' );
+
+				expect( getData( model ) ).to.equalMarkup( modelList( `
+					# 1. {style:decimal}
+					  # [2. {style:default}
+					  # 3.]
+				` ) );
+			} );
+
+			it( 'should copy `listStyle` attribute after indenting a single item into previously nested list', () => {
+				setData( model, modelList( `
+					* 1. {style:circle}
+					  * 1a. {style:square}
+					  * 1b.
+					* 2.[]
+					* 3.
+				` ) );
+
+				editor.execute( 'indentList' );
+
+				expect( getData( model ) ).to.equalMarkup( modelList( `
+					* 1. {style:circle}
+					  * 1a. {style:square}
+					  * 1b.
+					  * 2.[]
+					* 3.
+				` ) );
+			} );
+
+			it( 'should copy `listStyle` attribute after indenting a few items into previously nested list', () => {
+				setData( model, modelList( `
+					* 1. {style:circle}
+					  * 1a. {style:square}
+					  * 1b.
+					* [2.
+					* 3.]
+					* 4.
+				` ) );
+
+				editor.execute( 'indentList' );
+
+				expect( getData( model ) ).to.equalMarkup( modelList( `
+					* 1. {style:circle}
+					  * 1a. {style:square}
+					  * 1b.
+					  * [2.
+					  * 3.]
+					* 4.
+				` ) );
+			} );
+		} );
 	} );
 
 	describe( 'listReversed', () => {
@@ -277,6 +357,100 @@ describe( 'DocumentListPropertiesEditing', () => {
 				` ) );
 			} );
 		} );
+
+		describe( 'indenting lists', () => {
+			it( 'should reset `listReversed` attribute after indenting a single item', () => {
+				setData( model, modelList( `
+					# 1. {reversed:true}
+					  # 1a. {reversed:true}
+					# 2.
+					# 3.[]
+					# 4.
+				` ) );
+
+				editor.execute( 'indentList' );
+
+				expect( getData( model ) ).to.equalMarkup( modelList( `
+					# 1. {reversed:true}
+					  # 1a. {reversed:true}
+					# 2.
+					  # 3.[] {reversed:false}
+					# 4.
+				` ) );
+			} );
+
+			it( 'should reset `listReversed` attribute after indenting a few items', () => {
+				setData( model, modelList( `
+					# 1. {reversed:true}
+					# [2.
+					# 3.]
+				` ) );
+
+				editor.execute( 'indentList' );
+
+				expect( getData( model ) ).to.equalMarkup( modelList( `
+					# 1. {reversed:true}
+					  # [2. {reversed:false}
+					  # 3.]
+				` ) );
+			} );
+
+			it( 'should copy `listReversed` attribute after indenting a single item into previously nested list', () => {
+				setData( model, modelList( `
+					# 1. {reversed:false}
+					  # 1a. {reversed:true}
+					  # 1b.
+					# 2.[]
+					# 3.
+				` ) );
+
+				editor.execute( 'indentList' );
+
+				expect( getData( model ) ).to.equalMarkup( modelList( `
+					# 1. {reversed:false}
+					  # 1a. {reversed:true}
+					  # 1b.
+					  # 2.[]
+					# 3.
+				` ) );
+			} );
+
+			it( 'should copy `listReversed` attribute after indenting a few items into previously nested list', () => {
+				setData( model, modelList( `
+					# 1. {reversed:false}
+					  # 1a. {reversed:true}
+					  # 1b.
+					# [2.
+					# 3.]
+					# 4.
+				` ) );
+
+				editor.execute( 'indentList' );
+
+				expect( getData( model ) ).to.equalMarkup( modelList( `
+					# 1. {reversed:false}
+					  # 1a. {reversed:true}
+					  # 1b.
+					  # [2.
+					  # 3.]
+					# 4.
+				` ) );
+			} );
+
+			it( 'should not do anything with bulleted lists', () => {
+				setData( model, modelList( `
+					* 1.
+					* 2.[]
+				` ) );
+
+				editor.execute( 'indentList' );
+
+				expect( getData( model ) ).to.equalMarkup( modelList( `
+					* 1.
+					  * 2.[]
+				` ) );
+			} );
+		} );
 	} );
 
 	describe( 'listStart', () => {
@@ -392,6 +566,100 @@ describe( 'DocumentListPropertiesEditing', () => {
 					# 1. {start:5}
 					# 2.
 					# 3.
+				` ) );
+			} );
+		} );
+
+		describe( 'indenting lists', () => {
+			it( 'should reset `listStart` attribute after indenting a single item', () => {
+				setData( model, modelList( `
+					# 1. {start:5}
+					  # 1a. {start:3}
+					# 2.
+					# 3.[]
+					# 4.
+				` ) );
+
+				editor.execute( 'indentList' );
+
+				expect( getData( model ) ).to.equalMarkup( modelList( `
+					# 1. {start:5}
+					  # 1a. {start:3}
+					# 2.
+					  # 3.[] {start:1}
+					# 4.
+				` ) );
+			} );
+
+			it( 'should reset `listStart` attribute after indenting a few items', () => {
+				setData( model, modelList( `
+					# 1. {start:2}
+					# [2.
+					# 3.]
+				` ) );
+
+				editor.execute( 'indentList' );
+
+				expect( getData( model ) ).to.equalMarkup( modelList( `
+					# 1. {start:2}
+					  # [2. {start:1}
+					  # 3.]
+				` ) );
+			} );
+
+			it( 'should copy `listStart` attribute after indenting a single item into previously nested list', () => {
+				setData( model, modelList( `
+					# 1. {start:3}
+					  # 1a. {start:7}
+					  # 1b.
+					# 2.[]
+					# 3.
+				` ) );
+
+				editor.execute( 'indentList' );
+
+				expect( getData( model ) ).to.equalMarkup( modelList( `
+					# 1. {start:3}
+					  # 1a. {start:7}
+					  # 1b.
+					  # 2.[]
+					# 3.
+				` ) );
+			} );
+
+			it( 'should copy `listStart` attribute after indenting a few items into previously nested list', () => {
+				setData( model, modelList( `
+					# 1. {start:42}
+					  # 1a. {start:2}
+					  # 1b.
+					# [2.
+					# 3.]
+					# 4.
+				` ) );
+
+				editor.execute( 'indentList' );
+
+				expect( getData( model ) ).to.equalMarkup( modelList( `
+					# 1. {start:42}
+					  # 1a. {start:2}
+					  # 1b.
+					  # [2.
+					  # 3.]
+					# 4.
+				` ) );
+			} );
+
+			it( 'should not do anything with bulleted lists', () => {
+				setData( model, modelList( `
+					* 1.
+					* 2.[]
+				` ) );
+
+				editor.execute( 'indentList' );
+
+				expect( getData( model ) ).to.equalMarkup( modelList( `
+					* 1.
+					  * 2.[]
 				` ) );
 			} );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (list): Reset document list properties after indent. Closes #11357.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._