### PR TITLE
Docs: correcting error code.

### DIFF
--- a/packages/ckeditor5-mention/src/mentioncommand.js
+++ b/packages/ckeditor5-mention/src/mentioncommand.js
@@ -92,7 +92,7 @@ export default class MentionCommand extends Command {
 			 *
 			 * Correct markers: `'@'`, `'#'`.
 			 *
-			 * Incorrect markers: `'$$'`, `'[@'`.
+			 * Incorrect markers: `'@@'`, `'[@'`.
 			 *
 			 * See {@link module:mention/mention~MentionConfig}.
 			 *


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: correcting error code. Closes cksource/ckeditor5-internal#2310

---

### Additional information

The error code example used a dollar sign `$` which apparently disappears during code generation in Umberto. Using a double `$$` made only the second one appear. Possible follow-up for the DevOps/Umberto team.