### PR TITLE
Replacing data-placeholder attribute with aria-placeholder.

### DIFF
--- a/packages/ckeditor5-core/src/editor/editorconfig.jsdoc
+++ b/packages/ckeditor5-core/src/editor/editorconfig.jsdoc
@@ -286,9 +286,9 @@
  *		};
  *
  * The placeholder text is displayed as a pseudo–element of an empty paragraph in the editor content.
- * The paragraph has the `.ck-placeholder` CSS class and the `data-placeholder` attribute.
+ * The paragraph has the `.ck-placeholder` CSS class and the `aria-placeholder` attribute.
  *
- *		<p data-placeholder="Type some text..." class="ck-placeholder">
+ *		<p aria-placeholder="Type some text..." class="ck-placeholder">
  *			::before
  *		</p>
  *

--- a/packages/ckeditor5-editor-balloon/tests/ballooneditorui.js
+++ b/packages/ckeditor5-editor-balloon/tests/ballooneditorui.js
@@ -125,7 +125,7 @@ describe( 'BalloonEditorUI', () => {
 					.then( newEditor => {
 						const firstChild = newEditor.editing.view.document.getRoot().getChild( 0 );
 
-						expect( firstChild.getAttribute( 'data-placeholder' ) ).to.equal( 'placeholder-text' );
+						expect( firstChild.getAttribute( 'aria-placeholder' ) ).to.equal( 'placeholder-text' );
 
 						return newEditor.destroy();
 					} );
@@ -144,7 +144,7 @@ describe( 'BalloonEditorUI', () => {
 					.then( newEditor => {
 						const firstChild = newEditor.editing.view.document.getRoot().getChild( 0 );
 
-						expect( firstChild.getAttribute( 'data-placeholder' ) ).to.equal( 'placeholder-text' );
+						expect( firstChild.getAttribute( 'aria-placeholder' ) ).to.equal( 'placeholder-text' );
 
 						return newEditor.destroy();
 					} );
@@ -164,7 +164,7 @@ describe( 'BalloonEditorUI', () => {
 					.then( newEditor => {
 						const firstChild = newEditor.editing.view.document.getRoot().getChild( 0 );
 
-						expect( firstChild.getAttribute( 'data-placeholder' ) ).to.equal( 'config takes precedence' );
+						expect( firstChild.getAttribute( 'aria-placeholder' ) ).to.equal( 'config takes precedence' );
 
 						return newEditor.destroy();
 					} );

--- a/packages/ckeditor5-editor-balloon/tests/manual/placeholder.html
+++ b/packages/ckeditor5-editor-balloon/tests/manual/placeholder.html
@@ -2,4 +2,4 @@
 	<p>Remove this text to see the placeholder.</p>
 </div>
 <br />
-<div id="editor-2" data-placeholder="Placeholder from the attribute"></div>
+<div id="editor-2" aria-placeholder="Placeholder from the attribute"></div>

--- a/packages/ckeditor5-editor-classic/tests/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditorui.js
@@ -156,7 +156,7 @@ describe( 'ClassicEditorUI', () => {
 					.then( newEditor => {
 						const firstChild = newEditor.editing.view.document.getRoot().getChild( 0 );
 
-						expect( firstChild.getAttribute( 'data-placeholder' ) ).to.equal( 'placeholder-text' );
+						expect( firstChild.getAttribute( 'aria-placeholder' ) ).to.equal( 'placeholder-text' );
 
 						return newEditor.destroy();
 					} );
@@ -174,7 +174,7 @@ describe( 'ClassicEditorUI', () => {
 					.then( newEditor => {
 						const firstChild = newEditor.editing.view.document.getRoot().getChild( 0 );
 
-						expect( firstChild.getAttribute( 'data-placeholder' ) ).to.equal( 'placeholder-text' );
+						expect( firstChild.getAttribute( 'aria-placeholder' ) ).to.equal( 'placeholder-text' );
 
 						return newEditor.destroy();
 					} );
@@ -193,7 +193,7 @@ describe( 'ClassicEditorUI', () => {
 					.then( newEditor => {
 						const firstChild = newEditor.editing.view.document.getRoot().getChild( 0 );
 
-						expect( firstChild.getAttribute( 'data-placeholder' ) ).to.equal( 'config takes precedence' );
+						expect( firstChild.getAttribute( 'aria-placeholder' ) ).to.equal( 'config takes precedence' );
 
 						return newEditor.destroy();
 					} );

--- a/packages/ckeditor5-editor-classic/tests/manual/placeholder.html
+++ b/packages/ckeditor5-editor-classic/tests/manual/placeholder.html
@@ -2,4 +2,4 @@
 	<p>Remove this text to see the placeholder.</p>
 </textarea>
 <br />
-<div id="editor-2" data-placeholder="Placeholder from the attribute"></div>
+<div id="editor-2" aria-placeholder="Placeholder from the attribute"></div>

--- a/packages/ckeditor5-editor-decoupled/tests/decouplededitorui.js
+++ b/packages/ckeditor5-editor-decoupled/tests/decouplededitorui.js
@@ -92,7 +92,7 @@ describe( 'DecoupledEditorUI', () => {
 					.then( newEditor => {
 						const firstChild = newEditor.editing.view.document.getRoot().getChild( 0 );
 
-						expect( firstChild.getAttribute( 'data-placeholder' ) ).to.equal( 'placeholder-text' );
+						expect( firstChild.getAttribute( 'aria-placeholder' ) ).to.equal( 'placeholder-text' );
 
 						return newEditor.destroy();
 					} );
@@ -110,7 +110,7 @@ describe( 'DecoupledEditorUI', () => {
 					.then( newEditor => {
 						const firstChild = newEditor.editing.view.document.getRoot().getChild( 0 );
 
-						expect( firstChild.getAttribute( 'data-placeholder' ) ).to.equal( 'placeholder-text' );
+						expect( firstChild.getAttribute( 'aria-placeholder' ) ).to.equal( 'placeholder-text' );
 
 						return newEditor.destroy();
 					} );
@@ -129,7 +129,7 @@ describe( 'DecoupledEditorUI', () => {
 					.then( newEditor => {
 						const firstChild = newEditor.editing.view.document.getRoot().getChild( 0 );
 
-						expect( firstChild.getAttribute( 'data-placeholder' ) ).to.equal( 'config takes precedence' );
+						expect( firstChild.getAttribute( 'aria-placeholder' ) ).to.equal( 'config takes precedence' );
 
 						return newEditor.destroy();
 					} );

--- a/packages/ckeditor5-editor-decoupled/tests/manual/placeholder.html
+++ b/packages/ckeditor5-editor-decoupled/tests/manual/placeholder.html
@@ -2,4 +2,4 @@
 	<p>Remove this text to see the placeholder.</p>
 </div>
 <br />
-<div id="editor-2" data-placeholder="Placeholder from the attribute"></div>
+<div id="editor-2" aria-placeholder="Placeholder from the attribute"></div>

--- a/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
@@ -184,7 +184,7 @@ describe( 'InlineEditorUI', () => {
 					.then( newEditor => {
 						const firstChild = newEditor.editing.view.document.getRoot().getChild( 0 );
 
-						expect( firstChild.getAttribute( 'data-placeholder' ) ).to.equal( 'placeholder-text' );
+						expect( firstChild.getAttribute( 'aria-placeholder' ) ).to.equal( 'placeholder-text' );
 
 						return newEditor.destroy();
 					} );
@@ -202,7 +202,7 @@ describe( 'InlineEditorUI', () => {
 					.then( newEditor => {
 						const firstChild = newEditor.editing.view.document.getRoot().getChild( 0 );
 
-						expect( firstChild.getAttribute( 'data-placeholder' ) ).to.equal( 'placeholder-text' );
+						expect( firstChild.getAttribute( 'aria-placeholder' ) ).to.equal( 'placeholder-text' );
 
 						return newEditor.destroy();
 					} );
@@ -221,7 +221,7 @@ describe( 'InlineEditorUI', () => {
 					.then( newEditor => {
 						const firstChild = newEditor.editing.view.document.getRoot().getChild( 0 );
 
-						expect( firstChild.getAttribute( 'data-placeholder' ) ).to.equal( 'config takes precedence' );
+						expect( firstChild.getAttribute( 'aria-placeholder' ) ).to.equal( 'config takes precedence' );
 
 						return newEditor.destroy();
 					} );

--- a/packages/ckeditor5-editor-inline/tests/manual/placeholder.html
+++ b/packages/ckeditor5-editor-inline/tests/manual/placeholder.html
@@ -2,4 +2,4 @@
 	<p>Remove this text to see the placeholder.</p>
 </div>
 <br />
-<div id="editor-2" data-placeholder="Placeholder from the attribute"></div>
+<div id="editor-2" aria-placeholder="Placeholder from the attribute"></div>

--- a/packages/ckeditor5-engine/src/view/placeholder.js
+++ b/packages/ckeditor5-engine/src/view/placeholder.js
@@ -264,10 +264,10 @@ function updatePlaceholder( writer, element, config ) {
 
 			wasViewModified = true;
 		}
-	} else if ( hidePlaceholder( writer, hostElement ) ) {
+	} else if ( hidePlaceholder( writer, hostElement ) && hostElement.parent ) {
 		writer.removeAttribute(
 			'aria-placeholder',
-			hostElement.parent === hostElement.root ? hostElement.parent : hostElement
+			hostElement.parent === hostElement.root ? hostElement : hostElement.parent
 		);
 		writer.removeAttribute( 'aria-hidden', hostElement );
 

--- a/packages/ckeditor5-engine/src/view/placeholder.js
+++ b/packages/ckeditor5-engine/src/view/placeholder.js
@@ -104,13 +104,6 @@ export function showPlaceholder( writer, element ) {
 	if ( !element.hasClass( 'ck-placeholder' ) ) {
 		writer.addClass( 'ck-placeholder', element );
 
-		writer.setAttribute( 'aria-hidden', true, element );
-		writer.setAttribute(
-			'aria-placeholder',
-			element.getAttribute( 'data-placeholder' ),
-			element.root === element.parent ? element.parent : element
-		);
-
 		return true;
 	}
 
@@ -133,12 +126,6 @@ export function showPlaceholder( writer, element ) {
 export function hidePlaceholder( writer, element ) {
 	if ( element.hasClass( 'ck-placeholder' ) ) {
 		writer.removeClass( 'ck-placeholder', element );
-
-		writer.removeAttribute( 'aria-hidden', element );
-		writer.removeAttribute(
-			'aria-placeholder',
-			element.root === element.parent ? element.parent : element
-		);
 
 		return true;
 	}
@@ -269,9 +256,21 @@ function updatePlaceholder( writer, element, config ) {
 
 	if ( isOnlyChild && needsPlaceholder( hostElement, config.keepOnFocus ) ) {
 		if ( showPlaceholder( writer, hostElement ) ) {
+			writer.setAttribute(
+				'aria-placeholder',
+				text,
+				hostElement.parent === hostElement.root ? hostElement.parent : hostElement );
+			writer.setAttribute( 'aria-hidden', true, hostElement );
+
 			wasViewModified = true;
 		}
 	} else if ( hidePlaceholder( writer, hostElement ) ) {
+		writer.removeAttribute(
+			'aria-placeholder',
+			hostElement.parent === hostElement.root ? hostElement.parent : hostElement
+		);
+		writer.removeAttribute( 'aria-hidden', hostElement );
+
 		wasViewModified = true;
 	}
 

--- a/packages/ckeditor5-engine/src/view/placeholder.js
+++ b/packages/ckeditor5-engine/src/view/placeholder.js
@@ -75,7 +75,7 @@ export function disablePlaceholder( view, element ) {
 		const placeholders = documentPlaceholders.get( doc );
 		const config = placeholders.get( element );
 
-		writer.removeAttribute( 'data-placeholder', config.hostElement );
+		writer.removeAttribute( 'aria-placeholder', config.hostElement );
 		hidePlaceholder( writer, config.hostElement );
 
 		placeholders.delete( element );
@@ -246,8 +246,8 @@ function updatePlaceholder( writer, element, config ) {
 	let wasViewModified = false;
 
 	// This may be necessary when updating the placeholder text to something else.
-	if ( hostElement.getAttribute( 'data-placeholder' ) !== text ) {
-		writer.setAttribute( 'data-placeholder', text, hostElement );
+	if ( hostElement.getAttribute( 'aria-placeholder' ) !== text ) {
+		writer.setAttribute( 'aria-placeholder', text, hostElement );
 		wasViewModified = true;
 	}
 

--- a/packages/ckeditor5-engine/src/view/placeholder.js
+++ b/packages/ckeditor5-engine/src/view/placeholder.js
@@ -256,21 +256,9 @@ function updatePlaceholder( writer, element, config ) {
 
 	if ( isOnlyChild && needsPlaceholder( hostElement, config.keepOnFocus ) ) {
 		if ( showPlaceholder( writer, hostElement ) ) {
-			writer.setAttribute(
-				'aria-placeholder',
-				text,
-				hostElement.parent === hostElement.root ? hostElement.parent : hostElement );
-			writer.setAttribute( 'aria-hidden', true, hostElement );
-
 			wasViewModified = true;
 		}
-	} else if ( hidePlaceholder( writer, hostElement ) && hostElement.parent ) {
-		writer.removeAttribute(
-			'aria-placeholder',
-			hostElement.parent === hostElement.root ? hostElement : hostElement.parent
-		);
-		writer.removeAttribute( 'aria-hidden', hostElement );
-
+	} else if ( hidePlaceholder( writer, hostElement ) ) {
 		wasViewModified = true;
 	}
 

--- a/packages/ckeditor5-engine/src/view/placeholder.js
+++ b/packages/ckeditor5-engine/src/view/placeholder.js
@@ -104,6 +104,13 @@ export function showPlaceholder( writer, element ) {
 	if ( !element.hasClass( 'ck-placeholder' ) ) {
 		writer.addClass( 'ck-placeholder', element );
 
+		writer.setAttribute( 'aria-hidden', true, element );
+		writer.setAttribute(
+			'aria-placeholder',
+			element.getAttribute( 'data-placeholder' ),
+			element.root === element.parent ? element.parent : element
+		);
+
 		return true;
 	}
 
@@ -126,6 +133,12 @@ export function showPlaceholder( writer, element ) {
 export function hidePlaceholder( writer, element ) {
 	if ( element.hasClass( 'ck-placeholder' ) ) {
 		writer.removeClass( 'ck-placeholder', element );
+
+		writer.removeAttribute( 'aria-hidden', element );
+		writer.removeAttribute(
+			'aria-placeholder',
+			element.root === element.parent ? element.parent : element
+		);
 
 		return true;
 	}

--- a/packages/ckeditor5-engine/tests/view/placeholder.js
+++ b/packages/ckeditor5-engine/tests/view/placeholder.js
@@ -37,7 +37,7 @@ describe( 'placeholder', () => {
 				text: 'foo bar baz'
 			} );
 
-			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+			expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 		} );
 
@@ -52,7 +52,7 @@ describe( 'placeholder', () => {
 				isDirectHost: false
 			} );
 
-			expect( viewRoot.getChild( 0 ).getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+			expect( viewRoot.getChild( 0 ).getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.true;
 		} );
 
@@ -66,7 +66,7 @@ describe( 'placeholder', () => {
 				text: 'foo bar baz'
 			} );
 
-			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+			expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 
@@ -80,7 +80,7 @@ describe( 'placeholder', () => {
 				text: 'foo bar baz'
 			} );
 
-			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+			expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 		} );
 
@@ -94,7 +94,7 @@ describe( 'placeholder', () => {
 				text: 'foo bar baz'
 			} );
 
-			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+			expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 
@@ -111,7 +111,7 @@ describe( 'placeholder', () => {
 
 			view.forceRender();
 
-			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+			expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 		} );
 
@@ -125,7 +125,7 @@ describe( 'placeholder', () => {
 				text: 'foo bar baz'
 			} );
 
-			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+			expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 
 			view.change( writer => {
@@ -151,7 +151,7 @@ describe( 'placeholder', () => {
 				text: 'new text'
 			} );
 
-			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'new text' );
+			expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'new text' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 		} );
 
@@ -192,10 +192,10 @@ describe( 'placeholder', () => {
 				text: 'second placeholder'
 			} );
 
-			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'first placeholder' );
+			expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'first placeholder' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 
-			expect( secondElement.getAttribute( 'data-placeholder' ) ).to.equal( 'second placeholder' );
+			expect( secondElement.getAttribute( 'aria-placeholder' ) ).to.equal( 'second placeholder' );
 			expect( secondElement.hasClass( 'ck-placeholder' ) ).to.be.true;
 
 			// Move selection to the elements with placeholders.
@@ -207,10 +207,10 @@ describe( 'placeholder', () => {
 				writer.setSelection( ViewRange._createIn( secondElement ) );
 			} );
 
-			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'first placeholder' );
+			expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'first placeholder' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
 
-			expect( secondElement.getAttribute( 'data-placeholder' ) ).to.equal( 'second placeholder' );
+			expect( secondElement.getAttribute( 'aria-placeholder' ) ).to.equal( 'second placeholder' );
 			expect( secondElement.hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 
@@ -228,7 +228,7 @@ describe( 'placeholder', () => {
 				writer.setSelection( ViewRange._createIn( element ) );
 
 				// Here we are before rendering - placeholder is visible in first element;
-				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+				expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
 				expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 			} );
 
@@ -247,7 +247,7 @@ describe( 'placeholder', () => {
 				isDirectHost: false
 			} );
 
-			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.true;
+			expect( viewRoot.getChild( 0 ).hasAttribute( 'aria-placeholder' ) ).to.be.true;
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 
@@ -263,7 +263,7 @@ describe( 'placeholder', () => {
 				isDirectHost: false
 			} );
 
-			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.true;
+			expect( viewRoot.getChild( 0 ).hasAttribute( 'aria-placeholder' ) ).to.be.true;
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 
@@ -286,7 +286,7 @@ describe( 'placeholder', () => {
 				isDirectHost: true
 			} );
 
-			expect( viewRoot.getChild( 0 ).getAttribute( 'data-placeholder' ) ).to.equal( 'bar' );
+			expect( viewRoot.getChild( 0 ).getAttribute( 'aria-placeholder' ) ).to.equal( 'bar' );
 			expect( viewRoot.getChild( 0 ).isEmpty ).to.be.true;
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.true;
 		} );
@@ -304,7 +304,7 @@ describe( 'placeholder', () => {
 
 			view.forceRender();
 
-			expect( viewRoot.getChild( 0 ).getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+			expect( viewRoot.getChild( 0 ).getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.true;
 		} );
 
@@ -319,7 +319,7 @@ describe( 'placeholder', () => {
 				isDirectHost: false
 			} );
 
-			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.false;
+			expect( viewRoot.getChild( 0 ).hasAttribute( 'aria-placeholder' ) ).to.be.false;
 			expect( viewRoot.getChild( 0 ).isEmpty ).to.be.true;
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
@@ -335,7 +335,7 @@ describe( 'placeholder', () => {
 				isDirectHost: false
 			} );
 
-			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.false;
+			expect( viewRoot.getChild( 0 ).hasAttribute( 'aria-placeholder' ) ).to.be.false;
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 
@@ -350,7 +350,7 @@ describe( 'placeholder', () => {
 				isDirectHost: false
 			} );
 
-			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.false;
+			expect( viewRoot.getChild( 0 ).hasAttribute( 'aria-placeholder' ) ).to.be.false;
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 
@@ -365,18 +365,18 @@ describe( 'placeholder', () => {
 				keepOnFocus: true
 			} );
 
-			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.true;
+			expect( viewRoot.getChild( 0 ).hasAttribute( 'aria-placeholder' ) ).to.be.true;
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.true;
 
 			view.change( writer => {
 				writer.setSelection( ViewRange._createIn( element ) );
 
 				// Here we are before rendering - placeholder is visible in first element;
-				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+				expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
 				expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 			} );
 
-			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.true;
+			expect( viewRoot.getChild( 0 ).hasAttribute( 'aria-placeholder' ) ).to.be.true;
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.true;
 		} );
 
@@ -391,18 +391,18 @@ describe( 'placeholder', () => {
 				// Defaults: keepOnFocus = false
 			} );
 
-			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.true;
+			expect( viewRoot.getChild( 0 ).hasAttribute( 'aria-placeholder' ) ).to.be.true;
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.true;
 
 			view.change( writer => {
 				writer.setSelection( ViewRange._createIn( element ) );
 
 				// Here we are before rendering - placeholder is visible in first element;
-				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+				expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
 				expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 			} );
 
-			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.true;
+			expect( viewRoot.getChild( 0 ).hasAttribute( 'aria-placeholder' ) ).to.be.true;
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 	} );
@@ -418,12 +418,12 @@ describe( 'placeholder', () => {
 				text: 'foo bar baz'
 			} );
 
-			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+			expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 
 			disablePlaceholder( view, element );
 
-			expect( element.hasAttribute( 'data-placeholder' ) ).to.be.false;
+			expect( element.hasAttribute( 'aria-placeholder' ) ).to.be.false;
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 
@@ -433,7 +433,7 @@ describe( 'placeholder', () => {
 
 			disablePlaceholder( view, element );
 
-			expect( element.hasAttribute( 'data-placeholder' ) ).to.be.false;
+			expect( element.hasAttribute( 'aria-placeholder' ) ).to.be.false;
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 
@@ -448,12 +448,12 @@ describe( 'placeholder', () => {
 				isDirectHost: false
 			} );
 
-			expect( viewRoot.getChild( 0 ).getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+			expect( viewRoot.getChild( 0 ).getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.true;
 
 			disablePlaceholder( view, viewRoot );
 
-			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.false;
+			expect( viewRoot.getChild( 0 ).hasAttribute( 'aria-placeholder' ) ).to.be.false;
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
 	} );

--- a/packages/ckeditor5-engine/tests/view/placeholder.js
+++ b/packages/ckeditor5-engine/tests/view/placeholder.js
@@ -41,134 +41,9 @@ describe( 'placeholder', () => {
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 		} );
 
-		describe( 'should attach aria attributes', () => {
-			it( 'proper CSS class and data attribute to an only element in the editor', () => {
-				setData( view, '<div><div></div></div>' );
-				const element = viewRoot.getChild( 0 ).getChild( 0 );
-
-				enablePlaceholder( {
-					view,
-					element,
-					text: 'foo bar baz'
-				} );
-
-				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
-				expect( element.getAttribute( 'aria-hidden' ) ).to.equal( 'true' );
-				expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
-				expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
-			} );
-
-			it( 'proper CSS class and data attribute to the table caption', () => {
-				setData( view,
-					'<figure class="table">' +
-						'<table>' +
-							'<tbody>' +
-								'<tr>' +
-									'<td></td>' +
-								'</tr>' +
-							'</tbody>' +
-						'</table>' +
-						'<figcaption></figcaption>' +
-					'</figure>'
-				);
-				const element = viewRoot.getChild( 0 ).getChild( 1 );
-
-				enablePlaceholder( {
-					view,
-					element,
-					text: 'foo bar baz'
-				} );
-
-				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
-				expect( element.getAttribute( 'aria-hidden' ) ).to.equal( 'true' );
-				expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
-				expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
-			} );
-
-			it( 'proper CSS class and data attribute to the image caption', () => {
-				setData( view,
-					'<figure class="image"><img /><figcaption></figcaption></figure>'
-				);
-				const element = viewRoot.getChild( 0 ).getChild( 1 );
-
-				enablePlaceholder( {
-					view,
-					element,
-					text: 'foo bar baz'
-				} );
-
-				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
-				expect( element.getAttribute( 'aria-hidden' ) ).to.equal( 'true' );
-				expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
-				expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
-			} );
-
-			it( 'and remove it when text has been added to an only element in the editor', () => {
-				setData( view, '<div><div>foo</div></div>' );
-				const element = viewRoot.getChild( 0 ).getChild( 0 );
-
-				enablePlaceholder( {
-					view,
-					element,
-					text: 'foo bar baz'
-				} );
-
-				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
-				expect( element.hasAttribute( 'aria-hidden' ) ).to.be.false;
-				expect( element.hasAttribute( 'aria-placeholder' ) ).to.be.false;
-				expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
-			} );
-
-			it( 'and remove it when text has been added to the table caption', () => {
-				setData( view,
-					'<figure class="table">' +
-						'<table>' +
-							'<tbody>' +
-								'<tr>' +
-									'<td></td>' +
-								'</tr>' +
-							'</tbody>' +
-						'</table>' +
-						'<figcaption>foo</figcaption>' +
-					'</figure>'
-				);
-				const element = viewRoot.getChild( 0 ).getChild( 1 );
-
-				enablePlaceholder( {
-					view,
-					element,
-					text: 'foo bar baz'
-				} );
-
-				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
-				expect( element.hasAttribute( 'aria-hidden' ) ).to.be.false;
-				expect( element.hasAttribute( 'aria-placeholder' ) ).to.be.false;
-				expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
-			} );
-
-			it( 'and remove it when text has been added to the image caption', () => {
-				setData( view,
-					'<figure class="image"><img /><figcaption>foo</figcaption></figure>'
-				);
-				const element = viewRoot.getChild( 0 ).getChild( 1 );
-
-				enablePlaceholder( {
-					view,
-					element,
-					text: 'foo bar baz'
-				} );
-
-				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
-				expect( element.hasAttribute( 'aria-hidden' ) ).to.be.false;
-				expect( element.hasAttribute( 'aria-placeholder' ) ).to.be.false;
-				expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
-			} );
-		} );
-
 		it( 'should attach proper CSS class and data attribute (isDirectHost=false)', () => {
 			setData( view, '<p></p>' );
 			viewDocument.isFocused = false;
-			const element = viewRoot.getChild( 0 );
 
 			enablePlaceholder( {
 				view,
@@ -177,8 +52,8 @@ describe( 'placeholder', () => {
 				isDirectHost: false
 			} );
 
-			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
-			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
+			expect( viewRoot.getChild( 0 ).getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.true;
 		} );
 
 		it( 'if element has children set only data attribute', () => {

--- a/packages/ckeditor5-engine/tests/view/placeholder.js
+++ b/packages/ckeditor5-engine/tests/view/placeholder.js
@@ -41,9 +41,134 @@ describe( 'placeholder', () => {
 			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 		} );
 
+		describe( 'should attach aria attributes', () => {
+			it( 'proper CSS class and data attribute to an only element in the editor', () => {
+				setData( view, '<div><div></div></div>' );
+				const element = viewRoot.getChild( 0 ).getChild( 0 );
+
+				enablePlaceholder( {
+					view,
+					element,
+					text: 'foo bar baz'
+				} );
+
+				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+				expect( element.getAttribute( 'aria-hidden' ) ).to.equal( 'true' );
+				expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
+				expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
+			} );
+
+			it( 'proper CSS class and data attribute to the table caption', () => {
+				setData( view,
+					'<figure class="table">' +
+						'<table>' +
+							'<tbody>' +
+								'<tr>' +
+									'<td></td>' +
+								'</tr>' +
+							'</tbody>' +
+						'</table>' +
+						'<figcaption></figcaption>' +
+					'</figure>'
+				);
+				const element = viewRoot.getChild( 0 ).getChild( 1 );
+
+				enablePlaceholder( {
+					view,
+					element,
+					text: 'foo bar baz'
+				} );
+
+				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+				expect( element.getAttribute( 'aria-hidden' ) ).to.equal( 'true' );
+				expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
+				expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
+			} );
+
+			it( 'proper CSS class and data attribute to the image caption', () => {
+				setData( view,
+					'<figure class="image"><img /><figcaption></figcaption></figure>'
+				);
+				const element = viewRoot.getChild( 0 ).getChild( 1 );
+
+				enablePlaceholder( {
+					view,
+					element,
+					text: 'foo bar baz'
+				} );
+
+				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+				expect( element.getAttribute( 'aria-hidden' ) ).to.equal( 'true' );
+				expect( element.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo bar baz' );
+				expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
+			} );
+
+			it( 'and remove it when text has been added to an only element in the editor', () => {
+				setData( view, '<div><div>foo</div></div>' );
+				const element = viewRoot.getChild( 0 ).getChild( 0 );
+
+				enablePlaceholder( {
+					view,
+					element,
+					text: 'foo bar baz'
+				} );
+
+				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+				expect( element.hasAttribute( 'aria-hidden' ) ).to.be.false;
+				expect( element.hasAttribute( 'aria-placeholder' ) ).to.be.false;
+				expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
+			} );
+
+			it( 'and remove it when text has been added to the table caption', () => {
+				setData( view,
+					'<figure class="table">' +
+						'<table>' +
+							'<tbody>' +
+								'<tr>' +
+									'<td></td>' +
+								'</tr>' +
+							'</tbody>' +
+						'</table>' +
+						'<figcaption>foo</figcaption>' +
+					'</figure>'
+				);
+				const element = viewRoot.getChild( 0 ).getChild( 1 );
+
+				enablePlaceholder( {
+					view,
+					element,
+					text: 'foo bar baz'
+				} );
+
+				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+				expect( element.hasAttribute( 'aria-hidden' ) ).to.be.false;
+				expect( element.hasAttribute( 'aria-placeholder' ) ).to.be.false;
+				expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
+			} );
+
+			it( 'and remove it when text has been added to the image caption', () => {
+				setData( view,
+					'<figure class="image"><img /><figcaption>foo</figcaption></figure>'
+				);
+				const element = viewRoot.getChild( 0 ).getChild( 1 );
+
+				enablePlaceholder( {
+					view,
+					element,
+					text: 'foo bar baz'
+				} );
+
+				expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+				expect( element.hasAttribute( 'aria-hidden' ) ).to.be.false;
+				expect( element.hasAttribute( 'aria-placeholder' ) ).to.be.false;
+				expect( element.hasClass( 'ck-placeholder' ) ).to.be.false;
+			} );
+		} );
+
 		it( 'should attach proper CSS class and data attribute (isDirectHost=false)', () => {
 			setData( view, '<p></p>' );
 			viewDocument.isFocused = false;
+			const element = viewRoot.getChild( 0 );
 
 			enablePlaceholder( {
 				view,
@@ -52,8 +177,8 @@ describe( 'placeholder', () => {
 				isDirectHost: false
 			} );
 
-			expect( viewRoot.getChild( 0 ).getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
-			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.true;
+			expect( element.getAttribute( 'data-placeholder' ) ).to.equal( 'foo bar baz' );
+			expect( element.hasClass( 'ck-placeholder' ) ).to.be.true;
 		} );
 
 		it( 'if element has children set only data attribute', () => {

--- a/packages/ckeditor5-engine/tests/view/renderer.js
+++ b/packages/ckeditor5-engine/tests/view/renderer.js
@@ -3785,15 +3785,15 @@ describe( 'Renderer', () => {
 
 				const viewP = viewRoot.getChild( 0 );
 
-				writer.setAttribute( 'data-placeholder', 'Body', viewP );
+				writer.setAttribute( 'aria-placeholder', 'Body', viewP );
 
 				renderer.markToSync( 'children', viewRoot );
 				renderer.render();
 
-				expect( domRoot.innerHTML ).to.equal( '<p data-placeholder="Body">1</p>' );
+				expect( domRoot.innerHTML ).to.equal( '<p aria-placeholder="Body">1</p>' );
 
 				// 2. Modify view.
-				writer.removeAttribute( 'data-placeholder', viewP );
+				writer.removeAttribute( 'aria-placeholder', viewP );
 
 				viewRoot._removeChildren( 0, viewRoot.childCount );
 
@@ -3844,17 +3844,17 @@ describe( 'Renderer', () => {
 
 				const viewP = viewRoot.getChild( 0 );
 
-				writer.setAttribute( 'data-placeholder', 'Body', viewP );
+				writer.setAttribute( 'aria-placeholder', 'Body', viewP );
 
 				renderer.markToSync( 'children', viewRoot );
 				renderer.render();
 
-				expect( domRoot.innerHTML ).to.equal( '<p data-placeholder="Body">1</p>' );
+				expect( domRoot.innerHTML ).to.equal( '<p aria-placeholder="Body">1</p>' );
 
 				// 2. Modify view.
 				viewRoot._removeChildren( 0, viewRoot.childCount );
 
-				writer.removeAttribute( 'data-placeholder', viewP );
+				writer.removeAttribute( 'aria-placeholder', viewP );
 
 				viewRoot._appendChild( parse( '<container:p>1</container:p><container:p>2</container:p>' ) );
 

--- a/packages/ckeditor5-engine/theme/placeholder.css
+++ b/packages/ckeditor5-engine/theme/placeholder.css
@@ -12,7 +12,7 @@
 		position: absolute;
 		left: 0;
 		right: 0;
-		content: attr(data-placeholder);
+		content: attr(aria-placeholder);
 
 		/* See ckeditor/ckeditor5#469. */
 		pointer-events: none;

--- a/packages/ckeditor5-heading/src/title.js
+++ b/packages/ckeditor5-heading/src/title.js
@@ -361,10 +361,10 @@ export default class Title extends Plugin {
 			if ( body !== oldBody ) {
 				if ( oldBody ) {
 					hidePlaceholder( writer, oldBody );
-					writer.removeAttribute( 'data-placeholder', oldBody );
+					writer.removeAttribute( 'aria-placeholder', oldBody );
 				}
 
-				writer.setAttribute( 'data-placeholder', bodyPlaceholder, body );
+				writer.setAttribute( 'aria-placeholder', bodyPlaceholder, body );
 				oldBody = body;
 				hasChanged = true;
 			}

--- a/packages/ckeditor5-heading/tests/title.js
+++ b/packages/ckeditor5-heading/tests/title.js
@@ -602,8 +602,8 @@ describe( 'Title', () => {
 			const title = viewRoot.getChild( 0 );
 			const body = viewRoot.getChild( 1 );
 
-			expect( title.getAttribute( 'data-placeholder' ) ).to.equal( 'Type your title' );
-			expect( body.getAttribute( 'data-placeholder' ) ).to.equal( 'Type or paste your content here.' );
+			expect( title.getAttribute( 'aria-placeholder' ) ).to.equal( 'Type your title' );
+			expect( body.getAttribute( 'aria-placeholder' ) ).to.equal( 'Type or paste your content here.' );
 
 			expect( title.hasClass( 'ck-placeholder' ) ).to.equal( false );
 			expect( body.hasClass( 'ck-placeholder' ) ).to.equal( false );
@@ -618,8 +618,8 @@ describe( 'Title', () => {
 			const title = viewRoot.getChild( 0 );
 			const body = viewRoot.getChild( 1 );
 
-			expect( title.getAttribute( 'data-placeholder' ) ).to.equal( 'Type your title' );
-			expect( body.getAttribute( 'data-placeholder' ) ).to.equal( 'Type or paste your content here.' );
+			expect( title.getAttribute( 'aria-placeholder' ) ).to.equal( 'Type your title' );
+			expect( body.getAttribute( 'aria-placeholder' ) ).to.equal( 'Type or paste your content here.' );
 
 			expect( title.hasClass( 'ck-placeholder' ) ).to.equal( true );
 			expect( body.hasClass( 'ck-placeholder' ) ).to.equal( true );
@@ -634,7 +634,7 @@ describe( 'Title', () => {
 
 			const body = viewRoot.getChild( 1 );
 
-			expect( body.getAttribute( 'data-placeholder' ) ).to.equal( 'Type or paste your content here.' );
+			expect( body.getAttribute( 'aria-placeholder' ) ).to.equal( 'Type or paste your content here.' );
 			expect( body.hasClass( 'ck-placeholder' ) ).to.equal( false );
 		} );
 
@@ -646,7 +646,7 @@ describe( 'Title', () => {
 
 			const body = viewRoot.getChild( 1 );
 
-			expect( body.hasAttribute( 'data-placeholder' ) ).to.equal( true );
+			expect( body.hasAttribute( 'aria-placeholder' ) ).to.equal( true );
 			expect( body.hasClass( 'ck-placeholder' ) ).to.equal( false );
 		} );
 
@@ -694,14 +694,14 @@ describe( 'Title', () => {
 
 			bodyDomElement = domConverter.mapViewToDom( viewRoot.getChild( 1 ) );
 
-			expect( bodyDomElement.dataset.placeholder ).to.equal( 'Type or paste your content here.' );
+			expect( bodyDomElement.getAttribute( 'aria-placeholder' ) ).to.equal( 'Type or paste your content here.' );
 			expect( bodyDomElement.classList.contains( 'ck-placeholder' ) ).to.equal( true );
 
 			editor.execute( 'undo' );
 
 			bodyDomElement = domConverter.mapViewToDom( viewRoot.getChild( 1 ) );
 
-			expect( bodyDomElement.dataset.placeholder ).to.equal( 'Type or paste your content here.' );
+			expect( bodyDomElement.getAttribute( 'aria-placeholder' ) ).to.equal( 'Type or paste your content here.' );
 			expect( bodyDomElement.classList.contains( 'ck-placeholder' ) ).to.equal( false );
 		} );
 
@@ -739,8 +739,8 @@ describe( 'Title', () => {
 				const title = viewRoot.getChild( 0 );
 				const body = viewRoot.getChild( 1 );
 
-				expect( title.getAttribute( 'data-placeholder' ) ).to.equal( 'foo' );
-				expect( body.getAttribute( 'data-placeholder' ) ).to.equal( 'bar' );
+				expect( title.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo' );
+				expect( body.getAttribute( 'aria-placeholder' ) ).to.equal( 'bar' );
 
 				expect( title.hasClass( 'ck-placeholder' ) ).to.equal( true );
 				expect( body.hasClass( 'ck-placeholder' ) ).to.equal( true );
@@ -781,8 +781,8 @@ describe( 'Title', () => {
 				const title = viewRoot.getChild( 0 );
 				const body = viewRoot.getChild( 1 );
 
-				expect( title.getAttribute( 'data-placeholder' ) ).to.equal( 'foo' );
-				expect( body.getAttribute( 'data-placeholder' ) ).to.equal( 'bom' );
+				expect( title.getAttribute( 'aria-placeholder' ) ).to.equal( 'foo' );
+				expect( body.getAttribute( 'aria-placeholder' ) ).to.equal( 'bom' );
 
 				expect( title.hasClass( 'ck-placeholder' ) ).to.equal( true );
 				expect( body.hasClass( 'ck-placeholder' ) ).to.equal( true );

--- a/packages/ckeditor5-html-support/tests/integrations/image.js
+++ b/packages/ckeditor5-html-support/tests/integrations/image.js
@@ -1530,7 +1530,7 @@ describe( 'ImageElementSupport', () => {
 		// 				' style="font-size:12px;text-align:center">' +
 		// 			'<img class="bar baz" data-image="xyz" src="/assets/sample.png" style="background-color:blue;color:red"></img>' +
 		// 			'<figcaption class="bar baz ck-editor__editable ck-editor__nested-editable foo" contenteditable="true" ' +
-		// 						'data-figcaption="xxx" data-placeholder="Enter image caption" style="color:green">A caption</figcaption>' +
+		// 						'data-figcaption="xxx" aria-placeholder="Enter image caption" style="color:green">A caption</figcaption>' +
 		// 			'<div class="ck ck-reset_all ck-widget__type-around"></div>' +
 		// 		'</figure>'
 		// 	);
@@ -1592,7 +1592,7 @@ describe( 'ImageElementSupport', () => {
 		// 		'<figure class="ck-widget ck-widget_selected image" contenteditable="false">' +
 		// 			'<img src="/assets/sample.png"></img>' +
 		// 			'<figcaption class="ck-editor__editable ck-editor__nested-editable" contenteditable="true" ' +
-		// 						'data-placeholder="Enter image caption">A caption</figcaption>' +
+		// 						'aria-placeholder="Enter image caption">A caption</figcaption>' +
 		// 			'<div class="ck ck-reset_all ck-widget__type-around"></div>' +
 		// 		'</figure>'
 		// 	);

--- a/packages/ckeditor5-image/tests/imagecaption/imagecaptionediting.js
+++ b/packages/ckeditor5-image/tests/imagecaption/imagecaptionediting.js
@@ -256,7 +256,7 @@ describe( 'ImageCaptionEditing', () => {
 					'<p>{}foo</p>' +
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
+						'<figcaption aria-placeholder="Enter image caption" class="ck-editor__editable ck-editor__nested-editable" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">' +
 							'foo bar' +
 						'</figcaption>' +
@@ -278,7 +278,8 @@ describe( 'ImageCaptionEditing', () => {
 					'<p>{}foo</p>' +
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+						'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
+							'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">' +
 						'</figcaption>' +
 					'</figure>'
@@ -477,7 +478,8 @@ describe( 'ImageCaptionEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img alt="" src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption"></figcaption>' +
 				'</figure>]' +
 				'<p></p>'
@@ -528,7 +530,8 @@ describe( 'ImageCaptionEditing', () => {
 				'<p>foo</p>' +
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 					'</figcaption>' +
 				'</figure>]'
@@ -542,7 +545,8 @@ describe( 'ImageCaptionEditing', () => {
 				'<p>{}foo</p>' +
 				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 					'</figcaption>' +
 				'</figure>'
@@ -558,7 +562,8 @@ describe( 'ImageCaptionEditing', () => {
 				'<p>foo</p>' +
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 					'</figcaption>' +
 				'</figure>]'
@@ -578,6 +583,7 @@ describe( 'ImageCaptionEditing', () => {
 				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
 					'<figcaption ' +
+						'aria-hidden="true" aria-placeholder="Enter image caption" ' +
 						'class="ck-editor__editable ck-editor__nested-editable ck-editor__nested-editable_focused ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">[]' +
 					'</figcaption>' +
@@ -609,7 +615,8 @@ describe( 'ImageCaptionEditing', () => {
 				'<p>{}foo</p>' +
 				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 					'</figcaption>' +
 				'</figure>'
@@ -626,7 +633,8 @@ describe( 'ImageCaptionEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 						'[]' +
 					'</figcaption>' +
@@ -646,7 +654,8 @@ describe( 'ImageCaptionEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption"></figcaption>' +
 				'</figure>]'
 			);
@@ -670,7 +679,8 @@ describe( 'ImageCaptionEditing', () => {
 				'</figure>' +
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption"></figcaption>' +
 				'</figure>]'
 			);
@@ -684,7 +694,8 @@ describe( 'ImageCaptionEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src="img.png"></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="false" data-placeholder="Enter image caption"></figcaption>' +
 				'</figure>]'
 			);
@@ -709,7 +720,8 @@ describe( 'ImageCaptionEditing', () => {
 					'<p>{}foo</p>' +
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src=""></img>' +
-						'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+						'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
+							'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">' +
 						'</figcaption>' +
 					'</figure>'
@@ -722,7 +734,8 @@ describe( 'ImageCaptionEditing', () => {
 					'<p>foo</p>' +
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src=""></img>' +
-						'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
+						'<figcaption aria-placeholder="Enter image caption" ' +
+							'class="ck-editor__editable ck-editor__nested-editable" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">' +
 							'{foo bar baz}' +
 						'</figcaption>' +

--- a/packages/ckeditor5-image/tests/imagecaption/imagecaptionediting.js
+++ b/packages/ckeditor5-image/tests/imagecaption/imagecaptionediting.js
@@ -200,8 +200,9 @@ describe( 'ImageCaptionEditing', () => {
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
-							'contenteditable="true" data-placeholder="Enter image caption">' +
+						'<figcaption aria-placeholder="Enter image caption" ' +
+							'class="ck-editor__editable ck-editor__nested-editable" ' +
+							'contenteditable="true">' +
 							'Foo bar baz.' +
 						'</figcaption>' +
 					'</figure>'
@@ -256,8 +257,9 @@ describe( 'ImageCaptionEditing', () => {
 					'<p>{}foo</p>' +
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
-							'contenteditable="true" data-placeholder="Enter image caption">' +
+						'<figcaption aria-placeholder="Enter image caption" ' +
+							'class="ck-editor__editable ck-editor__nested-editable" ' +
+							'contenteditable="true">' +
 							'foo bar' +
 						'</figcaption>' +
 					'</figure>'
@@ -278,8 +280,9 @@ describe( 'ImageCaptionEditing', () => {
 					'<p>{}foo</p>' +
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
-							'contenteditable="true" data-placeholder="Enter image caption">' +
+						'<figcaption aria-placeholder="Enter image caption" ' +
+							'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+							'contenteditable="true">' +
 						'</figcaption>' +
 					'</figure>'
 				);
@@ -299,8 +302,9 @@ describe( 'ImageCaptionEditing', () => {
 					'<p>{}foo</p>' +
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
-							'contenteditable="true" data-placeholder="Enter image caption">baz</figcaption>' +
+						'<figcaption aria-placeholder="Enter image caption" ' +
+							'class="ck-editor__editable ck-editor__nested-editable" ' +
+							'contenteditable="true">baz</figcaption>' +
 					'</figure>'
 				);
 			} );
@@ -335,8 +339,9 @@ describe( 'ImageCaptionEditing', () => {
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption class="ck-editor__editable ck-editor__nested-editable highlight-yellow" ' +
-								'contenteditable="true" data-foo="yellow" data-placeholder="Enter image caption">' +
+						'<figcaption aria-placeholder="Enter image caption" ' +
+							'class="ck-editor__editable ck-editor__nested-editable highlight-yellow" ' +
+							'contenteditable="true" data-foo="yellow">' +
 							'Foo bar baz.' +
 						'</figcaption>' +
 					'</figure>'
@@ -349,8 +354,9 @@ describe( 'ImageCaptionEditing', () => {
 				expect( getViewData( view, { withoutSelection: true } ) ).to.equal(
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
-								'contenteditable="true" data-placeholder="Enter image caption">' +
+						'<figcaption aria-placeholder="Enter image caption" ' +
+							'class="ck-editor__editable ck-editor__nested-editable" ' +
+							'contenteditable="true">' +
 							'Foo bar baz.' +
 						'</figcaption>' +
 					'</figure>'
@@ -448,8 +454,9 @@ describe( 'ImageCaptionEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img alt="" src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
-						'contenteditable="true" data-placeholder="Enter image caption">' +
+					'<figcaption aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable" ' +
+						'contenteditable="true">' +
 						'foo bar' +
 					'</figcaption>' +
 				'</figure>]' +
@@ -477,8 +484,9 @@ describe( 'ImageCaptionEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img alt="" src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
-						'contenteditable="true" data-placeholder="Enter image caption"></figcaption>' +
+					'<figcaption aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+						'contenteditable="true"></figcaption>' +
 				'</figure>]' +
 				'<p></p>'
 			);
@@ -528,8 +536,9 @@ describe( 'ImageCaptionEditing', () => {
 				'<p>foo</p>' +
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
-						'contenteditable="true" data-placeholder="Enter image caption">' +
+					'<figcaption aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+						'contenteditable="true">' +
 					'</figcaption>' +
 				'</figure>]'
 			);
@@ -542,8 +551,9 @@ describe( 'ImageCaptionEditing', () => {
 				'<p>{}foo</p>' +
 				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
-						'contenteditable="true" data-placeholder="Enter image caption">' +
+					'<figcaption aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+						'contenteditable="true">' +
 					'</figcaption>' +
 				'</figure>'
 			);
@@ -558,8 +568,9 @@ describe( 'ImageCaptionEditing', () => {
 				'<p>foo</p>' +
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
-						'contenteditable="true" data-placeholder="Enter image caption">' +
+					'<figcaption aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+						'contenteditable="true">' +
 					'</figcaption>' +
 				'</figure>]'
 			);
@@ -578,8 +589,9 @@ describe( 'ImageCaptionEditing', () => {
 				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
 					'<figcaption ' +
+						'aria-placeholder="Enter image caption" ' +
 						'class="ck-editor__editable ck-editor__nested-editable ck-editor__nested-editable_focused ck-placeholder" ' +
-						'contenteditable="true" data-placeholder="Enter image caption">[]' +
+						'contenteditable="true">[]' +
 					'</figcaption>' +
 				'</figure>'
 			);
@@ -592,8 +604,9 @@ describe( 'ImageCaptionEditing', () => {
 				'<p>foo</p>' +
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
-						'contenteditable="true" data-placeholder="Enter image caption">foo bar</figcaption>' +
+					'<figcaption aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable" ' +
+						'contenteditable="true">foo bar</figcaption>' +
 				'</figure>]'
 			);
 		} );
@@ -609,8 +622,9 @@ describe( 'ImageCaptionEditing', () => {
 				'<p>{}foo</p>' +
 				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
-						'contenteditable="true" data-placeholder="Enter image caption">' +
+					'<figcaption aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+						'contenteditable="true">' +
 					'</figcaption>' +
 				'</figure>'
 			);
@@ -626,8 +640,9 @@ describe( 'ImageCaptionEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
-						'contenteditable="true" data-placeholder="Enter image caption">' +
+					'<figcaption aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+						'contenteditable="true">' +
 						'[]' +
 					'</figcaption>' +
 				'</figure>'
@@ -646,8 +661,9 @@ describe( 'ImageCaptionEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
-						'contenteditable="true" data-placeholder="Enter image caption"></figcaption>' +
+					'<figcaption aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+						'contenteditable="true"></figcaption>' +
 				'</figure>]'
 			);
 		} );
@@ -665,13 +681,15 @@ describe( 'ImageCaptionEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
-						'contenteditable="true" data-placeholder="Enter image caption">foo bar</figcaption>' +
+					'<figcaption aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable" ' +
+						'contenteditable="true">foo bar</figcaption>' +
 				'</figure>' +
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
-						'contenteditable="true" data-placeholder="Enter image caption"></figcaption>' +
+					'<figcaption aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+						'contenteditable="true"></figcaption>' +
 				'</figure>]'
 			);
 		} );
@@ -684,8 +702,9 @@ describe( 'ImageCaptionEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src="img.png"></img>' +
-					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
-						'contenteditable="false" data-placeholder="Enter image caption"></figcaption>' +
+					'<figcaption aria-placeholder="Enter image caption" ' +
+						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+						'contenteditable="false"></figcaption>' +
 				'</figure>]'
 			);
 		} );
@@ -709,8 +728,9 @@ describe( 'ImageCaptionEditing', () => {
 					'<p>{}foo</p>' +
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src=""></img>' +
-						'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
-							'contenteditable="true" data-placeholder="Enter image caption">' +
+						'<figcaption aria-placeholder="Enter image caption" ' +
+							'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+							'contenteditable="true">' +
 						'</figcaption>' +
 					'</figure>'
 				);
@@ -722,8 +742,9 @@ describe( 'ImageCaptionEditing', () => {
 					'<p>foo</p>' +
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src=""></img>' +
-						'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
-							'contenteditable="true" data-placeholder="Enter image caption">' +
+						'<figcaption aria-placeholder="Enter image caption" ' +
+							'class="ck-editor__editable ck-editor__nested-editable" ' +
+							'contenteditable="true">' +
 							'{foo bar baz}' +
 						'</figcaption>' +
 					'</figure>'

--- a/packages/ckeditor5-image/tests/imagecaption/imagecaptionediting.js
+++ b/packages/ckeditor5-image/tests/imagecaption/imagecaptionediting.js
@@ -256,7 +256,7 @@ describe( 'ImageCaptionEditing', () => {
 					'<p>{}foo</p>' +
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption aria-placeholder="Enter image caption" class="ck-editor__editable ck-editor__nested-editable" ' +
+						'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">' +
 							'foo bar' +
 						'</figcaption>' +
@@ -278,8 +278,7 @@ describe( 'ImageCaptionEditing', () => {
 					'<p>{}foo</p>' +
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src="img.png"></img>' +
-						'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
-							'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+						'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">' +
 						'</figcaption>' +
 					'</figure>'
@@ -478,8 +477,7 @@ describe( 'ImageCaptionEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img alt="" src=""></img>' +
-					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
-						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption"></figcaption>' +
 				'</figure>]' +
 				'<p></p>'
@@ -530,8 +528,7 @@ describe( 'ImageCaptionEditing', () => {
 				'<p>foo</p>' +
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
-						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 					'</figcaption>' +
 				'</figure>]'
@@ -545,8 +542,7 @@ describe( 'ImageCaptionEditing', () => {
 				'<p>{}foo</p>' +
 				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
-						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 					'</figcaption>' +
 				'</figure>'
@@ -562,8 +558,7 @@ describe( 'ImageCaptionEditing', () => {
 				'<p>foo</p>' +
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
-						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 					'</figcaption>' +
 				'</figure>]'
@@ -583,7 +578,6 @@ describe( 'ImageCaptionEditing', () => {
 				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
 					'<figcaption ' +
-						'aria-hidden="true" aria-placeholder="Enter image caption" ' +
 						'class="ck-editor__editable ck-editor__nested-editable ck-editor__nested-editable_focused ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">[]' +
 					'</figcaption>' +
@@ -615,8 +609,7 @@ describe( 'ImageCaptionEditing', () => {
 				'<p>{}foo</p>' +
 				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
-						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 					'</figcaption>' +
 				'</figure>'
@@ -633,8 +626,7 @@ describe( 'ImageCaptionEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
-						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption">' +
 						'[]' +
 					'</figcaption>' +
@@ -654,8 +646,7 @@ describe( 'ImageCaptionEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
-						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption"></figcaption>' +
 				'</figure>]'
 			);
@@ -679,8 +670,7 @@ describe( 'ImageCaptionEditing', () => {
 				'</figure>' +
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src=""></img>' +
-					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
-						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="true" data-placeholder="Enter image caption"></figcaption>' +
 				'</figure>]'
 			);
@@ -694,8 +684,7 @@ describe( 'ImageCaptionEditing', () => {
 			expect( getViewData( view ) ).to.equal(
 				'[<figure class="ck-widget image" contenteditable="false">' +
 					'<img src="img.png"></img>' +
-					'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
-						'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+					'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 						'contenteditable="false" data-placeholder="Enter image caption"></figcaption>' +
 				'</figure>]'
 			);
@@ -720,8 +709,7 @@ describe( 'ImageCaptionEditing', () => {
 					'<p>{}foo</p>' +
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src=""></img>' +
-						'<figcaption aria-hidden="true" aria-placeholder="Enter image caption" ' +
-							'class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
+						'<figcaption class="ck-editor__editable ck-editor__nested-editable ck-placeholder" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">' +
 						'</figcaption>' +
 					'</figure>'
@@ -734,8 +722,7 @@ describe( 'ImageCaptionEditing', () => {
 					'<p>foo</p>' +
 					'<figure class="ck-widget image" contenteditable="false">' +
 						'<img src=""></img>' +
-						'<figcaption aria-placeholder="Enter image caption" ' +
-							'class="ck-editor__editable ck-editor__nested-editable" ' +
+						'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
 							'contenteditable="true" data-placeholder="Enter image caption">' +
 							'{foo bar baz}' +
 						'</figcaption>' +

--- a/packages/ckeditor5-image/tests/pictureediting.js
+++ b/packages/ckeditor5-image/tests/pictureediting.js
@@ -1045,9 +1045,9 @@ describe( 'PictureEditing', () => {
 									'<img src="/assets/sample.png"></img>' +
 								'</picture>' +
 								'<figcaption ' +
+									'aria-placeholder="Enter image caption" ' +
 									'class="ck-editor__editable ck-editor__nested-editable" ' +
-									'contenteditable="true" ' +
-									'data-placeholder="Enter image caption"' +
+									'contenteditable="true"' +
 								'>' +
 									'Caption' +
 								'</figcaption>' +
@@ -1215,9 +1215,9 @@ describe( 'PictureEditing', () => {
 									'<img src="/assets/sample.png"></img>' +
 								'</picture>' +
 								'<figcaption ' +
+									'aria-placeholder="Enter image caption" ' +
 									'class="ck-editor__editable ck-editor__nested-editable" ' +
-									'contenteditable="true" ' +
-									'data-placeholder="Enter image caption"' +
+									'contenteditable="true"' +
 								'>' +
 									'Text of the caption' +
 								'</figcaption>' +
@@ -1377,9 +1377,9 @@ describe( 'PictureEditing', () => {
 								'[<figure class="ck-widget image" contenteditable="false">' +
 									'<img src="/assets/sample.png"></img>' +
 									'<figcaption ' +
+										'aria-placeholder="Enter image caption" ' +
 										'class="ck-editor__editable ck-editor__nested-editable" ' +
-										'contenteditable="true" ' +
-										'data-placeholder="Enter image caption"' +
+										'contenteditable="true"' +
 									'>' +
 										'Caption' +
 									'</figcaption>' +
@@ -1421,9 +1421,9 @@ describe( 'PictureEditing', () => {
 										'<img src="/assets/sample.png"></img>' +
 									'</a>' +
 									'<figcaption ' +
+										'aria-placeholder="Enter image caption" ' +
 										'class="ck-editor__editable ck-editor__nested-editable" ' +
-										'contenteditable="true" ' +
-										'data-placeholder="Enter image caption"' +
+										'contenteditable="true"' +
 									'>' +
 										'Text of the caption' +
 									'</figcaption>' +
@@ -1461,9 +1461,9 @@ describe( 'PictureEditing', () => {
 								'[<figure class="ck-widget image image_resized" contenteditable="false" style="width:123px">' +
 									'<img src="/assets/sample.png"></img>' +
 									'<figcaption ' +
+										'aria-placeholder="Enter image caption" ' +
 										'class="ck-editor__editable ck-editor__nested-editable" ' +
-										'contenteditable="true" ' +
-										'data-placeholder="Enter image caption"' +
+										'contenteditable="true"' +
 									'>' +
 										'Text of the caption' +
 									'</figcaption>' +

--- a/packages/ckeditor5-link/tests/linkimageediting.js
+++ b/packages/ckeditor5-link/tests/linkimageediting.js
@@ -518,8 +518,9 @@ describe( 'LinkImageEditing', () => {
 								'<a href="http://ckeditor.com">' +
 									'<img alt="alt text" src="/assets/sample.png"></img>' +
 								'</a>' +
-								'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
-									'contenteditable="true" data-placeholder="Enter image caption">' +
+								'<figcaption aria-placeholder="Enter image caption" ' +
+									'class="ck-editor__editable ck-editor__nested-editable" ' +
+									'contenteditable="true">' +
 										'Foo Bar.' +
 								'</figcaption>' +
 							'</figure>'

--- a/packages/ckeditor5-media-embed/tests/integration.js
+++ b/packages/ckeditor5-media-embed/tests/integration.js
@@ -53,7 +53,7 @@ describe( 'MediaEmbed integration', () => {
 			clock.tick( 100 );
 
 			expect( getViewData( editor.editing.view ) ).to.equal(
-				'[<figure class="ck-widget ck-widget_selected media" contenteditable="false" data-placeholder="foo">' +
+				'[<figure aria-placeholder="foo" class="ck-widget ck-widget_selected media" contenteditable="false">' +
 					'<div class="ck-media__wrapper" data-oembed-url="https://www.youtube.com/watch?v=H08tGjXNHO4"></div>' +
 					'<div class="ck ck-reset_all ck-widget__type-around"></div>' +
 				'</figure>]'

--- a/packages/ckeditor5-table/ckeditor5-metadata.json
+++ b/packages/ckeditor5-table/ckeditor5-metadata.json
@@ -166,7 +166,7 @@
 			"htmlOutput": [
 				{
 					"elements": "figcaption",
-					"attributes": "data-placeholder"
+					"attributes": "aria-placeholder"
 				}
 			]
 		},

--- a/packages/ckeditor5-table/tests/tablecaption/tablecaptionediting.js
+++ b/packages/ckeditor5-table/tests/tablecaption/tablecaptionediting.js
@@ -307,9 +307,10 @@ describe( 'TableCaptionEditing', () => {
 								'</tr>' +
 							'</tbody>' +
 						'</table>' +
-						'<figcaption class="ck-editor__editable ck-editor__nested-editable" ' +
-								'contenteditable="true" data-placeholder="Enter table caption">' +
-							'Foo caption' +
+						'<figcaption aria-placeholder="Enter table caption" ' +
+							'class="ck-editor__editable ck-editor__nested-editable" ' +
+							'contenteditable="true">' +
+								'Foo caption' +
 						'</figcaption>' +
 					'</figure>'
 				);


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

MINOR BREAKING CHANGE (engine): Replaced the `data-placeholder` attribute with `aria-placeholder`. Closes #11848.

Tests (editor-balloon, editor-classic, editor-decoupled, editor-inline, engine, heading, html-support, image, link, media-embed, table): Tests updated after the attribute replacement.

---

### Additional information

We’ve discussed adding the `aria-placeholder` alongside already existing `data-placeholder` because of the accessibility improvements, but decided it is a more coherent approach to replace it altogether.

So all the places in the project where we’ve been using the `data-placeholder` attribute should’ve been updated and now properly use `aria-placeholder`.

Additionally, in the original issue there was a comment about adding the `aria-hidden` attribute to prevent screen readers from reading the text rendered within the editable. Short research shows that:  
  
Image caption without the `aria-hidden` attribute is being read as follows:

*   **NVDA:**
    *   Enter image caption  caption  multi line  editable  blank
*   VoiceOver:
    *   Enter image caption, text editing, Enter image caption, courser at the end of the word: caption

Image caption with the `aria-hidden="true"` attribute is being read as follows:

*   NVDA:
    *   Enter image caption caption multi line editable selected Enter image caption
*   VoiceOver:
    *   Enter image caption, text editing

Different approach would be to alter the existing code and remove content being added with `::before` and replace it with a span, set with `aria-hidden="true"` attribute. Sample code:

```
<div contenteditable="true" aria-placeholder="A placeholder text">
	<span aria-hidden="true">A placeholder text</span>
</div>
```

This is being read by screen readers:

*   NVDA:
    *   A placeholder text  section  multi line  editable  A
*   VoiceOver:
    *   A placeholder text, text editing