### PR TITLE
Removed the `#resolutions` definitions from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,13 +170,6 @@
     "dll:build": "node ./scripts/dll/build-dlls.js",
     "check-dependencies": "ckeditor5-dev-tests-check-dependencies"
   },
-  "resolutions": {
-    "eslint-config-ckeditor5": "^4.0.0",
-    "karma-coverage": "2.1.0",
-    "postcss": "^8.0.0",
-    "postcss-loader": "^4.0.0",
-    "socket.io-client": "^4"
-  },
   "lint-staged": {
     "**/*.js": [
       "eslint --quiet"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Removed the `#resolutions` definitions from `package.json`.

---

### Additional information

Perhaps the `karma-coverage` package must be specified (see: https://github.com/ckeditor/ckeditor5/pull/11225). Let's see what CI thinks about these changes.
