### PR TITLE
Added toggleImageCaption that was missing from the metadata of ckeditor5-image

### DIFF
--- a/packages/ckeditor5-image/ckeditor5-metadata.json
+++ b/packages/ckeditor5-image/ckeditor5-metadata.json
@@ -27,6 +27,14 @@
 					"toolbars": [
 						"image.toolbar"
 					]
+				},
+				{
+					"type": "Button",
+					"name": "toggleImageCaption",
+					"iconPath": "",
+					"toolbars": [
+						"image.toolbar"
+					]
 				}
 			],
 			"htmlOutput": [
@@ -56,6 +64,14 @@
 				{
 					"type": "Button",
 					"name": "imageTextAlternative",
+					"iconPath": "",
+					"toolbars": [
+						"image.toolbar"
+					]
+				},
+				{
+					"type": "Button",
+					"name": "toggleImageCaption",
 					"iconPath": "",
 					"toolbars": [
 						"image.toolbar"

--- a/packages/ckeditor5-image/ckeditor5-metadata.json
+++ b/packages/ckeditor5-image/ckeditor5-metadata.json
@@ -27,14 +27,6 @@
 					"toolbars": [
 						"image.toolbar"
 					]
-				},
-				{
-					"type": "Button",
-					"name": "toggleImageCaption",
-					"iconPath": "",
-					"toolbars": [
-						"image.toolbar"
-					]
 				}
 			],
 			"htmlOutput": [
@@ -64,14 +56,6 @@
 				{
 					"type": "Button",
 					"name": "imageTextAlternative",
-					"iconPath": "",
-					"toolbars": [
-						"image.toolbar"
-					]
-				},
-				{
-					"type": "Button",
-					"name": "toggleImageCaption",
 					"iconPath": "",
 					"toolbars": [
 						"image.toolbar"
@@ -106,6 +90,16 @@
 			"path": "src/imagecaption.js",
 			"requires": [
 				"ImageBlock"
+			],
+			"uiComponents": [
+				{
+					"type": "Button",
+					"name": "toggleImageCaption",
+					"iconPath": "",
+					"toolbars": [
+						"image.toolbar"
+					]
+				}
 			],
 			"htmlOutput": [
 				{


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (image): Added the `toggleImageCaption` button to the image toolbar.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
