### PR TITLE
Link manual decorator attribute should be down-casted on selection

### DIFF
--- a/packages/ckeditor5-link/src/linkediting.js
+++ b/packages/ckeditor5-link/src/linkediting.js
@@ -195,7 +195,7 @@ export default class LinkEditing extends Plugin {
 				model: decorator.id,
 				view: ( manualDecoratorValue, { writer, schema }, { item } ) => {
 					// Manual decorators for block links are handled e.g. in LinkImageEditing.
-					if ( !schema.isInline( item ) ) {
+					if ( !( item.is( 'selection' ) || schema.isInline( item ) ) ) {
 						return;
 					}
 

--- a/packages/ckeditor5-link/tests/linkediting.js
+++ b/packages/ckeditor5-link/tests/linkediting.js
@@ -938,6 +938,14 @@ describe( 'LinkEditing', () => {
 				await editor.destroy();
 			} );
 		} );
+
+		it( 'should downcast manual decorator on document selection', () => {
+			setModelData( model, '<paragraph><$text linkHref="url" linkIsExternal="true">foo[]bar</$text></paragraph>' );
+
+			expect( getViewData( editor.editing.view ) ).to.equal(
+				'<p><a class="ck-link_selected" href="url" rel="noopener noreferrer" target="_blank">foo{}bar</a></p>'
+			);
+		} );
 	} );
 
 	describe( 'link following', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (link): Link manual decorators should be properly down-casted on the document selection. Closes #12046.

---

### Additional information


