### PR TITLE
The mention UI should not show up when matching an existing mention

### DIFF
--- a/packages/ckeditor5-mention/package.json
+++ b/packages/ckeditor5-mention/package.json
@@ -19,6 +19,7 @@
     "@ckeditor/ckeditor5-basic-styles": "^34.0.0",
     "@ckeditor/ckeditor5-block-quote": "^34.0.0",
     "@ckeditor/ckeditor5-clipboard": "^34.0.0",
+    "@ckeditor/ckeditor5-cloud-services": "^34.0.0",
     "@ckeditor/ckeditor5-core": "^34.0.0",
     "@ckeditor/ckeditor5-dev-utils": "^30.0.0",
     "@ckeditor/ckeditor5-editor-classic": "^34.0.0",

--- a/packages/ckeditor5-mention/src/mentionui.js
+++ b/packages/ckeditor5-mention/src/mentionui.js
@@ -388,8 +388,10 @@ export default class MentionUI extends Plugin {
 			const markerDefinition = getLastValidMarkerInText( feedsWithPattern, data.text );
 			const selection = editor.model.document.selection;
 			const focus = selection.focus;
+			const markerPosition = editor.model.createPositionAt( focus.parent, markerDefinition.position );
 
-			if ( hasExistingMention( focus ) ) {
+			// https://github.com/ckeditor/ckeditor5/issues/11400
+			if ( isPositionInExistingMention( focus ) || isMarkerInExistingMention( markerPosition ) ) {
 				this._hideUIAndRemoveMarker();
 
 				return;
@@ -784,7 +786,7 @@ function createFeedCallback( feedItems ) {
 //
 // @param {module:engine/model/position~Position} position.
 // @returns {Boolean}
-function hasExistingMention( position ) {
+function isPositionInExistingMention( position ) {
 	// The text watcher listens only to changed range in selection - so the selection attributes are not yet available
 	// and you cannot use selection.hasAttribute( 'mention' ) just yet.
 	// See https://github.com/ckeditor/ckeditor5-engine/issues/1723.
@@ -793,6 +795,18 @@ function hasExistingMention( position ) {
 	const nodeBefore = position.nodeBefore;
 
 	return hasMention || nodeBefore && nodeBefore.is( '$text' ) && nodeBefore.hasAttribute( 'mention' );
+}
+
+// Checks if the closest marker offset is at the beginning of a mention.
+//
+// See https://github.com/ckeditor/ckeditor5/issues/11400.
+//
+// @param {module:engine/model/position~Position} markerPosition
+// @returns {Boolean}
+function isMarkerInExistingMention( markerPosition ) {
+	const nodeAfter = markerPosition.nodeAfter;
+
+	return nodeAfter && nodeAfter.is( '$text' ) && nodeAfter.hasAttribute( 'mention' );
 }
 
 // Checks if string is a valid mention marker.

--- a/packages/ckeditor5-mention/src/mentionui.js
+++ b/packages/ckeditor5-mention/src/mentionui.js
@@ -300,6 +300,8 @@ export default class MentionUI extends Plugin {
 	 * @param {String} feedText
 	 */
 	_requestFeed( marker, feedText ) {
+		// @if CK_DEBUG_MENTION // console.log( '%c[Feed]%c Requesting for', 'color: blue', 'color: black', `"${ feedText }"` );
+
 		// Store the last requested feed - it is used to discard any out-of order requests.
 		this._lastRequested = feedText;
 
@@ -390,7 +392,6 @@ export default class MentionUI extends Plugin {
 			const focus = selection.focus;
 			const markerPosition = editor.model.createPositionAt( focus.parent, markerDefinition.position );
 
-			// https://github.com/ckeditor/ckeditor5/issues/11400
 			if ( isPositionInExistingMention( focus ) || isMarkerInExistingMention( markerPosition ) ) {
 				this._hideUIAndRemoveMarker();
 
@@ -406,20 +407,32 @@ export default class MentionUI extends Plugin {
 
 			const markerRange = editor.model.createRange( start, end );
 
+			// @if CK_DEBUG_MENTION // console.group( '%c[TextWatcher]%c matched', 'color: red', 'color: black', `"${ feedText }"` );
+			// @if CK_DEBUG_MENTION // console.log( 'data#text', `"${ data.text }"` );
+			// @if CK_DEBUG_MENTION // console.log( 'data#range', data.range.start.path, data.range.end.path );
+			// @if CK_DEBUG_MENTION // console.log( 'marker definition', markerDefinition );
+			// @if CK_DEBUG_MENTION // console.log( 'marker range', markerRange.start.path, markerRange.end.path );
+
 			if ( checkIfStillInCompletionMode( editor ) ) {
 				const mentionMarker = editor.model.markers.get( 'mention' );
 
 				// Update the marker - user might've moved the selection to other mention trigger.
 				editor.model.change( writer => {
+					// @if CK_DEBUG_MENTION // console.log( '%c[Editing]%c Updating the marker.', 'color: purple', 'color: black' );
+
 					writer.updateMarker( mentionMarker, { range: markerRange } );
 				} );
 			} else {
 				editor.model.change( writer => {
+					// @if CK_DEBUG_MENTION // console.log( '%c[Editing]%c Adding the marker.', 'color: purple', 'color: black' );
+
 					writer.addMarker( 'mention', { range: markerRange, usingOperation: false, affectsData: false } );
 				} );
 			}
 
 			this._requestFeedDebounced( markerDefinition.marker, feedText );
+
+			// @if CK_DEBUG_MENTION // console.groupEnd( '[TextWatcher] matched' );
 		} );
 
 		watcher.on( 'unmatched', () => {
@@ -440,6 +453,9 @@ export default class MentionUI extends Plugin {
 	 */
 	_handleFeedResponse( data ) {
 		const { feed, marker } = data;
+
+		// eslint-disable-next-line max-len
+		// @if CK_DEBUG_MENTION // console.log( `%c[Feed]%c Response for "${ data.feedText }" (${ feed.length })`, 'color: blue', 'color: black', feed );
 
 		// If the marker is not in the document happens when the selection had changed and the 'mention' marker was removed.
 		if ( !checkIfStillInCompletionMode( this.editor ) ) {
@@ -472,9 +488,13 @@ export default class MentionUI extends Plugin {
 	 */
 	_showOrUpdateUI( markerMarker ) {
 		if ( this._isUIVisible ) {
+			// @if CK_DEBUG_MENTION // console.log( '%c[UI]%c Updating position.', 'color: green', 'color: black' );
+
 			// Update balloon position as the mention list view may change its size.
 			this._balloon.updatePosition( this._getBalloonPanelPositionData( markerMarker, this._mentionsView.position ) );
 		} else {
+			// @if CK_DEBUG_MENTION // console.log( '%c[UI]%c Showing the UI.', 'color: green', 'color: black' );
+
 			this._balloon.add( {
 				view: this._mentionsView,
 				position: this._getBalloonPanelPositionData( markerMarker, this._mentionsView.position ),
@@ -494,10 +514,14 @@ export default class MentionUI extends Plugin {
 	_hideUIAndRemoveMarker() {
 		// Remove the mention view from balloon before removing marker - it is used by balloon position target().
 		if ( this._balloon.hasView( this._mentionsView ) ) {
+			// @if CK_DEBUG_MENTION // console.log( '%c[UI]%c Hiding the UI.', 'color: green', 'color: black' );
+
 			this._balloon.remove( this._mentionsView );
 		}
 
 		if ( checkIfStillInCompletionMode( this.editor ) ) {
+			// @if CK_DEBUG_MENTION // console.log( '%c[Editing]%c Removing marker.', 'color: purple', 'color: black' );
+
 			this.editor.model.change( writer => writer.removeMarker( 'mention' ) );
 		}
 

--- a/packages/ckeditor5-mention/tests/manual/tickets/11400.html
+++ b/packages/ckeditor5-mention/tests/manual/tickets/11400.html
@@ -1,0 +1,22 @@
+<div id="snippet-mention-customization">
+	<p><span class="mention" data-mention="@marry">@marry</span>&nbsp;</p>
+</div>
+
+<style>
+	.custom-item {
+		display: block;
+		padding: 1em;
+	}
+
+	.custom-item.ck-on {
+		color: white;
+	}
+
+	.custom-item .custom-item-username {
+		color: #666;
+	}
+
+	.custom-item.ck-on .custom-item-username{
+		color: #ddd;
+	}
+</style>

--- a/packages/ckeditor5-mention/tests/manual/tickets/11400.js
+++ b/packages/ckeditor5-mention/tests/manual/tickets/11400.js
@@ -1,0 +1,82 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global console, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import Mention from '../../../src/mention';
+import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import Font from '@ckeditor/ckeditor5-font/src/font';
+
+import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
+
+ClassicEditor
+	.create( document.querySelector( '#snippet-mention-customization' ), {
+		cloudServices: CS_CONFIG,
+		plugins: [ ArticlePluginSet, Mention, Underline, Font ],
+		toolbar: {
+			items: [
+				'heading', '|', 'bold', 'italic', '|', 'undo', 'redo'
+			]
+		},
+		mention: {
+			dropdownLimit: 4,
+			feeds: [
+				{
+					marker: '@',
+					feed: getFeedItems,
+					itemRenderer: customItemRenderer
+				}
+			]
+		}
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );
+
+const items = [
+	{ id: '@john', userId: '1', name: 'John Doe' },
+	{ id: '@jack', userId: '2', name: 'Jack Smith' },
+	{ id: '@marry', userId: '3', name: 'Marry Foo' },
+	{ id: '@marry', userId: '4', name: 'Marry Bar' },
+	{ id: '@marry', userId: '5', name: 'Marry Baz' },
+	{ id: '@linda', userId: '6', name: 'Linda Novak' },
+	{ id: '@peter', userId: '7', name: 'Peter Pan' },
+	{ id: '@mark', userId: '8', name: 'Mark Polack' }
+];
+
+function getFeedItems( queryText ) {
+	return items.filter( isItemMatching );
+
+	function isItemMatching( item ) {
+		const searchString = queryText.toLowerCase();
+
+		return (
+			item.name.toLowerCase().includes( searchString ) ||
+			item.id.toLowerCase().includes( searchString )
+		);
+	}
+}
+
+function customItemRenderer( item ) {
+	const itemElement = document.createElement( 'span' );
+
+	itemElement.classList.add( 'custom-item' );
+	itemElement.id = `mention-list-item-id-${ item.userId }`;
+	itemElement.textContent = `${ item.name } `;
+
+	const usernameElement = document.createElement( 'span' );
+
+	usernameElement.classList.add( 'custom-item-username' );
+	usernameElement.textContent = item.id;
+
+	itemElement.appendChild( usernameElement );
+
+	return itemElement;
+}

--- a/packages/ckeditor5-mention/tests/manual/tickets/11400.md
+++ b/packages/ckeditor5-mention/tests/manual/tickets/11400.md
@@ -1,0 +1,10 @@
+# Matching with existing mentions and whitespaces ([#11400](https://github.com/ckeditor/ckeditor5/issues/11400))
+
+In this test, a couple of feed items were provided for the `@` marker. The most relevant, though, is `@marry` that matches against three different entries.
+
+The point of this test is to make sure the UI will not show up when the selection is after an existing mention even if there's a white space between them and it matches against one of the items in the feed ("Marry Foo", "Marry Bar", or "Marry Baz").
+
+1. Put the caret at the end of the mention. The UI should **not** show up.
+1. Type a whitespace after the mention. The UI should **not** show up.
+1. Create a new line and type `@marry`. The UI should pop up with three suggestions.
+	1. After accepting the mention, the UI should disappear and stay out of sight.

--- a/packages/ckeditor5-mention/tests/mentionui.js
+++ b/packages/ckeditor5-mention/tests/mentionui.js
@@ -873,6 +873,69 @@ describe( 'MentionUI', () => {
 			} );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5/issues/11400
+		describe( 'matching with whitespaces', () => {
+			const feedItems = [
+				{ id: '@foo', name: 'Foo' },
+				{ id: '@marry', name: 'Marry Foo' },
+				{ id: '@marry', name: 'Marry Bar' },
+				{ id: '@marry', name: 'Marry Baz' }
+			];
+
+			beforeEach( async () => {
+				await createClassicTestEditor( {
+					feeds: [
+						{
+							feed: queryText => feedItems.filter( ( { name } ) => name.toLowerCase().includes( queryText ) ),
+							marker: '@'
+						}
+					]
+				} );
+			} );
+
+			it( 'should not show panel when the selection is at the whitespace after an existing mention', async () => {
+				setData( model, '<paragraph>foo @marry bar[]</paragraph>' );
+
+				model.change( writer => {
+					const range = writer.createRange(
+						// <paragraph>foo [@marry] bar</paragraph>
+						writer.createPositionAt( doc.getRoot().getChild( 0 ), 4 ),
+						writer.createPositionAt( doc.getRoot().getChild( 0 ), 10 )
+					);
+
+					writer.setAttribute( 'mention', { id: '@marry', uid: 1234 }, range );
+				} );
+
+				await waitForDebounce();
+
+				model.change( writer => {
+					writer.setSelection( doc.getRoot().getChild( 0 ), 0 );
+				} );
+
+				expect( panelView.isVisible ).to.be.false;
+
+				model.change( writer => {
+					// <paragraph>foo @marry []bar</paragraph>
+					// All "Marry *" could match here if it wasn't for the existing mention.
+					writer.setSelection( doc.getRoot().getChild( 0 ), 11 );
+				} );
+
+				expect( panelView.isVisible ).to.be.false;
+				expect( model.markers.has( 'mention' ) ).to.be.false;
+			} );
+
+			it( 'should show the panel when the selection is at the whitespace after a matching marker and text', async () => {
+				// This should match all "Marry *" because there's no marker for @marry yet.
+				setData( model, '<paragraph>foo @marry []bar</paragraph>' );
+
+				await waitForDebounce();
+
+				expect( panelView.isVisible ).to.be.true;
+				expect( model.markers.has( 'mention' ) ).to.be.true;
+				expect( mentionsView.items ).to.have.length( 3 );
+			} );
+		} );
+
 		describe( 'unicode', () => {
 			beforeEach( () => {
 				return createClassicTestEditor( {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (mention): The mention UI should not show up when matching an existing mention after a white space. Closes #11400.

