### PR TITLE
Fix (ckeditor5-table): Removed dom emitter listeners on plugin destroy. Closes #11870

### DIFF
--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -111,6 +111,14 @@ export default class TableColumnResizeEditing extends Plugin {
 		 * @member {Map}
 		 */
 		this._cellsModified = new Map();
+
+		/**
+		 * DOM emitter.
+		 *
+		 * @private
+		 * @type {DomEmitterMixin}
+		 */
+		this._domEmitter = Object.create( DomEmitterMixin );
 	}
 
 	/**
@@ -132,6 +140,14 @@ export default class TableColumnResizeEditing extends Plugin {
 			columnResizePlugin, 'isEnabled',
 			( isEditorReadOnly, isPluginEnabled ) => !isEditorReadOnly && isPluginEnabled
 		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	destroy() {
+		this._domEmitter.stopListening();
+		super.destroy();
 	}
 
 	/**
@@ -456,10 +472,8 @@ export default class TableColumnResizeEditing extends Plugin {
 		editingView.addObserver( MouseEventsObserver );
 		editingView.document.on( 'mousedown', this._onMouseDownHandler.bind( this ), { priority: 'high' } );
 
-		const domEmitter = Object.create( DomEmitterMixin );
-
-		domEmitter.listenTo( global.window.document, 'mouseup', this._onMouseUpHandler.bind( this ) );
-		domEmitter.listenTo( global.window.document, 'mousemove', throttle( this._onMouseMoveHandler.bind( this ), 50 ) );
+		this._domEmitter.listenTo( global.window.document, 'mouseup', this._onMouseUpHandler.bind( this ) );
+		this._domEmitter.listenTo( global.window.document, 'mousemove', throttle( this._onMouseMoveHandler.bind( this ), 50 ) );
 	}
 
 	/**


### PR DESCRIPTION


### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (ckeditor5-table): Removed dom emitter listeners on plugin destroy. Closes #11870.

---

### Additional information

Adds DomEmitterMixin instance to a private property on the `TableColumnResize` plugin then calls `stopListening()` when the plugin is destroyed to prevent a memory leak.
