### PR TITLE
Docs: relinking landing pages to overviews globally for CKE5 docs.

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -17,9 +17,9 @@ category: api-reference
 
 ## Documentation
 
-* {@link framework/index CKEditor 5 Framework} &ndash; Learn how to develop with CKEditor 5 Framework, customize it and create plugins.
-* {@link installation/index Installing CKEditor 5} &ndash; Learn how to install, integrate and configure CKEditor 5 builds. More complex aspects, like creating custom builds, are explained here, too.
-* {@link features/index Features} &ndash; Learn about some of the features included in CKEditor 5 builds.
+* {@link framework/guides/overview CKEditor 5 Framework} &ndash; Learn how to develop with CKEditor 5 Framework, customize it and create plugins.
+* {@link installation/overview Installing CKEditor 5} &ndash; Learn how to install, integrate and configure CKEditor 5 builds. More complex aspects, like creating custom builds, are explained here, too.
+* {@link features/overview Features} &ndash; Learn about some of the features included in CKEditor 5 builds.
 
 ## Contribute
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -12,11 +12,11 @@ meta-description: Navigate through CKEditor 5 examples to see what you are able 
 Check out these examples of different editor integrations. See the predefined builds in action, witness the unharnessed power of a full-featured editor and find out amazing, custom-tailored implementations using the CKEditor 5 Framework.
 
 <info-box>
-	Use the <span class="navigation-hint_desktop">**navigation tree on the left**</span><span class="navigation-hint_mobile">**main menu button in the upper-left corner**</span> to navigate through CKEditor 5 examples. Visit the {@link features/index Features} section to see even more examples!
+	Use the <span class="navigation-hint_desktop">**navigation tree on the left**</span><span class="navigation-hint_mobile">**main menu button in the upper-left corner**</span> to navigate through CKEditor 5 examples. Visit the {@link features/overview Features} section to see even more examples!
 </info-box>
 
 **Related links**
 
- * {@link installation/index CKEditor 5 installation} &ndash; Learn how to install, integrate and configure CKEditor 5. More complex aspects, like creating custom builds, are explained here, too.
- * {@link features/index CKEditor 5 features} &ndash; Learn more about the available CKEditor 5 features.
+ * {@link installation/overview CKEditor 5 installation} &ndash; Learn how to install, integrate and configure CKEditor 5. More complex aspects, like creating custom builds, are explained here, too.
+ * {@link features/overview CKEditor 5 features} &ndash; Learn more about the available CKEditor 5 features.
  * {@link framework/guides/overview CKEditor 5 Framework} &ndash; Learn how to work with CKEditor 5 Framework, customize it, create your own plugins, custom editors, how to change the UI or even bring your own UI to the editor.

--- a/docs/features/overview.md
+++ b/docs/features/overview.md
@@ -23,7 +23,7 @@ CKEditor 5 features cover several functional areas of application and use. Liste
 
 ### Collaboration
 
-The {@link framework/index CKEditor 5 Framework} was created with {@link features/collaboration collaboration} in mind.
+The {@link framework/guides/overview CKEditor 5 Framework} was created with {@link features/collaboration collaboration} in mind.
 
 The {@link features/users users API} is used by functions such as {@link features/track-changes track changes}, that allow the users to follow any changes made to the edited document in real time. Accepting or rejecting those changes is done with a single click from a convenient side panel.
 
@@ -69,7 +69,7 @@ Enrich you content further by {@link features/html-embed embedding HTML code} - 
 
 ### Productivity features
 
