### PR TITLE
Docs: Fix of removing features guide with additional examples

### DIFF
--- a/docs/installation/getting-started/configuration.md
+++ b/docs/installation/getting-started/configuration.md
@@ -76,7 +76,7 @@ However, using this snippet with the official classic build of CKEditor 5 will r
 CKEditorError: plugincollection-required {"plugin":"Link","requiredBy":"CKFinder"}`
 Read more: https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/error-codes.html#error-plugincollection-required
 ```
-At this moment it is good to remind you that some plugins in CKEditor 5 depend on each other and, in this case, the `CKFinder` plugin requires the `Link` plugin to work. To make the above snippet work the `CKFinder`plugin must also be deleted:
+This is a good time to remind you that some plugins in CKEditor 5 depend on each other. In this case, the `CKFinder` plugin requires the `Link` plugin to work. To make the above snippet work, the `CKFinder` plugin must also be deleted:
 
 ```js
 // Remove a few plugins from the default setup.

--- a/docs/installation/getting-started/configuration.md
+++ b/docs/installation/getting-started/configuration.md
@@ -43,7 +43,21 @@ The {@link installation/advanced/predefined-builds predefined CKEditor 5 builds}
 
 In some cases, you may want to have different editor setups in your application, all based on the same build. For that purpose, you need to control the plugins available in the editor at runtime.
 
-In the example below, the `Heading` and `Link` plugins are removed:
+In the example below, the `Heading` plugin is removed:
+
+```js
+// Remove a plugin from the default setup.
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		removePlugins: [ 'Heading' ],
+		toolbar: [ 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote' , 'link' ]
+	} )
+	.catch( error => {
+		console.log( error );
+	} );
+```
+
+You might want to delete the `Link` plugin also, as shown below:
 
 ```js
 // Remove a few plugins from the default setup.
@@ -56,6 +70,26 @@ ClassicEditor
 		console.log( error );
 	} );
 ```
+
+However, using this snippet with the official classic build of CKEditor 5 will result in an error thrown in the console of the browser:
+```
+CKEditorError: plugincollection-required {"plugin":"Link","requiredBy":"CKFinder"}`
+Read more: https://ckeditor.com/docs/ckeditor5/latest/framework/guides/support/error-codes.html#error-plugincollection-required
+```
+At this moment it is good to remind you that some plugins in CKEditor 5 depend on each other and, in this case, the `CKFinder` plugin requires the `Link` plugin to work. To make the above snippet work the `CKFinder`plugin must also be deleted:
+
+```js
+// Remove a few plugins from the default setup.
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		removePlugins: [ 'Heading', 'Link', 'CKFinder' ],
+		toolbar: [ 'bold', 'italic', 'bulletedList', 'numberedList', 'blockQuote' ]
+	} )
+	.catch( error => {
+		console.log( error );
+	} );
+```
+
 <info-box>
 	Be careful when removing plugins from CKEditor builds using {@link module:core/editor/editorconfig~EditorConfig#removePlugins `config.removePlugins`}. If removed plugins were providing toolbar buttons, the default toolbar configuration included in a build will become invalid. In such case you need to provide the {@link features/toolbar updated toolbar configuration} as in the example above or by providing only toolbar items that need to be removed using `config.toolbar.removeItems`.
 </info-box>


### PR DESCRIPTION
Docs: Fix of removing features guide with additional examples. Closes #11455.