### PR TITLE
Task (list): Provide list utils plugin so that list utils functions can be accessed externally

### DIFF
--- a/packages/ckeditor5-list/src/index.js
+++ b/packages/ckeditor5-list/src/index.js
@@ -17,6 +17,7 @@ export { default as List } from './list';
 export { default as ListEditing } from './list/listediting';
 export { default as ListUI } from './list/listui';
 export { default as ListProperties } from './listproperties';
+export { default as ListUtils } from './list/listutils';
 export { default as ListPropertiesEditing } from './listproperties/listpropertiesediting';
 export { default as ListPropertiesUI } from './listproperties/listpropertiesui';
 export { default as TodoList } from './todolist';

--- a/packages/ckeditor5-list/src/list/listediting.js
+++ b/packages/ckeditor5-list/src/list/listediting.js
@@ -9,6 +9,7 @@
 
 import ListCommand from './listcommand';
 import IndentCommand from './indentcommand';
+import ListUtils from './listutils';
 
 import { Plugin } from 'ckeditor5/src/core';
 import { Enter } from 'ckeditor5/src/enter';
@@ -50,7 +51,7 @@ export default class ListEditing extends Plugin {
 	 * @inheritDoc
 	 */
 	static get requires() {
-		return [ Enter, Delete ];
+		return [ Enter, Delete, ListUtils ];
 	}
 
 	/**

--- a/packages/ckeditor5-list/src/list/listutils.js
+++ b/packages/ckeditor5-list/src/list/listutils.js
@@ -1,0 +1,68 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module list/list/listutils
+ */
+
+import { Plugin } from 'ckeditor5/src/core';
+import {
+	getListTypeFromListStyleType,
+	getSelectedListItems,
+	getSiblingNodes
+} from './utils';
+
+/**
+ * A set of helpers related to document lists.
+ *
+ * @extends module:core/plugin~Plugin
+ */
+export default class ListUtils extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
+	static get pluginName() {
+		return 'ListUtils';
+	}
+
+	/**
+	 * Checks whether the given list-style-type is supported by numbered or bulleted list.
+	 *
+	 * @param {String} listStyleType
+	 * @returns {'bulleted'|'numbered'|null}
+	 */
+	getListTypeFromListStyleType( listStyleType ) {
+		return getListTypeFromListStyleType( listStyleType );
+	}
+
+	/**
+	 * Returns an array with all `listItem` elements in the model selection.
+	 *
+	 * It returns all the items even if only a part of the list is selected, including items that belong to nested lists.
+	 * If no list is selected, it returns an empty array.
+	 * The order of the elements is not specified.
+	 *
+	 * @param {module:engine/model/model~Model} model
+	 * @returns {Array.<module:engine/model/element~Element>}
+	 */
+	getSelectedListItems( model ) {
+		return getSelectedListItems( model );
+	}
+
+	/**
+	 * Returns an array with all `listItem` elements that represent the same list.
+	 *
+	 * It means that values of `listIndent`, `listType`, `listStyle`, `listReversed` and `listStart` for all items are equal.
+	 *
+	 * Additionally, if the `position` is inside a list item, that list item will be returned as well.
+	 *
+	 * @param {module:engine/model/position~Position} position Starting position.
+	 * @param {'forward'|'backward'} direction Walking direction.
+	 * @returns {Array.<module:engine/model/element~Element>}
+	 */
+	getSiblingNodes( position, direction ) {
+		return getSiblingNodes( position, direction );
+	}
+}

--- a/packages/ckeditor5-list/tests/list/listutils.js
+++ b/packages/ckeditor5-list/tests/list/listutils.js
@@ -1,0 +1,38 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import ListUtils from '../../src/list/listutils';
+import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
+
+describe( 'ListUtils', () => {
+	let editor, plugin;
+
+	beforeEach( async () => {
+		editor = await VirtualTestEditor.create( {
+			plugins: [ ListUtils ]
+		} );
+		plugin = editor.plugins.get( 'ListUtils' );
+	} );
+
+	it( 'should be named', () => {
+		expect( ListUtils.pluginName ).to.equal( 'ListUtils' );
+	} );
+
+	describe( 'coverage checks', () => {
+		it( 'getListTypeFromListStyleType', () => {
+			const mock = 'mock';
+			expect( plugin.getListTypeFromListStyleType( mock ) ).to.equal( null );
+		} );
+
+		it( 'getSelectedListItems', () => {
+			expect( plugin.getSelectedListItems( editor.model ) ).to.be.an( 'array' );
+		} );
+
+		it( 'getSiblingNodes', () => {
+			const position = editor.model.createPositionAt( editor.model.document.getRoot(), 0 );
+			expect( plugin.getSiblingNodes( position, 'forward' ) ).to.be.an( 'array' );
+		} );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (list): Added access to list-related utils functions through new \`ListUtils\` plugin to make it possible to use them in other packages.