### PR TITLE
Excluded the style preview from CSS UI reset

### DIFF
--- a/packages/ckeditor5-style/src/ui/stylegridbuttonview.js
+++ b/packages/ckeditor5-style/src/ui/stylegridbuttonview.js
@@ -82,6 +82,7 @@ export default class StyleGridButtonView extends ButtonView {
 			attributes: {
 				class: [
 					'ck',
+					'ck-reset_all-excluded',
 					'ck-style-grid__button__preview',
 					'ck-content'
 				]

--- a/packages/ckeditor5-style/tests/ui/stylegridbuttonview.js
+++ b/packages/ckeditor5-style/tests/ui/stylegridbuttonview.js
@@ -53,7 +53,14 @@ describe( 'StyleGridButtonView', () => {
 			it( 'should have CSS classes', () => {
 				expect( button.previewView.element.classList.contains( 'ck' ) ).to.be.true;
 				expect( button.previewView.element.classList.contains( 'ck-style-grid__button__preview' ) ).to.be.true;
+			} );
+
+			it( 'should use the .ck-content CSS class for easier integration (configuration)', () => {
 				expect( button.previewView.element.classList.contains( 'ck-content' ) ).to.be.true;
+			} );
+
+			it( 'should exclude its content from the UI CSS reset for easier integration (configuration)', () => {
+				expect( button.previewView.element.classList.contains( 'ck-reset_all-excluded' ) ).to.be.true;
 			} );
 
 			it( 'should render the inner preview as the element specified in definition if previewable', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (style): Excluded the style preview from CSS UI reset making it easier to integrate the feature. Closes #11520. See #11462.

---

### Additional information

For the record: This is not a silver bullet and does not replace web components in 100%. It's an improvement over what we had, though. Some styles will trickle down from parents because this is how inheritance works in CSS, there's no way to seal this up.

![](https://user-images.githubusercontent.com/1099479/160406082-4847fe17-967a-443d-9604-53eec9560542.png)