### PR TITLE
ModifySelection with word unit should not stop at the attribute boundary

### DIFF
--- a/packages/ckeditor5-engine/src/model/utils/modifyselection.ts
+++ b/packages/ckeditor5-engine/src/model/utils/modifyselection.ts
@@ -16,6 +16,7 @@ import type Model from '../model';
 import type Schema from '../schema';
 import type Selection from '../selection';
 import type Text from '../text';
+import type Node from '../node';
 
 import { isInsideSurrogatePair, isInsideCombinedSymbol, isInsideEmojiSequence } from '@ckeditor/ckeditor5-utils/src/unicode';
 
@@ -196,34 +197,28 @@ function getCorrectPosition(
 // @param {module:engine/model/treewalker~TreeWalker} walker
 // @param {Boolean} isForward Is the direction in which the selection should be modified is forward.
 function getCorrectWordBreakPosition( walker: TreeWalker, isForward: boolean ): Position {
-	let textNode = walker.position.textNode!;
+	let textNode: Node | null = walker.position.textNode;
 
-	if ( textNode ) {
-		let offset = walker.position.offset - textNode.startOffset!;
+	if ( !textNode ) {
+		textNode = isForward ? walker.position.nodeAfter : walker.position.nodeBefore;
+	}
 
-		while ( !isAtWordBoundary( textNode.data, offset, isForward ) && !isAtNodeBoundary( textNode, offset, isForward ) ) {
+	while ( textNode && textNode.is( '$text' ) ) {
+		const offset = walker.position.offset - textNode.startOffset!;
+
+		// Check of adjacent text nodes with different attributes (like BOLD).
+		// Example          : 'foofoo []bar<$text bold="true">bar</$text> bazbaz'
+		// should expand to : 'foofoo [bar<$text bold="true">bar</$text>] bazbaz'.
+		if ( isAtNodeBoundary( textNode, offset, isForward ) ) {
+			textNode = isForward ? walker.position.nodeAfter : walker.position.nodeBefore;
+		}
+		// Check if this is a word boundary.
+		else if ( isAtWordBoundary( textNode.data, offset, isForward ) ) {
+			break;
+		}
+		// Maybe one more character.
+		else {
 			walker.next();
-
-			// Check of adjacent text nodes with different attributes (like BOLD).
-			// Example          : 'foofoo []bar<$text bold="true">bar</$text> bazbaz'
-			// should expand to : 'foofoo [bar<$text bold="true">bar</$text>] bazbaz'.
-			const nextNode = isForward ? walker.position.nodeAfter : walker.position.nodeBefore;
-
-			// Scan only text nodes. Ignore inline elements (like `<softBreak>`).
-			if ( nextNode && nextNode.is( '$text' ) ) {
-				// Check boundary char of an adjacent text node.
-				const boundaryChar = nextNode.data.charAt( isForward ? 0 : nextNode.data.length - 1 );
-
-				// Go to the next node if the character at the boundary of that node belongs to the same word.
-				if ( !wordBoundaryCharacters.includes( boundaryChar ) ) {
-					// If adjacent text node belongs to the same word go to it & reset values.
-					walker.next();
-
-					textNode = walker.position.textNode!;
-				}
-			}
-
-			offset = walker.position.offset - textNode!.startOffset!;
 		}
 	}
 
@@ -259,5 +254,5 @@ function isAtWordBoundary( data: string, offset: number, isForward: boolean ) {
 // @param {Number} offset Position offset.
 // @param {Boolean} isForward Is the direction in which the selection should be modified is forward.
 function isAtNodeBoundary( textNode: Text, offset: number, isForward: boolean ) {
-	return offset === ( isForward ? textNode.endOffset : 0 );
+	return offset === ( isForward ? textNode.offsetSize : 0 );
 }

--- a/packages/ckeditor5-engine/tests/model/utils/modifyselection.js
+++ b/packages/ckeditor5-engine/tests/model/utils/modifyselection.js
@@ -675,6 +675,122 @@ describe( 'DataController utils', () => {
 				}
 			} );
 
+			describe( 'within element - multiple text nodes - backward', () => {
+				test(
+					'word end after 2 nodes',
+					'<p><$text bold="true">foo</$text>bar[]</p>',
+					'<p>[<$text bold="true">foo</$text>bar]</p>',
+					{ unit: 'word', direction: 'backward' }
+				);
+
+				test(
+					'word end inside second node',
+					'<p><$text bold="true">f oo</$text>bar[]</p>',
+					'<p><$text bold="true">f [oo</$text>bar]</p>',
+					{ unit: 'word', direction: 'backward' }
+				);
+
+				test(
+					'word end after 2 nodes (with text around)',
+					'<p>aaa <$text bold="true">foo</$text>bar[] bbb</p>',
+					'<p>aaa [<$text bold="true">foo</$text>bar] bbb</p>',
+					{ unit: 'word', direction: 'backward' }
+				);
+
+				test(
+					'word end after 3 nodes, start inside last node (2 chars to edge)',
+					'<p>aaa <$text bold="true">foo</$text><$text italic="true">bar</$text><$text bold="true">ba[]z</$text> bbb</p>',
+					'<p>aaa [<$text bold="true">foo</$text><$text italic="true">bar</$text><$text bold="true">ba]z</$text> bbb</p>',
+					{ unit: 'word', direction: 'backward' }
+				);
+
+				test(
+					'word end after 3 nodes, start inside last node (1 char to edge)',
+					'<p>aaa <$text bold="true">foo</$text><$text italic="true">bar</$text><$text bold="true">b[]az</$text> bbb</p>',
+					'<p>aaa [<$text bold="true">foo</$text><$text italic="true">bar</$text><$text bold="true">b]az</$text> bbb</p>',
+					{ unit: 'word', direction: 'backward' }
+				);
+
+				test(
+					'word end after 3 nodes, at the edge of the last node',
+					'<p>aaa <$text bold="true">foo</$text><$text italic="true">bar</$text><$text bold="true">[]baz</$text> bbb</p>',
+					'<p>aaa [<$text bold="true">foo</$text><$text italic="true">bar</$text>]<$text bold="true">baz</$text> bbb</p>',
+					{ unit: 'word', direction: 'backward' }
+				);
+
+				test(
+					'word end after 3 nodes (one is a single char long)',
+					'<p>aaa <$text bold="true">foo</$text><$text italic="true">[]b</$text><$text bold="true">baz</$text> bbb</p>',
+					'<p>aaa [<$text bold="true">foo</$text>]<$text italic="true">b</$text><$text bold="true">baz</$text> bbb</p>',
+					{ unit: 'word', direction: 'backward' }
+				);
+
+				test(
+					'word end after 3 nodes (start at end of 2 char node)',
+					'<p>aaa <$text bold="true">foo</$text><$text italic="true">b</$text><$text bold="true">ba[]</$text> bbb</p>',
+					'<p>aaa [<$text bold="true">foo</$text><$text italic="true">b</$text><$text bold="true">ba</$text>] bbb</p>',
+					{ unit: 'word', direction: 'backward' }
+				);
+			} );
+
+			describe( 'within element - multiple text nodes - forward', () => {
+				test(
+					'word end after 2 nodes',
+					'<p>[]<$text bold="true">foo</$text>bar</p>',
+					'<p>[<$text bold="true">foo</$text>bar]</p>',
+					{ unit: 'word', direction: 'forward' }
+				);
+
+				test(
+					'word end inside second node',
+					'<p>[]<$text bold="true">foo</$text>ba r</p>',
+					'<p>[<$text bold="true">foo</$text>ba] r</p>',
+					{ unit: 'word', direction: 'forward' }
+				);
+
+				test(
+					'word end after 2 nodes (with text around)',
+					'<p>aaa []<$text bold="true">foo</$text>bar bbb</p>',
+					'<p>aaa [<$text bold="true">foo</$text>bar] bbb</p>',
+					{ unit: 'word', direction: 'forward' }
+				);
+
+				test(
+					'word end after 3 nodes, start inside last node (2 chars to edge)',
+					'<p>aaa <$text bold="true">f[]oo</$text><$text italic="true">bar</$text><$text bold="true">baz</$text> bbb</p>',
+					'<p>aaa <$text bold="true">f[oo</$text><$text italic="true">bar</$text><$text bold="true">baz</$text>] bbb</p>',
+					{ unit: 'word', direction: 'forward' }
+				);
+
+				test(
+					'word end after 3 nodes, start inside last node (1 char to edge)',
+					'<p>aaa <$text bold="true">fo[]o</$text><$text italic="true">bar</$text><$text bold="true">baz</$text> bbb</p>',
+					'<p>aaa <$text bold="true">fo[o</$text><$text italic="true">bar</$text><$text bold="true">baz</$text>] bbb</p>',
+					{ unit: 'word', direction: 'forward' }
+				);
+
+				test(
+					'word end after 3 nodes, at the edge of the last node',
+					'<p>aaa <$text bold="true">foo[]</$text><$text italic="true">bar</$text><$text bold="true">baz</$text> bbb</p>',
+					'<p>aaa <$text bold="true">foo</$text>[<$text italic="true">bar</$text><$text bold="true">baz</$text>] bbb</p>',
+					{ unit: 'word', direction: 'forward' }
+				);
+
+				test(
+					'word end after 3 nodes (one is a single char long)',
+					'<p>aaa <$text bold="true">foo</$text><$text italic="true">b[]</$text><$text bold="true">baz</$text> bbb</p>',
+					'<p>aaa <$text bold="true">foo</$text><$text italic="true">b</$text>[<$text bold="true">baz</$text>] bbb</p>',
+					{ unit: 'word', direction: 'forward' }
+				);
+
+				test(
+					'word end after 3 nodes (start at end of 2 char node)',
+					'<p>aaa <$text bold="true">[]fo</$text><$text italic="true">b</$text><$text bold="true">ba</$text> bbb</p>',
+					'<p>aaa [<$text bold="true">fo</$text><$text italic="true">b</$text><$text bold="true">ba</$text>] bbb</p>',
+					{ unit: 'word', direction: 'forward' }
+				);
+			} );
+
 			describe( 'beyond element', () => {
 				test(
 					'extends over boundary of empty elements',
@@ -791,8 +907,50 @@ describe( 'DataController utils', () => {
 
 					modifySelection( model, doc.selection, { unit: 'word', direction: 'backward' } );
 
-					expect( stringify( doc.getRoot(), doc.selection ) ).to.equal( '<p><$text bold="true">foo[]</$text>b</p>' );
+					expect( stringify( doc.getRoot(), doc.selection ) ).to.equal( '<p>[<$text bold="true">foo</$text>]b</p>' );
 					expect( doc.selection.getAttribute( 'bold' ) ).to.equal( true );
+				} );
+
+				// https://github.com/ckeditor/ckeditor5/issues/12673.
+				it( 'should expand selection to the whole word', () => {
+					setData( model,
+						'<p>' +
+							'ABC ' +
+							'<$text bold="true">foo</$text>' +
+							'<$text bold="true" italic="true">b[]ar</$text>' +
+							'<$text bold="true">baz</$text>' +
+							' DEF' +
+						'</p>'
+					);
+
+					const newSelBackward = model.createSelection( model.document.selection.getFirstRange().start );
+					const newSelFwd = model.createSelection( model.document.selection.getFirstRange().end );
+
+					model.modifySelection( newSelBackward, {
+						direction: 'backward',
+						unit: 'word'
+					} );
+
+					model.modifySelection( newSelFwd, {
+						direction: 'forward',
+						unit: 'word'
+					} );
+
+					model.change( writer => writer.setSelection(
+						model.createSelection(
+							model.createRange( newSelBackward.getFirstRange().start, newSelFwd.getFirstRange().end )
+						)
+					) );
+
+					expect( stringify( doc.getRoot(), doc.selection ) ).to.equal(
+						'<p>' +
+							'ABC ' +
+							'[<$text bold="true">foo</$text>' +
+							'<$text bold="true" italic="true">bar</$text>' +
+							'<$text bold="true">baz</$text>]' +
+							' DEF' +
+						'</p>'
+					);
 				} );
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine): ModifySelection with word unit should not stop at the attribute boundary. Closes #12673. Closes #12657.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._