### PR TITLE
Enabled toolbar focus in source editing mode

### DIFF
--- a/packages/ckeditor5-source-editing/src/sourceediting.js
+++ b/packages/ckeditor5-source-editing/src/sourceediting.js
@@ -278,36 +278,34 @@ export default class SourceEditing extends Plugin {
 			this._dataFromRoots.set( rootName, data );
 		}
 
-		if ( document.querySelector( '.ck-source-editing-area > textarea' ) ) {
-			const textarea = document.querySelector( '.ck-source-editing-area > textarea' );
-			const toolbar = editor.ui.view.toolbar;
+		const textarea = document.querySelector( '.ck-source-editing-area > textarea' );
+		const toolbar = editor.ui.view.toolbar;
 
-			// Start listening for the keystrokes coming from the textarea.
-			this._keystrokes.listenTo( textarea );
+		// Start listening for the keystrokes coming from the textarea.
+		this._keystrokes.listenTo( textarea );
 
-			if ( toolbar ) {
-				this._focusTracker.add( toolbar.element );
-				this._focusTracker.add( textarea );
+		if ( toolbar ) {
+			this._focusTracker.add( toolbar.element );
+			this._focusTracker.add( textarea );
 
-				// Listen for the keystrokes coming from the editor's toolbar.
-				this._keystrokes.listenTo( toolbar.element );
+			// Listen for the keystrokes coming from the editor's toolbar.
+			this._keystrokes.listenTo( toolbar.element );
 
-				this._keystrokes.set( 'Alt+F10', ( data, cancel ) => {
-					if ( this._focusTracker.isFocused && !toolbar.focusTracker.isFocused ) {
-						toolbar.focus();
+			this._keystrokes.set( 'Alt+F10', ( data, cancel ) => {
+				if ( this._focusTracker.isFocused && !toolbar.focusTracker.isFocused ) {
+					toolbar.focus();
 
-						cancel();
-					}
-				} );
+					cancel();
+				}
+			} );
 
-				this._keystrokes.set( 'Esc', ( data, cancel ) => {
-					if ( toolbar.focusTracker.isFocused ) {
-						textarea.focus();
+			this._keystrokes.set( 'Esc', ( data, cancel ) => {
+				if ( toolbar.focusTracker.isFocused ) {
+					textarea.focus();
 
-						cancel();
-					}
-				} );
-			}
+					cancel();
+				}
+			} );
 		}
 		this._focusSourceEditing();
 	}

