### PR TITLE
Docs (clipboard): Update clipboardInput event signature

### DIFF
--- a/packages/ckeditor5-clipboard/_src/clipboardobserver.js
+++ b/packages/ckeditor5-clipboard/_src/clipboardobserver.js
@@ -126,8 +126,8 @@ function getDropViewRange( view, domEvent ) {
  * @event module:engine/view/document~Document#event:clipboardInput
  * @param {Object} data The event data.
  * @param {module:engine/view/datatransfer~DataTransfer} data.dataTransfer Data transfer instance.
- * @param {'paste'|'drop'} method Whether the event was triggered by a paste or drop operation.
- * @param {module:engine/view/element~Element} target The tree view element representing the target.
+ * @param {'paste'|'drop'} data.method Whether the event was triggered by a paste or drop operation.
+ * @param {module:engine/view/element~Element} data.target The tree view element representing the target.
  * @param {Array.<module:engine/view/range~Range>} data.targetRanges Ranges which are the target of the operation
  * (usually – into which the content should be inserted).
  * If the clipboard input was triggered by a paste operation, this property is not set. If by a drop operation,

--- a/packages/ckeditor5-clipboard/src/clipboardobserver.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardobserver.ts
@@ -163,8 +163,8 @@ function getDropViewRange( view: View, domEvent: DragEvent & { rangeParent?: Nod
  * @event module:engine/view/document~Document#event:clipboardInput
  * @param {Object} data The event data.
  * @param {module:engine/view/datatransfer~DataTransfer} data.dataTransfer Data transfer instance.
- * @param {'paste'|'drop'} method Whether the event was triggered by a paste or drop operation.
- * @param {module:engine/view/element~Element} target The tree view element representing the target.
+ * @param {'paste'|'drop'} data.method Whether the event was triggered by a paste or drop operation.
+ * @param {module:engine/view/element~Element} data.target The tree view element representing the target.
  * @param {Array.<module:engine/view/range~Range>} data.targetRanges Ranges which are the target of the operation
  * (usually – into which the content should be inserted).
  * If the clipboard input was triggered by a paste operation, this property is not set. If by a drop operation,


### PR DESCRIPTION
Closes #12839

Rebuilt docs show the correct function signature:

![image](https://user-images.githubusercontent.com/8739637/202451835-2f1f0afa-a439-4948-9f08-dde4eb482e5f.png)
