### PR TITLE
The formatHtml() helper should not crash

### DIFF
--- a/packages/ckeditor5-source-editing/src/utils/formathtml.js
+++ b/packages/ckeditor5-source-editing/src/utils/formathtml.js
@@ -138,5 +138,6 @@ function isClosingTag( line, elementsToFormat ) {
 // @param {String} [indentChar] Indentation character(s). 4 spaces by default.
 // @returns {String}
 function indentLine( line, indentCount, indentChar = '    ' ) {
-	return `${ indentChar.repeat( indentCount ) }${ line }`;
+	// More about Math.max() here in https://github.com/ckeditor/ckeditor5/issues/10698.
+	return `${ indentChar.repeat( Math.max( 0, indentCount ) ) }${ line }`;
 }

--- a/packages/ckeditor5-source-editing/tests/utils/formathtml.js
+++ b/packages/ckeditor5-source-editing/tests/utils/formathtml.js
@@ -222,5 +222,27 @@ describe( 'SourceEditing utils', () => {
 
 			expect( formatHtml( source ) ).to.equal( sourceFormatted );
 		} );
+
+		// More about this case in https://github.com/ckeditor/ckeditor5/issues/10698.
+		it( 'should not crash when a pathological <iframe> content appears in source', () => {
+			const source =
+				'<p>' +
+					'<iframe>' +
+						'<br></br>' +
+						'</body>' +
+					'</iframe>' +
+				'</p>';
+
+			// This is not pretty but it does not crash and was the point of it.
+			const sourceFormatted =
+			'<p>\n' +
+			'    <iframe>\n' +
+			'    <br>\n' +
+			'</br>\n' +
+			'</body></iframe>\n' +
+			'</p>';
+
+			expect( formatHtml( source ) ).to.equal( sourceFormatted );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-source-editing/tests/utils/formathtml.js
+++ b/packages/ckeditor5-source-editing/tests/utils/formathtml.js
@@ -233,7 +233,7 @@ describe( 'SourceEditing utils', () => {
 					'</iframe>' +
 				'</p>';
 
-			// This is not pretty but it does not crash and was the point of it.
+			// This is not pretty but at least it does not crash.
 			const sourceFormatted =
 			'<p>\n' +
 			'    <iframe>\n' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (source-editing): The `formatHtml()` helper should not crash when a pathological iframe content is passed. Closes #10698.

---

### Additional information

Whys in https://github.com/ckeditor/ckeditor5/issues/10698#issuecomment-1138643844.