### PR TITLE
The list style grid should ba navigable using the keyboard regardless of the geometry of the grid.

### DIFF
--- a/packages/ckeditor5-list/src/listproperties/ui/listpropertiesview.js
+++ b/packages/ckeditor5-list/src/listproperties/ui/listpropertiesview.js
@@ -18,7 +18,8 @@ import {
 } from 'ckeditor5/src/ui';
 import {
 	FocusTracker,
-	KeystrokeHandler
+	KeystrokeHandler,
+	global
 } from 'ckeditor5/src/utils';
 
 import CollapsibleView from './collapsibleview';
@@ -196,7 +197,13 @@ export default class ListPropertiesView extends View {
 				keystrokeHandler: this.stylesView.keystrokes,
 				focusTracker: this.stylesView.focusTracker,
 				gridItems: this.stylesView.children,
-				numberOfColumns: 4
+				// Note: The styles view has a different number of columns depending on whether the other properties
+				// are enabled in the dropdown or not (https://github.com/ckeditor/ckeditor5/issues/12340)
+				numberOfColumns: () => global.window
+					.getComputedStyle( this.stylesView.element )
+					.getPropertyValue( 'grid-template-columns' )
+					.split( ' ' )
+					.length
 			} );
 		}
 

--- a/packages/ckeditor5-list/tests/listproperties/ui/listpropertiesview.js
+++ b/packages/ckeditor5-list/tests/listproperties/ui/listpropertiesview.js
@@ -521,6 +521,28 @@ describe( 'ListPropertiesView', () => {
 						sinon.assert.calledOnce( keyEvtData.stopPropagation );
 						sinon.assert.calledOnce( spy );
 					} );
+
+					// https://github.com/ckeditor/ckeditor5/issues/12340
+					it( 'should work regardless of the geometry of the grid', () => {
+						view.stylesView.element.style.gridTemplateColumns = 'repeat(2, 1fr)';
+
+						const keyEvtData = {
+							keyCode: keyCodes.arrowdown,
+							preventDefault: sinon.spy(),
+							stopPropagation: sinon.spy()
+						};
+
+						// Mock the first style button is focused.
+						view.stylesView.focusTracker.isFocused = true;
+						view.stylesView.focusTracker.focusedElement = view.stylesView.children.first.element;
+
+						const spy = sinon.spy( view.stylesView.children.get( 2 ), 'focus' );
+
+						view.stylesView.keystrokes.press( keyEvtData );
+						sinon.assert.calledOnce( keyEvtData.preventDefault );
+						sinon.assert.calledOnce( keyEvtData.stopPropagation );
+						sinon.assert.calledOnce( spy );
+					} );
 				} );
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (list): The list style grid should ba navigable using the keyboard regardless of the geometry of the grid. Closes #12340.

---

### Additional information

Best place to test: http://fake.ckeditor.com:8125/ckeditor5-list/tests/manual/list-properties.html.

P.S. Don't mind https://github.com/ckeditor/ckeditor5/issues/12337 there.
