### PR TITLE
GHS: DualContent should search for block in all nested elements

### DIFF
--- a/packages/ckeditor5-html-support/src/integrations/dualcontent.js
+++ b/packages/ckeditor5-html-support/src/integrations/dualcontent.js
@@ -114,6 +114,9 @@ export default class DualContentModelElementSupport extends Plugin {
 		const view = this.editor.editing.view;
 		const blockElements = view.domConverter.blockElements;
 
+		// Traversing the viewElement subtree looking for block elements.
+		// Especially for the cases like <div><a href="#"><p>foo</p></a></div>.
+		// https://github.com/ckeditor/ckeditor5/issues/11513
 		for ( const viewItem of view.createRangeIn( viewElement ).getItems() ) {
 			if ( viewItem.is( 'element' ) && blockElements.includes( viewItem.name ) ) {
 				return true;

--- a/packages/ckeditor5-html-support/src/integrations/dualcontent.js
+++ b/packages/ckeditor5-html-support/src/integrations/dualcontent.js
@@ -113,8 +113,23 @@ export default class DualContentModelElementSupport extends Plugin {
 	_hasBlockContent( viewElement ) {
 		const blockElements = this.editor.editing.view.domConverter.blockElements;
 
-		return Array.from( viewElement.getChildren() )
-			.some( node => blockElements.includes( node.name ) );
+		return hasBlockContent( viewElement );
+
+		function isBlock( node ) {
+			if ( blockElements.includes( node.name ) ) {
+				return true;
+			}
+
+			if ( node.is( 'element' ) ) {
+				return hasBlockContent( node );
+			}
+
+			return false;
+		}
+
+		function hasBlockContent( viewElement ) {
+			return Array.from( viewElement.getChildren() ).some( isBlock );
+		}
 	}
 
 	/**

--- a/packages/ckeditor5-html-support/src/integrations/dualcontent.js
+++ b/packages/ckeditor5-html-support/src/integrations/dualcontent.js
@@ -111,25 +111,16 @@ export default class DualContentModelElementSupport extends Plugin {
 	 * @returns {Boolean}
 	 */
 	_hasBlockContent( viewElement ) {
-		const blockElements = this.editor.editing.view.domConverter.blockElements;
+		const view = this.editor.editing.view;
+		const blockElements = view.domConverter.blockElements;
 
-		return hasBlockContent( viewElement );
-
-		function isBlock( node ) {
-			if ( blockElements.includes( node.name ) ) {
+		for ( const viewItem of view.createRangeIn( viewElement ).getItems() ) {
+			if ( viewItem.is( 'element' ) && blockElements.includes( viewItem.name ) ) {
 				return true;
 			}
-
-			if ( node.is( 'element' ) ) {
-				return hasBlockContent( node );
-			}
-
-			return false;
 		}
 
-		function hasBlockContent( viewElement ) {
-			return Array.from( viewElement.getChildren() ).some( isBlock );
-		}
+		return false;
 	}
 
 	/**

--- a/packages/ckeditor5-html-support/tests/integrations/dualcontent.js
+++ b/packages/ckeditor5-html-support/tests/integrations/dualcontent.js
@@ -87,9 +87,9 @@ describe( 'DualContentModelElementSupport', () => {
 
 		expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
 			'<htmlDivParagraph>' +
-			'<$text italic="true" linkHref="example.com">foo</$text>' +
-			'<$text linkHref="example.com">bar</$text>' +
-			'baz' +
+				'<$text italic="true" linkHref="example.com">foo</$text>' +
+				'<$text linkHref="example.com">bar</$text>' +
+				'baz' +
 			'</htmlDivParagraph>'
 		);
 
@@ -115,8 +115,8 @@ describe( 'DualContentModelElementSupport', () => {
 
 		expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
 			'<htmlDiv>' +
-			'<paragraph><$text linkHref="example.com">foo</$text></paragraph>' +
-			'<paragraph>bar</paragraph>' +
+				'<paragraph><$text linkHref="example.com">foo</$text></paragraph>' +
+				'<paragraph>bar</paragraph>' +
 			'</htmlDiv>'
 		);
 

--- a/packages/ckeditor5-html-support/tests/integrations/dualcontent.js
+++ b/packages/ckeditor5-html-support/tests/integrations/dualcontent.js
@@ -8,6 +8,7 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
 import ShiftEnter from '@ckeditor/ckeditor5-enter/src/shiftenter';
+import LinkEditing from '@ckeditor/ckeditor5-link/src/linkediting';
 import GeneralHtmlSupport from '../../src/generalhtmlsupport';
 import { getModelDataWithAttributes } from '../_utils/utils';
 import { getData as getModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
@@ -23,7 +24,7 @@ describe( 'DualContentModelElementSupport', () => {
 
 		return ClassicTestEditor
 			.create( editorElement, {
-				plugins: [ Paragraph, Bold, Italic, ShiftEnter, GeneralHtmlSupport ]
+				plugins: [ Paragraph, Bold, Italic, ShiftEnter, LinkEditing, GeneralHtmlSupport ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;
@@ -79,6 +80,22 @@ describe( 'DualContentModelElementSupport', () => {
 		expect( editor.getData() ).to.equal( '<div>foo<br>bar</div>' );
 	} );
 
+	it( 'should recognize paragraph-like elements with nested structure', () => {
+		dataFilter.allowElement( 'div' );
+
+		editor.setData( '<div><a href="example.com"><i>foo</i>bar</a>baz</div>' );
+
+		expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+			'<htmlDivParagraph>' +
+			'<$text italic="true" linkHref="example.com">foo</$text>' +
+			'<$text linkHref="example.com">bar</$text>' +
+			'baz' +
+			'</htmlDivParagraph>'
+		);
+
+		expect( editor.getData() ).to.equal( '<div><a href="example.com"><i>foo</i>bar</a>baz</div>' );
+	} );
+
 	it( 'should recognize block elements', () => {
 		dataFilter.allowElement( 'div' );
 
@@ -89,6 +106,21 @@ describe( 'DualContentModelElementSupport', () => {
 		);
 
 		expect( editor.getData() ).to.equal( '<div><p>foobar</p></div>' );
+	} );
+
+	it( 'should recognize block elements with nested structure', () => {
+		dataFilter.allowElement( 'div' );
+
+		editor.setData( '<div><a href="example.com"><p>foo</p></a>bar</div>' );
+
+		expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+			'<htmlDiv>' +
+			'<paragraph><$text linkHref="example.com">foo</$text></paragraph>' +
+			'<paragraph>bar</paragraph>' +
+			'</htmlDiv>'
+		);
+
+		expect( editor.getData() ).to.equal( '<div><p><a href="example.com">foo</a></p><p>bar</p></div>' );
 	} );
 
 	it( 'should autoparagraph mixed content', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (html-support): `DualContentModelElementSupport` should upcast inline elements as block when they contain block inside. Closes #11513.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._