### PR TITLE
Fix typo in `isFocusChanging`

### DIFF
--- a/packages/ckeditor5-engine/tests/view/view/view.js
+++ b/packages/ckeditor5-engine/tests/view/view/view.js
@@ -651,8 +651,8 @@ describe( 'view', () => {
 			sinon.assert.calledOnce( layoutChangedSpy );
 		} );
 
-		it( 'should change the document#isFocusChanging property to false', () => {
-			view.document.isFocusChanging = true;
+		it( 'should change the document#_isFocusChanging property to false', () => {
+			view.document._isFocusChanging = true;
 
 			view.document.selection._setTo( null );
 			view.forceRender();

--- a/packages/ckeditor5-engine/tests/view/view/view.js
+++ b/packages/ckeditor5-engine/tests/view/view/view.js
@@ -651,8 +651,8 @@ describe( 'view', () => {
 			sinon.assert.calledOnce( layoutChangedSpy );
 		} );
 
-		it( 'should change the document#isFocusChaning property to false', () => {
-			view.document.isFocusChaning = true;
+		it( 'should change the document#isFocusChanging property to false', () => {
+			view.document.isFocusChanging = true;
 
 			view.document.selection._setTo( null );
 			view.forceRender();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Type: Message. Closes #000.

---

### Additional information

Spotted when investigating #12898 on behalf of the Drupal project.
