### PR TITLE
Fixes interference between TextPartLanguage and CodeBlock

### DIFF
--- a/packages/ckeditor5-language/src/textpartlanguageediting.js
+++ b/packages/ckeditor5-language/src/textpartlanguageediting.js
@@ -84,8 +84,12 @@ export default class TextPartLanguageEditing extends Plugin {
 
 		conversion.for( 'downcast' ).attributeToElement( {
 			model: 'language',
-			view: ( attributeValue, { writer } ) => {
+			view: ( attributeValue, { writer }, data ) => {
 				if ( !attributeValue ) {
+					return;
+				}
+
+				if ( !data.item.is( '$textProxy' ) && !data.item.is( 'documentSelection' ) ) {
 					return;
 				}
 

--- a/packages/ckeditor5-language/tests/textpartlanguageediting.js
+++ b/packages/ckeditor5-language/tests/textpartlanguageediting.js
@@ -106,6 +106,31 @@ describe( 'TextPartLanguageEditing', () => {
 			expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
 				.to.equal( '<p><span dir="ltr" lang="fr">foo</span>bar</p>' );
 		} );
+
+		// #11538.
+		// #11563.
+		it( 'should not convert attribute set on other items than text', () => {
+			editor.conversion.elementToElement( { view: 'fakeBlock', model: 'fakeBlock' } );
+			model.schema.register( 'fakeBlock', { inheritAllFrom: '$block' } );
+
+			setModelData( model, '<fakeBlock language="fr:ltr">foo</fakeBlock>' );
+
+			expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
+				.to.equal( '<fakeBlock>foo</fakeBlock>' );
+		} );
+
+		// #11538.
+		// #11563.
+		it( 'should convert attribute set on document selection', () => {
+			setModelData( model, '<paragraph>foo[]</paragraph>', {
+				selectionAttributes: {
+					language: 'fr:ltr'
+				}
+			} );
+
+			expect( getViewData( editor.editing.view ) )
+				.to.equal( '<p>foo<span dir="ltr" lang="fr">[]</span></p>' );
+		} );
 	} );
 
 	describe( 'config', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (language): Fixes interference between `TextPartLanguage` and `CodeBlock`. Closes #11538. Closes #11563.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._