### PR TITLE
Added missing tooltip for split button's down arrow

### DIFF
--- a/packages/ckeditor5-code-block/src/codeblockui.js
+++ b/packages/ckeditor5-code-block/src/codeblockui.js
@@ -44,12 +44,18 @@ export default class CodeBlockUI extends Plugin {
 			const command = editor.commands.get( 'codeBlock' );
 			const dropdownView = createDropdown( locale, SplitButtonView );
 			const splitButtonView = dropdownView.buttonView;
+			const splitButtonViewArrow = dropdownView.buttonView.arrowView;
 
 			splitButtonView.set( {
 				label: t( 'Insert code block' ),
 				tooltip: true,
 				icon: codeBlockIcon,
 				isToggleable: true
+			} );
+
+			splitButtonViewArrow.set( {
+				label: t( 'Insert code block' ),
+				tooltip: true
 			} );
 
 			splitButtonView.bind( 'isOn' ).to( command, 'value', value => !!value );

--- a/packages/ckeditor5-code-block/tests/codeblockui.js
+++ b/packages/ckeditor5-code-block/tests/codeblockui.js
@@ -197,6 +197,14 @@ describe( 'CodeBlockUI', () => {
 				expect( button ).to.have.property( 'isToggleable', true );
 			} );
 
+			it( 'and it\'s arrow has the base properties', () => {
+				const dropdown = editor.ui.componentFactory.create( 'codeBlock' );
+				const buttonArrow = dropdown.buttonView.arrowView;
+
+				expect( buttonArrow ).to.have.property( 'label', 'Insert code block' );
+				expect( buttonArrow ).to.have.property( 'tooltip', true );
+			} );
+
 			it( 'has #isOn bound to command\'s value', () => {
 				const dropdown = editor.ui.componentFactory.create( 'codeBlock' );
 				const button = dropdown.buttonView;

--- a/packages/ckeditor5-highlight/src/highlightui.js
+++ b/packages/ckeditor5-highlight/src/highlightui.js
@@ -183,7 +183,8 @@ export default class HighlightUI extends Plugin {
 			const splitButtonViewArrow = dropdownView.buttonView.arrowView;
 
 			splitButtonView.set( {
-				tooltip: t( 'Highlight' ),
+				label: t( 'Highlight' ),
+				tooltip: true,
 				// Holds last executed highlighter.
 				lastExecuted: startingHighlighter.model,
 				// Holds current highlighter to execute (might be different then last used).
@@ -192,7 +193,8 @@ export default class HighlightUI extends Plugin {
 			} );
 
 			splitButtonViewArrow.set( {
-				tooltip: t( 'Highlight' )
+				label: t( 'Highlight' ),
+				tooltip: true
 			} );
 
 			// Dropdown button changes to selection (command.value):

--- a/packages/ckeditor5-highlight/src/highlightui.js
+++ b/packages/ckeditor5-highlight/src/highlightui.js
@@ -180,6 +180,7 @@ export default class HighlightUI extends Plugin {
 			const command = editor.commands.get( 'highlight' );
 			const dropdownView = createDropdown( locale, SplitButtonView );
 			const splitButtonView = dropdownView.buttonView;
+			const splitButtonViewArrow = dropdownView.buttonView.arrowView;
 
 			splitButtonView.set( {
 				tooltip: t( 'Highlight' ),
@@ -188,6 +189,10 @@ export default class HighlightUI extends Plugin {
 				// Holds current highlighter to execute (might be different then last used).
 				commandValue: startingHighlighter.model,
 				isToggleable: true
+			} );
+
+			splitButtonViewArrow.set( {
+				tooltip: t( 'Highlight' )
 			} );
 
 			// Dropdown button changes to selection (command.value):

--- a/packages/ckeditor5-highlight/tests/highlightui.js
+++ b/packages/ckeditor5-highlight/tests/highlightui.js
@@ -78,7 +78,8 @@ describe( 'HighlightUI', () => {
 		it( 'button has the base properties', () => {
 			const button = dropdown.buttonView;
 
-			expect( button ).to.have.property( 'tooltip', 'Highlight' );
+			expect( button ).to.have.property( 'label', 'Highlight' );
+			expect( button ).to.have.property( 'tooltip', true );
 			expect( button ).to.have.property( 'icon', markerIcon );
 			expect( button ).to.have.property( 'isToggleable', true );
 		} );
@@ -86,7 +87,8 @@ describe( 'HighlightUI', () => {
 		it( 'button arrow has the base properties', () => {
 			const button = dropdown.buttonView.arrowView;
 
-			expect( button ).to.have.property( 'tooltip', 'Highlight' );
+			expect( button ).to.have.property( 'label', 'Highlight' );
+			expect( button ).to.have.property( 'tooltip', true );
 		} );
 
 		it( 'toolbar nas the basic properties', () => {
@@ -214,7 +216,7 @@ describe( 'HighlightUI', () => {
 			it( 'works for the #buttonView', () => {
 				const buttonView = dropdown.buttonView;
 
-				expect( buttonView.tooltip ).to.equal( 'Zakreślacz' );
+				expect( buttonView.label ).to.equal( 'Zakreślacz' );
 			} );
 
 			it( 'works for the listView#items in the panel', () => {

--- a/packages/ckeditor5-highlight/tests/highlightui.js
+++ b/packages/ckeditor5-highlight/tests/highlightui.js
@@ -83,6 +83,12 @@ describe( 'HighlightUI', () => {
 			expect( button ).to.have.property( 'isToggleable', true );
 		} );
 
+		it( 'button arrow has the base properties', () => {
+			const button = dropdown.buttonView.arrowView;
+
+			expect( button ).to.have.property( 'tooltip', 'Highlight' );
+		} );
+
 		it( 'toolbar nas the basic properties', () => {
 			const toolbarView = dropdown.toolbarView;
 

--- a/packages/ckeditor5-image/src/imageinsert/ui/imageinsertpanelview.js
+++ b/packages/ckeditor5-image/src/imageinsert/ui/imageinsertpanelview.js
@@ -235,11 +235,17 @@ export default class ImageInsertPanelView extends View {
 		const t = locale.t;
 		const dropdownView = createDropdown( locale, SplitButtonView );
 		const splitButtonView = dropdownView.buttonView;
+		const splitButtonViewArrow = dropdownView.buttonView.arrowView;
 		const panelView = dropdownView.panelView;
 
 		splitButtonView.set( {
 			label: t( 'Insert image' ),
 			icon: icons.image,
+			tooltip: true
+		} );
+
+		splitButtonViewArrow.set( {
+			label: t( 'Insert image' ),
 			tooltip: true
 		} );
 

--- a/packages/ckeditor5-image/src/imagestyle/imagestyleui.js
+++ b/packages/ckeditor5-image/src/imagestyle/imagestyleui.js
@@ -129,12 +129,18 @@ export default class ImageStyleUI extends Plugin {
 
 			const dropdownView = createDropdown( locale, SplitButtonView );
 			const splitButtonView = dropdownView.buttonView;
+			const splitButtonViewArrow = dropdownView.buttonView.arrowView;
 
 			addToolbarToDropdown( dropdownView, buttonViews );
 
 			splitButtonView.set( {
 				label: getDropdownButtonTitle( title, defaultButton.label ),
 				class: null,
+				tooltip: true
+			} );
+
+			splitButtonViewArrow.set( {
+				label: getDropdownButtonTitle( title, defaultButton.label ),
 				tooltip: true
 			} );
 

--- a/packages/ckeditor5-image/tests/imageinsert/imageinsertui.js
+++ b/packages/ckeditor5-image/tests/imageinsert/imageinsertui.js
@@ -74,10 +74,26 @@ describe( 'ImageInsertUI', () => {
 			return editor.destroy();
 		} );
 
-		it( 'should register the "insertImage" dropdown', () => {
-			const dropdown = editor.ui.componentFactory.create( 'insertImage' );
+		describe( 'should register the "insertImage" dropdown', () => {
+			it( 'button with proper properties set', () => {
+				expect( dropdown ).to.be.instanceOf( DropdownView );
 
-			expect( dropdown ).to.be.instanceOf( DropdownView );
+				const button = dropdown.buttonView;
+
+				expect( button.isOn ).to.be.false;
+				expect( button.tooltip ).to.be.true;
+				expect( button.label ).to.equal( 'Insert image' );
+				expect( button.icon ).to.match( /<svg / );
+			} );
+
+			it( 'button arrow with proper properties set', () => {
+				expect( dropdown ).to.be.instanceOf( DropdownView );
+
+				const buttonArrow = dropdown.buttonView.arrowView;
+
+				expect( buttonArrow.tooltip ).to.be.true;
+				expect( buttonArrow.label ).to.equal( 'Insert image' );
+			} );
 		} );
 
 		it( 'should register "imageInsert" dropdown as an alias for the "insertImage" dropdown', () => {

--- a/packages/ckeditor5-image/tests/imagestyle/imagestyleui.js
+++ b/packages/ckeditor5-image/tests/imagestyle/imagestyleui.js
@@ -248,6 +248,9 @@ describe( 'ImageStyleUI', () => {
 				expect( buttonView.tooltip ).to.be.true;
 				expect( buttonView.class ).to.be.null;
 
+				expect( buttonView.arrowView.label ).to.equal( ( config.title ? `${ config.title }: ` : '' ) + defaultItem.title );
+				expect( buttonView.arrowView.tooltip ).to.be.true;
+
 				expect( view.toolbarView.items ).to.have.lengthOf( config.items.length );
 
 				view.toolbarView.items.map( item => {

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.js
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.js
@@ -155,6 +155,7 @@ function getDropdownViewCreator( { editor, parentCommandName, buttonLabel, butto
 	return locale => {
 		const dropdownView = createDropdown( locale, SplitButtonView );
 		const mainButtonView = dropdownView.buttonView;
+		const mainButtonViewArrow = dropdownView.buttonView.arrowView;
 
 		dropdownView.bind( 'isEnabled' ).to( parentCommand );
 		dropdownView.class = 'ck-list-styles-dropdown';
@@ -170,6 +171,11 @@ function getDropdownViewCreator( { editor, parentCommandName, buttonLabel, butto
 			icon: buttonIcon,
 			tooltip: true,
 			isToggleable: true
+		} );
+
+		mainButtonViewArrow.set( {
+			label: buttonLabel,
+			tooltip: true
 		} );
 
 		mainButtonView.bind( 'isOn' ).to( parentCommand, 'value', value => !!value );

--- a/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
+++ b/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
@@ -207,6 +207,22 @@ describe( 'ListPropertiesUI', () => {
 				} );
 			} );
 
+			describe( 'main split button arrow', () => {
+				let mainButtonViewArrow;
+
+				beforeEach( () => {
+					mainButtonViewArrow = bulletedListDropdown.buttonView.arrowView;
+				} );
+
+				it( 'should have a #label', () => {
+					expect( mainButtonViewArrow.label ).to.equal( 'Bulleted List' );
+				} );
+
+				it( 'should have a #tooltip based on a label', () => {
+					expect( mainButtonViewArrow.tooltip ).to.be.true;
+				} );
+			} );
+
 			describe( 'grid with style buttons', () => {
 				let stylesView;
 

--- a/packages/ckeditor5-table/src/tableui.js
+++ b/packages/ckeditor5-table/src/tableui.js
@@ -291,6 +291,11 @@ export default class TableUI extends Plugin {
 			isEnabled: true
 		} );
 
+		dropdownView.buttonView.arrowView.set( {
+			label,
+			tooltip: true
+		} );
+
 		// Make dropdown button disabled when all options are disabled together with the main command.
 		dropdownView.bind( 'isEnabled' ).toMany( [ mergeCommand, ...commands ], 'isEnabled', ( ...areEnabled ) => {
 			return areEnabled.some( isEnabled => isEnabled );

--- a/packages/ckeditor5-table/tests/tableui.js
+++ b/packages/ckeditor5-table/tests/tableui.js
@@ -382,6 +382,15 @@ describe( 'TableUI', () => {
 			expect( button.icon ).to.match( /<svg / );
 		} );
 
+		it( 'have button arrow with proper properties set', () => {
+			expect( dropdown ).to.be.instanceOf( DropdownView );
+
+			const buttonArrow = dropdown.buttonView.arrowView;
+
+			expect( buttonArrow.tooltip ).to.be.true;
+			expect( buttonArrow.label ).to.equal( 'Merge cells' );
+		} );
+
 		it( 'should have a split button', () => {
 			expect( dropdown.buttonView ).to.be.instanceOf( SplitButtonView );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (accessibility): Added a separate label for the dropdown arrow. Closes #11833.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._