### PR TITLE
Prevent `PlainTableOutput` from interfering with other features caption downcast converters

### DIFF
--- a/packages/ckeditor5-table/src/plaintableoutput.js
+++ b/packages/ckeditor5-table/src/plaintableoutput.js
@@ -43,7 +43,7 @@ export default class PlainTableOutput extends Plugin {
 			converterPriority: 'high'
 		} );
 
-		// Make sure table <caption> is always downcasted to <caption> in the data pipeline.
+		// Make sure table <caption> is downcasted into <caption> in the data pipeline when necessary.
 		if ( editor.plugins.has( 'TableCaption' ) ) {
 			editor.conversion.for( 'dataDowncast' ).elementToElement( {
 				model: 'caption',
@@ -51,8 +51,6 @@ export default class PlainTableOutput extends Plugin {
 					if ( modelElement.parent.name === 'table' ) {
 						return writer.createContainerElement( 'caption' );
 					}
-
-					return writer.createContainerElement( 'figcaption' );
 				},
 				converterPriority: 'high'
 			} );

--- a/packages/ckeditor5-table/tests/plaintableoutput.js
+++ b/packages/ckeditor5-table/tests/plaintableoutput.js
@@ -452,6 +452,38 @@ describe( 'PlainTableOutput', () => {
 				testEditor.destroy();
 			} );
 
+			// See: https://github.com/ckeditor/ckeditor5/issues/11394
+			it( 'should allow overriding image caption converters', async () => {
+				const testEditor = await ClassicTestEditor.create( editorElement, {
+					plugins: [ ArticlePluginSet, Table, TableCaption, PlainTableOutput ],
+					image: { toolbar: [ '|' ] }
+				} );
+
+				testEditor.conversion.for( 'dataDowncast' ).elementToElement( {
+					model: 'caption',
+					view: ( modelElement, { writer } ) => {
+						return writer.createContainerElement( 'foobar' );
+					},
+					converterPriority: 'high'
+				} );
+
+				testEditor.setData(
+					'<figure class="image">' +
+						'<img src="/assets/sample.png" />' +
+						'<figcaption>Caption</figcaption>' +
+					'</figure>'
+				);
+
+				expect( testEditor.getData() ).to.equal(
+					'<figure class="image">' +
+						'<img src="/assets/sample.png">' +
+						'<foobar>Caption</foobar>' +
+					'</figure>'
+				);
+
+				testEditor.destroy();
+			} );
+
 			function createEmptyTable() {
 				setModelData(
 					model,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): Prevent plain table output converter from interfering with other features caption converters. Closes #11394.

---

### Additional information

After some testing we noticed that the new `PlainTableOutput` plugin converter for downcasting captions was doing a bit too much. For tables it was correctly changing the output from `<figcaption>` to `<caption>` element, but for all the other elements it was falling back to the `<figcaption>` element. This was preventing other converters to alter this behaviour on their own. Hence this change.
