### PR TITLE
Introducing `DataFilter#disallowElement()`.

### DIFF
--- a/packages/ckeditor5-html-support/src/datafilter.js
+++ b/packages/ckeditor5-html-support/src/datafilter.js
@@ -103,6 +103,15 @@ export default class DataFilter extends Plugin {
 		this._allowedElements = new Set();
 
 		/**
+		 * Disallowed element names by {@link module:html-support/datafilter~DataFilter#disallowElement} method.
+		 *
+		 * @readonly
+		 * @private
+		 * @member {Set.<String>} #_disallowedElements
+		 */
+		this._disallowedElements = new Set();
+
+		/**
 		 * Indicates if {@link module:engine/controller/datacontroller~DataController editor's data controller}
 		 * data has been already initialized.
 		 *
@@ -142,21 +151,46 @@ export default class DataFilter extends Plugin {
 	/**
 	 * Load a configuration of one or many elements, where their attributes should be allowed.
 	 *
+	 * **Note**: Rules will be applied just before next data pipeline data init or set.
+	 *
 	 * @param {Array.<module:engine/view/matcher~MatcherPattern>} config Configuration of elements
 	 * that should have their attributes accepted in the editor.
 	 */
 	loadAllowedConfig( config ) {
-		this._loadConfig( config, pattern => this.allowAttributes( pattern ) );
+		for ( const pattern of config ) {
+			// MatcherPattern allows omitting `name` to widen the search of elements.
+			// Let's keep it consistent and match every element if a `name` has not been provided.
+			const elementName = pattern.name || /[\s\S]+/;
+			const rules = splitRules( pattern );
+
+			this.allowElement( elementName );
+
+			rules.forEach( pattern => this.allowAttributes( pattern ) );
+		}
 	}
 
 	/**
 	 * Load a configuration of one or many elements, where their attributes should be disallowed.
 	 *
+	 * **Note**: Rules will be applied just before next data pipeline data init or set.
+	 *
 	 * @param {Array.<module:engine/view/matcher~MatcherPattern>} config Configuration of elements
 	 * that should have their attributes rejected from the editor.
 	 */
 	loadDisallowedConfig( config ) {
-		this._loadConfig( config, pattern => this.disallowAttributes( pattern ) );
+		for ( const pattern of config ) {
+			// MatcherPattern allows omitting `name` to widen the search of elements.
+			// Let's keep it consistent and match every element if a `name` has not been provided.
+			const elementName = pattern.name || /[\s\S]+/;
+			const rules = splitRules( pattern );
+
+			// Disallow element itself if there is no other rules.
+			if ( rules.length == 0 ) {
+				this.disallowElement( elementName );
+			} else {
+				rules.forEach( pattern => this.disallowAttributes( pattern ) );
+			}
+		}
 	}
 
 	/**
@@ -164,6 +198,8 @@ export default class DataFilter extends Plugin {
 	 *
 	 * This method will only allow elements described by the {@link module:html-support/dataschema~DataSchema} used
 	 * to create data filter.
+	 *
+	 * **Note**: Rules will be applied just before next data pipeline data init or set.
 	 *
 	 * @param {String|RegExp} viewName String or regular expression matching view name.
 	 */
@@ -180,11 +216,33 @@ export default class DataFilter extends Plugin {
 			// If the data has not been initialized yet, _registerElementsAfterInit() method will take care of
 			// registering elements.
 			if ( this._dataInitialized ) {
-				this._fireRegisterEvent( definition );
+				// Defer registration to the next data pipeline data set so any disallow rules could be applied
+				// even if added after allow rule (disallowElement).
+				this.editor.data.once( 'set', () => {
+					this._fireRegisterEvent( definition );
+				}, {
+					// With the highest priority listener we are able to register elements right before
+					// running data conversion.
+					priority: priorities.get( 'highest' ) + 1
+				} );
 			}
 
 			// Reset cached map to recalculate it on the next usage.
 			this._coupledAttributes = null;
+		}
+	}
+
+	/**
+	 * Disallow the given element in the editor context.
+	 *
+	 * This method will only disallow elements described by the {@link module:html-support/dataschema~DataSchema} used
+	 * to create data filter.
+	 *
+	 * @param {String|RegExp} viewName String or regular expression matching view name.
+	 */
+	disallowElement( viewName ) {
+		for ( const definition of this._dataSchema.getDefinitionsForView( viewName, false ) ) {
+			this._disallowedElements.add( definition.view );
 		}
 	}
 
