### PR TITLE
<ul type> & <ol type>

### DIFF
--- a/packages/ckeditor5-list/ckeditor5-metadata.json
+++ b/packages/ckeditor5-list/ckeditor5-metadata.json
@@ -87,8 +87,7 @@
 					],
 					"attributes": [
 						"start",
-						"reversed",
-						"type"
+						"reversed"
 					],
 					"styles": "list-style-type"
 				}

--- a/packages/ckeditor5-list/ckeditor5-metadata.json
+++ b/packages/ckeditor5-list/ckeditor5-metadata.json
@@ -87,7 +87,8 @@
 					],
 					"attributes": [
 						"start",
-						"reversed"
+						"reversed",
+						"type"
 					],
 					"styles": "list-style-type"
 				}
@@ -138,7 +139,8 @@
 					],
 					"attributes": [
 						"start",
-						"reversed"
+						"reversed",
+						"type"
 					],
 					"styles": "list-style-type"
 				}

--- a/packages/ckeditor5-list/src/documentlistproperties/documentlistpropertiesediting.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/documentlistpropertiesediting.js
@@ -270,9 +270,9 @@ function createAttributeStrategies( enabledProperties ) {
 				return getListTypeFromListStyleType( value ) == item.getAttribute( 'listType' );
 			},
 
