### PR TITLE
Placeholder should be hidden while composing.

### DIFF
--- a/packages/ckeditor5-engine/src/view/placeholder.ts
+++ b/packages/ckeditor5-engine/src/view/placeholder.ts
@@ -53,6 +53,10 @@ export function enablePlaceholder( options: {
 		// If a post-fixer callback makes a change, it should return `true` so other post–fixers
 		// can re–evaluate the document again.
 		doc.registerPostFixer( writer => updateDocumentPlaceholders( doc, writer ) );
+
+		doc.on( 'change:isComposing', () => {
+			view.change( writer => updateDocumentPlaceholders( doc, writer ) );
+		}, { priority: 'high' } );
 	}
 
 	// Store information about the element placeholder under its document.
@@ -171,20 +175,23 @@ export function needsPlaceholder( element: Element, keepOnFocus: boolean ): bool
 		return false;
 	}
 
+	const doc = element.document;
+	const viewSelection = doc.selection;
+	const selectionAnchor = viewSelection.anchor;
+
+	if ( doc.isComposing && selectionAnchor && selectionAnchor.parent === element ) {
+		return false;
+	}
+
 	// Skip the focus check and make the placeholder visible already regardless of document focus state.
 	if ( keepOnFocus ) {
 		return true;
 	}
 
-	const doc = element.document;
-
 	// If the document is blurred.
 	if ( !doc.isFocused ) {
 		return true;
 	}
-
-	const viewSelection = doc.selection;
-	const selectionAnchor = viewSelection.anchor;
 
 	// If document is focused and the element is empty but the selection is not anchored inside it.
 	return !!selectionAnchor && selectionAnchor.parent !== element;

--- a/packages/ckeditor5-engine/src/view/placeholder.ts
+++ b/packages/ckeditor5-engine/src/view/placeholder.ts
@@ -14,6 +14,8 @@ import type DowncastWriter from './downcastwriter';
 import type Element from './element';
 import type View from './view';
 
+import type { ChangeEvent } from '@ckeditor/ckeditor5-utils/src/observablemixin';
+
 // Each document stores information about its placeholder elements and check functions.
 const documentPlaceholders: WeakMap<Document, Map<Element, PlaceholderConfig>> = new WeakMap();
 
@@ -54,7 +56,8 @@ export function enablePlaceholder( options: {
 		// can re–evaluate the document again.
 		doc.registerPostFixer( writer => updateDocumentPlaceholders( doc, writer ) );
 
-		doc.on( 'change:isComposing', () => {
+		// Update placeholders on isComposing state change since rendering is disabled while in composition mode.
+		doc.on<ChangeEvent>( 'change:isComposing', () => {
 			view.change( writer => updateDocumentPlaceholders( doc, writer ) );
 		}, { priority: 'high' } );
 	}

--- a/packages/ckeditor5-engine/tests/view/placeholder.js
+++ b/packages/ckeditor5-engine/tests/view/placeholder.js
@@ -405,6 +405,34 @@ describe( 'placeholder', () => {
 			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.true;
 			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.false;
 		} );
+
+		it( 'should hide the placeholder when there is a composition in progress in the host element (keepOnFocus = true)', () => {
+			setData( view, '<div>[]</div>' );
+			const element = viewRoot.getChild( 0 );
+
+			enablePlaceholder( {
+				view,
+				element,
+				text: 'foo bar baz',
+				keepOnFocus: true
+			} );
+
+			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.true;
+			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.true;
+
+			// Make sure that renderer is not locked before the view got updated.
+			view._renderer.on( 'set:isComposing', () => {
+				expect( viewDocument.isComposing ).to.be.true;
+				expect( view._renderer.isComposing ).to.be.false;
+				expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.true;
+				expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.false;
+			} );
+
+			viewDocument.isComposing = true;
+
+			expect( viewRoot.getChild( 0 ).hasAttribute( 'data-placeholder' ) ).to.be.true;
+			expect( viewRoot.getChild( 0 ).hasClass( 'ck-placeholder' ) ).to.be.false;
+		} );
 	} );
 
 	describe( 'disablePlaceholder', () => {
@@ -573,6 +601,16 @@ describe( 'placeholder', () => {
 			const element = viewRoot.getChild( 0 );
 
 			expect( needsPlaceholder( element, true ) ).to.be.true;
+		} );
+
+		it( 'should return false if we want to keep placeholder when element is focused and document is in composition mode', () => {
+			setData( view, '<p>[]</p>' );
+			viewDocument.isFocused = true;
+			viewDocument.isComposing = true;
+
+			const element = viewRoot.getChild( 0 );
+
+			expect( needsPlaceholder( element, true ) ).to.be.false;
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): The placeholder should not be visible while composing. Closes #12389.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