--- a/packages/ckeditor5-source-editing/src/sourceediting.js
+++ b/packages/ckeditor5-source-editing/src/sourceediting.js
@@ -269,13 +269,13 @@ export default class SourceEditing extends Plugin {
 			const textarea = document.querySelector( '.ck-source-editing-area > textarea' );
 			const toolbar = editor.ui.view.toolbar;
 
-			// Start listening for the keystrokes coming from the textarea and the toolbar.
+			// Start listening for the keystrokes coming from the textarea.
 			this._keystrokes.listenTo( textarea );
-			if ( document.querySelector( '.ck.ck-toolbar.ck-toolbar_grouping' ) ) {
-				this._keystrokes.listenTo( document.querySelector( '.ck.ck-toolbar.ck-toolbar_grouping' ) );
-			}
 
 			if ( toolbar ) {
+				// Listen for the keystrokes coming from the editor's toolbar.
+				this._keystrokes.listenTo( toolbar.element );
+
 				this._keystrokes.set( 'Alt+F10', ( data, cancel ) => {
 					if ( document.activeElement === textarea && !toolbar.focusTracker.isFocused ) {
 						toolbar.focus();

--- a/packages/ckeditor5-source-editing/src/sourceediting.js
+++ b/packages/ckeditor5-source-editing/src/sourceediting.js
@@ -285,16 +285,17 @@ export default class SourceEditing extends Plugin {
 			// Start listening for the keystrokes coming from the textarea.
 			this._keystrokes.listenTo( textarea );
 
-			this._focusTracker.add( toolbar.element );
-			this._focusTracker.add( textarea );
-
 			if ( toolbar ) {
+				this._focusTracker.add( toolbar.element );
+				this._focusTracker.add( textarea );
+
 				// Listen for the keystrokes coming from the editor's toolbar.
 				this._keystrokes.listenTo( toolbar.element );
 
 				this._keystrokes.set( 'Alt+F10', ( data, cancel ) => {
 					if ( this._focusTracker.isFocused && !toolbar.focusTracker.isFocused ) {
 						toolbar.focus();
+
 						cancel();
 					}
 				} );

--- a/packages/ckeditor5-source-editing/src/sourceediting.js
+++ b/packages/ckeditor5-source-editing/src/sourceediting.js
@@ -330,12 +330,10 @@ export default class SourceEditing extends Plugin {
 
 		this._keystrokes.destroy();
 
-		// We have to remove all the tracker elements manually as `focusTracker.destroy()`
+		// We have to remove all the tracker elements directly as `focusTracker.destroy()`
 		// doesn't do that. If we don't cleare the list, each time the source editing mode is enabled
 		// a new textarea is created, so the list of tracked elements will grow making it messy.
-		for ( const element of ( this._focusTracker._elements ) ) {
-			this._focusTracker.remove( element );
-		}
+		this._focusTracker._elements.clear();
 	}
 
 	/**

--- a/packages/ckeditor5-source-editing/src/sourceediting.js
+++ b/packages/ckeditor5-source-editing/src/sourceediting.js
@@ -7,11 +7,11 @@
  * @module source-editing/sourceediting
  */
 
-/* global console */
+/* global console, document */
 
 import { Plugin, PendingActions } from 'ckeditor5/src/core';
 import { ButtonView } from 'ckeditor5/src/ui';
-import { createElement, ElementReplacer } from 'ckeditor5/src/utils';
+import { createElement, ElementReplacer, KeystrokeHandler } from 'ckeditor5/src/utils';
 import { formatHtml } from './utils/formathtml';
 
 import '../theme/sourceediting.css';
@@ -82,6 +82,15 @@ export default class SourceEditing extends Plugin {
 		 * @member {Map.<String,String>}
 		 */
 		this._dataFromRoots = new Map();
+
+		/**
+		 * An instance of the {@link module:utils/keystrokehandler~KeystrokeHandler}.
+		 *
+		 * @readonly
+		 * @protected
+		 * @member {module:utils/keystrokehandler~KeystrokeHandler}
+		 */
+		this._keystrokes = new KeystrokeHandler();
 	}
 
 	/**
@@ -254,6 +263,34 @@ export default class SourceEditing extends Plugin {
 			this._elementReplacer.replace( domRootElement, domSourceEditingElementWrapper );
 
 			this._dataFromRoots.set( rootName, data );
+		}
+
+		if ( document.querySelector( '.ck-source-editing-area > textarea' ) ) {
+			const textarea = document.querySelector( '.ck-source-editing-area > textarea' );
+			const toolbar = editor.ui.view.toolbar;
+
+			// Start listening for the keystrokes coming from the textarea and the toolbar.
+			this._keystrokes.listenTo( textarea );
+			if ( document.querySelector( '.ck.ck-toolbar.ck-toolbar_grouping' ) ) {
+				this._keystrokes.listenTo( document.querySelector( '.ck.ck-toolbar.ck-toolbar_grouping' ) );
+			}
+
+			if ( toolbar ) {
+				this._keystrokes.set( 'Alt+F10', ( data, cancel ) => {
+					if ( document.activeElement === textarea && !toolbar.focusTracker.isFocused ) {
+						toolbar.focus();
+						cancel();
+					}
+				} );
+
+				this._keystrokes.set( 'Esc', ( data, cancel ) => {
+					if ( toolbar.focusTracker.isFocused ) {
+						textarea.focus();
+
+						cancel();
+					}
+				} );
+			}
 		}
 
 		this._focusSourceEditing();

--- a/packages/ckeditor5-source-editing/src/sourceediting.js
+++ b/packages/ckeditor5-source-editing/src/sourceediting.js
@@ -281,15 +281,15 @@ export default class SourceEditing extends Plugin {
 		const textarea = document.querySelector( '.ck-source-editing-area > textarea' );
 		const toolbar = editor.ui.view.toolbar;
 
-		// Start listening for the keystrokes coming from the textarea.
-		this._keystrokes.listenTo( textarea );
-
-		if ( toolbar ) {
-			this._focusTracker.add( toolbar.element );
-			this._focusTracker.add( textarea );
+		if ( toolbar && textarea ) {
+			// Start listening for the keystrokes coming from the textarea.
+			this._keystrokes.listenTo( textarea );
 
 			// Listen for the keystrokes coming from the editor's toolbar.
 			this._keystrokes.listenTo( toolbar.element );
+
+			this._focusTracker.add( toolbar.element );
+			this._focusTracker.add( textarea );
 
 			this._keystrokes.set( 'Alt+F10', ( data, cancel ) => {
 				if ( this._focusTracker.isFocused && !toolbar.focusTracker.isFocused ) {
@@ -307,6 +307,7 @@ export default class SourceEditing extends Plugin {
 				}
 			} );
 		}
+
 		this._focusSourceEditing();
 	}
 

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -6,21 +6,16 @@
 /* globals document, Event, console */
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
-import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
-import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
-import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/inlineeditableuiview';
-import PendingActions from '@ckeditor/ckeditor5-core/src/pendingactions';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
-import { _getEmitterListenedTo, _getEmitterId } from '@ckeditor/ckeditor5-utils/src/emittermixin';
-import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import Markdown from '@ckeditor/ckeditor5-markdown-gfm/src/markdown';
 import Heading from '@ckeditor/ckeditor5-heading/src/heading';
-import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
-import FocusTracker from '@ckeditor/ckeditor5-utils/src/focustracker';
-import enableToolbarKeyboardFocus from '@ckeditor/ckeditor5-ui/src/toolbar/enabletoolbarkeyboardfocus';
-import ToolbarView from '@ckeditor/ckeditor5-ui/src/toolbar/toolbarview';
+import { _getEmitterListenedTo, _getEmitterId } from '@ckeditor/ckeditor5-utils/src/emittermixin';
+import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import { ButtonView, InlineEditableUIView, ToolbarView, enableToolbarKeyboardFocus } from '@ckeditor/ckeditor5-ui';
+import { keyCodes, FocusTracker } from '@ckeditor/ckeditor5-utils';
+import { Plugin, PendingActions } from '@ckeditor/ckeditor5-core';
 
 import SourceEditing from '../src/sourceediting';
 
@@ -525,6 +520,7 @@ describe( 'SourceEditing', () => {
 		} );
 
 		it( 'should allow the `alt+f10` key combination to focus the editor toolbar when in source editing mode ', () => {
+			const textarea = document.querySelector( '.ck-source-editing-area > textarea' );
 			const spy = sinon.spy( toolbar, 'focus' );
 			const keyEventData = {
 				keyCode: keyCodes.f10,
@@ -539,10 +535,9 @@ describe( 'SourceEditing', () => {
 				toolbar
 			} );
 
-			const textarea = document.querySelector( '.ck-source-editing-area > textarea' );
-
 			// Initially focused element should be the textarea
 			expect( document.activeElement ).to.equal( textarea );
+
 			toolbarFocusTracker.isFocused = false;
 			originFocusTracker.isFocused = false;
 

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -551,9 +551,8 @@ describe( 'SourceEditing', () => {
 	} );
 } );
 
-describe( 'SourceEditing toolbar keyboard focus', () => {
-	let originFocusTracker, originKeystrokeHandler, toolbar, toolbarFocusTracker;
-	let editor, editorElement, plugin, button;
+describe( 'SourceEditing toolbar keyboard focus integration', () => {
+	let editorElement, editor, toolbar, plugin, button, originFocusTracker, originKeystrokeHandler, toolbarFocusTracker;
 
 	testUtils.createSinonSandbox();
 
@@ -584,64 +583,82 @@ describe( 'SourceEditing toolbar keyboard focus', () => {
 		return editor.destroy();
 	} );
 
-	it( 'should allow the `alt+f10` key combination to focus the editor toolbar when in source editing mode ', () => {
-		const textarea = document.querySelector( '.ck-source-editing-area > textarea' );
-		const spy = sinon.spy( toolbar, 'focus' );
-		const keyEventData = {
-			keyCode: keyCodes.f10,
-			altKey: true,
-			preventDefault: sinon.spy(),
-			stopPropagation: sinon.spy()
-		};
+	describe( 'should make sure that the `alt+f10` key combination will', () => {
+		let textarea, spy, keyEventData;
 
-		// Initially focused element should be the textarea
-		expect( document.activeElement ).to.equal( textarea );
+		beforeEach( () => {
+			textarea = document.querySelector( '.ck-source-editing-area > textarea' );
+			spy = sinon.spy( toolbar, 'focus' );
+			keyEventData = {
+				keyCode: keyCodes.f10,
+				altKey: true,
+				preventDefault: sinon.spy(),
+				stopPropagation: sinon.spy()
+			};
 
-		toolbarFocusTracker.isFocused = false;
-		originFocusTracker.isFocused = false;
+			// Initially focused element should be the textarea
+			expect( document.activeElement ).to.equal( textarea );
+		} );
 
-		originKeystrokeHandler.press( keyEventData );
+		it( 'not do anything when `originFocusTracker` and `toolbarFocusTracker` are not focused', () => {
+			toolbarFocusTracker.isFocused = false;
+			originFocusTracker.isFocused = false;
 
-		sinon.assert.notCalled( spy );
+			originKeystrokeHandler.press( keyEventData );
 
-		toolbarFocusTracker.isFocused = true;
-		originFocusTracker.isFocused = true;
+			sinon.assert.notCalled( spy );
+		} );
 
-		originKeystrokeHandler.press( keyEventData );
+		it( 'not do anything when `originFocusTracker` and `toolbarFocusTracker` are both focused', () => {
+			toolbarFocusTracker.isFocused = true;
+			originFocusTracker.isFocused = true;
 
-		sinon.assert.notCalled( spy );
+			originKeystrokeHandler.press( keyEventData );
 
-		toolbarFocusTracker.isFocused = false;
-		originFocusTracker.isFocused = true;
+			sinon.assert.notCalled( spy );
+		} );
 
-		originKeystrokeHandler.press( keyEventData );
+		it( 'focus the toolbar when `originFocusTracker` has been focused', () => {
+			toolbarFocusTracker.isFocused = false;
+			originFocusTracker.isFocused = true;
 
-		sinon.assert.calledOnce( spy );
-		sinon.assert.calledOnce( keyEventData.preventDefault );
-		sinon.assert.calledOnce( keyEventData.stopPropagation );
+			originKeystrokeHandler.press( keyEventData );
+
+			sinon.assert.calledOnce( spy );
+			sinon.assert.calledOnce( keyEventData.preventDefault );
+			sinon.assert.calledOnce( keyEventData.stopPropagation );
+		} );
 	} );
 
-	it( 'should re–focus the origin on Esc when in source editing mode', () => {
-		const origin = document.querySelector( '.ck-source-editing-area > textarea' );
-		const spy = sinon.spy( origin, 'focus' );
-		const keyEventData = {
-			keyCode: keyCodes.esc,
-			preventDefault: sinon.spy(),
-			stopPropagation: sinon.spy()
-		};
+	describe( 'should make sure that the `Esc` key will', () => {
+		let origin, spy, keyEventData;
 
-		toolbarFocusTracker.isFocused = false;
+		beforeEach( () => {
+			origin = document.querySelector( '.ck-source-editing-area > textarea' );
+			spy = sinon.spy( origin, 'focus' );
+			keyEventData = {
+				keyCode: keyCodes.esc,
+				preventDefault: sinon.spy(),
+				stopPropagation: sinon.spy()
+			};
+		} );
 
-		toolbar.keystrokes.press( keyEventData );
-		sinon.assert.notCalled( spy );
+		it( 'not do anything if the `toolbarFocusTracker` is not focused', () => {
+			toolbarFocusTracker.isFocused = false;
 
-		toolbarFocusTracker.isFocused = true;
+			toolbar.keystrokes.press( keyEventData );
+			sinon.assert.notCalled( spy );
+		} );
 
-		originKeystrokeHandler.press( keyEventData );
+		it( 're–focus the origin if the `toolbarFocusTracker` is focused', () => {
+			toolbarFocusTracker.isFocused = true;
 
-		sinon.assert.calledOnce( spy );
-		sinon.assert.calledOnce( keyEventData.preventDefault );
-		sinon.assert.calledOnce( keyEventData.stopPropagation );
+			originKeystrokeHandler.press( keyEventData );
+
+			sinon.assert.calledOnce( spy );
+			sinon.assert.calledOnce( keyEventData.preventDefault );
+			sinon.assert.calledOnce( keyEventData.stopPropagation );
+		} );
 	} );
 } );
 

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -552,7 +552,7 @@ describe( 'SourceEditing', () => {
 } );
 
 describe( 'SourceEditing toolbar keyboard focus integration', () => {
-	let editorElement, editor, toolbar, plugin, button, originFocusTracker, originKeystrokeHandler, toolbarFocusTracker;
+	let editorElement, editor, toolbar, plugin, button, sourceEditingFocusTracker, sourceEditingKeystrokeHandler, toolbarFocusTracker;
 
 	testUtils.createSinonSandbox();
 
@@ -569,11 +569,11 @@ describe( 'SourceEditing toolbar keyboard focus integration', () => {
 		plugin = editor.plugins.get( 'SourceEditing' );
 		button = editor.ui.componentFactory.create( 'sourceEditing' );
 
-		// Switch to the source view
+		// All tests start in the source view.
 		button.fire( 'execute' );
 
-		originFocusTracker = plugin._focusTracker;
-		originKeystrokeHandler = plugin._keystrokes;
+		sourceEditingFocusTracker = plugin._focusTracker;
+		sourceEditingKeystrokeHandler = plugin._keystrokes;
 		toolbarFocusTracker = toolbar.focusTracker;
 	} );
 
@@ -584,10 +584,9 @@ describe( 'SourceEditing toolbar keyboard focus integration', () => {
 	} );
 
 	describe( 'should make sure that the `alt+f10` key combination will', () => {
-		let textarea, spy, keyEventData;
+		let spy, keyEventData;
 
 		beforeEach( () => {
-			textarea = document.querySelector( '.ck-source-editing-area > textarea' );
 			spy = sinon.spy( toolbar, 'focus' );
 			keyEventData = {
 				keyCode: keyCodes.f10,
@@ -595,34 +594,31 @@ describe( 'SourceEditing toolbar keyboard focus integration', () => {
 				preventDefault: sinon.spy(),
 				stopPropagation: sinon.spy()
 			};
-
-			// Initially focused element should be the textarea
-			expect( document.activeElement ).to.equal( textarea );
 		} );
 
-		it( 'not do anything when `originFocusTracker` and `toolbarFocusTracker` are not focused', () => {
+		it( 'not do anything when `sourceEditingFocusTracker` and `toolbarFocusTracker` are not focused', () => {
 			toolbarFocusTracker.isFocused = false;
-			originFocusTracker.isFocused = false;
+			sourceEditingFocusTracker.isFocused = false;
 
-			originKeystrokeHandler.press( keyEventData );
+			sourceEditingKeystrokeHandler.press( keyEventData );
 
 			sinon.assert.notCalled( spy );
 		} );
 
-		it( 'not do anything when `originFocusTracker` and `toolbarFocusTracker` are both focused', () => {
+		it( 'not do anything when `sourceEditingFocusTracker` and `toolbarFocusTracker` are both focused', () => {
 			toolbarFocusTracker.isFocused = true;
-			originFocusTracker.isFocused = true;
+			sourceEditingFocusTracker.isFocused = true;
 
-			originKeystrokeHandler.press( keyEventData );
+			sourceEditingKeystrokeHandler.press( keyEventData );
 
 			sinon.assert.notCalled( spy );
 		} );
 
-		it( 'focus the toolbar when `originFocusTracker` has been focused', () => {
+		it( 'focus the toolbar when `sourceEditingFocusTracker` has been focused', () => {
 			toolbarFocusTracker.isFocused = false;
-			originFocusTracker.isFocused = true;
+			sourceEditingFocusTracker.isFocused = true;
 
-			originKeystrokeHandler.press( keyEventData );
+			sourceEditingKeystrokeHandler.press( keyEventData );
 
 			sinon.assert.calledOnce( spy );
 			sinon.assert.calledOnce( keyEventData.preventDefault );
@@ -631,11 +627,11 @@ describe( 'SourceEditing toolbar keyboard focus integration', () => {
 	} );
 
 	describe( 'should make sure that the `Esc` key will', () => {
-		let origin, spy, keyEventData;
+		let textarea, spy, keyEventData;
 
 		beforeEach( () => {
-			origin = document.querySelector( '.ck-source-editing-area > textarea' );
-			spy = sinon.spy( origin, 'focus' );
+			textarea = document.querySelector( '.ck-source-editing-area > textarea' );
+			spy = sinon.spy( textarea, 'focus' );
 			keyEventData = {
 				keyCode: keyCodes.esc,
 				preventDefault: sinon.spy(),
@@ -646,19 +642,25 @@ describe( 'SourceEditing toolbar keyboard focus integration', () => {
 		it( 'not do anything if the `toolbarFocusTracker` is not focused', () => {
 			toolbarFocusTracker.isFocused = false;
 
-			originKeystrokeHandler.press( keyEventData );
+			sourceEditingKeystrokeHandler.press( keyEventData );
 			sinon.assert.notCalled( spy );
 		} );
 
-		it( 're–focus the origin if the `toolbarFocusTracker` is focused', () => {
+		it( 're-focus the textarea if the `toolbarFocusTracker` is focused', () => {
 			toolbarFocusTracker.isFocused = true;
 
-			originKeystrokeHandler.press( keyEventData );
+			sourceEditingKeystrokeHandler.press( keyEventData );
 
 			sinon.assert.calledOnce( spy );
 			sinon.assert.calledOnce( keyEventData.preventDefault );
 			sinon.assert.calledOnce( keyEventData.stopPropagation );
 		} );
+	} );
+
+	it( 'should clear the source editing focus tracker after switching back from the source editing mode', () => {
+		button.fire( 'execute' );
+
+		expect( plugin._focusTracker._elements.size ).to.equal( 0 );
 	} );
 } );
 

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -646,7 +646,7 @@ describe( 'SourceEditing toolbar keyboard focus integration', () => {
 		it( 'not do anything if the `toolbarFocusTracker` is not focused', () => {
 			toolbarFocusTracker.isFocused = false;
 
-			toolbar.keystrokes.press( keyEventData );
+			originKeystrokeHandler.press( keyEventData );
 			sinon.assert.notCalled( spy );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (source-editing): It is possible now to focus the toolbar with the keyboard in the source editing mode. Closes #10368.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
