### PR TITLE
Fix tableCell content inconsistency after executing editor.data.set

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.ts
@@ -523,7 +523,16 @@ export function convertText() {
 				return;
 			}
 
+			// Wrap $text in paragraph and include any marker that is directly before $text. #13053
+			const nodeBefore = position.nodeBefore;
+
 			position = wrapInParagraph( position, writer );
+
+			if ( nodeBefore && nodeBefore.is( 'element', '$marker' ) ) {
+				// Move `$marker` to the paragraph.
+				writer.move( writer.createRangeOn( nodeBefore ), position );
+				position = writer.createPositionAfter( nodeBefore );
+			}
 		}
 
 		consumable.consume( data.viewItem );

--- a/packages/ckeditor5-engine/src/conversion/upcasthelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/upcasthelpers.ts
@@ -523,7 +523,7 @@ export function convertText() {
 				return;
 			}
 
-			// Wrap $text in paragraph and include any marker that is directly before $text. #13053
+			// Wrap `$text` in paragraph and include any marker that is directly before `$text`. See #13053.
 			const nodeBefore = position.nodeBefore;
 
 			position = wrapInParagraph( position, writer );

--- a/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
@@ -1200,6 +1200,31 @@ describe( 'upcast-converters', () => {
 			expect( conversionResult.getChild( 0 ).data ).to.equal( 'foobar' );
 		} );
 
+		it( 'should also include $marker when auto-paragraphing $text.', () => {
+			// Make $text invalid to trigger auto-paragraphing.
+			schema.addChildCheck( ( ctx, childDef ) => {
+				if ( ( childDef.name == '$text' ) && ctx.endsWith( '$root' ) ) {
+					return false;
+				}
+			} );
+
+			const viewText = new ViewText( viewDocument, 'foobar' );
+			dispatcher.on( 'text', ( evt, data, conversionApi ) => {
+				// Add $marker element before processing $text.
+				const element = new ModelElement( '$marker', { 'data-name': 'marker1' } );
+				conversionApi.writer.insert( element, data.modelCursor );
+				data.modelCursor = conversionApi.writer.createPositionAfter( element );
+
+				// Convert $text.
+				convertText()( evt, data, conversionApi );
+			} );
+
+			const conversionResult = model.change( writer => dispatcher.convert( viewText, writer, context ) );
+
+			// Check that marker is in paragraph.
+			expect( conversionResult.markers.get( 'marker1' ).start.parent.name ).to.be.equal( 'paragraph' );
+		} );
+
 		it( 'should auto-paragraph a text if it is not allowed at the insertion position but would be inserted if auto-paragraphed', () => {
 			schema.addChildCheck( ( ctx, childDef ) => {
 				if ( childDef.name == '$text' && ctx.endsWith( '$root' ) ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (table): Fix tableCell content inconsistency after executing editor.data.set. Closes #13053.

### Additional information

Connected to: https://github.com/cksource/collaboration-features/issues/4061
