### PR TITLE
Added support for the `--ts` switch to build the docs for TypeScript sources

### DIFF
--- a/docs/umberto.json
+++ b/docs/umberto.json
@@ -253,7 +253,9 @@
 		]
 	},
 	"googleanalytics": {
-		"domains": [ "ckeditor5.github.io" ],
+		"domains": [
+			"ckeditor5.github.io"
+		],
 		"config": {
 			"trackingId": "UA-271067-19",
 			"cookieDomain": "ckeditor5.github.io"
@@ -307,35 +309,45 @@
 					"name": "Collaboration",
 					"id": "features-collaboration",
 					"slug": "collaboration",
-					"badges": [ "premium" ],
+					"badges": [
+						"premium"
+					],
 					"categories": [
 						{
 							"name": "Comments",
 							"id": "features-comments",
 							"slug": "comments",
 							"order": 100,
-							"badges": [ "premium" ]
+							"badges": [
+								"premium"
+							]
 						},
 						{
 							"name": "Track changes",
 							"id": "features-track-changes",
 							"slug": "track-changes",
 							"order": 200,
-							"badges": [ "premium" ]
+							"badges": [
+								"premium"
+							]
 						},
 						{
 							"name": "Real-time collaboration",
 							"id": "features-real-time-collaboration",
 							"slug": "real-time-collaboration",
 							"order": 300,
-							"badges": [ "premium" ]
+							"badges": [
+								"premium"
+							]
 						},
 						{
 							"name": "Revision history",
 							"id": "features-revision-history",
 							"slug": "revision-history",
 							"order": 400,
-							"badges": [ "premium" ]
+							"badges": [
+								"premium"
+							]
 						},
 						{
 							"name": "Annotations",
@@ -362,7 +374,9 @@
 					"name": "Import from Word",
 					"id": "import-word",
 					"slug": "import-word",
-					"badges": [ "premium" ]
+					"badges": [
+						"premium"
+					]
 				},
 				{
 					"name": "Lists",
@@ -373,7 +387,9 @@
 					"name": "Pagination",
 					"id": "features-pagination",
 					"slug": "pagination",
-					"badges": [ "premium" ]
+					"badges": [
+						"premium"
+					]
 				},
 				{
 					"name": "Pasting",

--- a/scripts/docs/build-docs.js
+++ b/scripts/docs/build-docs.js
@@ -9,8 +9,12 @@
 
 'use strict';
 
+const path = require( 'path' );
+const fs = require( 'fs' );
 const buildApiDocs = require( './buildapi' );
-const minimist = require( 'minimist' );
+const parseArguments = require( './parse-arguments' );
+
+const ROOT_DIRECTORY = path.join( __dirname, '..', '..' );
 
 buildDocs();
 
@@ -27,13 +31,46 @@ function buildDocs() {
 
 	return promise
 		.then( () => {
+			if ( !options.ts ) {
+				return;
+			}
+
+			setApiTypeForUmberto( 'typedoc' );
+		} )
+		.then( () => {
 			return runUmberto( options );
 		} )
 		.catch( err => {
 			console.error( err );
 
 			process.exitCode = 1;
+		} )
+		.finally( () => {
+			if ( !options.ts ) {
+				return;
+			}
+
+			setApiTypeForUmberto( 'jsdoc' );
 		} );
+}
+
+/**
+ * Updates the API type configuration for Umberto.
+ *
+ * @param {String} type
+ */
+function setApiTypeForUmberto( type ) {
+	const umbertoConfigPath = path.join( ROOT_DIRECTORY, 'docs', 'umberto.json' );
+	const umbertoConfig = JSON.parse( fs.readFileSync( umbertoConfigPath, 'utf-8' ) );
+	const umbertoConfigApi = umbertoConfig.groups.find( group => group.id === 'api-reference' );
+
+	if ( !umbertoConfigApi ) {
+		return;
+	}
+
+	umbertoConfigApi.type = type;
+
+	fs.writeFileSync( umbertoConfigPath, JSON.stringify( umbertoConfig, null, '\t' ) + '\n', 'utf-8' );
 }
 
 /**
@@ -60,105 +97,3 @@ function runUmberto( options ) {
 		guides: options.guides
 	} );
 }
-
-/**
- * @param {Array.<String>} args An array containing modifiers for the executed command.
- * @return {DocumentationOptions}
- */
-function parseArguments( args ) {
-	const options = minimist( args, {
-		boolean: [
-			'skip-api',
-			'skip-snippets',
-			'skip-validation',
-			'skip-guides',
-			'production',
-			'watch',
-			'verbose'
-		],
-		string: [
-			'snippets',
-			'guides'
-		],
-		default: {
-			'skip-api': false,
-			'skip-snippets': false,
-			'skip-validation': false,
-			'skip-guides': false,
-			production: false,
-			watch: false,
-			verbose: false,
-			snippets: [],
-			guides: []
-		}
-	} );
-
-	splitOptionsToArray( options, [
-		'snippets',
-		'guides'
-	] );
-
-	replaceKebabCaseWithCamelCase( options, [
-		'skip-api',
-		'skip-snippets',
-		'skip-validation',
-		'skip-guides'
-	] );
-
-	return options;
-}
-
-/**
- * Replaces all kebab-case keys in the `options` object with camelCase entries.
- * Kebab-case keys will be removed.
- *
- * @param {Object} options
- * @param {Array.<String>} keys Kebab-case keys in `options` object.
- */
-function replaceKebabCaseWithCamelCase( options, keys ) {
-	for ( const key of keys ) {
-		const camelCaseKey = key.replace( /-./g, match => match[ 1 ].toUpperCase() );
-
-		options[ camelCaseKey ] = options[ key ];
-		delete options[ key ];
-	}
-}
-
-/**
- * Splits by a comma (`,`) all values specified under keys to array.
- *
- * @param {Object} options
- * @param {Array.<String>} keys Kebab-case keys in `options` object.
- */
-function splitOptionsToArray( options, keys ) {
-	for ( const key of keys ) {
-		if ( typeof options[ key ] === 'string' ) {
-			options[ key ] = options[ key ].split( ',' ).filter( item => item.length );
-		}
-	}
-}
-
-/**
- * @typedef {Object} DocumentationOptions
- *
- * @param {Boolean} [skipApi=false] Whether to skip building API docs.
- *
- * @param {Boolean} [skipSnippets=false] Whether to skip building live snippets.
- *
- * @param {Boolean} [skipValidation=false] Whether to skip validating URLs in the generated documentation.
- *
- * @param {Boolean} [skipGuides=false] Whether to skip processing guides.
- *
- * @param {Boolean} [production=false] Whether the documentation is being built on the production environment. It means that all files
- * will be minified. Increases the time needed for processing all files.
- *
- * @param {Boolean} [watch=false] Whether to watch source files.
- *
- * @param {Boolean} [verbose=false] Whether to print additional logs.
- *
- * @param {Array.<String>} [snippets=[]] An array containing the names of snippets that the snippet adapter should process.
- * An empty array means that the filtering mechanism is disabled.
- *
- * @param {Array.<String>} [guides=[]] An array containing the names of guides that should be processed by Umberto.
- * An empty array means that the filtering mechanism is disabled.
- */

--- a/scripts/docs/build-docs.js
+++ b/scripts/docs/build-docs.js
@@ -31,11 +31,10 @@ function buildDocs() {
 
 	return promise
 		.then( () => {
-			if ( !options.ts ) {
-				return;
+			// Set the proper API type for Umberto if requested building the API docs for the TypeScript source code.
+			if ( options.ts ) {
+				setApiTypeForUmberto( 'typedoc' );
 			}
-
-			setApiTypeForUmberto( 'typedoc' );
 		} )
 		.then( () => {
 			return runUmberto( options );
@@ -46,11 +45,10 @@ function buildDocs() {
 			process.exitCode = 1;
 		} )
 		.finally( () => {
-			if ( !options.ts ) {
-				return;
+			// Restore the default JSDoc-based API type for Umberto if the docs were built for the TypeScript source code.
+			if ( options.ts ) {
+				setApiTypeForUmberto( 'jsdoc' );
 			}
-
-			setApiTypeForUmberto( 'jsdoc' );
 		} );
 }
 

--- a/scripts/docs/buildapi.js
+++ b/scripts/docs/buildapi.js
@@ -7,23 +7,60 @@
 
 'use strict';
 
-module.exports = function buildApiDocs() {
-	const ckeditor5Docs = require( '@ckeditor/ckeditor5-dev-docs' );
+const path = require( 'path' );
+const parseArguments = require( './parse-arguments' );
 
-	return ckeditor5Docs
-		.build( {
-			// Patterns that do not start with '/' are mounted onto process.cwd() path by default.
-			readmePath: 'README.md',
-			sourceFiles: [
-				'packages/@(ckeditor|ckeditor5)-*/src/**/*.@(js|jsdoc)',
-				'packages/@(ckeditor|ckeditor5)-*/_src/**/*.@(js|jsdoc)',
-				'!packages/@(ckeditor|ckeditor5)-*/src/lib/**/*.js',
-				'!packages/ckeditor5-build-*/src/**/*.js',
-				'external/@(ckeditor5-internal|collaboration-features)/packages/@(ckeditor|ckeditor5)-*/src/**/*.@(js|jsdoc)',
-				'!external/@(ckeditor5-internal|collaboration-features)/packages/@(ckeditor|ckeditor5)-*/src/lib/**/*.js',
-				'!external/@(ckeditor5-internal|collaboration-features)/packages/ckeditor5-build-*/src/**/*.js'
-			],
-			validateOnly: process.argv.includes( '--validate-only' ),
-			strict: process.argv.includes( '--strict' )
-		} );
+const ROOT_DIRECTORY = path.join( __dirname, '..', '..' );
+
+module.exports = function buildApiDocs() {
+	const options = parseArguments( process.argv.slice( 2 ) );
+	const type = options.ts ? 'typedoc' : 'jsdoc';
+	const config = getConfig( type );
+
+	return require( '@ckeditor/ckeditor5-dev-docs' ).build( config );
 };
+
+/**
+ * Prepares the configuration for the API docs builder.
+ *
+ * @param {'jsdoc'|'typedoc'} type The requested API type to build.
+ * @returns {Object}
+ */
+function getConfig( type ) {
+	const commonConfig = {
+		cwd: ROOT_DIRECTORY,
+		outputPath: path.join( ROOT_DIRECTORY, 'docs', 'api', 'output.json' ),
+		readmePath: 'README.md',
+		validateOnly: process.argv.includes( '--validate-only' ),
+		strict: process.argv.includes( '--strict' ),
+		type
+	};
+
+	if ( type === 'typedoc' ) {
+		return {
+			...commonConfig,
+			tsconfig: path.join( ROOT_DIRECTORY, 'tsconfig.docs.json' ),
+			sourceFiles: [
+				'packages/@(ckeditor|ckeditor5)-*/src/**/*.ts',
+				'!packages/@(ckeditor|ckeditor5)-*/src/lib/**/*.ts',
+				'!packages/ckeditor5-build-*/src/**/*.ts',
+				'external/@(ckeditor5-internal|collaboration-features)/packages/@(ckeditor|ckeditor5)-*/src/**/*.ts',
+				'!external/@(ckeditor5-internal|collaboration-features)/packages/@(ckeditor|ckeditor5)-*/src/lib/**/*.ts',
+				'!external/@(ckeditor5-internal|collaboration-features)/packages/ckeditor5-build-*/src/**/*.ts'
+			]
+		};
+	}
+
+	return {
+		...commonConfig,
+		sourceFiles: [
+			'packages/@(ckeditor|ckeditor5)-*/src/**/*.@(js|jsdoc)',
+			'packages/@(ckeditor|ckeditor5)-*/_src/**/*.@(js|jsdoc)',
+			'!packages/@(ckeditor|ckeditor5)-*/src/lib/**/*.js',
+			'!packages/ckeditor5-build-*/src/**/*.js',
+			'external/@(ckeditor5-internal|collaboration-features)/packages/@(ckeditor|ckeditor5)-*/src/**/*.@(js|jsdoc)',
+			'!external/@(ckeditor5-internal|collaboration-features)/packages/@(ckeditor|ckeditor5)-*/src/lib/**/*.js',
+			'!external/@(ckeditor5-internal|collaboration-features)/packages/ckeditor5-build-*/src/**/*.js'
+		]
+	};
+}

--- a/scripts/docs/parse-arguments.js
+++ b/scripts/docs/parse-arguments.js
@@ -1,0 +1,116 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* eslint-env node */
+
+'use strict';
+
+const minimist = require( 'minimist' );
+
+/**
+ * @param {Array.<String>} args An array containing modifiers for the executed command.
+ * @return {DocumentationOptions}
+ */
+module.exports = function parseArguments( args ) {
+	const options = minimist( args, {
+		boolean: [
+			'skip-api',
+			'skip-snippets',
+			'skip-validation',
+			'skip-guides',
+			'production',
+			'watch',
+			'verbose',
+			'ts'
+		],
+		string: [
+			'snippets',
+			'guides'
+		],
+		default: {
+			'skip-api': false,
+			'skip-snippets': false,
+			'skip-validation': false,
+			'skip-guides': false,
+			production: false,
+			watch: false,
+			verbose: false,
+			snippets: [],
+			guides: [],
+			ts: false
+		}
+	} );
+
+	splitOptionsToArray( options, [
+		'snippets',
+		'guides'
+	] );
+
+	replaceKebabCaseWithCamelCase( options, [
+		'skip-api',
+		'skip-snippets',
+		'skip-validation',
+		'skip-guides'
+	] );
+
+	return options;
+};
+
+/**
+ * Replaces all kebab-case keys in the `options` object with camelCase entries.
+ * Kebab-case keys will be removed.
+ *
+ * @param {Object} options
+ * @param {Array.<String>} keys Kebab-case keys in `options` object.
+ */
+function replaceKebabCaseWithCamelCase( options, keys ) {
+	for ( const key of keys ) {
+		const camelCaseKey = key.replace( /-./g, match => match[ 1 ].toUpperCase() );
+
+		options[ camelCaseKey ] = options[ key ];
+		delete options[ key ];
+	}
+}
+
+/**
+ * Splits by a comma (`,`) all values specified under keys to array.
+ *
+ * @param {Object} options
+ * @param {Array.<String>} keys Kebab-case keys in `options` object.
+ */
+function splitOptionsToArray( options, keys ) {
+	for ( const key of keys ) {
+		if ( typeof options[ key ] === 'string' ) {
+			options[ key ] = options[ key ].split( ',' ).filter( item => item.length );
+		}
+	}
+}
+
+/**
+ * @typedef {Object} DocumentationOptions
+ *
+ * @param {Boolean} [skipApi=false] Whether to skip building API docs.
+ *
+ * @param {Boolean} [skipSnippets=false] Whether to skip building live snippets.
+ *
+ * @param {Boolean} [skipValidation=false] Whether to skip validating URLs in the generated documentation.
+ *
+ * @param {Boolean} [skipGuides=false] Whether to skip processing guides.
+ *
+ * @param {Boolean} [production=false] Whether the documentation is being built on the production environment. It means that all files
+ * will be minified. Increases the time needed for processing all files.
+ *
+ * @param {Boolean} [watch=false] Whether to watch source files.
+ *
+ * @param {Boolean} [verbose=false] Whether to print additional logs.
+ *
+ * @param {Boolean} [ts=false] Whether to build API docs for TypeScript source code.
+ *
+ * @param {Array.<String>} [snippets=[]] An array containing the names of snippets that the snippet adapter should process.
+ * An empty array means that the filtering mechanism is disabled.
+ *
+ * @param {Array.<String>} [guides=[]] An array containing the names of guides that should be processed by Umberto.
+ * An empty array means that the filtering mechanism is disabled.
+ */

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./packages/*/src/**/*.ts",
+    "./typings/"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Added support for the `--ts` switch to build the API docs for TypeScript sources. See #12521.

---

### Additional information

I added a few cosmetic changes to the `umberto.json` file. This file is programmatically modified with `JSON.stringify()`, which has a built-in way to indent JSON. Now, the content of the `umberto.json` file is adjusted to `JSON.stringify()` output.
