### PR TITLE
Add support for "is" attribute in Template and createElement

### DIFF
--- a/packages/ckeditor5-ui/src/template.ts
+++ b/packages/ckeditor5-ui/src/template.ts
@@ -460,7 +460,7 @@ export default class Template extends EmitterMixin() {
 		let node = data.node;
 
 		if ( !node ) {
-			const options = this.attributes && this.attributes.is ? { is: this.attributes.is } : undefined;
+			const options = this.attributes && this.attributes.is ? { is: this.attributes.is as any } : undefined;
 			node = data.node = document.createElementNS( this.ns || xhtmlNs, this.tag!, options ) as any;
 		}
 

--- a/packages/ckeditor5-ui/src/template.ts
+++ b/packages/ckeditor5-ui/src/template.ts
@@ -460,7 +460,8 @@ export default class Template extends EmitterMixin() {
 		let node = data.node;
 
 		if ( !node ) {
-			node = data.node = document.createElementNS( this.ns || xhtmlNs, this.tag! ) as any;
+			const options = this.attributes && this.attributes.is ? { is: this.attributes.is } : undefined;
+			node = data.node = document.createElementNS( this.ns || xhtmlNs, this.tag!, options ) as any;
 		}
 
 		this._renderAttributes( data );

--- a/packages/ckeditor5-ui/tests/template.js
+++ b/packages/ckeditor5-ui/tests/template.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals HTMLElement, Event, document */
+/* globals HTMLElement, HTMLInputElement, Event, document, window */
 
 import { default as Template, TemplateToBinding, TemplateIfBinding } from '../src/template';
 import View from '../src/view';
@@ -384,6 +384,24 @@ describe( 'Template', () => {
 
 						expect( normalizeHtml( el.outerHTML ) ).to.equal( '<p></p>' );
 					} );
+				} );
+			} );
+
+			describe( 'is', () => {
+				it( 'passes attribute as createElementNS option', () => {
+					class CustomInput extends HTMLInputElement {}
+					window.customElements.define( 'custom-input', CustomInput, {
+						extends: 'input'
+					} );
+
+					const el = new Template( {
+						tag: 'input',
+						attributes: {
+							is: 'custom-input'
+						}
+					} ).render();
+
+					expect( el ).to.be.instanceof( CustomInput );
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-utils/src/dom/createelement.ts
+++ b/packages/ckeditor5-utils/src/dom/createelement.ts
@@ -34,7 +34,8 @@ export default function createElement(
 	children: Node | string | Iterable<Node | string> = []
 ): Element {
 	const namespace = attributes && attributes.xmlns;
-	const element = namespace ? doc.createElementNS( namespace, name ) : doc.createElement( name );
+	const options = attributes && attributes.is ? { is: attributes.is } : undefined;
+	const element = namespace ? doc.createElementNS( namespace, name, options ) : doc.createElement( name, options );
 
 	for ( const key in attributes ) {
 		element.setAttribute( key, attributes[ key ] );

--- a/packages/ckeditor5-utils/tests/dom/createelement.js
+++ b/packages/ckeditor5-utils/tests/dom/createelement.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals document */
+/* globals HTMLInputElement, document, window */
 
 import createElement from '../../src/dom/createelement';
 
@@ -30,6 +30,17 @@ describe( 'createElement', () => {
 		expect( svg.tagName.toLowerCase() ).to.equal( 'svg' );
 		expect( svg.getAttribute( 'xmlns' ) ).to.equal( namespace );
 		expect( svg.createSVGRect ).to.be.a( 'function' );
+	} );
+
+	it( 'should create custom element when \'is\' attribute is set', () => {
+		class CustomInput extends HTMLInputElement {}
+		window.customElements.define( 'custom-input', CustomInput, {
+			extends: 'input'
+		} );
+		const el = createElement( document, 'input', { is: 'custom-input' } );
+
+		expect( el.tagName.toLowerCase() ).to.equal( 'input' );
+		expect( el ).to.be.instanceof( CustomInput );
 	} );
 
 	it( 'should create element with child text node', () => {


### PR DESCRIPTION
Closes: #12867

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (ui): Add support for the "is" attribute in Template. Closes #12867.

Other (utils): Add support for the "is" attribute in createElement. Closes #12867.


---

### Additional information

This MR allows using custom elements that extend native HTML elements in templates and via the createElement utility method. It basically checks if the "is" attribute is set, and, if so, passes it to the createElement or createElementNS native methods.