### PR TITLE
Fix (engine): Use innerText instead of innerHTML in view/filler

### DIFF
--- a/packages/ckeditor5-engine/src/view/filler.js
+++ b/packages/ckeditor5-engine/src/view/filler.js
@@ -56,7 +56,7 @@ export const NBSP_FILLER = domDocument => domDocument.createTextNode( '\u00A0' )
 export const MARKED_NBSP_FILLER = domDocument => {
 	const span = domDocument.createElement( 'span' );
 	span.dataset.ckeFiller = true;
-	span.innerHTML = '\u00A0';
+	span.innerText = '\u00A0';
 
 	return span;
 };

--- a/packages/ckeditor5-engine/tests/view/filler.js
+++ b/packages/ckeditor5-engine/tests/view/filler.js
@@ -10,7 +10,8 @@ import {
 	INLINE_FILLER,
 	startsWithFiller,
 	isInlineFiller,
-	getDataWithoutFiller
+	getDataWithoutFiller,
+	MARKED_NBSP_FILLER
 } from '../../src/view/filler';
 
 describe( 'filler', () => {
@@ -117,6 +118,14 @@ describe( 'filler', () => {
 			expect( isInlineFiller( node ) ).to.be.true;
 
 			document.body.removeChild( iframe );
+		} );
+	} );
+
+	describe( 'MARKED_NBSP_FILLER', () => {
+		it( 'should return node with correct HTML', () => {
+			const node = MARKED_NBSP_FILLER( document ); // eslint-disable-line new-cap
+
+			expect( node.outerHTML ).to.equal( '<span data-cke-filler="true">&nbsp;</span>' );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message
Fix (engine): Use innerText instead of innerHTML in view/filler

---

### Additional information

This PR fixes one of the issues mentioned in #10845 . This should be a low-risk change IMHO, happy to redo if needed. 