### PR TITLE
Export insertToPriorityArray as default from index

### DIFF
--- a/packages/ckeditor5-utils/src/index.ts
+++ b/packages/ckeditor5-utils/src/index.ts
@@ -39,6 +39,7 @@ export { default as KeystrokeHandler } from './keystrokehandler';
 export { default as toArray } from './toarray';
 export { default as toMap } from './tomap';
 export { default as priorities } from './priorities';
+export { default as insertToPriorityArray } from './inserttopriorityarray';
 
 export { default as uid } from './uid';
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (utils): Export `insertToPriority()` as default from index file.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
