### PR TITLE
Dropdown split button divider does not stretch 100% height of the button

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/splitbutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/splitbutton.css
@@ -33,7 +33,8 @@
 		/* It's a text-less button and since the icon is positioned absolutely in such situation,
 		it must get some arbitrary min-width. */
 		min-width: unset;
-
+		border: none;
+		
 		@nest [dir="ltr"] & {
 			/* Don't round the arrow button on the left side */
 			border-top-left-radius: unset;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Type: Message. Closes #000.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
