### PR TITLE
Support for TypeScript when collecting translation entries

### DIFF
--- a/scripts/translations/utils.js
+++ b/scripts/translations/utils.js
@@ -70,11 +70,11 @@ function parseArguments( args ) {
  */
 function getCKEditor5SourceFiles( { cwd, includeExternalDirectory } ) {
 	const patterns = [
-		'packages/*/src/**/*.js'
+		'packages/*/src/**/*.[jt]s'
 	];
 
 	if ( includeExternalDirectory ) {
-		patterns.push( 'external/*/packages/*/src/**/*.js' );
+		patterns.push( 'external/*/packages/*/src/**/*.[jt]s' );
 	}
 
 	const globOptions = { cwd, absolute: true };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Support for TypeScript when collecting translation entries. Closes #12029.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
