### PR TITLE
Ck/11589 fix register downcast strategy

### DIFF
--- a/packages/ckeditor5-html-support/src/integrations/documentlist.js
+++ b/packages/ckeditor5-html-support/src/integrations/documentlist.js
@@ -84,18 +84,6 @@ export default class DocumentListElementSupport extends Plugin {
 			} );
 		} );
 
-		// Reset list attributes after indenting list items.
-		this.listenTo( editor.commands.get( 'indentList' ), 'afterExecute', ( evt, changedBlocks ) => {
-			editor.model.change( writer => {
-				for ( const node of changedBlocks ) {
-					// Just reset the attribute.
-					// If there is a previous indented list that this node should be merged into,
-					// the postfixer will unify all the attributes of both sub-lists.
-					writer.setAttribute( 'htmlListAttributes', {}, node );
-				}
-			} );
-		} );
-
 		// Make sure that all items in a single list (items at the same level & listType) have the same properties.
 		// Note: This is almost exact copy from DocumentListPropertiesEditing.
 		documentListEditing.on( 'postFixer', ( evt, { listNodes, writer } ) => {
@@ -150,6 +138,29 @@ export default class DocumentListElementSupport extends Plugin {
 					}
 				}
 			}
+		} );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	afterInit() {
+		const editor = this.editor;
+
+		if ( !editor.commands.get( 'indentList' ) ) {
+			return;
+		}
+
+		// Reset list attributes after indenting list items.
+		this.listenTo( editor.commands.get( 'indentList' ), 'afterExecute', ( evt, changedBlocks ) => {
+			editor.model.change( writer => {
+				for ( const node of changedBlocks ) {
+					// Just reset the attribute.
+					// If there is a previous indented list that this node should be merged into,
+					// the postfixer will unify all the attributes of both sub-lists.
+					writer.setAttribute( 'htmlListAttributes', {}, node );
+				}
+			} );
 		} );
 	}
 }

--- a/packages/ckeditor5-html-support/tests/integrations/documentlist.js
+++ b/packages/ckeditor5-html-support/tests/integrations/documentlist.js
@@ -28,7 +28,7 @@ describe( 'DocumentListElementSupport', () => {
 
 		editor = await ClassicTestEditor
 			.create( editorElement, {
-				plugins: [ DocumentListEditing, Paragraph, GeneralHtmlSupport ]
+				plugins: [ Paragraph, GeneralHtmlSupport, DocumentListEditing ]
 			} );
 		model = editor.model;
 		dataFilter = editor.plugins.get( 'DataFilter' );

--- a/packages/ckeditor5-list/src/documentlist/documentlistediting.js
+++ b/packages/ckeditor5-list/src/documentlist/documentlistediting.js
@@ -77,7 +77,9 @@ export default class DocumentListEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	init() {
+	constructor( editor ) {
+		super( editor );
+
 		/**
 		 * The list of registered downcast strategies.
 		 *
@@ -85,7 +87,12 @@ export default class DocumentListEditing extends Plugin {
 		 * @type {Array.<module:list/documentlist/documentlistediting~DowncastStrategy>}
 		 */
 		this._downcastStrategies = [];
+	}
 
+	/**
+	 * @inheritDoc
+	 */
+	init() {
 		const editor = this.editor;
 		const model = editor.model;
 

--- a/packages/ckeditor5-list/tests/documentlist/documentlistediting.js
+++ b/packages/ckeditor5-list/tests/documentlist/documentlistediting.js
@@ -784,7 +784,7 @@ describe( 'DocumentListEditing - registerDowncastStrategy()', () => {
 
 	async function createEditor( extraPlugin ) {
 		editor = await VirtualTestEditor.create( {
-			plugins: [ Paragraph, DocumentListEditing, UndoEditing, extraPlugin ]
+			plugins: [ extraPlugin, Paragraph, DocumentListEditing, UndoEditing ]
 		} );
 
 		model = editor.model;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (list): Allows invocation of `DocumentListEditing.registerDowncastStrategy` from `init()` in any order of plugin initialization. Closes #11589.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._