### PR TITLE
Pressing Alt+F10 in a toolbar focused by mouse should not throw an error

### DIFF
--- a/packages/ckeditor5-core/src/editor/editorui.js
+++ b/packages/ckeditor5-core/src/editor/editorui.js
@@ -371,10 +371,12 @@ export default class EditorUI {
 
 			const currentFocusedToolbarDefinition = this._getCurrentFocusedToolbarDefinition();
 
-			// When focusing a toolbar for the first time, set the array of definitions for successive presses of Alt+F10.
+			// * When focusing a toolbar for the first time, set the array of definitions for successive presses of Alt+F10.
 			// This ensures, the navigation works always the same and no pair of toolbars takes over
 			// (e.g. image and table toolbars when a selected image is inside a cell).
-			if ( !currentFocusedToolbarDefinition ) {
+			// * It could be that the focus went to the toolbar by clicking a toolbar item (e.g. a dropdown). In this case,
+			// there were no candidates so they must be obtained (#12339).
+			if ( !currentFocusedToolbarDefinition || !candidateDefinitions ) {
 				candidateDefinitions = this._getFocusableCandidateToolbarDefinitions( currentFocusedToolbarDefinition );
 			}
 

--- a/packages/ckeditor5-core/tests/editor/editorui.js
+++ b/packages/ckeditor5-core/tests/editor/editorui.js
@@ -605,7 +605,7 @@ describe( 'EditorUI', () => {
 			} );
 
 			// https://github.com/ckeditor/ckeditor5/issues/12339
-			it( 'should work if the focus was already in to the toolbar (e.g. a user clicked an item)', () => {
+			it( 'should work if the focus was already in the toolbar (e.g. a user clicked an item)', () => {
 				ui.focusTracker.focusedElement = visibleContextualToolbar.element;
 
 				pressAltF10();

--- a/packages/ckeditor5-core/tests/editor/editorui.js
+++ b/packages/ckeditor5-core/tests/editor/editorui.js
@@ -603,6 +603,17 @@ describe( 'EditorUI', () => {
 
 				secondToolbarWithSetupAndCleanup.element.remove();
 			} );
+
+			// https://github.com/ckeditor/ckeditor5/issues/12339
+			it( 'should work if the focus was already in to the toolbar (e.g. a user clicked an item)', () => {
+				ui.focusTracker.focusedElement = visibleContextualToolbar.element;
+
+				pressAltF10();
+				ui.focusTracker.focusedElement = visibleToolbar.element;
+
+				sinon.assert.calledOnce( visibleSpy );
+				sinon.assert.notCalled( visibleContextualSpy );
+			} );
 		} );
 
 		describe( 'Restoring focus on Esc key press', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (core): Pressing Alt+F10 in a toolbar focused by mouse should not throw an error. Closes #12339.

---

### Additional information

QA needed.
