### PR TITLE
Removed unnecessary `popper` package from the dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@ckeditor/ckeditor5-track-changes": ">=28.0.0",
     "@webspellchecker/wproofreader-ckeditor5": "^2.0.1",
     "@wiris/mathtype-ckeditor5": "^7.24.0",
+    "assert": "^2.0.0",
     "babel-standalone": "^6.26.0",
     "chalk": "^4.1.0",
     "cli-table": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.4",
     "nyc": "^15.0.1",
-    "popper": "^1.0.1",
     "postcss-loader": "^4.3.0",
     "progress-bar-webpack-plugin": "^2.1.0",
     "raw-loader": "^4.0.1",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Removed unnecessary `popper` package from the dependencies. Closes #12408.

Internal: Added missing `assert` package.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
