### PR TITLE
Markers should be properly downcasted and upcasted on bogus paragraphs

### DIFF
--- a/packages/ckeditor5-clipboard/tests/dragdrop.js
+++ b/packages/ckeditor5-clipboard/tests/dragdrop.js
@@ -863,7 +863,7 @@ describe( 'Drag and Drop', () => {
 				expect( spyClipboardOutput.firstCall.firstArg.method ).to.equal( 'dragstart' );
 				expect( spyClipboardOutput.firstCall.firstArg.dataTransfer ).to.equal( dataTransferMock );
 				expect( stringifyView( spyClipboardOutput.firstCall.firstArg.content ) ).to.equal(
-					'<figure class="table"><table><tbody><tr><td>abc</td></tr></tbody></table></figure>'
+					'<figure class="table"><table><tbody><tr><td><p>abc</p></td></tr></tbody></table></figure>'
 				);
 
 				dataTransferMock.dropEffect = 'move';
@@ -929,7 +929,7 @@ describe( 'Drag and Drop', () => {
 				expect( spyClipboardOutput.firstCall.firstArg.method ).to.equal( 'dragstart' );
 				expect( spyClipboardOutput.firstCall.firstArg.dataTransfer ).to.equal( dataTransferMock );
 				expect( stringifyView( spyClipboardOutput.firstCall.firstArg.content ) ).to.equal(
-					'<figure class="table"><table><tbody><tr><td>abc</td></tr></tbody></table></figure>'
+					'<figure class="table"><table><tbody><tr><td><p>abc</p></td></tr></tbody></table></figure>'
 				);
 			} );
 

--- a/packages/ckeditor5-engine/src/view/domconverter.ts
+++ b/packages/ckeditor5-engine/src/view/domconverter.ts
@@ -29,7 +29,8 @@ import {
 	indexOf,
 	getAncestors,
 	isText,
-	isComment
+	isComment,
+	first
 } from '@ckeditor/ckeditor5-utils';
 
 import type ViewNode from './node';
@@ -558,7 +559,8 @@ export default class DomConverter {
 			}
 
 			const transparentRendering = childView.is( 'element' ) &&
-				( childView.getCustomProperty( 'dataPipeline:transparentRendering' ) as boolean | undefined );
+				!!childView.getCustomProperty( 'dataPipeline:transparentRendering' ) &&
+				!first( childView.getAttributes() );
 
 			if ( transparentRendering && this.renderingMode == 'data' ) {
 				yield* this.viewChildrenToDom( childView, options );

--- a/packages/ckeditor5-html-support/tests/htmlcomment-integration.js
+++ b/packages/ckeditor5-html-support/tests/htmlcomment-integration.js
@@ -1157,8 +1157,8 @@ describe( 'HtmlComment integration', () => {
 						'<tbody>' +
 							'<tr>' +
 								'<td>' +
-									'<!-- c1 -->' +
 									'&nbsp;' +
+									'<!-- c1 -->' +
 								'</td>' +
 							'</tr>' +
 						'</tbody>' +

--- a/packages/ckeditor5-list/src/documentlist/converters.ts
+++ b/packages/ckeditor5-list/src/documentlist/converters.ts
@@ -369,11 +369,14 @@ export function bogusParagraphCreator(
 			return null;
 		}
 
-		const viewElement = writer.createContainerElement( 'span', { class: 'ck-list-bogus-paragraph' } );
-
-		if ( dataPipeline ) {
-			writer.setCustomProperty( 'dataPipeline:transparentRendering', true, viewElement );
+		if ( !dataPipeline ) {
+			return writer.createContainerElement( 'span', { class: 'ck-list-bogus-paragraph' } );
 		}
+
+		// Using `<p>` in case there are some markers on it and transparentRendering will render it anyway.
+		const viewElement = writer.createContainerElement( 'p' );
+
+		writer.setCustomProperty( 'dataPipeline:transparentRendering', true, viewElement );
 
 		return viewElement;
 	};

--- a/packages/ckeditor5-list/tests/documentlist/integrations/markers.js
+++ b/packages/ckeditor5-list/tests/documentlist/integrations/markers.js
@@ -1,0 +1,352 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global document */
+
+import DocumentListEditing from '../../../src/documentlist/documentlistediting';
+
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import ImageBlockEditing from '@ckeditor/ckeditor5-image/src/image/imageblockediting';
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+
+import stubUid from '../_utils/uid';
+
+describe( 'DocumentListEditing integrations: markers', () => {
+	let element, editor, model, root;
+
+	testUtils.createSinonSandbox();
+
+	beforeEach( async () => {
+		element = document.createElement( 'div' );
+		document.body.appendChild( element );
+
+		editor = await ClassicTestEditor.create( element, {
+			plugins: [ Paragraph, DocumentListEditing, ImageBlockEditing ]
+		} );
+
+		model = editor.model;
+		root = model.document.getRoot();
+
+		editor.conversion.for( 'upcast' ).dataToMarker( { view: 'foo' } );
+		editor.conversion.for( 'dataDowncast' ).markerToData( { model: 'foo' } );
+
+		stubUid();
+	} );
+
+	afterEach( async () => {
+		element.remove();
+
+		await editor.destroy();
+	} );
+
+	function addMarker( range ) {
+		model.change( writer => {
+			writer.addMarker( 'foo:bar', {
+				usingOperation: true,
+				affectsData: true,
+				range
+			} );
+		} );
+	}
+
+	function checkMarker( range ) {
+		const marker = model.markers.get( 'foo:bar' );
+
+		expect( marker ).to.not.be.null;
+		expect( marker.getRange().isEqual( range ) ).to.be.true;
+	}
+
+	describe( 'list item with a single paragraph', () => {
+		beforeEach( () => {
+			setModelData( model,
+				'<paragraph listType="bulleted" listItemId="a" listIndent="0">A</paragraph>'
+			);
+		} );
+
+		it( 'marker beginning before a paragraph and ending inside', () => {
+			const range = model.createRange(
+				model.createPositionBefore( root.getChild( 0 ) ),
+				model.createPositionAt( root.getChild( 0 ), 'end' )
+			);
+
+			addMarker( range );
+
+			const data = editor.getData();
+
+			expect( data ).to.equal(
+				'<ul>' +
+					'<li>' +
+						'<p data-foo-start-before="bar">A<foo-end name="bar"></foo-end></p>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			editor.setData( data );
+
+			checkMarker( range );
+			expect( editor.getData() ).to.equal( data );
+		} );
+
+		it( 'marker beginning before an empty paragraph and ending inside', () => {
+			model.change( writer => writer.remove( root.getChild( 0 ).getChild( 0 ) ) );
+
+			const range = model.createRange(
+				model.createPositionBefore( root.getChild( 0 ) ),
+				model.createPositionAt( root.getChild( 0 ), 'end' )
+			);
+
+			addMarker( range );
+
+			const data = editor.getData();
+
+			expect( data ).to.equal(
+				'<ul>' +
+					'<li>' +
+						'<p data-foo-start-before="bar"><foo-end name="bar"></foo-end>&nbsp;</p>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			editor.setData( data );
+
+			checkMarker( range );
+			expect( editor.getData() ).to.equal( data );
+		} );
+
+		it( 'marker beginning before a paragraph and ending after it', () => {
+			const range = model.createRangeOn( root.getChild( 0 ) );
+
+			addMarker( range );
+
+			const data = editor.getData();
+
+			expect( data ).to.equal(
+				'<ul>' +
+					'<li>' +
+						'<p data-foo-end-after="bar" data-foo-start-before="bar">A</p>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			editor.setData( data );
+
+			checkMarker( range );
+			expect( editor.getData() ).to.equal( data );
+		} );
+
+		it( 'marker inside a paragraph', () => {
+			const range = model.createRangeIn( root.getChild( 0 ) );
+
+			addMarker( range );
+
+			const data = editor.getData();
+
+			expect( data ).to.equal(
+				'<ul>' +
+					'<li>' +
+						'<foo-start name="bar"></foo-start>A<foo-end name="bar"></foo-end>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			editor.setData( data );
+
+			checkMarker( range );
+			expect( editor.getData() ).to.equal( data );
+		} );
+
+		it( 'marker inside an empty paragraph', () => {
+			model.change( writer => writer.remove( root.getChild( 0 ).getChild( 0 ) ) );
+
+			const range = model.createRangeIn( root.getChild( 0 ) );
+
+			addMarker( range );
+
+			const data = editor.getData();
+
+			expect( data ).to.equal(
+				'<ul>' +
+					'<li>' +
+						'<foo-start name="bar"></foo-start><foo-end name="bar"></foo-end>&nbsp;' +
+					'</li>' +
+				'</ul>'
+			);
+
+			editor.setData( data );
+
+			checkMarker( range );
+			expect( editor.getData() ).to.equal( data );
+		} );
+	} );
+
+	describe( 'list item with multiple paragraphs', () => {
+		beforeEach( () => {
+			setModelData( model,
+				'<paragraph listType="bulleted" listItemId="a" listIndent="0">A</paragraph>' +
+				'<paragraph listType="bulleted" listItemId="a" listIndent="0">B</paragraph>'
+			);
+		} );
+
+		it( 'marker beginning before a paragraph and ending inside', () => {
+			const range = model.createRange(
+				model.createPositionBefore( root.getChild( 0 ) ),
+				model.createPositionAt( root.getChild( 0 ), 'end' )
+			);
+
+			addMarker( range );
+
+			const data = editor.getData();
+
+			expect( data ).to.equal(
+				'<ul>' +
+					'<li>' +
+						'<p data-foo-start-before="bar">A<foo-end name="bar"></foo-end></p>' +
+						'<p>B</p>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			editor.setData( data );
+
+			checkMarker( range );
+			expect( editor.getData() ).to.equal( data );
+		} );
+
+		it( 'marker beginning before a paragraph and ending inside the next paragraph', () => {
+			const range = model.createRange(
+				model.createPositionBefore( root.getChild( 0 ) ),
+				model.createPositionAt( root.getChild( 1 ), 'end' )
+			);
+
+			addMarker( range );
+
+			const data = editor.getData();
+
+			expect( data ).to.equal(
+				'<ul>' +
+					'<li>' +
+						'<p data-foo-start-before="bar">A</p>' +
+						'<p>B<foo-end name="bar"></foo-end></p>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			editor.setData( data );
+
+			checkMarker( range );
+			expect( editor.getData() ).to.equal( data );
+		} );
+
+		it( 'marker beginning before an empty paragraph and ending inside the next paragraph', () => {
+			model.change( writer => {
+				writer.remove( root.getChild( 0 ).getChild( 0 ) );
+				writer.remove( root.getChild( 1 ).getChild( 0 ) );
+			} );
+
+			const range = model.createRange(
+				model.createPositionBefore( root.getChild( 0 ) ),
+				model.createPositionAt( root.getChild( 1 ), 'end' )
+			);
+
+			addMarker( range );
+
+			const data = editor.getData();
+
+			expect( data ).to.equal(
+				'<ul>' +
+					'<li>' +
+						'<p data-foo-start-before="bar">&nbsp;</p>' +
+						'<p><foo-end name="bar"></foo-end>&nbsp;</p>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			editor.setData( data );
+
+			checkMarker( range );
+			expect( editor.getData() ).to.equal( data );
+		} );
+
+		it( 'marker beginning before a paragraph and ending after the next paragraph', () => {
+			const range = model.createRangeIn( root );
+
+			addMarker( range );
+
+			const data = editor.getData();
+
+			expect( data ).to.equal(
+				'<ul>' +
+					'<li>' +
+						'<p data-foo-start-before="bar">A</p>' +
+						'<p data-foo-end-after="bar">B</p>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			editor.setData( data );
+
+			checkMarker( range );
+			expect( editor.getData() ).to.equal( data );
+		} );
+
+		it( 'marker starting in a paragraph and ending in next paragraph', () => {
+			const range = model.createRange(
+				model.createPositionAt( root.getChild( 0 ), 'end' ),
+				model.createPositionAt( root.getChild( 1 ), 0 )
+			);
+
+			addMarker( range );
+
+			const data = editor.getData();
+
+			expect( data ).to.equal(
+				'<ul>' +
+					'<li>' +
+						'<p>A<foo-start name="bar"></foo-start></p>' +
+						'<p><foo-end name="bar"></foo-end>B</p>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			editor.setData( data );
+
+			checkMarker( range );
+			expect( editor.getData() ).to.equal( data );
+		} );
+
+		it( 'marker starting in a empty paragraph and ending in next empty paragraph', () => {
+			model.change( writer => {
+				writer.remove( root.getChild( 0 ).getChild( 0 ) );
+				writer.remove( root.getChild( 1 ).getChild( 0 ) );
+			} );
+
+			const range = model.createRange(
+				model.createPositionAt( root.getChild( 0 ), 'end' ),
+				model.createPositionAt( root.getChild( 1 ), 0 )
+			);
+
+			addMarker( range );
+
+			const data = editor.getData();
+
+			expect( data ).to.equal(
+				'<ul>' +
+					'<li>' +
+						'<p><foo-start name="bar"></foo-start>&nbsp;</p>' +
+						'<p><foo-end name="bar"></foo-end>&nbsp;</p>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			editor.setData( data );
+
+			checkMarker( range );
+			expect( editor.getData() ).to.equal( data );
+		} );
+	} );
+} );

--- a/packages/ckeditor5-table/src/converters/downcast.js
+++ b/packages/ckeditor5-table/src/converters/downcast.js
@@ -114,7 +114,7 @@ export function downcastCell( options = {} ) {
  * @returns {Function} Element creator.
  */
 export function convertParagraphInTableCell( options = {} ) {
-	return ( modelElement, { writer, consumable, mapper } ) => {
+	return ( modelElement, { writer } ) => {
 		if ( !modelElement.parent.is( 'element', 'tableCell' ) ) {
 			return;
 		}
@@ -126,9 +126,12 @@ export function convertParagraphInTableCell( options = {} ) {
 		if ( options.asWidget ) {
 			return writer.createContainerElement( 'span', { class: 'ck-table-bogus-paragraph' } );
 		} else {
-			// Additional requirement for data pipeline to have backward compatible data tables.
-			consumable.consume( modelElement, 'insert' );
-			mapper.bindElements( modelElement, mapper.toViewElement( modelElement.parent ) );
+			// Using `<p>` in case there are some markers on it and transparentRendering will render it anyway.
+			const viewElement = writer.createContainerElement( 'p' );
+
+			writer.setCustomProperty( 'dataPipeline:transparentRendering', true, viewElement );
+
+			return viewElement;
 		}
 	};
 }

--- a/packages/ckeditor5-table/src/tableediting.js
+++ b/packages/ckeditor5-table/src/tableediting.js
@@ -152,11 +152,6 @@ export default class TableEditing extends Plugin {
 			view: 'rowspan'
 		} );
 
-		// Manually adjust model position mappings in a special case, when a table cell contains a paragraph, which is bound
-		// to its parent (to the table cell). This custom model-to-view position mapping is necessary in data pipeline only,
-		// because only during this conversion a paragraph can be bound to its parent.
-		editor.data.mapper.on( 'modelToViewPosition', mapTableCellModelPositionToView() );
-
 		// Define the config.
 		editor.config.define( 'table.defaultHeadings.rows', 0 );
 		editor.config.define( 'table.defaultHeadings.columns', 0 );
@@ -195,40 +190,6 @@ export default class TableEditing extends Plugin {
 			tableCellRefreshHandler( model, editor.editing );
 		} );
 	}
-}
-
-// Creates a mapper callback to adjust model position mappings in a table cell containing a paragraph, which is bound to its parent
-// (to the table cell). Only positions after this paragraph have to be adjusted, because after binding this paragraph to the table cell,
-// elements located after this paragraph would point either to a non-existent offset inside `tableCell` (if paragraph is empty), or after
-// the first character of the paragraph's text. See https://github.com/ckeditor/ckeditor5/issues/10116.
-//
-// <tableCell><paragraph></paragraph>^</tableCell> -> <td>^&nbsp;</td>
-//
-// <tableCell><paragraph>foobar</paragraph>^</tableCell> -> <td>foobar^</td>
-//
-// @returns {Function}
-function mapTableCellModelPositionToView() {
-	return ( evt, data ) => {
-		const modelParent = data.modelPosition.parent;
-		const modelNodeBefore = data.modelPosition.nodeBefore;
-
-		if ( !modelParent.is( 'element', 'tableCell' ) ) {
-			return;
-		}
-
-		if ( !modelNodeBefore || !modelNodeBefore.is( 'element', 'paragraph' ) ) {
-			return;
-		}
-
-		const viewNodeBefore = data.mapper.toViewElement( modelNodeBefore );
-		const viewParent = data.mapper.toViewElement( modelParent );
-
-		if ( viewNodeBefore === viewParent ) {
-			// Since the paragraph has already been bound to its parent, update the current position in the model with paragraph's
-			// max offset, so it points to the place which should normally (in all other cases) be the end position of this paragraph.
-			data.viewPosition = data.mapper.findPositionIn( viewParent, modelNodeBefore.maxOffset );
-		}
-	};
 }
 
 // Returns fixed colspan and rowspan attrbutes values.

--- a/packages/ckeditor5-table/tests/converters/upcasttable.js
+++ b/packages/ckeditor5-table/tests/converters/upcasttable.js
@@ -333,7 +333,7 @@ describe( 'upcastTable()', () => {
 		);
 
 		expectModel(
-			'<fooTable><fooRow><fooCell></fooCell></fooRow></fooTable>'
+			'<fooTable><fooRow><fooCell><paragraph></paragraph></fooCell></fooRow></fooTable>'
 		);
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (engine, list, table): Markers should not be lost on list items and in table cells in the data pipeline. Closes #13285.

---

### Additional information