### PR TITLE
Use global not as variable name to fix problem with Jest

### DIFF
--- a/packages/ckeditor5-utils/src/dom/global.ts
+++ b/packages/ckeditor5-utils/src/dom/global.ts
@@ -34,11 +34,11 @@ export interface GlobalType {
  * console.log( global.window.innerWidth );
  * ```
  */
-let global: GlobalType;
+let globalVar: GlobalType; // named globalVar instead of global: https://github.com/ckeditor/ckeditor5/issues/12971
 
 // In some environments window and document API might not be available.
 try {
-	global = { window, document };
+	globalVar = { window, document };
 } catch ( e ) {
 	// It's not possible to mock a window object to simulate lack of a window object without writing extremely convoluted code.
 	/* istanbul ignore next */
@@ -47,7 +47,7 @@ try {
 	// We only handle this so loading editor in environments without window and document doesn't fail.
 	// For better DX we shouldn't introduce mixed types and require developers to check the type manually.
 	// This module should not be used on purpose in any environment outside browser.
-	global = { window: {} as any, document: {} as any };
+	globalVar = { window: {} as any, document: {} as any };
 }
 
-export default global;
+export default globalVar;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Type: Message. Closes https://github.com/ckeditor/ckeditor5/issues/12971.

---

### Additional information

Currenlty jest tests failing when upgrading ckeditor from 34 to 35.