### PR TITLE
Keyboard navigation for styles grids

### DIFF
--- a/packages/ckeditor5-style/src/ui/stylegridbuttonview.js
+++ b/packages/ckeditor5-style/src/ui/stylegridbuttonview.js
@@ -85,7 +85,9 @@ export default class StyleGridButtonView extends ButtonView {
 					'ck-reset_all-excluded',
 					'ck-style-grid__button__preview',
 					'ck-content'
-				]
+				],
+				// The preview "AaBbCcDdEeFfGgHhIiJj" should not be read by screen readers because it is purely presentational.
+				'aria-hidden': 'true'
 			},
 
 			children: [

--- a/packages/ckeditor5-style/src/ui/stylegridview.js
+++ b/packages/ckeditor5-style/src/ui/stylegridview.js
@@ -7,7 +7,8 @@
  * @module style/ui/stylegridview
  */
 
-import { View } from 'ckeditor5/src/ui';
+import { View, addKeyboardHandlingForGrid } from 'ckeditor5/src/ui';
+import { FocusTracker, KeystrokeHandler } from 'ckeditor5/src/utils';
 import StyleGridButtonView from './stylegridbuttonview';
 
 import '../../theme/stylegrid.css';
@@ -28,6 +29,22 @@ export default class StyleGridView extends View {
 	 */
 	constructor( locale, styleDefinitions ) {
 		super( locale );
+
+		/**
+		 * Tracks information about the DOM focus in the view.
+		 *
+		 * @readonly
+		 * @member {module:utils/focustracker~FocusTracker}
+		 */
+		this.focusTracker = new FocusTracker();
+
+		/**
+		 * An instance of the {@link module:utils/keystrokehandler~KeystrokeHandler}.
+		 *
+		 * @readonly
+		 * @member {module:utils/keystrokehandler~KeystrokeHandler}
+		 */
+		this.keystrokes = new KeystrokeHandler();
 
 		/**
 		 * Array of active style names. They must correspond to the names of styles from
@@ -100,9 +117,40 @@ export default class StyleGridView extends View {
 	}
 
 	/**
+	 * @inheritDoc
+	 */
+	render() {
+		super.render();
+
+		for ( const child of this.children ) {
+			this.focusTracker.add( child.element );
+		}
+
+		addKeyboardHandlingForGrid( {
+			keystrokeHandler: this.keystrokes,
+			focusTracker: this.focusTracker,
+			gridItems: this.children,
+			numberOfColumns: 3
+		} );
+
+		// Start listening for the keystrokes coming from the grid view.
+		this.keystrokes.listenTo( this.element );
+	}
+
+	/**
 	 * Focuses the first style button in the grid.
 	 */
 	focus() {
 		this.children.first.focus();
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	destroy() {
+		super.destroy();
+
+		this.focusTracker.destroy();
+		this.keystrokes.destroy();
 	}
 }

--- a/packages/ckeditor5-style/src/ui/stylegridview.js
+++ b/packages/ckeditor5-style/src/ui/stylegridview.js
@@ -98,4 +98,11 @@ export default class StyleGridView extends View {
 		 * @event execute
 		 */
 	}
+
+	/**
+	 * Focuses the first style button in the grid.
+	 */
+	focus() {
+		this.children.first.focus();
+	}
 }

--- a/packages/ckeditor5-style/src/ui/stylepanelview.js
+++ b/packages/ckeditor5-style/src/ui/stylepanelview.js
@@ -169,18 +169,13 @@ export default class StylePanelView extends View {
 	render() {
 		super.render();
 
-		const childViews = [
-			...this.blockStylesGroupView.gridView.children,
-			...this.inlineStylesGroupView.gridView.children
-		];
+		// Register the views as focusable.
+		this._focusables.add( this.blockStylesGroupView.gridView );
+		this._focusables.add( this.inlineStylesGroupView.gridView );
 
-		childViews.forEach( v => {
-			// Register the view as focusable.
-			this._focusables.add( v );
-
-			// Register the view in the focus tracker.
-			this.focusTracker.add( v.element );
-		} );
+		// Register the views in the focus tracker.
+		this.focusTracker.add( this.blockStylesGroupView.gridView.element );
+		this.focusTracker.add( this.inlineStylesGroupView.gridView.element );
 
 		this.keystrokes.listenTo( this.element );
 	}

--- a/packages/ckeditor5-style/src/ui/stylepanelview.js
+++ b/packages/ckeditor5-style/src/ui/stylepanelview.js
@@ -121,11 +121,11 @@ export default class StylePanelView extends View {
 			focusTracker: this.focusTracker,
 			keystrokeHandler: this.keystrokes,
 			actions: {
-				// Navigate style buttons backwards using the ↑ or ← keystrokes.
-				focusPrevious: [ 'arrowup', 'arrowleft' ],
+				// Navigate style buttons backwards using the <kbd>Shift</kbd> + <kbd>Tab</kbd> keystroke.
+				focusPrevious: [ 'shift + tab' ],
 
-				// Navigate style buttons forward using the Arrow ↓ or → keystrokes.
-				focusNext: [ 'arrowdown', 'arrowright' ]
+				// Navigate style buttons forward using the <kbd>Tab</kbd> key.
+				focusNext: [ 'tab' ]
 			}
 		} );
 

--- a/packages/ckeditor5-style/src/ui/stylepanelview.js
+++ b/packages/ckeditor5-style/src/ui/stylepanelview.js
@@ -121,10 +121,10 @@ export default class StylePanelView extends View {
 			focusTracker: this.focusTracker,
 			keystrokeHandler: this.keystrokes,
 			actions: {
-				// Navigate style buttons backwards using the <kbd>Shift</kbd> + <kbd>Tab</kbd> keystroke.
+				// Navigate style groups backwards using the <kbd>Shift</kbd> + <kbd>Tab</kbd> keystroke.
 				focusPrevious: [ 'shift + tab' ],
 
-				// Navigate style buttons forward using the <kbd>Tab</kbd> key.
+				// Navigate style groups forward using the <kbd>Tab</kbd> key.
 				focusNext: [ 'tab' ]
 			}
 		} );

--- a/packages/ckeditor5-style/tests/ui/stylegridbuttonview.js
+++ b/packages/ckeditor5-style/tests/ui/stylegridbuttonview.js
@@ -63,6 +63,10 @@ describe( 'StyleGridButtonView', () => {
 				expect( button.previewView.element.classList.contains( 'ck-reset_all-excluded' ) ).to.be.true;
 			} );
 
+			it( 'should exclude the presentational preview text from assistive technologies', () => {
+				expect( button.previewView.element.getAttribute( 'aria-hidden' ) ).to.equal( 'true' );
+			} );
+
 			it( 'should render the inner preview as the element specified in definition if previewable', () => {
 				const previewElement = button.previewView.element.firstChild;
 

--- a/packages/ckeditor5-style/tests/ui/stylegridview.js
+++ b/packages/ckeditor5-style/tests/ui/stylegridview.js
@@ -152,6 +152,16 @@ describe( 'StyleGridView', () => {
 		} );
 	} );
 
+	describe( 'focus()', () => {
+		it( 'should focus the first style', () => {
+			const spy = sinon.spy( grid.children.first, 'focus' );
+
+			grid.focus();
+
+			sinon.assert.calledOnce( spy );
+		} );
+	} );
+
 	describe( 'destroy()', () => {
 		it( 'should destroy the FocusTracker instance', () => {
 			const destroySpy = sinon.spy( grid.focusTracker, 'destroy' );

--- a/packages/ckeditor5-style/tests/ui/stylegridview.js
+++ b/packages/ckeditor5-style/tests/ui/stylegridview.js
@@ -118,10 +118,6 @@ describe( 'StyleGridView', () => {
 	} );
 
 	describe( 'render()', () => {
-		beforeEach( () => {
-			grid.render();
-		} );
-
 		it( 'should register styleGridView children elements in #focusTracker', () => {
 			const grid = new StyleGridView( new Locale(), [
 				{

--- a/packages/ckeditor5-style/tests/ui/stylegridview.js
+++ b/packages/ckeditor5-style/tests/ui/stylegridview.js
@@ -151,4 +151,22 @@ describe( 'StyleGridView', () => {
 			grid.destroy();
 		} );
 	} );
+
+	describe( 'destroy()', () => {
+		it( 'should destroy the FocusTracker instance', () => {
+			const destroySpy = sinon.spy( grid.focusTracker, 'destroy' );
+
+			grid.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+
+		it( 'should destroy the KeystrokeHandler instance', () => {
+			const destroySpy = sinon.spy( grid.keystrokes, 'destroy' );
+
+			grid.destroy();
+
+			sinon.assert.calledOnce( destroySpy );
+		} );
+	} );
 } );

--- a/packages/ckeditor5-style/tests/ui/stylegridview.js
+++ b/packages/ckeditor5-style/tests/ui/stylegridview.js
@@ -4,7 +4,7 @@
  */
 
 import { ViewCollection } from '@ckeditor/ckeditor5-ui';
-import { Locale, FocusTracker, KeystrokeHandler } from '@ckeditor/ckeditor5-utils';
+import { Locale, FocusTracker, KeystrokeHandler, keyCodes } from '@ckeditor/ckeditor5-utils';
 
 import StyleGridButtonView from '../../src/ui/stylegridbuttonview';
 import StyleGridView from '../../src/ui/stylegridview';
@@ -125,6 +125,79 @@ describe( 'StyleGridView', () => {
 		it( 'should register styleGridView children elements in #focusTracker', () => {
 			expect( grid.focusTracker._elements ).to.include( grid.children.first.element );
 			expect( grid.focusTracker._elements ).to.include( grid.children.last.element );
+		} );
+
+		describe( 'keyboard navigation in the styleGridView', () => {
+			let grid;
+
+			beforeEach( async () => {
+				grid = new StyleGridView( locale, [
+					{
+						name: 'Red heading',
+						element: 'h2',
+						classes: [ 'red-heading' ]
+					},
+					{
+						name: 'Yellow heading',
+						element: 'h2',
+						classes: [ 'yellow-heading' ]
+					},
+					{
+						name: 'Green heading',
+						element: 'h2',
+						classes: [ 'green-heading' ]
+					},
+					{
+						name: 'Large heading',
+						element: 'h2',
+						classes: [ 'large-heading' ]
+					}
+				] );
+
+				grid.render();
+			} );
+
+			afterEach( async () => {
+				grid.destroy();
+			} );
+
+			it( '"arrow right" should focus the next focusable style', () => {
+				const keyEvtData = {
+					keyCode: keyCodes.arrowright,
+					preventDefault: sinon.spy(),
+					stopPropagation: sinon.spy()
+				};
+
+				// Mock the first color button is focused.
+				grid.focusTracker.isFocused = true;
+				grid.focusTracker.focusedElement = grid.children.first.element;
+
+				const spy = sinon.spy( grid.children.get( 1 ), 'focus' );
+
+				grid.keystrokes.press( keyEvtData );
+				sinon.assert.calledOnce( keyEvtData.preventDefault );
+				sinon.assert.calledOnce( keyEvtData.stopPropagation );
+				sinon.assert.calledOnce( spy );
+			} );
+
+			it( '"arrow down" should focus the focusable style in the second row', () => {
+				const keyEvtData = {
+					keyCode: keyCodes.arrowdown,
+					preventDefault: sinon.spy(),
+					stopPropagation: sinon.spy()
+				};
+
+				// Mock the first color button is focused.
+				grid.focusTracker.isFocused = true;
+				grid.focusTracker.focusedElement = grid.children.first.element;
+
+				const spy = sinon.spy( grid.children.get( 3 ), 'focus' );
+
+				grid.keystrokes.press( keyEvtData );
+				sinon.assert.calledOnce( keyEvtData.preventDefault );
+				sinon.assert.calledOnce( keyEvtData.stopPropagation );
+				sinon.assert.calledOnce( spy );
+			} );
 		} );
 
 		it( 'starts listening for #keystrokes coming from the #element of the grid view', () => {

--- a/packages/ckeditor5-style/tests/ui/stylegridview.js
+++ b/packages/ckeditor5-style/tests/ui/stylegridview.js
@@ -123,8 +123,27 @@ describe( 'StyleGridView', () => {
 		} );
 
 		it( 'should register styleGridView children elements in #focusTracker', () => {
-			expect( grid.focusTracker._elements ).to.include( grid.children.first.element );
-			expect( grid.focusTracker._elements ).to.include( grid.children.last.element );
+			const grid = new StyleGridView( new Locale(), [
+				{
+					name: 'Red heading',
+					element: 'h2',
+					classes: [ 'red-heading' ]
+				},
+				{
+					name: 'Large heading',
+					element: 'h2',
+					classes: [ 'large-heading' ]
+				}
+			] );
+
+			const spyView = sinon.spy( grid.focusTracker, 'add' );
+
+			grid.render();
+
+			sinon.assert.calledWithExactly( spyView.getCall( 0 ), grid.children.first.element );
+			sinon.assert.calledWithExactly( spyView.getCall( 1 ), grid.children.last.element );
+
+			grid.destroy();
 		} );
 
 		describe( 'keyboard navigation in the grid', () => {

--- a/packages/ckeditor5-style/tests/ui/stylegridview.js
+++ b/packages/ckeditor5-style/tests/ui/stylegridview.js
@@ -126,5 +126,29 @@ describe( 'StyleGridView', () => {
 			expect( grid.focusTracker._elements ).to.include( grid.children.first.element );
 			expect( grid.focusTracker._elements ).to.include( grid.children.last.element );
 		} );
+
+		it( 'starts listening for #keystrokes coming from the #element of the grid view', () => {
+			const grid = new StyleGridView( locale, [
+				{
+					name: 'Red heading',
+					element: 'h2',
+					classes: [ 'red-heading' ]
+				},
+				{
+					name: 'Large heading',
+					element: 'h2',
+					classes: [ 'large-heading' ]
+				}
+			] );
+
+			const spy = sinon.spy( grid.keystrokes, 'listenTo' );
+
+			grid.render();
+
+			sinon.assert.calledOnce( spy );
+			sinon.assert.calledWithExactly( spy, grid.element );
+
+			grid.destroy();
+		} );
 	} );
 } );

--- a/packages/ckeditor5-style/tests/ui/stylegridview.js
+++ b/packages/ckeditor5-style/tests/ui/stylegridview.js
@@ -4,7 +4,7 @@
  */
 
 import { ViewCollection } from '@ckeditor/ckeditor5-ui';
-import { Locale } from '@ckeditor/ckeditor5-utils';
+import { Locale, FocusTracker, KeystrokeHandler } from '@ckeditor/ckeditor5-utils';
 
 import StyleGridButtonView from '../../src/ui/stylegridbuttonview';
 import StyleGridView from '../../src/ui/stylegridview';
@@ -33,6 +33,14 @@ describe( 'StyleGridView', () => {
 	} );
 
 	describe( 'constructor()', () => {
+		it( 'should have #focusTracker', () => {
+			expect( grid.focusTracker ).to.be.instanceOf( FocusTracker );
+		} );
+
+		it( 'should have #keystrokes', () => {
+			expect( grid.keystrokes ).to.be.instanceOf( KeystrokeHandler );
+		} );
+
 		it( 'should set #children', () => {
 			expect( grid.children ).to.be.instanceOf( ViewCollection );
 		} );
@@ -106,6 +114,17 @@ describe( 'StyleGridView', () => {
 
 			expect( grid.element.firstChild ).to.equal( grid.children.first.element );
 			expect( grid.element.lastChild ).to.equal( grid.children.last.element );
+		} );
+	} );
+
+	describe( 'render()', () => {
+		beforeEach( () => {
+			grid.render();
+		} );
+
+		it( 'should register styleGridView children elements in #focusTracker', () => {
+			expect( grid.focusTracker._elements ).to.include( grid.children.first.element );
+			expect( grid.focusTracker._elements ).to.include( grid.children.last.element );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-style/tests/ui/stylegridview.js
+++ b/packages/ckeditor5-style/tests/ui/stylegridview.js
@@ -127,7 +127,7 @@ describe( 'StyleGridView', () => {
 			expect( grid.focusTracker._elements ).to.include( grid.children.last.element );
 		} );
 
-		describe( 'keyboard navigation in the styleGridView', () => {
+		describe( 'keyboard navigation in the grid', () => {
 			let grid;
 
 			beforeEach( async () => {

--- a/packages/ckeditor5-style/tests/ui/stylepanelview.js
+++ b/packages/ckeditor5-style/tests/ui/stylepanelview.js
@@ -251,8 +251,8 @@ describe( 'StylePanelView', () => {
 			} );
 
 			describe( 'focus()', () => {
-				it( 'should focus the first button in the first grid', () => {
-					const spy = sinon.spy( panel.blockStylesGroupView.gridView.children.first, 'focus' );
+				it( 'should focus the first grid', () => {
+					const spy = sinon.spy( panel.blockStylesGroupView.gridView, 'focus' );
 
 					panel.focus();
 
@@ -261,8 +261,8 @@ describe( 'StylePanelView', () => {
 			} );
 
 			describe( 'focusLast()', () => {
-				it( 'should focus the last button in the last grid', () => {
-					const spy = sinon.spy( panel.inlineStylesGroupView.gridView.children.last, 'focus' );
+				it( 'should focus the last grid', () => {
+					const spy = sinon.spy( panel.inlineStylesGroupView.gridView, 'focus' );
 
 					panel.focusLast();
 

--- a/packages/ckeditor5-style/tests/ui/stylepanelview.js
+++ b/packages/ckeditor5-style/tests/ui/stylepanelview.js
@@ -271,4 +271,27 @@ describe( 'StylePanelView', () => {
 			} );
 		} );
 	} );
+
+	describe( 'render()', () => {
+		beforeEach( () => {
+			panel.render();
+			document.body.appendChild( panel.element );
+		} );
+
+		afterEach( () => {
+			panel.element.remove();
+		} );
+
+		it( 'should register styleGroupView grids in #_focusables', () => {
+			expect( panel._focusables.map( f => f ) ).to.have.members( [
+				panel.blockStylesGroupView.gridView,
+				panel.inlineStylesGroupView.gridView
+			] );
+		} );
+
+		it( 'should register styleGroupView grid elements in #focusTracker', () => {
+			expect( panel.focusTracker._elements ).to.include( panel.blockStylesGroupView.gridView.element );
+			expect( panel.focusTracker._elements ).to.include( panel.inlineStylesGroupView.gridView.element );
+		} );
+	} );
 } );

--- a/packages/ckeditor5-style/tests/ui/stylepanelview.js
+++ b/packages/ckeditor5-style/tests/ui/stylepanelview.js
@@ -290,8 +290,31 @@ describe( 'StylePanelView', () => {
 		} );
 
 		it( 'should register styleGroupView grid elements in #focusTracker', () => {
-			expect( panel.focusTracker._elements ).to.include( panel.blockStylesGroupView.gridView.element );
-			expect( panel.focusTracker._elements ).to.include( panel.inlineStylesGroupView.gridView.element );
+			const panel = new StylePanelView( locale, {
+				block: [
+					{
+						name: 'Red heading',
+						element: 'h2',
+						classes: [ 'red-heading' ]
+					}
+				],
+				inline: [
+					{
+						name: 'Deleted text',
+						element: 'span',
+						classes: [ 'deleted' ]
+					}
+				]
+			} );
+
+			const spyView = sinon.spy( panel.focusTracker, 'add' );
+
+			panel.render();
+
+			sinon.assert.calledWithExactly( spyView.getCall( 0 ), panel.blockStylesGroupView.gridView.element );
+			sinon.assert.calledWithExactly( spyView.getCall( 1 ), panel.inlineStylesGroupView.gridView.element );
+
+			panel.destroy();
 		} );
 	} );
 } );

--- a/packages/ckeditor5-style/tests/ui/stylepanelview.js
+++ b/packages/ckeditor5-style/tests/ui/stylepanelview.js
@@ -209,7 +209,7 @@ describe( 'StylePanelView', () => {
 				panel.element.remove();
 			} );
 
-			describe( 'keyboard navigation in the panel', () => {
+			describe( 'keyboard navigation between style groups in the panel', () => {
 				it( 'should focus the next focusable item on "tab"', () => {
 					const keyEvtData = {
 						keyCode: keyCodes.tab,

--- a/packages/ckeditor5-style/tests/ui/stylepanelview.js
+++ b/packages/ckeditor5-style/tests/ui/stylepanelview.js
@@ -210,18 +210,18 @@ describe( 'StylePanelView', () => {
 			} );
 
 			describe( 'keyboard navigation in the panel', () => {
-				it( 'should focus the next focusable item on "arrowdown"', () => {
+				it( 'should focus the next focusable item on "tab"', () => {
 					const keyEvtData = {
-						keyCode: keyCodes.arrowdown,
+						keyCode: keyCodes.tab,
 						preventDefault: sinon.spy(),
 						stopPropagation: sinon.spy()
 					};
 
-					// Mock the first style button is focused.
+					// Mock the first style grid is focused.
 					panel.focusTracker.isFocused = true;
-					panel.focusTracker.focusedElement = panel.blockStylesGroupView.gridView.children.first.element;
+					panel.focusTracker.focusedElement = panel.blockStylesGroupView.gridView.element;
 
-					const spy = sinon.spy( panel.blockStylesGroupView.gridView.children.get( 1 ), 'focus' );
+					const spy = sinon.spy( panel.inlineStylesGroupView.gridView, 'focus' );
 
 					panel.keystrokes.press( keyEvtData );
 					sinon.assert.calledOnce( keyEvtData.preventDefault );
@@ -229,56 +229,19 @@ describe( 'StylePanelView', () => {
 					sinon.assert.calledOnce( spy );
 				} );
 
-				it( 'should focus the next focusable item on "arrowright"', () => {
+				it( 'should focus the previous focusable item on "sfift + tab"', () => {
 					const keyEvtData = {
-						keyCode: keyCodes.arrowright,
+						keyCode: keyCodes.tab,
+						shiftKey: true,
 						preventDefault: sinon.spy(),
 						stopPropagation: sinon.spy()
 					};
 
-					// Mock the first style button is focused.
+					// Mock the first style grid is focused.
 					panel.focusTracker.isFocused = true;
-					panel.focusTracker.focusedElement = panel.blockStylesGroupView.gridView.children.first.element;
+					panel.focusTracker.focusedElement = panel.blockStylesGroupView.gridView.element;
 
-					const spy = sinon.spy( panel.blockStylesGroupView.gridView.children.get( 1 ), 'focus' );
-
-					panel.keystrokes.press( keyEvtData );
-					sinon.assert.calledOnce( keyEvtData.preventDefault );
-					sinon.assert.calledOnce( keyEvtData.stopPropagation );
-					sinon.assert.calledOnce( spy );
-				} );
-
-				it( 'should focus the previous focusable item on "arrowleft"', () => {
-					const keyEvtData = {
-						keyCode: keyCodes.arrowleft,
-						preventDefault: sinon.spy(),
-						stopPropagation: sinon.spy()
-					};
-
-					// Mock the first style button is focused.
-					panel.focusTracker.isFocused = true;
-					panel.focusTracker.focusedElement = panel.blockStylesGroupView.gridView.children.first.element;
-
-					const spy = sinon.spy( panel.inlineStylesGroupView.gridView.children.last, 'focus' );
-
-					panel.keystrokes.press( keyEvtData );
-					sinon.assert.calledOnce( keyEvtData.preventDefault );
-					sinon.assert.calledOnce( keyEvtData.stopPropagation );
-					sinon.assert.calledOnce( spy );
-				} );
-
-				it( 'should focus the previous focusable item on "arrowup"', () => {
-					const keyEvtData = {
-						keyCode: keyCodes.arrowup,
-						preventDefault: sinon.spy(),
-						stopPropagation: sinon.spy()
-					};
-
-					// Mock the first style button is focused.
-					panel.focusTracker.isFocused = true;
-					panel.focusTracker.focusedElement = panel.blockStylesGroupView.gridView.children.first.element;
-
-					const spy = sinon.spy( panel.inlineStylesGroupView.gridView.children.last, 'focus' );
+					const spy = sinon.spy( panel.inlineStylesGroupView.gridView, 'focus' );
 
 					panel.keystrokes.press( keyEvtData );
 					sinon.assert.calledOnce( keyEvtData.preventDefault );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (style): Improves keyboard navigation for style feature. Closes #12250.

---

### Additional information

Now `(shift) tab` keystroke navigates between the two sections in style dropdown whilst `arrow keys` navigate between grid items within a single grid.