### PR TITLE
Resurrected the styles feature guide

### DIFF
--- a/packages/ckeditor5-style/README.md
+++ b/packages/ckeditor5-style/README.md
@@ -8,6 +8,10 @@ CKEditor 5 style feature
 
 This package implements the style feature for CKEditor 5.
 
+## Demo
+
+Check out the demo in the [style feature guide](https://ckeditor.com/docs/ckeditor5/latest/features/style.html#demo) in the CKEditor 5 documentation.
+
 ## Documentation
 
 See the [`@ckeditor/ckeditor5-style` package](https://ckeditor.com/docs/ckeditor5/latest/api/style.html) page in [CKEditor 5 documentation](https://ckeditor.com/docs/ckeditor5/latest/).

--- a/packages/ckeditor5-style/ckeditor5-metadata.json
+++ b/packages/ckeditor5-style/ckeditor5-metadata.json
@@ -4,7 +4,7 @@
 			"name": "Style",
 			"className": "Style",
 			"description": "Allows applying pre-configured styles to editor content.",
-			"docs": "",
+			"docs": "features/style.html",
 			"path": "src/style.js",
 			"uiComponents": [
 				{

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.html
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.html
@@ -64,3 +64,71 @@
 </table>
 
 </textarea>
+
+<style>
+	/* ---------------- Block --------------- */
+
+	.ck.ck-content .red-heading {
+		color: hsl(0, 100%, 50%);
+		font-size: 22px;
+	}
+
+	.ck.ck-content .large-heading {
+		font-size: 32px;
+	}
+
+	.ck.ck-content .rounded-container {
+		background: hsl(0, 0%, 80%);
+		padding: 5px 10px;
+		border: 1px solid hsl(0, 0%, 0%);
+		border-radius: 100px;
+	}
+
+	.ck.ck-content .large-preview {
+		font-size: 90px;
+	}
+
+	.ck.ck-content .bold-table {
+		border: 3px solid hsl(0, 0%, 0%);
+	}
+
+	.ck.ck-content .fancy-table {
+		border-color: red;
+		border-style: dotted;
+	}
+
+	.ck.ck-content .colorful-cell {
+		background: hsl(300, 100%, 50%);
+		color: hsl(0, 0%, 100%);
+		border: 1px solid hsl(0, 0%, 0%);
+		padding: 5px;
+	}
+
+	.ck.ck-content .vibrant-code {
+		background: hsl(135, 94%, 50%);
+		border: 1px solid hsl(120, 89%, 27%);
+	}
+
+	/* ---------------- Inline --------------- */
+
+	.ck.ck-content .marker {
+		background: hsl(56, 100%, 50%);
+	}
+
+	.ck.ck-content .typewriter {
+		font-family: monospace;
+	}
+
+	.ck.ck-content .deleted {
+		text-decoration: line-through;
+	}
+
+	.ck.ck-content .cited {
+		font-style: italic;
+	}
+
+	.ck.ck-content .small {
+		font-size: .75em;
+	}
+
+</style>

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.html
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.html
@@ -14,20 +14,20 @@
 		<p>CKEditor Team</p>
 	</blockquote>
 	<p>
-		More often than not in our modern times, <a href="https://ckeditor.com/blog/Collaborative-writing-and-how-to-implement-it-in-your-application/">writing is a team sport</a>. People used to meet face to face to discuss such matters, as trade deals, release notes or white papers. The <a href="https://ckeditor.com/blog/content-publishing-during-covid-19/">worldwide pandemic</a> has completely changed the way we cooperate and brought the very idea of cooperation and the demands toward collaborative writing tools to a whole different level. This is why we devoted the past two years to excel CKEditor 5.
+		More often than not in our modern times, <a href="https://ckeditor.com/blog/Collaborative-writing-and-how-to-implement-it-in-your-application/">writing is a team sport</a>. People used to meet face to face to discuss such matters, as trade deals, release notes, or white papers. The <a href="https://ckeditor.com/blog/content-publishing-during-covid-19/">worldwide pandemic</a> has completely changed the way we cooperate and brought the very idea of cooperation and the demands for collaborative writing tools to a whole different level. This is why we devoted the past two years to excel CKEditor 5.
 	</p>
 	<p>
-		Conference table and whiteboards have been replaced by functions such as <a href="https://ckeditor.com/docs/ckeditor5/latest/features/collaboration/track-changes/track-changes.html">track changes</a>, that allow the users to follow any changes made to the edited document in real time. Where tracking changes is not enough, the <a href="https://ckeditor.com/docs/ckeditor5/latest/features/collaboration/comments/comments.html">comments</a> come in, offering perfect collaboration communication platform for writing and editing as a team. <span>You can also easily track the progress and changes done in the content with the </span><a href="https://ckeditor.com/docs/ckeditor5/latest/features/revision-history/revision-history.html">revision history</a><span> feature.&nbsp;</span>
+		Conference tables and whiteboards have been replaced by functions such as <a href="https://ckeditor.com/docs/ckeditor5/latest/features/collaboration/track-changes/track-changes.html">track changes</a>, that allow the users to follow any changes made to the edited document in real-time. Where tracking changes is not enough, the <a href="https://ckeditor.com/docs/ckeditor5/latest/features/collaboration/comments/comments.html">comments</a> come in, offering a perfect collaboration communication platform for writing and editing as a team. <span>You can also easily track the progress and changes done in the content with the </span><a href="https://ckeditor.com/docs/ckeditor5/latest/features/revision-history/revision-history.html">revision history</a><span> feature.&nbsp;</span>
 	</p>
 	<p class="info-box">
-		<span>CKEditor 5 is an ultra-modern JavaScript rich text editor with MVC architecture, custom data model and virtual DOM. It is written from scratch in ES6 and has excellent webpack support. It provides every type of WYSIWYG editing solution imaginable with extensive collaboration support.&nbsp;</span>
+		<span>CKEditor 5 is an ultra-modern JavaScript rich text editor with MVC architecture, a custom data model, and virtual DOM. It is written from scratch in ES6 and has excellent webpack support. It provides every type of WYSIWYG editing solution imaginable with extensive collaboration support.&nbsp;</span>
 	</p>
 	<hr>
 	<h4>
 		Choose the best way to start
 	</h4>
 	<p>
-		CKEditor 5 is powerful tool that can be <span class="marker">tailored</span> to basically <a href="https://ckeditor.com/docs/ckeditor5/latest/examples/index.html">any kind of needs and solutions</a>. But don't let this discourage you! There are several ways to integrate the software with you system. From the easy ones, like simply downloading a <span class="spoiler">ready-to-go</span> zip from Online builder, through predefined builds, up to advanced framework integrations and DLL solutions.
+		CKEditor 5 is a powerful tool that can be <span class="marker">tailored</span> to basically <a href="https://ckeditor.com/docs/ckeditor5/latest/examples/index.html">any kind of needs and solutions</a>. But don't let this discourage you! There are several ways to integrate the software with you system. From the easy ones, like simply downloading a <span class="spoiler">ready-to-go</span> zip from Online builder, through predefined builds, up to advanced framework integrations and DLL solutions.
 	</p>
 	<p>
 		Start the configuration by creating the editor:

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.html
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.html
@@ -32,14 +32,14 @@
 	<p>
 		Start the configuration by creating the editor:
 	</p>
-	<pre><code class="language-javascript">ClassicEditor.create( document.querySelector( '#editor' ) )
+	<pre class="fancy-code fancy-code-bright"><code class="language-javascript">ClassicEditor.create( document.querySelector( '#editor' ) )
 	.then( editor =&gt; {
 		window.editor = editor;
 	} );</code></pre>
 	<p>
 		then enable some of the <a href="https://ckeditor.com/docs/ckeditor5/latest/features/collaboration/collaboration.html">collaboration features</a>:
 	</p>
-	<pre class="fancy-code"><code class="language-javascript">ClassicEditor.create( document.querySelector( '#editor' ), {
+	<pre class="fancy-code fancy-code-dark"><code class="language-javascript">ClassicEditor.create( document.querySelector( '#editor' ), {
 		toolbar: [ ..., 'comment', 'trackChanges' ],
 		cloudServices: {
 			tokenUrl: '...',
@@ -59,7 +59,7 @@
 		font-family: 'PT Serif', serif;
 		font-size: 16px;
 		line-height: 1.6;
-		padding-top: 2em;
+		padding: 2em;
 	}
 
 	.ck-content .ck-horizontal-line {
@@ -101,11 +101,14 @@
 	}
 
 	.ck.ck-content p.info-box {
+		--background-size: 30px;
+		--background-color: #e91e63;
 		padding: 1.2em 2em;
-		border: 1px solid #e91e63;
-		border-left: 10px solid #e91e63;
-		border-radius: 5px;
-		margin: 1.5em;
+		border: 1px solid var(--background-color);
+		background: linear-gradient(135deg, var(--background-color) 0%, var(--background-color) var(--background-size), transparent var(--background-size)), linear-gradient(135deg, transparent calc(100% - var(--background-size)), var(--background-color) calc(100% - var(--background-size)), var(--background-color));
+		border-radius: 10px;
+		margin: 1.5em 2em;
+		box-shadow: 5px 5px 0 #ffe6ef;
 	}
 
 	.ck.ck-content blockquote.side-quote {
@@ -158,12 +161,9 @@
 	}
 
 	.ck.ck-content pre.fancy-code {
-		background: #272822;
 		border: 0;
-		color: #fff;
-		margin-left: 3em;
-		margin-right: 3em;
-		box-shadow: 5px 5px 0 #0000001f;
+		margin-left: 2em;
+		margin-right: 2em;
 		border-radius: 10px;
 	}
 
@@ -175,4 +175,17 @@
 		margin-bottom: 8px;
 		background-repeat: no-repeat;
 	}
+
+	.ck.ck-content pre.fancy-code-dark {
+		background: #272822;
+		color: #fff;
+		box-shadow: 5px 5px 0 #0000001f;
+	}
+
+	.ck.ck-content pre.fancy-code-bright {
+		background: #dddfe0;
+		color: #000;
+		box-shadow: 5px 5px 0 #b3b3b3;
+	}
+
 </style>

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.html
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.html
@@ -1,0 +1,66 @@
+<textarea id="snippet-styles">
+
+<h2>The Markdown language</h2>
+<p>Markdown is a lightweight markup language that you can use to add formatting elements to plain text documents. Created by <a href="https://daringfireball.net/projects/markdown/" target="_blank">John Gruber</a> in <s>2003</s>2004, Markdown is now one of the world&rsquo;s most popular markup languages.</p>
+
+<hr />
+
+<h2>Editing with Markdown output</h2>
+<p>The <a href="https://ckeditor.com/">CKEditor 5 WYSIWYG</a> editor lets you use this flexible yet simple markup language in the GitHub flavor. The editor-produced Markdown output supports the most important features, like <a href="https://ckeditor.com/">links</a>, <strong>different</strong> kinds of <em>emphasis</em>, <code>inline code formatting</code> or code blocks:</p>
+
+&lt;pre>&lt;code class="language-css">p {
+	text-align: center;
+	color: red;
+  }&lt;/code>&lt;/pre>
+
+<h2>Formatting blocks with Markdown</h2>
+<p>Markdown can be used to create various block-level features, such as:</p>
+<ul>
+	<li>Block quotes</li>
+	<li>Headings
+		<ol>
+			<li>Heading 1</li>
+			<li>Heading 2</li>
+			<li>Heading 3</li>
+		</ol>
+	</li>
+	<li>Lists, including nested ones
+		<ul>
+			<li>Numbered lists</li>
+			<li>Bulleted lists</li>
+			<li>To-do lists</li>
+		</ul>
+	</li>
+</ul>
+
+<h2>Support for tables in Markdown</h2>
+<p>Bear in mind that Markdown has only very basic support for tables, so things like table styles or merged cells will not work.</p>
+
+<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
+	<thead>
+		<tr>
+			<th scope="row">&nbsp;</th>
+			<th scope="col">Income</th>
+			<th scope="col">Revenue</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th scope="row">Walker 3</th>
+			<td style="text-align:center">$104.000</td>
+			<td style="text-align:center">15%</td>
+		</tr>
+		<tr>
+			<th scope="row">Stroller</th>
+			<td style="text-align:center">$12.000</td>
+			<td style="text-align:center">10%</td>
+		</tr>
+		<tr>
+			<th scope="row">Runner</th>
+			<td style="text-align:center">$97.500</td>
+			<td style="text-align:center">15%</td>
+		</tr>
+	</tbody>
+</table>
+
+</textarea>

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.html
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.html
@@ -1,19 +1,17 @@
 <textarea id="snippet-styles">
-	&nbsp;
 	<h3 class="category">
-		OpinionS
+		Opinions
 	</h3>
 	<h2 class="document-title">
-		WHAT WE HAVE GAINED FROM ISOLATION
+		What we have gained from isolation
 	</h2>
 	<h3 class="document-subtitle">
 		How work-from-home has changed the face of collaboration?
 	</h3>
 	<hr>
 	<blockquote class="side-quote">
-		<p>
-			<span>Collaboration is essential in today’s world with so many people working remotely.</span>
-		</p>
+		<p>Collaboration is essential in today’s world with so many people working remotely.</p>
+		<p>CKEditor Team</p>
 	</blockquote>
 	<p>
 		More often than not in our modern times, <a href="https://ckeditor.com/blog/Collaborative-writing-and-how-to-implement-it-in-your-application/">writing is a team sport</a>. People used to meet face to face to discuss such matters, as trade deals, release notes or white papers. The <a href="https://ckeditor.com/blog/content-publishing-during-covid-19/">worldwide pandemic</a> has completely changed the way we cooperate and brought the very idea of cooperation and the demands toward collaborative writing tools to a whole different level. This is why we devoted the past two years to excel CKEditor 5.
@@ -125,7 +123,7 @@
 		line-height: 1;
 	}
 
-	.ck.ck-content blockquote.side-quote p:last-child {
+	.ck.ck-content blockquote.side-quote p:last-child:not(:first-child) {
 		font-size: 1.3em;
 		text-align: right;
 		color: #555;

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.html
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.html
@@ -1,134 +1,147 @@
 <textarea id="snippet-styles">
-
-<h2>The Markdown language</h2>
-<p>Markdown is a lightweight markup language that you can use to add formatting elements to plain text documents. Created by <a href="https://daringfireball.net/projects/markdown/" target="_blank">John Gruber</a> in <s>2003</s>2004, Markdown is now one of the world&rsquo;s most popular markup languages.</p>
-
-<hr />
-
-<h2>Editing with Markdown output</h2>
-<p>The <a href="https://ckeditor.com/">CKEditor 5 WYSIWYG</a> editor lets you use this flexible yet simple markup language in the GitHub flavor. The editor-produced Markdown output supports the most important features, like <a href="https://ckeditor.com/">links</a>, <strong>different</strong> kinds of <em>emphasis</em>, <code>inline code formatting</code> or code blocks:</p>
-
-&lt;pre>&lt;code class="language-css">p {
-	text-align: center;
-	color: red;
-  }&lt;/code>&lt;/pre>
-
-<h2>Formatting blocks with Markdown</h2>
-<p>Markdown can be used to create various block-level features, such as:</p>
-<ul>
-	<li>Block quotes</li>
-	<li>Headings
-		<ol>
-			<li>Heading 1</li>
-			<li>Heading 2</li>
-			<li>Heading 3</li>
-		</ol>
-	</li>
-	<li>Lists, including nested ones
-		<ul>
-			<li>Numbered lists</li>
-			<li>Bulleted lists</li>
-			<li>To-do lists</li>
-		</ul>
-	</li>
-</ul>
-
-<h2>Support for tables in Markdown</h2>
-<p>Bear in mind that Markdown has only very basic support for tables, so things like table styles or merged cells will not work.</p>
-
-<table border="1" cellpadding="1" cellspacing="1" style="width:500px">
-	<thead>
-		<tr>
-			<th scope="row">&nbsp;</th>
-			<th scope="col">Income</th>
-			<th scope="col">Revenue</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<th scope="row">Walker 3</th>
-			<td style="text-align:center">$104.000</td>
-			<td style="text-align:center">15%</td>
-		</tr>
-		<tr>
-			<th scope="row">Stroller</th>
-			<td style="text-align:center">$12.000</td>
-			<td style="text-align:center">10%</td>
-		</tr>
-		<tr>
-			<th scope="row">Runner</th>
-			<td style="text-align:center">$97.500</td>
-			<td style="text-align:center">15%</td>
-		</tr>
-	</tbody>
-</table>
-
+	&lt;h3 class="category">Opinion&lt;/h3&gt;
+	&lt;h2 class="document-title"&gt;Some important heading&lt;/h2&gt;
+	&lt;h3 class="document-subtitle"&gt;There's a sub-heading that follows with more text, which is pretty cool.&lt;/h3&gt;
+	&lt;hr&gt;
+	&lt;p&gt;Ante metus dictum at tempor commodo ullamcorper a lacus. Egestas pretium aenean pharetra magna ac placerat. Id
+		nibh tortor id aliquet lectust amet. Nibh venenatis cras sed felis
+		eget velit aliquet sagittis id.&lt;/p&gt;
+	&lt;p&gt;Sit amet massa vitae tortor condimentum lacinia quis vel. Egestas fringilla phasellus faucibus scelerisque
+		eleifend donec pretium vulputate sapien. Ullamcorper velit sed ullamcorper morbi tincidunt ornare massa eget.
+		&lt;span class="marker"&gt;Ipsum suspendisse ultrices&lt;/span&gt; gravida dictum fusce. Aliquet sagittis id consectetur
+		purus ut.
+		Gravida dictum fusce ut placerat orci nulla pellentesque dignissim.&lt;/p&gt;
+	&lt;p class="info-box"&gt;A paragraph that works as an info box. Tempus iaculis urna id volutpat lacus laoreet non
+		curabitur gravida. Duis ut diam quam nulla. Mi eget mauris &lt;a href="#"&gt;pharetra et ultrices neque&lt;/a&gt;. Natoque
+		penatibus et magnis dis parturient montes nascetur.&lt;/p&gt;
+	&lt;h4&gt;Some section begins here&lt;/h4&gt;
+	&lt;blockquote class="side-quote"&gt;
+		&lt;p&gt;Sit amet massa vitae tortor condimentum lacinia quis vel. Egestas fringilla phasellus faucibus scelerisque
+			eleifend.&lt;/p&gt;
+		&lt;p&gt;No one important&lt;/p&gt;
+	&lt;/blockquote&gt;
+	&lt;p&gt;Sit amet massa vitae tortor condimentum lacinia quis vel. Egestas fringilla phasellus faucibus scelerisque
+		eleifend donec pretium vulputate sapien. Ullamcorper velit sed ullamcorper morbi tincidunt ornare massa eget.
+		Ipsum suspendisse ultrices gravida dictum fusce. Aliquet sagittis id consectetur purus ut. Suspendisse faucibus
+		interdum posuere lorem ipsum.&lt;/p&gt;
+	&lt;p&gt;Sit amet massa vitae tortor condimentum lacinia quis vel. Egestas fringilla phasellus faucibus scelerisque
+		eleifend donec pretium vulputate sapien. &lt;span class="spoiler"&gt;Ullamcorper velit&lt;/span&gt; sed ullamcorper morbi tincidunt ornare massa eget.
+		Ipsum suspendisse ultrices gravida dictum fusce. Aliquet sagittis id consectetur purus ut. Suspendisse faucibus
+		interdum posuere lorem ipsum. Orci a scelerisque purus semper eget duis at.&lt;/p&gt;
+	&lt;pre class="fancy-code"&gt;&lt;code class="language-javascript"&gt;ClassicEditor
+	.create( document.querySelector( '#editor' ) )
+	.then( editor => {
+		window.editor = editor;
+	} );&lt;/code&gt;&lt;/pre&gt;
 </textarea>
 
 <style>
-	/* ---------------- Block --------------- */
+	@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=PT+Serif:ital,wght@0,400;0,700;1,400&display=swap');
 
-	.ck.ck-content .red-heading {
-		color: hsl(0, 100%, 50%);
-		font-size: 22px;
+	.ck.ck-content {
+		font-family: 'PT Serif', serif;
+		font-size: 16px;
+		line-height: 1.6;
+		padding-top: 2em;
 	}
 
-	.ck.ck-content .large-heading {
-		font-size: 32px;
+	.ck-content .ck-horizontal-line {
+		margin-bottom: 1em;
 	}
 
-	.ck.ck-content .rounded-container {
-		background: hsl(0, 0%, 80%);
-		padding: 5px 10px;
-		border: 1px solid hsl(0, 0%, 0%);
-		border-radius: 100px;
+	.ck.ck-content hr {
+		width: 100px;
+		border-top: 1px solid #aaa;
+		height: 1px;
+		margin: 1em auto;
 	}
 
-	.ck.ck-content .large-preview {
-		font-size: 90px;
+	.ck.ck-content h3.category {
+		font-family: 'Bebas Neue';
+		font-size: 20px;
+		font-weight: bold;
+		color: #d1d1d1;
+		letter-spacing: 10px;
+		margin: 0;
+		padding: 0;
 	}
 
-	.ck.ck-content .bold-table {
-		border: 3px solid hsl(0, 0%, 0%);
+	.ck.ck-content h2.document-title {
+		font-family: 'Bebas Neue';
+		font-size: 50px;
+		font-weight: bold;
+		margin: 0;
+		padding: 0;
+		border: 0;
 	}
 
-	.ck.ck-content .fancy-table {
-		border-color: red;
-		border-style: dotted;
+	.ck.ck-content h3.document-subtitle {
+		font-size: 20px;
+		color: #e91e63;
+		margin: 0 0 1em;
+		font-weight: normal;
+		padding: 0;
 	}
 
-	.ck.ck-content .colorful-cell {
-		background: hsl(300, 100%, 50%);
-		color: hsl(0, 0%, 100%);
-		border: 1px solid hsl(0, 0%, 0%);
-		padding: 5px;
+	.ck.ck-content p.info-box {
+		padding: 1.2em 2em;
+		border: 1px solid #e91e63;
+		border-left: 10px solid #e91e63;
+		border-radius: 5px;
+		margin: 1.5em;
 	}
 
-	.ck.ck-content .vibrant-code {
-		background: hsl(135, 94%, 50%);
-		border: 1px solid hsl(120, 89%, 27%);
+	.ck.ck-content blockquote.side-quote {
+		font-family: 'Bebas Neue';
+		font-style: normal;
+		float: right;
+		width: 35%;
+		position: relative;
+		border: 0;
+		overflow: visible;
+		z-index: 1;
+		margin-left: 1em;
 	}
 
-	/* ---------------- Inline --------------- */
-
-	.ck.ck-content .marker {
-		background: hsl(56, 100%, 50%);
+	.ck.ck-content blockquote.side-quote::before {
+		content: "“";
+		position: absolute;
+		top: -37px;
+		left: -10px;
+		display: block;
+		font-size: 200px;
+		color: #e7e7e7;
+		z-index: -1;
+		line-height: 1;
 	}
 
-	.ck.ck-content .typewriter {
-		font-family: monospace;
+	.ck.ck-content blockquote.side-quote p {
+		font-size: 2em;
+		line-height: 1;
 	}
 
-	.ck.ck-content .deleted {
-		text-decoration: line-through;
+	.ck.ck-content blockquote.side-quote p:last-child {
+		font-size: 1.3em;
+		text-align: right;
+		color: #555;
 	}
 
-	.ck.ck-content .cited {
-		font-style: italic;
+	.ck.ck-content span.marker {
+		background: yellow;
 	}
 
-	.ck.ck-content .small {
-		font-size: .75em;
+	.ck.ck-content span.spoiler {
+		background: #000;
+		color: #000;
 	}
 
+	.ck.ck-content span.spoiler:hover {
+		background: #000;
+		color: #fff;
+	}
+
+	.ck.ck-content pre.fancy-code {
+		background: rgb(254, 228, 155);
+		border: 1px solid rgb(193, 129, 0);
+	}
 </style>

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.html
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.html
@@ -14,9 +14,6 @@
 		<p>
 			<span>Collaboration is essential in today’s world with so many people working remotely.</span>
 		</p>
-		<p>
-			M. Duraj
-		</p>
 	</blockquote>
 	<p>
 		More often than not in our modern times, <a href="https://ckeditor.com/blog/Collaborative-writing-and-how-to-implement-it-in-your-application/">writing is a team sport</a>. People used to meet face to face to discuss such matters, as trade deals, release notes or white papers. The <a href="https://ckeditor.com/blog/content-publishing-during-covid-19/">worldwide pandemic</a> has completely changed the way we cooperate and brought the very idea of cooperation and the demands toward collaborative writing tools to a whole different level. This is why we devoted the past two years to excel CKEditor 5.

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.html
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.html
@@ -1,4 +1,5 @@
 <textarea id="snippet-styles">
+	&nbsp;
 	<h3 class="category">
 		OpinionS
 	</h3>

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.html
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.html
@@ -22,6 +22,7 @@
 	<p class="info-box">
 		<span>CKEditor 5 is an ultra-modern JavaScript rich text editor with MVC architecture, custom data model and virtual DOM. It is written from scratch in ES6 and has excellent webpack support. It provides every type of WYSIWYG editing solution imaginable with extensive collaboration support.&nbsp;</span>
 	</p>
+	<hr>
 	<h4>
 		Choose the best way to start
 	</h4>
@@ -29,13 +30,26 @@
 		CKEditor 5 is powerful tool that can be <span class="marker">tailored</span> to basically <a href="https://ckeditor.com/docs/ckeditor5/latest/examples/index.html">any kind of needs and solutions</a>. But don't let this discourage you! There are several ways to integrate the software with you system. From the easy ones, like simply downloading a <span class="spoiler">ready-to-go</span> zip from Online builder, through predefined builds, up to advanced framework integrations and DLL solutions.
 	</p>
 	<p>
-		Start the configuration by calling the editor:
+		Start the configuration by creating the editor:
 	</p>
-	<pre class="fancy-code"><code class="language-javascript">ClassicEditor
-		.create( document.querySelector( '#editor' ) )
-		.then( editor =&gt; {
-			window.editor = editor;
-		} );</code></pre>
+	<pre><code class="language-javascript">ClassicEditor.create( document.querySelector( '#editor' ) )
+	.then( editor =&gt; {
+		window.editor = editor;
+	} );</code></pre>
+	<p>
+		then enable some of the <a href="https://ckeditor.com/docs/ckeditor5/latest/features/collaboration/collaboration.html">collaboration features</a>:
+	</p>
+	<pre class="fancy-code"><code class="language-javascript">ClassicEditor.create( document.querySelector( '#editor' ), {
+		toolbar: [ ..., 'comment', 'trackChanges' ],
+		cloudServices: {
+			tokenUrl: '...',
+			uploadUrl: '...',
+			webSocketUrl: '...'
+		}
+	} )
+	.then( editor =&gt; {
+		window.editor = editor;
+	} );</code></pre>
 </textarea>
 
 <style>
@@ -144,7 +158,21 @@
 	}
 
 	.ck.ck-content pre.fancy-code {
-		background: rgb(254, 228, 155);
-		border: 1px solid rgb(193, 129, 0);
+		background: #272822;
+		border: 0;
+		color: #fff;
+		margin-left: 3em;
+		margin-right: 3em;
+		box-shadow: 5px 5px 0 #0000001f;
+		border-radius: 10px;
+	}
+
+	.ck.ck-content pre.fancy-code::before {
+		content: "";
+		display: block;
+		height: 13px;
+		background: url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1NCAxMyI+CiAgPGNpcmNsZSBjeD0iNi41IiBjeT0iNi41IiByPSI2LjUiIGZpbGw9IiNGMzZCNUMiLz4KICA8Y2lyY2xlIGN4PSIyNi41IiBjeT0iNi41IiByPSI2LjUiIGZpbGw9IiNGOUJFNEQiLz4KICA8Y2lyY2xlIGN4PSI0Ny41IiBjeT0iNi41IiByPSI2LjUiIGZpbGw9IiM1NkM0NTMiLz4KPC9zdmc+Cg==);
+		margin-bottom: 8px;
+		background-repeat: no-repeat;
 	}
 </style>

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.html
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.html
@@ -52,6 +52,7 @@
 	} );</code></pre>
 </textarea>
 
+<!-- Keep in sync with the code snippet in the feature guide. -->
 <style>
 	@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=PT+Serif:ital,wght@0,400;0,700;1,400&display=swap');
 

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.html
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.html
@@ -1,38 +1,45 @@
 <textarea id="snippet-styles">
-	&lt;h3 class="category">Opinion&lt;/h3&gt;
-	&lt;h2 class="document-title"&gt;Some important heading&lt;/h2&gt;
-	&lt;h3 class="document-subtitle"&gt;There's a sub-heading that follows with more text, which is pretty cool.&lt;/h3&gt;
-	&lt;hr&gt;
-	&lt;p&gt;Ante metus dictum at tempor commodo ullamcorper a lacus. Egestas pretium aenean pharetra magna ac placerat. Id
-		nibh tortor id aliquet lectust amet. Nibh venenatis cras sed felis
-		eget velit aliquet sagittis id.&lt;/p&gt;
-	&lt;p&gt;Sit amet massa vitae tortor condimentum lacinia quis vel. Egestas fringilla phasellus faucibus scelerisque
-		eleifend donec pretium vulputate sapien. Ullamcorper velit sed ullamcorper morbi tincidunt ornare massa eget.
-		&lt;span class="marker"&gt;Ipsum suspendisse ultrices&lt;/span&gt; gravida dictum fusce. Aliquet sagittis id consectetur
-		purus ut.
-		Gravida dictum fusce ut placerat orci nulla pellentesque dignissim.&lt;/p&gt;
-	&lt;p class="info-box"&gt;A paragraph that works as an info box. Tempus iaculis urna id volutpat lacus laoreet non
-		curabitur gravida. Duis ut diam quam nulla. Mi eget mauris &lt;a href="#"&gt;pharetra et ultrices neque&lt;/a&gt;. Natoque
-		penatibus et magnis dis parturient montes nascetur.&lt;/p&gt;
-	&lt;h4&gt;Some section begins here&lt;/h4&gt;
-	&lt;blockquote class="side-quote"&gt;
-		&lt;p&gt;Sit amet massa vitae tortor condimentum lacinia quis vel. Egestas fringilla phasellus faucibus scelerisque
-			eleifend.&lt;/p&gt;
-		&lt;p&gt;No one important&lt;/p&gt;
-	&lt;/blockquote&gt;
-	&lt;p&gt;Sit amet massa vitae tortor condimentum lacinia quis vel. Egestas fringilla phasellus faucibus scelerisque
-		eleifend donec pretium vulputate sapien. Ullamcorper velit sed ullamcorper morbi tincidunt ornare massa eget.
-		Ipsum suspendisse ultrices gravida dictum fusce. Aliquet sagittis id consectetur purus ut. Suspendisse faucibus
-		interdum posuere lorem ipsum.&lt;/p&gt;
-	&lt;p&gt;Sit amet massa vitae tortor condimentum lacinia quis vel. Egestas fringilla phasellus faucibus scelerisque
-		eleifend donec pretium vulputate sapien. &lt;span class="spoiler"&gt;Ullamcorper velit&lt;/span&gt; sed ullamcorper morbi tincidunt ornare massa eget.
-		Ipsum suspendisse ultrices gravida dictum fusce. Aliquet sagittis id consectetur purus ut. Suspendisse faucibus
-		interdum posuere lorem ipsum. Orci a scelerisque purus semper eget duis at.&lt;/p&gt;
-	&lt;pre class="fancy-code"&gt;&lt;code class="language-javascript"&gt;ClassicEditor
-	.create( document.querySelector( '#editor' ) )
-	.then( editor => {
-		window.editor = editor;
-	} );&lt;/code&gt;&lt;/pre&gt;
+	<h3 class="category">
+		OpinionS
+	</h3>
+	<h2 class="document-title">
+		WHAT WE HAVE GAINED FROM ISOLATION
+	</h2>
+	<h3 class="document-subtitle">
+		How work-from-home has changed the face of collaboration?
+	</h3>
+	<hr>
+	<blockquote class="side-quote">
+		<p>
+			<span>Collaboration is essential in today’s world with so many people working remotely.</span>
+		</p>
+		<p>
+			M. Duraj
+		</p>
+	</blockquote>
+	<p>
+		More often than not in our modern times, <a href="https://ckeditor.com/blog/Collaborative-writing-and-how-to-implement-it-in-your-application/">writing is a team sport</a>. People used to meet face to face to discuss such matters, as trade deals, release notes or white papers. The <a href="https://ckeditor.com/blog/content-publishing-during-covid-19/">worldwide pandemic</a> has completely changed the way we cooperate and brought the very idea of cooperation and the demands toward collaborative writing tools to a whole different level. This is why we devoted the past two years to excel CKEditor 5.
+	</p>
+	<p>
+		Conference table and whiteboards have been replaced by functions such as <a href="https://ckeditor.com/docs/ckeditor5/latest/features/collaboration/track-changes/track-changes.html">track changes</a>, that allow the users to follow any changes made to the edited document in real time. Where tracking changes is not enough, the <a href="https://ckeditor.com/docs/ckeditor5/latest/features/collaboration/comments/comments.html">comments</a> come in, offering perfect collaboration communication platform for writing and editing as a team. <span>You can also easily track the progress and changes done in the content with the </span><a href="https://ckeditor.com/docs/ckeditor5/latest/features/revision-history/revision-history.html">revision history</a><span> feature.&nbsp;</span>
+	</p>
+	<p class="info-box">
+		<span>CKEditor 5 is an ultra-modern JavaScript rich text editor with MVC architecture, custom data model and virtual DOM. It is written from scratch in ES6 and has excellent webpack support. It provides every type of WYSIWYG editing solution imaginable with extensive collaboration support.&nbsp;</span>
+	</p>
+	<h4>
+		Choose the best way to start
+	</h4>
+	<p>
+		CKEditor 5 is powerful tool that can be <span class="marker">tailored</span> to basically <a href="https://ckeditor.com/docs/ckeditor5/latest/examples/index.html">any kind of needs and solutions</a>. But don't let this discourage you! There are several ways to integrate the software with you system. From the easy ones, like simply downloading a <span class="spoiler">ready-to-go</span> zip from Online builder, through predefined builds, up to advanced framework integrations and DLL solutions.
+	</p>
+	<p>
+		Start the configuration by calling the editor:
+	</p>
+	<pre class="fancy-code"><code class="language-javascript">ClassicEditor
+		.create( document.querySelector( '#editor' ) )
+		.then( editor =&gt; {
+			window.editor = editor;
+		} );</code></pre>
 </textarea>
 
 <style>

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.js
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.js
@@ -43,6 +43,7 @@ ClassicEditor
 			],
 			shouldNotGroupWhenFull: true
 		},
+		// NOTE: Keep in sync with the code snippet in the feature guide.
 		style: {
 			definitions: [
 				{

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.js
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.js
@@ -81,9 +81,14 @@ ClassicEditor
 					classes: [ 'spoiler' ]
 				},
 				{
-					name: 'Featured code',
+					name: 'Code (dark)',
 					element: 'pre',
-					classes: [ 'fancy-code' ]
+					classes: [ 'fancy-code', 'fancy-code-dark' ]
+				},
+				{
+					name: 'Code (bright)',
+					element: 'pre',
+					classes: [ 'fancy-code', 'fancy-code-bright' ]
 				}
 			]
 		},

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.js
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.js
@@ -16,19 +16,20 @@ import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
 import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
 import HorizontalLine from '@ckeditor/ckeditor5-horizontal-line/src/horizontalline';
 import Style from '@ckeditor/ckeditor5-style/src/style';
+import GeneralHtmlSupport from '@ckeditor/ckeditor5-html-support/src/generalhtmlsupport';
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-styles' ), {
 		plugins: [
 			ArticlePluginSet, EasyImage, ImageUpload, CloudServices,
-			Code, CodeBlock, Strikethrough, HorizontalLine, Style
+			Code, CodeBlock, Strikethrough, HorizontalLine, GeneralHtmlSupport, Style
 		],
 		toolbar: {
 			items: [
-				'heading',
+				'style',
 				'|',
-				'styleDropdown',
+				'heading',
 				'|',
 				'bold',
 				'italic',
@@ -46,6 +47,80 @@ ClassicEditor
 				'horizontalLine'
 			],
 			shouldNotGroupWhenFull: true
+		},
+		style: {
+			definitions: [
+				{
+					name: 'Red heading',
+					element: 'h2',
+					classes: [ 'red-heading' ]
+				},
+				{
+					name: 'Large heading',
+					element: 'h2',
+					classes: [ 'large-heading' ]
+				},
+				{
+					name: 'Rounded container',
+					element: 'p',
+					classes: [ 'rounded-container' ]
+				},
+				{
+					name: 'Large preview',
+					element: 'p',
+					classes: [ 'large-preview' ]
+				},
+				{
+					name: 'Bold table',
+					element: 'table',
+					classes: [ 'bold-table' ]
+				},
+				{
+					name: 'Facncy table',
+					element: 'table',
+					classes: [ 'fancy-table' ]
+				},
+				{
+					name: 'Colorfull cell',
+					element: 'td',
+					classes: [ 'colorful-cell' ]
+				},
+				{
+					name: 'Vibrant code',
+					element: 'pre',
+					classes: [ 'vibrant-code' ]
+				},
+				{
+					name: 'Marker',
+					element: 'span',
+					classes: [ 'marker' ]
+				},
+				{
+					name: 'Typewriter',
+					element: 'span',
+					classes: [ 'typewriter' ]
+				},
+				{
+					name: 'Deleted text',
+					element: 'span',
+					classes: [ 'deleted' ]
+				},
+				{
+					name: 'Cited work',
+					element: 'span',
+					classes: [ 'cited', 'another-class' ]
+				},
+				{
+					name: 'Small text',
+					element: 'span',
+					classes: [ 'small' ]
+				},
+				{
+					name: 'Very long name of the style',
+					element: 'span',
+					classes: [ 'foo' ]
+				}
+			]
 		},
 		image: {
 			toolbar: [ 'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|', 'toggleImageCaption', 'imageTextAlternative' ]
@@ -78,6 +153,16 @@ ClassicEditor
 		setTimeout( () => {
 			outputElement.innerText = editor.getData();
 		}, 500 );
+
+		window.attachTourBalloon( {
+			target: window.findToolbarItem( editor.ui.view.toolbar,
+				item => item.buttonView && item.buttonView.label === 'Styles' ),
+			text: 'Click to apply styles.',
+			editor,
+			tippyOptions: {
+				placement: 'bottom-start'
+			}
+		} );
 	} )
 	.catch( err => {
 		console.error( err.stack );

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.js
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.js
@@ -8,8 +8,6 @@
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
-import EasyImage from '@ckeditor/ckeditor5-easy-image/src/easyimage';
-import ImageUpload from '@ckeditor/ckeditor5-image/src/imageupload';
 import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices';
 import CodeBlock from '@ckeditor/ckeditor5-code-block/src/codeblock';
 import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
@@ -17,13 +15,14 @@ import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
 import HorizontalLine from '@ckeditor/ckeditor5-horizontal-line/src/horizontalline';
 import Style from '@ckeditor/ckeditor5-style/src/style';
 import GeneralHtmlSupport from '@ckeditor/ckeditor5-html-support/src/generalhtmlsupport';
+import Highlight from '@ckeditor/ckeditor5-highlight/src/highlight';
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-styles' ), {
 		plugins: [
-			ArticlePluginSet, EasyImage, ImageUpload, CloudServices,
-			Code, CodeBlock, Strikethrough, HorizontalLine, GeneralHtmlSupport, Style
+			ArticlePluginSet, CloudServices,
+			Code, CodeBlock, Strikethrough, HorizontalLine, GeneralHtmlSupport, Style, Highlight
 		],
 		toolbar: {
 			items: [
@@ -36,13 +35,9 @@ ClassicEditor
 				'strikethrough',
 				'link',
 				'|',
-				'bulletedList',
-				'numberedList',
-				'|',
+				'highlight',
 				'code',
 				'codeBlock',
-				'|',
-				'uploadImage',
 				'blockQuote',
 				'horizontalLine'
 			],

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.js
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals console, window, document, setTimeout */
+/* globals console, window, document */
 
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 
@@ -51,44 +51,29 @@ ClassicEditor
 		style: {
 			definitions: [
 				{
-					name: 'Red heading',
+					name: 'Article category',
+					element: 'h3',
+					classes: [ 'category' ]
+				},
+				{
+					name: 'Title',
 					element: 'h2',
-					classes: [ 'red-heading' ]
+					classes: [ 'document-title' ]
 				},
 				{
-					name: 'Large heading',
-					element: 'h2',
-					classes: [ 'large-heading' ]
+					name: 'Subtitle',
+					element: 'h3',
+					classes: [ 'document-subtitle' ]
 				},
 				{
-					name: 'Rounded container',
+					name: 'Info box',
 					element: 'p',
-					classes: [ 'rounded-container' ]
+					classes: [ 'info-box' ]
 				},
 				{
-					name: 'Large preview',
-					element: 'p',
-					classes: [ 'large-preview' ]
-				},
-				{
-					name: 'Bold table',
-					element: 'table',
-					classes: [ 'bold-table' ]
-				},
-				{
-					name: 'Facncy table',
-					element: 'table',
-					classes: [ 'fancy-table' ]
-				},
-				{
-					name: 'Colorfull cell',
-					element: 'td',
-					classes: [ 'colorful-cell' ]
-				},
-				{
-					name: 'Vibrant code',
-					element: 'pre',
-					classes: [ 'vibrant-code' ]
+					name: 'Side quote',
+					element: 'blockquote',
+					classes: [ 'side-quote' ]
 				},
 				{
 					name: 'Marker',
@@ -96,29 +81,14 @@ ClassicEditor
 					classes: [ 'marker' ]
 				},
 				{
-					name: 'Typewriter',
+					name: 'Spoiler',
 					element: 'span',
-					classes: [ 'typewriter' ]
+					classes: [ 'spoiler' ]
 				},
 				{
-					name: 'Deleted text',
-					element: 'span',
-					classes: [ 'deleted' ]
-				},
-				{
-					name: 'Cited work',
-					element: 'span',
-					classes: [ 'cited', 'another-class' ]
-				},
-				{
-					name: 'Small text',
-					element: 'span',
-					classes: [ 'small' ]
-				},
-				{
-					name: 'Very long name of the style',
-					element: 'span',
-					classes: [ 'foo' ]
+					name: 'Featured code',
+					element: 'pre',
+					classes: [ 'fancy-code' ]
 				}
 			]
 		},
@@ -142,17 +112,6 @@ ClassicEditor
 	} )
 	.then( editor => {
 		window.editor = editor;
-
-		const outputElement = document.querySelector( '#snippet-styles' );
-
-		editor.model.document.on( 'change', () => {
-			outputElement.innerText = editor.getData();
-		} );
-
-		// Set the initial data with delay so hightlight.js doesn't catch it.
-		setTimeout( () => {
-			outputElement.innerText = editor.getData();
-		}, 500 );
 
 		window.attachTourBalloon( {
 			target: window.findToolbarItem( editor.ui.view.toolbar,

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.js
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.js
@@ -1,0 +1,84 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console, window, document, setTimeout */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import EasyImage from '@ckeditor/ckeditor5-easy-image/src/easyimage';
+import ImageUpload from '@ckeditor/ckeditor5-image/src/imageupload';
+import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices';
+import CodeBlock from '@ckeditor/ckeditor5-code-block/src/codeblock';
+import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
+import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
+import HorizontalLine from '@ckeditor/ckeditor5-horizontal-line/src/horizontalline';
+import Style from '@ckeditor/ckeditor5-style/src/style';
+import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
+
+ClassicEditor
+	.create( document.querySelector( '#snippet-styles' ), {
+		plugins: [
+			ArticlePluginSet, EasyImage, ImageUpload, CloudServices,
+			Code, CodeBlock, Strikethrough, HorizontalLine, Style
+		],
+		toolbar: {
+			items: [
+				'heading',
+				'|',
+				'styleDropdown',
+				'|',
+				'bold',
+				'italic',
+				'strikethrough',
+				'link',
+				'|',
+				'bulletedList',
+				'numberedList',
+				'|',
+				'code',
+				'codeBlock',
+				'|',
+				'uploadImage',
+				'blockQuote',
+				'horizontalLine'
+			],
+			shouldNotGroupWhenFull: true
+		},
+		image: {
+			toolbar: [ 'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|', 'toggleImageCaption', 'imageTextAlternative' ]
+		},
+		codeBlock: {
+			languages: [
+				{ language: 'css', label: 'CSS' },
+				{ language: 'html', label: 'HTML' },
+				{ language: 'javascript', label: 'JavaScript' },
+				{ language: 'php', label: 'PHP' }
+			]
+		},
+		cloudServices: CS_CONFIG,
+		ui: {
+			viewportOffset: {
+				top: window.getViewportTopOffsetConfig()
+			}
+		}
+	} )
+	.then( editor => {
+		window.editor = editor;
+
+		const outputElement = document.querySelector( '#snippet-styles' );
+
+		editor.model.document.on( 'change', () => {
+			outputElement.innerText = editor.getData();
+		} );
+
+		// Set the initial data with delay so hightlight.js doesn't catch it.
+		setTimeout( () => {
+			outputElement.innerText = editor.getData();
+		}, 500 );
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-style/docs/features/style.md
+++ b/packages/ckeditor5-style/docs/features/style.md
@@ -8,7 +8,7 @@ modified_at: 2022-05-12
 
 The {@link module:style/style~Style Style} feature lets the user apply pre-configured styles to existing elements in the editor content.
 
-Under the hood, every style apply one or more HTML classes to such an element which, depending on your integration requirements, can be used to either control the visual styles of that element or apply additional semantics. <!-- The {@link features/remove-format remove formatting} feature can be used to clear those styles. -->
+Under the hood, every style applies one or more HTML classes to such an element which, depending on your integration requirements, can be used to either control the visual styles of that element or apply additional semantics. <!-- The {@link features/remove-format remove formatting} feature can be used to clear those styles. -->
 
 ## Demo
 

--- a/packages/ckeditor5-style/docs/features/style.md
+++ b/packages/ckeditor5-style/docs/features/style.md
@@ -6,7 +6,7 @@ modified_at: 2022-04-15
 
 # Styles
 
-The {@link module:style/style~Style Style} feature lets you completely control the way the edited content is presented. It adds a dropdown to the CKEditor 5 toolbar which lets the user apply pre-configured visual styles, allowing for control of font face, color and other {@link features/basic-styles basic text styles} of the edited content. The {@link features/remove-format remove formatting} feature can be used to clear those styles.
+The {@link module:style/style~Style Style} feature lets you completely control the way the edited content is presented. It adds a dropdown to the CKEditor 5 toolbar which lets the user apply pre-configured visual styles, allowing for control of font face, color and other {@link features/basic-styles basic text styles} of the edited content.<!-- The {@link features/remove-format remove formatting} feature can be used to clear those styles. -->
 
 <info-box>
 	The styles feature is experimental and **still in development**.

--- a/packages/ckeditor5-style/docs/features/style.md
+++ b/packages/ckeditor5-style/docs/features/style.md
@@ -1,7 +1,7 @@
 ---
 menu-title: Styles
 category: features
-modified_at: 2022-05-12
+modified_at: 2022-07-22
 ---
 
 # Styles

--- a/packages/ckeditor5-style/docs/features/style.md
+++ b/packages/ckeditor5-style/docs/features/style.md
@@ -51,7 +51,47 @@ ClassicEditor
 
 ## Configuration
 
-TODO
+Configuring the styles feature takes two steps. First you need to define the styles in the configuration file, for example:
+
+```js
+style: {
+	definitions: [
+		{
+			name: 'Article category',
+			element: 'h3',
+			classes: [ 'category' ]
+		},
+		{
+			name: 'Info box',
+			element: 'p',
+			classes: [ 'info-box' ]
+		},
+	]
+},
+
+```
+
+The, the css styles need to be defined for the document:
+
+```css
+	.ck.ck-content h3.category {
+		font-family: 'Bebas Neue';
+		font-size: 20px;
+		font-weight: bold;
+		color: #d1d1d1;
+		letter-spacing: 10px;
+		margin: 0;
+		padding: 0;
+	}
+
+	.ck.ck-content p.info-box {
+		padding: 1.2em 2em;
+		border: 1px solid #e91e63;
+		border-left: 10px solid #e91e63;
+		border-radius: 5px;
+		margin: 1.5em;
+	}
+```
 
 ## Common API
 

--- a/packages/ckeditor5-style/docs/features/style.md
+++ b/packages/ckeditor5-style/docs/features/style.md
@@ -10,6 +10,10 @@ The {@link module:style/style~Style Style} feature lets you completely control t
 
 ## Demo
 
+<info-box>
+	The styles feature is experimental and **still in development**.
+</info-box>
+
 {@snippet features/styles}
 
 ## Related features

--- a/packages/ckeditor5-style/docs/features/style.md
+++ b/packages/ckeditor5-style/docs/features/style.md
@@ -1,20 +1,20 @@
 ---
 menu-title: Styles
 category: features
-modified_at: 2022-03-31
+modified_at: 2022-04-15
 ---
 
 # Styles
 
 The {@link module:style/style~Style Style} feature lets you completely control the way the edited content is presented. It adds a dropdown to the CKEditor 5 toolbar which lets the user apply pre-configured visual styles, allowing for control of font face, color and other {@link features/basic-styles basic text styles} of the edited content. The {@link features/remove-format remove formatting} feature can be used to clear those styles.
 
-## Demo
-
 <info-box>
 	The styles feature is experimental and **still in development**.
 </info-box>
 
-Use the demo below to test applying various styles to content.
+## Demo
+
+Use the demo below to test the styles feature. Select a passage or a header and try applying various styles to content.
 
 {@snippet features/styles}
 

--- a/packages/ckeditor5-style/docs/features/style.md
+++ b/packages/ckeditor5-style/docs/features/style.md
@@ -14,6 +14,8 @@ The {@link module:style/style~Style Style} feature lets you completely control t
 	The styles feature is experimental and **still in development**.
 </info-box>
 
+Use the demo below to test applying various styles to content.
+
 {@snippet features/styles}
 
 ## Related features

--- a/packages/ckeditor5-style/docs/features/style.md
+++ b/packages/ckeditor5-style/docs/features/style.md
@@ -42,6 +42,17 @@ import Style from '@ckeditor/ckeditor5-style/src/style';
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [ Style, ... ],
+		toolbar: {
+			items: [
+				// ...
+				'style'
+			],
+		},
+		style: {
+			definitions: [
+				// ...
+			]
+		}
 	} )
 	.then( ... )
 	.catch( ... );
@@ -56,51 +67,77 @@ ClassicEditor
 Configuring the styles feature takes two steps. First you need to define the styles in the configuration file, for example:
 
 ```js
-style: {
-	definitions: [
-		{
-			name: 'Article category',
-			element: 'h3',
-			classes: [ 'category' ]
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ Style, ... ],
+		toolbar: {
+			items: [
+				// ...
+				'style'
+			],
 		},
-		{
-			name: 'Info box',
-			element: 'p',
-			classes: [ 'info-box' ]
-		},
-	]
-},
+		style: {
+			definitions: [
+				{
+					name: 'Article category',
+					element: 'h3',
+					classes: [ 'category' ]
+				},
+				{
+					name: 'Info box',
+					element: 'p',
+					classes: [ 'info-box' ]
+				},
+			]
+		}
+	} )
+	.then( ... )
+	.catch( ... );
 
 ```
 
-The, the css styles need to be defined for the document:
+Then, corresponding CSS styles need to be defined for the document:
 
 ```css
-	.ck.ck-content h3.category {
-		font-family: 'Bebas Neue';
-		font-size: 20px;
-		font-weight: bold;
-		color: #d1d1d1;
-		letter-spacing: 10px;
-		margin: 0;
-		padding: 0;
-	}
+.ck.ck-content h3.category {
+	font-family: 'Bebas Neue';
+	font-size: 20px;
+	font-weight: bold;
+	color: #d1d1d1;
+	letter-spacing: 10px;
+	margin: 0;
+	padding: 0;
+}
 
-	.ck.ck-content p.info-box {
-		padding: 1.2em 2em;
-		border: 1px solid #e91e63;
-		border-left: 10px solid #e91e63;
-		border-radius: 5px;
-		margin: 1.5em;
-	}
+.ck.ck-content p.info-box {
+	padding: 1.2em 2em;
+	border: 1px solid #e91e63;
+	border-left: 10px solid #e91e63;
+	border-radius: 5px;
+	margin: 1.5em;
+}
 ```
+
+Note that the editor will automatically distinguish text and block styles and group them in the dropdown.
 
 ## Common API
 
 The {@link module:style/style~Style Style} plugin registers:
 
-* The {@link module:style/stylecommand~StyleCommand `'style'`} command.
+* The `'style'` command implemented by {@link module:style/stylecommand~StyleCommand}.
 * The `'style'` UI drop-down.
+
+The command can be executed using the {@link module:core/editor/editor~Editor#execute `editor.execute()`} method:
+
+```js
+// Applies the style to the selected content.
+// Executing the command again will remove the style from the selected content.
+editor.execute( 'style', 'Article category' );
+```
+
+<info-box>
+	We recommend using the official {@link framework/guides/development-tools#ckeditor-5-inspector CKEditor 5 inspector} for development and debugging. It will give you tons of useful information about the state of the editor such as internal data structures, selection, commands, and many more.
+</info-box>
 
 ## Contribute
 

--- a/packages/ckeditor5-style/docs/features/style.md
+++ b/packages/ckeditor5-style/docs/features/style.md
@@ -6,17 +6,219 @@ modified_at: 2022-05-12
 
 # Styles
 
-The {@link module:style/style~Style Style} feature lets you completely control the way the edited content is presented. It adds a dropdown to the CKEditor 5 toolbar which lets the user apply pre-configured visual styles, allowing for control of font face, color and other {@link features/basic-styles basic text styles} of the edited content.<!-- The {@link features/remove-format remove formatting} feature can be used to clear those styles. -->
+The {@link module:style/style~Style Style} feature lets the user apply pre-configured styles to existing elements in the editor content.
 
-<info-box>
-	The styles feature is experimental and **still in development**.
-</info-box>
+Under the hood, every style apply one or more HTML classes to such an element which, depending on your integration requirements, can be used to either control the visual styles of that element or apply additional semantics. <!-- The {@link features/remove-format remove formatting} feature can be used to clear those styles. -->
 
 ## Demo
 
 Use the demo below to test the styles feature. Select a passage or a header and try applying various styles to content.
 
 {@snippet features/styles}
+
+<details>
+<summary>Configuration of the above demo</summary>
+
+<info-box>
+	See the [Configuration](#configuration) section to learn more about the configuration format.
+</info-box>
+
+The editor configuration:
+
+```js
+// ...
+style: {
+	definitions: [
+		{
+			name: 'Article category',
+			element: 'h3',
+			classes: [ 'category' ]
+		},
+		{
+			name: 'Title',
+			element: 'h2',
+			classes: [ 'document-title' ]
+		},
+		{
+			name: 'Subtitle',
+			element: 'h3',
+			classes: [ 'document-subtitle' ]
+		},
+		{
+			name: 'Info box',
+			element: 'p',
+			classes: [ 'info-box' ]
+		},
+		{
+			name: 'Side quote',
+			element: 'blockquote',
+			classes: [ 'side-quote' ]
+		},
+		{
+			name: 'Marker',
+			element: 'span',
+			classes: [ 'marker' ]
+		},
+		{
+			name: 'Spoiler',
+			element: 'span',
+			classes: [ 'spoiler' ]
+		},
+		{
+			name: 'Code (dark)',
+			element: 'pre',
+			classes: [ 'fancy-code', 'fancy-code-dark' ]
+		},
+		{
+			name: 'Code (bright)',
+			element: 'pre',
+			classes: [ 'fancy-code', 'fancy-code-bright' ]
+		}
+	]
+},
+// ...
+```
+
+The stylesheet:
+
+```css
+@import url('https://fonts.googleapis.com/css2?family=Bebas+Neue&family=PT+Serif:ital,wght@0,400;0,700;1,400&display=swap');
+
+.ck.ck-content {
+	font-family: 'PT Serif', serif;
+	font-size: 16px;
+	line-height: 1.6;
+	padding: 2em;
+}
+
+.ck-content .ck-horizontal-line {
+	margin-bottom: 1em;
+}
+
+.ck.ck-content hr {
+	width: 100px;
+	border-top: 1px solid #aaa;
+	height: 1px;
+	margin: 1em auto;
+}
+
+.ck.ck-content h3.category {
+	font-family: 'Bebas Neue';
+	font-size: 20px;
+	font-weight: bold;
+	color: #d1d1d1;
+	letter-spacing: 10px;
+	margin: 0;
+	padding: 0;
+}
+
+.ck.ck-content h2.document-title {
+	font-family: 'Bebas Neue';
+	font-size: 50px;
+	font-weight: bold;
+	margin: 0;
+	padding: 0;
+	border: 0;
+}
+
+.ck.ck-content h3.document-subtitle {
+	font-size: 20px;
+	color: #e91e63;
+	margin: 0 0 1em;
+	font-weight: normal;
+	padding: 0;
+}
+
+.ck.ck-content p.info-box {
+	--background-size: 30px;
+	--background-color: #e91e63;
+	padding: 1.2em 2em;
+	border: 1px solid var(--background-color);
+	background: linear-gradient(135deg, var(--background-color) 0%, var(--background-color) var(--background-size), transparent var(--background-size)), linear-gradient(135deg, transparent calc(100% - var(--background-size)), var(--background-color) calc(100% - var(--background-size)), var(--background-color));
+	border-radius: 10px;
+	margin: 1.5em 2em;
+	box-shadow: 5px 5px 0 #ffe6ef;
+}
+
+.ck.ck-content blockquote.side-quote {
+	font-family: 'Bebas Neue';
+	font-style: normal;
+	float: right;
+	width: 35%;
+	position: relative;
+	border: 0;
+	overflow: visible;
+	z-index: 1;
+	margin-left: 1em;
+}
+
+.ck.ck-content blockquote.side-quote::before {
+	content: "“";
+	position: absolute;
+	top: -37px;
+	left: -10px;
+	display: block;
+	font-size: 200px;
+	color: #e7e7e7;
+	z-index: -1;
+	line-height: 1;
+}
+
+.ck.ck-content blockquote.side-quote p {
+	font-size: 2em;
+	line-height: 1;
+}
+
+.ck.ck-content blockquote.side-quote p:last-child:not(:first-child) {
+	font-size: 1.3em;
+	text-align: right;
+	color: #555;
+}
+
+.ck.ck-content span.marker {
+	background: yellow;
+}
+
+.ck.ck-content span.spoiler {
+	background: #000;
+	color: #000;
+}
+
+.ck.ck-content span.spoiler:hover {
+	background: #000;
+	color: #fff;
+}
+
+.ck.ck-content pre.fancy-code {
+	border: 0;
+	margin-left: 2em;
+	margin-right: 2em;
+	border-radius: 10px;
+}
+
+.ck.ck-content pre.fancy-code::before {
+	content: "";
+	display: block;
+	height: 13px;
+	background: url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1NCAxMyI+CiAgPGNpcmNsZSBjeD0iNi41IiBjeT0iNi41IiByPSI2LjUiIGZpbGw9IiNGMzZCNUMiLz4KICA8Y2lyY2xlIGN4PSIyNi41IiBjeT0iNi41IiByPSI2LjUiIGZpbGw9IiNGOUJFNEQiLz4KICA8Y2lyY2xlIGN4PSI0Ny41IiBjeT0iNi41IiByPSI2LjUiIGZpbGw9IiM1NkM0NTMiLz4KPC9zdmc+Cg==);
+	margin-bottom: 8px;
+	background-repeat: no-repeat;
+}
+
+.ck.ck-content pre.fancy-code-dark {
+	background: #272822;
+	color: #fff;
+	box-shadow: 5px 5px 0 #0000001f;
+}
+
+.ck.ck-content pre.fancy-code-bright {
+	background: #dddfe0;
+	color: #000;
+	box-shadow: 5px 5px 0 #b3b3b3;
+}
+```
+
+</details>
 
 ## Related features
 

--- a/packages/ckeditor5-style/docs/features/style.md
+++ b/packages/ckeditor5-style/docs/features/style.md
@@ -1,7 +1,7 @@
 ---
 menu-title: Styles
 category: features
-modified_at: 2022-04-15
+modified_at: 2022-05-12
 ---
 
 # Styles

--- a/packages/ckeditor5-style/docs/features/style.md
+++ b/packages/ckeditor5-style/docs/features/style.md
@@ -99,8 +99,8 @@ The, the css styles need to be defined for the document:
 
 The {@link module:style/style~Style Style} plugin registers:
 
-* TODO style command
-* The `'styleDropdown'` UI drop-down.
+* The {@link module:style/stylecommand~StyleCommand `'style'`} command.
+* The `'style'` UI drop-down.
 
 ## Contribute
 

--- a/packages/ckeditor5-style/docs/features/style.md
+++ b/packages/ckeditor5-style/docs/features/style.md
@@ -1,0 +1,61 @@
+---
+menu-title: Styles
+category: features
+modified_at: 2022-03-31
+---
+
+# Styles
+
+The {@link module:style/style~Style Style} feature lets you completely control the way the edited content is presented. It adds a dropdown to the CKEditor 5 toolbar which lets the user apply pre-configured visual styles, allowing for control of font face, color and other {@link features/basic-styles basic text styles} of the edited content. The {@link features/remove-format remove formatting} feature can be used to clear those styles.
+
+## Demo
+
+{@snippet features/styles}
+
+## Related features
+
+Check out also these CKEditor 5 features to gain better control over your content style and format:
+* {@link features/basic-styles Basic text styles} &ndash; Apply the most frequently used formatting such as bold, italic, underline, etc.
+* {@link features/font Font styles} &ndash; Easily and efficiently control the font {@link features/font#configuring-the-font-family-feature family}, {@link features/font#configuring-the-font-size-feature size}, {@link features/font#configuring-the-font-color-and-font-background-color-features text or background color}.
+* {@link features/remove-format Remove format} &ndash; Easily clean basic text formatting.
+* {@link features/general-html-support General HTML support} &ndash; Allows enabling additional HTML, such as `<style>` and `<classes>` attributes.
+
+### Installation
+
+To add this feature to your rich-text editor, install the [`@ckeditor/ckeditor5-style`](https://www.npmjs.com/package/@ckeditor/ckeditor5-style) package:
+
+```plaintext
+npm install --save @ckeditor/ckeditor5-style
+```
+
+Then add it to the editor configuration:
+
+```js
+import Style from '@ckeditor/ckeditor5-style/src/style';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ Style, ... ],
+	} )
+	.then( ... )
+	.catch( ... );
+```
+
+<info-box info>
+	Read more about {@link installation/getting-started/installing-plugins installing plugins}.
+</info-box>
+
+## Configuration
+
+TODO
+
+## Common API
+
+The {@link module:style/style~Style Style} plugin registers:
+
+* TODO style command
+* The `'styleDropdown'` UI drop-down.
+
+## Contribute
+
+The source code of the feature is available on GitHub in https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-style.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Styles feature guide. See #11311.

---

### Additional information

In https://github.com/ckeditor/ckeditor5/pull/11562 we incorrectly merged it to `master`. I reverted that in #12135. 

This PR should contain all the commits from the original PR but correctly rebased onto the latest `release`.
