### PR TITLE
[Document lists] The editor should strip list attributes from solo blocks to enhance UX on paste or drop

### DIFF
--- a/packages/ckeditor5-list/src/documentlist/documentlistediting.js
+++ b/packages/ckeditor5-list/src/documentlist/documentlistediting.js
@@ -490,14 +490,14 @@ export default class DocumentListEditing extends Plugin {
 		//
 		// See https://github.com/ckeditor/ckeditor5/issues/11608.
 		this.listenTo( model, 'getSelectedContent', ( evt, [ selection ] ) => {
-			const selectedBlockObject = getSelectedBlockObject( model );
-			const { focus, anchor } = selection;
-			const isBlockObjectInListSelected = selectedBlockObject && isListItemBlock( selectedBlockObject );
-			const isSelectionInTheSameListBlock = focus.parent === anchor.parent && isListItemBlock( focus.parent );
+			// Is a single block object or a $block (for example a paragraph) selected?
+			const selectedElement = selection.getSelectedElement();
+			const isSingleListBlockSelected = selectedElement && isListItemBlock( selectedElement );
 
-			// Strip all list attributes if a block object was selected as a list item block.
-			// Strip all list attributes if the selection started and ended in the same list item block.
-			if ( isBlockObjectInListSelected || isSelectionInTheSameListBlock ) {
+			// Multiple blocks of a single list item are selected.
+			const isSingleListItemSelected = isSingleListItem( Array.from( selection.getSelectedBlocks() ) );
+
+			if ( isSingleListBlockSelected || isSingleListItemSelected ) {
 				model.change( writer => removeListAttributes( Array.from( evt.return.getChildren() ), writer ) );
 			}
 		} );

--- a/packages/ckeditor5-list/src/documentlist/documentlistediting.js
+++ b/packages/ckeditor5-list/src/documentlist/documentlistediting.js
@@ -117,8 +117,6 @@ export default class DocumentListEditing extends Plugin {
 			} );
 		}
 
-		model.on( 'insertContent', createModelIndentPasteFixer( model ), { priority: 'high' } );
-
 		// Register commands.
 		editor.commands.add( 'numberedList', new DocumentListCommand( editor, 'numbered' ) );
 		editor.commands.add( 'bulletedList', new DocumentListCommand( editor, 'bulleted' ) );
