### PR TITLE
Change selection observer behavior

### DIFF
--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -221,6 +221,13 @@ export default class SelectionObserver extends Observer {
 		this._documentIsSelectingInactivityTimeoutDebounced.cancel();
 	}
 
+	// @if CK_DEBUG //	reportInfiniteLoop() {
+	// @if CK_DEBUG //		throw new Error(
+	// @if CK_DEBUG //			'Selection change observer detected an infinite rendering loop.\n\n' +
+	// @if CK_DEBUG //	 		'⚠️⚠️ Report this error on https://github.com/ckeditor/ckeditor5/issues/11658.'
+	// @if CK_DEBUG //		);
+	// @if CK_DEBUG //	}
+
 	/**
 	 * Selection change listener. {@link module:engine/view/observer/mutationobserver~MutationObserver#flush Flush} mutations, check if
 	 * a selection changes and fires {@link module:engine/view/document~Document#event:selectionChange} event on every change
@@ -271,7 +278,7 @@ export default class SelectionObserver extends Observer {
 			// by the browser and browser fixes it automatically what causes `selectionchange` event on
 			// which a loopback through a model tries to re-render the wrong selection and again.
 			//
-			// @if CK_DEBUG // console.warn( 'Selection change observer detected an infinite rendering loop.' );
+			// @if CK_DEBUG // this.reportInfiniteLoop();
 
 			return;
 		}

--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -221,7 +221,7 @@ export default class SelectionObserver extends Observer {
 		this._documentIsSelectingInactivityTimeoutDebounced.cancel();
 	}
 
-	// @if CK_DEBUG //	reportInfiniteLoop() {
+	// @if CK_DEBUG //	_reportInfiniteLoop() {
 	// @if CK_DEBUG //		throw new Error(
 	// @if CK_DEBUG //			'Selection change observer detected an infinite rendering loop.\n\n' +
 	// @if CK_DEBUG //	 		'⚠️⚠️ Report this error on https://github.com/ckeditor/ckeditor5/issues/11658.'
@@ -278,7 +278,7 @@ export default class SelectionObserver extends Observer {
 			// by the browser and browser fixes it automatically what causes `selectionchange` event on
 			// which a loopback through a model tries to re-render the wrong selection and again.
 			//
-			// @if CK_DEBUG // this.reportInfiniteLoop();
+			// @if CK_DEBUG // this._reportInfiniteLoop();
 
 			return;
 		}

--- a/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
@@ -212,7 +212,7 @@ describe( 'SelectionObserver', () => {
 		} );
 
 		let wasInfiniteLoopDetected = false;
-		sinon.stub( selectionObserver, 'reportInfiniteLoop' ).callsFake( () => {
+		sinon.stub( selectionObserver, '_reportInfiniteLoop' ).callsFake( () => {
 			wasInfiniteLoopDetected = true;
 		} );
 		const selectionChangeSpy = sinon.spy();
@@ -232,6 +232,15 @@ describe( 'SelectionObserver', () => {
 				counter--;
 			}
 		} );
+	} );
+
+	it( 'SelectionObserver#_reportInfiniteLoop() should throw an error', () => {
+		expect( () => {
+			selectionObserver._reportInfiniteLoop();
+		} ).to.throw( Error,
+			'Selection change observer detected an infinite rendering loop.\n\n' +
+			'⚠️⚠️ Report this error on https://github.com/ckeditor/ckeditor5/issues/11658.'
+		);
 	} );
 
 	it( 'should not be treated as an infinite loop if selection is changed only few times', done => {

--- a/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
@@ -211,15 +211,17 @@ describe( 'SelectionObserver', () => {
 			writer.setSelection( viewFoo, 0 );
 		} );
 
+		let wasInfiniteLoopDetected = false;
+		sinon.stub( selectionObserver, 'reportInfiniteLoop' ).callsFake( () => {
+			wasInfiniteLoopDetected = true;
+		} );
 		const selectionChangeSpy = sinon.spy();
-
-		// Catches the "Selection change observer detected an infinite rendering loop." warning in the CK_DEBUG mode.
-		sinon.stub( console, 'warn' );
 
 		viewDocument.on( 'selectionChange', selectionChangeSpy );
 
 		return new Promise( resolve => {
 			viewDocument.on( 'selectionChangeDone', () => {
+				expect( wasInfiniteLoopDetected ).to.be.true;
 				expect( selectionChangeSpy.callCount ).to.equal( 60 );
 
 				resolve();


### PR DESCRIPTION
Other (engine): Add a mechanism for detecting which tests fail because of too many selection changed events. Closes #12103.