@@ -204,25 +262,6 @@ export default class DataFilter extends Plugin {
 	 */
 	disallowAttributes( config ) {
 		this._disallowedAttributes.add( config );
-	}
-
-	/**
-	 * Batch load of the filtering configuration.
-	 *
-	 * @private
-	 * @param {Array.<module:engine/view/matcher~MatcherPattern>} config Filtering configuration.
-	 * @param {Function} handleAttributes Callback handling the way the attributes should be processed.
-	 */
-	_loadConfig( config, handleAttributes ) {
-		for ( const pattern of config ) {
-			// MatcherPattern allows omitting `name` to widen the search of elements.
-			// Let's keep it consistent and match every element if a `name` has not been provided.
-			const elementName = pattern.name || /[\s\S]+/;
-
-			this.allowElement( elementName );
-
-			splitRules( pattern ).forEach( handleAttributes );
-		}
 	}
 
 	/**
@@ -411,6 +450,10 @@ export default class DataFilter extends Plugin {
 	 * @param {module:html-support/dataschema~DataSchemaDefinition} definition
 	 */
 	_fireRegisterEvent( definition ) {
+		if ( definition.view && this._disallowedElements.has( definition.view ) ) {
+			return;
+		}
+
 		this.fire( definition.view ? `register:${ definition.view }` : 'register', definition );
 	}
 

--- a/packages/ckeditor5-html-support/tests/datafilter.js
+++ b/packages/ckeditor5-html-support/tests/datafilter.js
@@ -1256,6 +1256,9 @@ describe( 'DataFilter', () => {
 
 				dataFilter.allowElement( 'xyz' );
 
+				// Apply filtering rules added after initial data load.
+				editor.setData( '' );
+
 				expect( editor.model.schema.getAttributeProperties( 'htmlXyz' ) ).to.deep.equal( { copyOnEnter: true } );
 			} );
 
@@ -2551,6 +2554,9 @@ describe( 'DataFilter', () => {
 				dataFilter.allowAttributes( { name: 'cite', styles: true } );
 				dataFilter.allowAttributes( { name: 'cite', classes: true } );
 				dataFilter.allowAttributes( { name: 'cite', attributes: true } );
+
+				// Apply filtering rules added after initial data load.
+				editor.setData( '' );
 			} );
 
 			it( 'should add new styles if no attribute element is present', () => {
@@ -3560,6 +3566,9 @@ describe( 'DataFilter', () => {
 
 		expectToThrowCKEditorError( () => {
 			dataFilter.allowElement( 'xyz' );
+
+			// Apply filtering rules added after initial data load.
+			editor.setData( '' );
 		}, /data-filter-invalid-definition/, null, definition );
 	} );
 
@@ -4254,6 +4263,50 @@ describe( 'DataFilter', () => {
 			);
 		} );
 
+		it( 'should match attributes on any element', () => {
+			// First, allow all the elements matching config.
+			dataFilter.loadAllowedConfig( [
+				{
+					name: /.*/,
+					attributes: true
+				}
+			] );
+
+			// Then, disallow and verify it's actually working.
+			dataFilter.loadDisallowedConfig( [
+				{
+					attributes: [ { key: /^data-foo.*$/, value: true } ]
+				}
+			] );
+
+			editor.setData(
+				'<p>' +
+					'<span data-foo="foo data">aaa</span>' +
+					'<span data-bar="bar data">bbb</span>' +
+				'</p>'
+			);
+
+			// Font feature should take over color CSS property.
+			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+				data: '<paragraph><$text htmlSpan="(1)">aaa</$text><$text htmlSpan="(2)">bbb</$text></paragraph>',
+				attributes: {
+					1: {},
+					2: {
+						attributes: {
+							'data-bar': 'bar data'
+						}
+					}
+				}
+			} );
+
+			expect( editor.getData() ).to.equal(
+				'<p>' +
+					'<span>aaa</span>' +
+					'<span data-bar="bar data">bbb</span>' +
+				'</p>'
+			);
+		} );
+
 		it( 'should match classes', () => {
 			const allowedConfig = [
 				{
@@ -4370,6 +4423,112 @@ describe( 'DataFilter', () => {
 					'<span data-foo="foo data">bbb</span>' +
 					'<span data-bar="bar data">ccc</span>' +
 				'</p>'
+			);
+		} );
+
+		it( 'should match disallowed block element', () => {
+			// First, allow all the elements matching config.
+			dataFilter.loadAllowedConfig( [
+				{
+					name: /.*/,
+					styles: true,
+					classes: true,
+					attributes: true
+				}
+			] );
+
+			// Then, disallow and verify it's actually working.
+			dataFilter.loadDisallowedConfig( [
+				{
+					name: 'div'
+				}
+			] );
+
+			editor.setData(
+				'<p>foo</p>' +
+				'<div>bar</div>' +
+				'<p>baz</p>'
+			);
+
+			// Font feature should take over color CSS property.
+			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+				data:
+					'<paragraph>foo</paragraph>' +
+					'<paragraph>bar</paragraph>' +
+					'<paragraph>baz</paragraph>',
+				attributes: {}
+			} );
+
+			expect( editor.getData() ).to.equal(
+				'<p>foo</p>' +
+				'<p>bar</p>' +
+				'<p>baz</p>'
+			);
+		} );
+
+		it( 'should match disallowed inline element', () => {
+			// First, allow all the elements matching config.
+			dataFilter.loadAllowedConfig( [
+				{
+					name: /.*/,
+					styles: true,
+					classes: true,
+					attributes: true
+				}
+			] );
+
+			// Then, disallow and verify it's actually working.
+			dataFilter.loadDisallowedConfig( [
+				{
+					name: 'abbr'
+				}
+			] );
+
+			editor.setData(
+				'<p>foo <abbr>bar</abbr> baz</p>'
+			);
+
+			// Font feature should take over color CSS property.
+			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+				data: '<paragraph>foo bar baz</paragraph>',
+				attributes: {}
+			} );
+
+			expect( editor.getData() ).to.equal(
+				'<p>foo bar baz</p>'
+			);
+		} );
+
+		it( 'should match disallowed object element', () => {
+			// First, allow all the elements matching config.
+			dataFilter.loadAllowedConfig( [
+				{
+					name: /.*/,
+					styles: true,
+					classes: true,
+					attributes: true
+				}
+			] );
+
+			// Then, disallow and verify it's actually working.
+			dataFilter.loadDisallowedConfig( [
+				{
+					name: 'button'
+				}
+			] );
+
+			editor.setData(
+				'<p>foo <button>bar</button> baz</p>'
+			);
+
+			// Font feature should take over color CSS property.
+			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+				data: '<paragraph>foo bar baz</paragraph>',
+				attributes: {}
+			} );
+
+			expect( editor.getData() ).to.equal(
+				'<p>foo bar baz</p>'
 			);
 		} );
 	} );

