### PR TITLE
Created custom splice method to deal with very big number of elements

### DIFF
--- a/packages/ckeditor5-engine/src/model/nodelist.ts
+++ b/packages/ckeditor5-engine/src/model/nodelist.ts
@@ -18,7 +18,7 @@ import spliceArray from '@ckeditor/ckeditor5-utils/src/splicearray';
  * or {@link module:engine/model/documentfragment~DocumentFragment DocumentFragment}.
  */
 export default class NodeList implements Iterable<Node> {
-	private readonly _nodes: Node[];
+	private _nodes: Node[];
 
 	/**
 	 * Creates an empty node list.
@@ -195,7 +195,7 @@ export default class NodeList implements Iterable<Node> {
 			}
 		}
 
-		spliceArray<Node>( this._nodes, Array.from( nodes ), index, 0 );
+		this._nodes = spliceArray<Node>( this._nodes, Array.from( nodes ), index, 0 );
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/model/nodelist.ts
+++ b/packages/ckeditor5-engine/src/model/nodelist.ts
@@ -10,6 +10,7 @@
 import Node from './node';
 
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
+import spliceArray from '@ckeditor/ckeditor5-utils/src/splicearray';
 
 /**
  * Provides an interface to operate on a list of {@link module:engine/model/node~Node nodes}. `NodeList` is used internally
@@ -194,7 +195,7 @@ export default class NodeList implements Iterable<Node> {
 			}
 		}
 
-		this._nodes.splice( index, 0, ...nodes );
+		spliceArray<Node>( this._nodes, Array.from( nodes ), index, 0 );
 	}
 
 	/**

--- a/packages/ckeditor5-engine/tests/model/nodelist.js
+++ b/packages/ckeditor5-engine/tests/model/nodelist.js
@@ -162,6 +162,16 @@ describe( 'NodeList', () => {
 				nodes._insertNodes( 0, [ 'foo' ] );
 			}, 'nodelist-insertnodes-not-node', nodes );
 		} );
+
+		it( 'should insert large number of nodes (250 000) without throwing an error', () => {
+			const numberOfNodes = 250000;
+			const largeArray = 'a'.repeat( numberOfNodes ).split( '' ).map( el => new Text( el ) );
+			const expectedLength = nodes.length + largeArray.length;
+
+			nodes._insertNodes( 0, largeArray );
+
+			expect( nodes.length ).to.equal( expectedLength );
+		} );
 	} );
 
 	describe( '_removeNodes', () => {

--- a/packages/ckeditor5-utils/src/splicearray.ts
+++ b/packages/ckeditor5-utils/src/splicearray.ts
@@ -13,6 +13,8 @@ const BIG_CHUNK_SIZE = 10000;
  * Splices one array into another. To be used instead of `Array.prototype.splice` as the latter may
  * throw "Maximum call stack size exceeded" when passed huge number of items to insert.
  *
+ * Note: in contrary to Array.splice, this function does not modify the original `target`.
+ *
  * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 0, 0 );		// [ 3, 4, 1, 2 ]
  * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 1, 1 );		// [ 1, 3, 4 ]
  * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 1, 0 );		// [ 1, 3, 4, 2 ]

--- a/packages/ckeditor5-utils/src/splicearray.ts
+++ b/packages/ckeditor5-utils/src/splicearray.ts
@@ -7,16 +7,11 @@
  * @module utils/splicearray
  */
 
+const BIG_CHUNK_SIZE = 10000;
+
 /**
- * Function that splices Arrays and could be used instead of Array.prototype.splice as it results
- * into "Maximum call stack size exceeded" when dealing with very big number.
- *
- * @private
- * @param {Array} target Array to be spliced.
- * @param {Array} source Array of elements to be inserted to target.
- * @param {Number} start Index at which nodes should be inserted/removed.
- * @param {Number} count Number of items.
- * @param {Number} [chunkSize=10000] Chunk size of source array.
+ * Splices one array into another. To be used instead of `Array.prototype.splice` as the latter may
+ * throw "Maximum call stack size exceeded" when passed huge number of items to insert.
  *
  * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 0, 0 );		// [ 3, 4, 1, 2]
  * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 1, 1 );		// [ 1, 3, 4 ]
@@ -24,16 +19,23 @@
  * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 2, 0 );		// [ 1, 2, 3, 4 ]
  * 		spliceArray( [ 1, 2 ], [], 0, 1 );				// [ 2 ]
  *
+ * @private
+ * @param {Array} target Array to be spliced.
+ * @param {Array} source Array of elements to be inserted to target.
+ * @param {Number} start Index at which nodes should be inserted/removed.
+ * @param {Number} count Number of items.
+ *
+ * @returns {Array} New spliced array.
+ *
  */
-export default function spliceArray<T>( target: Array<T>, source: Array<T>, start: number, count: number, chunkSize = 10000 ): Array<T> {
-	target.splice( start, count );
+export default function spliceArray<T>( target: Array<T>, source: Array<T>, start: number, count: number ): Array<T> {
+	// In case of performance problems, see: https://github.com/ckeditor/ckeditor5/pull/12429/files#r965850568
+	if ( Math.max( source.length, target.length ) > BIG_CHUNK_SIZE ) {
+		return target.slice( 0, start ).concat( source ).concat( target.slice( start + count, target.length ) );
+	} else {
+		const newTarget = Array.from( target );
+		newTarget.splice( start, count, ...source );
 
-	if ( source && source.length ) {
-		for ( let idx = Math.floor( source.length / chunkSize ); idx >= 0; idx-- ) {
-			const sourceChunk = source.slice( idx * chunkSize, ( idx + 1 ) * chunkSize );
-			target.splice( start, 0, ...sourceChunk );
-		}
+		return newTarget;
 	}
-
-	return target;
 }

--- a/packages/ckeditor5-utils/src/splicearray.ts
+++ b/packages/ckeditor5-utils/src/splicearray.ts
@@ -1,0 +1,39 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module utils/splicearray
+ */
+
+/**
+ * Function that splices Arrays and could be used instead of Array.prototype.splice as it results
+ * into "Maximum call stack size exceeded" when dealing with very big number.
+ *
+ * @private
+ * @param {Array} target Array to be spliced.
+ * @param {Array} source Array of elements to be inserted to target.
+ * @param {Number} start Index at which nodes should be inserted/removed.
+ * @param {Number} count Number of items.
+ * @param {Number} [chunkSize=10000] Chunk size of source array.
+ *
+ * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 0, 0 );		// [ 3, 4, 1, 2]
+ * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 1, 1 );		// [ 1, 3, 4 ]
+ * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 1, 0 );		// [ 1, 3, 4, 2 ]
+ * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 2, 0 );		// [ 1, 2, 3, 4 ]
+ * 		spliceArray( [ 1, 2 ], [], 0, 1 );				// [ 2 ]
+ *
+ */
+export default function spliceArray<T>( target: Array<T>, source: Array<T>, start: number, count: number, chunkSize = 10000 ): Array<T> {
+	target.splice( start, count );
+
+	if ( source && source.length ) {
+		for ( let idx = Math.floor( source.length / chunkSize ); idx >= 0; idx-- ) {
+			const sourceChunk = source.slice( idx * chunkSize, ( idx + 1 ) * chunkSize );
+			target.splice( start, 0, ...sourceChunk );
+		}
+	}
+
+	return target;
+}

--- a/packages/ckeditor5-utils/src/splicearray.ts
+++ b/packages/ckeditor5-utils/src/splicearray.ts
@@ -26,7 +26,6 @@ const BIG_CHUNK_SIZE = 10000;
  * @param {Number} count Number of items.
  *
  * @returns {Array} New spliced array.
- *
  */
 export default function spliceArray<T>( target: Array<T>, source: Array<T>, start: number, count: number ): Array<T> {
 	// In case of performance problems, see: https://github.com/ckeditor/ckeditor5/pull/12429/files#r965850568

--- a/packages/ckeditor5-utils/src/splicearray.ts
+++ b/packages/ckeditor5-utils/src/splicearray.ts
@@ -13,7 +13,7 @@ const BIG_CHUNK_SIZE = 10000;
  * Splices one array into another. To be used instead of `Array.prototype.splice` as the latter may
  * throw "Maximum call stack size exceeded" when passed huge number of items to insert.
  *
- * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 0, 0 );		// [ 3, 4, 1, 2]
+ * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 0, 0 );		// [ 3, 4, 1, 2 ]
  * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 1, 1 );		// [ 1, 3, 4 ]
  * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 1, 0 );		// [ 1, 3, 4, 2 ]
  * 		spliceArray( [ 1, 2 ], [ 3, 4 ], 2, 0 );		// [ 1, 2, 3, 4 ]

