### PR TITLE
Fixes table column resize 'tableWidth' related issues

### DIFF
--- a/packages/ckeditor5-table-resize/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table-resize/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -121,7 +121,7 @@ export default class TableColumnResizeEditing extends Plugin {
 		const schema = editor.model.schema;
 
 		schema.extend( 'table', {
-			allowAttributes: [ 'width', 'columnWidths' ]
+			allowAttributes: [ 'tableWidth', 'columnWidths' ]
 		} );
 
 		schema.extend( 'tableCell', {
@@ -148,7 +148,7 @@ export default class TableColumnResizeEditing extends Plugin {
 			},
 			model: {
 				name: 'table',
-				key: 'width',
+				key: 'tableWidth',
 				value: viewElement => viewElement.getStyle( 'width' )
 			}
 		} );
@@ -156,7 +156,7 @@ export default class TableColumnResizeEditing extends Plugin {
 		conversion.for( 'downcast' ).attributeToAttribute( {
 			model: {
 				name: 'table',
-				key: 'width'
+				key: 'tableWidth'
 			},
 			view: width => ( {
 				name: 'figure',

--- a/packages/ckeditor5-table-resize/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table-resize/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -496,7 +496,7 @@ export default class TableColumnResizeEditing extends Plugin {
 
 		const isColumnWidthsAttributeChanged = columnWidthsAttributeOld !== columnWidthsAttributeNew;
 
-		const tableWidthAttributeOld = modelTable.getAttribute( 'width' );
+		const tableWidthAttributeOld = modelTable.getAttribute( 'tableWidth' );
 		const tableWidthAttributeNew = viewFigure.getStyle( 'width' );
 
 		const isTableWidthAttributeChanged = tableWidthAttributeOld !== tableWidthAttributeNew;
@@ -510,7 +510,7 @@ export default class TableColumnResizeEditing extends Plugin {
 					}
 
 					if ( isTableWidthAttributeChanged ) {
-						writer.setAttribute( 'width', `${ toPrecision( tableWidthAttributeNew ) }%`, modelTable );
+						writer.setAttribute( 'tableWidth', `${ toPrecision( tableWidthAttributeNew ) }%`, modelTable );
 					}
 				} );
 			} else {

--- a/packages/ckeditor5-table-resize/tests/manual/tablecolumnresizewithoutproperties.html
+++ b/packages/ckeditor5-table-resize/tests/manual/tablecolumnresizewithoutproperties.html
@@ -1,0 +1,17 @@
+<div id="editor">
+	<h3>Center aligned table</h3>
+	<figure class="table">
+		<table>
+			<tbody>
+				<tr>
+					<td>11</td>
+					<td>12</td>
+				</tr>
+				<tr>
+					<td>21</td>
+					<td>22</td>
+				</tr>
+			</tbody>
+		</table>
+	</figure>
+</div>

--- a/packages/ckeditor5-table-resize/tests/manual/tablecolumnresizewithoutproperties.js
+++ b/packages/ckeditor5-table-resize/tests/manual/tablecolumnresizewithoutproperties.js
@@ -1,0 +1,53 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console, document, window */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import Table from '@ckeditor/ckeditor5-table/src/table';
+import TableToolbar from '@ckeditor/ckeditor5-table/src/tabletoolbar';
+import TableSelection from '@ckeditor/ckeditor5-table/src/tableselection';
+import TableClipboard from '@ckeditor/ckeditor5-table/src/tableclipboard';
+import TableCaption from '@ckeditor/ckeditor5-table/src/tablecaption';
+
+import TableColumnResize from '../../src/tablecolumnresize';
+
+const editorConfig = {
+	image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
+	plugins: [
+		ArticlePluginSet,
+		Table,
+		TableToolbar,
+		TableSelection,
+		TableClipboard,
+		TableCaption,
+		TableColumnResize
+	],
+	toolbar: [
+		'heading', '|',
+		'insertTable', '|',
+		'bold', 'italic', 'link', '|',
+		'bulletedList', 'numberedList', 'blockQuote', '|',
+		'undo', 'redo'
+	],
+	table: {
+		contentToolbar: [
+			'tableColumn',
+			'tableRow',
+			'mergeTableCells',
+			'toggleTableCaption'
+		]
+	}
+};
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), editorConfig )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-table-resize/tests/manual/tablecolumnresizewithoutproperties.md
+++ b/packages/ckeditor5-table-resize/tests/manual/tablecolumnresizewithoutproperties.md
@@ -1,0 +1,7 @@
+# Table column resize without table properties
+
+### Paste into the console:
+
+```editor.setData('<h3>Center aligned table</h3><figure class="table" style="width:87.27%;"><table><colgroup><col style="width:57.18%;"><col style="width:42.82%;"></colgroup><tbody><tr><td>foo</td><td>bar</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td></tr></tbody></table></figure>')```
+
+Model should have the tableWidth attribute

--- a/packages/ckeditor5-table-resize/tests/tablecolumnresizer/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table-resize/tests/tablecolumnresizer/tablecolumnresizeediting.js
@@ -98,21 +98,19 @@ describe( 'TableColumnResizeEditing', () => {
 	} );
 
 	describe( 'conversion', () => {
-		describe( 'when upcasting <colgroup> attribute', () => {
-			it( 'should handle the correct number of <col> elements', () => {
+		describe( 'upcast', () => {
+			it( 'the width style to tableWidth attribute correctly', () => {
 				editor.setData(
-					`<figure class="table">
+					`<figure class="table" style="width: 100%">
 						<table>
 							<colgroup>
-								<col style="width:33.33%;">
-								<col style="width:33.33%;">
-								<col style="width:33.34%;">
+								<col style="width:50%;">
+								<col style="width:50%;">
 							</colgroup>
 							<tbody>
 								<tr>
 									<td>11</td>
 									<td>12</td>
-									<td>13</td>
 								</tr>
 							</tbody>
 						</table>
@@ -120,128 +118,189 @@ describe( 'TableColumnResizeEditing', () => {
 				);
 
 				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
-					'<table columnWidths="33.33%,33.33%,33.34%">' +
+					'<table columnWidths="50%,50%" tableWidth="100%">' +
 						'<tableRow>' +
 							'<tableCell columnIndex="0">' +
 								'<paragraph>11</paragraph>' +
 							'</tableCell>' +
 							'<tableCell columnIndex="1">' +
 								'<paragraph>12</paragraph>' +
-							'</tableCell>' +
-							'<tableCell columnIndex="2">' +
-								'<paragraph>13</paragraph>' +
 							'</tableCell>' +
 						'</tableRow>' +
 					'</table>'
 				);
 			} );
 
-			it( 'should handle too small number of <col> elements', () => {
-				editor.setData(
-					`<figure class="table">
-						<table>
-							<colgroup>
-								<col style="width:33.33%;">
-								<col style="width:33.33%;">
-							</colgroup>
-							<tbody>
-								<tr>
-									<td>11</td>
-									<td>12</td>
-									<td>13</td>
-								</tr>
-							</tbody>
-						</table>
-					</figure>`
-				);
+			describe( 'when upcasting <colgroup> attribute', () => {
+				it( 'should handle the correct number of <col> elements', () => {
+					editor.setData(
+						`<figure class="table">
+							<table>
+								<colgroup>
+									<col style="width:33.33%;">
+									<col style="width:33.33%;">
+									<col style="width:33.34%;">
+								</colgroup>
+								<tbody>
+									<tr>
+										<td>11</td>
+										<td>12</td>
+										<td>13</td>
+									</tr>
+								</tbody>
+							</table>
+						</figure>`
+					);
 
-				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
-					'<table columnWidths="33.33%,33.33%,33.34%">' +
-						'<tableRow>' +
-							'<tableCell columnIndex="0">' +
-								'<paragraph>11</paragraph>' +
-							'</tableCell>' +
-							'<tableCell columnIndex="1">' +
-								'<paragraph>12</paragraph>' +
-							'</tableCell>' +
-							'<tableCell columnIndex="2">' +
-								'<paragraph>13</paragraph>' +
-							'</tableCell>' +
-						'</tableRow>' +
-					'</table>'
-				);
+					expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+						'<table columnWidths="33.33%,33.33%,33.34%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'<paragraph>11</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="1">' +
+									'<paragraph>12</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="2">' +
+									'<paragraph>13</paragraph>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>'
+					);
+				} );
+
+				it( 'should handle too small number of <col> elements', () => {
+					editor.setData(
+						`<figure class="table">
+							<table>
+								<colgroup>
+									<col style="width:33.33%;">
+									<col style="width:33.33%;">
+								</colgroup>
+								<tbody>
+									<tr>
+										<td>11</td>
+										<td>12</td>
+										<td>13</td>
+									</tr>
+								</tbody>
+							</table>
+						</figure>`
+					);
+
+					expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+						'<table columnWidths="33.33%,33.33%,33.34%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'<paragraph>11</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="1">' +
+									'<paragraph>12</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="2">' +
+									'<paragraph>13</paragraph>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>'
+					);
+				} );
+
+				it( 'should handle too big number of <col> elements', () => {
+					editor.setData(
+						`<figure class="table">
+							<table>
+								<colgroup>
+									<col style="width:33.33%;">
+									<col style="width:33.33%;">
+									<col style="width:33.33%;">
+									<col style="width:33.33%;">
+								</colgroup>
+								<tbody>
+									<tr>
+										<td>11</td>
+										<td>12</td>
+										<td>13</td>
+									</tr>
+								</tbody>
+							</table>
+						</figure>`
+					);
+
+					expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+						'<table columnWidths="33.33%,33.33%,33.34%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'<paragraph>11</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="1">' +
+									'<paragraph>12</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="2">' +
+									'<paragraph>13</paragraph>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>'
+					);
+				} );
+
+				it( 'should handle the incorrect elements inside', () => {
+					editor.setData(
+						`<figure class="table">
+							<table>
+								<colgroup>
+									<p style="width:33.33%;"></p>
+								</colgroup>
+								<tbody>
+									<tr>
+										<td>11</td>
+										<td>12</td>
+										<td>13</td>
+									</tr>
+								</tbody>
+							</table>
+						</figure>`
+					);
+
+					expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+						'<table columnWidths="33.33%,33.33%,33.34%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'<paragraph>11</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="1">' +
+									'<paragraph>12</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="2">' +
+									'<paragraph>13</paragraph>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>'
+					);
+				} );
 			} );
+		} );
 
-			it( 'should handle too big number of <col> elements', () => {
-				editor.setData(
-					`<figure class="table">
-						<table>
-							<colgroup>
-								<col style="width:33.33%;">
-								<col style="width:33.33%;">
-								<col style="width:33.33%;">
-								<col style="width:33.33%;">
-							</colgroup>
-							<tbody>
-								<tr>
-									<td>11</td>
-									<td>12</td>
-									<td>13</td>
-								</tr>
-							</tbody>
-						</table>
-					</figure>`
-				);
+		describe( 'downcast', () => {
+			it( 'the tableWidth attribute correctly', () => {
+				setModelData( model, modelTable( [
+					[ '11', '12' ]
+				], { columnWidths: '50%,50%', tableWidth: '100%' } ) );
 
-				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
-					'<table columnWidths="33.33%,33.33%,33.34%">' +
-						'<tableRow>' +
-							'<tableCell columnIndex="0">' +
-								'<paragraph>11</paragraph>' +
-							'</tableCell>' +
-							'<tableCell columnIndex="1">' +
-								'<paragraph>12</paragraph>' +
-							'</tableCell>' +
-							'<tableCell columnIndex="2">' +
-								'<paragraph>13</paragraph>' +
-							'</tableCell>' +
-						'</tableRow>' +
-					'</table>'
-				);
-			} );
-
-			it( 'should handle the incorrect elements inside', () => {
-				editor.setData(
-					`<figure class="table">
-						<table>
-							<colgroup>
-								<p style="width:33.33%;"></p>
-							</colgroup>
-							<tbody>
-								<tr>
-									<td>11</td>
-									<td>12</td>
-									<td>13</td>
-								</tr>
-							</tbody>
-						</table>
-					</figure>`
-				);
-
-				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
-					'<table columnWidths="33.33%,33.33%,33.34%">' +
-						'<tableRow>' +
-							'<tableCell columnIndex="0">' +
-								'<paragraph>11</paragraph>' +
-							'</tableCell>' +
-							'<tableCell columnIndex="1">' +
-								'<paragraph>12</paragraph>' +
-							'</tableCell>' +
-							'<tableCell columnIndex="2">' +
-								'<paragraph>13</paragraph>' +
-							'</tableCell>' +
-						'</tableRow>' +
-					'</table>'
+				expect( editor.getData() ).to.equal(
+					'<figure class="table" style="width:100%;">' +
+						'<table>' +
+							'<colgroup>' +
+								'<col style="width:50%;">' +
+								'<col style="width:50%;">' +
+							'</colgroup>' +
+							'<tbody>' +
+								'<tr>' +
+									'<td>11</td>' +
+									'<td>12</td>' +
+								'</tr>' +
+							'</tbody>' +
+						'</table>' +
+					'</figure>'
 				);
 			} );
 		} );
@@ -907,7 +966,7 @@ describe( 'TableColumnResizeEditing', () => {
 						'<table columnWidths="100%">' +
 							'<tableRow>' +
 								'<tableCell columnIndex="0">' +
-									'<table columnWidths="50.9%,49.1%" width="98.15%">' +
+									'<table columnWidths="50.9%,49.1%" tableWidth="98.15%">' +
 										'<tableRow>' +
 											'<tableCell columnIndex="0">' +
 												'<paragraph>foo</paragraph>' +
@@ -932,7 +991,7 @@ describe( 'TableColumnResizeEditing', () => {
 						'<table columnWidths="100%">' +
 							'<tableRow>' +
 								'<tableCell columnIndex="0">' +
-									'[<table columnWidths="50%,50%" width="90%">' +
+									'[<table tableWidth="90%" columnWidths="50%,50%">' +
 										'<tableRow>' +
 											'<tableCell columnIndex="0">' +
 												'<paragraph>foo</paragraph>' +
@@ -978,7 +1037,7 @@ describe( 'TableColumnResizeEditing', () => {
 						'<table columnWidths="100%">' +
 							'<tableRow>' +
 								'<tableCell columnIndex="0">' +
-									'<table columnWidths="49.04%,50.96%" width="91.68%">' +
+									'<table columnWidths="49.04%,50.96%" tableWidth="91.68%">' +
 										'<tableRow>' +
 											'<tableCell columnIndex="0">' +
 												'<paragraph>foo</paragraph>' +
@@ -1003,7 +1062,7 @@ describe( 'TableColumnResizeEditing', () => {
 						'<table columnWidths="100%">' +
 							'<tableRow>' +
 								'<tableCell columnIndex="0">' +
-									'[<table columnWidths="25%,25%,50%" width="100%">' +
+									'[<table columnWidths="25%,25%,50%" tableWidth="100%">' +
 										'<tableRow>' +
 											'<tableCell columnIndex="0">' +
 												'<paragraph>foo</paragraph>' +
@@ -1052,7 +1111,7 @@ describe( 'TableColumnResizeEditing', () => {
 						'<table columnWidths="100%">' +
 							'<tableRow>' +
 								'<tableCell columnIndex="0">' +
-									'<table columnWidths="25%,25.88%,49.12%" width="100%">' +
+									'<table columnWidths="25%,25.88%,49.12%" tableWidth="100%">' +
 										'<tableRow>' +
 											'<tableCell columnIndex="0">' +
 												'<paragraph>foo</paragraph>' +
@@ -1624,16 +1683,16 @@ describe( 'TableColumnResizeEditing', () => {
 
 				it( 'is updated correctly after the last column has been resized', () => {
 					const columnToResizeIndex = 2;
-					const mouseMovementVector = { x: -10, y: 0 };
+					const mouseMovementVector = { x: 10, y: 0 };
 
 					setModelData( model, modelTable( [
 						[ '00', '01', '02' ]
-					], { tableWidth: '100px', columnWidths: '20%,25%,55%' } ) );
+					], { tableWidth: '100px', columnWidths: '25%,25%,50%' } ) );
 
 					tableColumnResizeMouseSimulator.resize( editor, getDomTable( view ), columnToResizeIndex, mouseMovementVector );
 
 					expect( getModelData( editor.model ) ).to.equal(
-						'[<table columnWidths="20.35%,25.44%,54.21%" tableWidth="98.17%">' +
+						'[<table columnWidths="20.8%,20.8%,58.4%" tableWidth="10.37%">' +
 							'<tableRow>' +
 								'<tableCell columnIndex="0">' +
 									'<paragraph>00</paragraph>' +
@@ -1650,17 +1709,17 @@ describe( 'TableColumnResizeEditing', () => {
 				} );
 
 				it( 'does not change when one of the middle columns is resized', () => {
-					const columnToResizeIndex = 2;
-					const mouseMovementVector = { x: -10, y: 0 };
+					const columnToResizeIndex = 1;
+					const mouseMovementVector = { x: 10, y: 0 };
 
 					setModelData( model, modelTable( [
 						[ '[00', '01', '02]' ]
-					], { columnWidths: '20%,25%,55%', tableWidth: '100px' } ) );
+					], { tableWidth: '100px', columnWidths: '25%,25%,50%' } ) );
 
 					tableColumnResizeMouseSimulator.resize( editor, getDomTable( view ), columnToResizeIndex, mouseMovementVector );
 
 					expect( getModelData( editor.model ) ).to.equal(
-						'[<table columnWidths="20.35%,25.44%,54.21%" tableWidth="98.17%">' +
+						'[<table columnWidths="25%,34.6%,40.4%" tableWidth="100px">' +
 							'<tableRow>' +
 								'<tableCell columnIndex="0">' +
 									'<paragraph>00</paragraph>' +

--- a/packages/ckeditor5-table-resize/tests/tablecolumnresizer/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table-resize/tests/tablecolumnresizer/tablecolumnresizeediting.js
@@ -1380,10 +1380,10 @@ describe( 'TableColumnResizeEditing', () => {
 						[ '00', '01', '02' ]
 					], { columnWidths: '20%,25%,55%' } ) );
 
-					tableColumnResizeMouseSimulator.resize( view, columnToResizeIndex, mouseMovementVector );
+					tableColumnResizeMouseSimulator.resize( editor, getDomTable( view ), columnToResizeIndex, mouseMovementVector );
 
 					expect( getModelData( editor.model ) ).to.equal(
-						'[<table columnWidths="20.39%,25.48%,54.13%" tableWidth="98.01%">' +
+						'[<table columnWidths="20.35%,25.44%,54.21%" tableWidth="98.17%">' +
 							'<tableRow>' +
 								'<tableCell columnIndex="0">' +
 									'<paragraph>00</paragraph>' +
@@ -1407,10 +1407,10 @@ describe( 'TableColumnResizeEditing', () => {
 						[ '00', '01', '02' ]
 					], { tableWidth: '100px', columnWidths: '20%,25%,55%' } ) );
 
-					tableColumnResizeMouseSimulator.resize( view, columnToResizeIndex, mouseMovementVector );
+					tableColumnResizeMouseSimulator.resize( editor, getDomTable( view ), columnToResizeIndex, mouseMovementVector );
 
 					expect( getModelData( editor.model ) ).to.equal(
-						'[<table columnWidths="20.39%,25.48%,54.13%" tableWidth="98.01%">' +
+						'[<table columnWidths="20.35%,25.44%,54.21%" tableWidth="98.17%">' +
 							'<tableRow>' +
 								'<tableCell columnIndex="0">' +
 									'<paragraph>00</paragraph>' +
@@ -1434,10 +1434,10 @@ describe( 'TableColumnResizeEditing', () => {
 						[ '[00', '01', '02]' ]
 					], { columnWidths: '20%,25%,55%', tableWidth: '100px' } ) );
 
-					tableColumnResizeMouseSimulator.resize( view, columnToResizeIndex, mouseMovementVector, 0 );
+					tableColumnResizeMouseSimulator.resize( editor, getDomTable( view ), columnToResizeIndex, mouseMovementVector );
 
 					expect( getModelData( editor.model ) ).to.equal(
-						'[<table columnWidths="20.39%,25.48%,54.13%" tableWidth="98.01%">' +
+						'[<table columnWidths="20.35%,25.44%,54.21%" tableWidth="98.17%">' +
 							'<tableRow>' +
 								'<tableCell columnIndex="0">' +
 									'<paragraph>00</paragraph>' +
@@ -1461,10 +1461,10 @@ describe( 'TableColumnResizeEditing', () => {
 						[ '00', '01', '02' ]
 					], { columnWidths: '20%,25%,55%' } ) );
 
-					tableColumnResizeMouseSimulator.resize( view, columnToResizeIndex, mouseMovementVector, 0 );
+					tableColumnResizeMouseSimulator.resize( editor, getDomTable( view ), columnToResizeIndex, mouseMovementVector );
 
 					expect( getModelData( editor.model ) ).to.equal(
-						'[<table columnWidths="20%,21.5%,58.5%">' +
+						'[<table columnWidths="20%,21.51%,58.49%">' +
 							'<tableRow>' +
 								'<tableCell columnIndex="0">' +
 									'<paragraph>00</paragraph>' +

--- a/packages/ckeditor5-table-resize/tests/tablecolumnresizer/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table-resize/tests/tablecolumnresizer/tablecolumnresizeediting.js
@@ -1397,9 +1397,6 @@ describe( 'TableColumnResizeEditing', () => {
 					setModelData( model, modelTable( [
 						[ '00', '01', '02' ]
 					], { tableWidth: '100px', columnWidths: '20%,25%,55%' } ) );
-					// setModelData( model, modelTable( [
-					// 	[ '00', '01', '02' ]
-					// ], { columnWidths: '20%,25%,55%' } ) );
 
 					tableColumnResizeMouseSimulator.resize( view, columnToResizeIndex, mouseMovementVector );
 

--- a/packages/ckeditor5-table-resize/tests/tablecolumnresizer/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table-resize/tests/tablecolumnresizer/tablecolumnresizeediting.js
@@ -1325,6 +1325,155 @@ describe( 'TableColumnResizeEditing', () => {
 					} );
 				} );
 			} );
+
+			describe( 'tableWidth attribute', () => {
+				it( 'should not be set initially when creating a table', () => {
+					setModelData( model, modelTable( [
+						[ '00', '01', '02' ]
+					], { columnWidths: '20%,25%,55%' } ) );
+
+					expect( getModelData( model ) ).to.equal(
+						'[<table columnWidths="20%,25%,55%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'<paragraph>00</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="1">' +
+									'<paragraph>01</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="2">' +
+									'<paragraph>02</paragraph>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>]'
+					);
+				} );
+
+				it( 'should be set if table was initiated with a tableWidth value', () => {
+					setModelData( model, modelTable( [ [ '[]foo' ] ], { tableWidth: '100px' } ) );
+
+					expect( getModelData( editor.model ) ).to.equal(
+						'<table columnWidths="100%" tableWidth="100px">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'<paragraph>[]foo</paragraph>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>'
+					);
+				} );
+
+				it( 'should be added to the table after the last column has been resized', () => {
+					const columnToResizeIndex = 2;
+					const mouseMovementVector = { x: -10, y: 0 };
+
+					setModelData( model, modelTable( [
+						[ '00', '01', '02' ]
+					], { columnWidths: '20%,25%,55%' } ) );
+
+					tableColumnResizeMouseSimulator.resize( view, columnToResizeIndex, mouseMovementVector );
+
+					expect( getModelData( editor.model ) ).to.equal(
+						'[<table columnWidths="20.39%,25.48%,54.13%" tableWidth="98.01%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'<paragraph>00</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="1">' +
+									'<paragraph>01</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="2">' +
+									'<paragraph>02</paragraph>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>]'
+					);
+				} );
+
+				it( 'is updated correctly after the last column has been resized', () => {
+					const columnToResizeIndex = 2;
+					const mouseMovementVector = { x: -10, y: 0 };
+
+					setModelData( model, modelTable( [
+						[ '00', '01', '02' ]
+					], { tableWidth: '100px', columnWidths: '20%,25%,55%' } ) );
+					// setModelData( model, modelTable( [
+					// 	[ '00', '01', '02' ]
+					// ], { columnWidths: '20%,25%,55%' } ) );
+
+					tableColumnResizeMouseSimulator.resize( view, columnToResizeIndex, mouseMovementVector );
+
+					expect( getModelData( editor.model ) ).to.equal(
+						'[<table columnWidths="20.39%,25.48%,54.13%" tableWidth="98.01%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'<paragraph>00</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="1">' +
+									'<paragraph>01</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="2">' +
+									'<paragraph>02</paragraph>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>]'
+					);
+				} );
+
+				it( 'does not change when one of the middle columns is resized', () => {
+					const columnToResizeIndex = 2;
+					const mouseMovementVector = { x: -10, y: 0 };
+
+					setModelData( model, modelTable( [
+						[ '[00', '01', '02]' ]
+					], { columnWidths: '20%,25%,55%', tableWidth: '100px' } ) );
+
+					tableColumnResizeMouseSimulator.resize( view, columnToResizeIndex, mouseMovementVector, 0 );
+
+					expect( getModelData( editor.model ) ).to.equal(
+						'[<table columnWidths="20.39%,25.48%,54.13%" tableWidth="98.01%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'<paragraph>00</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="1">' +
+									'<paragraph>01</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="2">' +
+									'<paragraph>02</paragraph>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>]'
+					);
+				} );
+
+				it( 'is not being added when any of the middle columns is resized', () => {
+					const columnToResizeIndex = 1;
+					const mouseMovementVector = { x: -40, y: 0 };
+
+					setModelData( model, modelTable( [
+						[ '00', '01', '02' ]
+					], { columnWidths: '20%,25%,55%' } ) );
+
+					tableColumnResizeMouseSimulator.resize( view, columnToResizeIndex, mouseMovementVector, 0 );
+
+					expect( getModelData( editor.model ) ).to.equal(
+						'[<table columnWidths="20%,21.5%,58.5%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'<paragraph>00</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="1">' +
+									'<paragraph>01</paragraph>' +
+								'</tableCell>' +
+								'<tableCell columnIndex="2">' +
+									'<paragraph>02</paragraph>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>]'
+					);
+				} );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table-resize): Resolved issue when resizing columns with fixed width was leading the table to increase the size and go out of the editor.
Fix (table-resize): Resolved issue where the table width was not reflected in table properties after the resize.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
