### PR TITLE
Fixed infinite loop after transpilation to ES5

### DIFF
--- a/packages/ckeditor5-list/src/documentlist/utils/postfixers.js
+++ b/packages/ckeditor5-list/src/documentlist/utils/postfixers.js
@@ -30,7 +30,9 @@ export function findAndAddListHeadToMap( position, itemToListHead ) {
 	} else {
 		let listHead = previousNode;
 
-		for ( { node: listHead } of iterateSiblingListBlocks( listHead, 'backward' ) ) {
+		for ( const { node } of iterateSiblingListBlocks( listHead, 'backward' ) ) {
+			listHead = node;
+
 			if ( itemToListHead.has( listHead ) ) {
 				return;
 			}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Fixed infinite loop after transpilation to ES5. Closes ckeditor/ckeditor5-react#345.

---

### Additional information

The description how to reproduce this issue is in ckeditor/ckeditor5-react#345.

In short, `create-react-app` uses by default very loose `browserslist` rules for production environment, that cause the generated (minified) code of the application targets the ES5. This in turn causes that the Babel (probably) does not handle properly the inline destructuring inside a `for of` loop with a generator.
