### PR TITLE
Brought back setter for model.Document#version

### DIFF
--- a/packages/ckeditor5-engine/src/model/document.js
+++ b/packages/ckeditor5-engine/src/model/document.js
@@ -153,15 +153,14 @@ export default class Document {
 	}
 
 	/**
-     * The document version. Every applied operation increases the version number. It is used to
-     * ensure that operations are applied on a proper document version.
-     *
-     * This property is equal to the {@link module:engine/model/history~History#version `model.Document#history#version`}.
-     *
-     * If the {@link module:engine/model/operation/operation~Operation#baseVersion base version} does not match the document version,
-     * a {@link module:utils/ckeditorerror~CKEditorError model-document-applyoperation-wrong-version} error is thrown.
+	 * The document version. Every applied operation increases the version number. It is used to
+	 * ensure that operations are applied on a proper document version.
 	 *
-	 * @readonly
+	 * This property is equal to {@link module:engine/model/history~History#version `model.Document#history#version`}.
+	 *
+	 * If the {@link module:engine/model/operation/operation~Operation#baseVersion base version} does not match the document version,
+	 * a {@link module:utils/ckeditorerror~CKEditorError model-document-applyoperation-wrong-version} error is thrown.
+	 *
 	 * @type {Number}
 	 */
 	get version() {

--- a/packages/ckeditor5-engine/src/model/document.js
+++ b/packages/ckeditor5-engine/src/model/document.js
@@ -168,6 +168,10 @@ export default class Document {
 		return this.history.version;
 	}
 
+	set version( version ) {
+		this.history.version = version;
+	}
+
 	/**
 	 * The graveyard tree root. A document always has a graveyard root that stores removed nodes.
 	 *

--- a/packages/ckeditor5-engine/tests/model/document.js
+++ b/packages/ckeditor5-engine/tests/model/document.js
@@ -96,6 +96,20 @@ describe( 'Document', () => {
 		} );
 	} );
 
+	describe( '#version', () => {
+		it( 'should equal to document.history.version', () => {
+			model.document.history.version = 20;
+
+			expect( model.document.version ).to.equal( 20 );
+		} );
+
+		it( 'should set document.history.version', () => {
+			model.document.version = 20;
+
+			expect( model.document.history.version ).to.equal( 20 );
+		} );
+	} );
+
 	describe( 'getRootNames()', () => {
 		it( 'should return empty iterator if no roots exist', () => {
 			expect( count( doc.getRootNames() ) ).to.equal( 0 );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (engine): Brought back setter for \`model.Document#version\`.

---

### Additional information

The setter was removed when working on #11226. However, it was a breaking change for cloud services.