### PR TITLE
Introduced ListItemView#isVisible

### DIFF
--- a/packages/ckeditor5-ui/src/list/listitemview.js
+++ b/packages/ckeditor5-ui/src/list/listitemview.js
@@ -21,6 +21,18 @@ export default class ListItemView extends View {
 	constructor( locale ) {
 		super( locale );
 
+		const bind = this.bindTemplate;
+
+		/**
+		 * Controls whether the item view is visible. Visible by default, list items are hidden
+		 * using a CSS class.
+		 *
+		 * @observable
+		 * @default true
+		 * @member {Boolean} #isVisible
+		 */
+		this.set( 'isVisible', true );
+
 		/**
 		 * Collection of the child views inside of the list item {@link #element}.
 		 *
@@ -35,7 +47,8 @@ export default class ListItemView extends View {
 			attributes: {
 				class: [
 					'ck',
-					'ck-list__item'
+					'ck-list__item',
+					bind.if( 'isVisible', 'ck-hidden', value => !value )
 				]
 			},
 

--- a/packages/ckeditor5-ui/tests/list/listitemview.js
+++ b/packages/ckeditor5-ui/tests/list/listitemview.js
@@ -25,6 +25,22 @@ describe( 'ListItemView', () => {
 		it( 'creates view#children collection', () => {
 			expect( view.children ).to.be.instanceOf( ViewCollection );
 		} );
+
+		it( 'sets the #isVisible property', () => {
+			expect( view.isVisible ).to.be.true;
+		} );
+
+		describe( '<button> bindings', () => {
+			describe( 'class', () => {
+				it( 'reacts on view#isVisible', () => {
+					view.isVisible = true;
+					expect( view.element.classList.contains( 'ck-hidden' ) ).to.be.false;
+
+					view.isVisible = false;
+					expect( view.element.classList.contains( 'ck-hidden' ) ).to.be.true;
+				} );
+			} );
+		} );
 	} );
 
 	describe( 'focus()', () => {

--- a/packages/ckeditor5-ui/tests/list/listitemview.js
+++ b/packages/ckeditor5-ui/tests/list/listitemview.js
@@ -30,7 +30,7 @@ describe( 'ListItemView', () => {
 			expect( view.isVisible ).to.be.true;
 		} );
 
-		describe( '<button> bindings', () => {
+		describe( 'DOM element bindings', () => {
 			describe( 'class', () => {
 				it( 'reacts on view#isVisible', () => {
 					view.isVisible = true;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (ui): Introduced the observable `#isVisible` property to `ListItemView` class instances. Closes #12357.

---

### Additional information

A requirement of cksource/collaboration-features#4731.

See cksource/collaboration-features#4719 to learn more.