### PR TITLE
Fix (paste-from-office): Use innerText instead of innerHTML in filters/space

### DIFF
--- a/packages/ckeditor5-paste-from-office/src/filters/space.js
+++ b/packages/ckeditor5-paste-from-office/src/filters/space.js
@@ -41,7 +41,7 @@ export function normalizeSpacerunSpans( htmlDocument ) {
 	htmlDocument.querySelectorAll( 'span[style*=spacerun]' ).forEach( el => {
 		const innerTextLength = el.innerText.length || 0;
 
-		el.innerHTML = Array( innerTextLength + 1 ).join( '\u00A0 ' ).substr( 0, innerTextLength );
+		el.innerText = Array( innerTextLength + 1 ).join( '\u00A0 ' ).substr( 0, innerTextLength );
 	} );
 }
 

--- a/packages/ckeditor5-paste-from-office/tests/filters/space.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/space.js
@@ -136,6 +136,22 @@ describe( 'PasteFromOffice - filters', () => {
 
 				expect( htmlDocument.body.innerHTML.replace( /'/g, '"' ).replace( /: /g, ':' ) ).to.equal( expected );
 			} );
+
+			it( 'should use innerText setter instead of innerHTML', () => {
+				const input = '<span style=\'mso-spacerun:yes\'>   </span>';
+
+				const domParser = new DOMParser();
+				const htmlDocument = domParser.parseFromString( input, 'text/html' );
+
+				const spanElement = htmlDocument.getElementsByTagName( 'span' )[ 0 ];
+				const innerHTMLSpy = sinon.spy( spanElement, 'innerHTML', [ 'set' ] );
+				const innerTextSpy = sinon.spy( spanElement, 'innerText', [ 'set' ] );
+
+				normalizeSpacerunSpans( htmlDocument );
+
+				sinon.assert.notCalled( innerHTMLSpy.set );
+				sinon.assert.calledOnce( innerTextSpy.set );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message

Fix (paste-from-office): Use innerText instead of innerHTML in filters/space

---

### Additional information

This PR fixes one of the issues mentioned in #10845 .