### PR TITLE
Fix (widget): Don't show image resizer handle when resizer is not enabled (commentsOnly mode)

### DIFF
--- a/packages/ckeditor5-image/tests/imageresize/imageresizehandles.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizehandles.js
@@ -128,7 +128,7 @@ describe( 'ImageResizeHandles', () => {
 				const resizerWrapper = editor.ui.getEditableElement().querySelector( '.ck-widget__resizer' );
 
 				expect( resizer.isEnabled ).to.be.false;
-				expect( resizerWrapper.style.display ).to.equal( 'none' );
+				expect( resizerWrapper.classList.contains( 'ck-hidden' ) ).to.be.true;
 			} );
 
 			it( 'removes the image_resized class if the command was overriden and canceled', async () => {
@@ -605,7 +605,7 @@ describe( 'ImageResizeHandles', () => {
 				const resizerWrapper = editor.ui.getEditableElement().querySelector( '.ck-widget__resizer' );
 
 				expect( resizer.isEnabled ).to.be.false;
-				expect( resizerWrapper.style.display ).to.equal( 'none' );
+				expect( resizerWrapper.classList.contains( 'ck-hidden' ) ).to.be.true;
 			} );
 		} );
 

--- a/packages/ckeditor5-widget/src/widgetresize.js
+++ b/packages/ckeditor5-widget/src/widgetresize.js
@@ -112,7 +112,7 @@ export default class WidgetResize extends Plugin {
 			if ( resizer ) {
 				this.select( resizer );
 			} else {
-				this.deselect( resizer );
+				this.deselect();
 			}
 		} );
 	}
@@ -148,6 +148,7 @@ export default class WidgetResize extends Plugin {
 		if ( this.selectedResizer ) {
 			this.selectedResizer.isSelected = false;
 		}
+
 		this.selectedResizer = null;
 	}
 

--- a/packages/ckeditor5-widget/src/widgetresize.js
+++ b/packages/ckeditor5-widget/src/widgetresize.js
@@ -131,7 +131,7 @@ export default class WidgetResize extends Plugin {
 	}
 
 	/**
-	 * mark resizer as selected
+	 * Marks resizer as selected.
 	 *
 	 * @param {module:widget/widgetresize/resizer~Resizer} resizer
 	 */
