### PR TITLE
Rewriting types for domconverter#mapViewToDom

### DIFF
--- a/packages/ckeditor5-engine/src/view/domconverter.ts
+++ b/packages/ckeditor5-engine/src/view/domconverter.ts
@@ -1022,17 +1022,21 @@ export default class DomConverter {
 		return null;
 	}
 
+	public mapViewToDom( element: ViewElement ): DomElement | undefined;
+	public mapViewToDom( documentFragment: ViewDocumentFragment ): DomDocumentFragment | undefined;
+	public mapViewToDom( documentFragmentOrElement: ViewElement | ViewDocumentFragment ): DomElement | DomDocumentFragment | undefined;
+
 	/**
 	 * Returns corresponding DOM item for provided {@link module:engine/view/element~Element Element} or
 	 * {@link module:engine/view/documentfragment~DocumentFragment DocumentFragment}.
 	 * To find a corresponding text for {@link module:engine/view/text~Text view Text instance}
 	 * use {@link #findCorrespondingDomText}.
 	 *
-	 * @param {module:engine/view/element~Element|module:engine/view/documentfragment~DocumentFragment} viewNode
+	 * @param {module:engine/view/element~Element|module:engine/view/documentfragment~DocumentFragment} documentFragmentOrElement
 	 * View element or document fragment.
-	 * @returns {Node|DocumentFragment|undefined} Corresponding DOM node or document fragment.
+	 * @returns {HTMLElement|DocumentFragment|undefined} Corresponding DOM node or document fragment.
 	 */
-	public mapViewToDom( documentFragmentOrElement: ViewElement | ViewDocumentFragment ): DomNode | DomDocumentFragment | undefined {
+	public mapViewToDom( documentFragmentOrElement: ViewElement | ViewDocumentFragment ): DomElement | DomDocumentFragment | undefined {
 		return this._viewToDomMapping.get( documentFragmentOrElement );
 	}
 
@@ -1073,7 +1077,7 @@ export default class DomConverter {
 	 * @param {module:engine/view/editableelement~EditableElement} viewEditable
 	 */
 	public focus( viewEditable: EditableElement ): void {
-		const domEditable = this.mapViewToDom( viewEditable ) as DomElement;
+		const domEditable = this.mapViewToDom( viewEditable );
 
 		if ( domEditable && domEditable.ownerDocument.activeElement !== domEditable ) {
 			// Save the scrollX and scrollY positions before the focus.

--- a/packages/ckeditor5-engine/src/view/observer/mutationobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/mutationobserver.ts
@@ -208,7 +208,7 @@ export default class MutationObserver extends Observer {
 		}
 
 		for ( const viewElement of elementsWithMutatedChildren ) {
-			const domElement = domConverter.mapViewToDom( viewElement ) as HTMLElement;
+			const domElement = domConverter.mapViewToDom( viewElement )!;
 			const viewChildren = Array.from( viewElement.getChildren() );
 			const newViewChildren = Array.from( domConverter.domChildrenToView( domElement, { withChildren: false } ) );
 

--- a/packages/ckeditor5-engine/src/view/renderer.ts
+++ b/packages/ckeditor5-engine/src/view/renderer.ts
@@ -909,7 +909,7 @@ export default class Renderer extends ObservableMixin() {
 			return;
 		}
 
-		const domRoot = this.domConverter.mapViewToDom( this.selection.editableElement! ) as DomElement;
+		const domRoot = this.domConverter.mapViewToDom( this.selection.editableElement! );
 
 		// Do nothing if there is no focus, or there is no DOM element corresponding to selection's editable element.
 		if ( !this.isFocused || !domRoot ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (engine): Fixed the return type from `DomConverter#mapViewToDom`.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._