### PR TITLE
Improve selecting enabled styles in styles dropdown refresh.

### DIFF
--- a/packages/ckeditor5-style/src/stylecommand.js
+++ b/packages/ckeditor5-style/src/stylecommand.js
@@ -270,9 +270,9 @@ function getAffectedBlocks( selectedBlocks, elementNames, schema ) {
 //
 // If there are multiple selected blocks we have two cases:
 // --- CASE 1 ---
-//	Multiple elements were selected with non-collapsed selection, then their
-//	common parent won't be in selection. Current logic of a command is to get
-//  enabled styles for the first element in a model for given selection, so let's
+// Multiple elements were selected with non-collapsed selection, then their
+// common parent won't be in selection. Current logic of a command is to get
+// enabled styles for the first element in a model for given selection, so let's
 // get the first element of selected blocks.
 
 //	--- CASE 2 ---

--- a/packages/ckeditor5-style/src/stylecommand.js
+++ b/packages/ckeditor5-style/src/stylecommand.js
@@ -8,7 +8,7 @@
  */
 
 import { Command } from 'ckeditor5/src/core';
-import { logWarning, first } from 'ckeditor5/src/utils';
+import { logWarning } from 'ckeditor5/src/utils';
 
 /**
  * Style command.
@@ -91,10 +91,20 @@ export default class StyleCommand extends Command {
 		}
 
 		// Block styles.
-		const firstBlock = first( selection.getSelectedBlocks() );
+		const selectedElement = selection.getSelectedElement();
+		const selectedBlocks = Array.from( selection.getSelectedBlocks() );
 
-		if ( firstBlock ) {
-			const ancestorBlocks = firstBlock.getAncestors( { includeSelf: true, parentFirst: true } );
+		// If there is a selected element it means that there is just a single tree of elements selected
+		// so we should start from the deepest block which is the last element from `getSelectedBlocks()`.
+		// Otherwise there could be neighbouring blocks selected for a non-collapsed selection - as we want
+		// to display enabled styles for a position where selection started, we should use first element from
+		// `getSelectedBlocks()`.
+		const index = selectedElement ? selectedBlocks.length - 1 : 0;
+
+		const startingBlock = selectedBlocks[ index ];
+
+		if ( startingBlock ) {
+			const ancestorBlocks = startingBlock.getAncestors( { includeSelf: true, parentFirst: true } );
 
 			for ( const block of ancestorBlocks ) {
 				// E.g. reached a model table when the selection is in a cell. The command should not modify

--- a/packages/ckeditor5-style/tests/stylecommand.js
+++ b/packages/ckeditor5-style/tests/stylecommand.js
@@ -822,6 +822,8 @@ describe( 'StyleCommand', () => {
 			} );
 
 			it( 'should not apply style on the not first element in selected element`', () => {
+				sinon.stub( console, 'warn' );
+
 				model.schema.register( 'div', { inheritAllFrom: '$block' } );
 				model.schema.extend( 'paragraph', { allowIn: [ 'div', 'paragraph' ] } );
 				model.schema.extend( 'heading1', { allowIn: 'div' } );

--- a/packages/ckeditor5-style/tests/stylecommand.js
+++ b/packages/ckeditor5-style/tests/stylecommand.js
@@ -775,6 +775,75 @@ describe( 'StyleCommand', () => {
 					'</div>'
 				);
 			} );
+
+			it( 'should apply a style to a element in a selection starting before element and ending inside`', () => {
+				model.schema.register( 'div', { inheritAllFrom: '$block' } );
+				model.schema.extend( 'paragraph', { allowIn: 'div' } );
+
+				editor.conversion.for( 'downcast' ).elementToElement( { view: 'div', model: 'div' } );
+
+				setData( model,
+					'<div>' +
+						'[<paragraph>Well hello there!]</paragraph>' +
+					'</div>'
+				);
+
+				command.execute( { styleName: 'Red paragraph' } );
+
+				expect( getData( model ) ).to.equal(
+					'<div>' +
+						'[<paragraph htmlAttributes="{"classes":["red"]}">Well hello there!]</paragraph>' +
+					'</div>'
+				);
+			} );
+
+			it( 'should apply style on the nested element in selected element`', () => {
+				model.schema.register( 'div', { inheritAllFrom: '$block' } );
+				model.schema.extend( 'paragraph', { allowIn: [ 'div', 'paragraph' ] } );
+				model.schema.extend( 'heading1', { allowIn: 'div' } );
+
+				editor.conversion.for( 'downcast' ).elementToElement( { view: 'div', model: 'div' } );
+
+				setData( model,
+					'[<div>' +
+						'<heading1>Foo</heading1>' +
+						'<paragraph>Bar</paragraph>' +
+					'</div>]'
+				);
+
+				command.execute( { styleName: 'Red heading' } );
+
+				expect( getData( model ) ).to.equal(
+					'<div>' +
+						'[<heading1 htmlAttributes="{"classes":["red"]}">Foo</heading1>' +
+						'<paragraph>Bar</paragraph>]' +
+					'</div>'
+				);
+			} );
+
+			it( 'should not apply style on the not first element in selected element`', () => {
+				model.schema.register( 'div', { inheritAllFrom: '$block' } );
+				model.schema.extend( 'paragraph', { allowIn: [ 'div', 'paragraph' ] } );
+				model.schema.extend( 'heading1', { allowIn: 'div' } );
+
+				editor.conversion.for( 'downcast' ).elementToElement( { view: 'div', model: 'div' } );
+
+				setData( model,
+					'[<div>' +
+						'<heading1>Foo</heading1>' +
+						'<paragraph>Bar</paragraph>' +
+					'</div>]'
+				);
+
+				command.execute( { styleName: 'Red paragraph' } );
+
+				expect( getData( model ) ).to.equal(
+					'<div>' +
+						'[<heading1>Foo</heading1>' +
+						'<paragraph>Bar</paragraph>]' +
+					'</div>'
+				);
+			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-style/tests/stylecommand.js
+++ b/packages/ckeditor5-style/tests/stylecommand.js
@@ -754,6 +754,27 @@ describe( 'StyleCommand', () => {
 					'<heading1>baz</heading1>'
 				);
 			} );
+
+			it( 'should apply a style to a selected element nested in a non-limit element`', () => {
+				model.schema.register( 'div', { inheritAllFrom: '$block' } );
+				model.schema.extend( 'paragraph', { allowIn: 'div' } );
+
+				editor.conversion.for( 'downcast' ).elementToElement( { view: 'div', model: 'div' } );
+
+				setData( model,
+					'<div>' +
+						'[<paragraph>Well hello there!</paragraph>]' +
+					'</div>'
+				);
+
+				command.execute( { styleName: 'Red paragraph' } );
+
+				expect( getData( model ) ).to.equal(
+					'<div>' +
+						'[<paragraph htmlAttributes="{"classes":["red"]}">Well hello there!</paragraph>]' +
+					'</div>'
+				);
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (style): Fixed selecting enabled block styles when a selection's range is on block element. Closes #12158.

---

### Additional information

https://github.com/ckeditor/ckeditor5/issues/12158#issuecomment-1196559680
