### PR TITLE
Label on insert table dropdown in RTL has wrong alignment

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/inserttable.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/inserttable.css
@@ -20,6 +20,10 @@
 	text-align: center;
 }
 
+.ck[dir=rtl] .ck-insert-table-dropdown__label {
+	text-align: center;
+}
+
 .ck .ck-insert-table-dropdown-grid-box {
 	min-width: var(--ck-insert-table-dropdown-box-width);
 	min-height: var(--ck-insert-table-dropdown-box-height);


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (Table): Center label in RTL in table dropdown. Closes #12833.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
