### PR TITLE
Docs: Removed unnecessary links to API from timestamp and abbreviation tutorials. 

### DIFF
--- a/docs/framework/guides/creating-simple-plugin-timestamp.md
+++ b/docs/framework/guides/creating-simple-plugin-timestamp.md
@@ -18,7 +18,7 @@ The editor has already been created in the `app.js` file with some basic plugins
 
 The webpack is also already configured, so you can just use the `npm run build` command to build your application. Whenever you want to check anything in the browser, save the changes and run build again. Then, refresh the page in your browser (remember to turn off caching, so that new changes are displayed instantly).
 
-If you want to set up the project yourself, you should follow the steps listed in the {@link framework/guides/quick-start the "Quick start" section}. Additionally, you will need to install the [`@ckeditor/ckeditor5-core`](https://www.npmjs.com/package/@ckeditor/ckeditor5-core) package, which contains the {@link module:core/plugin~Plugin} class, and the [`@ckeditor/ckeditor5-ui`](https://www.npmjs.com/package/@ckeditor/ckeditor5-ui) package, which contains the UI library and the framework.
+If you want to set up the project yourself, you should follow the steps listed in the {@link framework/guides/quick-start the "Quick start" section}. Additionally, you will need to install the [`@ckeditor/ckeditor5-core`](https://www.npmjs.com/package/@ckeditor/ckeditor5-core) package, which contains the `Plugin` class, and the [`@ckeditor/ckeditor5-ui`](https://www.npmjs.com/package/@ckeditor/ckeditor5-ui) package, which contains the UI library and the framework.
 
 We are going to write the whole plugin in your base `app.js` file. It should look like the code listed below. There maybe a couple of different imports if you chose to set up the environment yourself.
 
@@ -68,9 +68,9 @@ Your `index.html` should look as listed below. The editor will load with HTML co
 
 ## Creating a plugin
 
-All features in the CKEditor 5 are powered by plugins. In order to create our custom timestamp plugin, we need to import the {@link module:core/plugin~Plugin base `Plugin` class}.
+All features in the CKEditor 5 are powered by plugins. In order to create our custom timestamp plugin, we need to import the base `Plugin` class.
 
-We can now create a `Timestamp` class that extends the basic `Plugin` class. After we define it, we can add it into the editor's {@link module:core/editor/editorconfig~EditorConfig#plugins `config.plugins`} array.
+We can now create a `Timestamp` class that extends the basic `Plugin` class. After we define it, we can add it into the editor's plugins array.
 
 ```js
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
@@ -111,11 +111,11 @@ Rebuild the editor and check in your console whether the timestamp was initializ
 
 ## Registering a toolbar button
 
-CKEditor 5 has a rich UI library. Form it, we will grab the {@link module:ui/button/buttonview~ButtonView `ButtonView`} class for our toolbar button.
+CKEditor 5 has a rich UI library. From it, we will grab the `ButtonView` class for our toolbar button.
 
-Once we create a new instance of the `ButtonView`, we will be able to customize it by setting its properties. We will create a label, which will be visible on the button thanks to the {@link module:ui/button/buttonview~ButtonView#withText `withText`} property.
+Once we create a new instance of the `ButtonView`, we will be able to customize it by setting its properties. We will create a label, which will be visible on the button thanks to the `withText` property.
 
-We also need to register our button in the editor's UI {@link module:ui/componentfactory~ComponentFactory `componentFactory`}, so it can be displayed in the toolbar. To do it, we will pass the name of the button in the {@link module:ui/componentfactory~ComponentFactory#add `componentFactory.add`} method, in order to be able to add it into the {@link features/toolbar `config.toolbar`} array.
+We also need to register our button in the editor's UI `componentFactory`, so it can be displayed in the toolbar. To do it, we will pass the name of the button in the `componentFactory.add` method, in order to be able to add it into the {@link features/toolbar toolbar} array.
 
 ```js
 // ...
@@ -166,13 +166,13 @@ You should be able to see the timestamp button now. It doesn't do anything just 
 
 We can now define the core functionality of our plugin &ndash; the action that should be executed once our button is clicked.
 
-In order to insert anything into the document structure, we need to {@link framework/guides/architecture/editing-engine#changing-the-model change the model} using the model's `change()` method. This way we get access to the {@link module:engine/model/writer~Writer model writer}.
+In order to insert anything into the document structure, we need to {@link framework/guides/architecture/editing-engine#changing-the-model change the model} using the model's `change()` method. This way we get access to the model writer.
 
 <info-box>
 	What is the model? It is a DOM-like structure, that is converted into the view, which is the layer that the user interacts with. You can read more about {@link framework/guides/architecture/editing-engine#model the model} and {@link framework/guides/architecture/editing-engine#view the view} in dedicated guides.
 </info-box>
 
-We will use the {@link module:engine/model/model~Model#insertContent `insertContent()`} method to insert our timestamp into the document. Inside, we just need to create a new text node with the {@link module:engine/model/writer~Writer#createText `writer.createText()`} method.
+We will use the `insertContent()` method to insert our timestamp into the document. Inside, we just need to create a new text node with the  `writer.createText()` method.
 
 ```js
 class Timestamp extends Plugin {

--- a/docs/framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-1.md
+++ b/docs/framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-1.md
@@ -27,7 +27,7 @@ The webpack is also already configured, so you can just use the `npm run build` 
 	Our starter files come with the {@link framework/guides/development-tools#ckeditor-5-inspector CKEditor 5 Inspector} attached to the editor, so you can easily debug and observe what is happening in the model and the view layers. It will give you tons of useful information about the state of the editor such as internal data structures, selection, commands, and many more.
 </info-box>
 
-If you want to set up the project yourself, you should follow the steps listed in the {@link framework/guides/quick-start the "Quick start" section}. Additionally, you will need to install the [`@ckeditor/ckeditor5-core`](https://www.npmjs.com/package/@ckeditor/ckeditor5-core) package, which contains the {@link module:core/plugin~Plugin} class, and the [`@ckeditor/ckeditor5-ui`](https://www.npmjs.com/package/@ckeditor/ckeditor5-ui) package, which contains the UI library and the framework.
+If you want to set up the project yourself, you should follow the steps listed in the {@link framework/guides/quick-start the "Quick start" section}. Additionally, you will need to install the [`@ckeditor/ckeditor5-core`](https://www.npmjs.com/package/@ckeditor/ckeditor5-core) package, which contains the `Plugin` class, and the [`@ckeditor/ckeditor5-ui`](https://www.npmjs.com/package/@ckeditor/ckeditor5-ui) package, which contains the UI library and the framework.
 
 Your entry point to the plugin is `app.js`:
 
@@ -204,7 +204,7 @@ We can do it by defining the model's schema. Thanks to a couple lines of code, w
 	Schema defines what is allowed in the model in terms of structures, attributes, and other characteristics. This information is then used by the features and the engine to make decisions on how to process the model, so it is crucial that your custom plugins have a well-defined schema. Read more about it in our {@link framework/guides/architecture/editing-engine#schema introduction to the editing engine architecture}.
 </info-box>
 
-We will just extend the text node's schema to accept our abbreviation attribute, using the {@link module:engine/model/schema~Schema#extend `Schema#extend()`} method.
+We will just extend the text node's schema to accept our abbreviation attribute, using the `schema.extend()` method.
 
 Update the `AbbreviationEditing` plugin with this definition:
 
@@ -245,7 +245,7 @@ Converting the full title of the abbreviation is a little bit tricky, because we
 
 In the downcast conversion, we will use one of our conversion helpers &ndash; {@link framework/guides/deep-dive/conversion/helpers/downcast#attribute-to-element-conversion-helper `attributeToElement()`} &ndash; to transform the model abbreviation attribute into the view `<abbr>` element.
 
-We will need to use a callback function, in order to get the title stored as a model attribute value and transform it into the title value of the view element. Here, the second parameter of the view callback is the {@link module:engine/conversion/downcastdispatcher~DowncastConversionApi `DowncastConversionApi`} object. We will use its `writer` property, which will allow us to manipulate the data during downcast conversion, as it contains an instance of the {@link module:engine/view/downcastwriter~DowncastWriter `DowncastWriter`}.
+We will need to use a callback function, in order to get the title stored as a model attribute value and transform it into the title value of the view element. Here, the second parameter of the view callback is the `DowncastConversionApi` object. We will use its `writer` property, which will allow us to manipulate the data during downcast conversion, as it contains an instance of the `DowncastWriter`.
 
 ```js
 // abbreviation/abbreviationediting.js
@@ -287,7 +287,7 @@ export default class AbbreviationEditing extends Plugin {
 
 The upcast conversion tells the editor how the view `<abbr>` element is supposed to look like in the model. We will transform it using another conversion helper &ndash; {@link framework/guides/deep-dive/conversion/helpers/upcast#element-to-attribute-conversion-helper `elementToAttribute()`}.
 
-We also need to grab the title value from the content and use it in the model. We can do that thanks to a callback function, which gives us the access to the {@link module:engine/view/element~Element view element}.
+We also need to grab the title value from the content and use it in the model. We can do that thanks to a callback function, which gives us the access to the view element.
 
 ```js
 // abbreviation/abbreviationediting.js
@@ -338,7 +338,7 @@ Thanks to the upcast conversion, our abbreviation added in the `index.html` shou
 
 Now we can create our `Abbreviation` toolbar button using the {@link module:ui/button/buttonview~ButtonView `ButtonView`} class.
 
-We need to register it in the editor's UI {@link module:ui/componentfactory~ComponentFactory `componentFactory`}, so it can be displayed in the toolbar.
+We need to register it in the editor's UI `componentFactory`, so it can be displayed in the toolbar.
 
 ```js
 // abbreviation/abbreviationui.js
@@ -396,7 +396,7 @@ ClassicEditor
 
 We have the button, so let's define what should happen after the user clicks it.
 
-We will use the {@link module:engine/model/model~Model#insertContent `insertContent()`} method to insert our abbreviation and its title attribute into the document. Inside, we just need to create a new text node with {@link module:engine/model/writer~Writer#createText `writer.createText()`}.
+We will use the `insertContent()` method to insert our abbreviation and its title attribute into the document. Inside, we just need to create a new text node with `writer.createText()`.
 
 ```js
 // abbreviation/abbreviationui.js

--- a/docs/framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-2.md
+++ b/docs/framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-2.md
@@ -143,10 +143,10 @@ export default class FormView extends View {
 When the user clicks one of these buttons, we want to either submit or cancel the form view. These events should be fired off from the form view, so we need to delegate them from the buttons to the form view.
 
 <info-box>
-	Event delegation allows selected events of one {@link module:utils/emittermixin~Emitter emitter} to be fired off by another emitter. Read about it in our {@link framework/guides/architecture/core-editor-architecture#event-system-and-observables introduction to the event system} and more on {@link framework/guides/deep-dive/event-system#delegating-events delegating events}.
+	Event delegation allows selected events of one emitter to be fired off by another emitter. Read about it in our {@link framework/guides/architecture/core-editor-architecture#event-system-and-observables introduction to the event system} and more on {@link framework/guides/deep-dive/event-system#delegating-events delegating events}.
 </info-box>
 
-For now, we {@link module:utils/emittermixin~Emitter#delegate delegate} `cancelButtonView#execute` to the FormView, so pressing the `cancel` button will fire off `FormView#cancel`. We will handle delegating the submit event in a couple of steps.
+For now, we delegate `cancelButtonView#execute` to the FormView, so pressing the `cancel` button will fire off `FormView#cancel`. We will handle delegating the submit event in a couple of steps.
 
 ```js
 // abbreviation/abbreviationview.js
@@ -229,9 +229,9 @@ export default class AbbreviationUI extends Plugin {
 
 We are almost done with the form view, we just need to add a couple of finishing touches.
 
-In the `constructor`, we create a {@link module:ui/viewcollection~ViewCollection} with the {@link module:ui/view~View#createCollection `createCollection()`} method. We put all our input and button views in the collection, and use it to update the `FormView` template with its newly created children.
+In the `constructor`, we create a {@link module:ui/viewcollection~ViewCollection} with the `createCollection()` method. We put all our input and button views in the collection, and use it to update the `FormView` template with its newly created children.
 
-Let's also add `render()` method to our `FormView`.  We will use a helper {@link module:ui/bindings/submithandler~submitHandler `submitHandler()`} function there, which intercepts a native DOM submit event, prevents the default web browser behavior (navigation and page reload) and fires the `submit` event on a view instead.
+Let's also add `render()` method to our `FormView`.  We will use a helper `submitHandler()` function there, which intercepts a native DOM submit event, prevents the default web browser behavior (navigation and page reload) and fires the `submit` event on a view instead.
 
 We also need a `focus()` method, which will focus on the first child of our `abbreviation` input view each time the form is added to the editor. This is just a taste of what {@link framework/guides/deep-dive/focus-tracking focus tracking} can do in CKEditor 5. We will get into it more in next part of this tutorial.
 
@@ -295,7 +295,7 @@ Our `FormView` is done! However, we cannot see it just yet, so let's add it to o
 
 ## Adding the Contextual Balloon
 
-Our form needs to appear in a balloon, and we will use the {@link module:ui/panel/balloon/contextualballoon~ContextualBalloon `ContextualBalloon` class} from the CKEditor 5 UI library to make one.
+Our form needs to appear in a balloon, and we will use the {@link module:ui/panel/balloon/contextualballoon~ContextualBalloon `ContextualBalloon`} class from the CKEditor 5 UI library to make one.
 
 This is where we ended up with our UI in the first part of the tutorial.
 
@@ -339,7 +339,7 @@ We will need to change it quite a bit and add `ContextualBalloon` and `FormView`
 
 Let's write a basic `_createFormView()` function, just to create an instance of our `FormView` class (we will expand it later).
 
-We also need to create a function, which will give us the target position for our balloon from user's selection. We need to convert the selected view range into DOM range. We can use the {@link module:engine/view/domconverter~DomConverter#viewRangeToDom `viewRangeToDom()`} method to do so.
+We also need to create a function, which will give us the target position for our balloon from user's selection. We need to convert the selected view range into DOM range. We can use the `viewRangeToDom()` method to do so.
 
 Finally, we add our balloon and the form view to the `init()` method.
 
@@ -436,7 +436,7 @@ You should be able to see your balloon and form now! Check and see your balloon 
 
 ## Getting user input
 
-Now is the time to replace the hard-coded "WYSIWYG" abbreviation with the user input. We will be getting values from the form and listening to the `submit` event on the form view, which we delegated from the save button (with the help of {@link module:ui/bindings/submithandler~submitHandler `submitHandler`}).
+Now is the time to replace the hard-coded "WYSIWYG" abbreviation with the user input. We will be getting values from the form and listening to the `submit` event on the form view, which we delegated from the save button (with the help of `submitHandler`).
 
 We use the same callback function we had in the toolbar button in the first part of the tutorial. We just need to replace the "WYSIWYG" abbreviation with values from our input views.
 
@@ -493,7 +493,7 @@ We will need to hide the form view in these three situations:
 
 We will write a simple `_hideUI()` function, which will clear the input field values and remove the view from our balloon.
 
-Additionally, we will import the {@link module:ui/bindings/clickoutsidehandler~clickOutsideHandler `clickOutsideHandler()`} method, which will take our `_hideUI()` function as a callback. It will be emitted from our form view, and activated when the form view is visible. We also need to set `contextElements` for the handler to determine its scope. Clicking on HTML elements listed there will not fire the callback.
+Additionally, we will import the `clickOutsideHandler()` method, which will take our `_hideUI()` function as a callback. It will be emitted from our form view, and activated when the form view is visible. We also need to set `contextElements` for the handler to determine its scope. Clicking on HTML elements listed there will not fire the callback.
 
 ```js
 // abbreviation/abbreviationui.js

--- a/docs/framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-3.md
+++ b/docs/framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-3.md
@@ -21,11 +21,11 @@ First, we make our plugin accessible for users who rely on keyboards for navigat
 	In order to improve the accessibility of the plugin, it is important to understand how keystroke and focus management works in the CKEditor 5 framework. We recommend you {@link framework/guides/architecture/ui-library#keystrokes-and-focus-management read up on the basics}, or do a {@link framework/guides/deep-dive/focus-tracking deep dive into focus tracking}.
 </info-box>
 
-We have some ready-to-use options to help us out &ndash; the {@link framework/guides/deep-dive/focus-tracking#using-the-keystrokehandler-class the KeystrokeHandler}, {@link framework/guides/deep-dive/focus-tracking#using-the-focustracker-class FocusTracker}, and {@link framework/guides/deep-dive/focus-tracking#using-the-focuscycler-class FocusCycler} helper classes.
+We have some ready-to-use options to help us out &ndash; the {@link framework/guides/deep-dive/focus-tracking#using-the-keystrokehandler-class KeystrokeHandler}, {@link framework/guides/deep-dive/focus-tracking#using-the-focustracker-class FocusTracker}, and {@link framework/guides/deep-dive/focus-tracking#using-the-focuscycler-class FocusCycler} helper classes.
 
 ### Adding a keystroke handler and a focus tracker
 
-We start by importing the {@link module:utils/keystrokehandler~KeystrokeHandler `KeystrokeHandler`} and {@link module:utils/focustracker~FocusTracker `FocusTracker`} classes into our form view, and creating their new instances in the `constructor()`.
+We start by importing the `KeystrokeHandler` and `FocusTracker` classes into our form view, and creating their new instances in the `constructor()`.
 
 Now, in the `render()` method, we add each element of our `childViews` view collection to the `focusTracker`. There, we can also start listening for the keystrokes coming from the rendered view element.
 
@@ -79,7 +79,7 @@ export default class FormView extends View {
 
 ### Adding a focus cycler
 
-The {@link module:ui/focuscycler~FocusCycler `FocusCycler`} will allow the user to navigate through all the children of our form view, cycling over them. Check how our navigation works now in our form view &ndash; we can use <kbd>Tab</kbd> to move from the first input field to the second, but then the focus leaves the form, and the editor itself. Let's fix that.
+The `FocusCycler` will allow the user to navigate through all the children of our form view, cycling over them. Check how our navigation works now in our form view &ndash; we can use <kbd>Tab</kbd> to move from the first input field to the second, but then the focus leaves the form, and the editor itself. Let's fix that.
 
 We import the `FocusCycler` class, and create its instance in the form view `constructor()`. We need to pass an object with focusables (so our `childViews` collection), the focus tracker, the keystroke handler, and the actions connected to different keystrokes.
 
@@ -161,7 +161,7 @@ When the user selects a range (a letter, a word, or a whole document fragment) a
 
 In order to display the text from the user's selection in the form field, we need to first grab and concatenate all text from the selected range. If the user selects a couple of paragraphs, a heading, and an image, we need to go through all the nodes, and use only the ones containing text.
 
-Let's create a helper `getRangeText()` function in a separate `/utils.js` file. It will grab all items from a range using its {@link module:engine/model/range~Range#getItems `getItems()`} method. Then, it will concatenate all text from the {@link module:engine/model/text~Text `text`} and {@link module:engine/model/textproxy~TextProxy `textProxy`} nodes, and skip all the others.
+Let's create a helper `getRangeText()` function in a separate `/utils.js` file. It will grab all items from a range using its `getItems()` method. Then, it will concatenate all text from the {@link module:engine/model/text~Text `text`} and {@link module:engine/model/textproxy~TextProxy `textProxy`} nodes, and skip all the others.
 
 ```js
 // abbreviation/utils.js
@@ -179,7 +179,7 @@ export default function getRangeText( range ) {
 
 ```
 
-Now, in `AbbreviationUI` we can adjust the `_showUI()` method to display the selected text in the abbreviation input field. We import `getRangeText` and pass the first range in the selection (using the {@link module:engine/model/documentselection~DocumentSelection#getFirstRange `getFirstRange()`} method) as an argument.
+Now, in `AbbreviationUI` we can adjust the `_showUI()` method to display the selected text in the abbreviation input field. We import `getRangeText` and pass the first range in the selection (using the `getFirstRange()` method) as an argument.
 
 We will also disable the input field when the selection is not collapsed, because it would be hard to change the text of the abbreviation if the selection spans multiple paragraphs.
 
@@ -252,7 +252,7 @@ When the user makes a selection in the editor, the command will automatically ch
 
 Let's start by creating the command, and moving the existing action logic there.
 
-In the `/abbreviationcommand.js` file, we import the {@link module:core/command~Command `Command`} class and create its instance.
+In the `/abbreviationcommand.js` file, we import the `Command` class and create its instance.
 
 We will start by simply moving there the action we already created for `submit` in our `_createFormView()` method, passing the title and the abbreviation text into the command's `execute()` method.
 
@@ -333,9 +333,9 @@ The command should now work, and pressing the `submit` button should have the sa
 
 ### Refreshing the state
 
-Thanks to the command's {@link module:core/command~Command#refresh `refresh()`} method, we can observe the state and the value of our command not just when the user presses the button, but whenever any changes are made in the editor. We will use this to check if the user's selection has an abbreviation model attribute already.
+Thanks to the command's `refresh()` method, we can observe the state and the value of our command not just when the user presses the button, but whenever any changes are made in the editor. We will use this to check if the user's selection has an abbreviation model attribute already.
 
-Before we do that, we may want to check if the command can be used at all on a given selection. If the user selects an image, the command should be disabled. Let's check if our `abbreviation` attribute is allowed in the schema, using its {@link module:engine/model/schema~Schema#checkAttributeInSelection `checkAttributeInSelection()`} method.
+Before we do that, we may want to check if the command can be used at all on a given selection. If the user selects an image, the command should be disabled. Let's check if our `abbreviation` attribute is allowed in the schema, using its `checkAttributeInSelection()` method.
 
 ```js
 // abbreviation/abbreviationcommand.js
@@ -410,7 +410,7 @@ export default class AbbreviationCommand extends Command {
 
 If the selection is not collapsed, we check if it has the `abbreviation` model attribute. If so, we will again grab the full range of the abbreviation and compare it with the user selection.
 
-When the user selects a bit of text with the abbreviation attribute, along with a bit without it, we do not want to change the command's value. So, we will use the {@link module:engine/model/range~Range#containsRange `containsRange()`} method to see if the selected range is within the abbreviation range. The second parameter makes it a `loose` check, meaning the selected range can start, end, or be equal to the abbreviation range.
+When the user selects a bit of text with the abbreviation attribute, along with a bit without it, we do not want to change the command's value. So, we will use the `containsRange()` method to see if the selected range is within the abbreviation range. The second parameter makes it a `loose` check, meaning the selected range can start, end, or be equal to the abbreviation range.
 
 ```js
 // abbreviation/abbreviationcommand.js
@@ -515,7 +515,7 @@ export default class AbbreviationUI extends Plugin {
 
 We should now introduce more cases into our `execute()` method. For starters, if the user's selection is not collapsed, we just need to add the abbreviation attribute to their selection instead of inserting the abbreviation text into the model.
 
-So if the selection is not collapsed, we will gather all the ranges, that are allowed to use the `abbreviation` model attribute, using the schema's {@link module:engine/model/schema~Schema#getValidRanges `getValidRanges()`} method. Then we will use the {@link module:engine/model/writer~Writer#setAttribute `setAttribute()`}, to add the title value to each of the ranges.
+So if the selection is not collapsed, we will gather all the ranges, that are allowed to use the `abbreviation` model attribute, using the schema's `getValidRanges()` method. Then we will use the `setAttribute()`, to add the title value to each of the ranges.
 
 If the selection is collapsed, we will keep our `insertContent()` model method from before. Then, we need to use `removeSelectionAttribute` method, to stop adding new content into the abbreviation if the user starts to type.
 
@@ -562,7 +562,7 @@ export default class AbbreviationCommand extends Command {
 
 Now we can use the command's state to check whether the selection is inside an existing abbreviation. If the command's value is not `null`, we will grab the whole range, and update its text and title.
 
-We will create a position at the end of the inserted abbreviation, and set a selection there. The {@link module:engine/model/model~Model#insertContent `insertContent()`} method returns a range, and we grab its {@link module:engine/model/range~Range#end end} to define our `positionAfter`.
+We will create a position at the end of the inserted abbreviation, and set a selection there. The {@link module:engine/model/model~Model#insertContent `insertContent()`} method returns a range, and we grab its end position to define our `positionAfter`.
 
 ```js
 // abbreviation/abbreviationcommand.js


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Removed unnecessary links to API. Closes internal #[1889](https://github.com/cksource/ckeditor5-internal/issues/1889).

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
