### PR TITLE
Adjust the table element width calculations during resizing

### DIFF
--- a/packages/ckeditor5-table/src/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/utils.js
@@ -118,13 +118,25 @@ function getChildrenViewElement( modelTable, elementName, editor ) {
 }
 
 /**
- * Returns the computed width (in pixels) of the DOM element.
+ * Returns the computed width (in pixels) of the DOM element without padding and borders.
  *
  * @param {HTMLElement} domElement A DOM element.
  * @returns {Number} The width of the DOM element in pixels.
  */
 export function getElementWidthInPixels( domElement ) {
-	return parseFloat( global.window.getComputedStyle( domElement ).width );
+	const styles = global.window.getComputedStyle( domElement );
+
+	// In the 'border-box' box sizing algorithm, the element's width
+	// already includes the padding and border width (#12335).
+	if ( styles.boxSizing === 'border-box' ) {
+		return parseFloat( styles.width ) -
+			parseFloat( styles.paddingLeft ) -
+			parseFloat( styles.paddingRight ) -
+			parseFloat( styles.borderLeftWidth ) -
+			parseFloat( styles.borderRightWidth );
+	} else {
+		return parseFloat( styles.width );
+	}
 }
 
 /**
@@ -306,8 +318,14 @@ export function ensureColumnResizerElement( viewWriter, viewCell ) {
 export function getDomCellOuterWidth( domCell ) {
 	const styles = global.window.getComputedStyle( domCell );
 
-	return parseFloat( styles.width ) +
-		parseFloat( styles.paddingLeft ) +
-		parseFloat( styles.paddingRight ) +
-		parseFloat( styles.borderWidth );
+	// In the 'border-box' box sizing algorithm, the element's width
+	// already includes the padding and border width (#12335).
+	if ( styles.boxSizing === 'border-box' ) {
+		return parseInt( styles.width );
+	} else {
+		return parseFloat( styles.width ) +
+			parseFloat( styles.paddingLeft ) +
+			parseFloat( styles.paddingRight ) +
+			parseFloat( styles.borderWidth );
+	}
 }

--- a/packages/ckeditor5-table/tests/tablecolumnresize/utils.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/utils.js
@@ -28,7 +28,9 @@ import {
 	sumArray,
 	normalizeColumnWidths,
 	getTableWidthInPixels,
-	getColumnMinWidthAsPercentage
+	getColumnMinWidthAsPercentage,
+	getElementWidthInPixels,
+	getDomCellOuterWidth
 } from '../../src/tablecolumnresize/utils';
 
 /* globals window, document */
@@ -600,6 +602,63 @@ describe( 'TableColumnResize utils', () => {
 			expect( normalizeColumnWidths( [ '1%', '2%', '3%', '4%' ] ) ).to.deep.equal( [ 10, 20, 30, 40 ] );
 			expect( normalizeColumnWidths( [ '12.33%', '17.4%', '21.49%', '33.52%', '26.6%', '10.43%' ] ) )
 				.to.deep.equal( [ 10.13, 14.29, 17.65, 27.53, 21.84, 8.56 ] );
+		} );
+	} );
+
+	describe( 'getElementWidthInPixels()', () => {
+		let element;
+
+		beforeEach( () => {
+			element = document.createElement( 'div' );
+
+			document.body.appendChild( element );
+			element.style.width = '100px';
+			element.style.padding = '15px';
+			element.style.border = '10px solid #000';
+		} );
+
+		afterEach( () => {
+			element.remove();
+		} );
+
+		it( 'should return the correct width for content-box algorithm', () => {
+			expect( getElementWidthInPixels( element ) ).to.equal( 100 );
+		} );
+
+		it( 'should return the correct width for border-box algorithm', () => {
+			element.style.boxSizing = 'border-box';
+
+			expect( getElementWidthInPixels( element ) ).to.equal( 50 );
+		} );
+	} );
+
+	describe( 'getDomCellOuterWidth()', () => {
+		let tableElement, cellElement;
+
+		beforeEach( () => {
+			tableElement = document.createElement( 'table' );
+			tableElement.innerHTML = '<tr><td>foo</td></tr>';
+
+			document.body.appendChild( tableElement );
+
+			cellElement = tableElement.querySelector( 'td' );
+			cellElement.style.width = '100px';
+			cellElement.style.padding = '15px';
+			cellElement.style.border = '10px solid #000';
+		} );
+
+		afterEach( () => {
+			tableElement.remove();
+		} );
+
+		it( 'should return the correct width for content-box algorithm', () => {
+			expect( getDomCellOuterWidth( cellElement ) ).to.equal( 140 );
+		} );
+
+		it( 'should return the correct width for border-box algorithm', () => {
+			cellElement.style.boxSizing = 'border-box';
+
+			expect( getDomCellOuterWidth( cellElement ) ).to.equal( 100 );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal(table): Calculate the table parent width properly in various scenarios. Closes #12335.

---

### Additional information

There is a [comment in the original issue](https://github.com/ckeditor/ckeditor5/issues/12335#issuecomment-1230389708) where I've explained the reasoning behind this change.