### PR TITLE
Fixed balloon block toolbar not closing on click

### DIFF
--- a/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.js
+++ b/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.js
@@ -271,11 +271,21 @@ export default class BlockToolbar extends Plugin {
 		const editor = this.editor;
 		const t = editor.t;
 		const buttonView = new BlockButtonView( editor.locale );
+		const buttonBind = buttonView.bindTemplate;
 
 		buttonView.set( {
 			label: t( 'Edit block' ),
 			icon: pilcrow,
 			withText: false
+		} );
+
+		buttonView.extendTemplate( {
+			on: {
+				mousedown: buttonBind.to( evt => {
+					// Workaround to #12184, see https://github.com/ckeditor/ckeditor5/issues/12184#issuecomment-1199147964.
+					evt.preventDefault();
+				} )
+			}
 		} );
 
 		// Bind the panelView observable properties to the buttonView.

--- a/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.js
+++ b/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.js
@@ -25,6 +25,7 @@ import normalizeToolbarConfig from '../normalizetoolbarconfig';
 import ResizeObserver from '@ckeditor/ckeditor5-utils/src/dom/resizeobserver';
 
 import toUnit from '@ckeditor/ckeditor5-utils/src/dom/tounit';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 const toPx = toUnit( 'px' );
 
@@ -282,6 +283,10 @@ export default class BlockToolbar extends Plugin {
 		buttonView.extendTemplate( {
 			on: {
 				mousedown: buttonBind.to( evt => {
+					// Workaround to #12115.
+					if ( env.isSafari ) {
+						this.toolbarView.focus();
+					}
 					// Workaround to #12184, see https://github.com/ckeditor/ckeditor5/issues/12184#issuecomment-1199147964.
 					evt.preventDefault();
 				} )

--- a/packages/ckeditor5-ui/tests/toolbar/block/blocktoolbar.js
+++ b/packages/ckeditor5-ui/tests/toolbar/block/blocktoolbar.js
@@ -27,6 +27,7 @@ import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 import Rect from '@ckeditor/ckeditor5-utils/src/dom/rect';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 describe( 'BlockToolbar', () => {
 	let editor, element, blockToolbar;
@@ -300,6 +301,32 @@ describe( 'BlockToolbar', () => {
 			const ret = blockToolbar.buttonView.element.dispatchEvent( new Event( 'mousedown', { cancelable: true } ) );
 
 			expect( ret ).to.false;
+		} );
+
+		describe( 'in Safari', () => {
+			let view, stub;
+
+			beforeEach( () => {
+				stub = testUtils.sinon.stub( env, 'isSafari' ).value( true );
+				view = blockToolbar.buttonView;
+			} );
+
+			afterEach( () => {
+				stub.resetBehavior();
+			} );
+
+			it( 'the toolbar is focused', () => {
+				const spy = sinon.spy( blockToolbar.toolbarView, 'focus' );
+				view.element.dispatchEvent( new Event( 'mousedown', { cancelable: true } ) );
+
+				expect( spy.callCount ).to.equal( 1 );
+			} );
+
+			it( 'the event is prevented', () => {
+				const ret = view.element.dispatchEvent( new Event( 'mousedown', { cancelable: true } ) );
+
+				expect( ret ).to.false;
+			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-ui/tests/toolbar/block/blocktoolbar.js
+++ b/packages/ckeditor5-ui/tests/toolbar/block/blocktoolbar.js
@@ -295,6 +295,12 @@ describe( 'BlockToolbar', () => {
 				expect( blockToolbar.buttonView.isVisible ).to.be.false;
 			} );
 		} );
+
+		it( 'should prevent the mousedown event', () => {
+			const ret = blockToolbar.buttonView.element.dispatchEvent( new Event( 'mousedown', { cancelable: true } ) );
+
+			expect( ret ).to.false;
+		} );
 	} );
 
 	describe( 'allowed elements', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (ui): Block toolbar can now be closed correctly with a mouse click. Closes #12184.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
