### PR TITLE
Column resize nested tables can be resized correctly after paste

### DIFF
--- a/packages/ckeditor5-table-resize/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table-resize/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -197,7 +197,7 @@ export default class TableColumnResizeEditing extends Plugin {
 
 			let changed = false;
 
-			for ( const table of getAffectedTables( changes ) ) {
+			for ( const table of getAffectedTables( changes, editor.model ) ) {
 				// (1.1) Remove the `columnWidths` attribute from the table and the `columnIndex` attributes from all the table cells if the
 				// manual width is not allowed for a given cell. There is no need to process the given table anymore.
 				if ( this.fire( 'disableResize', table ) ) {

--- a/packages/ckeditor5-table-resize/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table-resize/src/tablecolumnresize/utils.js
@@ -73,21 +73,18 @@ function getAffectedTable( change, model ) {
 		return null;
 	}
 
-	const allTables = [];
-	const document = model.document;
+	const affectedTables = [];
+	const tableNode = ( referencePosition.nodeAfter && referencePosition.nodeAfter.name === 'table' ) ?
+		referencePosition.nodeAfter : referencePosition.findAncestor( 'table' );
+	const range = model.createRangeOn( tableNode );
 
-	for ( const rootName of document.getRootNames() ) {
-		const root = document.getRoot( rootName );
-		const range = model.createRangeIn( root );
-
-		for ( const node of range.getItems() ) {
-			if ( node.is( 'element' ) && node.name === 'table' ) {
-				allTables.push( node );
-			}
+	for ( const node of range.getItems() ) {
+		if ( node.is( 'element' ) && node.name === 'table' ) {
+			affectedTables.push( node );
 		}
 	}
 
-	return allTables;
+	return affectedTables;
 }
 
 /**

--- a/packages/ckeditor5-table-resize/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table-resize/src/tablecolumnresize/utils.js
@@ -18,16 +18,19 @@ import {
  * Collects all affected by the differ table model elements. The returned set may be empty.
  *
  * @param {Array.<module:engine/model/differ~DiffItem>} changes
+ * @param {module:engine/model/model~Model} model
  * @returns {Set.<module:engine/model/element~Element>}
  */
-export function getAffectedTables( changes ) {
+export function getAffectedTables( changes, model ) {
 	const tablesToProcess = new Set();
 
 	for ( const change of changes ) {
-		const table = getAffectedTable( change );
+		const table = getAffectedTable( change, model );
 
 		if ( table ) {
-			tablesToProcess.add( table );
+			for ( const tableItem of table ) {
+				tablesToProcess.add( tableItem );
+			}
 		}
 	}
 
@@ -42,8 +45,9 @@ export function getAffectedTables( changes ) {
 //
 // @private
 // @param {module:engine/model/differ~DiffItem} changes
+// @param {module:engine/model/model~Model} model
 // @returns {module:engine/model/element~Element|null}
-function getAffectedTable( change ) {
+function getAffectedTable( change, model ) {
 	let referencePosition = null;
 
 	switch ( change.type ) {
@@ -69,9 +73,21 @@ function getAffectedTable( change ) {
 		return null;
 	}
 
-	return ( referencePosition.nodeAfter && referencePosition.nodeAfter.name === 'table' ) ?
-		referencePosition.nodeAfter :
-		referencePosition.findAncestor( 'table' );
+	const allTables = [];
+	const document = model.document;
+
+	for ( const rootName of document.getRootNames() ) {
+		const root = document.getRoot( rootName );
+		const range = model.createRangeIn( root );
+
+		for ( const node of range.getItems() ) {
+			if ( node.is( 'element' ) && node.name === 'table' ) {
+				allTables.push( node );
+			}
+		}
+	}
+
+	return allTables;
 }
 
 /**

--- a/packages/ckeditor5-table-resize/tests/tablecolumnresizer/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table-resize/tests/tablecolumnresizer/tablecolumnresizeediting.js
@@ -550,7 +550,7 @@ describe( 'TableColumnResizeEditing', () => {
 			expect( Math.abs( 100 - finalViewColumnWidthsPx[ 1 ] ) < PIXEL_PRECISION ).to.be.true;
 		} );
 
-		it( 'should find and allow for resizing of all tables - when nested', () => {
+		it( 'should find and allow for resizing nested tables', () => {
 			editor.setData(
 				`<figure class="table">
 					<table>

--- a/packages/ckeditor5-table-resize/tests/tablecolumnresizer/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table-resize/tests/tablecolumnresizer/tablecolumnresizeediting.js
@@ -549,6 +549,34 @@ describe( 'TableColumnResizeEditing', () => {
 
 			expect( Math.abs( 100 - finalViewColumnWidthsPx[ 1 ] ) < PIXEL_PRECISION ).to.be.true;
 		} );
+
+		it( 'should find and allow for resizing of all tables - when nested', () => {
+			editor.setData(
+				`<figure class="table">
+					<table>
+						<tbody
+							<tr>
+								<td>
+									<figure class="table">
+										<table>
+											<tbody>
+												<tr>
+													<td>20</td>
+													<td>21</td>
+												</tr>
+											</tbody>
+										</table>
+									</figure>
+								</td>
+								<td>11</td>
+							</tr>
+						</tbody>
+					</table>
+				</figure>`
+			);
+
+			expect( document.getElementsByClassName( 'table-column-resizer' ).length ).to.equal( 4 );
+		} );
 	} );
 
 	describe( 'does not resize', () => {

--- a/packages/ckeditor5-table-resize/tests/tablecolumnresizer/utils.js
+++ b/packages/ckeditor5-table-resize/tests/tablecolumnresizer/utils.js
@@ -62,7 +62,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes );
+				const affectedTables = getAffectedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -86,7 +86,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes );
+				const affectedTables = getAffectedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -104,7 +104,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes );
+				const affectedTables = getAffectedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -122,7 +122,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes );
+				const affectedTables = getAffectedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -146,7 +146,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes );
+				const affectedTables = getAffectedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -170,7 +170,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes );
+				const affectedTables = getAffectedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -188,7 +188,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes );
+				const affectedTables = getAffectedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -206,7 +206,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes );
+				const affectedTables = getAffectedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -222,7 +222,7 @@ describe( 'TableColumnResize utils', () => {
 				attribute( model, range, 'attrName', null, 'attrVal' );
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes );
+				const affectedTables = getAffectedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -238,7 +238,7 @@ describe( 'TableColumnResize utils', () => {
 				attribute( model, range, 'attrName', null, 'attrVal' );
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes );
+				const affectedTables = getAffectedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -254,7 +254,7 @@ describe( 'TableColumnResize utils', () => {
 				attribute( model, range, 'attrName', null, 'attrVal' );
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes );
+				const affectedTables = getAffectedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -295,7 +295,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes );
+				const affectedTables = getAffectedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 3 );
 				expect( affectedTables.has( firstTable ), 'first table is affected' ).to.be.true;
@@ -325,7 +325,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes );
+				const affectedTables = getAffectedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 0 );
 			} );
@@ -352,7 +352,7 @@ describe( 'TableColumnResize utils', () => {
 			model.change( () => {
 				attribute( model, range, 'linkHref', 'www', null );
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes );
+				const affectedTables = getAffectedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 0 );
 			} );

--- a/packages/ckeditor5-table-resize/tests/tablecolumnresizer/utils.js
+++ b/packages/ckeditor5-table-resize/tests/tablecolumnresizer/utils.js
@@ -334,7 +334,7 @@ describe( 'TableColumnResize utils', () => {
 		it( 'should not find any affected table if it was a text formatting removal operation', () => {
 			let range;
 
-			// To test the getAffectedTable(), when the attribute is being removed we need
+			// To test the getAffectedTables(), when the attribute is being removed we need
 			// to frist insert the text inside one of the table cells.
 			model.change( () => {
 				insert(


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table-resize): Resolved issue with nested tables not being resizable after paste.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._