### PR TITLE
Certain markup breaks the Source Editing mode

### DIFF
--- a/packages/ckeditor5-html-support/src/integrations/image.js
+++ b/packages/ckeditor5-html-support/src/integrations/image.js
@@ -84,6 +84,10 @@ export default class ImageElementSupport extends Plugin {
 function viewToModelImageAttributeConverter( dataFilter ) {
 	return dispatcher => {
 		dispatcher.on( 'element:img', ( evt, data, conversionApi ) => {
+			if ( !data.modelRange ) {
+				return;
+			}
+
 			const viewImageElement = data.viewItem;
 			const viewContainerElement = viewImageElement.parent;
 

--- a/packages/ckeditor5-html-support/tests/integrations/image.js
+++ b/packages/ckeditor5-html-support/tests/integrations/image.js
@@ -1221,6 +1221,25 @@ describe( 'ImageElementSupport', () => {
 				'<p><img src="/assets/sample.png"></p>'
 			);
 		} );
+
+		// See: https://github.com/ckeditor/ckeditor5/issues/10703.
+		it( 'should not break inside <dir> element if image contains an attribute', () => {
+			dataFilter.loadAllowedConfig( [ {
+				name: 'img',
+				attributes: true
+			}, {
+				name: 'dir'
+			} ] );
+
+			editor.setData( '<dir><img data-foo="bar">' );
+
+			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+				data: '<htmlDir></htmlDir>',
+				attributes: {}
+			} );
+
+			expect( editor.getData() ).to.equal( '' );
+		} );
 	} );
 
 	describe( 'Inline image with link', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (html-support): Skip inline image upcast conversion inside not supported element. Closes #10703.