### PR TITLE
Docs: adding `$block` info

### DIFF
--- a/packages/ckeditor5-heading/ckeditor5-metadata.json
+++ b/packages/ckeditor5-heading/ckeditor5-metadata.json
@@ -33,7 +33,7 @@
 						"h4"
 					],
 					"implements": "$block",
-					"_comment": "The HTML element may contain classes, styles or attributes that are created by other plugins, which alter the <code>`$block`</code> element."
+					"_comment": "This element inherits all attributes, classes and styles that are allowed on the `<$block>` element by other features."
 				},
 				{
 					"elements": "*",

--- a/packages/ckeditor5-paragraph/ckeditor5-metadata.json
+++ b/packages/ckeditor5-paragraph/ckeditor5-metadata.json
@@ -9,7 +9,7 @@
 				{
 					"elements": "p",
 					"implements": "$block",
-					"_comment": "The HTML element may contain classes, styles or attributes that are created by other plugins, which alter the <code>`$block`</code> element."
+					"_comment": "This element inherits all attributes, classes and styles that are allowed on the `<$block>` element by other features."
 				}
 			]
 		}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: adding \`$block\` info. Closes #9698

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._