### PR TITLE
Delete event should not be fired on backspace keyup if delete event was stopped

### DIFF
--- a/packages/ckeditor5-typing/src/deleteobserver.ts
+++ b/packages/ckeditor5-typing/src/deleteobserver.ts
@@ -282,7 +282,7 @@ function enableChromeWorkaround( observer: DeleteObserver ) {
 		if ( isMatchingBeforeInput ) {
 			beforeInputReceived = true;
 		}
-	} );
+	}, { priority: 'high' } );
 
 	document.on<ViewDocumentInputEvent>( 'beforeinput', ( evt, { inputType, data } ) => {
 		const shouldIgnoreBeforeInput = pressedKeyCode == keyCodes.delete &&

--- a/packages/ckeditor5-typing/tests/tickets/11904.js
+++ b/packages/ckeditor5-typing/tests/tickets/11904.js
@@ -101,6 +101,24 @@ describe( 'Bug ckeditor5-typing#11904', () => {
 			sinon.assert.callCount( deleteSpy, 2 );
 		} );
 
+		it( 'should not fire additional `delete` event on `keyup` if delete event was stopped', () => {
+			viewDocument.fire( 'keydown', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'backspace' )
+			} ) );
+
+			viewDocument.on( 'delete', evt => evt.stop() );
+
+			fireBeforeInputDomEvent( domRoot, {
+				inputType: 'deleteContentBackward'
+			} );
+
+			viewDocument.fire( 'keyup', new DomEventData( viewDocument, getDomEvent(), {
+				keyCode: getCode( 'backspace' )
+			} ) );
+
+			sinon.assert.callCount( deleteSpy, 1, { unit: 'codePoint', directin: 'backward' } );
+		} );
+
 		it( 'should ignore `beforeinput` inserting single delete (x7f) character', () => {
 			const insertTextSpy = testUtils.sinon.spy();
 			viewDocument.on( 'insertText', insertTextSpy );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (typing): Delete event should not be fired on backspace keyup if delete event was stopped. Closes #12776.

---

### Additional information

The problem was that workaround for missing `beforeInput` events (https://github.com/ckeditor/ckeditor5/issues/11904) was checking whether the `beforeInput` was fired on `normal` priority and in case of custom widget delete handling, the `delete` event was stopped and as a result the `beforeInput` was stopped before it got noticed by the workaround code.
