### PR TITLE
Skip paste from office for code block parent

### DIFF
--- a/packages/ckeditor5-paste-from-office/package.json
+++ b/packages/ckeditor5-paste-from-office/package.json
@@ -18,6 +18,7 @@
     "@ckeditor/ckeditor5-basic-styles": "^34.0.0",
     "@ckeditor/ckeditor5-clipboard": "^34.0.0",
     "@ckeditor/ckeditor5-cloud-services": "^34.0.0",
+    "@ckeditor/ckeditor5-code-block": "^34.0.0",
     "@ckeditor/ckeditor5-core": "^34.0.0",
     "@ckeditor/ckeditor5-dev-utils": "^30.0.0",
     "@ckeditor/ckeditor5-easy-image": "^34.0.0",

--- a/packages/ckeditor5-paste-from-office/src/pastefromoffice.js
+++ b/packages/ckeditor5-paste-from-office/src/pastefromoffice.js
@@ -63,6 +63,11 @@ export default class PasteFromOffice extends Plugin {
 					return;
 				}
 
+				const codeBlock = editor.model.document.selection.getFirstPosition().parent;
+				if ( codeBlock.is( 'element', 'codeBlock' ) ) {
+					return;
+				}
+
 				const htmlString = data.dataTransfer.getData( 'text/html' );
 				const activeNormalizer = normalizers.find( normalizer => normalizer.isActive( htmlString ) );
 

--- a/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
+++ b/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
@@ -5,7 +5,7 @@
 
 import PasteFromOffice from '../src/pastefromoffice';
 import ClipboardPipeline from '@ckeditor/ckeditor5-clipboard/src/clipboardpipeline';
-import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
 import { createDataTransfer } from './_utils/utils';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
@@ -13,22 +13,35 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import { StylesProcessor } from '@ckeditor/ckeditor5-engine/src/view/stylesmap';
 import ViewDocument from '@ckeditor/ckeditor5-engine/src/view/document';
 import ViewDocumentFragment from '@ckeditor/ckeditor5-engine/src/view/documentfragment';
+import CodeBlockUI from '@ckeditor/ckeditor5-code-block/src/codeblockui';
+import CodeBlockEditing from '@ckeditor/ckeditor5-code-block/src/codeblockediting';
+import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+
+/* global document */
 
 describe( 'PasteFromOffice', () => {
 	const htmlDataProcessor = new HtmlDataProcessor( new ViewDocument( new StylesProcessor() ) );
-	let editor, pasteFromOffice, clipboard;
+	let editor, pasteFromOffice, clipboard, element;
 
 	testUtils.createSinonSandbox();
 
 	beforeEach( () => {
-		return VirtualTestEditor.create( {
-			plugins: [ PasteFromOffice, Paragraph ]
+		element = document.createElement( 'div' );
+		document.body.appendChild( element );
+		return ClassicTestEditor.create( element, {
+			plugins: [ PasteFromOffice, Paragraph, CodeBlockEditing, CodeBlockUI ]
 		} )
 			.then( _editor => {
 				editor = _editor;
 				pasteFromOffice = editor.plugins.get( 'PasteFromOffice' );
 				clipboard = editor.plugins.get( 'ClipboardPipeline' );
 			} );
+	} );
+
+	afterEach( () => {
+		element.remove();
+
+		return editor.destroy();
 	} );
 
 	it( 'should be loaded', () => {
@@ -81,6 +94,20 @@ describe( 'PasteFromOffice', () => {
 
 			it( 'should process data with similar headers to MS Word', () => {
 				checkNotProcessedData( '<meta name=Generator content="Other">' );
+			} );
+
+			it( 'should process data for codeBlock', () => {
+				setModelData( editor.model, '<codeBlock language="plaintext">[]</codeBlock>' );
+
+				const data = setUpData( '<p id="docs-internal-guid-12345678-1234-1234-1234-1234567890ab"></p>' );
+				const getDataSpy = sinon.spy( data.dataTransfer, 'getData' );
+
+				clipboard.fire( 'inputTransformation', data );
+
+				expect( data._isTransformedWithPasteFromOffice ).to.be.undefined;
+				expect( data._parsedData ).to.be.undefined;
+
+				sinon.assert.notCalled( getDataSpy );
 			} );
 
 			function checkNotProcessedData( inputString ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (paste-from-office): When you paste multiple lines from a google doc into a code block, the text is not added to the code block.

Obverse the bug with [the full featured editor demo](https://ckeditor.com/docs/ckeditor5/latest/examples/builds-custom/full-featured-editor.html.):
1. Highlight the first paragraph.
<img width="944" alt="Screen Shot 2022-05-06 at 4 10 31 PM" src="https://user-images.githubusercontent.com/5459594/167222547-c7e8f0aa-44f0-4568-a175-0d6fcbeaa57e.png">

2. Then click the "Code Block" button to make the paragraph a code block.
<img width="812" alt="Screen Shot 2022-05-06 at 4 13 48 PM" src="https://user-images.githubusercontent.com/5459594/167222884-2973cda8-fb39-43cd-8f99-0c0a0f616184.png">

3. Now make a Google Doc with a few lines of text. Or you can use [mine](https://docs.google.com/document/d/1nzeofDmDDXmuD4bv7wOktYcK0i37XpeWpbKfFu9BB6E/edit) if you'd like.
<img width="812" alt="Screen Shot 2022-05-06 at 4 14 09 PM" src="https://user-images.githubusercontent.com/5459594/167222894-77b7154e-063c-43ce-9725-6f8ae1430184.png">

4. Copy the lines from the Google Doc.
<img width="446" alt="Screen Shot 2022-05-06 at 4 13 15 PM" src="https://user-images.githubusercontent.com/5459594/167222797-66cbd008-d796-44f7-8e91-5245c0ffaf4a.png">

5. Paste them into the code block. See that the first line is added to the code block, but not the others.
<img width="814" alt="Screen Shot 2022-05-06 at 4 14 02 PM" src="https://user-images.githubusercontent.com/5459594/167222899-63497a96-53b2-433f-b936-b1a598c818fc.png">

---

### Additional information

You can see that the new test called "should process data for codeBlock" will fail when you comment out the fix. 