### PR TITLE
Internal (table, list): Use insertContent in table caption instead of using writer directly

### DIFF
--- a/packages/ckeditor5-list/src/list/converters.js
+++ b/packages/ckeditor5-list/src/list/converters.js
@@ -762,7 +762,7 @@ export function modelChangePostFixer( model, writer ) {
  * @param {module:utils/eventinfo~EventInfo} evt An object containing information about the fired event.
  * @param {Array} args Arguments of {@link module:engine/model/model~Model#insertContent}.
  */
-export function modelIndentPasteFixer( evt, [ content, selectable ] ) {
+export function modelIndentPasteFixer( evt, [ content, selectable, placeOrOffset ] ) {
 	// Check whether inserted content starts from a `listItem`. If it does not, it means that there are some other
 	// elements before it and there is no need to fix indents, because even if we insert that content into a list,
 	// that list will be broken.
@@ -775,7 +775,7 @@ export function modelIndentPasteFixer( evt, [ content, selectable ] ) {
 	if ( !selectable ) {
 		selection = this.document.selection;
 	} else {
-		selection = this.createSelection( selectable );
+		selection = this.createSelection( selectable, placeOrOffset );
 	}
 
 	if ( item && item.is( 'element', 'listItem' ) ) {

--- a/packages/ckeditor5-list/tests/list/listediting.js
+++ b/packages/ckeditor5-list/tests/list/listediting.js
@@ -4156,6 +4156,17 @@ describe( 'ListEditing', () => {
 			);
 		} );
 
+		it( 'should work if a selectable element is passed to DataController#insertContent()', () => {
+			model.change( writer => {
+				const listItem = writer.createElement( 'listItem', { listType: 'bulleted', listIndent: '0' } );
+				model.insertContent( listItem, modelRoot, 'in' );
+			} );
+
+			expect( getModelData( model ) ).to.equal(
+				'<listItem listIndent="0" listType="bulleted">[]</listItem>'
+			);
+		} );
+
 		it( 'should fix indents of pasted list items', () => {
 			setModelData( model,
 				'<listItem listType="bulleted" listIndent="0">A</listItem>' +

--- a/packages/ckeditor5-table/src/tablecaption/toggletablecaptioncommand.js
+++ b/packages/ckeditor5-table/src/tablecaption/toggletablecaptioncommand.js
@@ -89,7 +89,7 @@ export default class ToggleTableCaptionCommand extends Command {
 		// Try restoring the caption from the TableCaptionEditing plugin storage.
 		const newCaptionElement = savedCaptionElement || writer.createElement( 'caption' );
 
-		writer.append( newCaptionElement, tableElement );
+		model.insertContent( newCaptionElement, tableElement, 'end' );
 
 		if ( focusCaptionOnShow ) {
 			writer.setSelection( newCaptionElement, 'in' );
@@ -114,7 +114,8 @@ export default class ToggleTableCaptionCommand extends Command {
 		// Store the caption content so it can be restored quickly if the user changes their mind.
 		tableCaptionEditing._saveCaption( tableElement, captionElement );
 
+		writer.setSelection( captionElement, 'on' );
+		model.deleteContent( model.document.selection );
 		writer.setSelection( writer.createRangeIn( tableElement.getChild( 0 ).getChild( 0 ) ) );
-		writer.remove( captionElement );
 	}
 }

--- a/packages/ckeditor5-table/src/tablecaption/toggletablecaptioncommand.js
+++ b/packages/ckeditor5-table/src/tablecaption/toggletablecaptioncommand.js
@@ -114,8 +114,7 @@ export default class ToggleTableCaptionCommand extends Command {
 		// Store the caption content so it can be restored quickly if the user changes their mind.
 		tableCaptionEditing._saveCaption( tableElement, captionElement );
 
-		writer.setSelection( captionElement, 'on' );
-		model.deleteContent( model.document.selection );
+		model.deleteContent( writer.createSelection( captionElement, 'on' ) );
 		writer.setSelection( writer.createRangeIn( tableElement.getChild( 0 ).getChild( 0 ) ) );
 	}
 }

--- a/packages/ckeditor5-table/src/tablecaption/toggletablecaptioncommand.js
+++ b/packages/ckeditor5-table/src/tablecaption/toggletablecaptioncommand.js
@@ -115,6 +115,5 @@ export default class ToggleTableCaptionCommand extends Command {
 		tableCaptionEditing._saveCaption( tableElement, captionElement );
 
 		model.deleteContent( writer.createSelection( captionElement, 'on' ) );
-		writer.setSelection( writer.createRangeIn( tableElement.getChild( 0 ).getChild( 0 ) ) );
 	}
 }

--- a/packages/ckeditor5-table/tests/tablecaption/toggletablecaptioncommand.js
+++ b/packages/ckeditor5-table/tests/tablecaption/toggletablecaptioncommand.js
@@ -13,6 +13,7 @@ import { modelTable } from '../_utils/utils';
 
 import ToggleTableCaptionCommand from '../../src/tablecaption/toggletablecaptioncommand';
 import TableCaptionEditing from '../../src/tablecaption/tablecaptionediting';
+import { BoldEditing } from '@ckeditor/ckeditor5-basic-styles';
 
 describe( 'ToggleTableCaptionCommand', () => {
 	let editor, model, command;
@@ -20,7 +21,7 @@ describe( 'ToggleTableCaptionCommand', () => {
 	beforeEach( () => {
 		return ModelTestEditor
 			.create( {
-				plugins: [ Paragraph, TableEditing, TableCaptionEditing, TableSelection ]
+				plugins: [ Paragraph, TableEditing, TableCaptionEditing, TableSelection, BoldEditing ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;

--- a/packages/ckeditor5-table/tests/tablecaption/toggletablecaptioncommand.js
+++ b/packages/ckeditor5-table/tests/tablecaption/toggletablecaptioncommand.js
@@ -120,7 +120,7 @@ describe( 'ToggleTableCaptionCommand', () => {
 				'<table>' +
 					'<tableRow>' +
 						'<tableCell>' +
-							'<paragraph>[11]</paragraph>' +
+							'<paragraph>11[]</paragraph>' +
 						'</tableCell>' +
 						'<tableCell>' +
 							'<paragraph>12</paragraph>' +
@@ -178,13 +178,13 @@ describe( 'ToggleTableCaptionCommand', () => {
 			command.execute();
 
 			expect( getData( model ) ).to.equalMarkup(
-				'<table>' +
+				'[<table>' +
 					'<tableRow>' +
 						'<tableCell>' +
-							'<paragraph>[]</paragraph>' +
+							'<paragraph></paragraph>' +
 						'</tableCell>' +
 					'</tableRow>' +
-				'</table>'
+				'</table>]'
 			);
 		} );
 
@@ -218,7 +218,7 @@ describe( 'ToggleTableCaptionCommand', () => {
 				'<table>' +
 					'<tableRow>' +
 						'<tableCell>' +
-							'<paragraph></paragraph>' +
+							'<paragraph>[]</paragraph>' +
 						'</tableCell>' +
 					'</tableRow>' +
 					'<caption>Foo<$text bold="true">bar</$text></caption>' +
@@ -256,7 +256,7 @@ describe( 'ToggleTableCaptionCommand', () => {
 				'<table>' +
 					'<tableRow>' +
 						'<tableCell>' +
-							'<paragraph></paragraph>' +
+							'<paragraph>A[]bc</paragraph>' +
 						'</tableCell>' +
 					'</tableRow>' +
 					'<caption>Foo</caption>' +
@@ -270,7 +270,7 @@ describe( 'ToggleTableCaptionCommand', () => {
 				'<table>' +
 					'<tableRow>' +
 						'<tableCell>' +
-							'<paragraph>[]</paragraph>' +
+							'<paragraph>A[]bc</paragraph>' +
 						'</tableCell>' +
 					'</tableRow>' +
 				'</table>'
@@ -295,7 +295,7 @@ describe( 'ToggleTableCaptionCommand', () => {
 				'<table>' +
 					'<tableRow>' +
 						'<tableCell>' +
-							'<paragraph>[]</paragraph>' +
+							'<paragraph>A[]bc</paragraph>' +
 						'</tableCell>' +
 					'</tableRow>' +
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (table): Use insertContent in table caption instead of using writer directly.

---

### Additional information

This is needed / going to help with track changes integration
