### PR TITLE
Markers should not be lost while upcasting a plain table (without a <figure> element).

### DIFF
--- a/packages/ckeditor5-html-support/src/integrations/mediaembed.js
+++ b/packages/ckeditor5-html-support/src/integrations/mediaembed.js
@@ -83,7 +83,7 @@ export default class MediaEmbedElementSupport extends Plugin {
 
 function viewToModelMediaAttributesConverter( dataFilter, mediaElementName ) {
 	return dispatcher => {
-		dispatcher.on( `element:${ mediaElementName }`, upcastMedia );
+		dispatcher.on( `element:${ mediaElementName }`, upcastMedia, { priority: 'low' } );
 	};
 
 	function upcastMedia( evt, data, conversionApi ) {

--- a/packages/ckeditor5-html-support/src/integrations/table.js
+++ b/packages/ckeditor5-html-support/src/integrations/table.js
@@ -101,7 +101,7 @@ function viewToModelTableAttributeConverter( dataFilter ) {
 					conversionApi.writer.setAttribute( attributeName, viewAttributes, data.modelRange );
 				}
 			}
-		} );
+		}, { priority: 'low' } );
 	};
 }
 

--- a/packages/ckeditor5-html-support/tests/integrations/image.js
+++ b/packages/ckeditor5-html-support/tests/integrations/image.js
@@ -12,7 +12,6 @@ import ImageBlockEditing from '@ckeditor/ckeditor5-image/src/image/imageblockedi
 import ImageInlineEditing from '@ckeditor/ckeditor5-image/src/image/imageinlineediting';
 import LinkImage from '@ckeditor/ckeditor5-link/src/linkimage';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
-import { priorities } from 'ckeditor5/src/utils';
 
 import { getModelDataWithAttributes } from '../_utils/utils';
 import GeneralHtmlSupport from '../../src/generalhtmlsupport';
@@ -327,8 +326,7 @@ describe( 'ImageElementSupport', () => {
 			} ] );
 
 			editor.conversion.for( 'upcast' ).dataToMarker( {
-				view: 'commented',
-				converterPriority: priorities.get( 'highest' ) // For marker this priority equals to -999
+				view: 'commented'
 			} );
 
 			editor.setData(
@@ -872,8 +870,7 @@ describe( 'ImageElementSupport', () => {
 			} ] );
 
 			editor.conversion.for( 'upcast' ).dataToMarker( {
-				view: 'commented',
-				converterPriority: priorities.get( 'highest' ) // For marker this priority equals to -999
+				view: 'commented'
 			} );
 
 			editor.setData(
@@ -1407,8 +1404,7 @@ describe( 'ImageElementSupport', () => {
 			} ] );
 
 			editor.conversion.for( 'upcast' ).dataToMarker( {
-				view: 'commented',
-				converterPriority: priorities.get( 'highest' ) // For marker this priority equals to -999
+				view: 'commented'
 			} );
 
 			editor.setData(
@@ -1829,8 +1825,7 @@ describe( 'ImageElementSupport', () => {
 			} ] );
 
 			editor.conversion.for( 'upcast' ).dataToMarker( {
-				view: 'commented',
-				converterPriority: priorities.get( 'highest' ) // For marker this priority equals to -999
+				view: 'commented'
 			} );
 
 			editor.setData(
@@ -2198,8 +2193,7 @@ describe( 'ImageElementSupport', () => {
 			} ] );
 
 			editor.conversion.for( 'upcast' ).dataToMarker( {
-				view: 'commented',
-				converterPriority: priorities.get( 'highest' ) // For marker this priority equals to -999
+				view: 'commented'
 			} );
 
 			editor.setData(

--- a/packages/ckeditor5-html-support/tests/integrations/mediaembed.js
+++ b/packages/ckeditor5-html-support/tests/integrations/mediaembed.js
@@ -368,8 +368,7 @@ describe( 'MediaEmbedElementSupport', () => {
 			);
 		} );
 
