### PR TITLE
Add table column resize to the all-features manual tests.

### DIFF
--- a/packages/ckeditor5-paste-from-office/tests/manual/integration.js
+++ b/packages/ckeditor5-paste-from-office/tests/manual/integration.js
@@ -19,6 +19,7 @@ import FontBackgroundColor from '@ckeditor/ckeditor5-font/src/fontbackgroundcolo
 import PageBreak from '@ckeditor/ckeditor5-page-break/src/pagebreak';
 import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties';
 import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties';
+import TableColumnResize from '@ckeditor/ckeditor5-table/src/tablecolumnresize';
 import ImageUpload from '@ckeditor/ckeditor5-image/src/imageupload';
 import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices';
 
@@ -44,6 +45,7 @@ ClassicEditor
 			PageBreak,
 			TableProperties,
 			TableCellProperties,
+			TableColumnResize,
 			ImageUpload,
 			CloudServices,
 			EasyImage,

--- a/packages/ckeditor5-paste-from-office/tests/manual/tickets/7957/1.js
+++ b/packages/ckeditor5-paste-from-office/tests/manual/tickets/7957/1.js
@@ -18,6 +18,7 @@ import FontBackgroundColor from '@ckeditor/ckeditor5-font/src/fontbackgroundcolo
 import PageBreak from '@ckeditor/ckeditor5-page-break/src/pagebreak';
 import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties';
 import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties';
+import TableColumnResize from '@ckeditor/ckeditor5-table/src/tablecolumnresize';
 
 import PasteFromOffice from '../../../../src/pastefromoffice';
 
