### PR TITLE
Improved performance of the 'getSubNodes()' utility

### DIFF
--- a/packages/ckeditor5-watchdog/src/utils/getsubnodes.js
+++ b/packages/ckeditor5-watchdog/src/utils/getsubnodes.js
@@ -16,9 +16,11 @@ export default function getSubNodes( head, excludedProperties = new Set() ) {
 
 	// Nodes are stored to prevent infinite looping.
 	const subNodes = new Set();
+	let nodeIndex = 0;
 
-	while ( nodes.length > 0 ) {
-		const node = nodes.shift();
+	while ( nodes.length > nodeIndex ) {
+		// Incrementing the iterator is much faster than changing size of the array with Array.prototype.shift().
+		const node = nodes[ nodeIndex++ ];
 
 		if ( subNodes.has( node ) || shouldNodeBeSkipped( node ) || excludedProperties.has( node ) ) {
 			continue;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other: Improved performance of the `getSubNodes()` utility.

---

### Additional information

This function is a bottleneck when it comes to the watchdog restarting mechanism - watchdog traverses the whole editor structure to find the context of the thrown error. After this change, the `getSubNodes` function will be ~100 times faster for large documents.