-		it( 'should run marker upcast converter with priority higher ' +
-			'then low before GHS preserves remaining attributes on table model element', () => {
+		it( 'should create a marker before GHS converts attributes', () => {
 			dataFilter.loadAllowedConfig( [ {
 				name: /.*/,
 				attributes: true,
@@ -378,14 +377,42 @@ describe( 'MediaEmbedElementSupport', () => {
 			} ] );
 
 			editor.conversion.for( 'upcast' ).dataToMarker( {
-				view: 'commented',
-				converterPriority: 100000 // For marker this priority equals to -999
+				view: 'commented'
 			} );
 
 			editor.setData(
 				'<figure class="media" data-commented-end-after="foo:id" data-commented-start-before="foo:id">' +
 					'<oembed url="https://www.youtube.com/watch?v=ZVv7UMQPEWk"></oembed>' +
 				'</figure>'
+			);
+
+			expect( editor.getData() ).to.equal(
+				'<figure class="media">' +
+					'<oembed url="https://www.youtube.com/watch?v=ZVv7UMQPEWk"></oembed>' +
+				'</figure>'
+			);
+
+			const marker = model.markers.get( 'commented:foo:id' );
+
+			expect( marker.getStart().path ).to.deep.equal( [ 0 ] );
+			expect( marker.getEnd().path ).to.deep.equal( [ 1 ] );
+		} );
+
+		it( 'should create a marker before GHS converts attributes (without the figure element)', () => {
+			dataFilter.loadAllowedConfig( [ {
+				name: /.*/,
+				attributes: true,
+				styles: true,
+				classes: true
+			} ] );
+
+			editor.conversion.for( 'upcast' ).dataToMarker( {
+				view: 'commented'
+			} );
+
+			editor.setData(
+				'<oembed url="https://www.youtube.com/watch?v=ZVv7UMQPEWk"' +
+				' data-commented-end-after="foo:id" data-commented-start-before="foo:id"></oembed>'
 			);
 
 			expect( editor.getData() ).to.equal(
@@ -737,8 +764,7 @@ describe( 'MediaEmbedElementSupport', () => {
 			);
 		} );
 
-		it( 'should run marker upcast converter with priority higher ' +
-			'then low before GHS preserves remaining attributes on table model element', () => {
+		it( 'should create a marker before GHS converts attributes', () => {
 			dataFilter.loadAllowedConfig( [ {
 				name: /.*/,
 				attributes: true,
@@ -747,8 +773,7 @@ describe( 'MediaEmbedElementSupport', () => {
 			} ] );
 
 			editor.conversion.for( 'upcast' ).dataToMarker( {
-				view: 'commented',
-				converterPriority: 100000 // For marker this priority equals to -999
+				view: 'commented'
 			} );
 
 			editor.setData(
@@ -759,6 +784,35 @@ describe( 'MediaEmbedElementSupport', () => {
 
 			expect( editor.getData() ).to.equal(
 				'<figure class="media" data-foo="foo">' +
+					'<custom-oembed url="https://www.youtube.com/watch?v=ZVv7UMQPEWk" data-foo="foo"></custom-oembed>' +
+				'</figure>'
+			);
+
+			const marker = model.markers.get( 'commented:foo:id' );
+
+			expect( marker.getStart().path ).to.deep.equal( [ 0 ] );
+			expect( marker.getEnd().path ).to.deep.equal( [ 1 ] );
+		} );
+
+		it( 'should create a marker before GHS converts attributes(without figure)', () => {
+			dataFilter.loadAllowedConfig( [ {
+				name: /.*/,
+				attributes: true,
+				styles: true,
+				classes: true
+			} ] );
+
+			editor.conversion.for( 'upcast' ).dataToMarker( {
+				view: 'commented'
+			} );
+
+			editor.setData(
+				'<custom-oembed url="https://www.youtube.com/watch?v=ZVv7UMQPEWk" data-foo="foo"' +
+				' data-foo="foo" data-commented-end-after="foo:id" data-commented-start-before="foo:id"></custom-oembed>'
+			);
+
+			expect( editor.getData() ).to.equal(
+				'<figure class="media">' +
 					'<custom-oembed url="https://www.youtube.com/watch?v=ZVv7UMQPEWk" data-foo="foo"></custom-oembed>' +
 				'</figure>'
 			);
@@ -1256,8 +1310,7 @@ describe( 'MediaEmbedElementSupport', () => {
 			);
 		} );
 
-		it( 'should run marker upcast converter with priority higher ' +
-			'then low before GHS preserves remaining attributes on table model element', () => {
+		it( 'should create a marker before GHS converts attributes (with marker on the figure element)', () => {
 			dataFilter.loadAllowedConfig( [ {
 				name: /.*/,
 				attributes: true,
@@ -1265,13 +1318,12 @@ describe( 'MediaEmbedElementSupport', () => {
 				classes: true
 			} ] );
 
+			editor.conversion.for( 'upcast' ).dataToMarker( {
+				view: 'commented'
+			} );
+
 			// Apply filtering rules added after initial data load.
 			editor.setData( '' );
-
-			editor.conversion.for( 'upcast' ).dataToMarker( {
-				view: 'commented',
-				converterPriority: 100000 // For marker this priority equals to -999
-			} );
 
 			editor.setData(
 				'<figure class="media" data-foo="foo" data-commented-end-after="foo:id" data-commented-start-before="foo:id">' +

--- a/packages/ckeditor5-html-support/tests/integrations/table.js
+++ b/packages/ckeditor5-html-support/tests/integrations/table.js
@@ -942,6 +942,223 @@ describe( 'TableElementSupport', () => {
 		await editor.destroy();
 	} );
 
+	it( 'should upcast GHS attributes at the low priority (feature attribute converter at low + 1 priority)', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /.*/,
+			attributes: true,
+			styles: true,
+			classes: true
+		} ] );
+
+		editor.model.schema.extend( 'table', { allowAttributes: [ 'barAttr' ] } );
+
+		editor.conversion.for( 'upcast' ).attributeToAttribute( {
+			view: 'foo-attr',
+			model: 'barAttr',
+			converterPriority: priorities.get( 'low' ) + 1
+		} );
+
+		editor.setData(
+			'<figure class="table" foo-attr="100">' +
+				'<table>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>1.1</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+				'<table barAttr="100">' +
+					'<tableRow>' +
+						'<tableCell>' +
+							'<paragraph>1.1</paragraph>' +
+						'</tableCell>' +
+					'</tableRow>' +
+				'</table>',
+			attributes: { }
+		} );
+	} );
+
+	it( 'should upcast GHS attributes at the low priority (feature attribute converter at low priority)', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /.*/,
+			attributes: true,
+			styles: true,
+			classes: true
+		} ] );
+
+		// Apply filtering rules added after initial data load.
+		editor.setData( '' );
+
+		editor.model.schema.extend( 'table', { allowAttributes: [ 'barAttr' ] } );
+
+		editor.conversion.for( 'upcast' ).attributeToAttribute( {
+			view: 'foo-attr',
+			model: 'barAttr',
+			converterPriority: 'low'
+		} );
+
+		editor.setData(
+			'<figure class="table" foo-attr="100">' +
+				'<table>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>1.1</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+				'<table htmlFigureAttributes="(1)">' +
+					'<tableRow>' +
+						'<tableCell>' +
+							'<paragraph>1.1</paragraph>' +
+						'</tableCell>' +
+					'</tableRow>' +
+				'</table>',
+			attributes: {
+				1: { attributes: { 'foo-attr': '100' } }
+			}
+		} );
+	} );
+
+	it( 'should convert markers on the figure element', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /.*/,
+			attributes: true,
+			styles: true,
+			classes: true
+		} ] );
+
+		editor.conversion.for( 'upcast' ).dataToMarker( {
+			view: 'commented'
+		} );
+
+		editor.setData(
+			'<figure data-commented-end-after="foo:id" data-commented-start-before="foo:id" class="table">' +
+				'<table>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>1.1</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+				'<table>' +
+					'<tableRow>' +
+						'<tableCell>' +
+							'<paragraph>1.1</paragraph>' +
+						'</tableCell>' +
+					'</tableRow>' +
+				'</table>',
+			attributes: { }
+		} );
+
+		const marker = model.markers.get( 'commented:foo:id' );
+
+		expect( marker.getStart().path ).to.deep.equal( [ 0 ] );
+		expect( marker.getEnd().path ).to.deep.equal( [ 1 ] );
+	} );
+
+	it( 'should convert markers on the table element', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /.*/,
+			attributes: true,
+			styles: true,
+			classes: true
+		} ] );
+
+		editor.conversion.for( 'upcast' ).dataToMarker( {
+			view: 'commented'
+		} );
+
+		editor.setData(
+			'<table data-commented-end-after="foo:id" data-commented-start-before="foo:id">' +
+				'<tbody>' +
+					'<tr>' +
+						'<td>1.1</td>' +
+					'</tr>' +
+				'</tbody>' +
+			'</table>'
+		);
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+				'<table>' +
+					'<tableRow>' +
+						'<tableCell>' +
+							'<paragraph>1.1</paragraph>' +
+						'</tableCell>' +
+					'</tableRow>' +
+				'</table>',
+			attributes: { }
+		} );
+
+		const marker = model.markers.get( 'commented:foo:id' );
+
+		expect( marker.getStart().path ).to.deep.equal( [ 0 ] );
+		expect( marker.getEnd().path ).to.deep.equal( [ 1 ] );
+	} );
+
+	it( 'should upcast custom attributes with marker', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /.*/,
+			attributes: true,
+			styles: true,
+			classes: true
+		} ] );
+
+		editor.conversion.for( 'upcast' ).dataToMarker( {
+			view: 'commented'
+		} );
+
+		editor.setData(
+			'<figure data-commented-end-after="foo:id" data-commented-start-before="foo:id" class="table" foo="bar">' +
+				'<table>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>1.1</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+				'<table htmlFigureAttributes="(1)">' +
+					'<tableRow>' +
+						'<tableCell>' +
+							'<paragraph>1.1</paragraph>' +
+						'</tableCell>' +
+					'</tableRow>' +
+				'</table>',
+			attributes: {
+				1: {
+					attributes: {
+						foo: 'bar'
+					}
+				}
+			}
+		} );
+
+		const marker = model.markers.get( 'commented:foo:id' );
+
+		expect( marker.getStart().path ).to.deep.equal( [ 0 ] );
+		expect( marker.getEnd().path ).to.deep.equal( [ 1 ] );
+	} );
+
 	describe( 'TableCaption', () => {
 		// Sanity tests verifying if table caption is correctly handled by default converters.
 
@@ -1325,188 +1542,6 @@ describe( 'TableElementSupport', () => {
 				'</figure>'
 			);
 			/* eslint-enable max-len */
-		} );
-
-		it( 'should run attributes upcast converter with priority higher ' +
-			'then low before GHS preserves remaining attributes on table model element', () => {
-			dataFilter.loadAllowedConfig( [ {
-				name: /.*/,
-				attributes: true,
-				styles: true,
-				classes: true
-			} ] );
-
-			editor.model.schema.extend( 'table', { allowAttributes: [ 'barAttr' ] } );
-
-			editor.conversion.for( 'upcast' ).attributeToAttribute( {
-				view: 'foo-attr',
-				model: 'barAttr',
-				converterPriority: priorities.get( 'low' ) + 1
-			} );
-
-			editor.setData(
-				'<figure class="table" foo-attr="100">' +
-					'<table>' +
-						'<tbody>' +
-							'<tr>' +
-								'<td>1.1</td>' +
-							'</tr>' +
-						'</tbody>' +
-					'</table>' +
-				'</figure>'
-			);
-
-			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
-				data:
-					'<table barAttr="100">' +
-						'<tableRow>' +
-							'<tableCell>' +
-								'<paragraph>1.1</paragraph>' +
-							'</tableCell>' +
-						'</tableRow>' +
-					'</table>',
-				attributes: { }
-			} );
-		} );
-
-		it( 'should run attributes upcast converter with priority low ' +
-			'after GHS preserves remaining attributes on table model element', () => {
-			dataFilter.loadAllowedConfig( [ {
-				name: /.*/,
-				attributes: true,
-				styles: true,
-				classes: true
-			} ] );
-
-			// Apply filtering rules added after initial data load.
-			editor.setData( '' );
-
-			editor.model.schema.extend( 'table', { allowAttributes: [ 'barAttr' ] } );
-
-			editor.conversion.for( 'upcast' ).attributeToAttribute( {
-				view: 'foo-attr',
-				model: 'barAttr',
-				converterPriority: priorities.get( 'low' )
-			} );
-
-			editor.setData(
-				'<figure class="table" foo-attr="100">' +
-					'<table>' +
-						'<tbody>' +
-							'<tr>' +
-								'<td>1.1</td>' +
-							'</tr>' +
-						'</tbody>' +
-					'</table>' +
-				'</figure>'
-			);
-
-			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
-				data:
-					'<table htmlFigureAttributes="(1)">' +
-						'<tableRow>' +
-							'<tableCell>' +
-								'<paragraph>1.1</paragraph>' +
-							'</tableCell>' +
-						'</tableRow>' +
-					'</table>',
-				attributes: {
-					1: { attributes: { 'foo-attr': '100' } }
-				}
-			} );
-		} );
-
-		it( 'should run marker upcast converter with priority higher ' +
-		'then low before GHS preserves remaining attributes on table model element', () => {
-			dataFilter.loadAllowedConfig( [ {
-				name: /.*/,
-				attributes: true,
-				styles: true,
-				classes: true
-			} ] );
-
-			editor.conversion.for( 'upcast' ).dataToMarker( {
-				view: 'commented',
-				converterPriority: priorities.get( 'highest' ) // For marker this priority equals to -999
-			} );
-
-			editor.setData(
-				'<figure data-commented-end-after="foo:id" data-commented-start-before="foo:id" class="table">' +
-					'<table>' +
-						'<tbody>' +
-							'<tr>' +
-								'<td>1.1</td>' +
-							'</tr>' +
-						'</tbody>' +
-					'</table>' +
-				'</figure>'
-			);
-
-			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
-				data:
-					'<table>' +
-						'<tableRow>' +
-							'<tableCell>' +
-								'<paragraph>1.1</paragraph>' +
-							'</tableCell>' +
-						'</tableRow>' +
-					'</table>',
-				attributes: { }
-			} );
-
-			const marker = model.markers.get( 'commented:foo:id' );
-
-			expect( marker.getStart().path ).to.deep.equal( [ 0 ] );
-			expect( marker.getEnd().path ).to.deep.equal( [ 1 ] );
-		} );
-
-		it( 'should upcast custom attributes with marker', () => {
-			dataFilter.loadAllowedConfig( [ {
-				name: /.*/,
-				attributes: true,
-				styles: true,
-				classes: true
-			} ] );
-
-			editor.conversion.for( 'upcast' ).dataToMarker( {
-				view: 'commented',
-				converterPriority: priorities.get( 'high' )
-			} );
-
-			editor.setData(
-				'<figure data-commented-end-after="foo:id" data-commented-start-before="foo:id" class="table" foo="bar">' +
-					'<table>' +
-						'<tbody>' +
-							'<tr>' +
-								'<td>1.1</td>' +
-							'</tr>' +
-						'</tbody>' +
-					'</table>' +
-				'</figure>'
-			);
-
-			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
-				data:
-					'<table htmlFigureAttributes="(1)">' +
-						'<tableRow>' +
-							'<tableCell>' +
-								'<paragraph>1.1</paragraph>' +
-							'</tableCell>' +
-						'</tableRow>' +
-					'</table>',
-				attributes: {
-					1: {
-						attributes: {
-							foo: 'bar'
-						}
-					}
-				}
-			} );
-
-			const marker = model.markers.get( 'commented:foo:id' );
-
-			expect( marker.getStart().path ).to.deep.equal( [ 0 ] );
-			expect( marker.getEnd().path ).to.deep.equal( [ 1 ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (html-support): Markers should not be lost while upcasting a plain table (without a `<figure>` element).

---

### Additional information