### PR TITLE
Fix list ordering when block quote was inserted

### DIFF
--- a/packages/ckeditor5-list/src/list/utils.js
+++ b/packages/ckeditor5-list/src/list/utils.js
@@ -289,7 +289,7 @@ export function findNestedList( viewElement ) {
  *
  * It means that values of `listIndent`, `listType`, `listStyle`, `listReversed` and `listStart` for all items are equal.
  *
- * Additionally, if the `position` is inside a list item that list item will be returned as well.
+ * Additionally, if the `position` is inside a list item, that list item will be returned as well.
  *
  * @param {module:engine/model/position~Position} position Starting position.
  * @param {'forward'|'backward'} direction Walking direction.

--- a/packages/ckeditor5-list/src/list/utils.js
+++ b/packages/ckeditor5-list/src/list/utils.js
@@ -297,7 +297,7 @@ export function getSiblingNodes( position, direction ) {
 	const items = [];
 	const listItem = position.parent;
 	const walkerOptions = {
-		ignoreElementEnd: true,
+		ignoreElementEnd: false,
 		startPosition: position,
 		shallow: true,
 		direction
@@ -395,7 +395,6 @@ export function getSelectedListItems( model ) {
 		.filter( element => element.is( 'element', 'listItem' ) )
 		.map( element => {
 			const position = model.change( writer => writer.createPositionAt( element, 0 ) );
-
 			return [
 				...getSiblingNodes( position, 'backward' ),
 				...getSiblingNodes( position, 'forward' )

--- a/packages/ckeditor5-list/src/list/utils.js
+++ b/packages/ckeditor5-list/src/list/utils.js
@@ -289,6 +289,8 @@ export function findNestedList( viewElement ) {
  *
  * It means that values of `listIndent`, `listType`, `listStyle`, `listReversed` and `listStart` for all items are equal.
  *
+ * Additionally, if the `position` is inside a list item that list item will be returned as well.
+ *
  * @param {module:engine/model/position~Position} position Starting position.
  * @param {'forward'|'backward'} direction Walking direction.
  * @returns {Array.<module:engine/model/element~Element>}
@@ -395,6 +397,7 @@ export function getSelectedListItems( model ) {
 		.filter( element => element.is( 'element', 'listItem' ) )
 		.map( element => {
 			const position = model.change( writer => writer.createPositionAt( element, 0 ) );
+
 			return [
 				...getSiblingNodes( position, 'backward' ),
 				...getSiblingNodes( position, 'forward' )

--- a/packages/ckeditor5-list/tests/list/utils.js
+++ b/packages/ckeditor5-list/tests/list/utils.js
@@ -13,6 +13,7 @@ import ListPropertiesEditing from '../../src/listproperties/listpropertieseditin
 
 import { createViewListItemElement, getListTypeFromListStyleType, getSiblingListItem, getSiblingNodes } from '../../src/list/utils';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import BlockQuoteEditing from '@ckeditor/ckeditor5-block-quote/src/blockquoteediting';
 
 describe( 'utils', () => {
 	let writer;
@@ -271,7 +272,7 @@ describe( 'utils', () => {
 		let editor, model, document;
 
 		beforeEach( () => {
-			return VirtualTestEditor.create( { plugins: [ Paragraph, ListPropertiesEditing ] } )
+			return VirtualTestEditor.create( { plugins: [ Paragraph, BlockQuoteEditing, ListPropertiesEditing ] } )
 				.then( newEditor => {
 					editor = newEditor;
 					model = editor.model;
@@ -307,8 +308,8 @@ describe( 'utils', () => {
 				'<listItem listType="bulleted" listIndent="0">3.</listItem>' +
 				'<listItem listType="bulleted" listIndent="0">4.</listItem>'
 			);
-
 			expect( getSiblingNodes( document.selection.getFirstPosition(), 'forward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 2 ),
 				document.getRoot().getChild( 3 ),
 				document.getRoot().getChild( 4 )
 			] );
@@ -342,6 +343,7 @@ describe( 'utils', () => {
 			);
 
 			expect( getSiblingNodes( document.selection.getFirstPosition(), 'forward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 0 ),
 				document.getRoot().getChild( 1 ),
 				document.getRoot().getChild( 2 )
 			] );
@@ -374,6 +376,7 @@ describe( 'utils', () => {
 			);
 
 			expect( getSiblingNodes( document.selection.getFirstPosition(), 'forward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 0 ),
 				document.getRoot().getChild( 1 ),
 				document.getRoot().getChild( 2 )
 			] );
@@ -406,6 +409,7 @@ describe( 'utils', () => {
 			);
 
 			expect( getSiblingNodes( document.selection.getFirstPosition(), 'forward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 0 ),
 				document.getRoot().getChild( 1 ),
 				document.getRoot().getChild( 2 )
 			] );
@@ -425,6 +429,7 @@ describe( 'utils', () => {
 			);
 
 			expect( getSiblingNodes( document.selection.getFirstPosition(), 'forward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 0 ),
 				document.getRoot().getChild( 1 ),
 				document.getRoot().getChild( 2 ),
 				document.getRoot().getChild( 5 ),
@@ -444,8 +449,29 @@ describe( 'utils', () => {
 			);
 
 			expect( getSiblingNodes( document.selection.getFirstPosition(), 'forward' ) ).to.deep.equal( [
+				document.getRoot().getChild( 2 ),
 				document.getRoot().getChild( 3 ),
 				document.getRoot().getChild( 4 )
+			] );
+		} );
+
+		it( 'should return only list items from block quoted list when selection is inside (direction="forward")', () => {
+			setData( model,
+				'<listItem listStart="0" listType="numbered" listIndent="0">0.</listItem>' +
+				'<listItem listStart="0" listType="numbered" listIndent="0">1.</listItem>' +
+				'<blockQuote>' +
+					'<listItem listStart="0" listType="numbered" listIndent="0">[]2.</listItem>' +
+					'<listItem listStart="0" listType="numbered" listIndent="0">3.</listItem>' +
+				'</blockQuote>' +
+				'<listItem listStart="0" listType="numbered" listIndent="0">4.</listItem>' +
+				'<listItem listStart="0" listType="numbered" listIndent="0">5.</listItem>'
+			);
+
+			const blockQuoteElement = document.getRoot().getChild( 2 );
+
+			expect( getSiblingNodes( document.selection.getFirstPosition(), 'forward' ) ).to.deep.equal( [
+				blockQuoteElement.getChild( 0 ),
+				blockQuoteElement.getChild( 1 )
 			] );
 		} );
 	} );

--- a/packages/ckeditor5-list/tests/list/utils.js
+++ b/packages/ckeditor5-list/tests/list/utils.js
@@ -308,6 +308,7 @@ describe( 'utils', () => {
 				'<listItem listType="bulleted" listIndent="0">3.</listItem>' +
 				'<listItem listType="bulleted" listIndent="0">4.</listItem>'
 			);
+
 			expect( getSiblingNodes( document.selection.getFirstPosition(), 'forward' ) ).to.deep.equal( [
 				document.getRoot().getChild( 2 ),
 				document.getRoot().getChild( 3 ),
@@ -455,13 +456,32 @@ describe( 'utils', () => {
 			] );
 		} );
 
-		it( 'should return only list items from block quoted list when selection is inside (direction="forward")', () => {
+		it( 'should return only list items that are inside the same parent element (direction="backward")', () => {
 			setData( model,
 				'<listItem listStart="0" listType="numbered" listIndent="0">0.</listItem>' +
 				'<listItem listStart="0" listType="numbered" listIndent="0">1.</listItem>' +
 				'<blockQuote>' +
-					'<listItem listStart="0" listType="numbered" listIndent="0">[]2.</listItem>' +
-					'<listItem listStart="0" listType="numbered" listIndent="0">3.</listItem>' +
+				'<listItem listStart="0" listType="numbered" listIndent="0">[]2.</listItem>' +
+				'<listItem listStart="0" listType="numbered" listIndent="0">3.</listItem>' +
+				'</blockQuote>' +
+				'<listItem listStart="0" listType="numbered" listIndent="0">4.</listItem>' +
+				'<listItem listStart="0" listType="numbered" listIndent="0">5.</listItem>'
+			);
+
+			const blockQuoteElement = document.getRoot().getChild( 2 );
+
+			expect( getSiblingNodes( document.selection.getFirstPosition(), 'backward' ) ).to.deep.equal( [
+				blockQuoteElement.getChild( 0 )
+			] );
+		} );
+
+		it( 'should return only list items that are inside the same parent element (direction="forward")', () => {
+			setData( model,
+				'<listItem listStart="0" listType="numbered" listIndent="0">0.</listItem>' +
+				'<listItem listStart="0" listType="numbered" listIndent="0">1.</listItem>' +
+				'<blockQuote>' +
+				'<listItem listStart="0" listType="numbered" listIndent="0">[]2.</listItem>' +
+				'<listItem listStart="0" listType="numbered" listIndent="0">3.</listItem>' +
 				'</blockQuote>' +
 				'<listItem listStart="0" listType="numbered" listIndent="0">4.</listItem>' +
 				'<listItem listStart="0" listType="numbered" listIndent="0">5.</listItem>'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (list): Ordering problem when block quote was being inserted into the middle of the list. Closes #11082.

---

### Additional information

This issue was caused by by incorrectly ignoring closing tags when searching for list items.