### PR TITLE
Remove the second parameter from Editor#enableReadOnlyMode()

### DIFF
--- a/packages/ckeditor5-clipboard/tests/manual/dragdrop.js
+++ b/packages/ckeditor5-clipboard/tests/manual/dragdrop.js
@@ -211,7 +211,11 @@ ClassicEditor
 		button.addEventListener( 'click', () => {
 			isReadOnly = !isReadOnly;
 
-			editor.enableReadOnlyMode( 'manual-test', isReadOnly );
+			if ( isReadOnly ) {
+				editor.enableReadOnlyMode( 'manual-test' );
+			} else {
+				editor.disableReadOnlyMode( 'manual-test' );
+			}
 
 			button.textContent = isReadOnly ?
 				'Turn off read-only mode' :

--- a/packages/ckeditor5-core/src/editor/editor.js
+++ b/packages/ckeditor5-core/src/editor/editor.js
@@ -290,21 +290,9 @@ export default class Editor {
 	 * 		editor.disableReadOnlyMode( 'my-other-feature-id' );
 	 * 		editor.isReadOnly; // `false`.
 	 *
-	 * It is possible to pass an additional argument - `value` - to determine if the lock should be set or removed.
-	 * Passing `false` works the same way as calling {@link #disableReadOnlyMode `disableReadOnlyMode()`}:
-	 *
-	 *		// Assuming `isConnected` is an observable property in `myFeature`.
-	 * 		myFeature.on( 'change:isConnected', () => {
-	 * 			editor.enableReadOnlyMode( 'my-feature-id', !myFeature.isConnected );
-	 * 		} );
-	 *
-	 * 		myFeature.isConnected = false; // editor.isReadOnly -> true.
-	 * 		myFeature.isConnected = true; // editor.isReadOnly -> false.
-	 *
 	 * @param {String|Symbol} lockId A unique ID for setting the editor to the read-only state.
-	 * @param {Boolean} [value=true] An optional value indicating whether the lock should be set or removed.
 	 */
-	enableReadOnlyMode( lockId, value = true ) {
+	enableReadOnlyMode( lockId ) {
 		if ( typeof lockId !== 'string' && typeof lockId !== 'symbol' ) {
 			/**
 			 * The lock ID is missing or it is not a string or symbol.
@@ -312,12 +300,6 @@ export default class Editor {
 			 * @error editor-read-only-lock-id-invalid
 			 */
 			throw new CKEditorError( 'editor-read-only-lock-id-invalid', null, { lockId } );
-		}
-
-		if ( value === false ) {
-			this.disableReadOnlyMode( lockId );
-
-			return;
 		}
 
 		if ( this._readOnlyLocks.has( lockId ) ) {

--- a/packages/ckeditor5-core/tests/editor/editor.js
+++ b/packages/ckeditor5-core/tests/editor/editor.js
@@ -514,26 +514,6 @@ describe( 'Editor', () => {
 			expect( customPlugin.isEditorReadOnly ).to.equal( false );
 		} );
 
-		it( 'setting read-only lock to a value can be achieved by passing the additional argument', () => {
-			const editor = new TestEditor();
-
-			editor.enableReadOnlyMode( 'lock', true );
-
-			expect( editor.isReadOnly ).to.true;
-
-			editor.enableReadOnlyMode( 'lock', true );
-
-			expect( editor.isReadOnly ).to.true;
-
-			editor.enableReadOnlyMode( 'lock', false );
-
-			expect( editor.isReadOnly ).to.false;
-
-			editor.enableReadOnlyMode( 'lock', false );
-
-			expect( editor.isReadOnly ).to.false;
-		} );
-
 		it( 'setting read-only lock twice should not throw an error for the same lock ID', () => {
 			const editor = new TestEditor();
 

--- a/packages/ckeditor5-core/tests/manual/readonly.js
+++ b/packages/ckeditor5-core/tests/manual/readonly.js
@@ -38,7 +38,11 @@ function enableReadOnlyManagement( button, editor, lockName ) {
 	button.addEventListener( 'click', () => {
 		isReadOnly = !isReadOnly;
 
-		editor.enableReadOnlyMode( lockName, isReadOnly );
+		if ( isReadOnly ) {
+			editor.enableReadOnlyMode( lockName );
+		} else {
+			editor.disableReadOnlyMode( lockName );
+		}
 
 		button.textContent = isReadOnly ?
 			`${ lockName }: Clear the read-only mode lock` :

--- a/packages/ckeditor5-find-and-replace/tests/manual/findandreplace.js
+++ b/packages/ckeditor5-find-and-replace/tests/manual/findandreplace.js
@@ -33,7 +33,11 @@ ClassicEditor
 		document.getElementById( 'readonly-toggle' ).addEventListener( 'click', () => {
 			isReadOnly = !isReadOnly;
 
-			editor.enableReadOnlyMode( 'manual-test', isReadOnly );
+			if ( isReadOnly ) {
+				editor.enableReadOnlyMode( 'manual-test' );
+			} else {
+				editor.disableReadOnlyMode( 'manual-test' );
+			}
 
 			editor.editing.view.focus();
 		} );

--- a/packages/ckeditor5-find-and-replace/tests/manual/scrolling.js
+++ b/packages/ckeditor5-find-and-replace/tests/manual/scrolling.js
@@ -29,7 +29,11 @@ ClassicEditor
 		button.addEventListener( 'click', () => {
 			isReadOnly = !isReadOnly;
 
-			editor.enableReadOnlyMode( 'manual-test', isReadOnly );
+			if ( isReadOnly ) {
+				editor.enableReadOnlyMode( 'manual-test' );
+			} else {
+				editor.disableReadOnlyMode( 'manual-test' );
+			}
 
 			editor.editing.view.focus();
 		} );

--- a/packages/ckeditor5-widget/tests/manual/type-around.js
+++ b/packages/ckeditor5-widget/tests/manual/type-around.js
@@ -98,7 +98,11 @@ let isReadOnly = false;
 document.querySelector( '#toggleReadOnly' ).addEventListener( 'click', () => {
 	isReadOnly = !isReadOnly;
 
-	window.editor.enableReadOnlyMode( 'manual-test', isReadOnly );
+	if ( isReadOnly ) {
+		window.editor.enableReadOnlyMode( 'manual-test' );
+	} else {
+		window.editor.disableReadOnlyMode( 'manual-test' );
+	}
 
 	window.editor.editing.view.focus();
 } );

--- a/tests/manual/all-features.js
+++ b/tests/manual/all-features.js
@@ -213,7 +213,11 @@ ClassicEditor
 		button.addEventListener( 'click', () => {
 			isReadOnly = !isReadOnly;
 
-			editor.enableReadOnlyMode( 'manual-test', isReadOnly );
+			if ( isReadOnly ) {
+				editor.enableReadOnlyMode( 'manual-test' );
+			} else {
+				editor.disableReadOnlyMode( 'manual-test' );
+			}
 
 			button.textContent = isReadOnly ?
 				'Turn off read-only mode' :

--- a/tests/manual/memory/memory.js
+++ b/tests/manual/memory/memory.js
@@ -125,7 +125,11 @@ function initEditor() {
 			function toggleReadOnly() {
 				isReadOnly = !isReadOnly;
 
-				editor.enableReadOnlyMode( 'manual-test', isReadOnly );
+				if ( isReadOnly ) {
+					editor.enableReadOnlyMode( 'manual-test' );
+				} else {
+					editor.disableReadOnlyMode( 'manual-test' );
+				}
 
 				button.textContent = isReadOnly ?
 					'Turn off read-only mode' :


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (core): Removed the second parameter from `Editor#enableReadOnlyMode()`. Closes #11599.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._