### PR TITLE
Set tabindex to -1 to prevent focusing the checkbox element with Tab key

### DIFF
--- a/packages/ckeditor5-list/src/todolist/todolistconverters.js
+++ b/packages/ckeditor5-list/src/todolist/todolistconverters.js
@@ -301,7 +301,7 @@ function createCheckmarkElement( modelItem, viewWriter, isChecked, onChange ) {
 			contenteditable: false
 		},
 		function( domDocument ) {
-			const checkbox = createElement( document, 'input', { type: 'checkbox' } );
+			const checkbox = createElement( document, 'input', { type: 'checkbox', tabindex: -1 } );
 
 			if ( isChecked ) {
 				checkbox.setAttribute( 'checked', 'checked' );

--- a/packages/ckeditor5-list/tests/todolist/todolistediting.js
+++ b/packages/ckeditor5-list/tests/todolist/todolistediting.js
@@ -1265,7 +1265,6 @@ describe( 'TodoListEditing - checkbox rendering', () => {
 
 		expect( checkboxElement.tagName ).to.equal( 'INPUT' );
 		expect( checkboxElement.checked ).to.equal( false );
-		expect( checkboxElement.hasAttribute( 'tabindex' ) ).to.be.true;
 		expect( checkboxElement.getAttribute( 'tabindex' ) ).to.equal( '-1' );
 	} );
 

--- a/packages/ckeditor5-list/tests/todolist/todolistediting.js
+++ b/packages/ckeditor5-list/tests/todolist/todolistediting.js
@@ -1265,6 +1265,8 @@ describe( 'TodoListEditing - checkbox rendering', () => {
 
 		expect( checkboxElement.tagName ).to.equal( 'INPUT' );
 		expect( checkboxElement.checked ).to.equal( false );
+		expect( checkboxElement.hasAttribute( 'tabindex' ) ).to.be.true;
+		expect( checkboxElement.getAttribute( 'tabindex' ) ).to.equal( '-1' );
 	} );
 
 	it( 'should render checked checkbox inside a checkmark UIElement', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (list): To-do list items should not interrupt the Tab key navigation across the editor content. Closes #6535 .

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
