### PR TITLE
Fixed inline filler handling while isSelecting = true

### DIFF
--- a/packages/ckeditor5-engine/src/view/renderer.js
+++ b/packages/ckeditor5-engine/src/view/renderer.js
@@ -234,6 +234,10 @@ export default class Renderer {
 		else if ( this._inlineFiller && this._inlineFiller.parentNode ) {
 			// While the user is making selection, preserve the inline filler at its original position.
 			inlineFillerPosition = this.domConverter.domPositionToView( this._inlineFiller );
+
+			if ( inlineFillerPosition.parent.is( '$text' ) ) {
+				inlineFillerPosition = ViewPosition._createBefore( inlineFillerPosition.parent );
+			}
 		}
 
 		for ( const element of this.markedAttributes ) {

--- a/packages/ckeditor5-engine/tests/view/renderer.js
+++ b/packages/ckeditor5-engine/tests/view/renderer.js
@@ -4561,6 +4561,99 @@ describe( 'Renderer', () => {
 					expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( 1 );
 					expect( domSelection.getRangeAt( 0 ).endOffset ).to.equal( 2 );
 				} );
+
+				// https://github.com/ckeditor/ckeditor5/issues/11472.
+				it( 'should not remove the inline filler while the user is making selection', () => {
+					const domSelection = document.getSelection();
+
+					const {
+						view: viewParagraph,
+						selection: viewSelection
+					} = parse( '<container:p><attribute:b>foo<attribute:i>[]</attribute:i></attribute:b></container:p>' );
+
+					viewRoot._appendChild( viewParagraph );
+					selection._setTo( viewSelection );
+
+					// -----------------------------------------------------------------------------------------------
+					// STEP #1: The first render() is to set the initial state of the editor.
+					renderer.markToSync( 'children', viewRoot );
+					renderer.render();
+
+					const domParagraph = domRoot.childNodes[ 0 ];
+
+					// The filler was inserted <p><b>foo<i>FILLER{}</i></b></p>.
+					expect( domParagraph.childNodes.length ).to.equal( 1 );
+					expect( domParagraph.childNodes[ 0 ].outerHTML ).to.equal( `<b>foo<i>${ INLINE_FILLER }</i></b>` );
+
+					let domItalic = domParagraph.childNodes[ 0 ].childNodes[ 1 ];
+
+					expect( domSelection.rangeCount ).to.equal( 1 );
+					expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domItalic.childNodes[ 0 ] );
+					expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( INLINE_FILLER_LENGTH );
+					expect( domSelection.getRangeAt( 0 ).collapsed ).to.be.true;
+
+					// -----------------------------------------------------------------------------------------------
+					// STEP #2: Now typing in the same node as an inline filler.
+					// Then comes the second render().
+					// * The filler should be still at the beginning of a text node:   <p><b>foo<i>FILLER{}bar</i></b></p>
+
+					const viewItalic = viewParagraph.getChild( 0 ).getChild( 1 );
+					const viewText = new ViewText( viewDocument, 'bar' );
+
+					viewItalic._appendChild( viewText );
+
+					// <p><b>foo<i>bar{}</i></b></p>.
+					selection._setTo(
+						ViewRange._createFromParentsAndOffsets(
+							viewText, viewText.data.length,
+							viewText, viewText.data.length
+						)
+					);
+
+					renderer.markToSync( 'children', viewRoot );
+					renderer.markToSync( 'text', viewText );
+					renderer.render();
+
+					// The filler was still at the beginning of a text node <p><b>foo<i>FILLER{}bar</i></b></p>.
+					expect( domParagraph.childNodes.length ).to.equal( 1 );
+					expect( domParagraph.childNodes[ 0 ].outerHTML ).to.equal( `<b>foo<i>${ INLINE_FILLER }bar</i></b>` );
+
+					domItalic = domParagraph.childNodes[ 0 ].childNodes[ 1 ];
+
+					expect( domSelection.rangeCount ).to.equal( 1 );
+					expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domItalic.childNodes[ 0 ] );
+					expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( INLINE_FILLER_LENGTH + viewText.data.length );
+					expect( domSelection.getRangeAt( 0 ).collapsed ).to.be.true;
+
+					// -----------------------------------------------------------------------------------------------
+					// STEP #3: Now we're moving the selection somewhere else while isSelecting = true
+					// and rendering once again after isSelecting = false.
+					renderer.isSelecting = true;
+
+					// <p><b>foo{}<i>bar</i></b></p>.
+					selection._setTo(
+						ViewRange._createFromParentsAndOffsets(
+							viewParagraph.getChild( 0 ).getChild( 0 ), 3,
+							viewParagraph.getChild( 0 ).getChild( 0 ), 3
+						)
+					);
+
+					// Mark the text node to sync to verify if inline filler won't get removed.
+					renderer.markToSync( 'text', viewText );
+					renderer.render();
+
+					renderer.isSelecting = false;
+					renderer.render();
+
+					// The inline filler should be removed without crashing <p><b>foo{}<i>bar</i></b></p>.
+					expect( domParagraph.childNodes.length ).to.equal( 1 );
+					expect( domParagraph.childNodes[ 0 ].outerHTML ).to.equal( '<b>foo<i>bar</i></b>' );
+
+					expect( domSelection.rangeCount ).to.equal( 1 );
+					expect( domSelection.getRangeAt( 0 ).startContainer ).to.equal( domParagraph.childNodes[ 0 ].childNodes[ 0 ] );
+					expect( domSelection.getRangeAt( 0 ).startOffset ).to.equal( 3 );
+					expect( domSelection.getRangeAt( 0 ).collapsed ).to.be.true;
+				} );
 			} );
 
 			describe( 'in Blink (Android)', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): Inline filler should not be removed while updating a text node. Closes #11472 .

---

### Additional information