### PR TITLE
Enable table column resize feature in GHS

### DIFF
--- a/packages/ckeditor5-html-support/src/schemadefinitions.js
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.js
@@ -164,6 +164,23 @@ export default {
 			}
 		},
 		{
+			model: 'htmlColgroup',
+			view: 'colgroup',
+			modelSchema: {
+				allowIn: 'htmlTable',
+				allowChildren: 'col',
+				isBlock: true
+			}
+		},
+		{
+			model: 'htmlCol',
+			view: 'col',
+			modelSchema: {
+				allowIn: 'htmlColgroup',
+				isBlock: true
+			}
+		},
+		{
 			model: 'htmlTr',
 			view: 'tr',
 			modelSchema: {

--- a/packages/ckeditor5-html-support/tests/manual/ghs-all-features.html
+++ b/packages/ckeditor5-html-support/tests/manual/ghs-all-features.html
@@ -105,6 +105,31 @@
 				</tbody>
 			</table>
 
+			<figure class="table" style="width:100%;">
+				<table class="ck-table-resized">
+					<colgroup>
+						<col style="width:8.74%;">
+						<col style="width:8.94%;">
+						<col style="width:10.02%;">
+						<col style="width:72.3%;">
+					</colgroup>
+					<tbody>
+						<tr>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td>pre-resized table</td>
+						</tr>
+						<tr>
+							<td></td>
+							<td></td>
+							<td></td>
+							<td></td>
+						</tr>
+					</tbody>
+				</table>
+			</figure>
+
 			<oembed data-bar url="https://www.youtube.com/watch?v=ZVv7UMQPEWk"></oembed>
 
 			<div style="border: 1px solid blue" class="raw-html-embed">HTML snippet</div>

--- a/packages/ckeditor5-html-support/tests/manual/ghs-all-features.js
+++ b/packages/ckeditor5-html-support/tests/manual/ghs-all-features.js
@@ -30,6 +30,7 @@ import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting'
 import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties';
 import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties';
 import TableCaption from '@ckeditor/ckeditor5-table/src/tablecaption';
+import TableColumnResize from '@ckeditor/ckeditor5-table/src/tablecolumnresize';
 import TodoList from '@ckeditor/ckeditor5-list/src/todolist';
 import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
 import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices';
@@ -43,7 +44,7 @@ ClassicEditor
 			ArticlePluginSet, Underline, Strikethrough, Superscript, Subscript, Code,
 			FontColor, FontBackgroundColor, FontFamily, FontSize, Highlight,
 			CodeBlock, TodoList, ListProperties, TableProperties, TableCellProperties, TableCaption,
-			EasyImage, ImageResize, LinkImage, HtmlEmbed,
+			TableColumnResize, EasyImage, ImageResize, LinkImage, HtmlEmbed,
 			Alignment, IndentBlock,
 			PageBreak, HorizontalLine,
 			ImageUpload, CloudServices,

--- a/packages/ckeditor5-table/src/tablecolumnresize/converters.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/converters.js
@@ -76,6 +76,7 @@ export function downcastTableColumnWidthsAttribute() {
 			// OTOH the model element has the attribute already applied, so we can't compare the values.
 			// Hence we need to just recreate the <colgroup> element every time.
 			insertColgroupElement( viewWriter, viewTable, data.attributeNewValue );
+			viewWriter.addClass( 'ck-table-resized', viewTable );
 		} else {
 			removeColgroupElement( viewWriter, viewTable );
 			viewWriter.removeClass( 'ck-table-resized', viewTable );

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -599,8 +599,8 @@ export default class TableColumnResizeEditing extends Plugin {
 				// In read-only mode revert all changes in the editing view. The model is not touched so it does not need to be restored.
 				// This case can occur if the read-only mode kicks in during the resizing process.
 				editingView.change( writer => {
-					// If table was already resized before, restore the previous column widths.
-					// Otherwise clean up the view from the temporary resizing markup.
+					// If table had resized columns before, restore the previous column widths.
+					// Otherwise clean up the view from the temporary column resizing markup.
 					if ( columnWidthsAttributeOld ) {
 						const columnWidths = columnWidthsAttributeOld.split( ',' );
 
@@ -612,8 +612,8 @@ export default class TableColumnResizeEditing extends Plugin {
 					}
 
 					if ( isTableWidthAttributeChanged ) {
-						// If table was already resized before, restore the previous table width.
-						// Otherwise clean up the view from the temporary resizing markup.
+						// If the whole table was already resized before, restore the previous table width.
+						// Otherwise clean up the view from the temporary table resizing markup.
 						if ( tableWidthAttributeOld ) {
 							writer.setStyle( 'width', tableWidthAttributeOld, viewFigure );
 						} else {
@@ -621,6 +621,8 @@ export default class TableColumnResizeEditing extends Plugin {
 						}
 					}
 
+					// If a table and its columns weren't resized before,
+					// prune the remaining common resizing markup.
 					if ( !columnWidthsAttributeOld && !tableWidthAttributeOld ) {
 						writer.removeClass(
 							'ck-table-resized',

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.js
@@ -599,7 +599,6 @@ export default class TableColumnResizeEditing extends Plugin {
 							writer.setStyle( 'width', columnWidths.shift(), viewCol );
 						}
 					} else {
-						writer.removeClass( 'ck-table-resized', viewColgroup.findAncestor( 'table' ) );
 						writer.remove( viewColgroup );
 					}
 
@@ -610,11 +609,14 @@ export default class TableColumnResizeEditing extends Plugin {
 							writer.setStyle( 'width', tableWidthAttributeOld, viewFigure );
 						} else {
 							writer.removeStyle( 'width', viewFigure );
-							writer.removeClass(
-								'ck-table-resized',
-								[ ...viewFigure.getChildren() ].find( element => element.name === 'table' )
-							);
 						}
+					}
+
+					if ( !columnWidthsAttributeOld && !tableWidthAttributeOld ) {
+						writer.removeClass(
+							'ck-table-resized',
+							[ ...viewFigure.getChildren() ].find( element => element.name === 'table' )
+						);
 					}
 				} );
 			}

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -402,7 +402,7 @@ describe( 'TableColumnResizeEditing', () => {
 
 				expect( editor.getData() ).to.equal(
 					'<figure class="table" style="width:100%;">' +
-						'<table>' +
+						'<table class="ck-table-resized">' +
 							'<colgroup>' +
 								'<col style="width:50%;">' +
 								'<col style="width:50%;">' +
@@ -452,7 +452,7 @@ describe( 'TableColumnResizeEditing', () => {
 
 				expect( editor.getData() ).to.equal(
 					'<figure class="table" style="width:100%;">' +
-						'<table>' +
+						'<table class="ck-table-resized">' +
 							'<colgroup>' +
 								'<col style="width:50%;">' +
 								'<col style="width:50%;">' +

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -18,6 +18,7 @@ import { getData as getModelData, setData as setModelData } from '@ckeditor/cked
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import LinkEditing from '@ckeditor/ckeditor5-link/src/linkediting';
 import HighlightEditing from '@ckeditor/ckeditor5-highlight/src/highlightediting';
+import GeneralHtmlSupport from '@ckeditor/ckeditor5-html-support/src/generalhtmlsupport';
 
 import { focusEditor } from '@ckeditor/ckeditor5-widget/tests/widgetresize/_utils/utils';
 import { modelTable } from '../_utils/utils';
@@ -2502,6 +2503,71 @@ describe( 'TableColumnResizeEditing', () => {
 
 					expect( getModelData( model ) ).to.equal( '<paragraph>[]</paragraph>' );
 				} );
+			} );
+		} );
+
+		describe( 'GHS', () => {
+			it( 'should not filter out the <colgroup> element', async () => {
+				const ghsEditor = await createEditor( {
+					plugins: [ Table, TableColumnResize, Paragraph, WidgetResize, GeneralHtmlSupport ],
+					htmlSupport: {
+						allow: [
+							{
+								name: /^.*$/,
+								styles: true,
+								attributes: true,
+								classes: true
+							}
+						]
+					}
+				} );
+
+				ghsEditor.setData( `<figure class="table">
+					<table>
+						<colgroup>
+							<col style="width:33.33%;">
+							<col style="width:33.33%;">
+							<col style="width:33.34%;">
+						</colgroup>
+						<tbody>
+							<tr>
+								<td>test</td>
+								<td>&nbsp;</td>
+								<td>&nbsp;</td>
+							</tr>
+						</tbody>
+					</table>
+				</figure>` );
+
+				expect( ghsEditor.editing.view.getDomRoot().innerHTML.includes( 'data-ck-unsafe-element' ) ).to.be.false;
+			} );
+
+			it( 'should save and load data correctly', async () => {
+				const ghsEditor = await createEditor( {
+					plugins: [ Table, TableColumnResize, Paragraph, WidgetResize, GeneralHtmlSupport ],
+					htmlSupport: {
+						allow: [
+							{
+								name: /^.*$/,
+								styles: true,
+								attributes: true,
+								classes: true
+							}
+						]
+					}
+				} );
+
+				setModelData( ghsEditor.model, modelTable( [
+					[ '[00', '01', '02]' ]
+				], { tableWidth: '80%', columnWidths: '25%,25%,50%' } ) );
+
+				const initialViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( ghsEditor.editing.view ) );
+
+				ghsEditor.setData( ghsEditor.getData() );
+
+				const finalViewColumnWidthsPx = getViewColumnWidthsPx( getDomTable( ghsEditor.editing.view ) );
+
+				expect( initialViewColumnWidthsPx ).to.deep.equal( finalViewColumnWidthsPx );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -2506,9 +2506,11 @@ describe( 'TableColumnResizeEditing', () => {
 			} );
 		} );
 
-		describe( 'GHS', () => {
-			it( 'should not filter out the <colgroup> element', async () => {
-				const ghsEditor = await createEditor( {
+		describe( 'GHS integration', () => {
+			let ghsEditor;
+
+			beforeEach( async () => {
+				ghsEditor = await createEditor( {
 					plugins: [ Table, TableColumnResize, Paragraph, WidgetResize, GeneralHtmlSupport ],
 					htmlSupport: {
 						allow: [
@@ -2521,7 +2523,13 @@ describe( 'TableColumnResizeEditing', () => {
 						]
 					}
 				} );
+			} );
 
+			afterEach( async () => {
+				await ghsEditor.destroy();
+			} );
+
+			it( 'doesn\'t consider <colgroup> / <col> to be unsafe elements', () => {
 				ghsEditor.setData( `<figure class="table">
 					<table>
 						<colgroup>
@@ -2542,21 +2550,8 @@ describe( 'TableColumnResizeEditing', () => {
 				expect( ghsEditor.editing.view.getDomRoot().innerHTML.includes( 'data-ck-unsafe-element' ) ).to.be.false;
 			} );
 
-			it( 'should save and load data correctly', async () => {
-				const ghsEditor = await createEditor( {
-					plugins: [ Table, TableColumnResize, Paragraph, WidgetResize, GeneralHtmlSupport ],
-					htmlSupport: {
-						allow: [
-							{
-								name: /^.*$/,
-								styles: true,
-								attributes: true,
-								classes: true
-							}
-						]
-					}
-				} );
-
+			it( 'should save and load data correctly', () => {
+				// (#12191)
 				setModelData( ghsEditor.model, modelTable( [
 					[ '[00', '01', '02]' ]
 				], { tableWidth: '80%', columnWidths: '25%,25%,50%' } ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table,html-support): Fixed table column resize integration with General HTML Support. Closes #12191.

---

### Additional information

It's a two-parts fix:

1.  On the GHS side, it adds the `colgroup` and `col` elements schema. It resolves the issue where these elements were filtered out as `unsafe`. Please note that it only happened after using `editor.setData()` - if you just open a demo and insert a table, it can be resized normally.
2.  On the table column resize feature the `ck-table-resized` CSS class handling had to be improved as it was not always present when it should be. It was causing incorrect table rendering during the upcast in some cases (e.g. for a resized table with a lot of text in cell). Also it didn't work well for a table with `<colgroup>` element but without `width` attribute in the editor that was turned into read-only mode during resizing - the class was removed while it should stay intact (there is a unit test for that case - `if tableWidth was set for the first time`).

### Testing

PR should be tested against the epic branch it is targeted into - [ck/**epic**/11857-table-resize-improvements](https://github.com/ckeditor/ckeditor5/compare/ck/epic/11857-table-resize-improvements...ck/12191-table-resize-ghs?expand=1). **Please note that the behaviour on that branch can be different than on the `master` one, but it is still broken.** 

I created a separate branch to facilitate testing: `ck/12191-table-resize-ghs-testing`. Changes:

*   Unit tests - all table column resize tests are focused, so you can just run `yarn test -f table -wc`.
*   Manual tests:
    *   Primary focus should be put on http://localhost:8125/ckeditor5-html-support/tests/manual/ghs-all-features.html test. There is a table column resize feature included. Also there is already a resized table in the content. 
    *   Secondary focus - in http://localhost:8125/ckeditor5-table/tests/manual/tablecolumnresize.html I've adjusted it to test the case with enabling read-only that I described above - it:
        *   has a table with `<colgroup>` element but without `width` attribute,
        *   the editor turns into read-only mode after 2 seconds.