### PR TITLE
Break whitespace characters in a code block.

### DIFF
--- a/packages/ckeditor5-code-block/theme/codeblock.css
+++ b/packages/ckeditor5-code-block/theme/codeblock.css
@@ -22,7 +22,7 @@
 
 	/* Don't let the code be squashed e.g. when in a table cell. */
 	min-width: 200px;
-	
+
 	& code {
 		background: unset;
 		padding: 0;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (code-block): White-space characters are now broke to a new line inside `code` element to prevent an overflow. Closes #11935.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