-Keep full control of your work. Be safe and never lose anything thanks to the {@link features/real-time-collaboration-integration#the-autosave-plugin autosave plugin}. Configure {@link features/toolbar the toolbar} any way you like, use an additional {@link features/blocktoolbar block toolbar} and choose the right {@link installation/index editor build} to suit your needs.
+Keep full control of your work. Be safe and never lose anything thanks to the {@link features/real-time-collaboration-integration#the-autosave-plugin autosave plugin}. Configure {@link features/toolbar the toolbar} any way you like, use an additional {@link features/blocktoolbar block toolbar} and choose the right {@link installation/overview editor build} to suit your needs.
 
 The {@link features/word-count words and characters counter} will help you track progress and control the volume of the content.
 
@@ -85,7 +85,7 @@ Work as you like it - choose user interface approach from {@link installation/ge
 
 ### Cross-platform interoperability
 
-Do not get stopped by technology differences - CKEditor 5 offers cross-platform interoperability. Being a {@link framework/index web-based JavaScript framework} it works in any and all environments. What is more, you can easily use documents from other editors: easily paste content {@link features/paste-from-word from MS Word}, paste from {@link features/paste-from-google-docs from Google Docs} and we even have extended support for {@link features/paste-plain-text pasting plain text} to inherit formatting for convenience.
+Do not get stopped by technology differences - CKEditor 5 offers cross-platform interoperability. Being a {@link framework/guides/overview web-based JavaScript framework} it works in any and all environments. What is more, you can easily use documents from other editors: easily paste content {@link features/paste-from-word from MS Word}, paste from {@link features/paste-from-google-docs from Google Docs} and we even have extended support for {@link features/paste-plain-text pasting plain text} to inherit formatting for convenience.
 
 {@img assets/img/features-paste.png 800 CKEditor 5 paste features.}
 
@@ -120,6 +120,6 @@ CKEditor 5 is in active development now and new features are added all the time,
 ## How about creating your own features?
 
 Probably the most exciting features are the ones you can develop on top of CKEditor 5 Framework!
-We are gradually enhancing the {@link framework/index CKEditor 5 Framework documentation} together with {@link api/index API documentation}, hoping to give you a solid base for {@link framework/guides/creating-simple-plugin creating custom features}.
+We are gradually enhancing the {@link framework/guides/overview CKEditor 5 Framework documentation} together with {@link api/index API documentation}, hoping to give you a solid base for {@link framework/guides/creating-simple-plugin creating custom features}.
 
 The official add-ons repository for CKEditor 4 reached an impressive number of over 300 add-ons created and published by the community. Now it is time for you to add your contributions to the brand new CKEditor 5!

--- a/docs/features/toolbar.md
+++ b/docs/features/toolbar.md
@@ -68,7 +68,7 @@ toolbar: {
 }
 ```
 
- * **`items`** &ndash; An array of toolbar item names. Most of the components (buttons, dropdowns, etc.) which can be used as toolbar items are described under the {@link features/index Features} tab. A full list is defined in {@link module:ui/componentfactory~ComponentFactory editor.ui.componentFactory} and can be listed using the following snippet: `Array.from( editor.ui.componentFactory.names() )`. Besides button names, you can also use the dedicated separators for toolbar groups (`'|'`) and toolbar lines (`'-'`).
+ * **`items`** &ndash; An array of toolbar item names. Most of the components (buttons, dropdowns, etc.) which can be used as toolbar items are described under the {@link features/overview Features} tab. A full list is defined in {@link module:ui/componentfactory~ComponentFactory editor.ui.componentFactory} and can be listed using the following snippet: `Array.from( editor.ui.componentFactory.names() )`. Besides button names, you can also use the dedicated separators for toolbar groups (`'|'`) and toolbar lines (`'-'`).
 
  * **`removeItems`** &ndash; An array of toolbar item names. With this setting you can modify the default toolbar configuration without the need of defining the entire list (you can specify a couple of buttons that you want to remove instead of specifying all the buttons you want to keep). If, after removing an item, toolbar will have two or more consecutive separators (`'|'`), the duplicates will be removed automatically.
 

--- a/docs/features/ui-language.md
+++ b/docs/features/ui-language.md
@@ -104,7 +104,7 @@ See the {@link installation/getting-started/predefined-builds#zip-download zip i
 
 Currently, it is possible to change the UI language at the build stage and after the build. A single build of the editor supports the language which was defined in the [CKEditor 5 webpack plugin](https://www.npmjs.com/package/@ckeditor/ckeditor5-dev-webpack-plugin)'s configuration. Check the whole translation process to see how you can change the language later.
 
-If you use one of the {@link installation/index predefined editor builds}, refer to {@link installation/getting-started/quick-start-other#building-the-editor-from-source Creating custom builds} to learn how to change the language of your build.
+If you use one of the {@link installation/overview predefined editor builds}, refer to {@link installation/getting-started/quick-start-other#building-the-editor-from-source Creating custom builds} to learn how to change the language of your build.
 
 If you build CKEditor 5 from scratch or integrate it directly into your application, then all you need to do is to:
 

--- a/docs/installation/advanced/content-styles.md
+++ b/docs/installation/advanced/content-styles.md
@@ -9,7 +9,7 @@ order: 30
 
 # Content styles
 
-Some of the {@link features/index core editor features} bring additional CSS to control the look of the content they produce. Take, for example, the {@link features/images-overview image feature} that needs special content styles to render images and their captions in the content. Or the {@link module:block-quote/blockquote~BlockQuote block quote} feature that displays quotes in italic with a subtle border on the side.
+Some of the {@link features/overview core editor features} bring additional CSS to control the look of the content they produce. Take, for example, the {@link features/images-overview image feature} that needs special content styles to render images and their captions in the content. Or the {@link module:block-quote/blockquote~BlockQuote block quote} feature that displays quotes in italic with a subtle border on the side.
 
 {@img assets/img/builds-content-styles.png 823 Editor content styles.}
 

--- a/docs/installation/advanced/plugins.md
+++ b/docs/installation/advanced/plugins.md
@@ -32,12 +32,12 @@ Common use cases for plugins are:
 
 Creating your own plugins is a straightforward task but it requires good knowledge about a few aspects of the CKEditor 5 development environment. The following resources are recommended as a starting point:
 
-* The {@link framework/guides/creating-simple-plugin Plugin development guide} in the {@link framework/index CKEditor 5 Framework} documentation.
+* The {@link framework/guides/creating-simple-plugin Plugin development guide} in the {@link framework/guides/overview CKEditor 5 Framework} documentation.
 * The {@link framework/guides/package-generator Using package generator} that provides plugin development environment.
-* The {@link framework/guides/quick-start Quick start guide} in the {@link framework/index CKEditor 5 Framework} documentation.
+* The {@link framework/guides/quick-start Quick start guide} in the {@link framework/guides/overview CKEditor 5 Framework} documentation.
 * {@link installation/getting-started/quick-start-other#building-the-editor-from-source Creating custom builds} which is necessary to have your plugin included inside a CKEditor 5 build.
 
-A good understanding of the {@link framework/index CKEditor 5 Framework} is also very welcome when it comes to creating plugins.
+A good understanding of the {@link framework/guides/overview CKEditor 5 Framework} is also very welcome when it comes to creating plugins.
 
 ## Using third-party plugins
 

--- a/docs/installation/getting-started/installing-plugins.md
+++ b/docs/installation/getting-started/installing-plugins.md
@@ -10,7 +10,7 @@ order: 50
 <info-box hint>
 **Quick recap**
 
-In the {@link installation/getting-started/configuration previous tutorial} you have learned how to configure your editor with various options. Now, you will be extending it with some {@link features/index additional features}.
+In the {@link installation/getting-started/configuration previous tutorial} you have learned how to configure your editor with various options. Now, you will be extending it with some {@link features/overview additional features}.
 </info-box>
 
 CKEditor 5 plugins are distributed through [npm](https://www.npmjs.com) packages and are implemented in a modular way, which means that a single plugin may consist of multiple JavaScript files.
@@ -293,5 +293,5 @@ So, in short, both methods use very similar mechanisms. However, adding a plugin
 <info-box hint>
 **What's next?**
 
-That was fun, right? Don't hesitate and {@link features/index explore available CKEditor 5 features}, they are waiting to be installed! {@link installation/getting-started/basic-api In the next article}, you will learn more about the editor API and how to use it.
+That was fun, right? Don't hesitate and {@link features/overview explore available CKEditor 5 features}, they are waiting to be installed! {@link installation/getting-started/basic-api In the next article}, you will learn more about the editor API and how to use it.
 </info-box>

--- a/docs/installation/getting-started/migration-from-ckeditor-4.md
+++ b/docs/installation/getting-started/migration-from-ckeditor-4.md
@@ -31,7 +31,7 @@ The API for integrating CKEditor with your pages also changed. It is worth check
 
 ## Features
 
-When it comes to {@link features/index features}, there are two aspects that need to be taken into consideration:
+When it comes to {@link features/overview features}, there are two aspects that need to be taken into consideration:
 
 * CKEditor 5 may still not have the same features available as CKEditor 4.
 * Existing features may behave differently.
@@ -719,5 +719,5 @@ If you are missing any particular features or settings, feel free to {@link supp
 <info-box hint>
 **What's next?**
 
-You should now have the basic knowledge about differences between CKEditor 4 and CKEditor 5. Feel free to explore our {@link features/index features page} to compare the available plugins to your needs.
+You should now have the basic knowledge about differences between CKEditor 4 and CKEditor 5. Feel free to explore our {@link features/overview features page} to compare the available plugins to your needs.
 </info-box>

--- a/docs/installation/getting-started/predefined-builds.md
+++ b/docs/installation/getting-started/predefined-builds.md
@@ -27,7 +27,7 @@ Each build was designed to satisfy as many use cases as possible. They differ in
 
 ### When NOT to use predefined builds?
 
-{@link framework/index CKEditor 5 Framework} or a {@link installation/getting-started/quick-start-other custom build} should be used, instead of predefined builds, in the following cases:
+{@link framework/guides/overview CKEditor 5 Framework} or a {@link installation/getting-started/quick-start-other custom build} should be used, instead of predefined builds, in the following cases:
 
 * When you want to create your own text editor and have full control over its every aspect, from UI to features.
 * When the solution proposed by the builds does not fit your specific use case.

--- a/docs/installation/getting-started/quick-start.md
+++ b/docs/installation/getting-started/quick-start.md
@@ -85,7 +85,7 @@ A full webpage with embedded CKEditor 5 from the above example would look like t
 
 ## Running a full-featured editor from CDN
 
-The fastest way to run an advanced editor using the {@link features/index rich editing features offered by CKEditor 5} is using a superbuild. The superbuild, available instantly from CDN, is a preconfigured package that offers access to almost all available plugins and all predefined editor types.
+The fastest way to run an advanced editor using the {@link features/overview rich editing features offered by CKEditor 5} is using a superbuild. The superbuild, available instantly from CDN, is a preconfigured package that offers access to almost all available plugins and all predefined editor types.
 
 <info-box>
 	Please consider, that the superbuild contains a really whole lot of code. A good portion of that code may not be needed in your implementation, so using the superbuild should be considered for evaluation purposes and tests rather, than for the production environment.

--- a/docs/installation/overview.md
+++ b/docs/installation/overview.md
@@ -42,8 +42,8 @@ Find out more about the {@link installation/advanced/plugins plugin development}
 
 **Related links**
 
- * {@link updating/index Updating CKEditor 5} &ndash; Find out how to keep you installation up-to-date at all times.
- * {@link features/index Features} &ndash; Learn more about the CKEditor 5 features.
+ * {@link updating/updating Updating CKEditor 5} &ndash; Find out how to keep you installation up-to-date at all times.
+ * {@link features/overview Features} &ndash; Learn more about the CKEditor 5 features.
  * {@link examples/index Examples} &ndash; Try live demos of available predefined builds and custom solutions.
  * {@link framework/guides/overview CKEditor 5 Framework} &ndash; Learn how to work with CKEditor 5 Framework, customize it, create your own plugins or custom editors, how to change the UI or even bring your own UI to the editor.
 

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -39,7 +39,7 @@ You can get the full list of editor content styles in a {@link installation/adva
 
 See the {@link installation/getting-started/installing-plugins Installing plugins} guide to learn how to extend the editor with some additional features.
 
-You can learn which editor features are available in the {@link features/index feature index}.
+You can learn which editor features are available in the {@link features/overview feature index}.
 
 ## Where are the `editor.insertHtml()` and `editor.insertText()` methods? How to insert some content?
 
@@ -95,7 +95,7 @@ We plan to provide more official integrations with time. [Your feedback on what 
 
 We believe each editor build should serve its purpose. Including features that are not used makes little sense because they increase the size of the editor and make the website heavier for no good reason. This is why we do not provide a full editor package similar to what we offer in CKEditor 4.
 
-At the same time, we recommend you to {@link installation/getting-started/installing-plugins install plugins} to enable {@link features/index additional features} or even create a {@link installation/getting-started/quick-start-other#building-the-editor-from-source custom build} to make sure you make the most out of CKEditor 5.
+At the same time, we recommend you to {@link installation/getting-started/installing-plugins install plugins} to enable {@link features/overview additional features} or even create a {@link installation/getting-started/quick-start-other#building-the-editor-from-source custom build} to make sure you make the most out of CKEditor 5.
 
 ## How to customize the CKEditor 5 icons?
 

--- a/docs/updating/updating.md
+++ b/docs/updating/updating.md
@@ -45,7 +45,7 @@ It is good to follow [CKEditor Ecosystem Blog](https://ckeditor.com/blog/) as it
 
 ### Migration guides
 
-Should there be any breaking or important changes that affect your editor integration and require special attention, these will also be published in the CKEditor 5 documentation in the {@link updating/index Updating section}. These guides provide a more technical, code-oriented information directed at integrators, administrators and developers and offer solutions and necessary steps to take while updating.
+Should there be any breaking or important changes that affect your editor integration and require special attention, these will also be published in the CKEditor 5 documentation in the {@link updating/updating Updating section}. These guides provide a more technical, code-oriented information directed at integrators, administrators and developers and offer solutions and necessary steps to take while updating.
 
 Administrators and developers should always refer to migration guides after each release and make sure to implement all the introduced changes properly to ensure stable and uninterrupted operation.
 

--- a/packages/ckeditor5-editor-balloon/docs/api/editor-balloon.md
+++ b/packages/ckeditor5-editor-balloon/docs/api/editor-balloon.md
@@ -12,7 +12,7 @@ The balloon editor implementation (Medium-like editor) for CKEditor 5. See the {
 
 This package contains the {@link module:editor-balloon/ballooneditor~BalloonEditor} class. Follow there to learn more about this type of editor and how to initialize it.
 
-This package contains the source version of the balloon editor. This editor implementation is also available in the [balloon build](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-balloon). Read more about {@link installation/index CKEditor 5 builds}.
+This package contains the source version of the balloon editor. This editor implementation is also available in the [balloon build](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-balloon). Read more about {@link installation/overview CKEditor 5 builds}.
 
 ## Installation
 

--- a/packages/ckeditor5-editor-classic/docs/api/editor-classic.md
+++ b/packages/ckeditor5-editor-classic/docs/api/editor-classic.md
@@ -12,7 +12,7 @@ The classic editor implementation for CKEditor 5. See the {@link examples/builds
 
 This package contains the {@link module:editor-classic/classiceditor~ClassicEditor} class. Follow there to learn more about this type of editor and how to initialize it.
 
-This package contains the source version of the classic editor. This editor implementation is also available in the [classic build](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-classic). Read more about {@link installation/index CKEditor 5 builds}.
+This package contains the source version of the classic editor. This editor implementation is also available in the [classic build](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-classic). Read more about {@link installation/overview CKEditor 5 builds}.
 
 ## Installation
 

--- a/packages/ckeditor5-editor-decoupled/docs/api/editor-decoupled.md
+++ b/packages/ckeditor5-editor-decoupled/docs/api/editor-decoupled.md
@@ -12,7 +12,7 @@ The decoupled editor implementation for CKEditor 5. See the {@link examples/buil
 
 This package contains the {@link module:editor-decoupled/decouplededitor~DecoupledEditor} class. Follow there to learn more about this type of editor and how to initialize it.
 
-This package contains the source version of the decoupled editor. This editor implementation is also available in the [decoupled build](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-decoupled). Read more about {@link installation/index CKEditor 5 builds}.
+This package contains the source version of the decoupled editor. This editor implementation is also available in the [decoupled build](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-decoupled). Read more about {@link installation/overview CKEditor 5 builds}.
 
 ## Installation
 

--- a/packages/ckeditor5-editor-inline/docs/api/editor-inline.md
+++ b/packages/ckeditor5-editor-inline/docs/api/editor-inline.md
@@ -12,7 +12,7 @@ The inline editor implementation for CKEditor 5. See the {@link examples/builds/
 
 This package contains the {@link module:editor-inline/inlineeditor~InlineEditor} class. Follow there to learn more about this type of editor and how to initialize it.
 
-This package contains the source version of the inline editor. This editor implementation is also available in the [inline build](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-inline). Read more about {@link installation/index CKEditor 5 builds}.
+This package contains the source version of the inline editor. This editor implementation is also available in the [inline build](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-inline). Read more about {@link installation/overview CKEditor 5 builds}.
 
 ## Installation
 

--- a/packages/ckeditor5-engine/docs/framework/guides/deep-dive/conversion/helpers/intro.md
+++ b/packages/ckeditor5-engine/docs/framework/guides/deep-dive/conversion/helpers/intro.md
@@ -8,7 +8,7 @@ modified_at: 2022-03-02
 
 # Introduction to conversion helpers
 
-The editor supports a vast amount of the most commonly used HTML elements via {@link features/index existing editor features} out-of-the-box.
+The editor supports a vast amount of the most commonly used HTML elements via {@link features/overview existing editor features} out-of-the-box.
 
 If your aim is to easily enable common HTML features that are not explicitly supported by the dedicated CKEditor 5 features, use the {@link features/general-html-support General HTML Support feature}.
 

--- a/packages/ckeditor5-remove-format/docs/features/remove-format.md
+++ b/packages/ckeditor5-remove-format/docs/features/remove-format.md
@@ -33,7 +33,7 @@ There are more CKEditor 5 features that can help you format your content:
 
 ## Configuring the remove format feature
 
-This feature has no integration–level configuration. Once enabled, it works out–of–the–box with all {@link features/index core editor features}.
+This feature has no integration–level configuration. Once enabled, it works out–of–the–box with all {@link features/overview core editor features}.
 
 ## A short note about content types in the editor
 

--- a/packages/ckeditor5-utils/docs/framework/guides/deep-dive/observables.md
+++ b/packages/ckeditor5-utils/docs/framework/guides/deep-dive/observables.md
@@ -6,7 +6,7 @@ category: framework-deep-dive
 
 {@link module:utils/observablemixin~Observable Observables} are objects which have properties that can be observed. That means when the value of such property changes, an event is fired by the observable and the change can be reflected in other pieces of the code that listen to that event.
 
-Observables are common building blocks of the {@link framework/index CKEditor 5 Framework}. They are particularly popular in the UI, the {@link module:ui/view~View `View`} class and its subclasses  benefiting from the observable interface the most: it is the {@link framework/guides/architecture/ui-library#interaction templates bound to the observables} what makes the user interface dynamic and interactive. Some of the basic classes like {@link module:core/editor/editor~Editor `Editor`} or {@link module:core/command~Command `Command`} are observables too.
+Observables are common building blocks of the {@link framework/guides/overview CKEditor 5 Framework}. They are particularly popular in the UI, the {@link module:ui/view~View `View`} class and its subclasses  benefiting from the observable interface the most: it is the {@link framework/guides/architecture/ui-library#interaction templates bound to the observables} what makes the user interface dynamic and interactive. Some of the basic classes like {@link module:core/editor/editor~Editor `Editor`} or {@link module:core/command~Command `Command`} are observables too.
 
 Any class can become observable; all you need to do is mix the {@link module:utils/observablemixin~ObservableMixin} into it:
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: relinking landing pages to overviews globally for CKE5 docs.

Follow up to https://github.com/ckeditor/ckeditor5/pull/12091

Part of https://github.com/ckeditor/ckeditor5/issues/12081

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
