### PR TITLE
Docs: Removed "CKEditor 5" from navigation on "Updating" page.

### DIFF
--- a/docs/updating/release-process.md
+++ b/docs/updating/release-process.md
@@ -2,11 +2,10 @@
 category: updating
 order: 20
 meta-title: CKEditor 5 updating documentation
-menu-title: CKEditor 5 release process
 meta-description: Learn how to maintain and keep your CKEditor 5 up-to-date at all times.
 ---
 
-# CKEditor 5 release process
+# Release process
 
 Regular code releases (there are usually 10-12 of these a year) bring different changes and new features. They are often divided into major and minor changes, along the lines of {@link updating/versioning-policy Versioning policy}.
 

--- a/docs/updating/versioning-policy.md
+++ b/docs/updating/versioning-policy.md
@@ -3,7 +3,7 @@ category: updating
 order: 25
 ---
 
-# CKEditor 5  versioning policy
+# Versioning policy
 
 CKEditor 5 consists of multiple npm packages (over 50, at the moment of writing this guide). When releasing them, we use the following rules:
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Removed "CKEditor 5" from navigation on "Updating" page. Closes [#2319](https://github.com/cksource/ckeditor5-internal/issues/2319).

---

### Additional information

Removed CKEditor 5 branding from the navigation on the [Updating](https://ckeditor.com/docs/ckeditor5/latest/updating/index.html) page.

Before:

![image](https://user-images.githubusercontent.com/23510242/207283362-ef7a06c2-e674-4770-9a01-ab21848b00ad.png)

After:

![image](https://user-images.githubusercontent.com/23510242/207283138-875bd5e4-48da-4e0f-9632-ef59e90d65d1.png)