--- a/packages/ckeditor5-html-support/tests/datafilter.js
+++ b/packages/ckeditor5-html-support/tests/datafilter.js
@@ -863,6 +863,9 @@ describe( 'DataFilter', () => {
 			// At this point we will be trying to register converter without valid view name.
 			expect( () => {
 				dataFilter.allowElement( 'bar' );
+
+				// Apply filtering rules added after initial data load.
+				editor.setData( '' );
 			} ).to.not.throw();
 		} );
 
@@ -1269,6 +1272,9 @@ describe( 'DataFilter', () => {
 				} );
 
 				dataFilter.allowElement( 'xyz' );
+
+				// Apply filtering rules added after initial data load.
+				editor.setData( '' );
 
 				expect( editor.model.schema.getAttributeProperties( 'htmlXyz' ) ).to.deep.equal( {} );
 			} );
@@ -3695,7 +3701,7 @@ describe( 'DataFilter', () => {
 	} );
 
 	describe( 'loadAllowedConfig', () => {
-		it( 'should allow match all elements by ommiting pattern name', () => {
+		it( 'should allow match all elements by omitting pattern name', () => {
 			dataSchema.registerBlockElement( {
 				model: 'htmlXyz',
 				view: 'xyz',

--- a/packages/ckeditor5-html-support/tests/integrations/image.js
+++ b/packages/ckeditor5-html-support/tests/integrations/image.js
@@ -2401,6 +2401,9 @@ describe( 'ImageElementSupport', () => {
 						name: /^(img)$/
 					} ] );
 
+					// Apply filtering rules added after initial data load.
+					editor.setData( '' );
+
 					expect( schema.getDefinition( 'imageBlock' ).allowAttributes ).to.deep.equal( [
 						'alt',
 						'src',
@@ -2433,6 +2436,9 @@ describe( 'ImageElementSupport', () => {
 						name: /^(img)$/
 					} ] );
 
+					// Apply filtering rules added after initial data load.
+					editor.setData( '' );
+
 					expect( schema.getDefinition( 'imageInline' ).allowAttributes ).to.deep.equal( [
 						'alt',
 						'src',
@@ -2462,6 +2468,9 @@ describe( 'ImageElementSupport', () => {
 					dataFilter.loadAllowedConfig( [ {
 						name: /^(img)$/
 					} ] );
+
+					// Apply filtering rules added after initial data load.
+					editor.setData( '' );
 
 					expect( schema.getDefinition( 'imageBlock' ).allowAttributes ).to.deep.equal( [
 						'htmlAttributes'

--- a/packages/ckeditor5-html-support/tests/integrations/mediaembed.js
+++ b/packages/ckeditor5-html-support/tests/integrations/mediaembed.js
@@ -1265,6 +1265,9 @@ describe( 'MediaEmbedElementSupport', () => {
 				classes: true
 			} ] );
 
+			// Apply filtering rules added after initial data load.
+			editor.setData( '' );
+
 			editor.conversion.for( 'upcast' ).dataToMarker( {
 				view: 'commented',
 				converterPriority: 100000 // For marker this priority equals to -999

--- a/packages/ckeditor5-html-support/tests/integrations/table.js
+++ b/packages/ckeditor5-html-support/tests/integrations/table.js
@@ -1378,6 +1378,9 @@ describe( 'TableElementSupport', () => {
 				classes: true
 			} ] );
 
+			// Apply filtering rules added after initial data load.
+			editor.setData( '' );
+
 			editor.model.schema.extend( 'table', { allowAttributes: [ 'barAttr' ] } );
 
 			editor.conversion.for( 'upcast' ).attributeToAttribute( {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (html-support): GHS can exclude elements from the allowed list of elements.

---

### Additional information

This PR is modifying the flow of registering filtering rules for elements. Previously GHS was firing the `register` event on `DataController#init` event to defer the registration to the last possible moment before data load (to make sure that all plugins registered their schemas and converters). After the initial editor `init`, all GHS `register` events were fired immediately but this caused a problem with being able to exclude some elements from the allow rule (in most cases we pass the allow list and then the disallow list). To be able to defer registering only the difference between those sets of rules there is another delay in firing the `register` event after the initial data load so that those rules are registered at the next `DataController#set` event.

So the flow is as follows:
* `DataFilter#allowElement()`,  `DataFilter#disallowElement()`
* `DataController#init` event
  * `DataFilter` fires the `register` event and registers all allowed elements (and skips disallowed ones)
* `DataFilter#allowElement()`,  `DataFilter#disallowElement()`
* `DataController#set` event
  * `DataFilter` fires the `register` event and registers recently allowed elements (and skips disallowed ones)
