### PR TITLE
Allowed excluding certain elements from CSS reset

### DIFF
--- a/packages/ckeditor5-theme-lark/tests/manual/reset.html
+++ b/packages/ckeditor5-theme-lark/tests/manual/reset.html
@@ -1,0 +1,43 @@
+<h2>CSS reset exclusion</h2>
+
+<div class="ck ck-reset_all" style="border: 1px dotted gray; padding: 10px;">
+	<h3>A box with the <code>ck-reset_all</code> CSS class.</h3>
+	<p>Paragraph of text.</p>
+	<button type="button">Button</button>
+	<input type="text" value="Text of input" />
+	<div class="ck-rtl">
+		<p>.ck-rtl paragraph.</p>
+	</div>
+	<textarea>Textarea content</textarea>
+	<table><tbody><tr><td>table cell</td><td>table cell</td></tr><tr><td>table cell</td><td>table cell</td></tr></tbody></table>
+
+	<div class="ck-reset_all-excluded" style="outline: 1px solid hsl(120, 100%, 25%); padding: 10px;">
+		<h3>A box excluded from <code>.ck-reset_all</code> thanks to <code>.ck-reset_all-excluded</code> class</h3>
+		<p>Paragraph of text.</p>
+		<button type="button">Button</button>
+		<input type="text" value="Text of input" />
+		<div class="ck-rtl">
+			<p>.ck-rtl paragraph.</p>
+		</div>
+		<textarea>Textarea content</textarea>
+		<table><tbody><tr><td>table cell</td><td>table cell</td></tr><tr><td>table cell</td><td>table cell</td></tr></tbody></table>
+
+		<div style="outline: 1px solid hsl(120, 100%, 25%); padding: 10px;">
+			<h4>A nested box excluded from <code>.ck-reset_all</code> to check if selectors work fine in a deep structure</h4>
+			<p>Paragraph of text.</p>
+			<button type="button">Button</button>
+			<input type="text" value="Text of input" />
+			<div class="ck-rtl">
+				<p>.ck-rtl paragraph.</p>
+			</div>
+			<textarea>Textarea content</textarea>
+			<table><tbody><tr><td>table cell</td><td>table cell</td></tr><tr><td>table cell</td><td>table cell</td></tr></tbody></table>
+		</div>
+	</div>
+</div>
+
+<style>
+	table td {
+		border: 1px solid hsl(0, 0%, 27%);
+	}
+</style>

--- a/packages/ckeditor5-theme-lark/tests/manual/reset.js
+++ b/packages/ckeditor5-theme-lark/tests/manual/reset.js
@@ -1,0 +1,8 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+// Importing View to make sure resets are imported and injected
+// eslint-disable-next-line
+import View from '@ckeditor/ckeditor5-ui/src/view';

--- a/packages/ckeditor5-theme-lark/tests/manual/reset.md
+++ b/packages/ckeditor5-theme-lark/tests/manual/reset.md
@@ -1,0 +1,16 @@
+# Excluding elements from CSS reset
+
+In this test, there's a box with `.ck-reset_all` class and some child elements:
+
+1. In the first section, children styles should be reset. Inspect them visually:
+	* buttons, inputs, textarea should have no borders,
+	* heading should look like a paragraph (no bold text),
+	* paragraph should have no additional margins,
+	* a paragraph with `.ck-rtl` should be aligned to the right.
+2. In the second section, there's a box with `.ck-reset_all-excluded` that should exclude its content from CSS reset. Inspect it visually:
+	* buttons, inputs, textarea should have borders (like in UA styles),
+	* headings should look like raw HTML headings (bigger, bold...),
+	* etc. (anything reset in the previous section should not happen here)
+3. In the third section, there's a box inside the box with `.ck-reset_all-excluded`. Its content should look the same as in its parent. Inspect it visually.
+4. Open the dev tools and inspect elements in the "exclusion zones" (the first one and the nested one). Look at CSS selectors:
+	* there should be nothing there related to CKEditor and `.ck-reset_all` in particular, **only UA styles provided by the web browser**.

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_reset.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/globals/_reset.css
@@ -16,7 +16,7 @@
  */
 .ck.ck-reset,
 .ck.ck-reset_all,
-.ck.ck-reset_all * {
+.ck-reset_all *:not(.ck-reset_all-excluded *) {
 	/* Do not include inheritable rules here. */
 	margin: 0;
 	padding: 0;
@@ -34,7 +34,7 @@
  * Resets an element AND its children.
  */
 .ck.ck-reset_all,
-.ck.ck-reset_all * {
+.ck-reset_all *:not(.ck-reset_all-excluded *) {
 	/* These are rule inherited by all children elements. */
 	border-collapse: collapse;
 	font: normal normal normal var(--ck-font-size-base)/var(--ck-line-height-base) var(--ck-font-face);
@@ -45,38 +45,38 @@
 	float: none;
 }
 
-.ck.ck-reset_all {
-	& .ck-rtl * {
+.ck-reset_all {
+	& .ck-rtl *:not(.ck-reset_all-excluded *) {
 		text-align: right;
 	}
 
-	& iframe {
+	& iframe:not(.ck-reset_all-excluded *) {
 		/* For IE */
 		vertical-align: inherit;
 	}
 
-	& textarea {
+	& textarea:not(.ck-reset_all-excluded *) {
 		white-space: pre-wrap;
 	}
 
-	& textarea,
-	& input[type="text"],
-	& input[type="password"] {
+	& textarea:not(.ck-reset_all-excluded *),
+	& input[type="text"]:not(.ck-reset_all-excluded *),
+	& input[type="password"]:not(.ck-reset_all-excluded *) {
 		cursor: text;
 	}
 
-	& textarea[disabled],
-	& input[type="text"][disabled],
-	& input[type="password"][disabled] {
+	& textarea[disabled]:not(.ck-reset_all-excluded *),
+	& input[type="text"][disabled]:not(.ck-reset_all-excluded *),
+	& input[type="password"][disabled]:not(.ck-reset_all-excluded *) {
 		cursor: default;
 	}
 
-	& fieldset {
+	& fieldset:not(.ck-reset_all-excluded *) {
 		padding: 10px;
 		border: 2px groove hsl(255, 7%, 88%);
 	}
 
-	& button::-moz-focus-inner {
+	& button:not(.ck-reset_all-excluded *)::-moz-focus-inner {
 		/* See http://stackoverflow.com/questions/5517744/remove-extra-button-spacing-padding-in-firefox */
 		padding: 0;
 		border: 0

--- a/packages/ckeditor5-ui/theme/globals/_reset.css
+++ b/packages/ckeditor5-ui/theme/globals/_reset.css
@@ -5,7 +5,7 @@
 
 .ck.ck-reset,
 .ck.ck-reset_all,
-.ck.ck-reset_all * {
+.ck-reset_all *:not(.ck-reset_all-excluded *) {
 	box-sizing: border-box;
 	width: auto;
 	height: auto;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (theme-lark): Implemented a `.ck-reset_all-excluded` CSS class that excludes certain elements from CSS reset. Closes #11451.

---

### Additional information

Demo in the manual test in the `theme-lark` package.