### PR TITLE
Updated css styles for switchbutton

### DIFF
--- a/packages/ckeditor5-theme-lark/tests/manual/theme.js
+++ b/packages/ckeditor5-theme-lark/tests/manual/theme.js
@@ -591,6 +591,8 @@ function switchbutton( {
 
 	button.set( { label, isEnabled, isOn, withText, icon, keystroke, tooltip, tooltipPosition } );
 
+	button.on( 'execute', () => ( button.isOn = !button.isOn ) );
+
 	return button;
 }
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-list/collapsible.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-list/collapsible.css
@@ -13,6 +13,7 @@
 		font-weight: bold;
 		padding: var(--ck-spacing-medium) var(--ck-spacing-large);
 		border-radius: 0;
+		color: inherit;
 
 		&:focus {
 			background: transparent;

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/switchbutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/switchbutton.css
@@ -24,6 +24,15 @@ of the component, floating–point numbers have been used which, for the default
 }
 
 .ck.ck-button.ck-switchbutton {
+	/* Unlike a regular button, the switch button text color and background should never change.
+	 * Changing toggle switch (background, outline) is enough to carry the information about the
+	 * state of the entire component (https://github.com/ckeditor/ckeditor5/issues/12519)
+	 */
+	&, &:hover, &:focus, &:active, &.ck-on:hover, &.ck-on:focus, &.ck-on:active {
+		color: inherit;
+		background: transparent;
+	}
+
 	& .ck-button__label {
 		@mixin ck-dir ltr {
 			/* Separate the label from the switch */
@@ -95,9 +104,8 @@ of the component, floating–point numbers have been used which, for the default
 		}
 	}
 
+	/* stylelint-disable-next-line no-descending-specificity */
 	&.ck-on {
-		color: inherit;
-
 		& .ck-button__toggle {
 			background: var(--ck-color-switch-button-on-background);
 
@@ -119,10 +127,4 @@ of the component, floating–point numbers have been used which, for the default
 			}
 		}
 	}
-
-	/* Regular buttons get a backgound when active. Switch buttons announce that through the switch toggle instead */
-	&:active, &.ck-on:active {
-		background: transparent;
-	}
-
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/switchbutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/switchbutton.css
@@ -96,6 +96,8 @@ of the component, floating–point numbers have been used which, for the default
 	}
 
 	&.ck-on {
+		color: inherit;
+
 		& .ck-button__toggle {
 			background: var(--ck-color-switch-button-on-background);
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (theme-lark): SwitchButtonView should no longer change color when it is on. Closes #12519 .

---

### Additional information

The structure of the code for `find & replace` / `link decorators` differs from the one used for `listproperties` and because of that we need to add additional css rule for `.ck.ck-list__item.ck-switchbutton.ck-on` selector adding the missing `color: inherit`.  
Otherwise we would most likely have to update the `listproperties` implementation so it's not a single \<button> but a button placed inside of the list (similarly to the structure mentioned below).

For `find & replace` and `link decorators` it is added by the `.ck.ck-list__item .ck-switchbutton.ck-on` selector because the structure is:

```
<ul class="ck ck-reset ck-list"><li class="ck ck-list__item"><button>...
```