### PR TITLE
Move focus to editable after inserting image

### DIFF
--- a/packages/ckeditor5-image/src/imageupload/imageuploadui.js
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadui.js
@@ -59,6 +59,8 @@ export default class ImageUploadUI extends Plugin {
 
 				if ( imagesToUpload.length ) {
 					editor.execute( 'uploadImage', { file: imagesToUpload } );
+
+					editor.editing.view.focus();
 				}
 			} );
 

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadui.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadui.js
@@ -191,4 +191,16 @@ describe( 'ImageUploadUI', () => {
 		expect( executeStub.firstCall.args[ 0 ] ).to.equal( 'uploadImage' );
 		expect( executeStub.firstCall.args[ 1 ].file ).to.deep.equal( [ files[ 0 ] ] );
 	} );
+
+	it( 'should move focus to editable after executing the command', () => {
+		const spy = sinon.spy( editor.editing.view, 'focus' );
+		const button = editor.ui.componentFactory.create( 'uploadImage' );
+		const file = [ createNativeFileMock() ];
+
+		setModelData( model, '<paragraph>f[]oo</paragraph>' );
+
+		button.fire( 'done', file );
+
+		expect( spy ).to.be.calledOnce;
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (image): Fixed the focus after inserting an image - it is now moved moved to editable. Closes #12229.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._