### PR TITLE
Content should not get removed on the composition start if input is disabled

### DIFF
--- a/packages/ckeditor5-typing/src/input.ts
+++ b/packages/ckeditor5-typing/src/input.ts
@@ -157,6 +157,15 @@ declare module '@ckeditor/ckeditor5-core' {
 }
 
 function deleteSelectionContent( model: Model, insertTextCommand: InsertTextCommand ): void {
+	// By relying on the state of the input command we allow disabling the entire input easily
+	// by just disabling the input command. We could’ve used here the delete command but that
+	// would mean requiring the delete feature which would block loading one without the other.
+	// We could also check the editor.isReadOnly property, but that wouldn't allow to block
+	// the input without blocking other features.
+	if ( !insertTextCommand.isEnabled ) {
+		return;
+	}
+
 	const buffer = insertTextCommand.buffer;
 
 	buffer.lock();

--- a/packages/ckeditor5-typing/tests/input.js
+++ b/packages/ckeditor5-typing/tests/input.js
@@ -177,6 +177,19 @@ describe( 'Input', () => {
 
 				sinon.assert.notCalled( spy );
 			} );
+
+			it( 'should not call model.deleteContent() on composition start if insertText command is disabled', () => {
+				const spy = sinon.spy( editor.model, 'deleteContent' );
+				const root = editor.model.document.getRoot();
+
+				editor.commands.get( 'insertText' ).forceDisabled( 'commentsOnly' );
+
+				editor.model.change( writer => writer.setSelection( root.getChild( 0 ), 'in' ) );
+
+				viewDocument.fire( 'compositionstart' );
+
+				sinon.assert.notCalled( spy );
+			} );
 		} );
 	} );
 
@@ -379,6 +392,24 @@ describe( 'Input', () => {
 
 			editor.model.change( writer => writer.setSelection( root.getChild( 0 ), 'in' ) );
 
+			viewDocument.fire( 'keydown', {
+				keyCode: 229,
+				preventDefault: sinon.spy(),
+				stopPropagation: sinon.spy()
+			} );
+
+			sinon.assert.notCalled( spy );
+		} );
+
+		it( 'should not call model.deleteContent() on 229 keydown if insertText command is disabled', () => {
+			const spy = sinon.spy( editor.model, 'deleteContent' );
+			const root = editor.model.document.getRoot();
+
+			editor.model.change( writer => writer.setSelection( root.getChild( 0 ), 'in' ) );
+
+			editor.commands.get( 'insertText' ).forceDisabled( 'commentsOnly' );
+
+			viewDocument.isComposing = true;
 			viewDocument.fire( 'keydown', {
 				keyCode: 229,
 				preventDefault: sinon.spy(),


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (typing): Content should not get removed on the composition start if the input is disabled. Closes #12739.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._