### PR TITLE
Docs: adding moved icons to migration guide.

### DIFF
--- a/docs/updating/migration-to-35.md
+++ b/docs/updating/migration-to-35.md
@@ -78,6 +78,8 @@ Among other changes, a few icons have been moved around the project. Please obse
 * The `bold` icon has been moved to the `@ckeditor/ckeditor5-core` package.
 * The `paragraph` icon has been moved to the `@ckeditor/ckeditor5-core` package.
 
+The rest of the import path remained unchanged (`/theme/icons/`).
+
 ## Migration to CKEditor 5 v35.1.0
 
 ### Important changes

--- a/docs/updating/migration-to-35.md
+++ b/docs/updating/migration-to-35.md
@@ -2,7 +2,7 @@
 category: updating
 menu-title: Migration to v35.x
 order: 89
-modified_at: 2022-08-18
+modified_at: 2022-10-05
 ---
 
 # Migration to CKEditor 5 v35.x
@@ -70,6 +70,13 @@ const annotation = new Annotation( ... );
 editor.plugins.get( 'EditorAnnotations' ).registerAnnotation( annotation );
 editor.plugins.get( 'Annotations' ).add( annotation );
 ```
+
+### Icons paths changed
+
+Among other changes, a few icons have been moved around the project. Please observe these changes especially if you use custom UI elements that call these icons.
+
+* The `bold` icon has been moved to the `@ckeditor/ckeditor5-core` package.
+* The `paragraph` icon has been moved to the `@ckeditor/ckeditor5-core` package.
 
 ## Migration to CKEditor 5 v35.1.0
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: adding information about moved icons to the migration to 35.2.0 guide. Closes: #12586

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._