### PR TITLE
Fixing absolute internal URLs in installation docs

### DIFF
--- a/packages/ckeditor5-core/src/editor/editor.js
+++ b/packages/ckeditor5-core/src/editor/editor.js
@@ -361,7 +361,7 @@ mix( Editor, ObservableMixin );
  * This error is thrown when trying to pass a `<textarea>` element to a `create()` function of an editor class.
  *
  * The only editor type which can be initialized on `<textarea>` elements is
- * the {@glink /installation/advanced/alternative-setups/predefined-builds#classic-editor classic editor}.
+ * the {@glink installation/advanced/alternative-setups/predefined-builds#classic-editor classic editor}.
  * This editor hides the passed element and inserts its own UI next to it. Other types of editors reuse the passed element as their root
  * editable element and therefore `<textarea>` is not appropriate for them. Use a `<div>` or another text container instead:
  *

--- a/packages/ckeditor5-core/src/editor/editorconfig.jsdoc
+++ b/packages/ckeditor5-core/src/editor/editorconfig.jsdoc
@@ -24,7 +24,7 @@
  *			.then( ... )
  *			.catch( ... );
  *
- * Check the {@glink /installation/advanced/predefined-builds Configuration guide} for more information
+ * Check the {@glink installation/advanced/alternative-setups/predefined-builds Configuration guide} for more information
  * about setting configuration options.
  *
  * @interface EditorConfig
@@ -62,7 +62,7 @@
 /**
  * The list of plugins to load.
  *
- * If you use an {@glink /installation/advanced/predefined-builds editor build} you can define the list of plugins to load
+ * If you use an {@glink installation/advanced/alternative-setups/predefined-builds editor build} you can define the list of plugins to load
  * using the names of plugins that are available:
  *
  *		const config = {
@@ -94,7 +94,7 @@
 
 /**
  * The list of additional plugins to load along those already available in the
- * {@glink /installation/advanced/predefined-builds editor build}. It extends the {@link #plugins `plugins`} configuration.
+ * {@glink installation/advanced/alternative-setups/predefined-builds editor build}. It extends the {@link #plugins `plugins`} configuration.
  *
  *		function MyPlugin( editor ) {
  *			// ...
@@ -115,7 +115,7 @@
  */
 
 /**
- * The list of plugins which should not be loaded despite being available in an {@glink /installation/advanced/predefined-builds editor build}.
+ * The list of plugins which should not be loaded despite being available in an {@glink installation/advanced/alternative-setups/predefined-builds editor build}.
  *
  *		const config = {
  *			removePlugins: [ 'Bold', 'Italic' ]

--- a/packages/ckeditor5-core/src/plugincollection.js
+++ b/packages/ckeditor5-core/src/plugincollection.js
@@ -344,7 +344,7 @@ export default class PluginCollection {
 			 * This is usually done in CKEditor 5 builds by setting the {@link module:core/editor/editor~Editor.builtinPlugins}
 			 * property.
 			 *
-			 * **If you see this warning when using one of the {@glink /installation/advanced/alternative-setups/predefined-builds
+			 * **If you see this warning when using one of the {@glink installation/advanced/alternative-setups/predefined-builds
 			 * CKEditor 5 Builds}**,
 			 * it means that you try to enable a plugin which was not included in that build. This may be due to a typo
 			 * in the plugin name or simply because that plugin is not a part of this build. In the latter scenario,
@@ -354,7 +354,7 @@ export default class PluginCollection {
 			 * that you tried loading plugins by name. However, unlike CKEditor 4, CKEditor 5 does not implement a "plugin loader".
 			 * This means that CKEditor 5 does not know where to load the plugin modules from. Therefore, you need to
 			 * provide each plugin through a reference (as a constructor function). Check out the examples in
-			 * {@glink /installation/advanced/alternative-setups/integrating-from-source "Building from source"}.
+			 * {@glink installation/advanced/alternative-setups/integrating-from-source "Building from source"}.
 			 *
 			 * @error plugincollection-plugin-not-found
 			 * @param {String} plugin The name of the plugin which could not be loaded.

--- a/packages/ckeditor5-editor-balloon/src/ballooneditor.js
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditor.js
@@ -17,7 +17,8 @@ import BalloonEditorUI from './ballooneditorui';
 import BalloonEditorUIView from './ballooneditoruiview';
 
 /**
- * The {@glink /installation/advanced/predefined-builds#balloon-editor balloon editor} implementation (Medium-like editor).
+ * The {@glink installation/advanced/alternative-setups/predefined-builds#balloon-editor balloon editor}
+ * implementation (Medium-like editor).
  * It uses an inline editable and a toolbar based on the {@link module:ui/toolbar/balloon/balloontoolbar~BalloonToolbar}.
  * See the {@glink examples/builds/balloon-editor demo}.
  *
@@ -28,9 +29,10 @@ import BalloonEditorUIView from './ballooneditoruiview';
  *
  * The balloon editor can be used directly from source (if you installed the
  * [`@ckeditor/ckeditor5-editor-balloon`](https://www.npmjs.com/package/@ckeditor/ckeditor5-editor-balloon) package)
- * but it is also available in the {@glink /installation/advanced/predefined-builds#balloon-editor balloon build}.
+ * but it is also available in the {@glink installation/advanced/alternative-setups/predefined-builds#balloon-editor balloon build}.
  *
- * {@glink /installation/advanced/predefined-builds Builds} are ready-to-use editors with plugins bundled in. When using the editor from
+ * {@glink installation/advanced/alternative-setups/predefined-builds Builds}
+ * are ready-to-use editors with plugins bundled in. When using the editor from
  * source you need to take care of loading all plugins by yourself
  * (through the {@link module:core/editor/editorconfig~EditorConfig#plugins `config.plugins`} option).
  * Using the editor from source gives much better flexibility and allows easier customization.
@@ -169,13 +171,13 @@ export default class BalloonEditor extends Editor {
 	 * # Using the editor from source
 	 *
 	 * The code samples listed in the previous sections of this documentation assume that you are using an
-	 * {@glink /installation/advanced/predefined-builds editor build} (for example – `@ckeditor/ckeditor5-build-balloon`).
+	 * {@glink installation/advanced/alternative-setups/predefined-builds editor build} (for example – `@ckeditor/ckeditor5-build-balloon`).
 	 *
 	 * If you want to use the balloon editor from source (`@ckeditor/ckeditor5-editor-balloon/src/ballooneditor`),
 	 * you need to define the list of
 	 * {@link module:core/editor/editorconfig~EditorConfig#plugins plugins to be initialized} and
 	 * {@link module:core/editor/editorconfig~EditorConfig#toolbar toolbar items}. Read more about using the editor from
-	 * source in the {@glink /installation/advanced/integrating-from-source dedicated guide}.
+	 * source in the {@glink installation/advanced/alternative-setups/integrating-from-source dedicated guide}.
 	 *
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * or the editor's initial data.

--- a/packages/ckeditor5-editor-classic/src/classiceditor.js
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.js
@@ -16,7 +16,7 @@ import ClassicEditorUI from './classiceditorui';
 import ClassicEditorUIView from './classiceditoruiview';
 
 /**
- * The {@glink /installation/advanced/predefined-builds#classic-editor classic editor} implementation.
+ * The {@glink installation/advanced/alternative-setups/predefined-builds#classic-editor classic editor} implementation.
  * It uses an inline editable and a sticky toolbar, all enclosed in a boxed UI.
  * See the {@glink examples/builds/classic-editor demo}.
  *
@@ -27,9 +27,10 @@ import ClassicEditorUIView from './classiceditoruiview';
  *
  * The classic editor can be used directly from source (if you installed the
  * [`@ckeditor/ckeditor5-editor-classic`](https://www.npmjs.com/package/@ckeditor/ckeditor5-editor-classic) package)
- * but it is also available in the {@glink /installation/advanced/predefined-builds#classic-editor classic build}.
+ * but it is also available in the {@glink installation/advanced/alternative-setups/predefined-builds#classic-editor classic build}.
  *
- * {@glink /installation/advanced/predefined-builds Builds} are ready-to-use editors with plugins bundled in. When using the editor from
+ * {@glink installation/advanced/alternative-setups/predefined-builds Builds}
+ * are ready-to-use editors with plugins bundled in. When using the editor from
  * source you need to take care of loading all plugins by yourself
  * (through the {@link module:core/editor/editorconfig~EditorConfig#plugins `config.plugins`} option).
  * Using the editor from source gives much better flexibility and allows easier customization.
@@ -159,13 +160,13 @@ export default class ClassicEditor extends Editor {
 	 * # Using the editor from source
 	 *
 	 * The code samples listed in the previous sections of this documentation assume that you are using an
-	 * {@glink /installation/advanced/predefined-builds editor build} (for example – `@ckeditor/ckeditor5-build-classic`).
+	 * {@glink installation/advanced/alternative-setups/predefined-builds editor build} (for example – `@ckeditor/ckeditor5-build-classic`).
 	 *
 	 * If you want to use the classic editor from source (`@ckeditor/ckeditor5-editor-classic/src/classiceditor`),
 	 * you need to define the list of
 	 * {@link module:core/editor/editorconfig~EditorConfig#plugins plugins to be initialized} and
 	 * {@link module:core/editor/editorconfig~EditorConfig#toolbar toolbar items}. Read more about using the editor from
-	 * source in the {@glink /installation/advanced/integrating-from-source dedicated guide}.
+	 * source in the {@glink installation/advanced/alternative-setups/integrating-from-source dedicated guide}.
 	 *
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * or the editor's initial data.

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitor.js
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitor.js
@@ -16,7 +16,7 @@ import DecoupledEditorUI from './decouplededitorui';
 import DecoupledEditorUIView from './decouplededitoruiview';
 
 /**
- * The {@glink /installation/advanced/predefined-builds#document-editor decoupled editor} implementation.
+ * The {@glink installation/advanced/alternative-setups/predefined-builds#document-editor decoupled editor} implementation.
  * It provides an inline editable and a toolbar. However, unlike other editors,
  * it does not render these components anywhere in the DOM unless configured.
  *
@@ -33,9 +33,11 @@ import DecoupledEditorUIView from './decouplededitoruiview';
  *
  * The decoupled editor can be used directly from source (if you installed the
  * [`@ckeditor/ckeditor5-editor-decoupled`](https://www.npmjs.com/package/@ckeditor/ckeditor5-editor-decoupled) package)
- * but it is also available in the {@glink /installation/advanced/predefined-builds#document-editor document editor build}.
+ * but it is also available in the
+ * {@glink installation/advanced/alternative-setups/predefined-builds#document-editor document editor build}.
  *
- * {@glink /installation/advanced/predefined-builds Builds} are ready-to-use editors with plugins bundled in. When using the editor from
+ * {@glink installation/advanced/alternative-setups/predefined-builds Builds}
+ * are ready-to-use editors with plugins bundled in. When using the editor from
  * source you need to take care of loading all plugins by yourself
  * (through the {@link module:core/editor/editorconfig~EditorConfig#plugins `config.plugins`} option).
  * Using the editor from source gives much better flexibility and allows for easier customization.
@@ -193,13 +195,14 @@ export default class DecoupledEditor extends Editor {
 	 * # Using the editor from source
 	 *
 	 * The code samples listed in the previous sections of this documentation assume that you are using an
-	 * {@glink /installation/advanced/predefined-builds editor build} (for example – `@ckeditor/ckeditor5-build-decoupled`).
+	 * {@glink installation/advanced/alternative-setups/predefined-builds editor build}
+	 * (for example – `@ckeditor/ckeditor5-build-decoupled`).
 	 *
 	 * If you want to use the decoupled editor from source (`@ckeditor/ckeditor5-editor-decoupled/src/decouplededitor`),
 	 * you need to define the list of
 	 * {@link module:core/editor/editorconfig~EditorConfig#plugins plugins to be initialized} and
 	 * {@link module:core/editor/editorconfig~EditorConfig#toolbar toolbar items}. Read more about using the editor from
-	 * source in the {@glink /installation/advanced/integrating-from-source dedicated guide}.
+	 * source in the {@glink installation/advanced/alternative-setups/integrating-from-source dedicated guide}.
 	 *
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * or the editor's initial data.

--- a/packages/ckeditor5-editor-inline/src/inlineeditor.js
+++ b/packages/ckeditor5-editor-inline/src/inlineeditor.js
@@ -16,7 +16,7 @@ import InlineEditorUI from './inlineeditorui';
 import InlineEditorUIView from './inlineeditoruiview';
 
 /**
- * The {@glink /installation/advanced/predefined-builds#inline-editor inline editor} implementation.
+ * The {@glink installation/advanced/alternative-setups/predefined-builds#inline-editor inline editor} implementation.
  * It uses an inline editable and a floating toolbar.
  * See the {@glink examples/builds/inline-editor demo}.
  *
@@ -27,9 +27,10 @@ import InlineEditorUIView from './inlineeditoruiview';
  *
  * The inline editor can be used directly from source (if you installed the
  * [`@ckeditor/ckeditor5-editor-inline`](https://www.npmjs.com/package/@ckeditor/ckeditor5-editor-inline) package)
- * but it is also available in the {@glink /installation/advanced/predefined-builds#inline-editor inline build}.
+ * but it is also available in the {@glink installation/advanced/alternative-setups/predefined-builds#inline-editor inline build}.
  *
- * {@glink /installation/advanced/predefined-builds Builds} are ready-to-use editors with plugins bundled in. When using the editor from
+ * {@glink installation/advanced/alternative-setups/predefined-builds Builds}
+ * are ready-to-use editors with plugins bundled in. When using the editor from
  * source you need to take care of loading all plugins by yourself
  * (through the {@link module:core/editor/editorconfig~EditorConfig#plugins `config.plugins`} option).
  * Using the editor from source gives much better flexibility and allows easier customization.
@@ -165,13 +166,13 @@ export default class InlineEditor extends Editor {
 	 * # Using the editor from source
 	 *
 	 * The code samples listed in the previous sections of this documentation assume that you are using an
-	 * {@glink /installation/advanced/predefined-builds editor build} (for example – `@ckeditor/ckeditor5-build-inline`).
+	 * {@glink installation/advanced/alternative-setups/predefined-builds editor build} (for example – `@ckeditor/ckeditor5-build-inline`).
 	 *
 	 * If you want to use the inline editor from source (`@ckeditor/ckeditor5-editor-inline/src/inlineeditor`),
 	 * you need to define the list of
 	 * {@link module:core/editor/editorconfig~EditorConfig#plugins plugins to be initialized} and
 	 * {@link module:core/editor/editorconfig~EditorConfig#toolbar toolbar items}. Read more about using the editor from
-	 * source in the {@glink /installation/advanced/integrating-from-source dedicated guide}.
+	 * source in the {@glink installation/advanced/alternative-setups/integrating-from-source dedicated guide}.
 	 *
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * or the editor's initial data.

--- a/packages/ckeditor5-utils/src/version.js
+++ b/packages/ckeditor5-utils/src/version.js
@@ -56,7 +56,7 @@ if ( windowOrGlobal.CKEDITOR_VERSION ) {
 	 * This scenario is very similar to the previous one, but has a different origin.
 	 *
 	 * Let's assume that you wanted to use CKEditor 5 from source, as explained in the
-	 * {@glink /installation/advanced/alternative-setups/integrating-from-source "Building from source"} section
+	 * {@glink installation/advanced/alternative-setups/integrating-from-source "Building from source"} section
 	 * or in the {@glink framework/guides/quick-start "Quick start"} guide of CKEditor 5 Framework.
 	 *
 	 * The correct way to do so is to import an editor and plugins and run them together like this:


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: fixing invalid absolute URLs in installation API docs. Closes cksource/ckeditor5-internal#1554.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._