### PR TITLE
Nested upcasting issues with image captions

### DIFF
--- a/packages/ckeditor5-engine/tests/controller/datacontroller.js
+++ b/packages/ckeditor5-engine/tests/controller/datacontroller.js
@@ -1030,7 +1030,13 @@ describe( 'DataController', () => {
 		it( 'should allow nesting upcast conversion', () => {
 			const dataProcessor = data.processor;
 
+			model.schema.register( 'softBreak', {
+				allowWhere: '$text',
+				isInline: true
+			} );
+
 			upcastHelpers.elementToAttribute( { view: 'strong', model: 'bold' } );
+			upcastHelpers.elementToElement( { model: 'softBreak', view: 'br' } );
 
 			data.upcastDispatcher.on( 'element:div', ( evt, data, conversionApi ) => {
 				const viewItem = data.viewItem;
@@ -1074,10 +1080,10 @@ describe( 'DataController', () => {
 				conversionApi.updateConversionResult( container, data );
 			} );
 
-			data.set( '<div data-caption="foo<strong>baz</strong>">&nbsp;</div>' );
+			data.set( '<div data-caption="foo<br><strong>baz</strong>">&nbsp;</div>' );
 
 			expect( getData( model, { withoutSelection: true } ) ).to.equal(
-				'<container><caption>foo<$text bold="true">baz</$text></caption></container>'
+				'<container><caption>foo<softBreak></softBreak><$text bold="true">baz</$text></caption></container>'
 			);
 		} );
 


### PR DESCRIPTION
In Drupal we use the data-caption attribute to store image/media caption text.

Because we need to support existing content, some captions can have elements such as `<br>`, `<section>` or other block level HTML tags. When that is the case CKE5 crashes: https://www.drupal.org/project/drupal/issues/3276213

Thanks to @lauriii, it's possible to see the problem in the CKE5 test suite. 

What's the best way to address this? We tried to look at how to solve this but it's not clear for us.
