### PR TITLE
Docs: Replace double quotation marks with apostrophes.

### DIFF
--- a/docs/framework/guides/architecture/ui-library.md
+++ b/docs/framework/guides/architecture/ui-library.md
@@ -449,7 +449,7 @@ It is advised that for the best user experience the editing view gets {@link mod
 ```js
 // Execute some action on dropdown#execute event.
 dropdownView.buttonView.on( 'execute', () => {
-	editor.execute( 'command', { value: "command-value" } );
+	editor.execute( 'command', { value: 'command-value' } );
 	editor.editing.view.focus();
 } );
 ```


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Replace double quotation marks with apostrophes. Fix for #13181.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
