### PR TITLE
Validate view selection position in image and table helpers

### DIFF
--- a/packages/ckeditor5-image/src/imageutils.js
+++ b/packages/ckeditor5-image/src/imageutils.js
@@ -127,13 +127,19 @@ export default class ImageUtils extends Plugin {
 	 * @returns {module:engine/view/element~Element|null}
 	 */
 	getClosestSelectedImageWidget( selection ) {
+		const selectionPosition = selection.getFirstPosition();
+
+		if ( !selectionPosition ) {
+			return null;
+		}
+
 		const viewElement = selection.getSelectedElement();
 
 		if ( viewElement && this.isImageWidget( viewElement ) ) {
 			return viewElement;
 		}
 
-		let parent = selection.getFirstPosition().parent;
+		let parent = selectionPosition.parent;
 
 		while ( parent ) {
 			if ( parent.is( 'element' ) && this.isImageWidget( parent ) ) {

--- a/packages/ckeditor5-image/tests/imageutils.js
+++ b/packages/ckeditor5-image/tests/imageutils.js
@@ -161,6 +161,7 @@ describe( 'ImageUtils plugin', () => {
 			expect( imageUtils.getClosestSelectedImageWidget( selection ) ).to.be.null;
 		} );
 
+		// See https://github.com/ckeditor/ckeditor5/issues/11972.
 		it( 'should return null if view selection is empty', () => {
 			const selection = writer.createSelection();
 

--- a/packages/ckeditor5-image/tests/imageutils.js
+++ b/packages/ckeditor5-image/tests/imageutils.js
@@ -160,6 +160,12 @@ describe( 'ImageUtils plugin', () => {
 
 			expect( imageUtils.getClosestSelectedImageWidget( selection ) ).to.be.null;
 		} );
+
+		it( 'should return null if view selection is empty', () => {
+			const selection = writer.createSelection();
+
+			expect( imageUtils.getClosestSelectedImageWidget( selection ) ).to.be.null;
+		} );
 	} );
 
 	describe( 'getClosestSelectedImageElement()', () => {

--- a/packages/ckeditor5-table/src/utils/ui/widget.js
+++ b/packages/ckeditor5-table/src/utils/ui/widget.js
@@ -32,7 +32,13 @@ export function getSelectedTableWidget( selection ) {
  * @returns {module:engine/view/element~Element|null}
  */
 export function getTableWidgetAncestor( selection ) {
-	let parent = selection.getFirstPosition().parent;
+	const selectionPosition = selection.getFirstPosition();
+
+	if ( !selectionPosition ) {
+		return null;
+	}
+
+	let parent = selectionPosition.parent;
 
 	while ( parent ) {
 		if ( parent.is( 'element' ) && isTableWidget( parent ) ) {

--- a/packages/ckeditor5-table/tests/utils/ui/widget.js
+++ b/packages/ckeditor5-table/tests/utils/ui/widget.js
@@ -1,0 +1,22 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import ViewSelection from '@ckeditor/ckeditor5-engine/src/view/selection';
+import { getTableWidgetAncestor } from '../../../src/utils/ui/widget';
+
+describe( 'table utils', () => {
+	describe( 'widget', () => {
+		describe( 'getTableWidgetAncestor()', () => {
+			// This can happen if `editor#event:ui` is fired too soon, i.e. before view is initialized.
+			// This was happening for example when editor crashed. This error made debugging more difficult.
+			// I am not sure if this could ever happen in normal circumstances (when editor works without errors).
+			it( 'should return null if view selection is empty', () => {
+				const selection = new ViewSelection();
+
+				expect( getTableWidgetAncestor( selection ) ).to.be.null;
+			} );
+		} );
+	} );
+} );

--- a/packages/ckeditor5-table/tests/utils/ui/widget.js
+++ b/packages/ckeditor5-table/tests/utils/ui/widget.js
@@ -9,9 +9,7 @@ import { getTableWidgetAncestor } from '../../../src/utils/ui/widget';
 describe( 'table utils', () => {
 	describe( 'widget', () => {
 		describe( 'getTableWidgetAncestor()', () => {
-			// This can happen if `editor#event:ui` is fired too soon, i.e. before view is initialized.
-			// This was happening for example when editor crashed. This error made debugging more difficult.
-			// I am not sure if this could ever happen in normal circumstances (when editor works without errors).
+			// See https://github.com/ckeditor/ckeditor5/issues/11972.
 			it( 'should return null if view selection is empty', () => {
 				const selection = new ViewSelection();
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (image): Prevent `getClosestSelectedImageWidget()` from throwing when view selection is empty. Closes #11972.

Internal (table): Prevent `getTableWidgetAncestor()` from throwing when view selection is empty. Closes #11972.

---

### Additional information

Internal in the commit message instead of Fix because I am not sure if this ever happens when normal editor scenarios.