### PR TITLE
MutationObserver is no longer watching attribute changes.

### DIFF
--- a/packages/ckeditor5-engine/src/view/observer/mutationobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/mutationobserver.ts
@@ -53,7 +53,6 @@ export default class MutationObserver extends Observer {
 		this._config = {
 			childList: true,
 			characterData: true,
-			attributes: true,
 			subtree: true
 		};
 
@@ -152,9 +151,8 @@ export default class MutationObserver extends Observer {
 		// Use map and set for deduplication.
 		const mutatedTextNodes = new Set<ViewText>();
 		const elementsWithMutatedChildren = new Set<ViewElement>();
-		const elementsWithMutatedAttributes = new Set<ViewElement>();
 
-		// Handle `childList` and `attributes` mutations first, so we will be able to check if the `characterData` mutation is in the
+		// Handle `childList` mutations first, so we will be able to check if the `characterData` mutation is in the
 		// element with changed structure anyway.
 		for ( const mutation of domMutations ) {
 			const element = domConverter.mapDomToView( mutation.target as HTMLElement );
@@ -170,8 +168,6 @@ export default class MutationObserver extends Observer {
 
 			if ( mutation.type === 'childList' && !this._isBogusBrMutation( mutation ) ) {
 				elementsWithMutatedChildren.add( element as ViewElement );
-			} else if ( mutation.type === 'attributes' && !element.is( 'rootElement' ) ) {
-				elementsWithMutatedAttributes.add( element as ViewElement );
 			}
 		}
 
@@ -209,11 +205,6 @@ export default class MutationObserver extends Observer {
 		for ( const textNode of mutatedTextNodes ) {
 			hasMutations = true;
 			this.renderer.markToSync( 'text', textNode );
-		}
-
-		for ( const viewElement of elementsWithMutatedAttributes ) {
-			hasMutations = true;
-			this.renderer.markToSync( 'attributes', viewElement );
 		}
 
 		for ( const viewElement of elementsWithMutatedChildren ) {

--- a/packages/ckeditor5-engine/tests/view/observer/mutationobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/mutationobserver.js
@@ -113,16 +113,17 @@ describe( 'MutationObserver', () => {
 		sinon.assert.calledOnceWithExactly( spyRenderedMarkToSync, 'text', viewRoot.getChild( 0 ).getChild( 0 ) );
 	} );
 
-	it( 'should handle added attribute mutation', () => {
+	// https://github.com/ckeditor/ckeditor5/issues/12759.
+	it( 'should not handle added attribute mutation', () => {
 		domRoot.childNodes[ 0 ].setAttribute( 'foo', 'bar' );
 
 		mutationObserver.flush();
 
-		sinon.assert.calledOnce( spyRenderedMarkToSync );
-		sinon.assert.calledWithExactly( spyRenderedMarkToSync, 'attributes', viewRoot.getChild( 0 ) );
+		sinon.assert.notCalled( spyRenderedMarkToSync );
 	} );
 
-	it( 'should handle removed attribute mutation', () => {
+	// https://github.com/ckeditor/ckeditor5/issues/12759.
+	it( 'should not handle removed attribute mutation', () => {
 		view.change( writer => {
 			writer.setAttribute( 'foo', 'bar', viewRoot.getChild( 0 ) );
 		} );
@@ -131,11 +132,11 @@ describe( 'MutationObserver', () => {
 		domRoot.childNodes[ 0 ].removeAttribute( 'foo' );
 		mutationObserver.flush();
 
-		sinon.assert.calledOnce( spyRenderedMarkToSync );
-		sinon.assert.calledWithExactly( spyRenderedMarkToSync, 'attributes', viewRoot.getChild( 0 ) );
+		sinon.assert.notCalled( spyRenderedMarkToSync );
 	} );
 
-	it( 'should handle attribute value mutation', () => {
+	// https://github.com/ckeditor/ckeditor5/issues/12759.
+	it( 'should not handle attribute value mutation', () => {
 		view.change( writer => {
 			writer.setAttribute( 'foo', 'bar', viewRoot.getChild( 0 ) );
 		} );
@@ -144,8 +145,7 @@ describe( 'MutationObserver', () => {
 		domRoot.childNodes[ 0 ].setAttribute( 'foo', 'abc' );
 		mutationObserver.flush();
 
-		sinon.assert.calledOnce( spyRenderedMarkToSync );
-		sinon.assert.calledWithExactly( spyRenderedMarkToSync, 'attributes', viewRoot.getChild( 0 ) );
+		sinon.assert.notCalled( spyRenderedMarkToSync );
 	} );
 
 	it( 'should be able to observe multiple roots', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (engine): MutationObserver is no longer watching attribute changes. Closes #12759.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
