### PR TITLE
Fix focus after using dropdowns and splitbuttons

### DIFF
--- a/docs/_snippets/framework/tutorials/inline-widget.js
+++ b/docs/_snippets/framework/tutorials/inline-widget.js
@@ -85,7 +85,7 @@ class PlaceholderUI extends Plugin {
 			dropdownView.bind( 'isEnabled' ).to( command );
 
 			// Execute the command when the dropdown item is clicked (executed).
-			this.listenTo( dropdownView, 'execute', evt => {
+			dropdownView.on( 'execute', evt => {
 				editor.execute( 'placeholder', { value: evt.source.commandParam } );
 				editor.editing.view.focus();
 			} );

--- a/packages/ckeditor5-alignment/src/alignmentui.js
+++ b/packages/ckeditor5-alignment/src/alignmentui.js
@@ -118,7 +118,7 @@ export default class AlignmentUI extends Plugin {
 
 			// Focus the editable after executing the command.
 			// Overrides a default behaviour where the focus is moved to the dropdown button (#12125).
-			this.listenTo( dropdownView, 'execute', () => {
+			dropdownView.on( 'execute', () => {
 				editor.editing.view.focus();
 			} );
 

--- a/packages/ckeditor5-alignment/src/alignmentui.js
+++ b/packages/ckeditor5-alignment/src/alignmentui.js
@@ -116,6 +116,12 @@ export default class AlignmentUI extends Plugin {
 			// Enable button if any of the buttons is enabled.
 			dropdownView.bind( 'isEnabled' ).toMany( buttons, 'isEnabled', ( ...areEnabled ) => areEnabled.some( isEnabled => isEnabled ) );
 
+			// Focus the editable after executing the command.
+			// Overrides a default behaviour where the focus is moved to the dropdown button (#12125).
+			this.listenTo( dropdownView, 'execute', () => {
+				editor.editing.view.focus();
+			} );
+
 			return dropdownView;
 		} );
 	}
@@ -147,7 +153,6 @@ export default class AlignmentUI extends Plugin {
 			// Execute command.
 			this.listenTo( buttonView, 'execute', () => {
 				editor.execute( 'alignment', { value: option } );
-				editor.editing.view.focus();
 			} );
 
 			return buttonView;

--- a/packages/ckeditor5-alignment/tests/alignmentui.js
+++ b/packages/ckeditor5-alignment/tests/alignmentui.js
@@ -270,6 +270,15 @@ describe( 'Alignment UI', () => {
 			sinon.assert.calledOnce( spy );
 		} );
 
+		it( 'should return focus to editable after executing a command', () => {
+			const buttonAlignLeft = dropdown.toolbarView.items.get( 0 );
+			const spy = sinon.spy( editor.editing.view, 'focus' );
+			dropdown.render();
+
+			buttonAlignLeft.fire( 'execute' );
+			sinon.assert.calledOnce( spy );
+		} );
+
 		describe( 'config', () => {
 			beforeEach( async () => {
 				// Clean up the editor created in main test suite hook.

--- a/packages/ckeditor5-font/src/fontfamily/fontfamilyui.js
+++ b/packages/ckeditor5-font/src/fontfamily/fontfamilyui.js
@@ -60,7 +60,7 @@ export default class FontFamilyUI extends Plugin {
 			dropdownView.bind( 'isEnabled' ).to( command );
 
 			// Execute command when an item from the dropdown is selected.
-			this.listenTo( dropdownView, 'execute', evt => {
+			dropdownView.on( 'execute', evt => {
 				editor.execute( evt.source.commandName, { value: evt.source.commandParam } );
 				editor.editing.view.focus();
 			} );

--- a/packages/ckeditor5-font/src/fontsize/fontsizeui.js
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeui.js
@@ -64,7 +64,7 @@ export default class FontSizeUI extends Plugin {
 			dropdownView.bind( 'isEnabled' ).to( command );
 
 			// Execute command when an item from the dropdown is selected.
-			this.listenTo( dropdownView, 'execute', evt => {
+			dropdownView.on( 'execute', evt => {
 				editor.execute( evt.source.commandName, { value: evt.source.commandParam } );
 				editor.editing.view.focus();
 			} );

--- a/packages/ckeditor5-heading/src/headingui.js
+++ b/packages/ckeditor5-heading/src/headingui.js
@@ -104,7 +104,7 @@ export default class HeadingUI extends Plugin {
 			} );
 
 			// Execute command when an item from the dropdown is selected.
-			this.listenTo( dropdownView, 'execute', evt => {
+			dropdownView.on( 'execute', evt => {
 				editor.execute( evt.source.commandName, evt.source.commandValue ? { value: evt.source.commandValue } : undefined );
 				editor.editing.view.focus();
 			} );

--- a/packages/ckeditor5-highlight/src/highlightui.js
+++ b/packages/ckeditor5-highlight/src/highlightui.js
@@ -147,7 +147,6 @@ export default class HighlightUI extends Plugin {
 
 			buttonView.on( 'execute', () => {
 				editor.execute( 'highlight', { value } );
-				editor.editing.view.focus();
 			} );
 
 			// Add additional behavior for buttonView.
@@ -207,7 +206,9 @@ export default class HighlightUI extends Plugin {
 				const buttonView = componentFactory.create( 'highlight:' + option.model );
 
 				// Update lastExecutedHighlight on execute.
-				this.listenTo( buttonView, 'execute', () => dropdownView.buttonView.set( { lastExecuted: option.model } ) );
+				this.listenTo( buttonView, 'execute', () => {
+					dropdownView.buttonView.set( { lastExecuted: option.model } );
+				} );
 
 				return buttonView;
 			} );
@@ -227,6 +228,11 @@ export default class HighlightUI extends Plugin {
 			// Execute current action from dropdown's split button action button.
 			splitButtonView.on( 'execute', () => {
 				editor.execute( 'highlight', { value: splitButtonView.commandValue } );
+			} );
+
+			// Focus the editable after executing the command.
+			// Overrides a default behaviour where the focus is moved to the dropdown button (#12125).
+			this.listenTo( dropdownView, 'execute', () => {
 				editor.editing.view.focus();
 			} );
 

--- a/packages/ckeditor5-highlight/src/highlightui.js
+++ b/packages/ckeditor5-highlight/src/highlightui.js
@@ -232,7 +232,7 @@ export default class HighlightUI extends Plugin {
 
 			// Focus the editable after executing the command.
 			// Overrides a default behaviour where the focus is moved to the dropdown button (#12125).
-			this.listenTo( dropdownView, 'execute', () => {
+			dropdownView.on( 'execute', () => {
 				editor.editing.view.focus();
 			} );
 

--- a/packages/ckeditor5-highlight/tests/highlightui.js
+++ b/packages/ckeditor5-highlight/tests/highlightui.js
@@ -179,6 +179,7 @@ describe( 'HighlightUI', () => {
 			it( 'should change button on execute option', () => {
 				command.value = 'yellowMarker';
 				validateButton( 0 );
+				button.render();
 
 				buttons[ 5 ].fire( 'execute' );
 				command.value = 'greenPen';
@@ -192,8 +193,9 @@ describe( 'HighlightUI', () => {
 			it( 'should focus view after command execution', () => {
 				const focusSpy = testUtils.sinon.spy( editor.editing.view, 'focus' );
 
-				dropdown.buttonView.commandName = 'highlight';
-				dropdown.buttonView.fire( 'execute' );
+				button.render();
+				button.commandName = 'highlight';
+				button.fire( 'execute' );
 
 				sinon.assert.calledOnce( focusSpy );
 			} );

--- a/packages/ckeditor5-image/src/imagecaption/imagecaptionui.js
+++ b/packages/ckeditor5-image/src/imagecaption/imagecaptionui.js
@@ -68,6 +68,8 @@ export default class ImageCaptionUI extends Plugin {
 						writer.addClass( 'image__caption_highlighted', figcaptionElement );
 					} );
 				}
+
+				editor.editing.view.focus();
 			} );
 
 			return view;

--- a/packages/ckeditor5-image/src/imageresize/imageresizebuttons.js
+++ b/packages/ckeditor5-image/src/imageresize/imageresizebuttons.js
@@ -172,7 +172,7 @@ export default class ImageResizeButtons extends Plugin {
 			dropdownView.listView.ariaLabel = t( 'Image resize list' );
 
 			// Execute command when an item from the dropdown is selected.
-			this.listenTo( dropdownView, 'execute', evt => {
+			dropdownView.on( 'execute', evt => {
 				editor.execute( evt.source.commandName, { width: evt.source.commandValue } );
 				editor.editing.view.focus();
 			} );

--- a/packages/ckeditor5-image/src/imagestyle/imagestyleui.js
+++ b/packages/ckeditor5-image/src/imagestyle/imagestyleui.js
@@ -172,6 +172,12 @@ export default class ImageStyleUI extends Plugin {
 			dropdownView.bind( 'isEnabled' )
 				.toMany( buttonViews, 'isEnabled', ( ...areEnabled ) => areEnabled.some( identity ) );
 
+			// Focus the editable after executing the command.
+			// Overrides a default behaviour where the focus is moved to the dropdown button (#12125).
+			this.listenTo( dropdownView, 'execute', () => {
+				this.editor.editing.view.focus();
+			} );
+
 			return dropdownView;
 		} );
 	}
@@ -206,7 +212,6 @@ export default class ImageStyleUI extends Plugin {
 
 	_executeCommand( name ) {
 		this.editor.execute( 'imageStyle', { value: name } );
-		this.editor.editing.view.focus();
 	}
 }
 

--- a/packages/ckeditor5-image/src/imagestyle/imagestyleui.js
+++ b/packages/ckeditor5-image/src/imagestyle/imagestyleui.js
@@ -174,7 +174,7 @@ export default class ImageStyleUI extends Plugin {
 
 			// Focus the editable after executing the command.
 			// Overrides a default behaviour where the focus is moved to the dropdown button (#12125).
-			this.listenTo( dropdownView, 'execute', () => {
+			dropdownView.on( 'execute', () => {
 				this.editor.editing.view.focus();
 			} );
 

--- a/packages/ckeditor5-image/tests/imageresize/imageresizebuttons.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizebuttons.js
@@ -142,6 +142,7 @@ describe( 'ImageResizeButtons', () => {
 			const commandSpy = sinon.spy( command, 'execute' );
 			const resizeBy50Percent = dropdownView.listView.items._items[ 1 ].children._items[ 0 ];
 
+			dropdownView.render();
 			command.isEnabled = true;
 
 			resizeBy50Percent.fire( 'execute' );

--- a/packages/ckeditor5-image/tests/imagestyle/imagestyleui.js
+++ b/packages/ckeditor5-image/tests/imagestyle/imagestyleui.js
@@ -146,14 +146,12 @@ describe( 'ImageStyleUI', () => {
 
 		it( 'should execute the command when the button is being clicked', () => {
 			const commandSpy = sinon.spy( editor, 'execute' );
-			const focusSpy = sinon.stub( editor.editing.view, 'focus' );
 
 			for ( const { config, buttonView } of buttons ) {
 				buttonView.fire( 'execute' );
 
 				sinon.assert.calledOnce( commandSpy );
 				sinon.assert.calledWithExactly( commandSpy, 'imageStyle', { value: config.name } );
-				sinon.assert.called( focusSpy );
 
 				commandSpy.resetHistory();
 			}
@@ -470,6 +468,7 @@ describe( 'ImageStyleUI', () => {
 				const focusSpy = sinon.stub( editor.editing.view, 'focus' );
 
 				for ( const { buttonView, config, view } of dropdowns ) {
+					buttonView.render();
 					buttonView.fire( 'execute' );
 
 					expect( view.isOpen ).to.be.false;

--- a/packages/ckeditor5-language/src/textpartlanguageui.js
+++ b/packages/ckeditor5-language/src/textpartlanguageui.js
@@ -104,7 +104,7 @@ export default class TextPartLanguageUI extends Plugin {
 			} );
 
 			// Execute command when an item from the dropdown is selected.
-			this.listenTo( dropdownView, 'execute', evt => {
+			dropdownView.on( 'execute', evt => {
 				languageCommand.execute( {
 					languageCode: evt.source.languageCode,
 					textDirection: evt.source.textDirection

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.js
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.js
@@ -187,6 +187,12 @@ function getDropdownViewCreator( { editor, parentCommandName, buttonLabel, butto
 		// Accessibility: focus the first active style when opening the dropdown.
 		focusChildOnDropdownOpen( dropdownView, () => listPropertiesView.stylesView.children.find( child => child.isOn ) );
 
+		// Focus the editable after executing the command.
+		// Overrides a default behaviour where the focus is moved to the dropdown button (#12125).
+		editor.plugins.get( 'ListPropertiesUI' ).listenTo( dropdownView, 'execute', () => {
+			editor.editing.view.focus();
+		} );
+
 		return dropdownView;
 	};
 }
@@ -237,8 +243,6 @@ function getStyleButtonCreator( { editor, listStyleCommand, parentCommandName } 
 					editor.execute( 'listStyle', { type } );
 				} );
 			}
-
-			editor.editing.view.focus();
 		} );
 
 		return button;

--- a/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
+++ b/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
@@ -262,6 +262,7 @@ describe( 'ListPropertiesUI', () => {
 				it( 'should close the drop-down when any button gets executed', () => {
 					const spy = sinon.spy();
 
+					bulletedListDropdown.render();
 					bulletedListDropdown.on( 'execute', spy );
 					listPropertiesView.fire( 'execute' );
 
@@ -283,6 +284,7 @@ describe( 'ListPropertiesUI', () => {
 					beforeEach( () => {
 						// "circle"
 						styleButtonView = stylesView.children.get( 1 );
+						bulletedListDropdown.render();
 
 						sinon.spy( editor, 'execute' );
 						sinon.spy( editor.editing.view, 'focus' );
@@ -561,6 +563,7 @@ describe( 'ListPropertiesUI', () => {
 				it( 'should close the drop-down when any button gets executed', () => {
 					const spy = sinon.spy();
 
+					numberedListDropdown.render();
 					numberedListDropdown.on( 'execute', spy );
 					listPropertiesView.fire( 'execute' );
 
@@ -582,6 +585,7 @@ describe( 'ListPropertiesUI', () => {
 					beforeEach( () => {
 						// "decimal-leading-zero""
 						styleButtonView = stylesView.children.get( 1 );
+						numberedListDropdown.render();
 
 						sinon.spy( editor, 'execute' );
 						sinon.spy( editor.editing.view, 'focus' );

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.js
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.js
@@ -61,7 +61,7 @@ export default class RestrictedEditingModeUI extends Plugin {
 				isOn: false
 			} );
 
-			this.listenTo( dropdownView, 'execute', evt => {
+			dropdownView.on( 'execute', evt => {
 				editor.execute( evt.source._commandName );
 				editor.editing.view.focus();
 			} );

--- a/packages/ckeditor5-style/src/styleui.js
+++ b/packages/ckeditor5-style/src/styleui.js
@@ -89,6 +89,12 @@ export default class StyleUI extends Plugin {
 				editor.execute( 'style', { styleName: evt.source.styleDefinition.name } );
 			} );
 
+			// Focus the editable after executing the command.
+			// Overrides a default behaviour where the focus is moved to the dropdown button (#12125).
+			dropdown.on( 'execute', () => {
+				editor.editing.view.focus();
+			} );
+
 			// Bind the state of the styles panel to the command.
 			panelView.bind( 'activeStyles' ).to( styleCommand, 'value' );
 			panelView.bind( 'enabledStyles' ).to( styleCommand, 'enabledStyles' );

--- a/packages/ckeditor5-style/tests/styleui.js
+++ b/packages/ckeditor5-style/tests/styleui.js
@@ -98,6 +98,7 @@ describe( 'StyleUI', () => {
 
 				testUtils.sinon.stub( editor, 'execute' );
 
+				dropdown.render();
 				dropdown.isOpen = true;
 
 				dropdown.panelView.children.first.fire( new EventInfo( buttonMock, 'execute' ) );
@@ -152,6 +153,7 @@ describe( 'StyleUI', () => {
 						}
 					};
 
+					dropdown.render();
 					dropdown.on( 'execute', spy );
 
 					panel.fire( new EventInfo( buttonMock, 'execute' ) );
@@ -166,6 +168,7 @@ describe( 'StyleUI', () => {
 						}
 					};
 
+					dropdown.render();
 					panel.fire( new EventInfo( buttonMock, 'execute' ) );
 
 					sinon.assert.calledOnceWithExactly( commandExecuteStub, 'style', { styleName: 'foo' } );

--- a/packages/ckeditor5-table/src/tablecaption/tablecaptionui.js
+++ b/packages/ckeditor5-table/src/tablecaption/tablecaptionui.js
@@ -63,6 +63,8 @@ export default class TableCaptionUI extends Plugin {
 						writer.addClass( 'table__caption_highlighted', figcaptionElement );
 					} );
 				}
+
+				editor.editing.view.focus();
 			} );
 
 			return view;

--- a/packages/ckeditor5-table/src/tableui.js
+++ b/packages/ckeditor5-table/src/tableui.js
@@ -8,7 +8,7 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core';
-import { addListToDropdown, createDropdown, Model, SplitButtonView } from 'ckeditor5/src/ui';
+import { addListToDropdown, createDropdown, Model, SplitButtonView, SwitchButtonView } from 'ckeditor5/src/ui';
 import { Collection } from 'ckeditor5/src/utils';
 
 import InsertTableView from './ui/inserttableview';
@@ -256,7 +256,11 @@ export default class TableUI extends Plugin {
 
 		this.listenTo( dropdownView, 'execute', evt => {
 			editor.execute( evt.source.commandName );
-			editor.editing.view.focus();
+
+			// Toggling a switch button view should not move the focus to the editable.
+			if ( !( evt.source instanceof SwitchButtonView ) ) {
+				editor.editing.view.focus();
+			}
 		} );
 
 		return dropdownView;

--- a/packages/ckeditor5-table/src/tableui.js
+++ b/packages/ckeditor5-table/src/tableui.js
@@ -254,7 +254,7 @@ export default class TableUI extends Plugin {
 			return areEnabled.some( isEnabled => isEnabled );
 		} );
 
-		this.listenTo( dropdownView, 'execute', evt => {
+		dropdownView.on( 'execute', evt => {
 			editor.execute( evt.source.commandName );
 
 			// Toggling a switch button view should not move the focus to the editable.
@@ -307,7 +307,7 @@ export default class TableUI extends Plugin {
 		} );
 
 		// Execute commands for events coming from the list in the dropdown panel.
-		this.listenTo( dropdownView, 'execute', evt => {
+		dropdownView.on( 'execute', evt => {
 			editor.execute( evt.source.commandName );
 			editor.editing.view.focus();
 		} );

--- a/packages/ckeditor5-table/src/ui/colorinputview.js
+++ b/packages/ckeditor5-table/src/ui/colorinputview.js
@@ -177,6 +177,11 @@ export default class ColorInputView extends View {
 		const colorPreview = new View();
 		const removeColorButton = this._createRemoveColorButton();
 
+		// The color picker is not focusable, so let's focus the input instead.
+		this.listenTo( colorGrid, 'execute', () => {
+			this._inputView.focus();
+		} );
+
 		colorPreview.setTemplate( {
 			tag: 'span',
 			attributes: {

--- a/packages/ckeditor5-table/tests/tableui.js
+++ b/packages/ckeditor5-table/tests/tableui.js
@@ -82,7 +82,7 @@ describe( 'TableUI', () => {
 
 			tableSizeView.rows = 2;
 			tableSizeView.columns = 7;
-
+			insertTable.render();
 			insertTable.fire( 'execute' );
 
 			sinon.assert.calledOnce( executeSpy );
@@ -193,9 +193,19 @@ describe( 'TableUI', () => {
 		it( 'should focus view after command execution', () => {
 			const focusSpy = testUtils.sinon.spy( editor.editing.view, 'focus' );
 
-			dropdown.listView.items.first.children.first.fire( 'execute' );
+			dropdown.render();
+			dropdown.listView.items.get( 2 ).children.last.fire( 'execute' );
 
 			sinon.assert.calledOnce( focusSpy );
+		} );
+
+		it( 'should not focus view after using a switchbutton', () => {
+			const focusSpy = testUtils.sinon.spy( editor.editing.view, 'focus' );
+
+			dropdown.render();
+			dropdown.listView.items.first.children.last.fire( 'execute' );
+
+			sinon.assert.notCalled( focusSpy );
 		} );
 
 		it( 'executes command when it\'s executed', () => {
@@ -330,9 +340,19 @@ describe( 'TableUI', () => {
 		it( 'should focus view after command execution', () => {
 			const focusSpy = testUtils.sinon.spy( editor.editing.view, 'focus' );
 
-			dropdown.listView.items.first.children.first.fire( 'execute' );
+			dropdown.render();
+			dropdown.listView.items.get( 2 ).children.first.fire( 'execute' );
 
 			sinon.assert.calledOnce( focusSpy );
+		} );
+
+		it( 'should not focus view after using a switchbutton', () => {
+			const focusSpy = testUtils.sinon.spy( editor.editing.view, 'focus' );
+
+			dropdown.render();
+			dropdown.listView.items.first.children.last.fire( 'execute' );
+
+			sinon.assert.notCalled( focusSpy );
 		} );
 
 		it( 'executes command when it\'s executed', () => {
@@ -519,6 +539,7 @@ describe( 'TableUI', () => {
 		it( 'should focus view after command execution', () => {
 			const focusSpy = testUtils.sinon.spy( editor.editing.view, 'focus' );
 
+			dropdown.render();
 			dropdown.listView.items.first.children.first.fire( 'execute' );
 
 			sinon.assert.calledOnce( focusSpy );
@@ -527,6 +548,7 @@ describe( 'TableUI', () => {
 		it( 'executes command when it\'s executed', () => {
 			const spy = sinon.stub( editor, 'execute' );
 
+			dropdown.render();
 			dropdown.listView.items.first.children.first.fire( 'execute' );
 
 			expect( spy.calledOnce ).to.be.true;

--- a/packages/ckeditor5-ui/src/dropdown/utils.js
+++ b/packages/ckeditor5-ui/src/dropdown/utils.js
@@ -316,7 +316,11 @@ function closeDropdownOnBlur( dropdownView ) {
 	} );
 }
 
-// Adds a behavior to a dropdownView that closes the dropdown view on "execute" event.
+// Adds a behavior to a dropdownView that closes the dropdown view
+// and passes the focus back to the buttonView on "execute" event.
+// It is done with a high priority to allow particular features to
+// override the default behavior (e.g. move the focus to the editor editable)
+// using a low-priority listener.
 //
 // @param {module:ui/dropdown/dropdownview~DropdownView} dropdownView
 function closeDropdownOnExecute( dropdownView ) {
@@ -327,8 +331,9 @@ function closeDropdownOnExecute( dropdownView ) {
 			return;
 		}
 
+		dropdownView.buttonView.focus();
 		dropdownView.isOpen = false;
-	} );
+	}, { priority: 'high' } );
 }
 
 // Adds a behavior to a dropdownView that focuses the dropdown's panel view contents on keystrokes.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (ui): Choosing an option from dropdown should return the focus to the dropdown. Closes #12125. Closes #12121.

---

### Additional information

This PR fixes all issues from the table in [https://github.com/ckeditor/ckeditor5/issues/12125#issuecomment-1194119103](https://github.com/ckeditor/ckeditor5/issues/12125#issuecomment-1194119103) except for:

*   Track changes - this should be covered with a separate PR in the respective repository.
*   WProofReader - this should be covered by the WProofReader team. cc @mlewand @Reinmar 

The main issue was with split buttons. Previously, when they were used, the focus was in the editable all the time - so they didn't have to return it.

This PR also slightly improves the accessibility of the color pickers in the table and cell properties. After a color is picked, the focus is moved to the color input. In `34.2.0` it was moved to the first popover field (so border style), and at the current `master` the focus goes to the document body.