### PR TITLE
Upcasts img with display:block as block image

### DIFF
--- a/packages/ckeditor5-image/src/image/utils.js
+++ b/packages/ckeditor5-image/src/image/utils.js
@@ -69,7 +69,9 @@ export function getImgViewElementMatcher( editor, matchImageType ) {
 
 		// The <img> can be standalone, wrapped in <figure>...</figure> (ImageBlock plugin) or
 		// wrapped in <figure><a>...</a></figure> (LinkImage plugin).
-		const imageType = element.findAncestor( imageUtils.isBlockImageView ) ? 'imageBlock' : 'imageInline';
+		const imageType = element.getStyle( 'display' ) == 'block' || element.findAncestor( imageUtils.isBlockImageView ) ?
+			'imageBlock' :
+			'imageInline';
 
 		if ( imageType !== matchImageType ) {
 			return null;

--- a/packages/ckeditor5-image/tests/image/imageediting.js
+++ b/packages/ckeditor5-image/tests/image/imageediting.js
@@ -312,6 +312,13 @@ describe( 'ImageEditing', () => {
 					.to.equal( '<paragraph><imageInline alt="alt text" src="/assets/sample.png"></imageInline></paragraph>' );
 			} );
 
+			it( 'should convert image with `display:block` style', () => {
+				editor.setData( '<p><img src="/asserts/sample.png" alt="alt text" style="display:block" /></p>' );
+
+				expect( getModelData( model, { withoutSelection: true } ) )
+					.to.equal( '<imageBlock alt="alt text" src="/asserts/sample.png"></imageBlock>' );
+			} );
+
 			it( 'should not convert if there is no image class in figure', () => {
 				editor.setData( '<figure class="quote">My quote</figure>' );
 

--- a/packages/ckeditor5-image/tests/image/utils.js
+++ b/packages/ckeditor5-image/tests/image/utils.js
@@ -264,6 +264,15 @@ describe( 'image utils', () => {
 						} );
 					} );
 
+					it( 'should return a matcherPattern object if the element has `display:block` style', () => {
+						element = writer.createElement( 'img', { src: 'sample.jpg', style: 'display:block' } );
+
+						expect( matcherPattern( element ) ).to.deep.equal( {
+							name: true,
+							attributes: [ 'src' ]
+						} );
+					} );
+
 					it( 'should not include "src" in the matcher pattern if the image has no "src"', () => {
 						element = writer.createElement( 'img' );
 						writer.appendChild( element, writer.createElement( 'figure', { class: 'image' } ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (image): Upcasts `img` with `display:block` style as block image. Closes #12811.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._