@@ -142,7 +142,7 @@ export default class WidgetResize extends Plugin {
 	}
 
 	/**
-	 * deselect currently set resizer
+	 * Deselects currently set resizer.
 	 */
 	deselect() {
 		if ( this.selectedResizer ) {

--- a/packages/ckeditor5-widget/src/widgetresize.js
+++ b/packages/ckeditor5-widget/src/widgetresize.js
@@ -78,7 +78,7 @@ export default class WidgetResize extends Plugin {
 		this._observer.listenTo( domDocument, 'mouseup', this._mouseUpListener.bind( this ) );
 
 		const redrawFocusedResizer = () => {
-			if ( this.visibleResizer ) {
+			if ( this.visibleResizer && this.visibleResizer.isEnabled ) {
 				this.visibleResizer.redraw();
 			}
 		};

--- a/packages/ckeditor5-widget/src/widgetresize.js
+++ b/packages/ckeditor5-widget/src/widgetresize.js
@@ -42,12 +42,12 @@ export default class WidgetResize extends Plugin {
 		const domDocument = global.window.document;
 
 		/**
-		 * The currently visible resizer.
+		 * The currently selected resizer.
 		 *
 		 * @observable
-		 * @member {module:widget/widgetresize/resizer~Resizer|null} #visibleResizer
+		 * @member {module:widget/widgetresize/resizer~Resizer|null} #selectedResizer
 		 */
-		this.set( 'visibleResizer', null );
+		this.set( 'selectedResizer', null );
 
 		/**
 		 * References an active resizer.
@@ -77,20 +77,16 @@ export default class WidgetResize extends Plugin {
 		this._observer.listenTo( domDocument, 'mousemove', this._mouseMoveListener.bind( this ) );
 		this._observer.listenTo( domDocument, 'mouseup', this._mouseUpListener.bind( this ) );
 
-		const redrawFocusedResizer = () => {
-			if ( this.visibleResizer ) {
-				this.visibleResizer.redraw();
+		const redrawSelectedResizer = () => {
+			if ( this.selectedResizer && this.selectedResizer.isVisible ) {
+				this.selectedResizer.redraw();
 			}
 		};
 
-		this._redrawFocusedResizerThrottled = throttle( redrawFocusedResizer, 200 );
-
-		// Redraws occurring upon a change of visible resizer must not be throttled, as it is crucial for the initial
-		// render. Without it the resizer frame would be misaligned with resizing host for a fraction of second.
-		this.on( 'change:visibleResizer', redrawFocusedResizer );
+		this._redrawSelectedResizerThrottled = throttle( redrawSelectedResizer, 200 );
 
 		// Redrawing on any change of the UI of the editor (including content changes).
-		this.editor.ui.on( 'update', this._redrawFocusedResizerThrottled );
+		this.editor.ui.on( 'update', this._redrawSelectedResizerThrottled );
 
 		// Remove view widget-resizer mappings for widgets that have been removed from the document.
 		// https://github.com/ckeditor/ckeditor5/issues/10156
@@ -105,7 +101,7 @@ export default class WidgetResize extends Plugin {
 		}, { priority: 'lowest' } );
 
 		// Resizers need to be redrawn upon window resize, because new window might shrink resize host.
-		this._observer.listenTo( global.window, 'resize', this._redrawFocusedResizerThrottled );
+		this._observer.listenTo( global.window, 'resize', this._redrawSelectedResizerThrottled );
 
 		const viewSelection = this.editor.editing.view.document.selection;
 
@@ -113,8 +109,10 @@ export default class WidgetResize extends Plugin {
 			const selectedElement = viewSelection.getSelectedElement();
 
 			const resizer = this.getResizerByViewElement( selectedElement ) || null;
-			if ( resizer && resizer.isEnabled ) {
-				this.visibleResizer = resizer;
+			if ( resizer ) {
+				this.select( resizer );
+			} else {
+				this.deselect( resizer );
 			}
 		} );
 	}
@@ -129,7 +127,28 @@ export default class WidgetResize extends Plugin {
 			resizer.destroy();
 		}
 
-		this._redrawFocusedResizerThrottled.cancel();
+		this._redrawSelectedResizerThrottled.cancel();
+	}
+
+	/**
+	 * mark resizer as selected
+	 *
+	 * @param {module:widget/widgetresize/resizer~Resizer} resizer
+	 */
+	select( resizer ) {
+		this.deselect();
+		this.selectedResizer = resizer;
+		this.selectedResizer.isSelected = true;
+	}
+
+	/**
+	 * deselect currently set resizer
+	 */
+	deselect() {
+		if ( this.selectedResizer ) {
+			this.selectedResizer.isSelected = false;
+		}
+		this.selectedResizer = null;
 	}
 
 	/**
@@ -167,7 +186,7 @@ export default class WidgetResize extends Plugin {
 
 		// If the element the resizer is created for is currently focused, it should become visible.
 		if ( this.getResizerByViewElement( selectedElement ) == resizer ) {
-			this.visibleResizer = resizer;
+			this.select( resizer );
 		}
 
 		return resizer;

--- a/packages/ckeditor5-widget/src/widgetresize.js
+++ b/packages/ckeditor5-widget/src/widgetresize.js
@@ -78,7 +78,7 @@ export default class WidgetResize extends Plugin {
 		this._observer.listenTo( domDocument, 'mouseup', this._mouseUpListener.bind( this ) );
 
 		const redrawFocusedResizer = () => {
-			if ( this.visibleResizer && this.visibleResizer.isEnabled ) {
+			if ( this.visibleResizer ) {
 				this.visibleResizer.redraw();
 			}
 		};
@@ -112,7 +112,10 @@ export default class WidgetResize extends Plugin {
 		viewSelection.on( 'change', () => {
 			const selectedElement = viewSelection.getSelectedElement();
 
-			this.visibleResizer = this.getResizerByViewElement( selectedElement ) || null;
+			const resizer = this.getResizerByViewElement( selectedElement ) || null;
+			if ( resizer && resizer.isEnabled ) {
+				this.visibleResizer = resizer;
+			}
 		} );
 	}
 

--- a/packages/ckeditor5-widget/src/widgetresize/resizer.js
+++ b/packages/ckeditor5-widget/src/widgetresize/resizer.js
@@ -68,26 +68,26 @@ export default class Resizer {
 		 */
 
 		/**
-		 * flag that indicates whether resizer can be used
+		 * Flag that indicates whether resizer can be used.
 		 *
 		 * @observable
 		 */
 		this.set( 'isEnabled', true );
 
 		/**
-		 * flag that indicates that resizer is currently focused
+		 * Flag that indicates that resizer is currently focused.
 		 *
 		 * @observable
 		 */
 		this.set( 'isSelected', false );
 
 		/**
-		 * flag that indicates whether resizer is rendered (visible on the screen)
+		 * Flag that indicates whether resizer is rendered (visible on the screen).
 		 *
 		 * @readonly
 		 * @observable
 		 */
-		this.set( 'isVisible', false );
+		this.bind( 'isVisible' ).to( this, 'isEnabled', this, 'isSelected', ( isEnabled, isSelected ) => isEnabled && isSelected );
 
 		this.decorate( 'begin' );
 		this.decorate( 'cancel' );
@@ -103,8 +103,6 @@ export default class Resizer {
 			}
 		}, { priority: 'high' } );
 
-		this.on( 'change:isEnabled', this._updateIsVisible );
-		this.on( 'change:isSelected', this._updateIsVisible );
 		this.on( 'change:isVisible', () => {
 			if ( this.isVisible ) {
 				this.show();
@@ -115,6 +113,9 @@ export default class Resizer {
 		} );
 	}
 
+	/**
+	 * Makes resizer visible in the UI.
+	 */
 	show() {
 		const editingView = this._options.editor.editing.view;
 
@@ -123,6 +124,9 @@ export default class Resizer {
 		} );
 	}
 
+	/**
+	 * Hides resizer in the UI.
+	 */
 	hide() {
 		const editingView = this._options.editor.editing.view;
 
@@ -320,13 +324,6 @@ export default class Resizer {
 
 	static isResizeHandle( domElement ) {
 		return domElement.classList.contains( 'ck-widget__resizer__handle' );
-	}
-
-	/**
-	 * @private
-	 */
-	_updateIsVisible() {
-		this.isVisible = this.isEnabled && this.isSelected;
 	}
 
 	/**

--- a/packages/ckeditor5-widget/tests/widgetresize.js
+++ b/packages/ckeditor5-widget/tests/widgetresize.js
@@ -10,7 +10,6 @@ import WidgetResize from '../src/widgetresize';
 // ClassicTestEditor can't be used, as it doesn't handle the focus, which is needed to test resizer visual cues.
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
-import isVisible from '@ckeditor/ckeditor5-utils/src/dom/isvisible';
 
 import { toWidget } from '../src/utils';
 import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
@@ -139,43 +138,25 @@ describe( 'WidgetResize', () => {
 		} );
 	} );
 
-	describe( 'visibility', () => {
+	describe( 'selectability', () => {
 		beforeEach( () => {
 			createResizer();
 		} );
-
-		it( 'it\'s hidden when no widget is focused', () => {
+		it( 'handles resizer selection on view element focus', () => {
 			const widgetResizePlugin = editor.plugins.get( WidgetResize );
+			const viewSelection = editor.editing.view.document.selection;
+			const selectedElement = viewSelection.getSelectedElement();
+			const resizer = widgetResizePlugin.getResizerByViewElement( selectedElement );
+
+			widgetResizePlugin.select( resizer );
+
+			expect( widgetResizePlugin.selectedResizer ).to.not.be.null;
+			expect( resizer.isSelected ).to.be.true;
+
 			widgetResizePlugin.deselect();
 
-			const allResizers = editor.ui.getEditableElement().querySelectorAll( '.ck-widget__resizer__handle' );
-
-			for ( const resizer of allResizers ) {
-				expect( isVisible( resizer ) ).to.be.false;
-			}
-		} );
-
-		it( 'it\'s visible once the widget is focused', () => {
-			const widgetResizePlugin = editor.plugins.get( WidgetResize );
-			widgetResizePlugin.select( widgetResizePlugin.selectedResizer );
-
-			const allResizers = editor.ui.getEditableElement().querySelectorAll( '.ck-widget__resizer__handle' );
-
-			for ( const resizer of allResizers ) {
-				expect( isVisible( resizer ) ).to.be.true;
-			}
-		} );
-
-		it( 'it\'s hidden when resizer is not enabled and widget is focused', () => {
-			const widgetResizePlugin = editor.plugins.get( WidgetResize );
-			widgetResizePlugin.select( widgetResizePlugin.selectedResizer );
-			widgetResizePlugin.selectedResizer.isEnabled = false;
-
-			const allResizers = editor.ui.getEditableElement().querySelectorAll( '.ck-widget__resizer__handle' );
-
-			for ( const resizer of allResizers ) {
-				expect( isVisible( resizer ) ).to.be.false;
-			}
+			expect( widgetResizePlugin.selectedResizer ).to.be.null;
+			expect( resizer.isSelected ).to.be.false;
 		} );
 	} );
 

--- a/packages/ckeditor5-widget/tests/widgetresize.js
+++ b/packages/ckeditor5-widget/tests/widgetresize.js
@@ -163,6 +163,18 @@ describe( 'WidgetResize', () => {
 				expect( isVisible( resizer ) ).to.be.true;
 			}
 		} );
+
+		it( 'it\'s hidden when resizer is not enabled and widget is focused', () => {
+			// Widget is focused by default.
+			const widgetResizePlugin = editor.plugins.get( WidgetResize );
+			widgetResizePlugin.visibleResizer.isEnabled = false;
+
+			const allResizers = editor.ui.getEditableElement().querySelectorAll( '.ck-widget__resizer__handle' );
+
+			for ( const resizer of allResizers ) {
+				expect( isVisible( resizer ) ).to.be.false;
+			}
+		} );
 	} );
 
 	describe( 'integration (pixels)', () => {

--- a/packages/ckeditor5-widget/tests/widgetresize.js
+++ b/packages/ckeditor5-widget/tests/widgetresize.js
@@ -145,8 +145,8 @@ describe( 'WidgetResize', () => {
 		} );
 
 		it( 'it\'s hidden when no widget is focused', () => {
-			// This particular test needs a paragraph, so that widget is no longer focused.
-			setModelData( editor.model, '<widget></widget><paragraph>[]</paragraph>' );
+			const widgetResizePlugin = editor.plugins.get( WidgetResize );
+			widgetResizePlugin.deselect();
 
 			const allResizers = editor.ui.getEditableElement().querySelectorAll( '.ck-widget__resizer__handle' );
 
@@ -156,7 +156,9 @@ describe( 'WidgetResize', () => {
 		} );
 
 		it( 'it\'s visible once the widget is focused', () => {
-			// Widget is focused by default.
+			const widgetResizePlugin = editor.plugins.get( WidgetResize );
+			widgetResizePlugin.select( widgetResizePlugin.selectedResizer );
+
 			const allResizers = editor.ui.getEditableElement().querySelectorAll( '.ck-widget__resizer__handle' );
 
 			for ( const resizer of allResizers ) {
@@ -165,9 +167,9 @@ describe( 'WidgetResize', () => {
 		} );
 
 		it( 'it\'s hidden when resizer is not enabled and widget is focused', () => {
-			// Widget is focused by default.
 			const widgetResizePlugin = editor.plugins.get( WidgetResize );
-			widgetResizePlugin.visibleResizer.isEnabled = false;
+			widgetResizePlugin.select( widgetResizePlugin.selectedResizer );
+			widgetResizePlugin.selectedResizer.isEnabled = false;
 
 			const allResizers = editor.ui.getEditableElement().querySelectorAll( '.ck-widget__resizer__handle' );
 
@@ -503,13 +505,13 @@ describe( 'WidgetResize', () => {
 			// Nothing should be thrown.
 		} );
 
-		it( 'sets the visible resizer if associated widget is already selected', async () => {
+		it( 'sets the selected resizer if associated widget is already selected', async () => {
 			setModelData( localEditor.model, '[<widget></widget>]' );
 
 			const widgetResizePlugin = localEditor.plugins.get( WidgetResize );
 			const resizer = widgetResizePlugin.attachTo( gerResizerOptions( localEditor ) );
 
-			expect( widgetResizePlugin.visibleResizer ).to.eql( resizer );
+			expect( widgetResizePlugin.selectedResizer ).to.eql( resizer );
 		} );
 
 		it( 'sets the visible resizer if the associated inline widget surrounded by an attribute is already selected', async () => {
@@ -563,28 +565,11 @@ describe( 'WidgetResize', () => {
 				onCommit: commitStub
 			} );
 
-			expect( widgetResizePlugin.visibleResizer ).to.eql( resizer );
+			expect( widgetResizePlugin.selectedResizer ).to.eql( resizer );
 		} );
 	} );
 
 	describe( 'init()', () => {
-		it( 'adds listener to redraw resizer on visible resizer change', async () => {
-			setModelData( editor.model, '<widget></widget><paragraph>[]</paragraph>' );
-			widget = editor.editing.view.document.getRoot().getChild( 0 );
-
-			const resizer = createResizer();
-			const redrawSpy = sinon.spy( resizer, 'redraw' );
-
-			await focusEditor( editor );
-
-			editor.model.change( writer => {
-				const widgetModel = editor.model.document.getRoot().getChild( 0 );
-				writer.setSelection( widgetModel, 'on' );
-			} );
-
-			expect( redrawSpy.callCount ).to.equal( 1 );
-		} );
-
 		// https://github.com/ckeditor/ckeditor5/issues/10156
 		it( 'removes references to and destroys resizers of widget removed from the model document', () => {
 			const plugin = editor.plugins.get( WidgetResize );

--- a/packages/ckeditor5-widget/tests/widgetresize.js
+++ b/packages/ckeditor5-widget/tests/widgetresize.js
@@ -139,24 +139,74 @@ describe( 'WidgetResize', () => {
 	} );
 
 	describe( 'selectability', () => {
+		let resizer;
+
 		beforeEach( () => {
-			createResizer();
+			resizer = createResizer();
 		} );
-		it( 'handles resizer selection on view element focus', () => {
+
+		it( 'deselect() should properly deselected currently selected resizer', () => {
 			const widgetResizePlugin = editor.plugins.get( WidgetResize );
-			const viewSelection = editor.editing.view.document.selection;
-			const selectedElement = viewSelection.getSelectedElement();
-			const resizer = widgetResizePlugin.getResizerByViewElement( selectedElement );
+			const selectedResizer = widgetResizePlugin.selectedResizer;
 
-			widgetResizePlugin.select( resizer );
-
-			expect( widgetResizePlugin.selectedResizer ).to.not.be.null;
-			expect( resizer.isSelected ).to.be.true;
+			expect( selectedResizer ).not.to.be.null;
+			expect( selectedResizer.isSelected ).to.be.true;
 
 			widgetResizePlugin.deselect();
 
 			expect( widgetResizePlugin.selectedResizer ).to.be.null;
+			expect( selectedResizer.isSelected ).to.be.false;
+		} );
+
+		it( 'select() should properly set selected resizer', () => {
+			const widgetResizePlugin = editor.plugins.get( WidgetResize );
+
+			widgetResizePlugin.deselect();
+			widgetResizePlugin.select( resizer );
+
+			expect( widgetResizePlugin.selectedResizer ).to.equal( resizer );
+			expect( resizer.isSelected ).to.be.true;
+		} );
+
+		it( 'select() should deselect current resizer if different resizer is selected', () => {
+			const widgetResizePlugin = editor.plugins.get( WidgetResize );
+			const otherResizer = createResizer();
+
+			widgetResizePlugin.select( resizer );
+			widgetResizePlugin.select( otherResizer );
+
 			expect( resizer.isSelected ).to.be.false;
+		} );
+
+		it( 'should deselect and select resizer when view element with attached resizer is selected and deselected', () => {
+			const view = editor.editing.view;
+			const widgetResizePlugin = editor.plugins.get( WidgetResize );
+
+			sinon.spy( widgetResizePlugin, 'select' );
+			sinon.spy( widgetResizePlugin, 'deselect' );
+
+			view.change( writer => {
+				writer.setSelection( null );
+			} );
+
+			expect( widgetResizePlugin.deselect.calledOnce ).to.be.true;
+			expect( widgetResizePlugin.select.called ).to.be.false;
+
+			view.change( writer => {
+				writer.setSelection( widget, 'on' );
+			} );
+
+			expect( widgetResizePlugin.select.calledWithExactly( resizer ) ).to.be.true;
+
+			widgetResizePlugin.deselect.resetHistory();
+			widgetResizePlugin.select.resetHistory();
+
+			view.change( writer => {
+				writer.setSelection( null );
+			} );
+
+			expect( widgetResizePlugin.deselect.calledOnce ).to.be.true;
+			expect( widgetResizePlugin.select.called ).to.be.false;
 		} );
 	} );
 

--- a/packages/ckeditor5-widget/tests/widgetresize/resizer.js
+++ b/packages/ckeditor5-widget/tests/widgetresize/resizer.js
@@ -97,36 +97,72 @@ describe( 'Resizer', () => {
 		} );
 	} );
 
-	describe( 'attach()', () => {
-		it( 'doesn\'t show resizer if it\'s initialized as disabled', () => {
-			const resizerInstance = createResizer();
-			resizerInstance.isEnabled = false;
-			resizerInstance.attach();
-
-			const domResizerWrapper = resizerInstance._viewResizerWrapper.render( document );
-			expect( domResizerWrapper.classList.contains( 'ck-hidden' ) ).to.be.true;
-		} );
-
-		it( 'hides the resizer if it gets disabled at a runtime', () => {
-			const resizerInstance = createResizer();
-			resizerInstance.isEnabled = true;
-			resizerInstance.attach();
-			const domResizerWrapper = resizerInstance._viewResizerWrapper.render( document );
-
-			resizerInstance.isEnabled = false;
-			expect( domResizerWrapper.classList.contains( 'ck-hidden' ) ).to.be.true;
-		} );
-
-		it( 'restores the resizer if it gets enabled at a runtime', () => {
+	describe( 'visibility', () => {
+		it( 'doesn\'t show in the UI when resizer is set as not visible', () => {
 			const resizerInstance = createResizer( {
 				getHandleHost: widgetWrapper => widgetWrapper
 			} );
-			resizerInstance.isEnabled = false;
 			resizerInstance.attach();
+			resizerInstance.isVisible = true;
+
+			resizerInstance.isVisible = false;
+
 			const domResizerWrapper = resizerInstance._viewResizerWrapper.render( document );
+			expect( domResizerWrapper.classList.contains( 'ck-hidden' ) ).to.be.true;
+		} );
+
+		it( 'shows in the UI when resizer is set as visible', () => {
+			const resizerInstance = createResizer( {
+				getHandleHost: widgetWrapper => widgetWrapper
+			} );
+			resizerInstance.attach();
+			resizerInstance.isVisible = false;
+
+			resizerInstance.isVisible = true;
+
+			const domResizerWrapper = resizerInstance._viewResizerWrapper.render( document );
+			expect( domResizerWrapper.classList.contains( 'ck-hidden' ) ).to.be.false;
+		} );
+
+		it( 'is not visible when resizer is not selected', () => {
+			const resizerInstance = createResizer( {
+				getHandleHost: widgetWrapper => widgetWrapper
+			} );
+			resizerInstance.attach();
+			resizerInstance.isVisible = true;
+			resizerInstance.isSelected = true;
+
+			resizerInstance.isSelected = false;
+
+			expect( resizerInstance.isVisible ).to.be.false;
+		} );
+
+		it( 'is not visible when resizer is disabled', () => {
+			const resizerInstance = createResizer( {
+				getHandleHost: widgetWrapper => widgetWrapper
+			} );
+			resizerInstance.attach();
+			resizerInstance.isVisible = true;
+			resizerInstance.isEnabled = true;
+
+			resizerInstance.isEnabled = false;
+			expect( resizerInstance.isVisible ).to.be.false;
+		} );
+
+		it( 'is visible when resizer is both enabled and selected', () => {
+			const resizerInstance = createResizer( {
+				getHandleHost: widgetWrapper => widgetWrapper
+			} );
+			resizerInstance.attach();
+			resizerInstance.isEnabled = false;
+			resizerInstance.isSelected = false;
+			resizerInstance.isVisible = false;
 
 			resizerInstance.isEnabled = true;
-			expect( domResizerWrapper.style.display ).to.equal( '' );
+			expect( resizerInstance.isVisible ).to.be.false;
+
+			resizerInstance.isSelected = true;
+			expect( resizerInstance.isVisible ).to.be.true;
 		} );
 	} );
 

--- a/packages/ckeditor5-widget/tests/widgetresize/resizer.js
+++ b/packages/ckeditor5-widget/tests/widgetresize/resizer.js
@@ -104,7 +104,7 @@ describe( 'Resizer', () => {
 			resizerInstance.attach();
 
 			const domResizerWrapper = resizerInstance._viewResizerWrapper.render( document );
-			expect( domResizerWrapper.style.display ).to.equal( 'none' );
+			expect( domResizerWrapper.classList.contains( 'ck-hidden' ) ).to.be.true;
 		} );
 
 		it( 'hides the resizer if it gets disabled at a runtime', () => {
@@ -114,7 +114,7 @@ describe( 'Resizer', () => {
 			const domResizerWrapper = resizerInstance._viewResizerWrapper.render( document );
 
 			resizerInstance.isEnabled = false;
-			expect( domResizerWrapper.style.display ).to.equal( 'none' );
+			expect( domResizerWrapper.classList.contains( 'ck-hidden' ) ).to.be.true;
 		} );
 
 		it( 'restores the resizer if it gets enabled at a runtime', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (widget): Don't show image resizer handle when resizer is not enabled (commentsOnly mode). Closes #11891.

---

### Additional information

Main issue was, probably race condition between change of visibleResizer attribute(https://github.com/ckeditor/ckeditor5/blob/e51d6c564261889433c04fb8b2bcaa24a38bf0a5/packages/ckeditor5-widget/src/widgetresize.js#L90) and change of isEnabled attribute (https://github.com/ckeditor/ckeditor5/blob/e51d6c564261889433c04fb8b2bcaa24a38bf0a5/packages/ckeditor5-widget/src/widgetresize/resizer.js#L115).
