### PR TITLE
Table properties color picker label updated

### DIFF
--- a/packages/ckeditor5-table/src/ui/colorinputview.js
+++ b/packages/ckeditor5-table/src/ui/colorinputview.js
@@ -208,6 +208,7 @@ export default class ColorInputView extends View {
 
 		dropdown.buttonView.children.add( colorPreview );
 		dropdown.buttonView.tooltip = t( 'Color picker' );
+		dropdown.buttonView.label = t( 'Color picker' );
 
 		dropdown.panelPosition = locale.uiLanguageDirection === 'rtl' ? 'se' : 'sw';
 		dropdown.panelView.children.add( removeColorButton );

--- a/packages/ckeditor5-table/src/ui/colorinputview.js
+++ b/packages/ckeditor5-table/src/ui/colorinputview.js
@@ -207,8 +207,8 @@ export default class ColorInputView extends View {
 		} );
 
 		dropdown.buttonView.children.add( colorPreview );
-		dropdown.buttonView.tooltip = t( 'Color picker' );
 		dropdown.buttonView.label = t( 'Color picker' );
+		dropdown.buttonView.tooltip = true;
 
 		dropdown.panelPosition = locale.uiLanguageDirection === 'rtl' ? 'se' : 'sw';
 		dropdown.panelView.children.add( removeColorButton );

--- a/packages/ckeditor5-table/tests/ui/colorinputview.js
+++ b/packages/ckeditor5-table/tests/ui/colorinputview.js
@@ -99,7 +99,7 @@ describe( 'ColorInputView', () => {
 			it( 'should be created', () => {
 				expect( view._dropdownView ).to.be.instanceOf( DropdownView );
 				expect( view._dropdownView.buttonView.element.classList.contains( 'ck-input-color__button' ) ).to.be.true;
-				expect( view._dropdownView.buttonView.tooltip ).to.equal( 'Color picker' );
+				expect( view._dropdownView.buttonView.tooltip ).to.be.true;
 				expect( view._dropdownView.buttonView.label ).to.equal( 'Color picker' );
 			} );
 

--- a/packages/ckeditor5-table/tests/ui/colorinputview.js
+++ b/packages/ckeditor5-table/tests/ui/colorinputview.js
@@ -100,6 +100,7 @@ describe( 'ColorInputView', () => {
 				expect( view._dropdownView ).to.be.instanceOf( DropdownView );
 				expect( view._dropdownView.buttonView.element.classList.contains( 'ck-input-color__button' ) ).to.be.true;
 				expect( view._dropdownView.buttonView.tooltip ).to.equal( 'Color picker' );
+				expect( view._dropdownView.buttonView.label ).to.equal( 'Color picker' );
 			} );
 
 			it( 'should bind #isEnabled to the view\'s #isReadOnly', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): Added label for the Table properties color grid dropdown. Closes #11895.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
