### PR TITLE
Docs: adding the GHS+RTC info.

### DIFF
--- a/packages/ckeditor5-html-support/docs/features/general-html-support.md
+++ b/packages/ckeditor5-html-support/docs/features/general-html-support.md
@@ -321,7 +321,7 @@ dataFilter.allowElement( 'object-block' );
 It is possible to add support for arbitrary styles, classes and other attributes to existing CKEditor 5 features (such as paragraphs, headings, list items, etc.). Most of the existing CKEditor 5 features can already be extended this way, however, some cannot yet. This includes e.g.: the `<ul>` and `<ol>` elements of the list feature (see: [#9917](https://github.com/ckeditor/ckeditor5/issues/9917)).
 
 <info-box info>
-	While the GHS feature is stable, if it is used in connection with {@link features/real-time-collaboration real-time collaboration} there may be problems with complex documents.
+	While the GHS feature is stable, some problems with complex documents may occur if it is used together with {@link features/real-time-collaboration real-time collaboration}.
 </info-box>
 
 We are open for feedback, so if you find any issue, feel free to report it in the [main CKEditor 5 repository](https://github.com/ckeditor/ckeditor5/issues/). You can also track other [GHS-related issues](https://github.com/ckeditor/ckeditor5/issues/9856) on GitHub <!-- To be removed at some point, as the main issue is closed already -->.

--- a/packages/ckeditor5-html-support/docs/features/general-html-support.md
+++ b/packages/ckeditor5-html-support/docs/features/general-html-support.md
@@ -320,7 +320,11 @@ dataFilter.allowElement( 'object-block' );
 
 It is possible to add support for arbitrary styles, classes and other attributes to existing CKEditor 5 features (such as paragraphs, headings, list items, etc.). Most of the existing CKEditor 5 features can already be extended this way, however, some cannot yet. This includes e.g.: the `<ul>` and `<ol>` elements of the list feature (see: [#9917](https://github.com/ckeditor/ckeditor5/issues/9917)).
 
-We are open for feedback, so if you find any issue, feel free to report it in the [main CKEditor 5 repository](https://github.com/ckeditor/ckeditor5/issues/). You can also track other [GHS-related issues](https://github.com/ckeditor/ckeditor5/issues/9856) on GitHub.
+<info-box info>
+	While the GHS feature is stable, if it is used in connection with {@link features/real-time-collaboration real-time collaboration} there may be problems with complex documents.
+</info-box>
+
+We are open for feedback, so if you find any issue, feel free to report it in the [main CKEditor 5 repository](https://github.com/ckeditor/ckeditor5/issues/). You can also track other [GHS-related issues](https://github.com/ckeditor/ckeditor5/issues/9856) on GitHub <!-- To be removed at some point, as the main issue is closed already -->.
 
 ## HTML comments
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: adding the GHS+RTC info to known issues. Closes cksource/ckeditor5-internal#2408

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._