### PR TITLE
Docs: changing menu titles for overview sections

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -1,5 +1,6 @@
 ---
 category: features
+menu-title: Overview
 order: -999
 feedback-widget: false
 ---

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -1,6 +1,5 @@
 ---
 category: features
-menu-title: Overview
 order: -999
 feedback-widget: false
 ---

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -1,6 +1,7 @@
 ---
 category: framework
 order: 10
+menu-title: Overview
 meta-title: CKEditor 5 Framework documentation
 meta-description: Learn how to install, integrate, configure and develop CKEditor 5 Framework. Browse through API documentation and online samples.
 ---

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -1,7 +1,7 @@
 ---
 category: installation
 order: 10
-menu-title: CKEditor 5 installation overview
+menu-title: Overview
 meta-title: CKEditor 5 installation documentation
 meta-description: Learn how to install, integrate, configure and develop CKEditor 5. Browse through API documentation and online samples.
 ---


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: changing menu titles for overview sections.

### Additional information

Assumption:
Overviews (index.md) are not indexed in algolia so naming them the same way just for UX purposes is okay
