### PR TITLE
Implemented focusing first item after opening a dropdown

### DIFF
--- a/packages/ckeditor5-ui/src/dropdown/dropdownview.js
+++ b/packages/ckeditor5-ui/src/dropdown/dropdownview.js
@@ -265,6 +265,15 @@ export default class DropdownView extends View {
 			}
 		} );
 
+		// Focus the first item in the dropdown when the dropdown opened
+		this.on( 'change:isOpen', () => {
+			if ( !this.isOpen ) {
+				return;
+			}
+
+			this.panelView.focus();
+		} );
+
 		// Listen for keystrokes coming from within #element.
 		this.keystrokes.listenTo( this.element );
 

--- a/packages/ckeditor5-ui/src/dropdown/utils.js
+++ b/packages/ckeditor5-ui/src/dropdown/utils.js
@@ -127,8 +127,10 @@ export function createDropdown( locale, ButtonClass = DropdownButtonView ) {
  *
  * @param {module:ui/dropdown/dropdownview~DropdownView} dropdownView A dropdown instance to which `ToolbarView` will be added.
  * @param {Iterable.<module:ui/button/buttonview~ButtonView>} buttons
+ * @param {Object} [options]
+ * @param {Boolean} [options.skipAutoFocus=false]
  */
-export function addToolbarToDropdown( dropdownView, buttons ) {
+export function addToolbarToDropdown( dropdownView, buttons, options = {} ) {
 	const locale = dropdownView.locale;
 	const t = locale.t;
 	const toolbarView = dropdownView.toolbarView = new ToolbarView( locale );
@@ -143,19 +145,21 @@ export function addToolbarToDropdown( dropdownView, buttons ) {
 
 	buttons.map( view => toolbarView.items.add( view ) );
 
-	dropdownView.on( 'change:isOpen', () => {
-		// A listener to focus the first active dropdown option upon opening, see #11838.
-		if ( !dropdownView.isOpen ) {
-			return;
-		}
-
-		for ( const toolbarItem of toolbarView.items ) {
-			if ( toolbarItem.isOn ) {
-				toolbarItem.focus();
-				break;
+	if ( !options.skipAutoFocus ) {
+		dropdownView.on( 'change:isOpen', () => {
+			// A listener to focus the first active dropdown option upon opening, see #11838.
+			if ( !dropdownView.isOpen ) {
+				return;
 			}
-		}
-	}, { priority: 'low' } );
+
+			for ( const toolbarItem of toolbarView.items ) {
+				if ( toolbarItem.isOn ) {
+					toolbarItem.focus();
+					break;
+				}
+			}
+		}, { priority: 'low' } );
+	}
 
 	dropdownView.panelView.children.add( toolbarView );
 	toolbarView.items.delegate( 'execute' ).to( dropdownView );

--- a/packages/ckeditor5-ui/src/dropdown/utils.js
+++ b/packages/ckeditor5-ui/src/dropdown/utils.js
@@ -143,6 +143,20 @@ export function addToolbarToDropdown( dropdownView, buttons ) {
 
 	buttons.map( view => toolbarView.items.add( view ) );
 
+	dropdownView.on( 'change:isOpen', () => {
+		// A listener to focus the first active dropdown option upon opening, see #11838.
+		if ( !dropdownView.isOpen ) {
+			return;
+		}
+
+		for ( const toolbarItem of toolbarView.items ) {
+			if ( toolbarItem.isOn ) {
+				toolbarItem.focus();
+				break;
+			}
+		}
+	}, { priority: 'low' } );
+
 	dropdownView.panelView.children.add( toolbarView );
 	toolbarView.items.delegate( 'execute' ).to( dropdownView );
 }
@@ -227,11 +241,7 @@ export function addListToDropdown( dropdownView, items ) {
 
 			if ( item.model && item.model.isOn ) {
 				const listItemView = listView.items.get( i );
-
-				// Calling focus tracker to focus the view is not enough. It sets the focused element
-				// internally, but doesn't actually call focus method on a given view.
-				listView.focusTracker._focus( listItemView );
-				listView._focusCycler._focus( listItemView );
+				listItemView.focus();
 				break;
 			}
 		}

--- a/packages/ckeditor5-ui/src/dropdown/utils.js
+++ b/packages/ckeditor5-ui/src/dropdown/utils.js
@@ -216,6 +216,27 @@ export function addListToDropdown( dropdownView, items ) {
 		}
 	} );
 
+	dropdownView.on( 'change:isOpen', () => {
+		// A listener to focus the first active dropdown option upon opening, see #11838.
+		if ( !dropdownView.isOpen ) {
+			return;
+		}
+
+		for ( let i = 0; i < items.length; i++ ) {
+			const item = items.get( i );
+
+			if ( item.model && item.model.isOn ) {
+				const listItemView = listView.items.get( i );
+
+				// Calling focus tracker to focus the view is not enough. It sets the focused element
+				// internally, but doesn't actually call focus method on a given view.
+				listView.focusTracker._focus( listItemView );
+				listView._focusCycler._focus( listItemView );
+				break;
+			}
+		}
+	}, { priority: 'low' } );
+
 	dropdownView.panelView.children.add( listView );
 
 	listView.items.delegate( 'execute' ).to( dropdownView );

--- a/packages/ckeditor5-ui/tests/dropdown/dropdownview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/dropdownview.js
@@ -104,6 +104,26 @@ describe( 'DropdownView', () => {
 				} );
 			} );
 
+			describe( 'view#isOpen to view.panelView#focus', () => {
+				it( 'gets called upon opening', () => {
+					const spy = sinon.spy( view.panelView, 'focus' );
+
+					view.isOpen = true;
+
+					expect( spy.callCount ).to.equal( 1 );
+				} );
+
+				it( 'does not get called upon closing', () => {
+					view.isOpen = true;
+
+					const spy = sinon.spy( view.panelView, 'focus' );
+
+					view.isOpen = false;
+
+					expect( spy.callCount ).to.equal( 0 );
+				} );
+			} );
+
 			describe( 'view.panelView#isVisible to view#isOpen', () => {
 				it( 'is activated', () => {
 					const values = [];

--- a/packages/ckeditor5-ui/tests/dropdown/utils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/utils.js
@@ -324,6 +324,38 @@ describe( 'utils', () => {
 
 				expect( document.activeElement ).to.equal( dropdownView.toolbarView.items.get( 0 ).element );
 			} );
+
+			it( 'can be turned off', () => {
+				// Remove old dropdown (created in test case's setup procedure).
+				dropdownView.element.remove();
+
+				// Create a new one.
+				buttons = [ '<svg>foo</svg>', '<svg>bar</svg>' ].map( icon => {
+					const button = new ButtonView();
+
+					button.icon = icon;
+
+					return button;
+				} );
+
+				dropdownView = createDropdown( locale );
+
+				addToolbarToDropdown( dropdownView, buttons, {
+					skipAutoFocus: true
+				} );
+
+				dropdownView.render();
+				document.body.appendChild( dropdownView.element );
+
+				// And the test itself.
+
+				dropdownView.toolbarView.items.get( 1 ).isOn = true;
+
+				// The focus logic happens when the dropdown is opened.
+				dropdownView.isOpen = true;
+
+				expect( document.activeElement ).to.not.equal( dropdownView.toolbarView.items.get( 1 ).element );
+			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-ui/tests/dropdown/utils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/utils.js
@@ -460,5 +460,82 @@ describe( 'utils', () => {
 				} );
 			} );
 		} );
+
+		describe( 'extra dropdown open listener', () => {
+			it( 'focuses active item upon dropdown opening', () => {
+				const buttonModels = [
+					new Model( { label: 'a', isOn: true } ),
+					new Model( { label: 'b' } )
+				];
+
+				definitions.add( {
+					type: 'button',
+					model: buttonModels[ 0 ]
+				} );
+
+				definitions.add( {
+					type: 'button',
+					model: buttonModels[ 1 ]
+				} );
+
+				// The focus logic happens when the dropdown is opened.
+				dropdownView.isOpen = true;
+
+				expect( dropdownView.listView.focusTracker.isFocused ).to.be.true;
+				expect( dropdownView.listView.focusTracker.focusedElement ).to.equal( listItems.get( 0 ) );
+			} );
+
+			it( 'focuses nth active item upon dropdown opening', () => {
+				const buttonModels = [
+					new Model( { label: 'a' } ),
+					new Model( { label: 'b', isOn: true } )
+				];
+
+				definitions.add( {
+					type: 'button',
+					model: buttonModels[ 0 ]
+				} );
+
+				definitions.add( {
+					type: 'button',
+					model: buttonModels[ 1 ]
+				} );
+
+				// The focus logic happens when the dropdown is opened.
+				dropdownView.isOpen = true;
+
+				expect( dropdownView.listView.focusTracker.isFocused ).to.be.true;
+				expect( dropdownView.listView.focusTracker.focusedElement ).to.equal( listItems.get( 1 ) );
+			} );
+
+			it( 'focuses the item if multiple items are active', () => {
+				const buttonModels = [
+					new Model( { label: 'a' } ),
+					new Model( { label: 'b', isOn: true } ),
+					new Model( { label: 'c', isOn: true } )
+				];
+
+				definitions.add( {
+					type: 'button',
+					model: buttonModels[ 0 ]
+				} );
+
+				definitions.add( {
+					type: 'button',
+					model: buttonModels[ 1 ]
+				} );
+
+				definitions.add( {
+					type: 'button',
+					model: buttonModels[ 2 ]
+				} );
+
+				// The focus logic happens when the dropdown is opened.
+				dropdownView.isOpen = true;
+
+				expect( dropdownView.listView.focusTracker.isFocused ).to.be.true;
+				expect( dropdownView.listView.focusTracker.focusedElement ).to.equal( listItems.get( 1 ) );
+			} );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-ui/tests/dropdown/utils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/utils.js
@@ -296,6 +296,35 @@ describe( 'utils', () => {
 				dropdownView.toolbarView.items.first.fire( 'execute' );
 			} );
 		} );
+
+		describe( 'extra dropdown open listener', () => {
+			it( 'focuses active item upon dropdown opening', () => {
+				dropdownView.toolbarView.items.get( 0 ).isOn = true;
+
+				// The focus logic happens when the dropdown is opened.
+				dropdownView.isOpen = true;
+
+				expect( document.activeElement ).to.equal( dropdownView.toolbarView.items.get( 0 ).element );
+			} );
+
+			it( 'focuses nth active item upon dropdown opening', () => {
+				dropdownView.toolbarView.items.get( 1 ).isOn = true;
+
+				// The focus logic happens when the dropdown is opened.
+				dropdownView.isOpen = true;
+
+				expect( document.activeElement ).to.equal( dropdownView.toolbarView.items.get( 1 ).element );
+			} );
+
+			it( 'focuses the first item if multiple items are active', () => {
+				dropdownView.toolbarView.items.get( 0 ).isOn = true;
+
+				// The focus logic happens when the dropdown is opened.
+				dropdownView.isOpen = true;
+
+				expect( document.activeElement ).to.equal( dropdownView.toolbarView.items.get( 0 ).element );
+			} );
+		} );
 	} );
 
 	describe( 'addListToDropdown()', () => {
@@ -481,8 +510,7 @@ describe( 'utils', () => {
 				// The focus logic happens when the dropdown is opened.
 				dropdownView.isOpen = true;
 
-				expect( dropdownView.listView.focusTracker.isFocused ).to.be.true;
-				expect( dropdownView.listView.focusTracker.focusedElement ).to.equal( listItems.get( 0 ) );
+				expect( document.activeElement ).to.equal( getFirstListViewDomButton( listItems.get( 0 ) ) );
 			} );
 
 			it( 'focuses nth active item upon dropdown opening', () => {
@@ -504,11 +532,10 @@ describe( 'utils', () => {
 				// The focus logic happens when the dropdown is opened.
 				dropdownView.isOpen = true;
 
-				expect( dropdownView.listView.focusTracker.isFocused ).to.be.true;
-				expect( dropdownView.listView.focusTracker.focusedElement ).to.equal( listItems.get( 1 ) );
+				expect( document.activeElement ).to.equal( getFirstListViewDomButton( listItems.get( 1 ) ) );
 			} );
 
-			it( 'focuses the item if multiple items are active', () => {
+			it( 'focuses the first item if multiple items are active', () => {
 				const buttonModels = [
 					new Model( { label: 'a' } ),
 					new Model( { label: 'b', isOn: true } ),
@@ -533,9 +560,12 @@ describe( 'utils', () => {
 				// The focus logic happens when the dropdown is opened.
 				dropdownView.isOpen = true;
 
-				expect( dropdownView.listView.focusTracker.isFocused ).to.be.true;
-				expect( dropdownView.listView.focusTracker.focusedElement ).to.equal( listItems.get( 1 ) );
+				expect( document.activeElement ).to.equal( getFirstListViewDomButton( listItems.get( 1 ) ) );
 			} );
+
+			function getFirstListViewDomButton( listView ) {
+				return listView.children.first.element;
+			}
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (ui): Opening a dropdown will cause the first enabled item to be focused. If there are no enabled items inside it will focus just the first item. Closes #2000.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._