### PR TITLE
Remove color button tooltip

### DIFF
--- a/packages/ckeditor5-font/src/ui/colortableview.js
+++ b/packages/ckeditor5-font/src/ui/colortableview.js
@@ -321,7 +321,6 @@ export default class ColorTableView extends View {
 		buttonView.set( {
 			withText: true,
 			icon: icons.eraser,
-			tooltip: true,
 			label: this.removeButtonLabel
 		} );
 

--- a/packages/ckeditor5-font/tests/ui/colortableview.js
+++ b/packages/ckeditor5-font/tests/ui/colortableview.js
@@ -123,7 +123,7 @@ describe( 'ColorTableView', () => {
 			expect( colorTableView.selectedColor ).to.equal( 'white' );
 		} );
 
-		it( 'should set tooltip for the remove color button', () => {
+		it( 'should set label for the remove color button', () => {
 			expect( colorTableView.removeButtonLabel ).to.equal( 'Remove color' );
 		} );
 
@@ -255,7 +255,6 @@ describe( 'ColorTableView', () => {
 		it( 'should have proper settings', () => {
 			expect( removeButton.withText ).to.be.true;
 			expect( removeButton.icon ).to.equal( removeButtonIcon );
-			expect( removeButton.tooltip ).to.be.true;
 			expect( removeButton.label ).to.equal( 'Remove color' );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (font): Removed an unnecessary color button tooltip. Closes #12277.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._