### PR TITLE
Fixed table column resize width reset for nested tables

### DIFF
--- a/packages/ckeditor5-table-resize/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table-resize/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -46,14 +46,14 @@ import { COLUMN_MIN_WIDTH_IN_PIXELS } from './constants';
 export default class TableColumnResizeEditing extends Plugin {
 	/**
 	 * @inheritDoc
- 	 */
+	 */
 	static get requires() {
 		return [ TableEditing ];
 	}
 
 	/**
 	 * @inheritDoc
- 	 */
+	 */
 	static get pluginName() {
 		return 'TableColumnResizeEditing';
 	}
@@ -93,7 +93,7 @@ export default class TableColumnResizeEditing extends Plugin {
 
 	/**
 	 * @inheritDoc
- 	 */
+	 */
 	init() {
 		this._extendSchema();
 		this._setupConversion();
@@ -571,7 +571,7 @@ export default class TableColumnResizeEditing extends Plugin {
 				isTableCentered
 			},
 			widths: {
-				rootWidth,
+				viewFigureParentWidth,
 				tableWidth,
 				leftColumnWidth,
 				rightColumnWidth
@@ -586,7 +586,7 @@ export default class TableColumnResizeEditing extends Plugin {
 		const dxLowerBound = -leftColumnWidth + COLUMN_MIN_WIDTH_IN_PIXELS;
 
 		const dxUpperBound = isRightEdge ?
-			rootWidth - tableWidth :
+			viewFigureParentWidth - tableWidth :
 			rightColumnWidth - COLUMN_MIN_WIDTH_IN_PIXELS;
 
 		// The multiplier is needed for calculating the proper movement offset:
@@ -610,22 +610,7 @@ export default class TableColumnResizeEditing extends Plugin {
 			writer.setStyle( 'width', `${ leftColumnWidthAsPercentage }%`, viewLeftColumn );
 
 			if ( isRightEdge ) {
-				const tableAncestors = viewFigure.getAncestors().filter( element => element.name === 'table' );
-				let tableWidthAsPercentage;
-
-				if ( tableAncestors && tableAncestors.length >= 1 ) {
-					let numberOfTablesChildren = 0;
-
-					tableAncestors.forEach( tableElement => {
-						numberOfTablesChildren += Array.from( tableElement.getChild( 0 ).getChildren() ).length;
-					} );
-
-					const updatedRootWidth = rootWidth / numberOfTablesChildren;
-
-					tableWidthAsPercentage = toPrecision( ( tableWidth + dx ) * 100 / updatedRootWidth );
-				} else {
-					tableWidthAsPercentage = toPrecision( ( tableWidth + dx ) * 100 / rootWidth );
-				}
+				const tableWidthAsPercentage = toPrecision( ( tableWidth + dx ) * 100 / viewFigureParentWidth );
 
 				writer.setStyle( 'width', `${ tableWidthAsPercentage }%`, viewFigure );
 			} else {
@@ -666,7 +651,7 @@ export default class TableColumnResizeEditing extends Plugin {
 		const viewLeftColumn = viewColgroup.getChild( leftColumnIndex );
 		const viewRightColumn = isRightEdge ? undefined : viewColgroup.getChild( leftColumnIndex + 1 );
 
-		const rootWidth = getElementWidthInPixels( editor.editing.view.getDomRoot() );
+		const viewFigureParentWidth = getElementWidthInPixels( editor.editing.view.domConverter.mapViewToDom( viewFigure.parent ) );
 		const tableWidth = getTableWidthInPixels( modelTable, editor );
 		const columnWidths = getColumnWidthsInPixels( modelTable, editor );
 		const leftColumnWidth = columnWidths[ leftColumnIndex ];
@@ -683,7 +668,7 @@ export default class TableColumnResizeEditing extends Plugin {
 				viewResizer
 			},
 			widths: {
-				rootWidth,
+				viewFigureParentWidth,
 				tableWidth,
 				leftColumnWidth,
 				rightColumnWidth

--- a/packages/ckeditor5-table-resize/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table-resize/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -610,7 +610,22 @@ export default class TableColumnResizeEditing extends Plugin {
 			writer.setStyle( 'width', `${ leftColumnWidthAsPercentage }%`, viewLeftColumn );
 
 			if ( isRightEdge ) {
-				const tableWidthAsPercentage = toPrecision( ( tableWidth + dx ) * 100 / rootWidth );
+				const tableAncestors = viewFigure.getAncestors().filter( element => element.name === 'table' );
+				let tableWidthAsPercentage;
+
+				if ( tableAncestors && tableAncestors.length >= 1 ) {
+					let numberOfTablesChildren = 0;
+
+					tableAncestors.forEach( tableElement => {
+						numberOfTablesChildren += Array.from( tableElement.getChild( 0 ).getChildren() ).length;
+					} );
+
+					const updatedRootWidth = rootWidth / numberOfTablesChildren;
+
+					tableWidthAsPercentage = toPrecision( ( tableWidth + dx ) * 100 / updatedRootWidth );
+				} else {
+					tableWidthAsPercentage = toPrecision( ( tableWidth + dx ) * 100 / rootWidth );
+				}
 
 				writer.setStyle( 'width', `${ tableWidthAsPercentage }%`, viewFigure );
 			} else {

--- a/packages/ckeditor5-table-resize/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table-resize/src/tablecolumnresize/utils.js
@@ -190,7 +190,11 @@ function getColgroupViewElement( table, editor ) {
  */
 export function toPrecision( value ) {
 	const multiplier = Math.pow( 10, COLUMN_WIDTH_PRECISION );
-	const number = parseFloat( value );
+	let number = parseFloat( value );
+
+	if ( number > 100 ) {
+		number = 100;
+	}
 
 	return Math.round( number * multiplier ) / multiplier;
 }

--- a/packages/ckeditor5-table-resize/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table-resize/src/tablecolumnresize/utils.js
@@ -190,11 +190,7 @@ function getColgroupViewElement( table, editor ) {
  */
 export function toPrecision( value ) {
 	const multiplier = Math.pow( 10, COLUMN_WIDTH_PRECISION );
-	let number = parseFloat( value );
-
-	if ( number > 100 ) {
-		number = 100;
-	}
+	const number = parseFloat( value );
 
 	return Math.round( number * multiplier ) / multiplier;
 }

--- a/packages/ckeditor5-table-resize/tests/tablecolumnresizer/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table-resize/tests/tablecolumnresizer/tablecolumnresizeediting.js
@@ -848,6 +848,227 @@ describe( 'TableColumnResizeEditing', () => {
 					expect( Math.abs( widthDifference - mouseMovementVector.x ) < PIXEL_PRECISION ).to.be.true;
 				} );
 			} );
+
+			describe( 'nested table ', () => {
+				it( 'correctly shrinks when the last column is dragged to the left', () => {
+					// Test-specific.
+					const columnToResizeIndex = 1;
+					const mouseMovementVector = { x: -10, y: 0 };
+
+					setModelData( editor.model,
+						'<table columnWidths="100%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'[<table columnWidths="50%,50%">' +
+										'<tableRow>' +
+											'<tableCell columnIndex="0">' +
+												'<paragraph>foo</paragraph>' +
+											'</tableCell>' +
+											'<tableCell columnIndex="1">' +
+												'<paragraph>bar</paragraph>' +
+											'</tableCell>' +
+										'</tableRow>' +
+									'</table>]' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>'
+					);
+
+					const modelNestedTable = model.document.selection.getSelectedElement();
+					const domNestedTable = getDomTable( view ).querySelectorAll( 'table' )[ 1 ];
+					const viewNestedTable = view.document.selection.getSelectedElement().getChild( 1 );
+
+					// Test-agnostic.
+					const initialViewColumnWidthsPx = getViewColumnWidthsPx( domNestedTable );
+
+					tableColumnResizeMouseSimulator.resize( editor, domNestedTable, columnToResizeIndex, mouseMovementVector, 0 );
+
+					const finalModelColumnWidthsPc = getModelColumnWidthsPc( modelNestedTable );
+
+					assertModelWidthsSum( finalModelColumnWidthsPc );
+
+					const finalViewColumnWidthsPc = getViewColumnWidthsPc( viewNestedTable );
+
+					assertModelViewSync( finalModelColumnWidthsPc, finalViewColumnWidthsPc );
+
+					const finalViewColumnWidthsPx = getViewColumnWidthsPx( domNestedTable );
+					const expectedViewColumnWidthsPx = calculateExpectedWidthPixels(
+						initialViewColumnWidthsPx,
+						mouseMovementVector,
+						contentDirection,
+						columnToResizeIndex
+					);
+
+					assertViewPixelWidths( finalViewColumnWidthsPx, expectedViewColumnWidthsPx );
+
+					expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+						'<table columnWidths="100%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'<table columnWidths="50.9%,49.1%" width="98.15%">' +
+										'<tableRow>' +
+											'<tableCell columnIndex="0">' +
+												'<paragraph>foo</paragraph>' +
+											'</tableCell>' +
+											'<tableCell columnIndex="1">' +
+												'<paragraph>bar</paragraph>' +
+											'</tableCell>' +
+										'</tableRow>' +
+									'</table>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>'
+					);
+				} );
+
+				it( 'correctly expands when the last column is dragged to the right', () => {
+					// Test-specific.
+					const columnToResizeIndex = 1;
+					const mouseMovementVector = { x: 10, y: 0 };
+
+					setModelData( editor.model,
+						'<table columnWidths="100%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'[<table columnWidths="50%,50%" width="90%">' +
+										'<tableRow>' +
+											'<tableCell columnIndex="0">' +
+												'<paragraph>foo</paragraph>' +
+											'</tableCell>' +
+											'<tableCell columnIndex="1">' +
+												'<paragraph>bar</paragraph>' +
+											'</tableCell>' +
+										'</tableRow>' +
+									'</table>]' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>'
+					);
+
+					const modelNestedTable = model.document.selection.getSelectedElement();
+					const domNestedTable = getDomTable( view ).querySelectorAll( 'table' )[ 1 ];
+					const viewNestedTable = view.document.selection.getSelectedElement().getChild( 1 );
+
+					// Test-agnostic.
+					const initialViewColumnWidthsPx = getViewColumnWidthsPx( domNestedTable );
+
+					tableColumnResizeMouseSimulator.resize( editor, domNestedTable, columnToResizeIndex, mouseMovementVector, 0 );
+
+					const finalModelColumnWidthsPc = getModelColumnWidthsPc( modelNestedTable );
+
+					assertModelWidthsSum( finalModelColumnWidthsPc );
+
+					const finalViewColumnWidthsPc = getViewColumnWidthsPc( viewNestedTable );
+
+					assertModelViewSync( finalModelColumnWidthsPc, finalViewColumnWidthsPc );
+
+					const finalViewColumnWidthsPx = getViewColumnWidthsPx( domNestedTable );
+					const expectedViewColumnWidthsPx = calculateExpectedWidthPixels(
+						initialViewColumnWidthsPx,
+						mouseMovementVector,
+						contentDirection,
+						columnToResizeIndex
+					);
+
+					assertViewPixelWidths( finalViewColumnWidthsPx, expectedViewColumnWidthsPx );
+
+					expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+						'<table columnWidths="100%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'<table columnWidths="49.04%,50.96%" width="91.68%">' +
+										'<tableRow>' +
+											'<tableCell columnIndex="0">' +
+												'<paragraph>foo</paragraph>' +
+											'</tableCell>' +
+											'<tableCell columnIndex="1">' +
+												'<paragraph>bar</paragraph>' +
+											'</tableCell>' +
+										'</tableRow>' +
+									'</table>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>'
+					);
+				} );
+
+				it( 'correctly updates the widths of the columns, when any of the inside ones has been resized', () => {
+					// Test-specific.
+					const columnToResizeIndex = 1;
+					const mouseMovementVector = { x: 10, y: 0 };
+
+					setModelData( editor.model,
+						'<table columnWidths="100%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'[<table columnWidths="25%,25%,50%" width="100%">' +
+										'<tableRow>' +
+											'<tableCell columnIndex="0">' +
+												'<paragraph>foo</paragraph>' +
+											'</tableCell>' +
+											'<tableCell columnIndex="1">' +
+												'<paragraph>bar</paragraph>' +
+											'</tableCell>' +
+											'<tableCell columnIndex="2">' +
+												'<paragraph>baz</paragraph>' +
+											'</tableCell>' +
+										'</tableRow>' +
+									'</table>]' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>'
+					);
+
+					const modelNestedTable = model.document.selection.getSelectedElement();
+					const domNestedTable = getDomTable( view ).querySelectorAll( 'table' )[ 1 ];
+					const viewNestedTable = view.document.selection.getSelectedElement().getChild( 1 );
+
+					// Test-agnostic.
+					const initialViewColumnWidthsPx = getViewColumnWidthsPx( domNestedTable );
+
+					tableColumnResizeMouseSimulator.resize( editor, domNestedTable, columnToResizeIndex, mouseMovementVector, 0 );
+
+					const finalModelColumnWidthsPc = getModelColumnWidthsPc( modelNestedTable );
+
+					assertModelWidthsSum( finalModelColumnWidthsPc );
+
+					const finalViewColumnWidthsPc = getViewColumnWidthsPc( viewNestedTable );
+
+					assertModelViewSync( finalModelColumnWidthsPc, finalViewColumnWidthsPc );
+
+					const finalViewColumnWidthsPx = getViewColumnWidthsPx( domNestedTable );
+
+					const expectedViewColumnWidthsPx = calculateExpectedWidthPixels(
+						initialViewColumnWidthsPx,
+						mouseMovementVector,
+						contentDirection,
+						columnToResizeIndex
+					);
+					assertViewPixelWidths( finalViewColumnWidthsPx, expectedViewColumnWidthsPx );
+
+					expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+						'<table columnWidths="100%">' +
+							'<tableRow>' +
+								'<tableCell columnIndex="0">' +
+									'<table columnWidths="25%,25.88%,49.12%" width="100%">' +
+										'<tableRow>' +
+											'<tableCell columnIndex="0">' +
+												'<paragraph>foo</paragraph>' +
+											'</tableCell>' +
+											'<tableCell columnIndex="1">' +
+												'<paragraph>bar</paragraph>' +
+											'</tableCell>' +
+											'<tableCell columnIndex="2">' +
+												'<paragraph>baz</paragraph>' +
+											'</tableCell>' +
+										'</tableRow>' +
+									'</table>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>'
+					);
+				} );
+			} );
 		} );
 
 		describe( 'right or left (RTL)', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table-resize): Nested tables should no longer reset its width when resizing.

---

### Additional information

Replaced the `rootWidth` with  `viewFigureParentWidth` as it is more useful because of the nested tables possibility.
