### PR TITLE
PoC for table resize fixes

### DIFF
--- a/packages/ckeditor5-table/src/tablecolumnresize/converters.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/converters.js
@@ -9,7 +9,7 @@
 
 /* istanbul ignore file */
 
-import { getNumberOfColumn } from './utils';
+import { getNumberOfColumn, normalizeColumnWidthsAttribute } from './utils';
 
 /**
  * Returns a helper for converting a view `<colgroup>` and `<col>` elements to the model table `columnWidths` attribute.
@@ -35,7 +35,7 @@ export function upcastColgroupElement( editor ) {
 		const viewColgroupElement = data.viewItem;
 		const numberOfColumns = getNumberOfColumn( modelTable, editor );
 
-		const columnWidthsAttribute = [ ...Array( numberOfColumns ).keys() ]
+		let columnWidthsAttribute = [ ...Array( numberOfColumns ).keys() ]
 			.map( columnIndex => {
 				const viewChild = viewColgroupElement.getChild( columnIndex );
 
@@ -52,6 +52,10 @@ export function upcastColgroupElement( editor ) {
 				return viewColWidth;
 			} )
 			.join( ',' );
+
+		if ( columnWidthsAttribute.match( 'auto' ) ) {
+			columnWidthsAttribute = normalizeColumnWidthsAttribute( columnWidthsAttribute ).map( width => width + '%' ).join( ',' );
+		}
 
 		modelWriter.setAttribute( 'columnWidths', columnWidthsAttribute, modelTable );
 	} );

--- a/packages/ckeditor5-table/src/tablecolumnresize/converters.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/converters.js
@@ -76,6 +76,7 @@ export function downcastTableColumnWidthsAttribute() {
 			}
 		} else {
 			removeColgroupElement( viewWriter, viewTable );
+			viewWriter.removeClass( 'ck-table-resized', viewTable );
 		}
 	} );
 }

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -37,7 +37,7 @@ import {
 	getNumberOfColumn,
 	normalizeColumnWidthsAttribute,
 	toPrecision,
-	insertColumnResizerElements,
+	insertColumnResizerElement,
 	getDomCellWidth
 } from './utils';
 
@@ -701,7 +701,7 @@ export default class TableColumnResizeEditing extends Plugin {
 				}
 
 				view.change( viewWriter => {
-					insertColumnResizerElements( viewWriter, item.item );
+					insertColumnResizerElement( viewWriter, item.item );
 				} );
 			}
 		}, { priority: 'lowest' } );

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -495,7 +495,7 @@ export default class TableColumnResizeEditing extends Plugin {
 		for ( const cellSlot of tableWalker ) {
 			const viewCell = editor.editing.mapper.toViewElement( cellSlot.cell );
 			const domCell = editor.editing.view.domConverter.mapViewToDom( viewCell );
-			const computedStyles = window.getComputedStyle( domCell );
+			const computedStyles = global.window.getComputedStyle( domCell );
 			const domCellWidth = parseFloat( computedStyles.width ) + parseFloat( computedStyles.paddingLeft ) + parseFloat( computedStyles.paddingRight ) + parseFloat( computedStyles.borderWidth );
 
 			if ( !this._columnIndexMap.has( cellSlot.cell ) ) {
@@ -719,7 +719,7 @@ export default class TableColumnResizeEditing extends Plugin {
 		for ( const cellSlot of tableWalker ) {
 			const viewCell = editor.editing.mapper.toViewElement( cellSlot.cell );
 			const domCell = editor.editing.view.domConverter.mapViewToDom( viewCell );
-			const computedStyles = window.getComputedStyle( domCell );
+			const computedStyles = global.window.getComputedStyle( domCell );
 			const domCellWidth = parseFloat( computedStyles.width ) + parseFloat( computedStyles.paddingLeft ) + parseFloat( computedStyles.paddingRight ) + parseFloat( computedStyles.borderWidth );
 
 			if ( !this._columnIndexMap.has( cellSlot.cell ) ) {

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -37,7 +37,8 @@ import {
 	getNumberOfColumn,
 	normalizeColumnWidthsAttribute,
 	toPrecision,
-	insertColumnResizerElements
+	insertColumnResizerElements,
+	getDomCellWidth
 } from './utils';
 
 import { COLUMN_MIN_WIDTH_IN_PIXELS } from './constants';
@@ -397,8 +398,7 @@ export default class TableColumnResizeEditing extends Plugin {
 		for ( const cellSlot of tableWalker ) {
 			const viewCell = editor.editing.mapper.toViewElement( cellSlot.cell );
 			const domCell = editor.editing.view.domConverter.mapViewToDom( viewCell );
-			const computedStyles = global.window.getComputedStyle( domCell );
-			const domCellWidth = parseFloat( computedStyles.width ) + parseFloat( computedStyles.paddingLeft ) + parseFloat( computedStyles.paddingRight ) + parseFloat( computedStyles.borderWidth );
+			const domCellWidth = getDomCellWidth( domCell );
 
 			if ( !this._columnIndexMap.has( cellSlot.cell ) ) {
 				this._columnIndexMap.set( cellSlot.cell, cellSlot.column );
@@ -621,8 +621,7 @@ export default class TableColumnResizeEditing extends Plugin {
 		for ( const cellSlot of tableWalker ) {
 			const viewCell = editor.editing.mapper.toViewElement( cellSlot.cell );
 			const domCell = editor.editing.view.domConverter.mapViewToDom( viewCell );
-			const computedStyles = global.window.getComputedStyle( domCell );
-			const domCellWidth = parseFloat( computedStyles.width ) + parseFloat( computedStyles.paddingLeft ) + parseFloat( computedStyles.paddingRight ) + parseFloat( computedStyles.borderWidth );
+			const domCellWidth = getDomCellWidth( domCell );
 
 			if ( !this._columnIndexMap.has( cellSlot.cell ) ) {
 				this._columnIndexMap.set( cellSlot.cell, cellSlot.column );

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -392,8 +392,9 @@ export default class TableColumnResizeEditing extends Plugin {
 		const modelTable = editor.editing.mapper.toModelElement( target.findAncestor( 'figure' ) );
 		const viewTable = target.findAncestor( 'table' );
 
-		const tableWalker = new TableWalker( modelTable );
+		// Calculate the dom cell widths.
 		const widths = Array( getNumberOfColumn( modelTable, editor ) );
+		const tableWalker = new TableWalker( modelTable );
 
 		for ( const cellSlot of tableWalker ) {
 			const viewCell = editor.editing.mapper.toViewElement( cellSlot.cell );
@@ -409,6 +410,7 @@ export default class TableColumnResizeEditing extends Plugin {
 			}
 		}
 
+		// Insert colgroup for table that is resized for the first time.
 		if ( ![ ...domEventData.target.findAncestor( 'table' ).getChildren() ].find( viewCol => viewCol.is( 'element', 'colgroup' ) ) ) {
 			editingView.change( viewWriter => {
 				const colgroup = viewWriter.createContainerElement( 'colgroup' );
@@ -615,8 +617,9 @@ export default class TableColumnResizeEditing extends Plugin {
 		const modelLeftCell = editor.editing.mapper.toModelElement( viewLeftCell );
 		const modelTable = modelLeftCell.findAncestor( 'table' );
 
-		const tableWalker = new TableWalker( modelTable );
+		// Calculate the dom cell widths.
 		const widths = Array( getNumberOfColumn( modelTable, editor ) );
+		const tableWalker = new TableWalker( modelTable );
 
 		for ( const cellSlot of tableWalker ) {
 			const viewCell = editor.editing.mapper.toViewElement( cellSlot.cell );

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -810,7 +810,7 @@ export default class TableColumnResizeEditing extends Plugin {
 
 		view.on( 'render', () => {
 			for ( const item of view.createRangeIn( view.document.getRoot() ) ) {
-				if ( item.item.name !== 'td' ) {
+				if ( ![ 'td', 'th' ].includes( item.item.name ) ) {
 					continue;
 				}
 

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -118,6 +118,7 @@ export default class TableColumnResizeEditing extends Plugin {
 	 */
 	init() {
 		this._extendSchema();
+		this._setupPostFixer();
 		this._setupConversion();
 		this._setupColumnResizers();
 		this._registerColgroupFixer();
@@ -381,8 +382,6 @@ export default class TableColumnResizeEditing extends Plugin {
 		if ( !this._isResizingAllowed ) {
 			return;
 		}
-
-		this._setupPostFixer();
 
 		domEventData.preventDefault();
 		eventInfo.stop();

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -376,7 +376,7 @@ export default class TableColumnResizeEditing extends Plugin {
 		const editor = this.editor;
 		const editingView = editor.editing.view;
 
-		if ( !domEventData.target.hasClass( 'table-column-resizer' ) ) {
+		if ( !domEventData.target.hasClass( 'ck-table-column-resizer' ) ) {
 			return;
 		}
 
@@ -435,7 +435,7 @@ export default class TableColumnResizeEditing extends Plugin {
 			const figureInitialPcWidth = this._resizingData.widths.viewFigureWidth / this._resizingData.widths.viewFigureParentWidth;
 
 			writer.setStyle( 'width', `${ toPrecision( figureInitialPcWidth * 100 ) }%`, domEventData.target.findAncestor( 'figure' ) );
-			writer.addClass( 'table-column-resizer__active', this._resizingData.elements.viewResizer );
+			writer.addClass( 'ck-table-column-resizer__active', this._resizingData.elements.viewResizer );
 			writer.addClass( 'ck-table-resized', domEventData.target.findAncestor( 'table' ) );
 		} );
 	}
@@ -593,7 +593,7 @@ export default class TableColumnResizeEditing extends Plugin {
 		}
 
 		editingView.change( writer => {
-			writer.removeClass( 'table-column-resizer__active', viewResizer );
+			writer.removeClass( 'ck-table-column-resizer__active', viewResizer );
 		} );
 
 		this._isResizingActive = false;

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnwidthscommand.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnwidthscommand.js
@@ -1,0 +1,46 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module
+ */
+
+import TablePropertyCommand from '../tableproperties/commands/tablepropertycommand';
+
+/**
+ * @extends module:table/tableproperties/commands/tablepropertycommand~TablePropertyCommand
+ */
+export default class TableColumnWidths extends TablePropertyCommand {
+	/**
+	 * Creates a new `TableColumnWidths` instance.
+	 *
+	 * @param {module:core/editor/editor~Editor} editor An editor in which this command will be used.
+	 * @param {String} defaultValue The default value of the attribute.
+	 */
+	constructor( editor, defaultValue ) {
+		super( editor, 'columnWidths', defaultValue );
+	}
+
+	execute( options = {} ) {
+		const editor = this.editor;
+		const model = editor.model;
+
+		const { columnWidths, batch } = options;
+
+		const table = options.table || model.document.selection.getSelectedElement();
+
+		model.enqueueChange( batch, writer => {
+			if ( columnWidths ) {
+				writer.setAttribute( this.attributeName, columnWidths, table );
+			} else {
+				writer.removeAttribute( this.attributeName, table );
+			}
+		} );
+	}
+
+	refresh() {
+		this.isEnabled = true;
+	}
+}

--- a/packages/ckeditor5-table/src/tablecolumnresize/tableresizewidthcommand.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tableresizewidthcommand.js
@@ -1,0 +1,47 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module
+ */
+
+import TableWidthCommand from '../tableproperties/commands/tablewidthcommand';
+
+/**
+ * @extends module:table/tableproperties/commands/tablewidthcommand~TableWidthCommand
+ */
+export default class TableResizeWidthCommand extends TableWidthCommand {
+	/**
+	 * Creates a new `TableResizeWidthCommand` instance.
+	 *
+	 * @param {module:core/editor/editor~Editor} editor An editor in which this command will be used.
+	 * @param {String} defaultValue The default value of the attribute.
+	 */
+	constructor( editor, defaultValue ) {
+		super( editor, 'tableWidth', defaultValue );
+	}
+
+	execute( options = {} ) {
+		const editor = this.editor;
+		const model = editor.model;
+
+		const { tableWidth, batch, columnWidths } = options;
+
+		const table = options.table || model.document.selection.getSelectedElement();
+
+		model.enqueueChange( batch, writer => {
+			if ( tableWidth ) {
+				writer.setAttribute( this.attributeName, tableWidth, table );
+				writer.setAttribute( 'columnWidths', columnWidths, table );
+			} else {
+				writer.removeAttribute( this.attributeName, table );
+			}
+		} );
+	}
+
+	refresh() {
+		this.isEnabled = true;
+	}
+}

--- a/packages/ckeditor5-table/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/utils.js
@@ -333,7 +333,7 @@ function prepareColumnWidths( columnWidthsAttribute ) {
 //
 // @param {module:engine/view/downcastwriter~DowncastWriter} viewWriter View writer instance.
 // @param {module:engine/view/element~Element} viewCell View cell.
-export function insertColumnResizerElements( viewWriter, viewCell ) {
+export function insertColumnResizerElement( viewWriter, viewCell ) {
 	let viewTableColumnResizerElement = [ ...viewCell.getChildren() ]
 		.find( viewElement => viewElement.hasClass( 'table-column-resizer' ) );
 

--- a/packages/ckeditor5-table/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/utils.js
@@ -365,3 +365,13 @@ export function removeColumnResizerElements( viewWriter, viewCell ) {
 
 	viewWriter.remove( viewTableColumnResizerElement );
 }
+
+//
+export function getDomCellWidth( domCell ) {
+	const styles = global.window.getComputedStyle( domCell );
+
+	return parseFloat( styles.width ) +
+		parseFloat( styles.paddingLeft ) +
+		parseFloat( styles.paddingRight ) +
+		parseFloat( styles.borderWidth );
+}

--- a/packages/ckeditor5-table/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/utils.js
@@ -335,14 +335,14 @@ function prepareColumnWidths( columnWidthsAttribute ) {
 // @param {module:engine/view/element~Element} viewCell View cell.
 export function insertColumnResizerElement( viewWriter, viewCell ) {
 	let viewTableColumnResizerElement = [ ...viewCell.getChildren() ]
-		.find( viewElement => viewElement.hasClass( 'table-column-resizer' ) );
+		.find( viewElement => viewElement.hasClass( 'ck-table-column-resizer' ) );
 
 	if ( viewTableColumnResizerElement ) {
 		return;
 	}
 
 	viewTableColumnResizerElement = viewWriter.createUIElement( 'div', {
-		class: 'table-column-resizer'
+		class: 'ck-table-column-resizer'
 	} );
 
 	viewWriter.insert(
@@ -357,7 +357,7 @@ export function insertColumnResizerElement( viewWriter, viewCell ) {
 // @param {module:engine/view/element~Element} viewCell View cell.
 export function removeColumnResizerElements( viewWriter, viewCell ) {
 	const viewTableColumnResizerElement = [ ...viewCell.getChildren() ]
-		.find( viewElement => viewElement.hasClass( 'table-column-resizer' ) );
+		.find( viewElement => viewElement.hasClass( 'ck-table-column-resizer' ) );
 
 	if ( !viewTableColumnResizerElement ) {
 		return;

--- a/packages/ckeditor5-table/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/utils.js
@@ -61,7 +61,7 @@ export function getAffectedTables( changes, model ) {
 				const range = model.createRangeOn( tableNode );
 
 				for ( const node of range.getItems() ) {
-					if ( node.is( 'element' ) && node.name === 'table' ) {
+					if ( node.is( 'element' ) && node.name === 'table' && node.hasAttribute( 'columnWidths' ) ) {
 						affectedTables.push( node );
 					}
 				}

--- a/packages/ckeditor5-table/tests/manual/tablecolumnresize.html
+++ b/packages/ckeditor5-table/tests/manual/tablecolumnresize.html
@@ -1,29 +1,43 @@
 <div id="editor">
-	<h3>Center aligned table</h3>
-	<!-- <figure class="table" style="width: 800px;">
+	<h3>Table with colgroup</h3>
+	<figure class="table" style="width:43.13%;">
 		<table>
+			<colgroup>
+				<col style="width:35.79%;">
+				<col style="width:64.21%;">
+			</colgroup>
+			<thead>
+				<tr>
+					<th colspan="2">Saturday, July 14</th>
+				</tr>
+			</thead>
 			<tbody>
 				<tr>
-					<td>11</td>
-					<td>12</td>
-					<td>13</td>
-					<td>14</td>
+					<td>9:30 AM - 11:30 AM</td>
+					<td>
+						<p><strong>Americano vs. Brewed</strong> - “know your coffee” with:&nbsp;</p>
+						<ul>
+							<li>Giulia Bianchi</li>
+							<li>Stefano Garau</li>
+							<li>Giuseppe Russo</li>
+						</ul>
+					</td>
 				</tr>
 				<tr>
-					<td>21</td>
-					<td>22</td>
-					<td>23</td>
-					<td>24</td>
+					<td>1:00 PM - 3:00 PM</td>
+					<td>
+						<p><strong>Pappardelle al pomodoro</strong> - live cooking</p>
+						<p>Incorporate the freshest ingredients&nbsp;<br>with Rita Fresco</p>
+					</td>
 				</tr>
 				<tr>
-					<td>31</td>
-					<td>32</td>
-					<td>33</td>
-					<td>34</td>
+					<td>5:00 PM - 8:00 PM</td>
+					<td><strong>Tuscan vineyards at a glance</strong> - wine-tasting&nbsp;<br>with Frederico Riscoli</td>
 				</tr>
 			</tbody>
 		</table>
-	</figure> -->
+	</figure>
+
 	<h3>Table with cell width</h3>
 	<figure class="table" style="width:700px;">
 		<table>

--- a/packages/ckeditor5-table/tests/manual/tablecolumnresize.html
+++ b/packages/ckeditor5-table/tests/manual/tablecolumnresize.html
@@ -1,6 +1,6 @@
 <div id="editor">
 	<h3>Center aligned table</h3>
-	<figure class="table" style="width: 800px;">
+	<!-- <figure class="table" style="width: 800px;">
 		<table>
 			<tbody>
 				<tr>
@@ -20,6 +20,27 @@
 					<td>32</td>
 					<td>33</td>
 					<td>34</td>
+				</tr>
+			</tbody>
+		</table>
+	</figure> -->
+	<h3>Table with cell width</h3>
+	<figure class="table" style="width:700px;">
+		<table>
+			<tbody>
+				<tr>
+					<td style="text-align:center;" colspan="4"><span class="text-small"><strong>Color coding for
+								missions</strong></span></td>
+				</tr>
+				<tr>
+					<td style="background-color:hsl(0, 0%, 90%);text-align:center;width:100px;"><span
+							class="text-small"><i>Failed</i></span></td>
+					<td style="background-color:hsl(150, 75%, 60%);text-align:center;"><span
+							class="text-small"><i>Successful</i></span></td>
+					<td style="background-color:hsl(180, 75%, 60%);text-align:center;"><span class="text-small"><i>In
+								progress</i></span></td>
+					<td style="background-color:hsl(210, 75%, 60%);text-align:center;"><span
+							class="text-small"><i>Planned</i></span></td>
 				</tr>
 			</tbody>
 		</table>

--- a/packages/ckeditor5-table/tests/manual/tablecolumnresize.html
+++ b/packages/ckeditor5-table/tests/manual/tablecolumnresize.html
@@ -1,6 +1,6 @@
 <div id="editor">
 	<h3>Table with colgroup</h3>
-	<figure class="table" style="width:43.13%;">
+	<figure class="table" style="width:200px;">
 		<table>
 			<colgroup>
 				<col style="width:35.79%;">

--- a/packages/ckeditor5-table/tests/manual/tablecolumnresize.html
+++ b/packages/ckeditor5-table/tests/manual/tablecolumnresize.html
@@ -33,7 +33,7 @@
 								missions</strong></span></td>
 				</tr>
 				<tr>
-					<td style="background-color:hsl(0, 0%, 90%);text-align:center;width:100px;"><span
+					<td style="background-color:hsl(0, 0%, 90%);text-align:center;width:300px;"><span
 							class="text-small"><i>Failed</i></span></td>
 					<td style="background-color:hsl(150, 75%, 60%);text-align:center;"><span
 							class="text-small"><i>Successful</i></span></td>

--- a/packages/ckeditor5-table/tests/tablecolumnresize/_utils/utils.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/_utils/utils.js
@@ -99,7 +99,7 @@ export function getViewColumnWidthsPc( viewTable ) {
 export function getDomResizer( domTable, columnIndex, rowIndex ) {
 	const rows = Array.from( domTable.querySelectorAll( 'tr' ) );
 	const row = rows[ rowIndex ? rowIndex : 0 ];
-	const domResizer = Array.from( row.querySelectorAll( '.table-column-resizer' ) )[ columnIndex ];
+	const domResizer = Array.from( row.querySelectorAll( '.ck-table-column-resizer' ) )[ columnIndex ];
 
 	return domResizer;
 }

--- a/packages/ckeditor5-table/tests/tablecolumnresize/_utils/utils.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/_utils/utils.js
@@ -9,7 +9,7 @@ import { Point } from '@ckeditor/ckeditor5-widget/tests/widgetresize/_utils/util
 import TableColumnResizeEditing from '../../../src/tablecolumnresize/tablecolumnresizeediting';
 
 export const tableColumnResizeMouseSimulator = {
-	down( editor, domTarget, options ) {
+	down( editor, domTarget, options = {} ) {
 		const preventDefault = options.preventDefault || sinon.spy().named( 'preventDefault' );
 		const stop = options.stop || sinon.spy().named( 'stop' );
 

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -319,7 +319,7 @@ describe( 'TableColumnResizeEditing', () => {
 					} );
 
 					const domTable = getDomTable( view );
-					const resizers = Array.from( domTable.querySelectorAll( '.table-column-resizer' ) );
+					const resizers = Array.from( domTable.querySelectorAll( '.ck-table-column-resizer' ) );
 
 					expect( resizers.length ).to.equal( 4 );
 				} );
@@ -333,7 +333,7 @@ describe( 'TableColumnResizeEditing', () => {
 					editor.execute( 'insertTableRowBelow' );
 
 					const domTable = getDomTable( view );
-					const resizers = Array.from( domTable.querySelectorAll( '.table-column-resizer' ) );
+					const resizers = Array.from( domTable.querySelectorAll( '.ck-table-column-resizer' ) );
 
 					expect( resizers.length ).to.equal( 9 );
 				} );
@@ -347,7 +347,7 @@ describe( 'TableColumnResizeEditing', () => {
 					editor.execute( 'splitTableCellVertically' );
 
 					const domTable = getDomTable( view );
-					const resizers = Array.from( domTable.querySelectorAll( '.table-column-resizer' ) );
+					const resizers = Array.from( domTable.querySelectorAll( '.ck-table-column-resizer' ) );
 
 					expect( resizers.length ).to.equal( 7 );
 				} );
@@ -545,7 +545,7 @@ describe( 'TableColumnResizeEditing', () => {
 				</figure>`
 			);
 
-			expect( document.getElementsByClassName( 'table-column-resizer' ).length ).to.equal( 4 );
+			expect( document.getElementsByClassName( 'ck-table-column-resizer' ).length ).to.equal( 4 );
 		} );
 	} );
 

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -214,7 +214,7 @@ describe( 'TableColumnResizeEditing', () => {
 								<colgroup>
 									<col style="width:33.33%;">
 									<col style="width:33.33%;">
-									<col style="width:33.33%;">
+									<col style="width:33.34%;">
 									<col style="width:33.33%;">
 								</colgroup>
 								<tbody>
@@ -1773,7 +1773,7 @@ describe( 'TableColumnResizeEditing', () => {
 				} );
 
 				it( 'is not being added when any of the middle columns is resized', () => {
-					const columnToResizeIndex = 1;
+					const columnToResizeIndex = 0;
 					const mouseMovementVector = { x: -40, y: 0 };
 
 					setModelData( model, modelTable( [

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -872,7 +872,7 @@ describe( 'TableColumnResizeEditing', () => {
 					const mouseMovementVector = { x: -10, y: 0 };
 
 					editor.setData(
-						`<figure class="table" style="float:left;">
+						`<figure class="table" style="float:left;width:500px;">
 							<table>
 								<tbody>
 									<tr>
@@ -889,7 +889,7 @@ describe( 'TableColumnResizeEditing', () => {
 					const alignedTableColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
 
 					editor.setData(
-						`<figure class="table">
+						`<figure class="table" style="width:500px;">
 							<table>
 								<tbody>
 									<tr>
@@ -917,7 +917,7 @@ describe( 'TableColumnResizeEditing', () => {
 					const mouseMovementVector = { x: -10, y: 0 };
 
 					setModelData( editor.model,
-						'<table columnWidths="100%">' +
+						'<table columnWidths="100%" tableWidth="100%">' +
 							'<tableRow>' +
 								'<tableCell>' +
 									'[<table columnWidths="50%,50%">' +
@@ -939,7 +939,7 @@ describe( 'TableColumnResizeEditing', () => {
 					const domNestedTable = getDomTable( view ).querySelectorAll( 'table' )[ 1 ];
 					const viewNestedTable = view.document.selection.getSelectedElement().getChild( 1 );
 
-					setInitialWidthsInPx( editor, viewNestedTable, 201, 300 );
+					setInitialWidthsInPx( editor, viewNestedTable, 201, 400 );
 
 					// Test-agnostic.
 					const initialViewColumnWidthsPx = getViewColumnWidthsPx( domNestedTable );
@@ -965,10 +965,10 @@ describe( 'TableColumnResizeEditing', () => {
 					assertViewPixelWidths( finalViewColumnWidthsPx, expectedViewColumnWidthsPx );
 
 					expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
-						'<table columnWidths="100%">' +
+						'<table columnWidths="100%" tableWidth="100%">' +
 							'<tableRow>' +
 								'<tableCell>' +
-									'<table columnWidths="55.56%,44.44%" tableWidth="63.11%">' +
+									'<table columnWidths="55.56%,44.44%" tableWidth="46.72%">' +
 										'<tableRow>' +
 											'<tableCell>' +
 												'<paragraph>foo</paragraph>' +
@@ -990,7 +990,7 @@ describe( 'TableColumnResizeEditing', () => {
 					const mouseMovementVector = { x: 10, y: 0 };
 
 					setModelData( editor.model,
-						'<table columnWidths="100%">' +
+						'<table columnWidths="100%" tableWidth="100%">' +
 							'<tableRow>' +
 								'<tableCell>' +
 									'[<table tableWidth="90%" columnWidths="50%,50%">' +
@@ -1039,7 +1039,7 @@ describe( 'TableColumnResizeEditing', () => {
 
 					expect( getModelData( model, { withoutSelection: true } ) ).to.match(
 						new RegExp(
-							'<table columnWidths="100%">' +
+							'<table columnWidths="100%" tableWidth="100%">' +
 								'<tableRow>' +
 									'<tableCell>' +
 										'<table columnWidths="45\\.45%,54\\.55%" tableWidth="77\\.1[\\d]%">' +
@@ -1065,7 +1065,7 @@ describe( 'TableColumnResizeEditing', () => {
 					const mouseMovementVector = { x: 10, y: 0 };
 
 					setModelData( editor.model,
-						'<table columnWidths="100%">' +
+						'<table columnWidths="100%" tableWidth="100%">' +
 							'<tableRow>' +
 								'<tableCell>' +
 									'[<table columnWidths="25%,25%,50%" tableWidth="100%">' +
@@ -1116,7 +1116,7 @@ describe( 'TableColumnResizeEditing', () => {
 					assertViewPixelWidths( finalViewColumnWidthsPx, expectedViewColumnWidthsPx );
 
 					expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
-						'<table columnWidths="100%">' +
+						'<table columnWidths="100%" tableWidth="100%">' +
 							'<tableRow>' +
 								'<tableCell>' +
 									'<table columnWidths="25%,28.52%,46.48%" tableWidth="100%">' +
@@ -1160,7 +1160,7 @@ describe( 'TableColumnResizeEditing', () => {
 				setModelData( model, modelTable( [
 					[ '00', '01', '02' ],
 					[ '10', '11', '12' ]
-				], { columnWidths: '25%,25%,50%' } ) );
+				], { columnWidths: '25%,25%,50%', tableWidth: '100%' } ) );
 
 				const columnToResizeIndex = 0;
 				const mouseMovementVector = { x: 10, y: 0 };
@@ -1194,7 +1194,7 @@ describe( 'TableColumnResizeEditing', () => {
 				setModelData( model, modelTable( [
 					[ '00', '01', '02' ],
 					[ '10', '11', '12' ]
-				], { columnWidths: '25%,25%,50%' } ) );
+				], { columnWidths: '25%,25%,50%', tableWidth: '100%' } ) );
 
 				const columnToResizeIndex = 0;
 				const mouseMovementVector = { x: -10, y: 0 };
@@ -1231,7 +1231,7 @@ describe( 'TableColumnResizeEditing', () => {
 				setModelData( model, modelTable( [
 					[ '00', '01', '02' ],
 					[ '10', '11', '12' ]
-				], { columnWidths: '25%,25%,50%' } ) );
+				], { columnWidths: '25%,25%,50%', tableWidth: '100%' } ) );
 
 				// Test-agnostic.
 				const initialViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
@@ -1262,7 +1262,7 @@ describe( 'TableColumnResizeEditing', () => {
 				setModelData( model, modelTable( [
 					[ '00', '01', '02' ],
 					[ '10', '11', '12' ]
-				], { columnWidths: '20%,25%,55%' } ) );
+				], { columnWidths: '20%,25%,55%', tableWidth: '100%' } ) );
 
 				const columnToResizeIndex = 1;
 				const initialColumnWidth = getColumnWidth( getDomTable( view ), columnToResizeIndex );
@@ -1305,7 +1305,7 @@ describe( 'TableColumnResizeEditing', () => {
 				setModelData( model, modelTable( [
 					[ '00', '01', '02' ],
 					[ '10', '11', '12' ]
-				], { columnWidths: '20%,25%,55%' } ) );
+				], { columnWidths: '20%,25%,55%', tableWidth: '100%' } ) );
 
 				const columnToResizeIndex = 0;
 				const initialColumnWidth = getColumnWidth( getDomTable( view ), columnToResizeIndex );
@@ -1342,7 +1342,7 @@ describe( 'TableColumnResizeEditing', () => {
 				setModelData( model, modelTable( [
 					[ '00', '01', '02' ],
 					[ '10', '11', '12' ]
-				], { columnWidths: '20%,25%,55%' } ) );
+				], { columnWidths: '20%,25%,55%', tableWidth: '100%' } ) );
 
 				const columnToResizeIndex = 0;
 				const cellRect = getDomTableCellRects( getDomTable( view ), columnToResizeIndex );
@@ -1377,7 +1377,7 @@ describe( 'TableColumnResizeEditing', () => {
 				setModelData( model, modelTable( [
 					[ '00', '01', '02' ],
 					[ '10', '11', '12' ]
-				], { columnWidths: '20%,25%,55%' } ) );
+				], { columnWidths: '20%,25%,55%', tableWidth: '100%' } ) );
 
 				const columnToResizeIndex = 0;
 				const tableRect = getDomTableRects( getDomTable( view ) );
@@ -1412,7 +1412,7 @@ describe( 'TableColumnResizeEditing', () => {
 				setModelData( model, modelTable( [
 					[ '00', '01', '02' ],
 					[ '10', '11', '12' ]
-				], { columnWidths: '20%,25%,55%' } ) );
+				], { columnWidths: '20%,25%,55%', tableWidth: '100%' } ) );
 
 				const columnToResizeIndex = 0;
 				const cellRect = getDomTableCellRects( getDomTable( view ), columnToResizeIndex );
@@ -1447,7 +1447,7 @@ describe( 'TableColumnResizeEditing', () => {
 				setModelData( model, modelTable( [
 					[ '00', '01', '02' ],
 					[ '10', '11', '12' ]
-				], { columnWidths: '20%,25%,55%' } ) );
+				], { columnWidths: '20%,25%,55%', tableWidth: '100%' } ) );
 
 				const columnToResizeIndex = 1;
 				// We need the width of the last cell to move the cursor beyond it.
@@ -1652,7 +1652,7 @@ describe( 'TableColumnResizeEditing', () => {
 					setModelData( model, modelTable( [ [ '[]foo' ] ], { tableWidth: '100px' } ) );
 
 					expect( getModelData( editor.model ) ).to.equal(
-						'<table columnWidths="100%" tableWidth="100px">' +
+						'<table tableWidth="100px">' +
 							'<tableRow>' +
 								'<tableCell>' +
 									'<paragraph>[]foo</paragraph>' +
@@ -1664,18 +1664,18 @@ describe( 'TableColumnResizeEditing', () => {
 
 				it( 'should be added to the table after the last column has been resized', () => {
 					const columnToResizeIndex = 2;
-					const mouseMovementVector = { x: -10, y: 0 };
+					const mouseMovementVector = { x: 10, y: 0 };
 
 					setModelData( model, modelTable( [
 						[ '00', '01', '02' ]
-					], { columnWidths: '20%,25%,55%' } ) );
+					] ) );
 
-					setInitialWidthsInPx( editor, null, 201, 300 );
+					setInitialWidthsInPx( editor, null, null, 300 );
 
 					tableColumnResizeMouseSimulator.resize( editor, getDomTable( view ), columnToResizeIndex, mouseMovementVector );
 
 					expect( getModelData( editor.model ) ).to.equal(
-						'[<table columnWidths="22.22%,27.78%,50%" tableWidth="60%">' +
+						'[<table columnWidths="29.1%,29.1%,41.8%" tableWidth="52.46%">' +
 							'<tableRow>' +
 								'<tableCell>' +
 									'<paragraph>00</paragraph>' +
@@ -1726,41 +1726,12 @@ describe( 'TableColumnResizeEditing', () => {
 
 					setModelData( model, modelTable( [
 						[ '[00', '01', '02]' ]
-					], { tableWidth: '100px', columnWidths: '25%,25%,50%' } ) );
+					], { tableWidth: '40%', columnWidths: '25%,25%,50%' } ) );
 
 					tableColumnResizeMouseSimulator.resize( editor, getDomTable( view ), columnToResizeIndex, mouseMovementVector );
 
 					expect( getModelData( editor.model ) ).to.equal(
-						'[<table columnWidths="25%,34.6%,40.4%" tableWidth="100px">' +
-							'<tableRow>' +
-								'<tableCell>' +
-									'<paragraph>00</paragraph>' +
-								'</tableCell>' +
-								'<tableCell>' +
-									'<paragraph>01</paragraph>' +
-								'</tableCell>' +
-								'<tableCell>' +
-									'<paragraph>02</paragraph>' +
-								'</tableCell>' +
-							'</tableRow>' +
-						'</table>]'
-					);
-				} );
-
-				it( 'is not being added when any of the middle columns is resized', () => {
-					const columnToResizeIndex = 0;
-					const mouseMovementVector = { x: -40, y: 0 };
-
-					setModelData( model, modelTable( [
-						[ '00', '01', '02' ]
-					], { columnWidths: '20%,25%,55%' } ) );
-
-					setInitialWidthsInPx( editor, null, null, 300 );
-
-					tableColumnResizeMouseSimulator.resize( editor, getDomTable( view ), columnToResizeIndex, mouseMovementVector );
-
-					expect( getModelData( editor.model ) ).to.equal(
-						'[<table columnWidths="20%,13.38%,66.62%">' +
+						'[<table columnWidths="25%,27.18%,47.82%" tableWidth="40%">' +
 							'<tableRow>' +
 								'<tableCell>' +
 									'<paragraph>00</paragraph>' +

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -42,7 +42,7 @@ import {
 import WidgetResize from '@ckeditor/ckeditor5-widget/src/widgetresize';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 
-describe.only( 'TableColumnResizeEditing', () => {
+describe( 'TableColumnResizeEditing', () => {
 	let model, editor, view, editorElement, contentDirection;
 	const PERCENTAGE_PRECISION = 0.001;
 	const PIXEL_PRECISION = 1;
@@ -558,7 +558,7 @@ describe.only( 'TableColumnResizeEditing', () => {
 			setModelData( model, modelTable( [
 				[ '00', '01', '02' ],
 				[ '10', '11', '12' ]
-			], { columnWidths: '20%,25%,55%' } ) );
+			], { columnWidths: '20%,25%,55%', tableWidth: '500px' } ) );
 
 			// Test-agnostic.
 			const initialViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
@@ -595,7 +595,7 @@ describe.only( 'TableColumnResizeEditing', () => {
 				setModelData( model, modelTable( [
 					[ '00', '01', '02' ],
 					[ '10', '11', '12' ]
-				], { columnWidths: '25%,25%,50%' } ) );
+				], { columnWidths: '25%,25%,50%', tableWidth: '500px' } ) );
 
 				// Test-agnostic.
 				const initialViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
@@ -629,7 +629,7 @@ describe.only( 'TableColumnResizeEditing', () => {
 				setModelData( model, modelTable( [
 					[ '00', '01', '02' ],
 					[ '10', '11', '12' ]
-				], { columnWidths: '25%,25%,50%' } ) );
+				], { columnWidths: '25%,25%,50%', tableWidth: '500px' } ) );
 
 				// Test-agnostic.
 				const initialViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
@@ -663,7 +663,7 @@ describe.only( 'TableColumnResizeEditing', () => {
 				setModelData( model, modelTable( [
 					[ '00', '01', '02' ],
 					[ '10', '11', '12' ]
-				], { columnWidths: '25%,25%,50%' } ) );
+				], { columnWidths: '25%,25%,50%', tableWidth: '500px' } ) );
 
 				// Test-agnostic.
 				const initialViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
@@ -694,7 +694,7 @@ describe.only( 'TableColumnResizeEditing', () => {
 				setModelData( model, modelTable( [
 					[ '00', '01', '02' ],
 					[ '10', '11', '12' ]
-				], { columnWidths: '20%,25%,55%' } ) );
+				], { columnWidths: '20%,25%,55%', tableWidth: '500px' } ) );
 
 				const columnToResizeIndex = 1;
 				const initialColumnWidth = getColumnWidth( getDomTable( view ), columnToResizeIndex );
@@ -737,7 +737,7 @@ describe.only( 'TableColumnResizeEditing', () => {
 				setModelData( model, modelTable( [
 					[ '00', '01', '02' ],
 					[ '10', '11', '12' ]
-				], { columnWidths: '20%,25%,55%' } ) );
+				], { columnWidths: '20%,25%,55%', tableWidth: '500px' } ) );
 
 				const columnToResizeIndex = 0;
 				const initialColumnWidth = getColumnWidth( getDomTable( view ), columnToResizeIndex );
@@ -784,7 +784,7 @@ describe.only( 'TableColumnResizeEditing', () => {
 					[ { contents: '00', colspan: 2 }, '02' ],
 					[ '10', '11', '12' ],
 					[ '20', '21', '22' ]
-				], { columnWidths: '20%,25%,55%' } ) );
+				], { columnWidths: '20%,25%,55%', tableWidth: '500px' } ) );
 
 				// Test-agnostic.
 				const initialViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
@@ -819,7 +819,7 @@ describe.only( 'TableColumnResizeEditing', () => {
 					[ '00', '01', { contents: '02', rowspan: 3 } ],
 					[ '10', '11' ],
 					[ '20', '21' ]
-				], { columnWidths: '20%,25%,55%' } ) );
+				], { columnWidths: '20%,25%,55%', tableWidth: '500px' } ) );
 
 				// Test-agnostic.
 				const initialViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
@@ -1969,7 +1969,7 @@ describe.only( 'TableColumnResizeEditing', () => {
 			return sum;
 		}, 0 );
 
-		expect( ( Math.abs( 100 - widthsSum ) ) < PERCENTAGE_PRECISION ).to.be.true;
+		expect( ( Math.abs( 100 - widthsSum ) ) < PERCENTAGE_PRECISION, 'Models widths dont sum up well' ).to.be.true;
 	}
 
 	function calculateExpectedWidthPixels( initialWidths, vector, contentDirection, columnIndex ) {

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -42,7 +42,7 @@ import {
 import WidgetResize from '@ckeditor/ckeditor5-widget/src/widgetresize';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 
-describe( 'TableColumnResizeEditing', () => {
+describe.only( 'TableColumnResizeEditing', () => {
 	let model, editor, view, editorElement, contentDirection;
 	const PERCENTAGE_PRECISION = 0.001;
 	const PIXEL_PRECISION = 1;
@@ -518,31 +518,6 @@ describe( 'TableColumnResizeEditing', () => {
 					}
 				}
 			} );
-		} );
-
-		it( 'transfers the inline cell width to the whole column', () => {
-			setModelData( model, modelTable( [
-				[ '00', '01', '[02]' ],
-				[ '10', '11', '12' ]
-			], { columnWidths: '25%,25%,50%' } ) );
-
-			const table = model.document.getRoot().getChild( 0 );
-
-			setInitialWidthsInPx( editor, null, 201 );
-
-			model.change( writer => {
-				const cell = table.getChild( 1 ).getChild( 1 );
-
-				writer.setAttribute( 'width', '100px', cell );
-			} );
-
-			const tableWidths = table.getAttribute( 'columnWidths' );
-
-			expect( tableWidths ).to.be.equal( '25%,50%,25%' );
-
-			const finalViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
-
-			expect( Math.abs( 100 - finalViewColumnWidthsPx[ 1 ] ) < PIXEL_PRECISION ).to.be.true;
 		} );
 
 		it( 'should find and allow for resizing nested tables', () => {

--- a/packages/ckeditor5-table/tests/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/utils.js
@@ -586,7 +586,11 @@ describe( 'TableColumnResize utils', () => {
 } );
 
 function createTable( rows, cols ) {
-	return new Element( 'table', {}, createTableRows( rows, cols ) );
+	// We need to set the `columnWidths` attribute because tables without it are ignored.
+	const colWidth = `${ 100 / cols }%`;
+	const columnWidths = new Array( cols ).fill( colWidth ).join( ',' );
+
+	return new Element( 'table', { columnWidths }, createTableRows( rows, cols ) );
 }
 
 function createTableRows( rows, cols ) {

--- a/packages/ckeditor5-table/tests/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/utils.js
@@ -29,6 +29,7 @@ import {
 	normalizeColumnWidthsAttribute,
 	getTableWidthInPixels
 } from '../../src/tablecolumnresize/utils';
+import { getDomResizer, getDomTable, tableColumnResizeMouseSimulator } from './_utils/utils';
 
 /* globals window */
 
@@ -389,6 +390,8 @@ describe( 'TableColumnResize utils', () => {
 			const row0 = [ ...table.getChildren() ][ 0 ];
 			const cell00 = [ ...row0.getChildren() ][ 0 ];
 
+			tableColumnResizeMouseSimulator.down( editor, getDomResizer( getDomTable( editor.editing.view ), 1, 0 ) );
+
 			expect(
 				getColumnIndex( cell00, getColumnIndexMap( editor ) )
 			).to.deep.equal( { leftEdge: 0, rightEdge: 0 } );
@@ -410,6 +413,8 @@ describe( 'TableColumnResize utils', () => {
 			const row0 = [ ...table.getChildren() ][ 0 ];
 			const cell01 = [ ...row0.getChildren() ][ 1 ];
 
+			tableColumnResizeMouseSimulator.down( editor, getDomResizer( getDomTable( editor.editing.view ), 1, 0 ) );
+
 			expect(
 				getColumnIndex( cell01, getColumnIndexMap( editor ) )
 			).to.deep.equal( { leftEdge: 1, rightEdge: 2 } );
@@ -425,6 +430,8 @@ describe( 'TableColumnResize utils', () => {
 			const row0 = [ ...table.getChildren() ][ 0 ];
 			const cell01 = [ ...row0.getChildren() ][ 1 ];
 
+			tableColumnResizeMouseSimulator.down( editor, getDomResizer( getDomTable( editor.editing.view ), 1, 0 ) );
+
 			expect(
 				getColumnIndex( cell01, getColumnIndexMap( editor ) )
 			).to.deep.equal( { leftEdge: 1, rightEdge: 3 } );
@@ -439,6 +446,8 @@ describe( 'TableColumnResize utils', () => {
 			const table = editor.model.document.getRoot().getChild( 0 );
 			const row0 = [ ...table.getChildren() ][ 0 ];
 			const cell02 = [ ...row0.getChildren() ][ 2 ];
+
+			tableColumnResizeMouseSimulator.down( editor, getDomResizer( getDomTable( editor.editing.view ), 1, 0 ) );
 
 			expect(
 				getColumnIndex( cell02, getColumnIndexMap( editor ) )

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -25,7 +25,7 @@
 	position: relative;
 }
 
-.ck-content .table .table-column-resizer {
+.ck-content .table .ck-table-column-resizer {
 	position: absolute;
 	/* The resizer element resides in each cell so to occupy the entire height of the table, which is unknown from a CSS point of view,
 	   it is extended to an extremely high height. Even for screens with a very high pixel density, the resizer will fulfill its role as
@@ -42,21 +42,21 @@
 
 /* The resizer elements, which are extended to an extremely high height, break the drag & drop feature in Chrome. To make it work again,
    all resizers must be hidden while the table is dragged. */
-.ck-content .table[draggable] .table-column-resizer {
+.ck-content .table[draggable] .ck-table-column-resizer {
 	display: none;
 }
 
-.ck-content .table .table-column-resizer:hover,
-.ck-content .table .table-column-resizer__active {
+.ck-content .table .ck-table-column-resizer:hover,
+.ck-content .table .ck-table-column-resizer__active {
 	background-color: var(--ck-color-table-column-resizer-hover);
 	opacity: 0.25;
 }
 
-.ck-content[dir=rtl] .table .table-column-resizer {
+.ck-content[dir=rtl] .table .ck-table-column-resizer {
 	left: var(--ck-table-column-resizer-position-offset);
 	right: unset;
 }
 
-.ck-content.ck-read-only .table .table-column-resizer {
+.ck-content.ck-read-only .table .ck-table-column-resizer {
 	display: none;
 }

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -14,7 +14,7 @@
 
 .ck-content .table table {
 	overflow: hidden;
-	table-layout: fixed;
+	/* table-layout: fixed; */
 }
 
 .ck-content .table td,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Type: Message. Closes #11858.

---

### Additional information

The main functional change is that model tables don't receive the `columnWidths` attribute automatically. It is added only after the first resize conducted on the given table. That means that non-resized tables should behave the same as in the previous editor versions in terms of column and cell widths.

This is PoC, so there is much more we could do to improve the code, but for now the functional changes take the priority.