### PR TITLE
Docs: add missing export statement to code snippet

### DIFF
--- a/docs/installation/frameworks/react.md
+++ b/docs/installation/frameworks/react.md
@@ -141,6 +141,8 @@ class App extends Component {
 		);
 	}
 }
+
+export default App;
 ```
 
 ### Context feature properties


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Type: Adding a missing export statement to a code snippet in the docs. Closes #12761.