### PR TITLE
Added aria-expanded for dropdownbuttonview

### DIFF
--- a/packages/ckeditor5-ui/src/dropdown/button/dropdownbuttonview.js
+++ b/packages/ckeditor5-ui/src/dropdown/button/dropdownbuttonview.js
@@ -49,7 +49,8 @@ export default class DropdownButtonView extends ButtonView {
 
 		this.extendTemplate( {
 			attributes: {
-				'aria-haspopup': true
+				'aria-haspopup': true,
+				'aria-expanded': this.bindTemplate.to( 'isOn', value => String( value ) )
 			}
 		} );
 

--- a/packages/ckeditor5-ui/tests/dropdown/button/dropdownbuttonview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/button/dropdownbuttonview.js
@@ -44,5 +44,13 @@ describe( 'DropdownButtonView', () => {
 
 			sinon.assert.calledOnce( spy );
 		} );
+
+		it( 'binds button\'s aria-expanded attribute to #isOn', () => {
+			view.isOn = true;
+			expect( view.element.getAttribute( 'aria-expanded' ) ).to.equal( 'true' );
+
+			view.isOn = false;
+			expect( view.element.getAttribute( 'aria-expanded' ) ).to.equal( 'false' );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (ui): Added aria-expanded attribute for the dropdownbuttonview. Closes #12258.

---

### Additional information

Tested briefly with VoiceOver and it seems that the screen reader will now properly announce if the button has a popup.  
You can check this behavior with all-features manual tests and insertImageViaUrl.