### PR TITLE
ckeditor5-link: linkui: do not submit invalid URLs

### DIFF
--- a/packages/ckeditor5-link/src/linkui.js
+++ b/packages/ckeditor5-link/src/linkui.js
@@ -171,8 +171,11 @@ export default class LinkUI extends Plugin {
 		this.listenTo( formView, 'submit', () => {
 			const { value } = formView.urlInputView.fieldView.element;
 			const parsedUrl = addLinkProtocolIfApplicable( value, defaultProtocol );
-			editor.execute( 'link', parsedUrl, formView.getDecoratorSwitchesState() );
-			this._closeFormView();
+			try {
+				const _url = new URL(parsedUrl).toString();
+				editor.execute( 'link', _url, formView.getDecoratorSwitchesState() );
+				this._closeFormView();
+			} catch(err) { console.error(err.message); }
 		} );
 
 		// Hide the panel after clicking the "Cancel" button.

--- a/packages/ckeditor5-link/src/linkui.js
+++ b/packages/ckeditor5-link/src/linkui.js
@@ -172,10 +172,11 @@ export default class LinkUI extends Plugin {
 			const { value } = formView.urlInputView.fieldView.element;
 			const parsedUrl = addLinkProtocolIfApplicable( value, defaultProtocol );
 			try {
-				const _url = new URL(parsedUrl).toString();
+				// eslint-disable-next-line
+				const _url = new URL( parsedUrl ).toString();
 				editor.execute( 'link', _url, formView.getDecoratorSwitchesState() );
 				this._closeFormView();
-			} catch(err) { console.error(err.message); }
+			} catch ( err ) { /**/ }
 		} );
 
 		// Hide the panel after clicking the "Cancel" button.


### PR DESCRIPTION
master behaviour:
text like "http://a b c" is submitted as if it is valid and causes issues when the output of the editor is converted to html

the result is href="http://a b c", which is obviously wrong, and the string [_http://a b c_](http://a b c) in markdown instead of the correct html tag

this pr:
when the user press the submit button, nothing happens if the URL is not valid, ie they cannot submit invalid URLs