-			setAttributeOnDowncast: useAttribute ?
-				( writer, listStyle, element ) => {
-					if ( listStyle && listStyle !== DEFAULT_LIST_TYPE ) {
+			setAttributeOnDowncast( writer, listStyle, element ) {
+				if ( listStyle && listStyle !== DEFAULT_LIST_TYPE ) {
+					if ( useAttribute ) {
 						const value = getTypeAttributeFromListStyleType( listStyle );
 
 						if ( value ) {
@@ -280,16 +280,16 @@ function createAttributeStrategies( enabledProperties ) {
 
 							return;
 						}
-					}
-					writer.removeAttribute( 'type', element );
-				} :
-				( writer, listStyle, element ) => {
-					if ( listStyle && listStyle !== DEFAULT_LIST_TYPE ) {
-						writer.setStyle( 'list-style-type', listStyle, element );
 					} else {
-						writer.removeStyle( 'list-style-type', element );
+						writer.setStyle( 'list-style-type', listStyle, element );
+
+						return;
 					}
-				},
+				}
+
+				writer.removeStyle( 'list-style-type', element );
+				writer.removeAttribute( 'type', element );
+			},
 
 			getAttributeOnUpcast( listParent ) {
 				const style = listParent.getStyle( 'list-style-type' );

--- a/packages/ckeditor5-list/src/documentlistproperties/documentliststylecommand.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/documentliststylecommand.js
@@ -29,8 +29,9 @@ export default class DocumentListStyleCommand extends Command {
 	 * @param {module:core/editor/editor~Editor} editor The editor instance.
 	 * @param {String} defaultType The list type that will be used by default if the value was not specified during
 	 * the command execution.
+	 * @param {Array.<String>} [supportedTypes] The list of supported style types by this command.
 	 */
-	constructor( editor, defaultType ) {
+	constructor( editor, defaultType, supportedTypes ) {
 		super( editor );
 
 		/**
@@ -40,6 +41,14 @@ export default class DocumentListStyleCommand extends Command {
 		 * @member {String}
 		 */
 		this._defaultType = defaultType;
+
+		/**
+		 * The list of supported style types by this command.
+		 *
+		 * @private
+		 * @member {Array.<String>|undefined}
+		 */
+		this._supportedTypes = supportedTypes;
 	}
 
 	/**
@@ -78,6 +87,20 @@ export default class DocumentListStyleCommand extends Command {
 				writer.setAttribute( 'listStyle', options.type || this._defaultType, block );
 			}
 		} );
+	}
+
+	/**
+	 * Checks if the given style type is supported by this plugin.
+	 *
+	 * @param {String} value
+	 * @returns {Boolean}
+	 */
+	isStyleTypeSupported( value ) {
+		if ( !this._supportedTypes ) {
+			return true;
+		}
+
+		return this._supportedTypes.includes( value );
 	}
 
 	/**

--- a/packages/ckeditor5-list/src/documentlistproperties/utils/style.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/utils/style.js
@@ -7,20 +7,32 @@
 * @module list/documentlistproperties/utils/style
 */
 
-const BULLETED_LIST_STYLE_TYPES = [ 'disc', 'circle', 'square' ];
+const LIST_STYLE_TO_LIST_TYPE = {};
+const LIST_STYLE_TO_TYPE_ATTRIBUTE = {};
+const TYPE_ATTRIBUTE_TO_LIST_STYLE = {};
 
-// There's a lot of them (https://www.w3.org/TR/css-counter-styles-3/#typedef-counter-style).
-// Let's support only those that can be selected by ListPropertiesUI.
-const NUMBERED_LIST_STYLE_TYPES = [
-	'decimal',
-	'decimal-leading-zero',
-	'lower-roman',
-	'upper-roman',
-	'lower-latin',
-	'upper-latin',
-	'lower-alpha',
-	'upper-alpha'
+const LIST_STYLE_TYPES = [
+	{ listStyle: 'disc', typeAttribute: 'disc', listType: 'bulleted' },
+	{ listStyle: 'circle', typeAttribute: 'circle', listType: 'bulleted' },
+	{ listStyle: 'square', typeAttribute: 'square', listType: 'bulleted' },
+	{ listStyle: 'decimal', typeAttribute: '1', listType: 'numbered' },
+	{ listStyle: 'decimal-leading-zero', typeAttribute: null, listType: 'numbered' },
+	{ listStyle: 'lower-roman', typeAttribute: 'i', listType: 'numbered' },
+	{ listStyle: 'upper-roman', typeAttribute: 'I', listType: 'numbered' },
+	{ listStyle: 'lower-alpha', typeAttribute: 'a', listType: 'numbered' },
+	{ listStyle: 'upper-alpha', typeAttribute: 'A', listType: 'numbered' },
+	{ listStyle: 'lower-latin', typeAttribute: 'a', listType: 'numbered' },
+	{ listStyle: 'upper-latin', typeAttribute: 'A', listType: 'numbered' }
 ];
+
+for ( const { listStyle, typeAttribute, listType } of LIST_STYLE_TYPES ) {
+	LIST_STYLE_TO_LIST_TYPE[ listStyle ] = listType;
+	LIST_STYLE_TO_TYPE_ATTRIBUTE[ listStyle ] = typeAttribute;
+
+	if ( typeAttribute ) {
+		TYPE_ATTRIBUTE_TO_LIST_STYLE[ typeAttribute ] = listStyle;
+	}
+}
 
 /**
 * Checks whether the given list-style-type is supported by numbered or bulleted list.
@@ -29,13 +41,25 @@ const NUMBERED_LIST_STYLE_TYPES = [
 * @returns {'bulleted'|'numbered'|null}
 */
 export function getListTypeFromListStyleType( listStyleType ) {
-	if ( BULLETED_LIST_STYLE_TYPES.includes( listStyleType ) ) {
-		return 'bulleted';
-	}
+	return LIST_STYLE_TO_LIST_TYPE[ listStyleType ] || null;
+}
 
-	if ( NUMBERED_LIST_STYLE_TYPES.includes( listStyleType ) ) {
-		return 'numbered';
-	}
+/**
+ * Converts `type` attribute of `<ul>` or `<ol>` elements to `list-style-type` equivalent.
+ *
+ * @param {String} value
+ * @retun {String|null}
+ */
+export function getListStyleTypeFromTypeAttribute( value ) {
+	return TYPE_ATTRIBUTE_TO_LIST_STYLE[ value ] || null;
+}
 
-	return null;
+/**
+ * Converts `list-style-type` style to `type` attribute of `<ul>` or `<ol>` elements.
+ *
+ * @param {String} value
+ * @retun {String|null}
+ */
+export function getTypeAttributeFromListStyleType( value ) {
+	return LIST_STYLE_TO_TYPE_ATTRIBUTE[ value ] || null;
 }

--- a/packages/ckeditor5-list/src/documentlistproperties/utils/style.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/utils/style.js
@@ -57,7 +57,7 @@ export function getListTypeFromListStyleType( listStyleType ) {
  * Converts `type` attribute of `<ul>` or `<ol>` elements to `list-style-type` equivalent.
  *
  * @param {String} value
- * @retun {String|null}
+ * @returns {String|null}
  */
 export function getListStyleTypeFromTypeAttribute( value ) {
 	return TYPE_ATTRIBUTE_TO_LIST_STYLE[ value ] || null;
@@ -67,7 +67,7 @@ export function getListStyleTypeFromTypeAttribute( value ) {
  * Converts `list-style-type` style to `type` attribute of `<ul>` or `<ol>` elements.
  *
  * @param {String} value
- * @retun {String|null}
+ * @returns {String|null}
  */
 export function getTypeAttributeFromListStyleType( value ) {
 	return LIST_STYLE_TO_TYPE_ATTRIBUTE[ value ] || null;

--- a/packages/ckeditor5-list/src/documentlistproperties/utils/style.js
+++ b/packages/ckeditor5-list/src/documentlistproperties/utils/style.js
@@ -35,6 +35,15 @@ for ( const { listStyle, typeAttribute, listType } of LIST_STYLE_TYPES ) {
 }
 
 /**
+ * Gets all the style types supported by given list type.
+ *
+ * @returns {Array.<String>}
+ */
+export function getAllSupportedStyleTypes() {
+	return LIST_STYLE_TYPES.map( x => x.listStyle );
+}
+
+/**
 * Checks whether the given list-style-type is supported by numbered or bulleted list.
 *
 * @param {String} listStyleType

--- a/packages/ckeditor5-list/src/listproperties.js
+++ b/packages/ckeditor5-list/src/listproperties.js
@@ -65,7 +65,7 @@ export default class ListProperties extends Plugin {
  */
 
 /**
- * When set, the list style feature will be enabled. It allows changing the `list-style-type` HTML attribute of the lists.
+ * When set, the list style feature will be enabled. It allows changing the `list-style-type` style or `type` HTML attribute of the lists.
  *
  * @default true
  * @member {Boolean|module:list/listproperties~ListPropertiesStyleConfig} module:list/listproperties~ListPropertiesConfig#styles
@@ -106,6 +106,7 @@ export default class ListProperties extends Plugin {
 
 /**
  * When set, the list style feature will use `type` attribute of `<ul>` and `<ol>` elements instead of `list-style-type` style.
+ * Decimal with leading zero style is not available when it's set to `true`.
  *
  * **Note**: This configuration works only with {@link module:list/documentlistproperties~DocumentListProperties document list properties}.
  *

--- a/packages/ckeditor5-list/src/listproperties.js
+++ b/packages/ckeditor5-list/src/listproperties.js
@@ -65,7 +65,11 @@ export default class ListProperties extends Plugin {
  */
 
 /**
- * When set, the list style feature will be enabled. It allows changing the `list-style-type` style or `type` HTML attribute of the lists.
+ * When set, the list style feature will be enabled. It allows changing the `list-style-type` style or the `type` HTML attribute of a list.
+ *
+ * **Note**: Styling using the `type` HTML attribute is only available in
+ * {@link module:list/documentlistproperties~DocumentListProperties document list properties}
+ * ({@link module:list/listproperties~ListPropertiesStyleConfig learn more}).
  *
  * @default true
  * @member {Boolean|module:list/listproperties~ListPropertiesStyleConfig} module:list/listproperties~ListPropertiesConfig#styles
@@ -105,8 +109,24 @@ export default class ListProperties extends Plugin {
  */
 
 /**
- * When set, the list style feature will use `type` attribute of `<ul>` and `<ol>` elements instead of `list-style-type` style.
- * Decimal with leading zero style is not available when it's set to `true`.
+ * When set `true`, the list style feature will use the `type` attribute of `<ul>` and `<ol>` elements instead of the `list-style-type`
+ * style.
+ *
+ *		{
+ *			list: {
+ *				properties: {
+ *					styles: {
+ *						useAttribute: true
+ *					},
+ *
+ *					// ...
+ *				}
+ *			},
+ *
+ *			// ...
+ *		}
+ *
+ * **Note**: Due to limitations of HTML, the "Decimal with leading zero" style is impossible to set using the `type` attribute.
  *
  * **Note**: This configuration works only with {@link module:list/documentlistproperties~DocumentListProperties document list properties}.
  *

--- a/packages/ckeditor5-list/src/listproperties.js
+++ b/packages/ckeditor5-list/src/listproperties.js
@@ -68,7 +68,7 @@ export default class ListProperties extends Plugin {
  * When set, the list style feature will be enabled. It allows changing the `list-style-type` HTML attribute of the lists.
  *
  * @default true
- * @member {Boolean} module:list/listproperties~ListPropertiesConfig#styles
+ * @member {Boolean|module:list/listproperties~ListPropertiesStyleConfig} module:list/listproperties~ListPropertiesConfig#styles
  */
 
 /**
@@ -98,4 +98,17 @@ export default class ListProperties extends Plugin {
  * Read more in {@link module:list/listproperties~ListPropertiesConfig}.
  *
  * @member {module:list/listproperties~ListPropertiesConfig} module:list/list~ListConfig#properties
+ */
+
+/**
+ * @interface ListPropertiesStyleConfig
+ */
+
+/**
+ * When set, the list style feature will use `type` attribute of `<ul>` and `<ol>` elements instead of `list-style-type` style.
+ *
+ * **Note**: This configuration works only with {@link module:list/documentlistproperties~DocumentListProperties document list properties}.
+ *
+ * @default false
+ * @member {Boolean} module:list/listproperties~ListPropertiesStyleConfig#useAttribute
  */

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.js
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.js
@@ -278,7 +278,7 @@ function createListPropertiesView( {
 		} );
 
 		// The command can be ListStyleCommand or DocumentListStyleCommand.
-		const isStyleTypeSupported = listStyleCommand.constructor.name === 'DocumentListStyleCommand' ?
+		const isStyleTypeSupported = typeof listStyleCommand.isStyleTypeSupported == 'function' ?
 			styleDefinition => listStyleCommand.isStyleTypeSupported( styleDefinition.type ) :
 			() => true;
 

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.js
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.js
@@ -277,7 +277,12 @@ function createListPropertiesView( {
 			listStyleCommand
 		} );
 
-		styleButtonViews = styleDefinitions.map( styleButtonCreator );
+		// The command can be ListStyleCommand or DocumentListStyleComman. Let's checks if it has expected function.
+		const isStyleTypeSupported = typeof listStyleCommand.isStyleTypeSupported == 'function' ?
+			styleDefinition => listStyleCommand.isStyleTypeSupported( styleDefinition.type ) :
+			() => true;
+
+		styleButtonViews = styleDefinitions.filter( isStyleTypeSupported ).map( styleButtonCreator );
 	}
 
 	const listPropertiesView = new ListPropertiesView( locale, {

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.js
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.js
@@ -277,8 +277,8 @@ function createListPropertiesView( {
 			listStyleCommand
 		} );
 
-		// The command can be ListStyleCommand or DocumentListStyleCommand. Let's checks if it has expected function.
-		const isStyleTypeSupported = typeof listStyleCommand.isStyleTypeSupported == 'function' ?
+		// The command can be ListStyleCommand or DocumentListStyleCommand.
+		const isStyleTypeSupported = listStyleCommand.constructor.name === 'DocumentListStyleCommand' ?
 			styleDefinition => listStyleCommand.isStyleTypeSupported( styleDefinition.type ) :
 			() => true;
 

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.js
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.js
@@ -277,7 +277,7 @@ function createListPropertiesView( {
 			listStyleCommand
 		} );
 
-		// The command can be ListStyleCommand or DocumentListStyleComman. Let's checks if it has expected function.
+		// The command can be ListStyleCommand or DocumentListStyleCommand. Let's checks if it has expected function.
 		const isStyleTypeSupported = typeof listStyleCommand.isStyleTypeSupported == 'function' ?
 			styleDefinition => listStyleCommand.isStyleTypeSupported( styleDefinition.type ) :
 			() => true;

--- a/packages/ckeditor5-list/tests/documentlistproperties/documentlistpropertiesediting.js
+++ b/packages/ckeditor5-list/tests/documentlistproperties/documentlistpropertiesediting.js
@@ -4,14 +4,18 @@
  */
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import UndoEditing from '@ckeditor/ckeditor5-undo/src/undoediting';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import DocumentListPropertiesEditing from '../../src/documentlistproperties/documentlistpropertiesediting';
 import { modelList } from '../documentlist/_utils/utils';
+import stubUid from '../documentlist/_utils/uid';
 
 describe( 'DocumentListPropertiesEditing', () => {
 	let editor, model;
+
+	testUtils.createSinonSandbox();
 
 	it( 'should have pluginName', () => {
 		expect( DocumentListPropertiesEditing.pluginName ).to.equal( 'DocumentListPropertiesEditing' );
@@ -53,6 +57,8 @@ describe( 'DocumentListPropertiesEditing', () => {
 			} );
 
 			model = editor.model;
+
+			stubUid();
 		} );
 
 		afterEach( () => {
@@ -160,6 +166,108 @@ describe( 'DocumentListPropertiesEditing', () => {
 			} );
 		} );
 
+		describe( 'conversion', () => {
+			describe( 'upcast', () => {
+				it( 'should upcast to `listStyle` property (bulleted, default)', () => {
+					editor.setData( '<ul><li>Foo</li></ul>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						* Foo {id:a00} {style:default}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property (numbered, default)', () => {
+					editor.setData( '<ol><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:default}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property (bulleted, listStyleType="circle")', () => {
+					editor.setData( '<ul style="list-style-type:circle;"><li>Foo</li></ul>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						* Foo {id:a00} {style:circle}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property (numbered, listStyleType="decimal")', () => {
+					editor.setData( '<ol style="list-style-type:decimal;"><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:decimal}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property (bulleted, type="square")', () => {
+					editor.setData( '<ul type="square"><li>Foo</li></ul>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						* Foo {id:a00} {style:square}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property (numbered, type="A")', () => {
+					editor.setData( '<ol type="A"><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:upper-latin}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property (bulleted, list-style-type="circle" type="square")', () => {
+					editor.setData( '<ul style="list-style-type:circle;" type="circle"><li>Foo</li></ul>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						* Foo {id:a00} {style:circle}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property (numbered, list-style-type="decimal" type="A")', () => {
+					editor.setData( '<ol type="A" style="list-style-type:decimal"><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:decimal}
+					` ) );
+				} );
+			} );
+
+			describe( 'downcast', () => {
+				it( 'should downcast to `list-style-type` style (bulleted, default)', () => {
+					setData( model, modelList( `
+						* Foo {style:default}
+					` ) );
+
+					expect( editor.getData() ).to.equal( '<ul><li>Foo</li></ul>' );
+				} );
+
+				it( 'should downcast to `list-style-type` style (bulleted, circle)', () => {
+					setData( model, modelList( `
+						* Foo {style:circle}
+					` ) );
+
+					expect( editor.getData() ).to.equal( '<ul style="list-style-type:circle;"><li>Foo</li></ul>' );
+				} );
+
+				it( 'should downcast to `list-style-type` style (numbered, default)', () => {
+					setData( model, modelList( `
+						# Foo {style:default}
+					` ) );
+
+					expect( editor.getData() ).to.equal( '<ol><li>Foo</li></ol>' );
+				} );
+
+				it( 'should downcast to `list-style-type` style (numbered, decimal)', () => {
+					setData( model, modelList( `
+						# Foo {style:decimal}
+					` ) );
+
+					expect( editor.getData() ).to.equal( '<ol style="list-style-type:decimal;"><li>Foo</li></ol>' );
+				} );
+			} );
+		} );
+
 		describe( 'indenting lists', () => {
 			it( 'should reset `listStyle` attribute after indenting a single item', () => {
 				setData( model, modelList( `
@@ -237,6 +345,131 @@ describe( 'DocumentListPropertiesEditing', () => {
 					  * 3.]
 					* 4.
 				` ) );
+			} );
+		} );
+	} );
+
+	describe( 'listStyle (type attribute)', () => {
+		beforeEach( async () => {
+			editor = await VirtualTestEditor.create( {
+				plugins: [ Paragraph, DocumentListPropertiesEditing, UndoEditing ],
+				list: {
+					properties: { styles: { useAttribute: true }, startIndex: false, reversed: false }
+				}
+			} );
+
+			model = editor.model;
+
+			stubUid();
+		} );
+
+		describe( 'conversion', () => {
+			describe( 'upcast', () => {
+				it( 'should upcast to `listStyle` property (bulleted, default)', () => {
+					editor.setData( '<ul><li>Foo</li></ul>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						* Foo {id:a00} {style:default}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property (numbered, default)', () => {
+					editor.setData( '<ol><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:default}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property (bulleted, listStyleType="circle")', () => {
+					editor.setData( '<ul style="list-style-type:circle;"><li>Foo</li></ul>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						* Foo {id:a00} {style:circle}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property (numbered, listStyleType="decimal")', () => {
+					editor.setData( '<ol style="list-style-type:decimal;"><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:decimal}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property (bulleted, type="square")', () => {
+					editor.setData( '<ul type="square"><li>Foo</li></ul>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						* Foo {id:a00} {style:square}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property (numbered, type="A")', () => {
+					editor.setData( '<ol type="A"><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:upper-latin}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property (bulleted, list-style-type="circle" type="square")', () => {
+					editor.setData( '<ul style="list-style-type:circle;" type="circle"><li>Foo</li></ul>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						* Foo {id:a00} {style:circle}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property (numbered, list-style-type="decimal" type="A")', () => {
+					editor.setData( '<ol type="A" style="list-style-type:decimal"><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:decimal}
+					` ) );
+				} );
+			} );
+
+			describe( 'downcast', () => {
+				it( 'should downcast to `type` attribute (bulleted, default)', () => {
+					setData( model, modelList( `
+						* Foo {style:default}
+					` ) );
+
+					expect( editor.getData() ).to.equal( '<ul><li>Foo</li></ul>' );
+				} );
+
+				it( 'should downcast to `type` attribute (bulleted, circle)', () => {
+					setData( model, modelList( `
+						* Foo {style:circle}
+					` ) );
+
+					expect( editor.getData() ).to.equal( '<ul type="circle"><li>Foo</li></ul>' );
+				} );
+
+				it( 'should downcast to `type` attribute (numbered, default)', () => {
+					setData( model, modelList( `
+						# Foo {style:default}
+					` ) );
+
+					expect( editor.getData() ).to.equal( '<ol><li>Foo</li></ol>' );
+				} );
+
+				it( 'should downcast to `type` attribute (numbered, decimal)', () => {
+					setData( model, modelList( `
+						# Foo {style:decimal}
+					` ) );
+
+					expect( editor.getData() ).to.equal( '<ol type="1"><li>Foo</li></ol>' );
+				} );
+
+				it( 'should downcast to `type` attribute (numbered, decimal-leading-zero)', () => {
+					setData( model, modelList( `
+						# Foo {style:decimal-leading-zero}
+					` ) );
+
+					expect( editor.getData() ).to.equal( '<ol><li>Foo</li></ol>' );
+				} );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-list/tests/documentlistproperties/documentlistpropertiesediting.js
+++ b/packages/ckeditor5-list/tests/documentlistproperties/documentlistpropertiesediting.js
@@ -65,6 +65,24 @@ describe( 'DocumentListPropertiesEditing', () => {
 			return editor.destroy();
 		} );
 
+		describe( 'command', () => {
+			it( 'should register `listStyle` command with support for all style types', () => {
+				const command = editor.commands.get( 'listStyle' );
+
+				expect( command.isStyleTypeSupported( 'disc' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'circle' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'square' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'decimal' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'decimal-leading-zero' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'lower-roman' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'upper-roman' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'lower-alpha' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'upper-alpha' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'lower-latin' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'upper-latin' ) ).to.be.true;
+			} );
+		} );
+
 		describe( 'schema rules', () => {
 			it( 'should allow set `listStyle` on the `paragraph`', () => {
 				expect( model.schema.checkAttribute( [ '$root', 'paragraph' ], 'listStyle' ) ).to.be.true;
@@ -361,6 +379,24 @@ describe( 'DocumentListPropertiesEditing', () => {
 			model = editor.model;
 
 			stubUid();
+		} );
+
+		describe( 'command', () => {
+			it( 'should register `listStyle` command with support for all style types except `decimal-leading-zero`', () => {
+				const command = editor.commands.get( 'listStyle' );
+
+				expect( command.isStyleTypeSupported( 'disc' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'circle' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'square' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'decimal' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'decimal-leading-zero' ) ).to.be.false;
+				expect( command.isStyleTypeSupported( 'lower-roman' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'upper-roman' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'lower-alpha' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'upper-alpha' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'lower-latin' ) ).to.be.true;
+				expect( command.isStyleTypeSupported( 'upper-latin' ) ).to.be.true;
+			} );
 		} );
 
 		describe( 'conversion', () => {

--- a/packages/ckeditor5-list/tests/documentlistproperties/documentliststylecommand.js
+++ b/packages/ckeditor5-list/tests/documentlistproperties/documentliststylecommand.js
@@ -516,4 +516,54 @@ describe( 'DocumentListStyleCommand', () => {
 			` ) );
 		} );
 	} );
+
+	describe( 'isStyleTypeSupported()', () => {
+		it( 'should return `true` for all styles provided in constructor', () => {
+			const editor = new Editor();
+			const listStyleCommand = new DocumentListStyleCommand( editor, 'default', [
+				'circle',
+				'decimal',
+				'upper-roman'
+			] );
+
+			expect( listStyleCommand.isStyleTypeSupported( 'circle' ) ).to.be.true;
+			expect( listStyleCommand.isStyleTypeSupported( 'decimal' ) ).to.be.true;
+			expect( listStyleCommand.isStyleTypeSupported( 'upper-roman' ) ).to.be.true;
+		} );
+
+		it( 'should return `false` for styles not provided in constructor', () => {
+			const editor = new Editor();
+			const listStyleCommand = new DocumentListStyleCommand( editor, 'default', [
+				'circle',
+				'decimal',
+				'upper-roman'
+			] );
+
+			expect( listStyleCommand.isStyleTypeSupported( 'disc' ) ).to.be.false;
+			expect( listStyleCommand.isStyleTypeSupported( 'square' ) ).to.be.false;
+			expect( listStyleCommand.isStyleTypeSupported( 'decimal-leading-zero' ) ).to.be.false;
+			expect( listStyleCommand.isStyleTypeSupported( 'lower-roman' ) ).to.be.false;
+			expect( listStyleCommand.isStyleTypeSupported( 'lower-alpha' ) ).to.be.false;
+			expect( listStyleCommand.isStyleTypeSupported( 'upper-alpha' ) ).to.be.false;
+			expect( listStyleCommand.isStyleTypeSupported( 'lower-latin' ) ).to.be.false;
+			expect( listStyleCommand.isStyleTypeSupported( 'upper-latin' ) ).to.be.false;
+		} );
+
+		it( 'should return `true` for all the styles by default', () => {
+			const editor = new Editor();
+			const listStyleCommand = new DocumentListStyleCommand( editor, 'default' );
+
+			expect( listStyleCommand.isStyleTypeSupported( 'disc' ) ).to.be.true;
+			expect( listStyleCommand.isStyleTypeSupported( 'circle' ) ).to.be.true;
+			expect( listStyleCommand.isStyleTypeSupported( 'square' ) ).to.be.true;
+			expect( listStyleCommand.isStyleTypeSupported( 'decimal' ) ).to.be.true;
+			expect( listStyleCommand.isStyleTypeSupported( 'decimal-leading-zero' ) ).to.be.true;
+			expect( listStyleCommand.isStyleTypeSupported( 'lower-roman' ) ).to.be.true;
+			expect( listStyleCommand.isStyleTypeSupported( 'upper-roman' ) ).to.be.true;
+			expect( listStyleCommand.isStyleTypeSupported( 'lower-alpha' ) ).to.be.true;
+			expect( listStyleCommand.isStyleTypeSupported( 'upper-alpha' ) ).to.be.true;
+			expect( listStyleCommand.isStyleTypeSupported( 'lower-latin' ) ).to.be.true;
+			expect( listStyleCommand.isStyleTypeSupported( 'upper-latin' ) ).to.be.true;
+		} );
+	} );
 } );

--- a/packages/ckeditor5-list/tests/documentlistproperties/utils/style.js
+++ b/packages/ckeditor5-list/tests/documentlistproperties/utils/style.js
@@ -3,7 +3,11 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import { getListTypeFromListStyleType } from '../../../src/documentlistproperties/utils/style';
+import {
+	getListTypeFromListStyleType,
+	getTypeAttributeFromListStyleType,
+	getListStyleTypeFromTypeAttribute
+} from '../../../src/documentlistproperties/utils/style';
 
 describe( 'DocumentListProperties - utils - style', () => {
 	describe( 'getListTypeFromListStyleType()', () => {
@@ -26,5 +30,45 @@ describe( 'DocumentListProperties - utils - style', () => {
 				expect( getListTypeFromListStyleType( style ) ).to.equal( type );
 			} );
 		}
+	} );
+
+	describe( 'converting between `style:list-style-type` and `type`', () => {
+		const testData = [
+			[ 'decimal', '1' ],
+			[ 'lower-roman', 'i' ],
+			[ 'upper-roman', 'I' ],
+			[ 'lower-alpha', 'a' ],
+			[ 'upper-alpha', 'A' ],
+			[ 'lower-latin', 'a' ],
+			[ 'upper-latin', 'A' ]
+		];
+
+		describe( 'getTypeAttributeFromListStyleType()', () => {
+			for ( const [ styleType, typeAttribute ] of testData ) {
+				it( `should return "${ typeAttribute }" for "${ styleType }" style`, () => {
+					expect( getTypeAttributeFromListStyleType( styleType ) ).to.equal( typeAttribute );
+				} );
+			}
+
+			it( 'should return null for "default" style', () => {
+				expect( getTypeAttributeFromListStyleType( 'default' ) ).to.be.null;
+			} );
+
+			it( 'should return null for unknown style', () => {
+				expect( getTypeAttributeFromListStyleType( 'strange-style' ) ).to.be.null;
+			} );
+		} );
+
+		describe( 'getListStyleTypeFromTypeAttribute()', () => {
+			for ( const [ styleType, typeAttribute ] of testData.filter( ( [ style ] ) => !style.endsWith( '-alpha' ) ) ) {
+				it( `should return "${ typeAttribute }" for "${ styleType }" attribute value`, () => {
+					expect( getListStyleTypeFromTypeAttribute( typeAttribute ) ).to.equal( styleType );
+				} );
+			}
+
+			it( 'should return null for unknown attribute value', () => {
+				expect( getListStyleTypeFromTypeAttribute( 'Q' ) ).to.be.null;
+			} );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
+++ b/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
@@ -242,6 +242,23 @@ describe( 'ListPropertiesUI', () => {
 					expect( buttonView.icon ).to.equal( listStyleSquareIcon );
 				} );
 
+				it( 'should only bring the style buttons supported by the command', () => {
+					return withEditor( { styles: true }, editor => {
+						const listStyleCommand = editor.commands.get( 'listStyle' );
+
+						listStyleCommand.isStyleTypeSupported = style => style == 'square';
+
+						const componentFactory = editor.ui.componentFactory;
+						const bulletedListDropdown = componentFactory.create( 'bulletedList' );
+						const listPropertiesView = bulletedListDropdown.panelView.children.first;
+						const stylesView = listPropertiesView.stylesView;
+
+						expect( stylesView.children.map( b => b.label ) ).to.deep.equal( [
+							'Toggle the square list style'
+						] );
+					} );
+				} );
+
 				it( 'should close the drop-down when any button gets executed', () => {
 					const spy = sinon.spy();
 
@@ -510,6 +527,26 @@ describe( 'ListPropertiesUI', () => {
 					expect( buttonView.label ).to.equal( 'Toggle the upper–latin list style' );
 					expect( buttonView.tooltip ).to.equal( 'Upper-latin' );
 					expect( buttonView.icon ).to.equal( listStyleUpperLatinIcon );
+				} );
+
+				it( 'should only bring the style buttons supported by the command', () => {
+					return withEditor( { styles: true }, editor => {
+						const listStyleCommand = editor.commands.get( 'listStyle' );
+
+						listStyleCommand.isStyleTypeSupported = style => style != 'lower-latin' && style != 'decimal';
+
+						const componentFactory = editor.ui.componentFactory;
+						const numberedListDropdown = componentFactory.create( 'numberedList' );
+						const listPropertiesView = numberedListDropdown.panelView.children.first;
+						const stylesView = listPropertiesView.stylesView;
+
+						expect( stylesView.children.map( b => b.label ) ).to.deep.equal( [
+							'Toggle the decimal with leading zero list style',
+							'Toggle the lower–roman list style',
+							'Toggle the upper–roman list style',
+							'Toggle the upper–latin list style'
+						] );
+					} );
 				} );
 
 				it( 'should close the drop-down when any button gets executed', () => {

--- a/packages/ckeditor5-list/tests/manual/documentlist-properties.html
+++ b/packages/ckeditor5-list/tests/manual/documentlist-properties.html
@@ -100,7 +100,26 @@
 
 <h2>Just styles</h2>
 
+<h3>Using "list-style-type" style</h3>
+
 <div id="editor-style">
+	<h3>Ordered list</h3>
+	<ol>
+		<li>First item</li>
+		<li>Second item</li>
+		<li>Third item</li>
+	</ol>
+	<h3>Unordered list</h3>
+	<ul>
+		<li>First item</li>
+		<li>Second item</li>
+		<li>Third item</li>
+	</ul>
+</div>
+
+<h3>Using "type" attribute</h3>
+
+<div id="editor-style-attribute">
 	<h3>Ordered list</h3>
 	<ol>
 		<li>First item</li>

--- a/packages/ckeditor5-list/tests/manual/documentlist-properties.js
+++ b/packages/ckeditor5-list/tests/manual/documentlist-properties.js
@@ -162,6 +162,12 @@ createEditor( 'style', {
 	reversed: false
 } );
 
+createEditor( 'style-attribute', {
+	styles: { useAttribute: true },
+	startIndex: false,
+	reversed: false
+} );
+
 createEditor( 'none', {
 	styles: false,
 	startIndex: false,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (list): Adds support for `type` attribute of `<ul>` and `<ol>` elements in addition to `list-style-type` style. Closes #11615.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._