### PR TITLE
Set correct value (false) for CKFinderCommand#affectsData

### DIFF
--- a/packages/ckeditor5-ckfinder/src/ckfindercommand.js
+++ b/packages/ckeditor5-ckfinder/src/ckfindercommand.js
@@ -33,6 +33,9 @@ export default class CKFinderCommand extends Command {
 	constructor( editor ) {
 		super( editor );
 
+		// The CKFinder command does not affect data by itself.
+		this._affectsData = false;
+
 		// Remove default document listener to lower its priority.
 		this.stopListening( this.editor.model.document, 'change' );
 

--- a/packages/ckeditor5-ckfinder/tests/ckfindercommand.js
+++ b/packages/ckeditor5-ckfinder/tests/ckfindercommand.js
@@ -455,4 +455,10 @@ describe( 'CKFinderCommand', () => {
 			mockFinderEvent( 'files:choose', data );
 		}
 	} );
+
+	describe( '_affectsData', () => {
+		it( 'does not affect data', () => {
+			expect( command._affectsData ).to.be.false;
+		} );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Feature (track-changes): Add track changes integration for CKFinder feature.

Other (ckfinder): Set correct value (false) for `CKFinderCommand#affectsData`. Now the command's state depends only on related commands (`insertImage` and `link`). Closes #13213.