### PR TITLE
Added missing CloudServices plugin for CKBox

### DIFF
--- a/packages/ckeditor5-ckbox/src/ckboxediting.js
+++ b/packages/ckeditor5-ckbox/src/ckboxediting.js
@@ -34,7 +34,7 @@ export default class CKBoxEditing extends Plugin {
 	 * @inheritDoc
 	 */
 	static get requires() {
-		return [ 'CloudServicesCore', 'LinkEditing', 'PictureEditing', CKBoxUploadAdapter ];
+		return [ 'CloudServices', 'LinkEditing', 'PictureEditing', CKBoxUploadAdapter ];
 	}
 
 	/**

--- a/packages/ckeditor5-ckbox/tests/ckboxediting.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxediting.js
@@ -68,7 +68,7 @@ describe( 'CKBoxEditing', () => {
 	} );
 
 	it( 'should load link and picture features', () => {
-		expect( CKBoxEditing.requires ).to.deep.equal( [ 'CloudServicesCore', 'LinkEditing', 'PictureEditing', CKBoxUploadAdapter ] );
+		expect( CKBoxEditing.requires ).to.deep.equal( [ 'CloudServices', 'LinkEditing', 'PictureEditing', CKBoxUploadAdapter ] );
 	} );
 
 	it( 'should register the "ckbox" command if CKBox lib is loaded', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (ckbox): Added missing CloudServices plugin for CKBox. Closes #12040.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
