### PR TITLE
Fix removing tables

### DIFF
--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -27,7 +27,7 @@ import {
 	clamp,
 	fillArray,
 	sumArray,
-	getAffectedTables,
+	getChangedTables,
 	getColumnIndex,
 	getColumnMinWidthAsPercentage,
 	getElementWidthInPixels,
@@ -215,7 +215,7 @@ export default class TableColumnResizeEditing extends Plugin {
 
 			let changed = false;
 
-			for ( const table of getAffectedTables( changes, editor.model ) ) {
+			for ( const table of getChangedTables( changes, editor.model ) ) {
 				// (1) Adjust the `columnWidths` attribute to guarantee that the sum of the widths from all columns is 100%.
 				// It's an array at this point.
 				const columnWidths = normalizeColumnWidths( table.getAttribute( 'columnWidths' ).split( ',' ) );

--- a/packages/ckeditor5-table/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/utils.js
@@ -33,8 +33,15 @@ export function getAffectedTables( changes, model ) {
 		// - an attribute change on a table, a row or a cell.
 		switch ( change.type ) {
 			case 'insert':
-			case 'remove':
 				referencePosition = [ 'table', 'tableRow', 'tableCell' ].includes( change.name ) ?
+					change.position :
+					null;
+
+				break;
+
+			case 'remove':
+				// If the whole table is removed, we won't update its column widths.
+				referencePosition = [ 'tableRow', 'tableCell' ].includes( change.name ) ?
 					change.position :
 					null;
 

--- a/packages/ckeditor5-table/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/utils.js
@@ -24,7 +24,7 @@ import {
  * @param {module:engine/model/model~Model} model
  * @returns {Set.<module:engine/model/element~Element>}
  */
-export function getAffectedTables( changes, model ) {
+export function getChangedTables( changes, model ) {
 	const affectedTables = new Set();
 
 	for ( const change of changes ) {

--- a/packages/ckeditor5-table/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/utils.js
@@ -15,8 +15,10 @@ import {
 } from './constants';
 
 /**
- * Collects all table model elements affected by the differ. Only tables with 'columnsWidth' attribute
- * are taken into account. The returned set may be empty.
+ * Returns all the inserted or changed table model elements in a given change set. Only the tables
+ * with 'columnsWidth' attribute are taken into account. The returned set may be empty.
+ *
+ * Most notably if an entire table is removed it will not be included in returned set.
  *
  * @param {Array.<module:engine/model/differ~DiffItem>} changes
  * @param {module:engine/model/model~Model} model
@@ -40,7 +42,7 @@ export function getAffectedTables( changes, model ) {
 				break;
 
 			case 'remove':
-				// If the whole table is removed, we won't update its column widths.
+				// If the whole table is removed, there's no need to update its column widths (#12201).
 				referencePosition = [ 'tableRow', 'tableCell' ].includes( change.name ) ?
 					change.position :
 					null;

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -2326,6 +2326,24 @@ describe( 'TableColumnResizeEditing', () => {
 						'</table>'
 					);
 				} );
+
+				it( 'when table is being removed', () => {
+					setModelData( model,
+						'[<table columnWidths="100%" tableWidth="100%">' +
+							'<tableRow>' +
+								'<tableCell>' +
+									'<paragraph>' +
+										'foo' +
+									'</paragraph>' +
+								'</tableCell>' +
+							'</tableRow>' +
+						'</table>]'
+					);
+
+					model.deleteContent( model.document.selection );
+
+					expect( getModelData( model ) ).to.equal( '<paragraph>[]</paragraph>' );
+				} );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-table/tests/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/utils.js
@@ -404,7 +404,7 @@ describe( 'TableColumnResize utils', () => {
 			let range;
 
 			// To test the getChangedTables(), when the attribute is being removed we need
-			// to frist insert the text inside one of the table cells.
+			// to first insert the text inside one of the table cells.
 			model.change( () => {
 				insert(
 					model,
@@ -417,7 +417,7 @@ describe( 'TableColumnResize utils', () => {
 				attribute( model, range, 'linkHref', null, 'www' );
 			} );
 
-			// And in a different model.change() remove the attribute, beacuse otherwise the changes would be empty.
+			// And in a different model.change() remove the attribute, because otherwise the changes would be empty.
 			model.change( () => {
 				attribute( model, range, 'linkHref', 'www', null );
 				const changes = differ.getChanges();

--- a/packages/ckeditor5-table/tests/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/utils.js
@@ -344,6 +344,35 @@ describe( 'TableColumnResize utils', () => {
 			} );
 		} );
 
+		it( 'should not find affected table - table removal', () => {
+			model.change( () => {
+				remove( model, new Position( root, [ 0 ] ), 1 );
+
+				const changes = differ.getChanges();
+				const affectedTables = getAffectedTables( changes, model );
+
+				expect( affectedTables.size ).to.equal( 0 );
+			} );
+		} );
+
+		it( 'should not find affected table - table replacement', () => {
+			model.change( () => {
+				remove( model, new Position( root, [ 0 ] ), 1 );
+
+				// Table plugin inserts a paragraph when a table is removed - #12201.
+				insert(
+					model,
+					new Element( 'paragraph' ),
+					new Position( root, [ 0 ] )
+				);
+
+				const changes = differ.getChanges();
+				const affectedTables = getAffectedTables( changes, model );
+
+				expect( affectedTables.size ).to.equal( 0 );
+			} );
+		} );
+
 		it( 'should not find any affected table if operation is not related to a table, row or cell element', () => {
 			model.change( () => {
 				insert(

--- a/packages/ckeditor5-table/tests/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/utils.js
@@ -20,7 +20,7 @@ import AttributeOperation from '@ckeditor/ckeditor5-engine/src/model/operation/a
 
 import TableColumnResize from '../../src/tablecolumnresize';
 import {
-	getAffectedTables,
+	getChangedTables,
 	getColumnIndex,
 	toPrecision,
 	clamp,
@@ -34,7 +34,7 @@ import {
 /* globals window, document */
 
 describe( 'TableColumnResize utils', () => {
-	describe( 'getAffectedTables()', () => {
+	describe( 'getChangedTables()', () => {
 		let differ, root, model;
 
 		beforeEach( () => {
@@ -58,7 +58,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 0 );
 			} );
@@ -79,7 +79,7 @@ describe( 'TableColumnResize utils', () => {
 				attribute( model, range, 'attrName', null, 'attrVal' );
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 0 );
 			} );
@@ -102,7 +102,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -126,7 +126,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -144,7 +144,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -162,7 +162,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -186,7 +186,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -210,7 +210,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -228,7 +228,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -246,7 +246,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -262,7 +262,7 @@ describe( 'TableColumnResize utils', () => {
 				attribute( model, range, 'attrName', null, 'attrVal' );
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -278,7 +278,7 @@ describe( 'TableColumnResize utils', () => {
 				attribute( model, range, 'attrName', null, 'attrVal' );
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -294,7 +294,7 @@ describe( 'TableColumnResize utils', () => {
 				attribute( model, range, 'attrName', null, 'attrVal' );
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 1 );
 				expect( affectedTables.has( firstTable ) ).to.be.true;
@@ -335,7 +335,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 3 );
 				expect( affectedTables.has( firstTable ), 'first table is affected' ).to.be.true;
@@ -349,7 +349,7 @@ describe( 'TableColumnResize utils', () => {
 				remove( model, new Position( root, [ 0 ] ), 1 );
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 0 );
 			} );
@@ -367,7 +367,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 0 );
 			} );
@@ -394,7 +394,7 @@ describe( 'TableColumnResize utils', () => {
 				);
 
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 0 );
 			} );
@@ -403,7 +403,7 @@ describe( 'TableColumnResize utils', () => {
 		it( 'should not find any affected table if it was a text formatting removal operation', () => {
 			let range;
 
-			// To test the getAffectedTables(), when the attribute is being removed we need
+			// To test the getChangedTables(), when the attribute is being removed we need
 			// to frist insert the text inside one of the table cells.
 			model.change( () => {
 				insert(
@@ -421,7 +421,7 @@ describe( 'TableColumnResize utils', () => {
 			model.change( () => {
 				attribute( model, range, 'linkHref', 'www', null );
 				const changes = differ.getChanges();
-				const affectedTables = getAffectedTables( changes, model );
+				const affectedTables = getChangedTables( changes, model );
 
 				expect( affectedTables.size ).to.equal( 0 );
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (table): Fixed removing tables from the editor. Closes #12201.

---

### Additional information

As described in the issue, previously this was handled by the `if` statement located in https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-table/src/tablecolumnresize/utils.js#L60. Writing the unit tests revealed though that this solution works because of a coincidence.

When a table is removed, the table plugin immediately inserts a paragraph instead. That means that (fortunately) there is always a paragraph as a `position.nodeAfter`, so the removed table is not classified as "affected" by change. However, if that behaviour is altered (i.e. a paragraph won't be inserted) and there will be another table right after a removed one, the code will classify that second table as affected - which is not true.

For that reason there are two unit tests - one performing a "pure" table removal, and one that mimics  the table plugin behaviour, so inserting a paragraph (effectively replacing the table). As the previous solution didn't work for the first test, I proposed a more general fix.