### PR TITLE
Fix description lists upcasting using ghs

### DIFF
--- a/packages/ckeditor5-html-support/src/integrations/dualcontent.js
+++ b/packages/ckeditor5-html-support/src/integrations/dualcontent.js
@@ -91,7 +91,7 @@ export default class DualContentModelElementSupport extends Plugin {
 				},
 				// With a `low` priority, `paragraph` plugin auto-paragraphing mechanism is executed. Make sure
 				// this listener is called before it. If not, some elements will be transformed into a paragraph.
-				converterPriority: priorities.get( 'low' ) + 1
+				converterPriority: priorities.get( 'low' ) + 0.5
 			} );
 
 			conversion.for( 'downcast' ).elementToElement( {

--- a/packages/ckeditor5-html-support/src/schemadefinitions.js
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.js
@@ -463,11 +463,19 @@ export default {
 			}
 		},
 		{
+			model: 'htmlDivDl',
+			view: 'div',
+			modelSchema: {
+				allowChildren: [ 'htmlDt', 'htmlDd' ],
+				allowIn: 'htmlDl'
+			}
+		},
+		{
 			model: 'htmlDl',
 			view: 'dl',
 			modelSchema: {
 				allowWhere: '$container',
-				allowChildren: [ 'htmlDt', 'htmlDd' ],
+				allowChildren: [ 'htmlDt', 'htmlDd', 'htmlDivDl' ],
 				isBlock: false
 			}
 		},

--- a/packages/ckeditor5-html-support/tests/integrations/dualcontent.js
+++ b/packages/ckeditor5-html-support/tests/integrations/dualcontent.js
@@ -238,17 +238,13 @@ describe( 'DualContentModelElementSupport', () => {
 			return allowAllEditor.destroy();
 		} );
 
-		it( 'should handle description list', () => {
+		it( 'should upcast description list', () => {
 			allowAllEditor.setData(
 				'<dl>' +
 					'<dt>Name</dt>' +
 					'<dd>Godzilla</dd>' +
 					'<dt>Born</dt>' +
 					'<dd>1952</dd>' +
-					'<dt>Birthplace</dt>' +
-					'<dd>Japan</dd>' +
-					'<dt>Color</dt>' +
-					'<dd>Green</dd>' +
 				'</dl>'
 			);
 
@@ -258,15 +254,11 @@ describe( 'DualContentModelElementSupport', () => {
 					'<htmlDd><paragraph>Godzilla</paragraph></htmlDd>' +
 					'<htmlDt><paragraph>Born</paragraph></htmlDt>' +
 					'<htmlDd><paragraph>1952</paragraph></htmlDd>' +
-					'<htmlDt><paragraph>Birthplace</paragraph></htmlDt>' +
-					'<htmlDd><paragraph>Japan</paragraph></htmlDd>' +
-					'<htmlDt><paragraph>Color</paragraph></htmlDt>' +
-					'<htmlDd><paragraph>Green</paragraph></htmlDd>' +
 				'</htmlDl>'
 			);
 		} );
 
-		it( 'should handle description list when name-value groups are wrapped in div elements', () => {
+		it( 'should upcast description list when name-value groups are wrapped in div elements', () => {
 			allowAllEditor.setData(
 				'<dl>' +
 					'<div>' +
@@ -277,36 +269,50 @@ describe( 'DualContentModelElementSupport', () => {
 						'<dt>Born</dt>' +
 						'<dd>1952</dd>' +
 					'</div>' +
-					'<div>' +
-						'<dt>Birthplace</dt>' +
-						'<dd>Japan</dd>' +
-					'</div>' +
-					'<div>' +
-						'<dt>Color</dt>' +
-						'<dd>Green</dd>' +
-					'</div>' +
 				'</dl>'
 			);
 
 			expect( getModelData( allowAllModel, { withoutSelection: true } ) ).to.equal(
 				'<htmlDl>' +
-						'<htmlDivDl>' +
+					'<htmlDivDl>' +
 						'<htmlDt><paragraph>Name</paragraph></htmlDt>' +
 						'<htmlDd><paragraph>Godzilla</paragraph></htmlDd>' +
-						'</htmlDivDl>' +
-						'<htmlDivDl>' +
+					'</htmlDivDl>' +
+					'<htmlDivDl>' +
 						'<htmlDt><paragraph>Born</paragraph></htmlDt>' +
 						'<htmlDd><paragraph>1952</paragraph></htmlDd>' +
-						'</htmlDivDl>' +
-						'<htmlDivDl>' +
-						'<htmlDt><paragraph>Birthplace</paragraph></htmlDt>' +
-						'<htmlDd><paragraph>Japan</paragraph></htmlDd>' +
-						'</htmlDivDl>' +
-						'<htmlDivDl>' +
-						'<htmlDt><paragraph>Color</paragraph></htmlDt>' +
-						'<htmlDd><paragraph>Green</paragraph></htmlDd>' +
-						'</htmlDivDl>' +
-						'</htmlDl>'
+					'</htmlDivDl>' +
+				'</htmlDl>'
+			);
+		} );
+
+		it( 'should upcast description list div elements as well as other mixed-content div', () => {
+			allowAllEditor.setData(
+				'<div><div>inline</div><div><p>sectioning</p></div></div>' +
+				'<dl>' +
+					'<div>' +
+						'<dt>Name</dt>' +
+						'<dd>Godzilla</dd>' +
+					'</div>' +
+					'<div>' +
+						'<dt>Born</dt>' +
+						'<dd>1952</dd>' +
+					'</div>' +
+				'</dl>'
+			);
+
+			expect( getModelData( allowAllModel, { withoutSelection: true } ) ).to.equal(
+				'<htmlDiv><htmlDivParagraph>inline</htmlDivParagraph><htmlDiv><paragraph>sectioning</paragraph></htmlDiv></htmlDiv>' +
+				'<htmlDl>' +
+					'<htmlDivDl>' +
+						'<htmlDt><paragraph>Name</paragraph></htmlDt>' +
+						'<htmlDd><paragraph>Godzilla</paragraph></htmlDd>' +
+					'</htmlDivDl>' +
+					'<htmlDivDl>' +
+						'<htmlDt><paragraph>Born</paragraph></htmlDt>' +
+						'<htmlDd><paragraph>1952</paragraph></htmlDd>' +
+					'</htmlDivDl>' +
+				'</htmlDl>'
 			);
 		} );
 	} );

--- a/packages/ckeditor5-html-support/tests/integrations/dualcontent.js
+++ b/packages/ckeditor5-html-support/tests/integrations/dualcontent.js
@@ -205,4 +205,109 @@ describe( 'DualContentModelElementSupport', () => {
 
 		expect( editor.getData() ).to.equal( '<p>xyz</p>' );
 	} );
+
+	describe( 'with ghs configured to allow all', () => {
+		let allowAllEditor, allowAllModel, allowAllEditorElement;
+
+		beforeEach( () => {
+			allowAllEditorElement = document.createElement( 'div' );
+			document.body.appendChild( allowAllEditorElement );
+			return ClassicTestEditor
+				.create( allowAllEditorElement, {
+					plugins: [ Paragraph, Bold, Italic, ShiftEnter, LinkEditing, GeneralHtmlSupport ],
+					htmlSupport: {
+						allow: [
+							{
+								name: /^.*$/,
+								styles: true,
+								attributes: true,
+								classes: true
+							}
+						]
+					}
+				} )
+				.then( newEditor => {
+					allowAllEditor = newEditor;
+					allowAllModel = newEditor.model;
+				} );
+		} );
+
+		afterEach( () => {
+			allowAllEditorElement.remove();
+
+			return allowAllEditor.destroy();
+		} );
+
+		it( 'should handle description list', () => {
+			allowAllEditor.setData(
+				'<dl>' +
+					'<dt>Name</dt>' +
+					'<dd>Godzilla</dd>' +
+					'<dt>Born</dt>' +
+					'<dd>1952</dd>' +
+					'<dt>Birthplace</dt>' +
+					'<dd>Japan</dd>' +
+					'<dt>Color</dt>' +
+					'<dd>Green</dd>' +
+				'</dl>'
+			);
+
+			expect( getModelData( allowAllModel, { withoutSelection: true } ) ).to.equal(
+				'<htmlDl>' +
+					'<htmlDt><paragraph>Name</paragraph></htmlDt>' +
+					'<htmlDd><paragraph>Godzilla</paragraph></htmlDd>' +
+					'<htmlDt><paragraph>Born</paragraph></htmlDt>' +
+					'<htmlDd><paragraph>1952</paragraph></htmlDd>' +
+					'<htmlDt><paragraph>Birthplace</paragraph></htmlDt>' +
+					'<htmlDd><paragraph>Japan</paragraph></htmlDd>' +
+					'<htmlDt><paragraph>Color</paragraph></htmlDt>' +
+					'<htmlDd><paragraph>Green</paragraph></htmlDd>' +
+				'</htmlDl>'
+			);
+		} );
+
+		it( 'should handle description list when name-value groups are wrapped in div elements', () => {
+			allowAllEditor.setData(
+				'<dl>' +
+					'<div>' +
+						'<dt>Name</dt>' +
+						'<dd>Godzilla</dd>' +
+					'</div>' +
+					'<div>' +
+						'<dt>Born</dt>' +
+						'<dd>1952</dd>' +
+					'</div>' +
+					'<div>' +
+						'<dt>Birthplace</dt>' +
+						'<dd>Japan</dd>' +
+					'</div>' +
+					'<div>' +
+						'<dt>Color</dt>' +
+						'<dd>Green</dd>' +
+					'</div>' +
+				'</dl>'
+			);
+
+			expect( getModelData( allowAllModel, { withoutSelection: true } ) ).to.equal(
+				'<htmlDl>' +
+						'<htmlDivDl>' +
+						'<htmlDt><paragraph>Name</paragraph></htmlDt>' +
+						'<htmlDd><paragraph>Godzilla</paragraph></htmlDd>' +
+						'</htmlDivDl>' +
+						'<htmlDivDl>' +
+						'<htmlDt><paragraph>Born</paragraph></htmlDt>' +
+						'<htmlDd><paragraph>1952</paragraph></htmlDd>' +
+						'</htmlDivDl>' +
+						'<htmlDivDl>' +
+						'<htmlDt><paragraph>Birthplace</paragraph></htmlDt>' +
+						'<htmlDd><paragraph>Japan</paragraph></htmlDd>' +
+						'</htmlDivDl>' +
+						'<htmlDivDl>' +
+						'<htmlDt><paragraph>Color</paragraph></htmlDt>' +
+						'<htmlDd><paragraph>Green</paragraph></htmlDd>' +
+						'</htmlDivDl>' +
+						'</htmlDl>'
+			);
+		} );
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Fix (html-support): Fix description lists with name-value groups wrapped in div elements upcasting using GHS. Closes #12240.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
