### PR TITLE
Redundant elements and text nodes should be removed from `<pre>`

### DIFF
--- a/packages/ckeditor5-code-block/src/codeblockediting.js
+++ b/packages/ckeditor5-code-block/src/codeblockediting.js
@@ -23,7 +23,8 @@ import {
 	modelToViewCodeBlockInsertion,
 	modelToDataViewSoftBreakInsertion,
 	dataViewToModelCodeBlockInsertion,
-	dataViewToModelTextNewlinesInsertion
+	dataViewToModelTextNewlinesInsertion,
+	dataViewToModelOrphanNodeConsumer
 } from './converters';
 
 const DEFAULT_ELEMENT = 'paragraph';
@@ -150,6 +151,10 @@ export default class CodeBlockEditing extends Plugin {
 
 		editor.data.upcastDispatcher.on( 'element:code', dataViewToModelCodeBlockInsertion( view, normalizedLanguagesDefs ) );
 		editor.data.upcastDispatcher.on( 'text', dataViewToModelTextNewlinesInsertion() );
+
+		// Note: Low priority to allow marker upcast first.
+		editor.data.upcastDispatcher.on( 'element', dataViewToModelOrphanNodeConsumer(), { priority: 'low' } );
+		editor.data.upcastDispatcher.on( 'text', dataViewToModelOrphanNodeConsumer() );
 
 		// Intercept the clipboard input (paste) when the selection is anchored in the code block and force the clipboard
 		// data to be pasted as a single plain text. Otherwise, the code lines will split the code block and

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -1388,6 +1388,44 @@ describe( 'CodeBlockEditing', () => {
 			element.remove();
 		} );
 
+		it( 'should upcast <pre> with single spaces around <code>', () => {
+			editor.setData( '<pre> <code>Hello World!</code> </pre>' );
+
+			expect( getModelData( model ) ).to.equal( '<codeBlock language="plaintext">[]Hello World!</codeBlock>' );
+		} );
+
+		it( 'should upcast <pre> with multiple spaces around <code>', () => {
+			editor.setData( '<pre>    <code>Hello World!</code>    </pre>' );
+
+			expect( getModelData( model ) ).to.equal( '<codeBlock language="plaintext">[]Hello World!</codeBlock>' );
+		} );
+
+		it( 'should upcast <pre> with tabs around <code>', () => {
+			editor.setData( '<pre>		<code>Hello World!</code>		</pre>' );
+
+			expect( getModelData( model ) ).to.equal( '<codeBlock language="plaintext">[]Hello World!</codeBlock>' );
+		} );
+
+		it( 'should upcast <pre> with line breaks around <code>', () => {
+			editor.setData( `<pre>
+				<code>Hello World!</code>
+			</pre>` );
+
+			expect( getModelData( model ) ).to.equal( '<codeBlock language="plaintext">[]Hello World!</codeBlock>' );
+		} );
+
+		it( 'should upcast <pre> with accidental text around <code>', () => {
+			editor.setData( '<pre>foo<code>Hello World!</code>bar</pre>' );
+
+			expect( getModelData( model ) ).to.equal( '<codeBlock language="plaintext">[]Hello World!</codeBlock>' );
+		} );
+
+		it( 'should upcast <pre> with accidental elements around <code>', () => {
+			editor.setData( '<pre><b>foo</b><code>Hello World!</code><span>bar</span></pre>' );
+
+			expect( getModelData( model ) ).to.equal( '<codeBlock language="plaintext">[]Hello World!</codeBlock>' );
+		} );
+
 		describe( 'config.codeBlock.languages', () => {
 			it( 'should be respected when upcasting', () => {
 				return ClassicTestEditor.create(


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (code-block): Redundant elements and text nodes should be removed from `<pre>` on upcast to avoid breaking the code block. Closes #11616.
