### PR TITLE
Added support for handling specified packages when downloading or uploading translations

### DIFF
--- a/scripts/translations/download.js
+++ b/scripts/translations/download.js
@@ -24,6 +24,12 @@ async function main() {
 	const options = parseArguments( process.argv.slice( 2 ) );
 	const packages = getCKEditor5PackageNames( 'download', options );
 
+	if ( packages.length === 0 ) {
+		console.log( 'No package has been found.' );
+
+		return;
+	}
+
 	return downloadTranslations( {
 		// Token used for authentication with the Transifex service.
 		token: await getToken(),

--- a/scripts/translations/upload.js
+++ b/scripts/translations/upload.js
@@ -29,6 +29,12 @@ async function main() {
 			return fs.existsSync( normalizePath( options.cwd, relativePath ) );
 		} );
 
+	if ( packages.length === 0 ) {
+		console.log( 'No package has been found.' );
+
+		return;
+	}
+
 	return uploadPotFiles( {
 		// Token used for authentication with the Transifex service.
 		token: await getToken(),


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Added support for handling specified packages when downloading or uploading translations by providing the `--packages` argument. Closes #11570.

---

### Additional information

The `--packages` support has been added for downloading and uploading translations.
