### PR TITLE
Add DocumentLists to ckeditor5-metadata.json

### DIFF
--- a/packages/ckeditor5-list/ckeditor5-metadata.json
+++ b/packages/ckeditor5-list/ckeditor5-metadata.json
@@ -92,6 +92,58 @@
 					"styles": "list-style-type"
 				}
 			]
+		},
+		{
+			"name": "Document list",
+			"className": "DocumentList",
+			"description": "Implements bulleted and numbered list features. Supports block content inside list elements. Incompatible with the list plugin.",
+			"path": "src/documentlist.js",
+			"uiComponents": [
+				{
+					"type": "Button",
+					"name": "numberedList",
+					"iconPath": "theme/icons/numberedlist.svg"
+				},
+				{
+					"type": "Button",
+					"name": "bulletedList",
+					"iconPath": "theme/icons/bulletedlist.svg"
+				}
+			],
+			"htmlOutput": [
+				{
+					"elements": [
+						"ol",
+						"ul"
+					]
+				},
+				{
+					"elements": "li",
+					"implements": "$block"
+				}
+			]
+		},
+		{
+			"name": "Document list properties",
+			"className": "DocumentListProperties",
+			"description": "Enables styling the list item markers for both ordered and unordered lists created by the document list plugin. You can choose various types of numerals and letters or visual markers to use with these lists. Also enables setting start index (initial marker value) and list reversal (from ascending to descending) for numbered lists.",
+			"path": "src/documentlistproperties.js",
+			"requires": [
+				"DocumentList"
+			],
+			"htmlOutput": [
+				{
+					"elements": [
+						"ol",
+						"ul"
+					],
+					"attributes": [
+						"start",
+						"reversed"
+					],
+					"styles": "list-style-type"
+				}
+			]
 		}
 	]
 }

--- a/packages/ckeditor5-list/ckeditor5-metadata.json
+++ b/packages/ckeditor5-list/ckeditor5-metadata.json
@@ -118,8 +118,7 @@
 					]
 				},
 				{
-					"elements": "li",
-					"implements": "$block"
+					"elements": "li"
 				}
 			]
 		},

--- a/packages/ckeditor5-list/ckeditor5-metadata.json
+++ b/packages/ckeditor5-list/ckeditor5-metadata.json
@@ -96,7 +96,7 @@
 		{
 			"name": "Document list",
 			"className": "DocumentList",
-			"description": "Implements bulleted and numbered list features. Supports block content inside list elements. Incompatible with the list plugin.",
+			"description": "Implements bulleted and numbered list features. Supports block content inside list elements. Incompatible with the List plugin.",
 			"path": "src/documentlist.js",
 			"uiComponents": [
 				{


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (list): Adds `DocumentList` and `DocumentListProperties` to `ckeditor5-metadata.json`. Closes #11613.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._