--- a/packages/ckeditor5-utils/tests/splicearray.js
+++ b/packages/ckeditor5-utils/tests/splicearray.js
@@ -11,45 +11,36 @@ describe( 'utils', () => {
 			const target = [ 1, 2 ];
 			const source = [ 3, 4 ];
 
-			spliceArray( target, source, 0, 0 );
+			const result = spliceArray( target, source, 0, 0 );
 
-			expect( target ).to.have.members( [ 3, 4, 1, 2 ] );
+			expect( result ).to.have.members( [ 3, 4, 1, 2 ] );
 		} );
 
 		it( 'should insert elements in the middle of the target array', () => {
 			const target = [ 1, 2 ];
 			const source = [ 3, 4 ];
 
-			spliceArray( target, source, 1, 0 );
+			const result = spliceArray( target, source, 1, 0 );
 
-			expect( target ).to.have.members( [ 1, 3, 4, 2 ] );
+			expect( result ).to.have.members( [ 1, 3, 4, 2 ] );
 		} );
 
 		it( 'should insert elements at the end of the target array', () => {
 			const target = [ 1, 2 ];
 			const source = [ 3, 4 ];
 
-			spliceArray( target, source, 2, 0 );
+			const result = spliceArray( target, source, 2, 0 );
 
-			expect( target ).to.have.members( [ 1, 2, 3, 4 ] );
-		} );
-
-		it( 'should return reference to target array', () => {
-			const target = [ 1, 2 ];
-			const source = [ 3, 4 ];
-
-			const result = spliceArray( target, source, 0, 0 );
-
-			expect( result ).to.equal( target );
+			expect( result ).to.have.members( [ 1, 2, 3, 4 ] );
 		} );
 
 		it( 'should only splice target array when source is empty', () => {
 			const target = [ 1, 2 ];
 			const source = [];
 
-			spliceArray( target, source, 0, 1 );
+			const result = spliceArray( target, source, 0, 1 );
 
-			expect( target ).to.have.members( [ 2 ] );
+			expect( result ).to.have.members( [ 2 ] );
 		} );
 
 		it( 'should insert elements into array which contains a large number of elements (250 000)', () => {
@@ -57,9 +48,19 @@ describe( 'utils', () => {
 			const source = [ 'b', 'c' ];
 			const expectedLength = target.length + source.length;
 
-			spliceArray( target, source, 0, 0 );
+			const result = spliceArray( target, source, 0, 0 );
 
-			expect( target.length ).to.equal( expectedLength );
+			expect( result.length ).to.equal( expectedLength );
+			expect( result[ 0 ] ).to.equal( source[ 0 ] );
+		} );
+
+		it( 'should insert elements in the middle of the target array which contains a large number of elements (250 000)', () => {
+			const target = 'a'.repeat( 250000 ).split( '' );
+			const source = [ 'b', 'c' ];
+
+			const result = spliceArray( target, source, 5, 0 );
+
+			expect( result[ 5 ] ).to.equal( source[ 0 ] );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-utils/tests/splicearray.js
+++ b/packages/ckeditor5-utils/tests/splicearray.js
@@ -1,0 +1,65 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import spliceArray from '../src/splicearray';
+
+describe( 'utils', () => {
+	describe( 'spliceArray', () => {
+		it( 'should insert elements at the beginning of the target array', () => {
+			const target = [ 1, 2 ];
+			const source = [ 3, 4 ];
+
+			spliceArray( target, source, 0, 0 );
+
+			expect( target ).to.have.members( [ 3, 4, 1, 2 ] );
+		} );
+
+		it( 'should insert elements in the middle of the target array', () => {
+			const target = [ 1, 2 ];
+			const source = [ 3, 4 ];
+
+			spliceArray( target, source, 1, 0 );
+
+			expect( target ).to.have.members( [ 1, 3, 4, 2 ] );
+		} );
+
+		it( 'should insert elements at the end of the target array', () => {
+			const target = [ 1, 2 ];
+			const source = [ 3, 4 ];
+
+			spliceArray( target, source, 2, 0 );
+
+			expect( target ).to.have.members( [ 1, 2, 3, 4 ] );
+		} );
+
+		it( 'should return reference to target array', () => {
+			const target = [ 1, 2 ];
+			const source = [ 3, 4 ];
+
+			const result = spliceArray( target, source, 0, 0 );
+
+			expect( result ).to.equal( target );
+		} );
+
+		it( 'should only splice target array when source is empty', () => {
+			const target = [ 1, 2 ];
+			const source = [];
+
+			spliceArray( target, source, 0, 1 );
+
+			expect( target ).to.have.members( [ 2 ] );
+		} );
+
+		it( 'should insert elements into array which contains a large number of elements (250 000)', () => {
+			const target = 'a'.repeat( 250000 ).split( '' );
+			const source = [ 'b', 'c' ];
+			const expectedLength = target.length + source.length;
+
+			spliceArray( target, source, 0, 0 );
+
+			expect( target.length ).to.equal( expectedLength );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): Fixed editor throwing `Maximum call stack size exceeded` error when huge number of nodes were inserted at once into an element. Closes #12428.

---

### Additional information

Generally, the editor crashes with error _"Maximum call stack size exceeded"_ when there are at least 200 000 elements in one paragraph and someone opens the revision history feature. This issue has been solved, however, there is still situation when browser crashes because of large content (like 1-2 mln of chars in one paragraph) and this issue cannot be fix on our side.