### PR TITLE
Restored the ckeditor5-utils package in the `translations:collect` script

### DIFF
--- a/packages/ckeditor5-utils/src/dom/emittermixin.ts
+++ b/packages/ckeditor5-utils/src/dom/emittermixin.ts
@@ -299,7 +299,7 @@ class ProxyEmitter {
 		options: CallbackOptions
 	): void {
 		this.attach( event );
-		EmitterMixin._addEventListener<TEvent>.call( this, event, callback, options );
+		( EmitterMixin._addEventListener<TEvent> ).call( this, event, callback, options );
 	}
 
 	/**

--- a/packages/ckeditor5-utils/src/emittermixin.ts
+++ b/packages/ckeditor5-utils/src/emittermixin.ts
@@ -790,7 +790,7 @@ function addEventListener<TEvent extends BaseEvent>(
 	} else {
 		// Allow listening on objects that do not implement Emitter interface.
 		// This is needed in some tests that are using mocks instead of the real objects with EmitterMixin mixed.
-		listener._addEventListener<TEvent>.call( emitter, event, callback, options );
+		( listener._addEventListener<TEvent> ).call( emitter, event, callback, options );
 	}
 }
 

--- a/scripts/translations/collect.js
+++ b/scripts/translations/collect.js
@@ -19,29 +19,12 @@ main();
 function main() {
 	const options = parseArguments( process.argv.slice( 2 ) );
 
-	// `ckeditor5-utils` does not contain any translations. Hence, we can temporary skip it.
-	// However. we need to align the AST parser to load TypeScript source code.
-
 	return createPotFiles( {
 		// An array containing absolute paths to CKEditor 5 source files.
-		sourceFiles: getCKEditor5SourceFiles( options )
-			.filter( fileName => {
-				if ( fileName.includes( 'ckeditor5-utils' ) ) {
-					return false;
-				}
-
-				return true;
-			} ),
+		sourceFiles: getCKEditor5SourceFiles( options ),
 
 		// Packages to process.
-		packagePaths: getCKEditor5PackagePaths( options )
-			.filter( packagePath => {
-				if ( packagePath.includes( 'ckeditor5-utils' ) ) {
-					return false;
-				}
-
-				return true;
-			} ),
+		packagePaths: getCKEditor5PackagePaths( options ),
 
 		// A relative path to the `@ckeditor/ckeditor5-core` package where common translations are located.
 		corePackagePath: 'packages/ckeditor5-core',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Restored the ckeditor5-utils package in the `translations:collect` script.

---

### Additional information

Changes from ckeditor/ckeditor5-dev#780 are required.
