### PR TITLE
GHS: fix mergeViewElementAttributes

### DIFF
--- a/packages/ckeditor5-html-support/src/conversionutils.js
+++ b/packages/ckeditor5-html-support/src/conversionutils.js
@@ -45,7 +45,7 @@ export function mergeViewElementAttributes( target, source ) {
 	for ( const key in source ) {
 		// Merge classes.
 		if ( Array.isArray( source[ key ] ) ) {
-			result[ key ] = Array.from( new Set( [ ...target[ key ], ...source[ key ] ] ) );
+			result[ key ] = Array.from( new Set( [ ...( target[ key ] || [] ), ...source[ key ] ] ) );
 		}
 
 		// Merge attributes or styles.

--- a/packages/ckeditor5-html-support/tests/datafilter.js
+++ b/packages/ckeditor5-html-support/tests/datafilter.js
@@ -1100,6 +1100,29 @@ describe( 'DataFilter', () => {
 			} );
 		} );
 
+		// #10657.
+		// #11450.
+		// #11477.
+		it( 'should not throw exception when outer element doesn\'t have attributes', () => {
+			dataFilter.allowElement( 'span' );
+			dataFilter.allowAttributes( { name: 'span', classes: /[\s\S]+/ } );
+
+			editor.setData( '<p><span>foo<span class="test">bar</span></span></p>' );
+
+			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+				data: '<paragraph>' +
+						'<$text htmlSpan="(1)">foo</$text>' +
+						'<$text htmlSpan="(2)">bar</$text>' +
+					'</paragraph>',
+				attributes: {
+					1: {},
+					2: {
+						classes: [ 'test' ]
+					}
+				}
+			} );
+		} );
+
 		describe( 'attribute properties', () => {
 			it( 'should set if given', () => {
 				dataSchema.registerInlineElement( {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (html-support): Prevents `TypeError` in `mergeViewElementAttributes`. Closes #10657. Closes #11450. Closes #11477.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._