### PR TITLE
Corrected autolinking urls without protocol

### DIFF
--- a/packages/ckeditor5-link/src/autolink.js
+++ b/packages/ckeditor5-link/src/autolink.js
@@ -10,7 +10,7 @@
 import { Plugin } from 'ckeditor5/src/core';
 import { Delete, TextWatcher, getLastTextLine } from 'ckeditor5/src/typing';
 
-import { addLinkProtocolIfApplicable } from './utils';
+import { addLinkProtocolIfApplicable, linkHasProtocol } from './utils';
 
 const MIN_LINK_LENGTH_WITH_SPACE_AT_END = 4; // Ie: "t.co " (length 5).
 
@@ -233,14 +233,15 @@ export default class AutoLink extends Plugin {
 		const model = this.editor.model;
 		const deletePlugin = this.editor.plugins.get( 'Delete' );
 
-		if ( !this.isEnabled || !isLinkAllowedOnRange( range, model ) ) {
+		const defaultProtocol = this.editor.config.get( 'link.defaultProtocol' );
+		const parsedUrl = addLinkProtocolIfApplicable( link, defaultProtocol );
+
+		if ( !this.isEnabled || !isLinkAllowedOnRange( range, model ) || !linkHasProtocol( parsedUrl ) ) {
 			return;
 		}
 
 		// Enqueue change to make undo step.
 		model.enqueueChange( writer => {
-			const defaultProtocol = this.editor.config.get( 'link.defaultProtocol' );
-			const parsedUrl = addLinkProtocolIfApplicable( link, defaultProtocol );
 			writer.setAttribute( 'linkHref', parsedUrl, range );
 
 			model.enqueueChange( () => {

--- a/packages/ckeditor5-link/src/utils.js
+++ b/packages/ckeditor5-link/src/utils.js
@@ -175,8 +175,7 @@ export function addLinkProtocolIfApplicable( link, defaultProtocol ) {
 }
 
 /**
- * Checks if protocol is already included in the link
- *
+ * Checks if protocol is already included in the link.
  *
  * @param {String} link
  * @returns {Boolean}

--- a/packages/ckeditor5-link/src/utils.js
+++ b/packages/ckeditor5-link/src/utils.js
@@ -165,13 +165,24 @@ export function isEmail( value ) {
  *
  * @params {String} link
  * @params {String} defaultProtocol
- * @returns {Boolean}
+ * @returns {String}
  */
 export function addLinkProtocolIfApplicable( link, defaultProtocol ) {
 	const protocol = isEmail( link ) ? 'mailto:' : defaultProtocol;
-	const isProtocolNeeded = !!protocol && !PROTOCOL_REG_EXP.test( link );
+	const isProtocolNeeded = !!protocol && !linkHasProtocol( link );
 
 	return link && isProtocolNeeded ? protocol + link : link;
+}
+
+/**
+ * Checks if protocol is already included in the link
+ *
+ *
+ * @param {String} link
+ * @returns {Boolean}
+ */
+export function linkHasProtocol( link ) {
+	return PROTOCOL_REG_EXP.test( link );
 }
 
 /**

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -237,6 +237,15 @@ describe( 'AutoLink', () => {
 			);
 		} );
 
+		it( 'does not autolink address without protocol (defaultProtocol is not set or not valid)', () => {
+			editor.config.set( 'link.defaultProtocol', '' );
+			simulateTyping( 'www.cksource.com ' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph>www.cksource.com []</paragraph>'
+			);
+		} );
+
 		// Some examples came from https://mathiasbynens.be/demo/url-regex.
 		describe( 'supported URL', () => {
 			const supportedURLs = [
@@ -245,7 +254,6 @@ describe( 'AutoLink', () => {
 				'https://cksource.com:8080',
 				'http://www.cksource.com',
 				'hTtP://WwW.cKsOuRcE.cOm',
-				'www.cksource.com',
 				'http://foo.bar.cksource.com',
 				'http://www.cksource.com/some/path/index.html#abc',
 				'http://www.cksource.com/some/path/index.html?foo=bar',
@@ -303,7 +311,7 @@ describe( 'AutoLink', () => {
 			}
 		} );
 
-		describe( 'invalid or supported URL', () => {
+		describe( 'invalid or unsupported URL', () => {
 			// Some examples came from https://mathiasbynens.be/demo/url-regex.
 			const unsupportedOrInvalid = [
 				'http://',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (link): Corrected autolinking URLs without protocol. Closes #11040.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._