### PR TITLE
Ck/12763 remove i from collection

### DIFF
--- a/packages/ckeditor5-core/src/pendingactions.ts
+++ b/packages/ckeditor5-core/src/pendingactions.ts
@@ -55,7 +55,7 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 export default class PendingActions extends ContextPlugin implements Iterable<PendingAction> {
 	declare public hasAny: boolean;
 
-	private _actions!: Collection<PendingAction & { _id?: string }, '_id'>;
+	private _actions!: Collection<PendingAction>;
 
 	/**
 	 * @inheritDoc

--- a/packages/ckeditor5-engine/src/model/document.ts
+++ b/packages/ckeditor5-engine/src/model/document.ts
@@ -51,7 +51,7 @@ export default class Document extends EmitterMixin() {
 	public readonly model: Model;
 	public readonly history: History;
 	public readonly selection: DocumentSelection;
-	public readonly roots: Collection<RootElement, 'rootName'>;
+	public readonly roots: Collection<RootElement>;
 	public readonly differ: Differ;
 
 	private readonly _postFixers: Set<( writer: Writer ) => boolean>;

--- a/packages/ckeditor5-engine/src/model/documentselection.ts
+++ b/packages/ckeditor5-engine/src/model/documentselection.ts
@@ -177,7 +177,7 @@ export default class DocumentSelection extends EmitterMixin( TypeCheckable ) {
 	 * @readonly
 	 * @type {module:utils/collection~Collection}
 	 */
-	public get markers(): Collection<Marker, 'name'> {
+	public get markers(): Collection<Marker> {
 		return this._selection.markers;
 	}
 
@@ -627,7 +627,7 @@ export type DocumentSelectionChangeEvent = {
 // @extends module:engine/model/selection~Selection
 //
 class LiveSelection extends Selection {
-	public markers: Collection<Marker, 'name'>;
+	public markers: Collection<Marker>;
 
 	protected _model: Model;
 	protected _document: Document;

--- a/packages/ckeditor5-engine/src/view/document.ts
+++ b/packages/ckeditor5-engine/src/view/document.ts
@@ -29,7 +29,7 @@ import type DowncastWriter from './downcastwriter';
  */
 export default class Document extends BubblingEmitterMixin( ObservableMixin() ) {
 	public readonly selection: DocumentSelection;
-	public readonly roots: Collection<RootEditableElement, 'rootName'>;
+	public readonly roots: Collection<RootEditableElement>;
 	public readonly stylesProcessor: StylesProcessor;
 
 	declare public isReadOnly: boolean;

--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -225,9 +225,9 @@ export function addToolbarToDropdown(
  * @param {Iterable.<module:ui/dropdown/utils~ListDropdownItemDefinition>} items
  * A collection of the list item definitions to populate the list.
  */
-export function addListToDropdown<I extends string>(
+export function addListToDropdown(
 	dropdownView: DropdownView,
-	items: Collection<ListDropdownItemDefinition & { [ id in I ]?: string }, I>
+	items: Collection<ListDropdownItemDefinition>
 ): void {
 	const locale = dropdownView.locale;
 	const listView = dropdownView.listView = new ListView( locale );

--- a/packages/ckeditor5-ui/src/viewcollection.ts
+++ b/packages/ckeditor5-ui/src/viewcollection.ts
@@ -49,7 +49,7 @@ import type View from './view';
  * @extends module:utils/collection~Collection
  * @mixes module:utils/observablemixin~ObservableMixin
  */
-export default class ViewCollection extends Collection<View, 'viewUid'> {
+export default class ViewCollection extends Collection<View> {
 	public id?: string;
 
 	private _parentElement: DocumentFragment | HTMLElement | null;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (utils): Removed `I` generic parameter from `Collection`. Closes #12763.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._