### PR TITLE
Set proper order of guides in "Advanced tutorials" submenu

### DIFF
--- a/docs/framework/guides/tutorials/data-from-external-source.md
+++ b/docs/framework/guides/tutorials/data-from-external-source.md
@@ -1,6 +1,6 @@
 ---
 category: framework-tutorials
-order: 10
+order: 12
 ---
 
 # Data from external source

--- a/docs/framework/guides/tutorials/implementing-an-inline-widget.md
+++ b/docs/framework/guides/tutorials/implementing-an-inline-widget.md
@@ -1,6 +1,6 @@
 ---
 category: framework-tutorials
-order: 10
+order: 11
 ---
 
 # Implementing an inline widget

--- a/docs/framework/guides/tutorials/using-react-in-a-widget.md
+++ b/docs/framework/guides/tutorials/using-react-in-a-widget.md
@@ -1,7 +1,7 @@
 ---
 menu-title: Using a React component in a widget
 category: framework-tutorials
-order: 10
+order: 13
 ---
 
 # Using a React component in a block widget


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Change order of items in submenu "Advanced tutorials". Closes #12859.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
