### PR TITLE
Revert patch for displaying tooltips for focused buttons

### DIFF
--- a/packages/ckeditor5-ui/tests/button/buttonview.js
+++ b/packages/ckeditor5-ui/tests/button/buttonview.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals Event, document, getComputedStyle */
+/* globals Event */
 
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import ButtonView from '../../src/button/buttonview';
@@ -12,7 +12,6 @@ import TooltipView from '../../src/tooltip/tooltipview';
 import View from '../../src/view';
 import ViewCollection from '../../src/viewcollection';
 import env from '@ckeditor/ckeditor5-utils/src/env';
-import ToolbarView from '../../src/toolbar/toolbarview';
 
 describe( 'ButtonView', () => {
 	let locale, view;
@@ -417,33 +416,6 @@ describe( 'ButtonView', () => {
 			view.focus();
 
 			sinon.assert.calledOnce( spy );
-		} );
-	} );
-
-	describe( 'Tooltip in toolbar button', () => {
-		let toolbar;
-
-		beforeEach( () => {
-			toolbar = new ToolbarView( locale );
-			toolbar.render();
-			document.body.append( toolbar.element );
-		} );
-
-		afterEach( () => {
-			toolbar.element.remove();
-			toolbar.destroy();
-		} );
-
-		it( 'is displayed when the button is focused', () => {
-			toolbar.items.add( view );
-
-			const tooltip = view.element.children[ 0 ];
-
-			expect( getComputedStyle( tooltip ).visibility ).to.equal( 'hidden' );
-
-			view.focus();
-
-			expect( getComputedStyle( tooltip ).visibility ).to.equal( 'visible' );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-ui/theme/components/button/button.css
+++ b/packages/ckeditor5-ui/theme/components/button/button.css
@@ -31,9 +31,12 @@ a.ck.ck-button {
 		justify-content: center;
 	}
 
-	&:hover,
-	/* Enable toolbar button tooltips for keyboard users too. See https://github.com/ckeditor/ckeditor5/issues/5581. */
-	&:focus {
+	&:hover {
 		@mixin ck-tooltip_visible;
+	}
+
+	/* Get rid of the native focus outline around the tooltip when focused (but not :hover). */
+	&:focus:not(:hover) {
+		@mixin ck-tooltip_disabled;
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (toolbar): Reverted changes introduced by https://github.com/ckeditor/ckeditor5/pull/11869 PR. Closes #12068.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
