### PR TITLE
Improve editor-is-readonly-has-no-setter error message.

### DIFF
--- a/packages/ckeditor5-core/src/editor/editor.js
+++ b/packages/ckeditor5-core/src/editor/editor.js
@@ -246,8 +246,19 @@ export default class Editor {
 
 	set isReadOnly( value ) {
 		/**
-		 * `Editor#isReadOnly` does not have a setter and should be set using `Editor#enableReadOnlyMode( lockId )` and
-		 * `Editor#disableReadOnlyMode( lockId )`.
+		 * {@link #isReadOnly Editor#isReadOnly} property is read-only since the version 34.0.0 and can be set only using
+		 * {@link #enableReadOnlyMode Editor#enableReadOnlyMode( lockId )} and
+		 * {@link #disableReadOnlyMode Editor#disableReadOnlyMode( lockId )}.
+		 *
+		 * Before the version 34.0.0:
+		 *
+		 *		editor.isReadOnly = true;
+		 * 		editor.isReadOnly = false;
+		 *
+		 * Since the version 34.0.0:
+		 *
+		 *		editor.enableReadOnlyMode( 'my-feature-id' );
+		 * 		editor.disableReadOnlyMode( 'my-feature-id' );
 		 *
 		 * @error editor-isreadonly-has-no-setter
 		 */

--- a/packages/ckeditor5-core/src/editor/editor.js
+++ b/packages/ckeditor5-core/src/editor/editor.js
@@ -246,16 +246,16 @@ export default class Editor {
 
 	set isReadOnly( value ) {
 		/**
-		 * {@link #isReadOnly Editor#isReadOnly} property is read-only since the version 34.0.0 and can be set only using
-		 * {@link #enableReadOnlyMode Editor#enableReadOnlyMode( lockId )} and
-		 * {@link #disableReadOnlyMode Editor#disableReadOnlyMode( lockId )}.
+		 * {@link #isReadOnly Editor#isReadOnly} property is read-only since version `34.0.0` and can be set only using
+		 * {@link #enableReadOnlyMode `Editor#enableReadOnlyMode( lockId )`} and
+		 * {@link #disableReadOnlyMode `Editor#disableReadOnlyMode( lockId )`}.
 		 *
-		 * Before the version 34.0.0:
+		 * Before version `34.0.0`:
 		 *
 		 *		editor.isReadOnly = true;
 		 * 		editor.isReadOnly = false;
 		 *
-		 * Since the version 34.0.0:
+		 * Since version `34.0.0`:
 		 *
 		 *		editor.enableReadOnlyMode( 'my-feature-id' );
 		 * 		editor.disableReadOnlyMode( 'my-feature-id' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (core): Improved an error message when trying to set the editor in read-only mode by using `Editor#isReadOnly` setter. Closes #11695.

---

### Additional information

How it looks now

![obraz](https://user-images.githubusercontent.com/34556745/168831612-d8c50ec0-b321-463c-ba19-0e5845f6326f.png)

