### PR TITLE
Special characters form header should use a heading markup

### DIFF
--- a/packages/ckeditor5-ui/src/formheader/formheaderview.ts
+++ b/packages/ckeditor5-ui/src/formheader/formheaderview.ts
@@ -90,7 +90,7 @@ export default class FormHeaderView extends View {
 		const label = new View( locale );
 
 		label.setTemplate( {
-			tag: 'span',
+			tag: 'h2',
 			attributes: {
 				class: [
 					'ck',

--- a/packages/ckeditor5-ui/tests/formheader/formheaderview.js
+++ b/packages/ckeditor5-ui/tests/formheader/formheaderview.js
@@ -39,8 +39,8 @@ describe( 'FormHeaderView', () => {
 		} );
 
 		it( 'should set the template', () => {
-			expect( view.element.classList.contains( 'ck' ) ).to.be.true;
-			expect( view.element.classList.contains( 'ck-form__header' ) ).to.be.true;
+			expect( view.template.attributes.class ).to.include( 'ck' );
+			expect( view.template.attributes.class ).to.include( 'ck-form__header' );
 		} );
 
 		it( 'should set view#tag', () => {

--- a/packages/ckeditor5-ui/tests/formheader/formheaderview.js
+++ b/packages/ckeditor5-ui/tests/formheader/formheaderview.js
@@ -43,12 +43,15 @@ describe( 'FormHeaderView', () => {
 			expect( view.element.classList.contains( 'ck-form__header' ) ).to.be.true;
 		} );
 
+		it( 'should has the "h2" tag in header', () => {
+			expect( view.element.getElementsByClassName( 'ck ck-form__header__label' )[ 0 ].tagName ).to.equal( 'H2' );
+		} );
+
 		describe( 'options', () => {
 			it( 'should set view#class when class was passed', () => {
 				const view = new FormHeaderView( locale, {
 					class: 'foo'
 				} );
-
 				expect( view.class ).to.equal( 'foo' );
 
 				view.destroy();

--- a/packages/ckeditor5-ui/tests/formheader/formheaderview.js
+++ b/packages/ckeditor5-ui/tests/formheader/formheaderview.js
@@ -43,8 +43,8 @@ describe( 'FormHeaderView', () => {
 			expect( view.element.classList.contains( 'ck-form__header' ) ).to.be.true;
 		} );
 
-		it( 'should has the "h2" tag in header', () => {
-			expect( view.element.getElementsByClassName( 'ck ck-form__header__label' )[ 0 ].tagName ).to.equal( 'H2' );
+		it( 'should set view#tag', () => {
+			expect( view.children.first.template.tag ).to.equal( 'h2' );
 		} );
 
 		describe( 'options', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (Special Characters): Special characters form header should use a heading markup. Closes #12464.

---

### Additional information
In this pull request I also provided little changes of neighbouring unit test, I mean "should set the template". First reason is better to getting to property through template not through DOM. Second reason is to increase the readability of test in case it failed. 

_For example – It will no display "**expect false to be true**", however it will display "**expect [ 'ck', 'ck-form__header'] should include  'wrong data'** "_
