### PR TITLE
Docs: unifying predefined builds naming.

### DIFF
--- a/docs/installation/frameworks/overview.md
+++ b/docs/installation/frameworks/overview.md
@@ -22,7 +22,7 @@ When checking how to integrate CKEditor 5 with your framework you can follow the
 2. **If not, search for community-driven integrations.** Most of them are available on [npm](https://www.npmjs.com/).
 3. **If none exists, integrate CKEditor 5 with your framework by yourself.**
 
-	CKEditor 5 offers {@link installation/advanced/predefined-builds ready-to-use builds} that expose a {@link installation/getting-started/basic-api rich JavaScript API} which you can use to {@link installation/getting-started/basic-api#creating-an-editor create editors} and {@link installation/getting-started/basic-api#interacting-with-the-editor control them}.
+	CKEditor 5 offers {@link installation/advanced/predefined-builds predefined builds} that expose a {@link installation/getting-started/basic-api rich JavaScript API} which you can use to {@link installation/getting-started/basic-api#creating-an-editor create editors} and {@link installation/getting-started/basic-api#interacting-with-the-editor control them}.
 
 ## Official WYSIWYG editor integrations
 

--- a/docs/installation/frameworks/react.md
+++ b/docs/installation/frameworks/react.md
@@ -564,7 +564,7 @@ You can read more about using CKEditor 5 from source in the {@link installation/
 
 CKEditor 5 supports {@link features/ui-language multiple UI languages}, and so does the official React component. Follow the instructions below to translate CKEditor 5 in your React application.
 
-### Ready-to-use builds
+### Predefined builds
 
 When using one of the {@link installation/advanced/predefined-builds#available-builds official editor builds} or the editor built by the [online builder](https://ckeditor.com/ckeditor-5/online-builder/), you need to import the translations first:
 

--- a/docs/installation/frameworks/vuejs-v2.md
+++ b/docs/installation/frameworks/vuejs-v2.md
@@ -460,7 +460,7 @@ Since accessing the editor toolbar is not possible until after the editor instan
 
 CKEditor 5 supports {@link features/ui-language multiple UI languages}, and so does the official Vue.js component. Follow the instructions below to translate CKEditor 5 in your Vue.js application.
 
-### Ready-to-use builds
+### Predefined builds
 
 When using one of the {@link installation/advanced/predefined-builds#available-builds official editor builds}, you need to import the translations first.
 

--- a/docs/installation/frameworks/vuejs-v3.md
+++ b/docs/installation/frameworks/vuejs-v3.md
@@ -460,7 +460,7 @@ Since accessing the editor toolbar is not possible until after the editor instan
 
 CKEditor 5 supports {@link features/ui-language multiple UI languages}, and so does the official Vue.js component. Follow the instructions below to translate CKEditor 5 in your Vue.js application.
 
-### Ready-to-use builds
+### Predefined builds
 
 When using one of the {@link installation/advanced/predefined-builds#available-builds official editor builds}, you need to import the translations first.
 

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -87,7 +87,7 @@ The {@link features/images-overview Image} and {@link features/image-upload Imag
 
 For the full list of official integrations see the {@link installation/frameworks/overview#official-wysiwyg-editor-integrations "Official integrations"} section.
 
-If an official integration for the framework of your choice does not exist yet, make sure to read the {@link installation/frameworks/overview "Integrating CKEditor 5 with JavaScript frameworks"} guide. CKEditor 5 offers a rich JavaScript API and ready-to-use builds that make it possible to use CKEditor 5 with whichever framework you need.
+If an official integration for the framework of your choice does not exist yet, make sure to read the {@link installation/frameworks/overview "Integrating CKEditor 5 with JavaScript frameworks"} guide. CKEditor 5 offers a rich JavaScript API and predefined builds that make it possible to use CKEditor 5 with whichever framework you need.
 
 We plan to provide more official integrations with time. [Your feedback on what should we work on next](https://github.com/ckeditor/ckeditor5/issues/1002) will be most welcome!
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: changing the ready-to-use to predefined builds in docs. Closes #11827

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._