### PR TITLE
Replace tab with four spaces when pasting data from clipboard

### DIFF
--- a/packages/ckeditor5-clipboard/src/utils/plaintexttohtml.ts
+++ b/packages/ckeditor5-clipboard/src/utils/plaintexttohtml.ts
@@ -22,6 +22,8 @@ export default function plainTextToHtml( text: string ): string {
 		.replace( /\r?\n\r?\n/g, '</p><p>' )
 		// Creates a line break for each single line break.
 		.replace( /\r?\n/g, '<br>' )
+		// Replace tabs with four spaces.
+		.replace( /\t/g, '&nbsp;&nbsp;&nbsp;&nbsp;' )
 		// Preserve trailing spaces (only the first and last one – the rest is handled below).
 		.replace( /^\s/, '&nbsp;' )
 		.replace( /\s$/, '&nbsp;' )

--- a/packages/ckeditor5-clipboard/tests/utils/plaintexttohtml.js
+++ b/packages/ckeditor5-clipboard/tests/utils/plaintexttohtml.js
@@ -30,6 +30,10 @@ describe( 'plainTextToHtml()', () => {
 		expect( plainTextToHtml( 'a\n\nb\nc\n\n\n\nd\ne' ) ).to.equal( '<p>a</p><p>b<br>c</p><p></p><p>d<br>e</p>' );
 	} );
 
+	it( 'turns tabs into four spaces', () => {
+		expect( plainTextToHtml( '\tx\t' ) ).to.equal( '&nbsp;&nbsp;&nbsp;&nbsp;x&nbsp;&nbsp;&nbsp;&nbsp;' );
+	} );
+
 	it( 'preserves trailing spaces', () => {
 		expect( plainTextToHtml( ' x ' ) ).to.equal( '&nbsp;x&nbsp;' );
 	} );


### PR DESCRIPTION
Fix (clipboard): Replace tab with four spaces when pasting data from clipboard. Closes #12806.

---
![image](https://user-images.githubusercontent.com/114912428/205061226-0504df9e-fb57-4fee-9b6b-fca06431ed5b.png)

---

### Additional information

_Replacing tab with four spaces to be consistent with CKEditor 4._

### Testing

1. Visit https://www.editpad.org/.
2. Prepare text with tabs.
3. Copy the code from editpad.org and paste to CKEditor 5.
4. Compare with current version https://ckeditor.com/ckeditor-5/demo/.