### PR TITLE
Translation utils - support for skipping packages

### DIFF
--- a/scripts/translations/utils.js
+++ b/scripts/translations/utils.js
@@ -31,7 +31,8 @@ function parseArguments( args ) {
 	const config = {
 		string: [
 			'cwd',
-			'packages'
+			'packages',
+			'ignore'
 		],
 
 		boolean: [
@@ -41,6 +42,7 @@ function parseArguments( args ) {
 		default: {
 			cwd: process.cwd(),
 			packages: [],
+			ignore: [],
 			'include-external-directory': false
 		}
 	};
@@ -57,6 +59,11 @@ function parseArguments( args ) {
 	// Convert packages to an array.
 	if ( typeof options.packages === 'string' ) {
 		options.packages = options.packages.split( ',' );
+	}
+
+	// Convert packages to skip to an array.
+	if ( typeof options.ignore === 'string' ) {
+		options.ignore = options.ignore.split( ',' );
 	}
 
 	return options;
@@ -113,7 +120,7 @@ function getCKEditor5PackagePaths( { cwd, includeExternalDirectory } ) {
  * @param {TranslationOptions} options
  * @return {Array.<CKEditor5Entry>}
  */
-function getCKEditor5PackageNames( transifexProcess, { cwd, packages } ) {
+function getCKEditor5PackageNames( transifexProcess, { cwd, packages, ignore } ) {
 	const packagesPath = normalizePath( cwd, 'packages' );
 
 	return fs.readdirSync( packagesPath )
@@ -145,6 +152,13 @@ function getCKEditor5PackageNames( transifexProcess, { cwd, packages } ) {
 			const relativePath = path.posix.relative( cwd, absolutePath );
 
 			return [ resourceName, relativePath ];
+		} )
+		.filter( ( [ packageName ] ) => {
+			if ( ignore.includes( packageName ) ) {
+				return false;
+			}
+
+			return true;
 		} );
 }
 
@@ -164,6 +178,8 @@ function normalizePath( ...values ) {
  * @property {String} cwd An absolute path to the root directory from which a command is called.
  *
  * @property {Array.<String>} packages Package names to be processed. If empty, all found packages will be processed.
+ *
+ * @property {Array.<String>} [ignore] Name of packages that should be skipped while processing then.
  *
  * @property {Boolean} includeExternalDirectory Whether to look for packages located in the `external/` directory.
  */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Translation utils allow specifying packages that should not be processed.
