### PR TITLE
Fix column resizing in table with only heading rows

### DIFF
--- a/packages/ckeditor5-table/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/utils.js
@@ -92,7 +92,7 @@ export function getElementWidthInPixels( domElement ) {
  * @returns {Number}
  */
 export function getTableWidthInPixels( table, editor ) {
-	// It is possible for table to not have a <tbody> element - see #11878.
+	// It is possible for a table to not have a <tbody> element - see #11878.
 	const referenceElement = getChildrenViewElement( table, 'tbody', editor ) || getChildrenViewElement( table, 'thead', editor );
 	const domReferenceElement = editor.editing.view.domConverter.mapViewToDom( referenceElement );
 

--- a/packages/ckeditor5-table/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/utils.js
@@ -92,23 +92,37 @@ export function getElementWidthInPixels( domElement ) {
  * @returns {Number}
  */
 export function getTableWidthInPixels( table, editor ) {
-	const viewTbody = getTbodyViewElement( table, editor );
-	const domTbody = editor.editing.view.domConverter.mapViewToDom( viewTbody );
+	// It is possible for table to not have a <tbody> element - see #11878.
+	const referenceElement = getTbodyViewElement( table, editor ) || getTheadViewElement( table, editor );
+	const domReferenceElement = editor.editing.view.domConverter.mapViewToDom( referenceElement );
 
-	return getElementWidthInPixels( domTbody );
+	return getElementWidthInPixels( domReferenceElement );
 }
 
 // Returns the `<tbody>` view element, if it exists in a table. Returns `undefined` otherwise.
 //
 // @private
-// @param {module:engine/model/element~Element} table
+// @param {module:engine/model/element~Element} modelTable
 // @param {module:core/editor/editor~Editor} editor
 // @returns {module:engine/view/element~Element|undefined}
-function getTbodyViewElement( table, editor ) {
-	const viewFigure = editor.editing.mapper.toViewElement( table );
+function getTbodyViewElement( modelTable, editor ) {
+	const viewFigure = editor.editing.mapper.toViewElement( modelTable );
 	const viewTable = [ ...viewFigure.getChildren() ].find( viewChild => viewChild.is( 'element', 'table' ) );
 
 	return [ ...viewTable.getChildren() ].find( viewChild => viewChild.is( 'element', 'tbody' ) );
+}
+
+// Returns the `<thead>` view element, if it exists in a table. Returns `undefined` otherwise.
+//
+// @private
+// @param {module:engine/model/element~Element} modelTable
+// @param {module:core/editor/editor~Editor} editor
+// @returns {module:engine/view/element~Element|undefined}
+function getTheadViewElement( modelTable, editor ) {
+	const viewFigure = editor.editing.mapper.toViewElement( modelTable );
+	const viewTable = [ ...viewFigure.getChildren() ].find( viewChild => viewChild.is( 'element', 'table' ) );
+
+	return [ ...viewTable.getChildren() ].find( viewChild => viewChild.is( 'element', 'thead' ) );
 }
 
 /**

--- a/packages/ckeditor5-table/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/utils.js
@@ -93,36 +93,25 @@ export function getElementWidthInPixels( domElement ) {
  */
 export function getTableWidthInPixels( table, editor ) {
 	// It is possible for table to not have a <tbody> element - see #11878.
-	const referenceElement = getTbodyViewElement( table, editor ) || getTheadViewElement( table, editor );
+	const referenceElement = getChildrenViewElement( table, 'tbody', editor ) || getChildrenViewElement( table, 'thead', editor );
 	const domReferenceElement = editor.editing.view.domConverter.mapViewToDom( referenceElement );
 
 	return getElementWidthInPixels( domReferenceElement );
 }
 
-// Returns the `<tbody>` view element, if it exists in a table. Returns `undefined` otherwise.
+// Returns the a view element with a given name that is nested directly in a `<table>` element
+// related to a given `modelTable`.
 //
 // @private
-// @param {module:engine/model/element~Element} modelTable
+// @param {module:engine/model/element~Element} table
 // @param {module:core/editor/editor~Editor} editor
-// @returns {module:engine/view/element~Element|undefined}
-function getTbodyViewElement( modelTable, editor ) {
+// @param {String} elementName Name of a view to be looked for, e.g. `'colgroup`', `'thead`'.
+// @returns {module:engine/view/element~Element|undefined} Matched view or `undefined` otherwise.
+function getChildrenViewElement( modelTable, elementName, editor ) {
 	const viewFigure = editor.editing.mapper.toViewElement( modelTable );
 	const viewTable = [ ...viewFigure.getChildren() ].find( viewChild => viewChild.is( 'element', 'table' ) );
 
-	return [ ...viewTable.getChildren() ].find( viewChild => viewChild.is( 'element', 'tbody' ) );
-}
-
-// Returns the `<thead>` view element, if it exists in a table. Returns `undefined` otherwise.
-//
-// @private
-// @param {module:engine/model/element~Element} modelTable
-// @param {module:core/editor/editor~Editor} editor
-// @returns {module:engine/view/element~Element|undefined}
-function getTheadViewElement( modelTable, editor ) {
-	const viewFigure = editor.editing.mapper.toViewElement( modelTable );
-	const viewTable = [ ...viewFigure.getChildren() ].find( viewChild => viewChild.is( 'element', 'table' ) );
-
-	return [ ...viewTable.getChildren() ].find( viewChild => viewChild.is( 'element', 'thead' ) );
+	return [ ...viewTable.getChildren() ].find( viewChild => viewChild.is( 'element', elementName ) );
 }
 
 /**
@@ -173,20 +162,7 @@ export function getNumberOfColumn( table, editor ) {
  * @returns {Number}
  */
 export function isTableRendered( table, editor ) {
-	return !!getColgroupViewElement( table, editor );
-}
-
-// Returns the `<colgroup>` view element, if it exists in a table. Returns `undefined` otherwise.
-//
-// @private
-// @param {module:engine/model/element~Element} table
-// @param {module:core/editor/editor~Editor} editor
-// @returns {module:engine/view/element~Element|undefined}
-function getColgroupViewElement( modelTable, editor ) {
-	const viewFigure = editor.editing.mapper.toViewElement( modelTable );
-	const viewTable = [ ...viewFigure.getChildren() ].find( viewChild => viewChild.is( 'element', 'table' ) );
-
-	return [ ...viewTable.getChildren() ].find( viewChild => viewChild.is( 'element', 'colgroup' ) );
+	return !!getChildrenViewElement( table, 'colgroup', editor );
 }
 
 /**

--- a/packages/ckeditor5-table/tests/manual/tablecolumnresize.html
+++ b/packages/ckeditor5-table/tests/manual/tablecolumnresize.html
@@ -59,6 +59,29 @@
 			</tbody>
 		</table>
 	</figure>
+
+	<h3>Table without &lt;tbody&gt;</h3>
+	<figure class="table">
+		<table>
+			<colgroup>
+				<col style="width:20%;">
+				<col style="width:20%;">
+				<col style="width:20%;">
+				<col style="width:20%;">
+				<col style="width:20%;">
+			</colgroup>
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th>Region</th>
+					<th>Orbital radius (AU)</th>
+					<th>Orbital period (years)</th>
+					<th>Number of moons</th>
+				</tr>
+			</thead>
+		</table>
+	</figure>
+
 	<h3>Left aligned table</h3>
 	<figure class="table" style="width: 800px;float:left;">
 		<table>
@@ -150,6 +173,29 @@
 			</tbody>
 		</table>
 	</figure>
+
+	<h3>Table without &lt;tbody&gt;</h3>
+	<figure class="table">
+		<table>
+			<colgroup>
+				<col style="width:20%;">
+				<col style="width:20%;">
+				<col style="width:20%;">
+				<col style="width:20%;">
+				<col style="width:20%;">
+			</colgroup>
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th>Region</th>
+					<th>Orbital radius (AU)</th>
+					<th>Orbital period (years)</th>
+					<th>Number of moons</th>
+				</tr>
+			</thead>
+		</table>
+	</figure>
+
 	<h3>Left aligned table</h3>
 	<figure class="table" style="width: 800px;float:left;">
 		<table>

--- a/packages/ckeditor5-table/tests/manual/tablecolumnresize.html
+++ b/packages/ckeditor5-table/tests/manual/tablecolumnresize.html
@@ -60,7 +60,7 @@
 		</table>
 	</figure>
 
-	<h3>Table without &lt;tbody&gt;</h3>
+	<h3>Table with headers only</h3>
 	<figure class="table">
 		<table>
 			<colgroup>
@@ -174,7 +174,7 @@
 		</table>
 	</figure>
 
-	<h3>Table without &lt;tbody&gt;</h3>
+	<h3>Table with headers only</h3>
 	<figure class="table">
 		<table>
 			<colgroup>

--- a/packages/ckeditor5-table/tests/tablecolumnresize/_utils/utils.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/_utils/utils.js
@@ -78,6 +78,7 @@ export function getViewColumnWidthsPx( domTable ) {
 	Array.from( domTable.querySelectorAll( 'col' ) ).forEach( col => {
 		widths.push( getWidth( col ) );
 	} );
+
 	return widths;
 }
 

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -724,6 +724,37 @@ describe( 'TableColumnResizeEditing', () => {
 				assertViewPixelWidths( finalViewColumnWidthsPx, expectedViewColumnWidthsPx );
 			} );
 
+			it( 'correctly resizes a table with only header rows', () => {
+				// Test-specific.
+				const columnToResizeIndex = 0;
+				const mouseMovementVector = { x: 10, y: 0 };
+
+				setModelData( model, modelTable( [ [ '0', '1' ] ], { headingRows: '1', columnWidths: '50%,50%' } ) );
+
+				// Test-agnostic.
+				const initialViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
+
+				tableColumnResizeMouseSimulator.resize( editor, getDomTable( view ), columnToResizeIndex, mouseMovementVector );
+
+				const finalModelColumnWidthsPc = getModelColumnWidthsPc( getModelTable( model ) );
+
+				assertModelWidthsSum( finalModelColumnWidthsPc );
+
+				const finalViewColumnWidthsPc = getViewColumnWidthsPc( getViewTable( view ) );
+
+				assertModelViewSync( finalModelColumnWidthsPc, finalViewColumnWidthsPc );
+
+				const finalViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( view ) );
+				const expectedViewColumnWidthsPx = calculateExpectedWidthPixels(
+					initialViewColumnWidthsPx,
+					mouseMovementVector,
+					contentDirection,
+					columnToResizeIndex
+				);
+
+				assertViewPixelWidths( finalViewColumnWidthsPx, expectedViewColumnWidthsPx );
+			} );
+
 			it( 'does not remove column when it was shrinked to negative width', () => {
 				// Test-specific.
 				setModelData( model, modelTable( [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): Fixed column resize for tables containing only table headers. Closes #11878.

---

### Additional information

Tested also with a table pasted from CKE4 containing only `<thead>` element - see https://github.com/ckeditor/ckeditor5/issues/11975#issue-1285829256 for details.