### PR TITLE
DomConverter should not reverse order of attributes while converting from DOM to view

### DIFF
--- a/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
@@ -575,7 +575,7 @@ describe( 'ClipboardPipeline feature', () => {
 					'<li>ol item</li>' +
 				'</ol>' +
 				'<figure>' +
-					'<img alt="image foo" src="foo.jpg">' + // Weird attributes ordering behavior + no closing "/>".
+					'<img src="foo.jpg" alt="image foo">' +
 					'<figcaption>caption</figcaption>' +
 				'</figure>';
 

--- a/packages/ckeditor5-engine/src/view/domconverter.js
+++ b/packages/ckeditor5-engine/src/view/domconverter.js
@@ -680,7 +680,7 @@ export default class DomConverter {
 				const attrs = domNode.attributes;
 
 				if ( attrs ) {
-					for ( let i = attrs.length - 1; i >= 0; i-- ) {
+					for ( let l = attrs.length, i = 0; i < l; i++ ) {
 						viewElement._setAttribute( attrs[ i ].name, attrs[ i ].value );
 					}
 				}

--- a/packages/ckeditor5-engine/tests/view/domconverter/dom-to-view.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/dom-to-view.js
@@ -206,6 +206,22 @@ describe( 'DomConverter', () => {
 			expect( viewComment ).to.be.null;
 		} );
 
+		it( 'should set attributes in the same order as in the DOM', () => {
+			const domP = createElement( document, 'p', { 'data-foo': 'a', 'data-bar': 'b' } );
+			const viewP = converter.domToView( domP );
+
+			expect( viewP ).to.be.an.instanceof( ViewElement );
+			expect( viewP.name ).to.equal( 'p' );
+
+			const attributes = Array.from( viewP.getAttributes() );
+
+			expect( attributes.length ).to.equal( 2 );
+			expect( attributes ).to.deep.equal( [
+				[ 'data-foo', 'a' ],
+				[ 'data-bar', 'b' ]
+			] );
+		} );
+
 		describe( 'it should clear whitespaces', () => {
 			it( 'at the beginning of block element', () => {
 				const domDiv = createElement( document, 'div', {}, [

--- a/packages/ckeditor5-html-support/tests/datafilter.js
+++ b/packages/ckeditor5-html-support/tests/datafilter.js
@@ -605,6 +605,24 @@ describe( 'DataFilter', () => {
 			);
 		} );
 
+		it( 'should not change order of attributes', () => {
+			dataFilter.allowElement( 'section' );
+			dataFilter.allowAttributes( {
+				name: 'section',
+				attributes: true
+			} );
+
+			editor.setData( '<section data-foo="a" data-bar="b"><p>foobar</p></section>' );
+
+			expect( getModelData( model, { withoutSelection: true } ) ).to.deep.equal(
+				'<htmlSection htmlAttributes="{"attributes":{"data-foo":"a","data-bar":"b"}}"><paragraph>foobar</paragraph></htmlSection>'
+			);
+
+			expect( editor.getData() ).to.equal(
+				'<section data-foo="a" data-bar="b"><p>foobar</p></section>'
+			);
+		} );
+
 		it( 'should disallow attributes', () => {
 			dataFilter.allowElement( 'section' );
 			dataFilter.allowAttributes( { name: 'section', attributes: { 'data-foo': /[\s\S]+/ } } );
@@ -1765,7 +1783,7 @@ describe( 'DataFilter', () => {
 				} );
 
 				expect( editor.getData() ).to.equal(
-					'<p><input data-bar="bar" data-foo="baz"></p>'
+					'<p><input data-foo="baz" data-bar="bar"></p>'
 				);
 			} );
 
@@ -2346,7 +2364,7 @@ describe( 'DataFilter', () => {
 				} );
 
 				expect( editor.getData() ).to.equal(
-					'<section data-bar="baz bar" data-foo="bar baz"><p>foobar</p></section>'
+					'<section data-foo="bar baz" data-bar="baz bar"><p>foobar</p></section>'
 				);
 			} );
 

--- a/packages/ckeditor5-html-support/tests/integrations/mediaembed.js
+++ b/packages/ckeditor5-html-support/tests/integrations/mediaembed.js
@@ -1159,7 +1159,7 @@ describe( 'MediaEmbedElementSupport', () => {
 			} );
 
 			expect( editor.getData() ).to.equal(
-				'<p><oembed data-foo="foo" url="https://www.youtube.com/watch?v=ZVv7UMQPEWk"></oembed></p>'
+				'<p><oembed url="https://www.youtube.com/watch?v=ZVv7UMQPEWk" data-foo="foo"></oembed></p>'
 			);
 		} );
 
@@ -1278,7 +1278,7 @@ describe( 'MediaEmbedElementSupport', () => {
 
 			expect( editor.getData() ).to.equal(
 				'<figure class="media" data-foo="foo">' +
-					'<p><oembed data-foo="foo" url="https://www.youtube.com/watch?v=ZVv7UMQPEWk"></oembed></p>' +
+					'<p><oembed url="https://www.youtube.com/watch?v=ZVv7UMQPEWk" data-foo="foo"></oembed></p>' +
 				'</figure>'
 			);
 

--- a/packages/ckeditor5-html-support/tests/integrations/table.js
+++ b/packages/ckeditor5-html-support/tests/integrations/table.js
@@ -925,14 +925,14 @@ describe( 'TableElementSupport', () => {
 		expect( editor.getData() ).to.equalMarkup(
 			'<figure class="table">' +
 				'<table>' +
-					'<thead valign="bottom" lang="en" dir="ltr" align="right">' +
+					'<thead align="right" dir="ltr" lang="en" valign="bottom">' +
 						'<tr>' +
 							'<th>Bar</th>' +
 						'</tr>' +
 					'</thead>' +
-					'<tbody valign="bottom" lang="en" dir="ltr" align="right">' +
-						'<tr valign="bottom" align="right">' +
-							'<td valign="bottom" align="right">Foo</td>' +
+					'<tbody align="right" dir="ltr" lang="en" valign="bottom">' +
+						'<tr align="right" valign="bottom">' +
+							'<td align="right" valign="bottom">Foo</td>' +
 						'</tr>' +
 					'</tbody>' +
 				'</table>' +

--- a/packages/ckeditor5-image/tests/image/imageblockediting.js
+++ b/packages/ckeditor5-image/tests/image/imageblockediting.js
@@ -129,7 +129,7 @@ describe( 'ImageBlockEditing', () => {
 			it( 'should convert', () => {
 				setModelData( model, '<imageBlock src="/assets/sample.png" alt="alt text"></imageBlock>' );
 
-				expect( editor.getData() ).to.equal( '<figure class="image"><img alt="alt text" src="/assets/sample.png"></figure>' );
+				expect( editor.getData() ).to.equal( '<figure class="image"><img src="/assets/sample.png" alt="alt text"></figure>' );
 			} );
 
 			it( 'should convert without alt attribute', () => {
@@ -190,7 +190,7 @@ describe( 'ImageBlockEditing', () => {
 
 				expect( editor.getData() ).to.equal(
 					'<figure class="image">' +
-						'<img alt="alt text" src="/assets/sample.png">' +
+						'<img src="/assets/sample.png" alt="alt text">' +
 					'</figure>'
 				);
 			} );
@@ -210,7 +210,7 @@ describe( 'ImageBlockEditing', () => {
 
 				expect( editor.getData() ).to.equal(
 					'<figure class="image">' +
-						'<img alt="alt text" src="/assets/sample.png">' +
+						'<img src="/assets/sample.png" alt="alt text">' +
 					'</figure>'
 				);
 			} );

--- a/packages/ckeditor5-image/tests/image/imageediting.js
+++ b/packages/ckeditor5-image/tests/image/imageediting.js
@@ -142,11 +142,11 @@ describe( 'ImageEditing', () => {
 			it( 'should convert', () => {
 				setModelData( model, '<imageBlock src="/assets/sample.png" alt="alt text"></imageBlock>' );
 
-				expect( editor.getData() ).to.equal( '<figure class="image"><img alt="alt text" src="/assets/sample.png"></figure>' );
+				expect( editor.getData() ).to.equal( '<figure class="image"><img src="/assets/sample.png" alt="alt text"></figure>' );
 
 				setModelData( model, '<paragraph><imageInline src="/assets/sample.png" alt="alt text"></imageInline></paragraph>' );
 
-				expect( editor.getData() ).to.equal( '<p><img alt="alt text" src="/assets/sample.png"></p>' );
+				expect( editor.getData() ).to.equal( '<p><img src="/assets/sample.png" alt="alt text"></p>' );
 			} );
 
 			it( 'should convert without alt attribute', () => {
@@ -241,7 +241,7 @@ describe( 'ImageEditing', () => {
 
 				expect( editor.getData() ).to.equal(
 					'<figure class="image">' +
-						'<img alt="alt text" src="/assets/sample.png">' +
+						'<img src="/assets/sample.png" alt="alt text">' +
 					'</figure>'
 				);
 
@@ -259,7 +259,7 @@ describe( 'ImageEditing', () => {
 					'</imageInline></paragraph>'
 				);
 
-				expect( editor.getData() ).to.equal( '<p><img alt="alt text" src="/assets/sample.png"></p>' );
+				expect( editor.getData() ).to.equal( '<p><img src="/assets/sample.png" alt="alt text"></p>' );
 			} );
 
 			it( 'should not convert srcset attribute if has wrong data', () => {
@@ -277,7 +277,7 @@ describe( 'ImageEditing', () => {
 
 				expect( editor.getData() ).to.equal(
 					'<figure class="image">' +
-						'<img alt="alt text" src="/assets/sample.png">' +
+						'<img src="/assets/sample.png" alt="alt text">' +
 					'</figure>'
 				);
 
@@ -293,7 +293,7 @@ describe( 'ImageEditing', () => {
 					writer.removeAttribute( 'srcset', imageInline );
 				} );
 
-				expect( editor.getData() ).to.equal( '<p><img alt="alt text" src="/assets/sample.png"></p>' );
+				expect( editor.getData() ).to.equal( '<p><img src="/assets/sample.png" alt="alt text"></p>' );
 			} );
 		} );
 

--- a/packages/ckeditor5-image/tests/image/imageinlineediting.js
+++ b/packages/ckeditor5-image/tests/image/imageinlineediting.js
@@ -136,7 +136,7 @@ describe( 'ImageInlineEditing', () => {
 			it( 'should convert', () => {
 				setModelData( model, '<paragraph><imageInline src="/assets/sample.png" alt="alt text"></imageInline></paragraph>' );
 
-				expect( editor.getData() ).to.equal( '<p><img alt="alt text" src="/assets/sample.png"></p>' );
+				expect( editor.getData() ).to.equal( '<p><img src="/assets/sample.png" alt="alt text"></p>' );
 			} );
 
 			it( 'should convert without alt attribute', () => {
@@ -194,7 +194,7 @@ describe( 'ImageInlineEditing', () => {
 					'</imageInline></paragraph>'
 				);
 
-				expect( editor.getData() ).to.equal( '<p><img alt="alt text" src="/assets/sample.png"></p>' );
+				expect( editor.getData() ).to.equal( '<p><img src="/assets/sample.png" alt="alt text"></p>' );
 			} );
 
 			it( 'should not convert srcset attribute if has wrong data', () => {
@@ -210,7 +210,7 @@ describe( 'ImageInlineEditing', () => {
 					writer.removeAttribute( 'srcset', imageInline );
 				} );
 
-				expect( editor.getData() ).to.equal( '<p><img alt="alt text" src="/assets/sample.png"></p>' );
+				expect( editor.getData() ).to.equal( '<p><img src="/assets/sample.png" alt="alt text"></p>' );
 			} );
 		} );
 

--- a/packages/ckeditor5-link/tests/linkimageediting.js
+++ b/packages/ckeditor5-link/tests/linkimageediting.js
@@ -84,7 +84,7 @@ describe( 'LinkImageEditing', () => {
 				setModelData( model, '<imageBlock src="/assets/sample.png" alt="alt text" linkHref="http://ckeditor.com"></imageBlock>' );
 
 				expect( editor.getData() ).to.equal(
-					'<figure class="image"><a href="http://ckeditor.com"><img alt="alt text" src="/assets/sample.png"></a></figure>'
+					'<figure class="image"><a href="http://ckeditor.com"><img src="/assets/sample.png" alt="alt text"></a></figure>'
 				);
 			} );
 
@@ -125,7 +125,7 @@ describe( 'LinkImageEditing', () => {
 				setModelData( model, '<imageBlock src="/assets/sample.png" alt="alt text" linkHref="http://ckeditor.com"></imageBlock>' );
 
 				expect( editor.getData() ).to.equal(
-					'<figure class="image"><img alt="alt text" src="/assets/sample.png"></figure>'
+					'<figure class="image"><img src="/assets/sample.png" alt="alt text"></figure>'
 				);
 				expect( spy.calledOnce ).to.be.true;
 			} );
@@ -145,7 +145,7 @@ describe( 'LinkImageEditing', () => {
 				);
 
 				expect( editor.getData() ).to.equal(
-					'<p>foo <a href="http://ckeditor.com"><img alt="alt text" src="/assets/sample.png"></a>bar</p>'
+					'<p>foo <a href="http://ckeditor.com"><img src="/assets/sample.png" alt="alt text"></a>bar</p>'
 				);
 
 				return editor.destroy();
@@ -201,7 +201,7 @@ describe( 'LinkImageEditing', () => {
 					'<p>' +
 						'foo' +
 						'<a href="http://ckeditor.com">' +
-							'<picture><source srcset="small.png"><img alt="alt text" src="/assets/sample.png"></picture>' +
+							'<picture><source srcset="small.png"><img src="/assets/sample.png" alt="alt text"></picture>' +
 						'</a>' +
 						'bar' +
 					'</p>'
@@ -1096,7 +1096,7 @@ describe( 'LinkImageEditing', () => {
 					'<figure class="image">' +
 						'<a class="gallery highlighted" style="text-decoration:underline;" href="https://cksource.com" ' +
 						'download="download" target="_blank" rel="noopener noreferrer">' +
-							'<img src="sample.jpg" alt="bar">' +
+							'<img alt="bar" src="sample.jpg">' +
 						'</a>' +
 					'</figure>' +
 					'<p>' +
@@ -1134,7 +1134,7 @@ describe( 'LinkImageEditing', () => {
 
 				expect( editor.getData() ).to.equal(
 					'<figure class="image">' +
-							'<img src="sample.jpg" alt="bar">' +
+							'<img alt="bar" src="sample.jpg">' +
 						'</figure>'
 				);
 			} );

--- a/packages/ckeditor5-link/tests/linkimageediting.js
+++ b/packages/ckeditor5-link/tests/linkimageediting.js
@@ -159,8 +159,8 @@ describe( 'LinkImageEditing', () => {
 
 				setModelData( model,
 					'<imageBlock src="/assets/sample.png" ' +
-						'linkHref="http://ckeditor.com" ' +
-						'sources=\'[ { "srcset": "small.png" } ]\'>' +
+						'sources=\'[ { "srcset": "small.png" } ]\' ' +
+						'linkHref="http://ckeditor.com">' +
 					'</imageBlock>'
 				);
 
@@ -1134,8 +1134,8 @@ describe( 'LinkImageEditing', () => {
 
 				expect( editor.getData() ).to.equal(
 					'<figure class="image">' +
-							'<img alt="bar" src="sample.jpg">' +
-						'</figure>'
+						'<img alt="bar" src="sample.jpg">' +
+					'</figure>'
 				);
 			} );
 

--- a/packages/ckeditor5-list/tests/documentlist/converters.js
+++ b/packages/ckeditor5-list/tests/documentlist/converters.js
@@ -627,10 +627,8 @@ describe( 'DocumentListEditing - converters', () => {
 				} );
 
 				expect( getViewData( editor.editing.view, { withoutSelection: true } ) ).to.equal(
-					'<ul>' +
-						'<li><span class="ck-list-bogus-paragraph">a</span></li>' +
-						'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
-					'</ul>'
+					'<span class="ck-list-bogus-paragraph">a</span>' +
+					'<span class="ck-list-bogus-paragraph">b</span>'
 				);
 			} );
 

--- a/packages/ckeditor5-list/tests/listproperties/listpropertiesediting.js
+++ b/packages/ckeditor5-list/tests/listproperties/listpropertiesediting.js
@@ -5232,7 +5232,7 @@ describe( 'ListPropertiesEditing', () => {
 					);
 
 					expect( editor.getData() ).to.equal(
-						'<ol style="list-style-type:circle;" reversed="reversed" start="5"><li>Foo</li><li>Bar</li></ol>'
+						'<ol style="list-style-type:circle;" start="5" reversed="reversed"><li>Foo</li><li>Bar</li></ol>'
 					);
 				} );
 
@@ -5282,7 +5282,7 @@ describe( 'ListPropertiesEditing', () => {
 							'</li>' +
 							'<li>2</li>' +
 							'<li>3' +
-								'<ol style="list-style-type:circle;" reversed="reversed" start="3">' +
+								'<ol style="list-style-type:circle;" start="3" reversed="reversed">' +
 									'<li>3.1</li>' +
 								'</ol>' +
 							'</li>' +

--- a/packages/ckeditor5-table/tests/converters/downcast.js
+++ b/packages/ckeditor5-table/tests/converters/downcast.js
@@ -398,7 +398,7 @@ describe( 'downcast converters', () => {
 								'<tbody>' +
 									'<tr><th rowspan="2">00</th><th>01</th><th rowspan="3">02</th><td>03</td></tr>' +
 									'<tr><th>11</th><td>13</td></tr>' +
-									'<tr><th rowspan="2" colspan="2">20</th><td>23</td></tr>' +
+									'<tr><th colspan="2" rowspan="2">20</th><td>23</td></tr>' +
 									'<tr><th>32</th><td>33</td></tr>' +
 								'</tbody>' +
 							'</table>' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): The order of attributes should not get reversed while loading editor data. Closes #11850.

Tests (html-support, clipboard, image, link, list, table): The order of attributes should not get reversed while loading editor data.

---

### Additional information