### PR TITLE
Hide resizers when resizing commands are disabled (e.g. in comments-only mode)

### DIFF
--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -598,12 +598,18 @@ export default class TableColumnResizeEditing extends Plugin {
 				}
 			} else {
 				// In read-only mode revert all changes in the editing view. The model is not touched so it does not need to be restored.
+				// This case can occur if the read-only mode kicks in during the resizing process.
 				editingView.change( writer => {
 					if ( isColumnWidthsAttributeChanged ) {
-						const columnWidths = columnWidthsAttributeOld.split( ',' );
+						if ( columnWidthsAttributeOld ) {
+							const columnWidths = columnWidthsAttributeOld.split( ',' );
 
-						for ( const viewCol of viewColgroup.getChildren() ) {
-							writer.setStyle( 'width', columnWidths.shift(), viewCol );
+							for ( const viewCol of viewColgroup.getChildren() ) {
+								writer.setStyle( 'width', columnWidths.shift(), viewCol );
+							}
+						} else {
+							writer.removeClass( 'ck-table-resized', viewColgroup.findAncestor( 'table' ) );
+							writer.remove( viewColgroup );
 						}
 					}
 

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -144,7 +144,8 @@ export default class TableColumnResizeEditing extends Plugin {
 
 		// Currently the states of column resize and table resize (which is actually the last column resize) features
 		// are bound together. They can be separated in the future by adding distinct listeners and applying
-		// different CSS classes (e.g. `ck-column-resize_disabled` and `ck-table-resize-disabled`) to the editor root.
+		// different CSS classes (e.g. `ck-column-resize_disabled` and `ck-table-resize_disabled`) to the editor root.
+		// See #12148 for the details.
 		this.bind( '_isResizingAllowed' ).to(
 			editor, 'isReadOnly',
 			columnResizePlugin, 'isEnabled',

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -88,9 +88,9 @@ export default class TableColumnResizeEditing extends Plugin {
 		this.set( '_isResizingAllowed', true );
 
 		this.on( 'change:_isResizingAllowed', ( evt, name, value ) => {
-			// Toggling the `ck-column-resize-disabled` class shows and hides the resizers through CSS.
+			// Toggling the `ck-column-resize_disabled` class shows and hides the resizers through CSS.
 			editor.editing.view.change( writer => {
-				writer[ value ? 'removeClass' : 'addClass' ]( 'ck-column-resize-disabled', editor.editing.view.document.getRoot() );
+				writer[ value ? 'removeClass' : 'addClass' ]( 'ck-column-resize_disabled', editor.editing.view.document.getRoot() );
 			} );
 		} );
 
@@ -144,7 +144,7 @@ export default class TableColumnResizeEditing extends Plugin {
 
 		// Currently the states of column resize and table resize (which is actually the last column resize) features
 		// are bound together. They can be separated in the future by adding distinct listeners and applying
-		// different CSS classes (e.g. `ck-column-resize-disabled` and `ck-table-resize-disabled`) to the editor root.
+		// different CSS classes (e.g. `ck-column-resize_disabled` and `ck-table-resize-disabled`) to the editor root.
 		this.bind( '_isResizingAllowed' ).to(
 			editor, 'isReadOnly',
 			columnResizePlugin, 'isEnabled',

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -601,6 +601,8 @@ export default class TableColumnResizeEditing extends Plugin {
 				// This case can occur if the read-only mode kicks in during the resizing process.
 				editingView.change( writer => {
 					if ( isColumnWidthsAttributeChanged ) {
+						// If table was already resized before, restore the previous column widths.
+						// Otherwise clean up the view from the temporary resizing markup.
 						if ( columnWidthsAttributeOld ) {
 							const columnWidths = columnWidthsAttributeOld.split( ',' );
 
@@ -614,6 +616,8 @@ export default class TableColumnResizeEditing extends Plugin {
 					}
 
 					if ( isTableWidthAttributeChanged ) {
+						// If table was already resized before, restore the previous table width.
+						// Otherwise clean up the view from the temporary resizing markup.
 						if ( tableWidthAttributeOld ) {
 							writer.setStyle( 'width', tableWidthAttributeOld, viewFigure );
 						} else {

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -87,13 +87,6 @@ export default class TableColumnResizeEditing extends Plugin {
 		 */
 		this.set( '_isResizingAllowed', true );
 
-		this.on( 'change:_isResizingAllowed', ( evt, name, value ) => {
-			// Toggling the `ck-column-resize_disabled` class shows and hides the resizers through CSS.
-			editor.editing.view.change( writer => {
-				writer[ value ? 'removeClass' : 'addClass' ]( 'ck-column-resize_disabled', editor.editing.view.document.getRoot() );
-			} );
-		} );
-
 		/**
 		 * A temporary storage for the required data needed to correctly calculate the widths of the resized columns. This storage is
 		 * initialized when column resizing begins, and is purged upon completion.
@@ -120,6 +113,13 @@ export default class TableColumnResizeEditing extends Plugin {
 		 * @member {Map}
 		 */
 		this._cellsModified = new Map();
+
+		this.on( 'change:_isResizingAllowed', ( evt, name, value ) => {
+			// Toggling the `ck-column-resize_disabled` class shows and hides the resizers through CSS.
+			editor.editing.view.change( writer => {
+				writer[ value ? 'removeClass' : 'addClass' ]( 'ck-column-resize_disabled', editor.editing.view.document.getRoot() );
+			} );
+		} );
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -86,16 +86,12 @@ export default class TableColumnResizeEditing extends Plugin {
 		 * @member {Boolean}
 		 */
 		this.set( '_isResizingAllowed', true );
+
 		this.on( 'change:_isResizingAllowed', ( evt, name, value ) => {
-			if ( value ) {
-				editor.editing.view.change( writer => {
-					writer.removeClass( 'ck-comments-only', editor.editing.view.document.getRoot() );
-				} );
-			} else {
-				editor.editing.view.change( writer => {
-					writer.addClass( 'ck-comments-only', editor.editing.view.document.getRoot() );
-				} );
-			}
+			// Toggling the `ck-column-resize-disabled` class shows and hides the resizers through CSS.
+			editor.editing.view.change( writer => {
+				writer[ value ? 'removeClass' : 'addClass' ]( 'ck-column-resize-disabled', editor.editing.view.document.getRoot() );
+			} );
 		} );
 
 		/**
@@ -146,6 +142,9 @@ export default class TableColumnResizeEditing extends Plugin {
 		const resizeTableWidthCommand = editor.commands.get( 'resizeTableWidth' );
 		const resizeColumnWidthsCommand = editor.commands.get( 'resizeColumnWidths' );
 
+		// Currently the states of column resize and table resize (which is actually the last column resize) features
+		// are bound together. They can be separated in the future by adding distinct listeners and applying
+		// different CSS classes (e.g. `ck-column-resize-disabled` and `ck-table-resize-disabled`) to the editor root.
 		this.bind( '_isResizingAllowed' ).to(
 			editor, 'isReadOnly',
 			columnResizePlugin, 'isEnabled',

--- a/packages/ckeditor5-table/tests/manual/tablecolumnresize.html
+++ b/packages/ckeditor5-table/tests/manual/tablecolumnresize.html
@@ -1,3 +1,7 @@
+<button id="read-only">Toggle read-only</button>
+
+<h1>LTR editor</h1>
+
 <div id="editor">
 	<h3>Table with colgroup</h3>
 	<figure class="table" style="width:400px;">

--- a/packages/ckeditor5-table/tests/manual/tablecolumnresize.js
+++ b/packages/ckeditor5-table/tests/manual/tablecolumnresize.js
@@ -67,3 +67,8 @@ ClassicEditor
 	.catch( err => {
 		console.error( err.stack );
 	} );
+
+document.querySelector( 'button#read-only' ).addEventListener( 'click', () => {
+	window.editor.isReadOnly ? window.editor.disableReadOnlyMode( 'test' ) : window.editor.enableReadOnlyMode( 'test' );
+	window.editorRTL.isReadOnly ? window.editorRTL.disableReadOnlyMode( 'test' ) : window.editorRTL.enableReadOnlyMode( 'test' );
+} );

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -729,16 +729,16 @@ describe( 'TableColumnResizeEditing', () => {
 			} );
 		} );
 
-		it( 'editable should not have the "ck-column-resize-disabled" class if "_isResizingAllowed" is set to "true"', () => {
+		it( 'editable should not have the "ck-column-resize_disabled" class if "_isResizingAllowed" is set to "true"', () => {
 			editor.plugins.get( 'TableColumnResizeEditing' )._isResizingAllowed = true;
 
-			expect( editor.editing.view.document.getRoot().hasClass( 'ck-column-resize-disabled' ) ).to.equal( false );
+			expect( editor.editing.view.document.getRoot().hasClass( 'ck-column-resize_disabled' ) ).to.equal( false );
 		} );
 
-		it( 'editable should have the "ck-column-resize-disabled" class if "_isResizingAllowed" is set to "false"', () => {
+		it( 'editable should have the "ck-column-resize_disabled" class if "_isResizingAllowed" is set to "false"', () => {
 			editor.plugins.get( 'TableColumnResizeEditing' )._isResizingAllowed = false;
 
-			expect( editor.editing.view.document.getRoot().hasClass( 'ck-column-resize-disabled' ) ).to.equal( true );
+			expect( editor.editing.view.document.getRoot().hasClass( 'ck-column-resize_disabled' ) ).to.equal( true );
 		} );
 	} );
 

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -584,6 +584,164 @@ describe( 'TableColumnResizeEditing', () => {
 		} );
 	} );
 
+	describe( '_isResizingAllowed property', () => {
+		describe( 'should be set to "false"', () => {
+			it( 'if editor is in the read-only mode', () => {
+				editor.enableReadOnlyMode( 'test' );
+
+				expect( editor.plugins.get( 'TableColumnResizeEditing' )._isResizingAllowed ).to.equal( false );
+			} );
+
+			it( 'if the TableColumnResize plugin is disabled', () => {
+				editor.plugins.get( 'TableColumnResize' ).isEnabled = false;
+
+				expect( editor.plugins.get( 'TableColumnResizeEditing' )._isResizingAllowed ).to.equal( false );
+			} );
+
+			it( 'if resizeTableWidth command is disabled', () => {
+				editor.commands.get( 'resizeTableWidth' ).isEnabled = false;
+
+				expect( editor.plugins.get( 'TableColumnResizeEditing' )._isResizingAllowed ).to.equal( false );
+			} );
+
+			it( 'if resizeColumnWidths command is disabled', () => {
+				editor.commands.get( 'resizeColumnWidths' ).isEnabled = false;
+
+				expect( editor.plugins.get( 'TableColumnResizeEditing' )._isResizingAllowed ).to.equal( false );
+			} );
+		} );
+
+		describe( 'should be set to "true"', () => {
+			it( 'if the editor is not read-only and plugin and commands are enabled', () => {
+				editor.plugins.get( 'TableColumnResize' ).isEnabled = true;
+				editor.commands.get( 'resizeTableWidth' ).isEnabled = true;
+				editor.commands.get( 'resizeColumnWidths' ).isEnabled = true;
+
+				expect( editor.plugins.get( 'TableColumnResizeEditing' )._isResizingAllowed ).to.equal( true );
+			} );
+		} );
+
+		describe( 'should change value to "false"', () => {
+			it( 'if editor was switched to the read-only mode at runtime', () => {
+				const spy = sinon.spy();
+				const TableColumnResizeEditingPlugin = editor.plugins.get( 'TableColumnResizeEditing' );
+
+				editor.listenTo( TableColumnResizeEditingPlugin, 'change:_isResizingAllowed', spy );
+
+				editor.enableReadOnlyMode( 'test' );
+
+				expect( spy.calledOnce, 'Property value should have changed once' ).to.be.true;
+				expect( TableColumnResizeEditingPlugin._isResizingAllowed ).to.equal( false );
+			} );
+
+			it( 'if the TableResizeEditing plugin was disabled at runtime', () => {
+				const spy = sinon.spy();
+				const TableColumnResizeEditingPlugin = editor.plugins.get( 'TableColumnResizeEditing' );
+
+				editor.listenTo( TableColumnResizeEditingPlugin, 'change:_isResizingAllowed', spy );
+
+				editor.plugins.get( 'TableColumnResize' ).isEnabled = false;
+
+				expect( spy.calledOnce, 'Property value should have changed once' ).to.be.true;
+				expect( TableColumnResizeEditingPlugin._isResizingAllowed ).to.equal( false );
+			} );
+
+			it( 'if resizeTableWidth command was disabled at runtime', () => {
+				const spy = sinon.spy();
+				const TableColumnResizeEditingPlugin = editor.plugins.get( 'TableColumnResizeEditing' );
+
+				editor.listenTo( TableColumnResizeEditingPlugin, 'change:_isResizingAllowed', spy );
+
+				editor.commands.get( 'resizeTableWidth' ).isEnabled = false;
+
+				expect( spy.calledOnce, 'Property value should have changed once' ).to.be.true;
+				expect( TableColumnResizeEditingPlugin._isResizingAllowed ).to.equal( false );
+			} );
+
+			it( 'if resizeColumnWidths command was disabled at runtime', () => {
+				const spy = sinon.spy();
+				const TableColumnResizeEditingPlugin = editor.plugins.get( 'TableColumnResizeEditing' );
+
+				editor.listenTo( TableColumnResizeEditingPlugin, 'change:_isResizingAllowed', spy );
+
+				editor.commands.get( 'resizeColumnWidths' ).isEnabled = false;
+
+				expect( spy.calledOnce, 'Property value should have changed once' ).to.be.true;
+				expect( TableColumnResizeEditingPlugin._isResizingAllowed ).to.equal( false );
+			} );
+		} );
+
+		describe( 'should change value to "true"', () => {
+			it( 'if read-only mode was disabled at runtime', () => {
+				editor.enableReadOnlyMode( 'test' );
+
+				const spy = sinon.spy();
+				const TableColumnResizeEditingPlugin = editor.plugins.get( 'TableColumnResizeEditing' );
+
+				editor.listenTo( TableColumnResizeEditingPlugin, 'change:_isResizingAllowed', spy );
+
+				editor.disableReadOnlyMode( 'test' );
+
+				expect( spy.calledOnce, 'Property value should have changed once' ).to.be.true;
+				expect( TableColumnResizeEditingPlugin._isResizingAllowed ).to.equal( true );
+			} );
+
+			it( 'if the TableResizeEditing plugin was enabled at runtime', () => {
+				editor.plugins.get( 'TableColumnResize' ).isEnabled = false;
+
+				const spy = sinon.spy();
+				const TableColumnResizeEditingPlugin = editor.plugins.get( 'TableColumnResizeEditing' );
+
+				editor.listenTo( TableColumnResizeEditingPlugin, 'change:_isResizingAllowed', spy );
+
+				editor.plugins.get( 'TableColumnResize' ).isEnabled = true;
+
+				expect( spy.calledOnce, 'Property value should have changed once' ).to.be.true;
+				expect( TableColumnResizeEditingPlugin._isResizingAllowed ).to.equal( true );
+			} );
+
+			it( 'if resizeTableWidth command was enabled at runtime', () => {
+				editor.commands.get( 'resizeTableWidth' ).isEnabled = false;
+
+				const spy = sinon.spy();
+				const TableColumnResizeEditingPlugin = editor.plugins.get( 'TableColumnResizeEditing' );
+
+				editor.listenTo( TableColumnResizeEditingPlugin, 'change:_isResizingAllowed', spy );
+
+				editor.commands.get( 'resizeTableWidth' ).isEnabled = true;
+
+				expect( spy.calledOnce, 'Property value should have changed once' ).to.be.true;
+				expect( TableColumnResizeEditingPlugin._isResizingAllowed ).to.equal( true );
+			} );
+
+			it( 'if resizeColumnWidths command was enabled at runtime', () => {
+				editor.commands.get( 'resizeColumnWidths' ).isEnabled = false;
+
+				const spy = sinon.spy();
+				const TableColumnResizeEditingPlugin = editor.plugins.get( 'TableColumnResizeEditing' );
+
+				editor.listenTo( TableColumnResizeEditingPlugin, 'change:_isResizingAllowed', spy );
+
+				editor.commands.get( 'resizeColumnWidths' ).isEnabled = true;
+
+				expect( spy.calledOnce, 'Property value should have changed once' ).to.be.true;
+				expect( TableColumnResizeEditingPlugin._isResizingAllowed ).to.equal( true );
+			} );
+		} );
+
+		it( 'editable should not have the "ck-column-resize-disabled" class if "_isResizingAllowed" is set to "true"', () => {
+			editor.plugins.get( 'TableColumnResizeEditing' )._isResizingAllowed = true;
+
+			expect( editor.editing.view.document.getRoot().hasClass( 'ck-column-resize-disabled' ) ).to.equal( false );
+		} );
+
+		it( 'editable should have the "ck-column-resize-disabled" class if "_isResizingAllowed" is set to "false"', () => {
+			editor.plugins.get( 'TableColumnResizeEditing' )._isResizingAllowed = false;
+
+			expect( editor.editing.view.document.getRoot().hasClass( 'ck-column-resize-disabled' ) ).to.equal( true );
+		} );
+	} );
+
 	describe( 'does not resize', () => {
 		it( 'without dragging', () => {
 			// Test-specific.

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -40,7 +40,7 @@
 	z-index: var(--ck-z-default);
 }
 
-.ck-content.ck-column-resize_disabled .table .ck-table-column-resizer {
+.ck.ck-editor__editable.ck-column-resize_disabled .table .ck-table-column-resizer {
 	display: none;
 }
 

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -61,6 +61,6 @@
 	display: none;
 }
 
-.ck-content.ck-column-resize-disabled .table .ck-table-column-resizer {
+.ck-content.ck-column-resize_disabled .table .ck-table-column-resizer {
 	display: none;
 }

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -61,6 +61,6 @@
 	display: none;
 }
 
-.ck-content.ck-comments-only .table .ck-table-column-resizer {
+.ck-content.ck-column-resize-disabled .table .ck-table-column-resizer {
 	display: none;
 }

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -60,3 +60,7 @@
 .ck-content.ck-read-only .table .ck-table-column-resizer {
 	display: none;
 }
+
+.ck-content.ck-comments-only .table .ck-table-column-resizer {
+	display: none;
+}

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -57,10 +57,6 @@
 	right: unset;
 }
 
-.ck-content.ck-read-only .table .ck-table-column-resizer {
-	display: none;
-}
-
 .ck-content.ck-column-resize_disabled .table .ck-table-column-resizer {
 	display: none;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): Table column resizers should be hidden when resizing commands are disabled. Closes #11886.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._