### PR TITLE
Migration guide entry for changes to the tooltip system

### DIFF
--- a/docs/updating/migration-to-35.md
+++ b/docs/updating/migration-to-35.md
@@ -82,9 +82,9 @@ export default class MyEditorUI extends EditorUI {
 	Please note, that this change does not affect integrations that configure tooltips of core UI components, for instance {@link module:ui/button/buttonview~ButtonView#tooltip}.
 </info-box>
 
-Starting with v35.1.0, the `TooltipView` UI component has been removed from the [ckeditor5-ui](https://www.npmjs.com/package/@ckeditor/ckeditor5-ui) package. Instead, a new tooltip API is available based on `data-cke-tooltip-*` DOM element attributes.
+Starting with v35.1.0, the `TooltipView` UI component has been removed from the [ckeditor5-ui](https://www.npmjs.com/package/@ckeditor/ckeditor5-ui) package. Instead, a new tooltip API is available based on the `data-cke-tooltip-*` DOM element attributes.
 
-If your integration creates instances `TooltipView` and injects them into the DOM in a similar way:
+It may happen that your integration creates instances of `TooltipView` and injects them into the DOM in a similar way:
 
 ```js
 // ❌ Old tooltip API
@@ -107,7 +107,7 @@ DOMElementThatNeedsTooltip.appendChild( tooltip.element );
 }
 ```
 
-you should now use the `data-cke-tooltip-*` attributes and let the editor's built–in {@link module:ui/tooltipmanager~TooltipManager} handle the rest:
+If this is the case, you should now use the `data-cke-tooltip-*` attributes and let the editor's built–in {@link module:ui/tooltipmanager~TooltipManager} handle the rest:
 
 ```js
 // ✅ New tooltip API
@@ -115,7 +115,7 @@ DOMElementThatNeedsTooltip.dataset.ckeTooltipText = 'Tooltip text';
 DOMElementThatNeedsTooltip.dataset.ckeTooltipPosition = 'sw';
 ```
 
-Keep in mind that you do not have to worry about showing and hiding your custom tooltip in CSS. The `TooltipManager` will attach a tooltip whenever the user moves the mouse or brings the focus to a DOM element with the `data-cke-tooltip-*` attributes. For more information, please refer to the API of {@link module:ui/tooltipmanager~TooltipManager}.
+Keep in mind that you do not need to worry about showing and hiding your custom tooltips in CSS. The `TooltipManager` will attach a tooltip whenever the user moves the mouse or brings the focus to a DOM element with the `data-cke-tooltip-*` attributes. For more information, please refer to the {@link module:ui/tooltipmanager~TooltipManager} API.
 
 ## Migration to CKEditor 5 v35.0.0
 

--- a/docs/updating/migration-to-35.md
+++ b/docs/updating/migration-to-35.md
@@ -9,7 +9,9 @@ modified_at: 2022-08-18
 
 ## Migration to CKEditor 5 v35.1.0
 
-### Changes to API providing the accessible navigation between editing roots and toolbars on <kbd>Alt</kbd>+<kbd>F10</kbd> and <kbd>Esc</kbd> keystrokes
+### Important changes
+
+#### Changes to API providing the accessible navigation between editing roots and toolbars on <kbd>Alt</kbd>+<kbd>F10</kbd> and <kbd>Esc</kbd> keystrokes
 
 <info-box>
 	This information applies only to integrators who develop their own {@link framework/guides/custom-editor-creator editor creators} from scratch by using the {@link module:core/editor/editor~Editor} and {@link module:core/editor/editorui~EditorUI} classes as building blocks.
@@ -76,7 +78,7 @@ export default class MyEditorUI extends EditorUI {
 }
 ```
 
-### Removal of the `TooltipView` class and changes to the tooltip system
+#### Removal of the `TooltipView` class and changes to the tooltip system
 
 <info-box>
 	Please note, that this change does not affect integrations that configure tooltips of core UI components, for instance {@link module:ui/button/buttonview~ButtonView#tooltip}.

--- a/docs/updating/migration-to-35.md
+++ b/docs/updating/migration-to-35.md
@@ -76,6 +76,47 @@ export default class MyEditorUI extends EditorUI {
 }
 ```
 
+### Removal of the `TooltipView` class and changes to the tooltip system
+
+<info-box>
+	Please note, that this change does not affect integrations that configure tooltips of core UI components, for instance {@link module:ui/button/buttonview~ButtonView#tooltip}.
+</info-box>
+
+Starting with v35.1.0, the `TooltipView` UI component has been removed from the [ckeditor5-ui](https://www.npmjs.com/package/@ckeditor/ckeditor5-ui) package. Instead, a new tooltip API is available based on `data-cke-tooltip-*` DOM element attributes.
+
+If your integration creates instances `TooltipView` and injects them into the DOM in a similar way:
+
+```js
+// ❌ Old tooltip API
+import { TooltipView } from 'ckeditor5/src/ui';
+
+const tooltip = new TooltipView();
+
+tooltip.text = 'Tooltip text';
+tooltip.position = 'sw';
+tooltip.render();
+
+DOMElementThatNeedsTooltip.appendChild( tooltip.element );
+```
+
+```css
+/* ❌ Old tooltip API */
+.dom-element-that-needs-tooltip:hover .ck-tooltip {
+	visibility: visible;
+	opacity: 1;
+}
+```
+
+you should now use the `data-cke-tooltip-*` attributes and let the editor's built–in {@link module:ui/tooltipmanager~TooltipManager} handle the rest:
+
+```js
+// ✅ New tooltip API
+DOMElementThatNeedsTooltip.dataset.ckeTooltipText = 'Tooltip text';
+DOMElementThatNeedsTooltip.dataset.ckeTooltipPosition = 'sw';
+```
+
+Keep in mind that you do not have to worry about showing and hiding your custom tooltip in CSS. The `TooltipManager` will attach a tooltip whenever the user moves the mouse or brings the focus to a DOM element with the `data-cke-tooltip-*` attributes. For more information, please refer to the API of {@link module:ui/tooltipmanager~TooltipManager}.
+
 ## Migration to CKEditor 5 v35.0.0
 
 <info-box>

--- a/docs/updating/migration-to-35.md
+++ b/docs/updating/migration-to-35.md
@@ -2,7 +2,7 @@
 category: updating
 menu-title: Migration to v35.x
 order: 89
-modified_at: 2022-07-18
+modified_at: 2022-08-18
 ---
 
 # Migration to CKEditor 5 v35.x


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (ckeditor5): Created a migration guide entry for changes to the tooltip system made in CKEditor v35.1.0. Closes #12384.