### PR TITLE
Added new eslint rule to use require in debug imports and updated docs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,8 @@ module.exports = {
 				' * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license',
 				' */'
 			]
-		} ]
+		} ],
+		'ckeditor5-rules/use-require-for-debug-mode-imports': 'error'
 	},
 	overrides: [
 		{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,8 +18,7 @@ module.exports = {
 				' * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license',
 				' */'
 			]
-		} ],
-		'ckeditor5-rules/use-require-for-debug-mode-imports': 'error'
+		} ]
 	},
 	overrides: [
 		{

--- a/docs/framework/guides/contributing/code-style.md
+++ b/docs/framework/guides/contributing/code-style.md
@@ -944,3 +944,33 @@ import toArray from '@ckeditor/ckeditor5-utils/src/toarray';
 ```
 
 [History of the change.](https://github.com/ckeditor/ckeditor5/issues/9318)
+
+### Importing modules in debug comments: `ckeditor5-rules/use-require-for-debug-mode-imports`
+
+In order to run code in debug mode only, create a comment that starts with `@if CK_DEBUG` text.
+
+If any module is imported in debug mode using `import` keyword, an error is thrown to the console.
+
+Modules need to be imported with a `require()` keyword in order to avoid such errors.
+
+👎&nbsp; Examples of incorrect code for this rule:
+
+```js
+// @if CK_DEBUG // import defaultExport from \'module-name\'
+// @if CK_DEBUG // import * as name from \'module-name\';
+// @if CK_DEBUG // import { testFunction } from \'module-name\';
+// @if CK_DEBUG // import { default as alias } from \'module-name\';
+// @if CK_DEBUG // import { exported as alias } from \'module-name\';
+// @if CK_DEBUG // import \'module-name\';
+```
+
+👍&nbsp; Examples of correct code for this rule:
+
+```js
+// @if CK_DEBUG // const defaultExport = require( \'module-name\' ).default;
+// @if CK_DEBUG // const name = require( \'module-name\' );
+// @if CK_DEBUG // const { testFunction } = require( \'module-name\' );
+// @if CK_DEBUG // const alias = require( \'module-name\' ).default;
+// @if CK_DEBUG // const { exported: alias } = require( \'module-name\' );
+// @if CK_DEBUG // require( \'module-name\' );
+```

--- a/docs/framework/guides/contributing/code-style.md
+++ b/docs/framework/guides/contributing/code-style.md
@@ -1,7 +1,7 @@
 ---
 category: framework-contributing
 order: 30
-modified_at: 2021-10-25
+modified_at: 2022-11-03
 ---
 
 # Code style

--- a/docs/framework/guides/contributing/code-style.md
+++ b/docs/framework/guides/contributing/code-style.md
@@ -956,21 +956,21 @@ Modules need to be imported with a `require()` keyword in order to avoid such er
 👎&nbsp; Examples of incorrect code for this rule:
 
 ```js
-// @if CK_DEBUG // import defaultExport from \'module-name\';
-// @if CK_DEBUG // import * as name from \'module-name\';
-// @if CK_DEBUG // import { testFunction } from \'module-name\';
-// @if CK_DEBUG // import { default as alias } from \'module-name\';
-// @if CK_DEBUG // import { exported as alias } from \'module-name\';
-// @if CK_DEBUG // import \'module-name\';
+// @if CK_DEBUG // import defaultExport from 'module-name';
+// @if CK_DEBUG // import * as name from 'module-name';
+// @if CK_DEBUG // import { testFunction } from 'module-name';
+// @if CK_DEBUG // import { default as alias } from 'module-name';
+// @if CK_DEBUG // import { exported as alias } from 'module-name';
+// @if CK_DEBUG // import 'module-name';
 ```
 
 👍&nbsp; Examples of correct code for this rule:
 
 ```js
-// @if CK_DEBUG // const defaultExport = require( \'module-name\' ).default;
-// @if CK_DEBUG // const name = require( \'module-name\' );
-// @if CK_DEBUG // const { testFunction } = require( \'module-name\' );
-// @if CK_DEBUG // const alias = require( \'module-name\' ).default;
-// @if CK_DEBUG // const { exported: alias } = require( \'module-name\' );
-// @if CK_DEBUG // require( \'module-name\' );
+// @if CK_DEBUG // const defaultExport = require( 'module-name' ).default;
+// @if CK_DEBUG // const name = require( 'module-name' );
+// @if CK_DEBUG // const { testFunction } = require( 'module-name' );
+// @if CK_DEBUG // const alias = require( 'module-name' ).default;
+// @if CK_DEBUG // const { exported: alias } = require( 'module-name' );
+// @if CK_DEBUG // require( 'module-name' );
 ```

--- a/docs/framework/guides/contributing/code-style.md
+++ b/docs/framework/guides/contributing/code-style.md
@@ -986,3 +986,5 @@ To create a code executed only in the debug mode, follow the description of the 
 // @if CK_DEBUG // const { exported: alias } = require( 'module-name' );
 // @if CK_DEBUG // require( 'module-name' );
 ```
+
+[History of the change.](https://github.com/ckeditor/ckeditor5/issues/12479)

--- a/docs/framework/guides/contributing/code-style.md
+++ b/docs/framework/guides/contributing/code-style.md
@@ -956,7 +956,7 @@ Modules need to be imported with a `require()` keyword in order to avoid such er
 👎&nbsp; Examples of incorrect code for this rule:
 
 ```js
-// @if CK_DEBUG // import defaultExport from \'module-name\'
+// @if CK_DEBUG // import defaultExport from \'module-name\';
 // @if CK_DEBUG // import * as name from \'module-name\';
 // @if CK_DEBUG // import { testFunction } from \'module-name\';
 // @if CK_DEBUG // import { default as alias } from \'module-name\';

--- a/docs/framework/guides/contributing/code-style.md
+++ b/docs/framework/guides/contributing/code-style.md
@@ -947,11 +947,23 @@ import toArray from '@ckeditor/ckeditor5-utils/src/toarray';
 
 ### Importing modules in debug comments: `ckeditor5-rules/use-require-for-debug-mode-imports`
 
-In order to run code in debug mode only, create a comment that starts with `@if CK_DEBUG` text.
+The debug mode allows importing additional modules for testing purposes. Unfortunately, the debug comment is not removed, so webpack reports the following error.
 
-If any module is imported in debug mode using `import` keyword, an error is thrown to the console.
+```
+Module parse failed: 'import' and 'export' may only appear at the top level (15204:20)
+File was processed with these loaders:
+ * ./node_modules/@ckeditor/ckeditor5-dev-tests/lib/utils/ck-debug-loader.js
+You may need an additional loader to handle the result of these loaders.
+|  */
+|
+> /* @if CK_DEBUG */  import { CKEditorError } from 'ckeditor5/src/utils';
+|
+| /**
+```
 
-Modules need to be imported with a `require()` keyword in order to avoid such errors.
+Modules need to be imported with a `require()` function.
+
+To create a code executed only in the debug mode, follow the description of the `--debug` flag in the {@link framework/guides/contributing/testing-environment#running-manual-tests testing environment} guide.
 
 👎&nbsp; Examples of incorrect code for this rule:
 

--- a/packages/ckeditor5-minimap/src/minimap.js
+++ b/packages/ckeditor5-minimap/src/minimap.js
@@ -19,7 +19,7 @@ import {
 	findClosestScrollableAncestor
 } from './utils';
 
-// @if CK_DEBUG_MINIMAP // import RectDrawer from '@ckeditor/ckeditor5-utils/tests/_utils/rectdrawer';
+// @if CK_DEBUG_MINIMAP // const RectDrawer = require( '@ckeditor/ckeditor5-utils/tests/_utils/rectdrawer' ).default;
 
 import '../theme/minimap.css';
 

--- a/packages/ckeditor5-table/src/tablewalker.js
+++ b/packages/ckeditor5-table/src/tablewalker.js
@@ -7,7 +7,7 @@
  * @module table/tablewalker
  */
 
-// @if CK_DEBUG // import { CKEditorError } from 'ckeditor5/src/utils';
+// @if CK_DEBUG // const { CKEditorError } = require( 'ckeditor5/src/utils' );
 
 /**
  * The table iterator class. It allows to iterate over table cells. For each cell the iterator yields

--- a/packages/ckeditor5-utils/_src/dom/position.js
+++ b/packages/ckeditor5-utils/_src/dom/position.js
@@ -17,7 +17,7 @@ import getPositionedAncestor from './getpositionedancestor';
 import getBorderWidths from './getborderwidths';
 import { isFunction } from 'lodash-es';
 
-// @if CK_DEBUG_POSITION // import { RectDrawer } from '@ckeditor/ckeditor5-minimap/src/utils';
+// @if CK_DEBUG_POSITION // const { RectDrawer } = require( '@ckeditor/ckeditor5-minimap/src/utils' );
 
 /**
  * Calculates the `position: absolute` coordinates of a given element so it can be positioned with respect to the

--- a/packages/ckeditor5-utils/src/dom/position.ts
+++ b/packages/ckeditor5-utils/src/dom/position.ts
@@ -13,7 +13,7 @@ import getPositionedAncestor from './getpositionedancestor';
 import getBorderWidths from './getborderwidths';
 import { isFunction } from 'lodash-es';
 
-// @if CK_DEBUG_POSITION // import { RectDrawer } from '@ckeditor/ckeditor5-minimap/src/utils';
+// @if CK_DEBUG_POSITION // const { RectDrawer } = require( '@ckeditor/ckeditor5-minimap/src/utils' );
 
 /**
  * Calculates the `position: absolute` coordinates of a given element so it can be positioned with respect to the


### PR DESCRIPTION
Docs: Added the new rule (`ckeditor5-rules/use-require-for-debug-mode-imports`) in the "Code style" guide. See #12479.

Internal: Fixed errors reported by `eslint` after introducing the new rule.