@@ -28,7 +29,7 @@ import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices'
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
-		plugins: [ ArticlePluginSet, Strikethrough, Underline, Table, TableToolbar, PageBreak, CloudServices,
+		plugins: [ ArticlePluginSet, Strikethrough, Underline, Table, TableToolbar, PageBreak, CloudServices, TableColumnResize,
 			TableProperties, TableCellProperties, EasyImage, PasteFromOffice, FontColor, FontBackgroundColor, ImageUpload ],
 		toolbar: [ 'heading', '|', 'bold', 'italic', 'strikethrough', 'underline', 'link',
 			'bulletedList', 'numberedList', 'blockQuote', 'insertTable', 'pageBreak', 'undo', 'redo' ],

--- a/tests/manual/all-features-dll.js
+++ b/tests/manual/all-features-dll.js
@@ -59,7 +59,7 @@ const { FontColor, FontFamily, FontSize, FontBackgroundColor } = window.CKEditor
 const { Indent, IndentBlock } = window.CKEditor5.indent;
 const { List, ListProperties, TodoList } = window.CKEditor5.list;
 const { SpecialCharacters, SpecialCharactersEssentials } = window.CKEditor5.specialCharacters;
-const { Table, TableToolbar, TableCellProperties, TableProperties, TableCaption } = window.CKEditor5.table;
+const { Table, TableToolbar, TableCellProperties, TableProperties, TableCaption, TableColumnResize } = window.CKEditor5.table;
 const { Alignment } = window.CKEditor5.alignment;
 const { Autoformat } = window.CKEditor5.autoformat;
 const { BlockQuote } = window.CKEditor5.blockQuote;
@@ -135,7 +135,7 @@ const config = {
 		PasteFromOffice,
 		RemoveFormat,
 		SpecialCharacters, SpecialCharactersEssentials,
-		Table, TableToolbar, TableCellProperties, TableProperties, TableCaption,
+		Table, TableToolbar, TableCellProperties, TableProperties, TableCaption, TableColumnResize,
 		TextPartLanguage,
 		WordCount,
 		SourceEditing

--- a/tests/manual/all-features.js
+++ b/tests/manual/all-features.js
@@ -40,6 +40,7 @@ import Superscript from '@ckeditor/ckeditor5-basic-styles/src/superscript';
 import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties';
 import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties';
 import TableCaption from '@ckeditor/ckeditor5-table/src/tablecaption';
+import TableColumnResize from '@ckeditor/ckeditor5-table/src/tablecolumnresize';
 import TextTransformation from '@ckeditor/ckeditor5-typing/src/texttransformation';
 import TextPartLanguage from '@ckeditor/ckeditor5-language/src/textpartlanguage';
 import TodoList from '@ckeditor/ckeditor5-list/src/todolist';
@@ -56,7 +57,7 @@ ClassicEditor
 		plugins: [
 			ArticlePluginSet, Underline, Strikethrough, Superscript, Subscript, Code, RemoveFormat,
 			FindAndReplace, FontColor, FontBackgroundColor, FontFamily, FontSize, Highlight,
-			CodeBlock, TodoList, ListProperties, TableProperties, TableCellProperties, TableCaption,
+			CodeBlock, TodoList, ListProperties, TableProperties, TableCellProperties, TableCaption, TableColumnResize,
 			EasyImage, ImageResize, ImageInsert, LinkImage, AutoImage, HtmlEmbed, HtmlComment,
 			AutoLink, Mention, TextTransformation,
 			Alignment, IndentBlock,

--- a/tests/manual/memory/memory-semi-automated.js
+++ b/tests/manual/memory/memory-semi-automated.js
@@ -39,6 +39,7 @@ import Superscript from '@ckeditor/ckeditor5-basic-styles/src/superscript';
 import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties';
 import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties';
 import TableCaption from '@ckeditor/ckeditor5-table/src/tablecaption';
+import TableColumnResize from '@ckeditor/ckeditor5-table/src/tablecolumnresize';
 import TextTransformation from '@ckeditor/ckeditor5-typing/src/texttransformation';
 import TextPartLanguage from '@ckeditor/ckeditor5-language/src/textpartlanguage';
 import TodoList from '@ckeditor/ckeditor5-list/src/todolist';
@@ -57,7 +58,7 @@ function initEditor() {
 				ArticlePluginSet, Underline, Strikethrough, Superscript, Subscript, Code, RemoveFormat,
 				FindAndReplace, FontColor, FontBackgroundColor, FontFamily, FontSize, Highlight,
 				CodeBlock, TodoList, ListProperties, TableProperties, TableCellProperties, TableCaption,
-				EasyImage, ImageResize, LinkImage, AutoImage, HtmlEmbed, HtmlComment,
+				TableColumnResize, EasyImage, ImageResize, LinkImage, AutoImage, HtmlEmbed, HtmlComment,
 				AutoLink, Mention, TextTransformation,
 				Alignment, IndentBlock,
 				PasteFromOffice, PageBreak, HorizontalLine,

--- a/tests/manual/memory/memory.js
+++ b/tests/manual/memory/memory.js
@@ -8,6 +8,7 @@
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties';
 import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties';
+import TableColumnResize from '@ckeditor/ckeditor5-table/src/tablecolumnresize';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
 import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
@@ -47,7 +48,7 @@ function initEditor() {
 	ClassicEditor
 		.create( document.querySelector( '#editor' ), {
 			plugins: [
-				ArticlePluginSet, CodeBlock, Alignment,
+				ArticlePluginSet, CodeBlock, Alignment, TableColumnResize,
 				TableProperties, TableCellProperties, SpecialCharacters, SpecialCharactersEssentials,
 				Code, Underline, Strikethrough, Superscript, Subscript,
 				Highlight, FontColor, FontBackgroundColor, FontFamily, FontSize,

--- a/tests/manual/performance/richeditor.js
+++ b/tests/manual/performance/richeditor.js
@@ -33,6 +33,7 @@ import SpecialCharacters from '@ckeditor/ckeditor5-special-characters/src/specia
 import SpecialCharactersEssentials from '@ckeditor/ckeditor5-special-characters/src/specialcharactersessentials';
 import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties';
 import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties';
+import TableColumnResize from '@ckeditor/ckeditor5-table/src/tablecolumnresize';
 import ImageUpload from '@ckeditor/ckeditor5-image/src/imageupload';
 import ImageResize from '@ckeditor/ckeditor5-image/src/imageresize';
 import IndentBlock from '@ckeditor/ckeditor5-indent/src/indentblock';
@@ -78,6 +79,7 @@ ClassicEditor
 			SpecialCharactersEssentials,
 			TableProperties,
 			TableCellProperties,
+			TableColumnResize,
 			ImageUpload,
 			ImageResize,
 			WordCount,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Tests: Added table column resize to the manual tests with all features. Closes #12255.

---

### Additional information

That's actually part of the ticket, there are two more related PRs in different repos. 

The list of updated manual tests is a bit arbitrary (e.g. I decided it can be useful to update PfO test, but not document lists). I'm open for discussion about the choice.