### PR TITLE
HtmlDataProcessor should skip comments by default

### DIFF
--- a/packages/ckeditor5-engine/src/dataprocessor/dataprocessor.ts
+++ b/packages/ckeditor5-engine/src/dataprocessor/dataprocessor.ts
@@ -71,4 +71,9 @@ export default interface DataProcessor {
 	toView( data: string ): ViewDocumentFragment;
 	registerRawContentMatcher( pattern: MatcherPattern ): void;
 	useFillerType( type: 'default' | 'marked' ): void;
+
+	/**
+	 * If `false`, comment nodes will be converted to `$comment`. Otherwise comment nodes are ignored.
+	 */
+	skipComments?: boolean;
 }

--- a/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.ts
+++ b/packages/ckeditor5-engine/src/dataprocessor/htmldataprocessor.ts
@@ -28,6 +28,7 @@ export default class HtmlDataProcessor implements DataProcessor {
 	public domParser: DOMParser;
 	public domConverter: DomConverter;
 	public htmlWriter: HtmlWriter;
+	public skipComments: boolean = true;
 
 	/**
 	 * Creates a new instance of the HTML data processor class.
@@ -83,7 +84,7 @@ export default class HtmlDataProcessor implements DataProcessor {
 		const domFragment = this._toDom( data );
 
 		// Convert DOM DocumentFragment to view DocumentFragment.
-		return this.domConverter.domToView( domFragment ) as ViewDocumentFragment;
+		return this.domConverter.domToView( domFragment, { skipComments: this.skipComments } ) as ViewDocumentFragment;
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.ts
+++ b/packages/ckeditor5-engine/src/dataprocessor/xmldataprocessor.ts
@@ -31,6 +31,7 @@ export default class XmlDataProcessor implements DataProcessor {
 	public domParser: DOMParser;
 	public domConverter: DomConverter;
 	public htmlWriter: HtmlWriter;
+	public skipComments: boolean = true;
 
 	/**
 	 * Creates a new instance of the XML data processor class.
@@ -100,7 +101,13 @@ export default class XmlDataProcessor implements DataProcessor {
 		const domFragment = this._toDom( data );
 
 		// Convert DOM DocumentFragment to view DocumentFragment.
-		return this.domConverter.domToView( domFragment, { keepOriginalCase: true } ) as ViewDocumentFragment;
+		return this.domConverter.domToView(
+			domFragment,
+			{
+				keepOriginalCase: true,
+				skipComments: this.skipComments
+			}
+		) as ViewDocumentFragment;
 	}
 
 	/**

--- a/packages/ckeditor5-engine/tests/dataprocessor/htmldataprocessor.js
+++ b/packages/ckeditor5-engine/tests/dataprocessor/htmldataprocessor.js
@@ -27,10 +27,12 @@ describe( 'HtmlDataProcessor', () => {
 			expect( dataProcessor ).to.have.property( 'domParser' );
 			expect( dataProcessor ).to.have.property( 'domConverter' );
 			expect( dataProcessor ).to.have.property( 'htmlWriter' );
+			expect( dataProcessor ).to.have.property( 'skipComments' );
 
 			expect( dataProcessor.domParser ).to.be.an.instanceOf( DOMParser );
 			expect( dataProcessor.domConverter ).to.be.an.instanceOf( DomConverter );
 			expect( dataProcessor.htmlWriter ).to.be.an.instanceOf( BasicHtmlWriter );
+			expect( dataProcessor.skipComments ).to.be.true;
 		} );
 	} );
 
@@ -413,6 +415,48 @@ describe( 'HtmlDataProcessor', () => {
 			dataProcessor.useFillerType( 'default' );
 
 			expect( dataProcessor.toData( fragment ) ).to.equal( '<p>&nbsp;</p>' );
+		} );
+	} );
+
+	describe( 'skipComments', () => {
+		it( 'should skip comments when `true`', () => {
+			const fragment = dataProcessor.toView(
+				'<html>' +
+					'<head></head>' +
+					'<body>' +
+						'<!-- Comment 1 -->' +
+						'<p>' +
+							'foo' +
+							'<!-- Comment 2 -->' +
+							'bar' +
+						'</p>' +
+						'<!-- Comment 3 -->' +
+					'</body>' +
+				'</html>'
+			);
+
+			expect( stringify( fragment ) ).to.equal( '<p>foobar</p>' );
+		} );
+
+		it( 'should preserve comments when `false`', () => {
+			dataProcessor.skipComments = false;
+
+			const fragment = dataProcessor.toView(
+				'<html>' +
+					'<head></head>' +
+					'<body>' +
+						'<!-- Comment 1 -->' +
+						'<p>' +
+							'foo' +
+							'<!-- Comment 2 -->' +
+							'bar' +
+						'</p>' +
+						'<!-- Comment 3 -->' +
+					'</body>' +
+				'</html>'
+			);
+
+			expect( stringify( fragment ) ).to.equal( '<$comment></$comment><p>foo<$comment></$comment>bar</p><$comment></$comment>' );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-engine/tests/dataprocessor/xmldataprocessor.js
+++ b/packages/ckeditor5-engine/tests/dataprocessor/xmldataprocessor.js
@@ -28,11 +28,13 @@ describe( 'XmlDataProcessor', () => {
 			expect( dataProcessor ).to.have.property( 'domParser' );
 			expect( dataProcessor ).to.have.property( 'domConverter' );
 			expect( dataProcessor ).to.have.property( 'htmlWriter' );
+			expect( dataProcessor ).to.have.property( 'skipComments' );
 
 			expect( dataProcessor.namespaces ).to.be.an.instanceOf( Array );
 			expect( dataProcessor.domParser ).to.be.an.instanceOf( DOMParser );
 			expect( dataProcessor.domConverter ).to.be.an.instanceOf( DomConverter );
 			expect( dataProcessor.htmlWriter ).to.be.an.instanceOf( BasicHtmlWriter );
+			expect( dataProcessor.skipComments ).to.be.true;
 		} );
 	} );
 
@@ -152,6 +154,38 @@ describe( 'XmlDataProcessor', () => {
 			dataProcessor.useFillerType( 'default' );
 
 			expect( dataProcessor.toData( fragment ) ).to.equal( '<p>&nbsp;</p>' );
+		} );
+	} );
+
+	describe( 'skipComments', () => {
+		it( 'should skip comments when `true`', () => {
+			const fragment = dataProcessor.toView(
+				'<!-- Comment 1 -->' +
+				'<foo>' +
+					'bar' +
+					'<!-- Comment 2 -->' +
+					'baz' +
+				'</foo>' +
+				'<!-- Comment 3 -->'
+			);
+
+			expect( stringify( fragment ) ).to.equal( '<foo>barbaz</foo>' );
+		} );
+
+		it( 'should preserve comments when `false`', () => {
+			dataProcessor.skipComments = false;
+
+			const fragment = dataProcessor.toView(
+				'<!-- Comment 1 -->' +
+				'<foo>' +
+					'bar' +
+					'<!-- Comment 2 -->' +
+					'baz' +
+				'</foo>' +
+				'<!-- Comment 3 -->'
+			);
+
+			expect( stringify( fragment ) ).to.equal( '<$comment></$comment><foo>bar<$comment></$comment>baz</foo><$comment></$comment>' );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-html-support/src/htmlcomment.js
+++ b/packages/ckeditor5-html-support/src/htmlcomment.js
@@ -31,6 +31,8 @@ export default class HtmlComment extends Plugin {
 	init() {
 		const editor = this.editor;
 
+		editor.data.processor.skipComments = false;
+
 		// Allow storing comment's content as the $root attribute with the name `$comment:<unique id>`.
 		editor.model.schema.addAttributeCheck( ( context, attributeName ) => {
 			if ( context.endsWith( '$root' ) && attributeName.startsWith( '$comment' ) ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (engine): The `HtmlDataProcessor` exposes an option to `skipComments`. Closes #12813.

MINOR BREAKING CHANGE: `HtmlDataProcessor` skips HTML comments by default. Set its `skipComments` property to `false` to retain comments.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._