### PR TITLE
Change bahavior of table upcast to read width and height from figure …

### DIFF
--- a/packages/ckeditor5-table/src/converters/tableproperties.js
+++ b/packages/ckeditor5-table/src/converters/tableproperties.js
@@ -19,7 +19,7 @@
  * @param {Boolean} [options.reduceBoxSides=false]
  */
 export function upcastStyleToAttribute( conversion, options ) {
-	const { viewElement, defaultValue, modelAttribute, styleName, reduceBoxSides = false } = options;
+	const { viewElement, defaultValue, modelAttribute, styleName, reduceBoxSides = false, skipCondition = () => false } = options;
 
 	conversion.for( 'upcast' ).attributeToAttribute( {
 		view: {
@@ -31,6 +31,10 @@ export function upcastStyleToAttribute( conversion, options ) {
 		model: {
 			key: modelAttribute,
 			value: viewElement => {
+				if ( skipCondition( viewElement ) ) {
+					return;
+				}
+
 				const normalized = viewElement.getNormalizedStyle( styleName );
 				const value = reduceBoxSides ? reduceBoxSidesValue( normalized ) : normalized;
 

--- a/packages/ckeditor5-table/src/converters/tableproperties.js
+++ b/packages/ckeditor5-table/src/converters/tableproperties.js
@@ -17,9 +17,10 @@
  * @param {String} options.viewElement The view element name that should be converted.
  * @param {String} options.defaultValue The default value for the specified `modelAttribute`.
  * @param {Boolean} [options.reduceBoxSides=false]
+ * @param {Function} [options.isApllicable] The function which returns `true` if style should be checked for this element.
  */
 export function upcastStyleToAttribute( conversion, options ) {
-	const { viewElement, defaultValue, modelAttribute, styleName, reduceBoxSides = false, skipCondition = () => false } = options;
+	const { viewElement, defaultValue, modelAttribute, styleName, reduceBoxSides = false, isApplicable = () => true } = options;
 
 	conversion.for( 'upcast' ).attributeToAttribute( {
 		view: {
@@ -31,7 +32,7 @@ export function upcastStyleToAttribute( conversion, options ) {
 		model: {
 			key: modelAttribute,
 			value: viewElement => {
-				if ( skipCondition( viewElement ) ) {
+				if ( !isApplicable( viewElement ) ) {
 					return;
 				}
 

--- a/packages/ckeditor5-table/src/converters/tableproperties.js
+++ b/packages/ckeditor5-table/src/converters/tableproperties.js
@@ -17,10 +17,10 @@
  * @param {String} options.viewElement The view element name that should be converted.
  * @param {String} options.defaultValue The default value for the specified `modelAttribute`.
  * @param {Boolean} [options.reduceBoxSides=false]
- * @param {Function} [options.isApllicable] The function which returns `true` if style should be checked for this element.
+ * @param {Function} [options.shouldUpcast] The function which returns `true` if style should be upcasted from this element.
  */
 export function upcastStyleToAttribute( conversion, options ) {
-	const { viewElement, defaultValue, modelAttribute, styleName, reduceBoxSides = false, isApplicable = () => true } = options;
+	const { viewElement, defaultValue, modelAttribute, styleName, reduceBoxSides = false, shouldUpcast = () => true } = options;
 
 	conversion.for( 'upcast' ).attributeToAttribute( {
 		view: {
@@ -32,7 +32,7 @@ export function upcastStyleToAttribute( conversion, options ) {
 		model: {
 			key: modelAttribute,
 			value: viewElement => {
-				if ( !isApplicable( viewElement ) ) {
+				if ( !shouldUpcast( viewElement ) ) {
 					return;
 				}
 

--- a/packages/ckeditor5-table/src/converters/upcasttable.js
+++ b/packages/ckeditor5-table/src/converters/upcasttable.js
@@ -29,7 +29,7 @@ export function upcastTableFigure() {
 				return;
 			}
 
-			// Find an table element inside the figure element.
+			// Find a table element inside the figure element.
 			const viewTable = getViewTableFromFigure( data.viewItem );
 
 			// Do not convert if table element is absent or was already converted.

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.js
@@ -93,16 +93,14 @@ export default class TablePropertiesEditing extends Plugin {
 		enableTableToFigureProperty( schema, conversion, {
 			modelAttribute: 'tableWidth',
 			styleName: 'width',
-			defaultValue: defaultTableProperties.width,
-			skipCondition: element => element.name == 'table' && element.parent.name == 'figure'
+			defaultValue: defaultTableProperties.width
 		} );
 		editor.commands.add( 'tableWidth', new TableWidthCommand( editor, defaultTableProperties.width ) );
 
 		enableTableToFigureProperty( schema, conversion, {
 			modelAttribute: 'tableHeight',
 			styleName: 'height',
-			defaultValue: defaultTableProperties.height,
-			skipCondition: element => element.name == 'table' && element.parent.name == 'figure'
+			defaultValue: defaultTableProperties.height
 		} );
 		editor.commands.add( 'tableHeight', new TableHeightCommand( editor, defaultTableProperties.height ) );
 
@@ -244,6 +242,12 @@ function enableTableToFigureProperty( schema, conversion, options ) {
 	schema.extend( 'table', {
 		allowAttributes: [ modelAttribute ]
 	} );
-	upcastStyleToAttribute( conversion, { viewElement: /^(table|figure)$/, ...options } );
+
+	upcastStyleToAttribute( conversion, {
+		viewElement: /^(table|figure)$/,
+		isApplicable: element => element.name != 'table' || element.parent.name != 'figure',
+		...options
+	} );
+
 	downcastAttributeToStyle( conversion, { modelElement: 'table', ...options } );
 }

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.js
@@ -245,7 +245,7 @@ function enableTableToFigureProperty( schema, conversion, options ) {
 
 	upcastStyleToAttribute( conversion, {
 		viewElement: /^(table|figure)$/,
-		isApplicable: element => !( element.name == 'table' && element.parent.name == 'figure' ),
+		shouldUpcast: element => !( element.name == 'table' && element.parent.name == 'figure' ),
 		...options
 	} );
 

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.js
@@ -93,14 +93,16 @@ export default class TablePropertiesEditing extends Plugin {
 		enableTableToFigureProperty( schema, conversion, {
 			modelAttribute: 'tableWidth',
 			styleName: 'width',
-			defaultValue: defaultTableProperties.width
+			defaultValue: defaultTableProperties.width,
+			skipCondition: element => element.name == 'table' && element.parent.name == 'figure'
 		} );
 		editor.commands.add( 'tableWidth', new TableWidthCommand( editor, defaultTableProperties.width ) );
 
 		enableTableToFigureProperty( schema, conversion, {
 			modelAttribute: 'tableHeight',
 			styleName: 'height',
-			defaultValue: defaultTableProperties.height
+			defaultValue: defaultTableProperties.height,
+			skipCondition: element => element.name == 'table' && element.parent.name == 'figure'
 		} );
 		editor.commands.add( 'tableHeight', new TableHeightCommand( editor, defaultTableProperties.height ) );
 

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.js
@@ -245,7 +245,7 @@ function enableTableToFigureProperty( schema, conversion, options ) {
 
 	upcastStyleToAttribute( conversion, {
 		viewElement: /^(table|figure)$/,
-		isApplicable: element => element.name != 'table' || element.parent.name != 'figure',
+		isApplicable: element => !( element.name == 'table' && element.parent.name == 'figure' ),
 		...options
 	} );
 

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -957,6 +957,36 @@ describe( 'table properties', () => {
 
 					expect( table.getAttribute( 'tableWidth' ) ).to.equal( '1337px' );
 				} );
+
+				it( 'should upcast width from <figure> if both <figure> and <table> has width style set', () => {
+					editor.setData(
+						'<figure class="table" style="width:75%">' +
+							'<table style="width:95%"><tbody><tr><td>1</td></tr></tbody></table>' +
+						'</figure>'
+					);
+					const expectModel = data => expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup( data );
+
+					expectModel(
+						'<table tableWidth="75%">' +
+						'<tableRow><tableCell><paragraph>1</paragraph></tableCell></tableRow>' +
+						'</table>'
+					);
+				} );
+
+				it( 'should not upcast width if <table> inside <figure> has width style set', () => {
+					editor.setData(
+						'<figure class="table">' +
+							'<table style="width:95%"><tbody><tr><td>1</td></tr></tbody></table>' +
+						'</figure>'
+					);
+					const expectModel = data => expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup( data );
+
+					expectModel(
+						'<table>' +
+						'<tableRow><tableCell><paragraph>1</paragraph></tableCell></tableRow>' +
+						'</table>'
+					);
+				} );
 			} );
 
 			describe( 'downcast conversion', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -961,16 +961,13 @@ describe( 'table properties', () => {
 				it( 'should upcast width from <figure> if both <figure> and <table> has width style set', () => {
 					editor.setData(
 						'<figure class="table" style="width:75%">' +
-							'<table style="width:95%"><tbody><tr><td>1</td></tr></tbody></table>' +
+							'<table style="width:95%"><tbody><tr><td>foo</td></tr></tbody></table>' +
 						'</figure>'
 					);
-					const expectModel = data => expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup( data );
 
-					expectModel(
-						'<table tableWidth="75%">' +
-						'<tableRow><tableCell><paragraph>1</paragraph></tableCell></tableRow>' +
-						'</table>'
-					);
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableWidth' ) ).to.equal( '75%' );
 				} );
 
 				it( 'should not upcast width if <table> inside <figure> has width style set', () => {
@@ -979,13 +976,10 @@ describe( 'table properties', () => {
 							'<table style="width:95%"><tbody><tr><td>1</td></tr></tbody></table>' +
 						'</figure>'
 					);
-					const expectModel = data => expect( getModelData( model, { withoutSelection: true } ) ).to.equalMarkup( data );
 
-					expectModel(
-						'<table>' +
-						'<tableRow><tableCell><paragraph>1</paragraph></tableCell></tableRow>' +
-						'</table>'
-					);
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableWidth' ) ).to.be.undefined;
 				} );
 			} );
 
@@ -1060,6 +1054,30 @@ describe( 'table properties', () => {
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
 					expect( table.getAttribute( 'tableHeight' ) ).to.equal( '1337px' );
+				} );
+
+				it( 'should upcast height from <figure> if both <figure> and <table> has height style set', () => {
+					editor.setData(
+						'<figure class="table" style="height:75%">' +
+							'<table style="height:95%"><tbody><tr><td>foo</td></tr></tbody></table>' +
+						'</figure>'
+					);
+
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableHeight' ) ).to.equal( '75%' );
+				} );
+
+				it( 'should not upcast height if <table> inside <figure> has height style set', () => {
+					editor.setData(
+						'<figure class="table">' +
+							'<table style="height:95%"><tbody><tr><td>1</td></tr></tbody></table>' +
+						'</figure>'
+					);
+
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableHeight' ) ).to.be.undefined;
 				} );
 			} );
 


### PR DESCRIPTION
…element.

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): On upcast, skip width and height on table element if the figure element exists. Closes #12812.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
