### PR TITLE
Fix (ui): Use removeChild instead of innerHTML in icon/iconview

### DIFF
--- a/packages/ckeditor5-ui/src/icon/iconview.js
+++ b/packages/ckeditor5-ui/src/icon/iconview.js
@@ -103,7 +103,9 @@ export default class IconView extends View {
 				this.viewBox = viewBox;
 			}
 
-			this.element.innerHTML = '';
+			while ( this.element.firstChild ) {
+				this.element.removeChild( this.element.firstChild );
+			}
 
 			while ( svg.childNodes.length > 0 ) {
 				this.element.appendChild( svg.childNodes[ 0 ] );

--- a/packages/ckeditor5-ui/tests/icon/iconview.js
+++ b/packages/ckeditor5-ui/tests/icon/iconview.js
@@ -71,6 +71,20 @@ describe( 'IconView', () => {
 				view.content = '<svg version="1.1" viewBox="10 20 30 40" xmlns="http://www.w3.org/2000/svg"><g id="test"></g></svg>';
 				expect( view.viewBox ).to.equal( '10 20 30 40' );
 			} );
+
+			it( 'should use removeChild instead of innerHTML', () => {
+				view.content = '<svg><g id="test"></g><g id="test"></g></svg>';
+				assertIconInnerHTML( view, '<g id="test"></g><g id="test"></g>' );
+
+				const innerHTMLSpy = sinon.spy( view.element, 'innerHTML', [ 'set' ] );
+				const removeChildSpy = sinon.spy( view.element, 'removeChild' );
+
+				view.content = '<svg><g id="test"></g></svg>';
+				assertIconInnerHTML( view, '<g id="test"></g>' );
+
+				sinon.assert.notCalled( innerHTMLSpy.set );
+				sinon.assert.calledTwice( removeChildSpy );
+			} );
 		} );
 
 		describe( 'fill color', () => {


### PR DESCRIPTION
### Suggested merge commit message

Fix (ui): Use removeChild instead of innerHTML in icon/iconview

---

### Additional information

This PR fixes one of the issues mentioned in #10845 .