### PR TITLE
Fixed down arrow label for image style buttons in docs

### DIFF
--- a/packages/ckeditor5-image/docs/_snippets/features/image-style-custom.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-style-custom.js
@@ -53,10 +53,12 @@ ClassicEditor
 			},
 			toolbar: [ {
 				name: 'imageStyle:icons',
+				title: 'Alignment',
 				items: [ 'imageStyle:margin-left', 'imageStyle:margin-right', 'imageStyle:inline' ],
 				defaultItem: 'imageStyle:margin-left'
 			}, {
 				name: 'imageStyle:pictures',
+				title: 'Style',
 				items: [ 'imageStyle:block', 'imageStyle:side' ],
 				defaultItem: 'imageStyle:block'
 			}, '|', 'toggleImageCaption', 'linkImage'

--- a/packages/ckeditor5-image/docs/features/images-styles.md
+++ b/packages/ckeditor5-image/docs/features/images-styles.md
@@ -214,6 +214,7 @@ ClassicEditor
 				// Grouping the buttons for the icon-like image styling
 				// into one drop-down.
 				name: 'imageStyle:icons',
+				title: 'Alignment',
 				items: [
 					'imageStyle:margin-left',
 					'imageStyle:margin-right',
@@ -224,6 +225,7 @@ ClassicEditor
 				// Grouping the buttons for the regular
 				// picture-like image styling into one drop-down.
 				name: 'imageStyle:pictures',
+				title: 'Style',
 				items: [ 'imageStyle:block', 'imageStyle:side' ],
 				defaultItem: 'imageStyle:block'
 			}, '|', 'toggleImageCaption', 'linkImage'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs (image): Fixed down arrow label for image style buttons in docs. Closes #12468.

---

### Additional information

Double check the label - that was the best we were able to come up with 😂