### PR TITLE
Bump up TypeScript version

### DIFF
--- a/packages/ckeditor5-core/package.json
+++ b/packages/ckeditor5-core/package.json
@@ -42,7 +42,7 @@
     "@ckeditor/ckeditor5-media-embed": "^35.2.1",
     "@ckeditor/ckeditor5-paragraph": "^35.2.1",
     "@ckeditor/ckeditor5-table": "^35.2.1",
-    "typescript": "^4.6.4",
+    "typescript": "^4.8.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-engine/package.json
+++ b/packages/ckeditor5-engine/package.json
@@ -47,7 +47,7 @@
     "@ckeditor/ckeditor5-ui": "^35.2.1",
     "@ckeditor/ckeditor5-undo": "^35.2.1",
     "@ckeditor/ckeditor5-widget": "^35.2.1",
-    "typescript": "^4.6.4",
+    "typescript": "^4.8.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-ui/package.json
+++ b/packages/ckeditor5-ui/package.json
@@ -34,7 +34,7 @@
     "@ckeditor/ckeditor5-horizontal-line": "^35.2.1",
     "@ckeditor/ckeditor5-table": "^35.2.1",
     "@ckeditor/ckeditor5-typing": "^35.2.1",
-    "typescript": "^4.6.4",
+    "typescript": "^4.8.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-utils/package.json
+++ b/packages/ckeditor5-utils/package.json
@@ -19,7 +19,7 @@
     "@ckeditor/ckeditor5-core": "^35.2.1",
     "@ckeditor/ckeditor5-engine": "^35.2.1",
     "@types/lodash-es": "^4.17.6",
-    "typescript": "^4.6.4"
+    "typescript": "^4.8.4"
   },
   "depcheckIgnore": [
     "typescript"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Updates TypeScript version to 4.8.4. Closes #12470.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._