### PR TITLE
Other (table): Reset column widths when table width is reset

### DIFF
--- a/packages/ckeditor5-table/src/tablecolumnresize/tablewidthresizecommand.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablewidthresizecommand.js
@@ -51,9 +51,14 @@ export default class TableWidthResizeCommand extends TablePropertyCommand {
 		model.change( writer => {
 			if ( tableWidth ) {
 				writer.setAttribute( this.attributeName, tableWidth, table );
-				writer.setAttribute( 'columnWidths', columnWidths, table );
 			} else {
 				writer.removeAttribute( this.attributeName, table );
+			}
+
+			if ( columnWidths ) {
+				writer.setAttribute( 'columnWidths', columnWidths, table );
+			} else {
+				writer.removeAttribute( 'columnWidths', table );
 			}
 		} );
 	}

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablewidthresizecommand.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablewidthresizecommand.js
@@ -39,8 +39,8 @@ export default class TableWidthResizeCommand extends TablePropertyCommand {
 	 * Changes the `tableWidth` and `columnWidths` attribute values for the given or currently selected table.
 	 *
 	 * @param {Object} options
-	 * @param {String} [options.tableWidth] The new table width. Model attribute gets removed if skipped.
-	 * @param {String} [options.columnWidths] The new table column widths. Model attribute gets removed if skipped.
+	 * @param {String} [options.tableWidth] The new table width. If skipped, the model attribute will be removed.
+	 * @param {String} [options.columnWidths] The new table column widths. If skipped, the model attribute will be removed.
 	 * @param {module:engine/model/element~Element} [options.table] The table that is affected by the resize.
 	 */
 	execute( options = {} ) {

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablewidthresizecommand.js
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablewidthresizecommand.js
@@ -39,8 +39,8 @@ export default class TableWidthResizeCommand extends TablePropertyCommand {
 	 * Changes the `tableWidth` and `columnWidths` attribute values for the given or currently selected table.
 	 *
 	 * @param {Object} options
-	 * @param {String} [options.tableWidth] The new table width.
-	 * @param {String} [options.columnWidths] The new table column widths.
+	 * @param {String} [options.tableWidth] The new table width. Model attribute gets removed if skipped.
+	 * @param {String} [options.columnWidths] The new table column widths. Model attribute gets removed if skipped.
 	 * @param {module:engine/model/element~Element} [options.table] The table that is affected by the resize.
 	 */
 	execute( options = {} ) {

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablewidthresizecommand.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablewidthresizecommand.js
@@ -71,11 +71,11 @@ describe( 'TableWidthResizeCommand', () => {
 		);
 	} );
 
-	it( 'should remove the attribute if new value was not passed', () => {
+	it( 'should remove the attributes if new value was not passed', () => {
 		setModelData( model, modelTable( [
 			[ '11', '12' ],
 			[ '21', '22' ]
-		], { tableWidth: '40%' } ) );
+		], { tableWidth: '40%', columnWidths: '40%,60%' } ) );
 
 		command.execute();
 

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablewidthresizecommand.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablewidthresizecommand.js
@@ -42,62 +42,68 @@ describe( 'TableWidthResizeCommand', () => {
 	} );
 
 	it( 'should work on the currently selected table if it was not passed to execute()', () => {
-		setModelData( model, modelTable( [
-			[ '11', '12' ],
-			[ '21', '22' ]
-		] ) );
+		const data = [ [ '11', '12' ], [ '21', '22' ] ];
+		const attributesBefore = {};
+		setModelData( model, modelTable( data, attributesBefore ) );
 
 		command.execute( { tableWidth: '40%' } );
 
-		expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
-			'<table tableWidth="40%">' +
-				'<tableRow>' +
-					'<tableCell>' +
-						'<paragraph>11</paragraph>' +
-					'</tableCell>' +
-					'<tableCell>' +
-						'<paragraph>12</paragraph>' +
-					'</tableCell>' +
-				'</tableRow>' +
-				'<tableRow>' +
-					'<tableCell>' +
-						'<paragraph>21</paragraph>' +
-					'</tableCell>' +
-					'<tableCell>' +
-						'<paragraph>22</paragraph>' +
-					'</tableCell>' +
-				'</tableRow>' +
-			'</table>'
-		);
+		const attributesAfter = { tableWidth: '40%' };
+		expect( getModelData( model, { withoutSelection: true } ) ).to.equal( modelTable( data, attributesAfter ) );
 	} );
 
 	it( 'should remove the attributes if new value was not passed', () => {
-		setModelData( model, modelTable( [
-			[ '11', '12' ],
-			[ '21', '22' ]
-		], { tableWidth: '40%', columnWidths: '40%,60%' } ) );
+		const data = [ [ '11', '12' ], [ '21', '22' ] ];
+		const attributesBefore = { tableWidth: '40%', columnWidths: '40%,60%' };
+		setModelData( model, modelTable( data, attributesBefore ) );
 
 		command.execute();
 
-		expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
-			'<table>' +
-				'<tableRow>' +
-					'<tableCell>' +
-						'<paragraph>11</paragraph>' +
-					'</tableCell>' +
-					'<tableCell>' +
-						'<paragraph>12</paragraph>' +
-					'</tableCell>' +
-				'</tableRow>' +
-				'<tableRow>' +
-					'<tableCell>' +
-						'<paragraph>21</paragraph>' +
-					'</tableCell>' +
-					'<tableCell>' +
-						'<paragraph>22</paragraph>' +
-					'</tableCell>' +
-				'</tableRow>' +
-			'</table>'
-		);
+		const attributesAfter = {};
+		expect( getModelData( model, { withoutSelection: true } ) ).to.equal( modelTable( data, attributesAfter ) );
+	} );
+
+	it( 'should work when only columnWidths is provided', () => {
+		const data = [ [ '11', '12' ], [ '21', '22' ] ];
+		const attributesBefore = { tableWidth: '40%', columnWidths: '40%,60%' };
+		setModelData( model, modelTable( data, attributesBefore ) );
+
+		command.execute( { columnWidths: '40%,60%' } );
+
+		const attributesAfter = { columnWidths: '40%,60%' };
+		expect( getModelData( model, { withoutSelection: true } ) ).to.equal( modelTable( data, attributesAfter ) );
+	} );
+
+	it( 'should work when only tableWidth is provided', () => {
+		const data = [ [ '11', '12' ], [ '21', '22' ] ];
+		const attributesBefore = { tableWidth: '40%', columnWidths: '40%,60%' };
+		setModelData( model, modelTable( data, attributesBefore ) );
+
+		command.execute( { tableWidth: '40%' } );
+
+		const attributesAfter = { tableWidth: '40%' };
+		expect( getModelData( model, { withoutSelection: true } ) ).to.equal( modelTable( data, attributesAfter ) );
+	} );
+
+	it( 'should add attributes when they are provided, but were not present before', () => {
+		const data = [ [ '11', '12' ], [ '21', '22' ] ];
+		const attributesBefore = {};
+		setModelData( model, modelTable( data, attributesBefore ) );
+
+		command.execute( { tableWidth: '40%', columnWidths: '40%,60%' } );
+
+		const attributesAfter = { tableWidth: '40%', columnWidths: '40%,60%' };
+		expect( getModelData( model, { withoutSelection: true } ) ).to.equal( modelTable( data, attributesAfter ) );
+	} );
+
+	it( 'should change attributes when they were present before', () => {
+		const data = [ [ '11', '12' ], [ '21', '22' ] ];
+		const attributesBefore = { tableWidth: '40%', columnWidths: '40%,60%' };
+		setModelData( model, modelTable( data, attributesBefore ) );
+
+		command.execute( { tableWidth: '30%', columnWidths: '30%,70%' } );
+
+		const attributesAfter = { tableWidth: '30%', columnWidths: '30%,70%' };
+		expect( getModelData( model, { withoutSelection: true } ) ).to.equal( modelTable( data, attributesAfter ) );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Other (table): Reset column widths when table width is reset. Closes #12916.