@@ -459,12 +457,15 @@ export default class DocumentListEditing extends Plugin {
 	}
 
 	/**
-	 * Integrates the feature with the clipboard via {@link module:engine/model/model~Model#getSelectedContent}.
+	 * Integrates the feature with the clipboard via {@link module:engine/model/model~Model#insertContent} and
+	 * {@link module:engine/model/model~Model#getSelectedContent}.
 	 *
 	 * @private
 	 */
 	_setupClipboardIntegration() {
 		const model = this.editor.model;
+
+		model.on( 'insertContent', createModelIndentPasteFixer( model ), { priority: 'high' } );
 
 		// To enhance the UX, the editor should not copy list attributes to the clipboard if the selection
 		// started and ended in the same list item block or a block object as a list block was selected.

--- a/packages/ckeditor5-list/src/documentlist/documentlistediting.js
+++ b/packages/ckeditor5-list/src/documentlist/documentlistediting.js
@@ -471,7 +471,7 @@ export default class DocumentListEditing extends Plugin {
 		// started and ended in the same list item.
 		//
 		// If the selection was enclosed in a single list item, there is a good chance the user did not want it
-		// to copied as a list item but plain blocks.
+		// copied as a list item but plain blocks.
 		//
 		// This avoids pasting orphaned list items instead of paragraphs, for instance, straight into the root.
 		//

--- a/packages/ckeditor5-list/tests/documentlist/integrations/clipboard.js
+++ b/packages/ckeditor5-list/tests/documentlist/integrations/clipboard.js
@@ -82,13 +82,13 @@ describe( 'DocumentListEditing integrations: clipboard copy & paste', () => {
 
 			expect( data ).to.equal(
 				'<ul>' +
-				'<li>' +
-				'<p>B1</p>' +
-				'<p>B2</p>' +
-				'<ul>' +
-				'<li>C1</li>' +
-				'</ul>' +
-				'</li>' +
+					'<li>' +
+						'<p>B1</p>' +
+						'<p>B2</p>' +
+						'<ul>' +
+							'<li>C1</li>' +
+						'</ul>' +
+					'</li>' +
 				'</ul>'
 			);
 		} );
@@ -99,7 +99,7 @@ describe( 'DocumentListEditing integrations: clipboard copy & paste', () => {
 				'<paragraph listType="bulleted" listItemId="b" listIndent="1">B1</paragraph>' +
 				'<paragraph listType="bulleted" listItemId="b" listIndent="1">B2</paragraph>' +
 				'[<paragraph listType="bulleted" listItemId="c" listIndent="2">C1</paragraph>' +
-				'<paragraph listType="bulleted" listItemId="c" listIndent="2">C2</paragraph>]'
+				'<paragraph listType="bulleted" listItemId="d" listIndent="2">C2</paragraph>]'
 			);
 
 			const modelFragment = model.getSelectedContent( model.document.selection );
@@ -108,10 +108,8 @@ describe( 'DocumentListEditing integrations: clipboard copy & paste', () => {
 
 			expect( data ).to.equal(
 				'<ul>' +
-				'<li>' +
-				'<p>C1</p>' +
-				'<p>C2</p>' +
-				'</li>' +
+					'<li>C1</li>' +
+					'<li>C2</li>' +
 				'</ul>'
 			);
 		} );

--- a/packages/ckeditor5-list/tests/documentlist/integrations/clipboard.js
+++ b/packages/ckeditor5-list/tests/documentlist/integrations/clipboard.js
@@ -3,7 +3,11 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+/* global document */
+
 import DocumentListEditing from '../../../src/documentlist/documentlistediting';
+import { isListItemBlock } from '../../../src/documentlist/utils/model';
+import { modelList } from '../_utils/utils';
 
 import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting';
 import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
@@ -12,9 +16,10 @@ import BlockQuoteEditing from '@ckeditor/ckeditor5-block-quote/src/blockquoteedi
 import HeadingEditing from '@ckeditor/ckeditor5-heading/src/headingediting';
 import TableEditing from '@ckeditor/ckeditor5-table/src/tableediting';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Image from '@ckeditor/ckeditor5-image/src/image';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
-import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import {
 	getData as getModelData,
 	parse as parseModel,
@@ -25,15 +30,18 @@ import { parse as parseView } from '@ckeditor/ckeditor5-engine/src/dev-utils/vie
 import stubUid from '../_utils/uid';
 
 describe( 'DocumentListEditing integrations: clipboard copy & paste', () => {
-	let editor, model, modelDoc, modelRoot, view;
+	let element, editor, model, modelDoc, modelRoot, view;
 
 	testUtils.createSinonSandbox();
 
 	beforeEach( async () => {
-		editor = await VirtualTestEditor.create( {
+		element = document.createElement( 'div' );
+		document.body.appendChild( element );
+
+		editor = await ClassicTestEditor.create( element, {
 			plugins: [
 				Paragraph, ClipboardPipeline, BoldEditing, DocumentListEditing, UndoEditing,
-				BlockQuoteEditing, TableEditing, HeadingEditing
+				BlockQuoteEditing, TableEditing, HeadingEditing, Image
 			]
 		} );
 
@@ -53,6 +61,8 @@ describe( 'DocumentListEditing integrations: clipboard copy & paste', () => {
 	} );
 
 	afterEach( async () => {
+		element.remove();
+
 		await editor.destroy();
 	} );
 
@@ -105,6 +115,142 @@ describe( 'DocumentListEditing integrations: clipboard copy & paste', () => {
 				'</ul>'
 			);
 		} );
+
+		describe( 'UX enhancements', () => {
+			// https://github.com/ckeditor/ckeditor5/issues/11608.
+			describe( 'stripping list when a content of a single block was selected', () => {
+				it( 'should return an object stripped of list attributes, if that object was selected as a first list item block', () => {
+					setModelData( model, modelList( [
+						'* [<imageBlock src=""></imageBlock>]'
+					] ) );
+
+					const modelFragment = model.getSelectedContent( model.document.selection );
+
+					expect( modelFragment.childCount ).to.equal( 1 );
+					expect( hasAnyListAttribute( modelFragment.getChild( 0 ) ) ).to.be.false;
+				} );
+
+				it( 'should return an object stripped of list attributes, if that object was selected as a middle list item block', () => {
+					setModelData( model, modelList( [
+						'* foo',
+						'  [<imageBlock src=""></imageBlock>]',
+						'  bar'
+					] ) );
+
+					const modelFragment = model.getSelectedContent( model.document.selection );
+
+					expect( modelFragment.childCount ).to.equal( 1 );
+					expect( hasAnyListAttribute( modelFragment.getChild( 0 ) ) ).to.be.false;
+				} );
+
+				it( 'should strip other list attributes', () => {
+					setModelData( model, modelList( [
+						'* [<imageBlock listStyle="square" src=""></imageBlock>]'
+					] ) );
+
+					const modelFragment = model.getSelectedContent( model.document.selection );
+
+					expect( modelFragment.childCount ).to.equal( 1 );
+					expect( hasAnyListAttribute( modelFragment.getChild( 0 ) ) ).to.be.false;
+				} );
+
+				// ---------------------------------- Mostly paranoid checks below --------------------------------------------------
+
+				it( 'should return just a text, if a list item block was partially selected', () => {
+					setModelData( model, modelList( [
+						'* Fo[o b]ar.'
+					] ) );
+
+					const modelFragment = model.getSelectedContent( model.document.selection );
+
+					expect( modelFragment.childCount ).to.equal( 1 );
+					expect( hasAnyListAttribute( modelFragment.getChild( 0 ) ) ).to.be.false;
+				} );
+
+				it( 'should return just a text, if a list item block was completely selected', () => {
+					setModelData( model, modelList( [
+						'* [Foo bar.]'
+					] ) );
+
+					const modelFragment = model.getSelectedContent( model.document.selection );
+
+					expect( modelFragment.childCount ).to.equal( 1 );
+					expect( hasAnyListAttribute( modelFragment.getChild( 0 ) ) ).to.be.false;
+				} );
+
+				it( 'should return just a text, if a list item block in the middle was completely selected', () => {
+					setModelData( model, modelList( [
+						'* Foo',
+						'  [Bar]',
+						'  Baz'
+					] ) );
+
+					const modelFragment = model.getSelectedContent( model.document.selection );
+
+					expect( modelFragment.childCount ).to.equal( 1 );
+					expect( hasAnyListAttribute( modelFragment.getChild( 0 ) ) ).to.be.false;
+				} );
+
+				it( 'should return an inline object stripped of list attributes, if that object was selected in a list item', () => {
+					setModelData( model, modelList( [
+						'* Foo [<imageInline src=""></imageInline>] bar.'
+					] ) );
+
+					const modelFragment = model.getSelectedContent( model.document.selection );
+
+					expect( modelFragment.childCount ).to.equal( 1 );
+					expect( hasAnyListAttribute( modelFragment.getChild( 0 ) ) ).to.be.false;
+				} );
+
+				it( 'should return nodes stripped of list attributes, if a single list item block was partially selected', () => {
+					setModelData( model, modelList( [
+						'* Fo[o <imageInline src=""></imageInline> b]ar.'
+					] ) );
+
+					const modelFragment = model.getSelectedContent( model.document.selection );
+
+					expect( modelFragment.childCount ).to.equal( 3 );
+					expect( Array.from( modelFragment.getChildren() ).some( hasAnyListAttribute ) ).to.be.false;
+				} );
+			} );
+
+			describe( 'preserving list structure when a cross-block selection existed', () => {
+				it( 'should return a list structure, if more than a single block of the same item was selected', () => {
+					setModelData( model, modelList( [
+						'* Fo[o',
+						'  Bar',
+						'  B]az'
+					] ) );
+
+					const modelFragment = model.getSelectedContent( model.document.selection );
+
+					expect( modelFragment.childCount ).to.equal( 3 );
+					expect( Array.from( modelFragment.getChildren() ).every( isListItemBlock ) ).to.be.true;
+				} );
+
+				it( 'should return a list structure, if more than a single item was selected', () => {
+					setModelData( model, modelList( [
+						'* Fo[o',
+						'* Ba]r'
+					] ) );
+
+					const modelFragment = model.getSelectedContent( model.document.selection );
+
+					expect( modelFragment.childCount ).to.equal( 2 );
+					expect( Array.from( modelFragment.getChildren() ).every( isListItemBlock ) ).to.be.true;
+				} );
+			} );
+		} );
+
+		function hasAnyListAttribute( node ) {
+			for ( const attributeKey of node.getAttributeKeys() ) {
+				if ( attributeKey.startsWith( 'list' ) ) {
+					return true;
+				}
+			}
+
+			return false;
+		}
 	} );
 
 	describe( 'paste and insertContent() integration', () => {

--- a/packages/ckeditor5-list/tests/documentlist/integrations/clipboard.js
+++ b/packages/ckeditor5-list/tests/documentlist/integrations/clipboard.js
@@ -25,6 +25,7 @@ import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictest
 import {
 	getData as getModelData,
 	parse as parseModel,
+	stringify as stringifyModel,
 	setData as setModelData
 } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import { parse as parseView } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
@@ -238,6 +239,26 @@ describe( 'DocumentListEditing integrations: clipboard copy & paste', () => {
 
 					expect( modelFragment.childCount ).to.equal( 1 );
 					expect( Array.from( modelFragment.getChildren() ).some( hasAnyListAttribute ) ).to.be.false;
+				} );
+
+				it( 'should not strip attributes of wrapped list', () => {
+					setModelData( model, modelList( `
+						* [<blockQuote>${ modelList( `
+							* foo
+						` ) }</blockQuote>]
+					` ) );
+
+					const modelFragment = model.getSelectedContent( model.createSelection( model.document.getRoot(), 'in' ) );
+
+					expect( modelFragment.childCount ).to.equal( 1 );
+					expect( Array.from( modelFragment.getChildren() ).every( isListItemBlock ) ).to.be.false;
+					expect( Array.from( modelFragment.getChild( 0 ).getChildren() ).every( isListItemBlock ) ).to.be.true;
+
+					expect( stringifyModel( modelFragment ) ).to.equal(
+						'<blockQuote>' +
+							'<paragraph listIndent="0" listItemId="a00" listType="bulleted">foo</paragraph>' +
+						'</blockQuote>'
+					);
 				} );
 			} );
 

--- a/packages/ckeditor5-list/tests/documentlist/integrations/clipboard.js
+++ b/packages/ckeditor5-list/tests/documentlist/integrations/clipboard.js
@@ -117,6 +117,7 @@ describe( 'DocumentListEditing integrations: clipboard copy & paste', () => {
 		describe( 'UX enhancements', () => {
 			// https://github.com/ckeditor/ckeditor5/issues/11608.
 			describe( 'stripping list when a content of a single block was selected', () => {
+				// Note: this allows the heuristics in ImageInlineEditing to kick in.
 				it( 'should return an object stripped of list attributes, if that object was selected as a first list item block', () => {
 					setModelData( model, modelList( [
 						'* [<imageBlock src=""></imageBlock>]'
@@ -152,7 +153,18 @@ describe( 'DocumentListEditing integrations: clipboard copy & paste', () => {
 					expect( hasAnyListAttribute( modelFragment.getChild( 0 ) ) ).to.be.false;
 				} );
 
-				// ---------------------------------- Mostly paranoid checks below --------------------------------------------------
+				it( 'should return nodes stripped of list attributes, if more than a single block of the same item was selected', () => {
+					setModelData( model, modelList( [
+						'* Fo[o',
+						'  Bar',
+						'  B]az'
+					] ) );
+
+					const modelFragment = model.getSelectedContent( model.document.selection );
+
+					expect( modelFragment.childCount ).to.equal( 3 );
+					expect( Array.from( modelFragment.getChildren() ).some( isListItemBlock ) ).to.be.false;
+				} );
 
 				it( 'should return just a text, if a list item block was partially selected', () => {
 					setModelData( model, modelList( [
@@ -210,14 +222,41 @@ describe( 'DocumentListEditing integrations: clipboard copy & paste', () => {
 					expect( modelFragment.childCount ).to.equal( 3 );
 					expect( Array.from( modelFragment.getChildren() ).some( hasAnyListAttribute ) ).to.be.false;
 				} );
+
+				// Note: This test also verifies support for arbitrary selection passed to getSelectedContent().
+				it( 'should return a node stripped of list attributes, if a single item was selected from the outside', () => {
+					setModelData( model, modelList( [
+						'* Foo'
+					] ) );
+
+					// [* Foo]
+					//
+					// Note: It is impossible to set a document selection like this because the postfixer will normalize it to * [Foo].
+					const modelFragment = model.getSelectedContent( model.createSelection( model.document.getRoot(), 'in' ) );
+
+					expect( modelFragment.childCount ).to.equal( 1 );
+					expect( Array.from( modelFragment.getChildren() ).some( isListItemBlock ) ).to.be.false;
+				} );
 			} );
 
-			describe( 'preserving list structure when a cross-block selection existed', () => {
-				it( 'should return a list structure, if more than a single block of the same item was selected', () => {
+			describe( 'preserving list structure when a cross-list item selection existed', () => {
+				it( 'should return a list structure, if more than a single list item was selected', () => {
+					setModelData( model, modelList( [
+						'* Fo[o',
+						'* Ba]r'
+					] ) );
+
+					const modelFragment = model.getSelectedContent( model.document.selection );
+
+					expect( modelFragment.childCount ).to.equal( 2 );
+					expect( Array.from( modelFragment.getChildren() ).every( isListItemBlock ) ).to.be.true;
+				} );
+
+				it( 'should return a list structure, if a nested items were included in the selection', () => {
 					setModelData( model, modelList( [
 						'* Fo[o',
 						'  Bar',
-						'  B]az'
+						'  * B]az'
 					] ) );
 
 					const modelFragment = model.getSelectedContent( model.document.selection );
@@ -226,13 +265,20 @@ describe( 'DocumentListEditing integrations: clipboard copy & paste', () => {
 					expect( Array.from( modelFragment.getChildren() ).every( isListItemBlock ) ).to.be.true;
 				} );
 
-				it( 'should return a list structure, if more than a single item was selected', () => {
+				// Note: This test also verifies support for arbitrary selection passed to getSelectedContent().
+				it( 'should return a list structure, if multiple list items were selected from the outside', () => {
 					setModelData( model, modelList( [
-						'* Fo[o',
-						'* Ba]r'
+						'* Foo',
+						'* Bar'
 					] ) );
 
-					const modelFragment = model.getSelectedContent( model.document.selection );
+					// [* Foo
+					//  * Bar]
+					//
+					// Note: It is impossible to set a document selection like this because the postfixer will normalize it to
+					// * [Foo
+					// * Bar]
+					const modelFragment = model.getSelectedContent( model.createSelection( model.document.getRoot(), 'in' ) );
 
 					expect( modelFragment.childCount ).to.equal( 2 );
 					expect( Array.from( modelFragment.getChildren() ).every( isListItemBlock ) ).to.be.true;

--- a/packages/ckeditor5-list/tests/documentlist/integrations/clipboard.js
+++ b/packages/ckeditor5-list/tests/documentlist/integrations/clipboard.js
@@ -16,7 +16,9 @@ import BlockQuoteEditing from '@ckeditor/ckeditor5-block-quote/src/blockquoteedi
 import HeadingEditing from '@ckeditor/ckeditor5-heading/src/headingediting';
 import TableEditing from '@ckeditor/ckeditor5-table/src/tableediting';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import Image from '@ckeditor/ckeditor5-image/src/image';
+import ImageBlockEditing from '@ckeditor/ckeditor5-image/src/image/imageblockediting';
+import ImageInlineEditing from '@ckeditor/ckeditor5-image/src/image/imageinlineediting';
+import Widget from '@ckeditor/ckeditor5-widget/src/widget';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
@@ -41,7 +43,7 @@ describe( 'DocumentListEditing integrations: clipboard copy & paste', () => {
 		editor = await ClassicTestEditor.create( element, {
 			plugins: [
 				Paragraph, ClipboardPipeline, BoldEditing, DocumentListEditing, UndoEditing,
-				BlockQuoteEditing, TableEditing, HeadingEditing, Image
+				BlockQuoteEditing, TableEditing, HeadingEditing, ImageBlockEditing, ImageInlineEditing, Widget
 			]
 		} );
 

--- a/packages/ckeditor5-list/tests/documentlist/integrations/clipboard.js
+++ b/packages/ckeditor5-list/tests/documentlist/integrations/clipboard.js
@@ -237,7 +237,7 @@ describe( 'DocumentListEditing integrations: clipboard copy & paste', () => {
 					const modelFragment = model.getSelectedContent( model.createSelection( model.document.getRoot(), 'in' ) );
 
 					expect( modelFragment.childCount ).to.equal( 1 );
-					expect( Array.from( modelFragment.getChildren() ).some( isListItemBlock ) ).to.be.false;
+					expect( Array.from( modelFragment.getChildren() ).some( hasAnyListAttribute ) ).to.be.false;
 				} );
 			} );
 

--- a/packages/ckeditor5-list/tests/documentlistproperties/converters.js
+++ b/packages/ckeditor5-list/tests/documentlistproperties/converters.js
@@ -397,7 +397,7 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 						  * B1 {style:circle}
 						    B2
 						    * [C1 {style:square}
-						      C2]
+						    * C2]
 					` ) );
 
 					const modelFragment = model.getSelectedContent( model.document.selection );
@@ -406,10 +406,8 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 
 					expect( data ).to.equal(
 						'<ul style="list-style-type:square;">' +
-							'<li>' +
-								'<p>C1</p>' +
-								'<p>C2</p>' +
-							'</li>' +
+							'<li>C1</li>' +
+							'<li>C2</li>' +
 						'</ul>'
 					);
 				} );
@@ -1114,7 +1112,7 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 						  # B1 {reversed:true}
 						    B2
 						    # [C1 {reversed:true}
-						      C2]
+						    # C2]
 					` ) );
 
 					const modelFragment = model.getSelectedContent( model.document.selection );
@@ -1123,10 +1121,8 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 
 					expect( data ).to.equal(
 						'<ol reversed="reversed">' +
-							'<li>' +
-								'<p>C1</p>' +
-								'<p>C2</p>' +
-							'</li>' +
+							'<li>C1</li>' +
+							'<li>C2</li>' +
 						'</ol>'
 					);
 				} );
@@ -1758,7 +1754,7 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 						  # B1 {start:4}
 						    B2
 						    # [C1 {start:7}
-						      C2]
+						    # C2]
 					` ) );
 
 					const modelFragment = model.getSelectedContent( model.document.selection );
@@ -1767,10 +1763,8 @@ describe( 'DocumentListPropertiesEditing - converters', () => {
 
 					expect( data ).to.equal(
 						'<ol start="7">' +
-							'<li>' +
-								'<p>C1</p>' +
-								'<p>C2</p>' +
-							'</li>' +
+							'<li>C1</li>' +
+							'<li>C2</li>' +
 						'</ol>'
 					);
 				} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (list): The editor should strip list attributes from solo blocks to enhance UX on paste or drop in document lists. Closes #11608.
