### PR TITLE
Docs: Rename "abbreviation plugin" tutorials

### DIFF
--- a/docs/framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-1.md
+++ b/docs/framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-1.md
@@ -1,17 +1,17 @@
 ---
-category: simple-plugin
-menu-title: Abbreviation plugin (part 1)
+category: abbreviation-plugin
+menu-title: Creating a toolbar button
 order: 24
 modified_at: 2022-07-15
 ---
 
-# Abbreviation plugin tutorial &ndash; part 1
+# Creating a toolbar button
 
 This guide will show you how to create a simple abbreviation plugin for CKEditor 5.
 
 We will create a toolbar button that lets the users insert abbreviations into their document. These abbreviations will use the [`<abbr>` <abbr title="HyperText Markup Language">HTML</abbr> element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr) with a ‘title’ attribute that will show up in a tooltip when the user hovers over the element. You can check the mechanism hovering over the underlined "HTML" text in the previous sentence.
 
-This first part of the tutorial will only cover the basics. We will just insert one possible abbreviation: "WYSIWYG". We will get user input in the {@link framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-2 next part of this tutorial series}.
+This first part of the tutorial will only cover the basics. We will just insert one possible abbreviation: "WYSIWYG". We will get user input in the {@link framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-2 next part of this tutorial series}.
 
 If you want to see the final product of this tutorial before you plunge in, check out the [live demo](#demo).
 
@@ -442,6 +442,6 @@ If you got lost at any point, this is [the final implementation of the plugin](h
 <info-box>
 	**What's next?**
 
-	That's it for the first part of this tutorial! Your plugin should now work (at least in its most basic form). Move on to the {@link framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-2 second part}, where you will create a balloon with a form to get user's input, replacing our hard-coded "WYSIWYG" abbreviation.
+	That's it for the first part of this tutorial! Your plugin should now work (at least in its most basic form). Move on to the {@link framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-2 second part}, where you will create a balloon with a form to get user's input, replacing our hard-coded "WYSIWYG" abbreviation.
 </info-box>
 

--- a/docs/framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-2.md
+++ b/docs/framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-2.md
@@ -1,15 +1,15 @@
 ---
-category: simple-plugin
-menu-title: Abbreviation plugin (part 2)
+category: abbreviation-plugin
+menu-title: Getting user input with a custom UI
 order: 25
 modified_at: 2022-07-15
 ---
 
-# Abbreviation plugin tutorial &ndash; part 2
+# Getting user input with a custom UI
 
 In this part of the tutorial we will focus on creating a dialog box, which will get the user's input.
 
-We will pick up where we left off in the first part, so make sure you {@link framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-1 start there}, or grab our [starter files for this part](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/abbreviation-plugin/part-1).
+We will pick up where we left off in the first part, so make sure you {@link framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-1 start there}, or grab our [starter files for this part](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/abbreviation-plugin/part-1).
 
 <info-box>
 	As we will mostly work on the UI, we recommend reading about our {@link framework/guides/architecture/ui-library UI library} before you start coding.
@@ -570,5 +570,5 @@ If you got lost at any point, this is [the final implementation of the plugin](h
 <info-box>
 	**What's next?**
 
-	That's it for the second part of the tutorial! We have a working UI, and our plugin does what we want it to do. We can improve it according to our best practices, adding a {@link framework/guides/architecture/core-editor-architecture#commands command}, focus tracking, and more. We will do it in the {@link framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-3 third part of the tutorial}, so head over there.
+	That's it for the second part of the tutorial! We have a working UI, and our plugin does what we want it to do. We can improve it according to our best practices, adding a {@link framework/guides/architecture/core-editor-architecture#commands command}, focus tracking, and more. We will do it in the {@link framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-3 third part of the tutorial}, so head over there.
 </info-box>

--- a/docs/framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-3.md
+++ b/docs/framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-3.md
@@ -1,15 +1,15 @@
 ---
-category: simple-plugin
-menu-title: Abbreviation plugin (part 3)
+category: abbreviation-plugin
+menu-title: Improving accessibility and adding a command
 order: 26
 modified_at: 2022-07-15
 ---
 
-# Abbreviation plugin tutorial &ndash; part 3
+# Improving accessibility and adding a command
 
 You made it to the final part of the abbreviation plugin tutorial. In this part, we will improve accessibility of our plugin. We will also work on a command, which will additionally grab the text from user's selection, and insert it into our form. And more!
 
-We pick up where we left off in the {@link framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-2 second part}, so make sure you finished it, or grab our [starter files for this part](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/abbreviation-plugin/part-2).
+We pick up where we left off in the {@link framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-2 second part}, so make sure you finished it, or grab our [starter files for this part](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/abbreviation-plugin/part-2).
 
 If you want to see the final product of this tutorial before you plunge in, check out the [live demo](#demo).
 

--- a/docs/framework/guides/creating-simple-plugin-timestamp.md
+++ b/docs/framework/guides/creating-simple-plugin-timestamp.md
@@ -241,5 +241,5 @@ If you got lost at any point, see [the final implementation of the plugin](https
 <info-box>
 	**What's next?**
 
-	You can continue with our next tutorial, where we will create {@link framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-1 an abbreviation plugin} or read more about the {@link framework/index CKEditor 5 framework}.
+	You can continue with our next tutorial, where we will create {@link framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-1 an abbreviation plugin} or read more about the {@link framework/index CKEditor 5 framework}.
 </info-box>

--- a/docs/umberto.json
+++ b/docs/umberto.json
@@ -124,6 +124,9 @@
 		"framework/guides/ui/external-ui.html": "framework/guides/deep-dive/ui/external-ui.html",
 		"framework/guides/ui/theme-customization.html": "framework/guides/deep-dive/ui/theme-customization.html",
 		"framework/guides/plugins/creating-simple-plugin.html": "framework/guides/plugins/creating-simple-plugin-timestamp.html",
+		"framework/guides/plugins/simple-plugin/abbreviation-plugin-level-1.html": "framework/guides/plugins/abbreviation-plugin/abbreviation-plugin-level-1.html",
+		"framework/guides/plugins/simple-plugin/abbreviation-plugin-level-2.html": "framework/guides/plugins/abbreviation-plugin/abbreviation-plugin-level-2.html",
+		"framework/guides/plugins/simple-plugin/abbreviation-plugin-level-3.html": "framework/guides/plugins/abbreviation-plugin/abbreviation-plugin-level-3.html",
 		"builds/index.html": "installation/index.html",
 		"builds/guides/migrate.html": "updating/migration-from-ckeditor-4.html",
 		"builds/guides/migration/migration-to-25.0.0.html": "updating/guides/update-to-25.html",
@@ -449,9 +452,9 @@
 							"order": 200,
 							"categories": [
 								{
-									"name": "Creating a simple plugin",
-									"id": "simple-plugin",
-									"slug": "simple-plugin",
+									"name": "Creating an abbreviation plugin",
+									"id": "abbreviation-plugin",
+									"slug": "abbreviation-plugin",
 									"order": 20
 								},
 								{

--- a/tests/manual/abbreviation-level-1.md
+++ b/tests/manual/abbreviation-level-1.md
@@ -1,5 +1,5 @@
 ---
-category: simple-plugin
+category: abbreviation-plugin
 order: 25
 ---
 
@@ -421,7 +421,7 @@ class AbbreviationUI extends Plugin {
 }
 ```
 
-That's it for the first part of this tutorial! Your plugin should now work (in its most basic form). Go on to {@link framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-2 the second part}, where you will create a balloon with a form to get user's input, replacing our hard-coded "WYSIWYG" abbreviation.
+That's it for the first part of this tutorial! Your plugin should now work (in its most basic form). Go on to {@link framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-2 the second part}, where you will create a balloon with a form to get user's input, replacing our hard-coded "WYSIWYG" abbreviation.
 
 ## Demo
 

--- a/tests/manual/abbreviation-level-2.md
+++ b/tests/manual/abbreviation-level-2.md
@@ -1,5 +1,5 @@
 ---
-category: simple-plugin
+category: abbreviation-plugin
 order: 25
 ---
 
@@ -7,7 +7,7 @@ order: 25
 
 In this part of the tutorial we will focus on creating a dialog box, which will get user's input.
 
-We will pick up where we left off in the first part, so make sure you {@link framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-1 start there}, or grab our starter files for this part.
+We will pick up where we left off in the first part, so make sure you {@link framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-1 start there}, or grab our starter files for this part.
 
 <info-box>
 As we will mostly work on the UI, we recommend reading up on our {@link framework/guides/architecture/ui-library UI library} before you start coding.
@@ -523,7 +523,7 @@ class AbbreviationUI extends Plugin {
 	}
 }
 ```
-That's it for this part of the tutorial! We have a working UI, and our plugin does what we want it to do. We can improve it according to our best practices, adding {@link framework/guides/architecture/core-editor-architecture#commands a command}, focus tracking, and more. We will do it in {@link framework/guides/simple-plugin-tutorial/abbreviation-plugin-level-3 the third part of the tutorial}, so head there.
+That's it for this part of the tutorial! We have a working UI, and our plugin does what we want it to do. We can improve it according to our best practices, adding {@link framework/guides/architecture/core-editor-architecture#commands a command}, focus tracking, and more. We will do it in {@link framework/guides/abbreviation-plugin-tutorial/abbreviation-plugin-level-3 the third part of the tutorial}, so head there.
 
 ## Demo
 

--- a/tests/manual/abbreviation-level-3.md
+++ b/tests/manual/abbreviation-level-3.md
@@ -1,5 +1,5 @@
 ---
-category: simple-plugin
+category: abbreviation-plugin
 order: 25
 ---
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Rename "abbreviation plugin" tutorials. Closes https://github.com/cksource/ckeditor5-internal/issues/2352.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
