### PR TITLE
Model#insertContent() and Model#insertObject() should pass all parameters to the event as it would be a decorated method.

### DIFF
--- a/packages/ckeditor5-engine/src/model/model.ts
+++ b/packages/ckeditor5-engine/src/model/model.ts
@@ -384,11 +384,13 @@ export default class Model extends ObservableMixin() {
 	public insertContent(
 		content: Item | ModelDocumentFragment,
 		selectable: Node,
-		placeOrOffset: PlaceOrOffset
+		placeOrOffset: PlaceOrOffset,
+		...rest: Array<unknown>
 	): ModelRange;
 	public insertContent(
 		content: Item | ModelDocumentFragment,
-		selectable?: Exclude<Selectable, Node>
+		selectable?: Exclude<Selectable, Node>,
+		...rest: Array<unknown>
 	): ModelRange;
 
 	/**
@@ -536,11 +538,13 @@ export default class Model extends ObservableMixin() {
 	public insertContent(
 		content: Item | ModelDocumentFragment,
 		selectable?: Selectable,
-		placeOrOffset?: PlaceOrOffset
+		placeOrOffset?: PlaceOrOffset,
+		...rest: Array<unknown>
 	): ModelRange {
 		const selection = normalizeSelectable( selectable, placeOrOffset );
 
-		return this.fire<ModelInsertContentEvent>( 'insertContent', [ content, selection ] )!;
+		// Passing all call arguments so it acts like decorated method.
+		return this.fire<ModelInsertContentEvent>( 'insertContent', [ content, selection, placeOrOffset, ...rest ] )!;
 	}
 
 	public insertObject(
@@ -550,7 +554,8 @@ export default class Model extends ObservableMixin() {
 		options?: {
 			findOptimalPosition?: 'auto' | 'before' | 'after';
 			setSelection?: 'on' | 'after';
-		}
+		},
+		...rest: Array<unknown>
 	): ModelRange;
 	public insertObject(
 		object: ModelElement,
@@ -559,7 +564,8 @@ export default class Model extends ObservableMixin() {
 		options?: {
 			findOptimalPosition?: 'auto' | 'before' | 'after';
 			setSelection?: 'on' | 'after';
-		}
+		},
+		...rest: Array<unknown>
 	): ModelRange;
 
 	/**
@@ -652,12 +658,14 @@ export default class Model extends ObservableMixin() {
 		options?: {
 			findOptimalPosition?: 'auto' | 'before' | 'after';
 			setSelection?: 'on' | 'after';
-		}
+		},
+		...rest: Array<unknown>
 	): ModelRange {
 		const selection = normalizeSelectable( selectable, placeOrOffset );
 
 		// Note that options are fired as 2 arguments for backward compatibility with the decorated method.
-		return this.fire<ModelInsertObjectEvent>( 'insertObject', [ object, selection, options, options ] )!;
+		// Passing all call arguments so it acts like decorated method.
+		return this.fire<ModelInsertObjectEvent>( 'insertObject', [ object, selection, options, options, ...rest ] )!;
 	}
 
 	/**
@@ -1186,7 +1194,8 @@ export type ModelInsertContentEvent = {
 	name: 'insertContent';
 	args: [ [
 		content: Item | ModelDocumentFragment,
-		selectable?: ModelSelection | DocumentSelection
+		selectable?: ModelSelection | DocumentSelection,
+		...rest: Array<unknown>
 	] ];
 	return: ModelRange;
 };
@@ -1212,7 +1221,7 @@ export type ModelInsertObjectEvent = {
 			findOptimalPosition?: 'auto' | 'before' | 'after';
 			setSelection?: 'on' | 'after';
 		},
-		_?: unknown
+		...rest: Array<unknown>
 	] ];
 	return: ModelRange;
 };

--- a/packages/ckeditor5-engine/tests/model/model.js
+++ b/packages/ckeditor5-engine/tests/model/model.js
@@ -506,6 +506,24 @@ describe( 'Model', () => {
 			expect( spy.calledOnce ).to.be.true;
 		} );
 
+		it( 'should be decorated and pass all parameters in the event data', () => {
+			schema.extend( '$text', { allowIn: '$root' } ); // To surpress warnings.
+
+			const spy = sinon.spy();
+			const obj1 = { foo: 'bar' };
+			const obj2 = { baz: 7 };
+			const obj3 = { abc: true };
+
+			model.on( 'insertContent', spy );
+
+			model.insertContent( new ModelText( 'a' ), model.document.selection, obj1, obj2, obj3 );
+
+			expect( spy.calledOnce ).to.be.true;
+			expect( spy.firstCall.args[ 1 ][ 2 ] ).to.equal( obj1 );
+			expect( spy.firstCall.args[ 1 ][ 3 ] ).to.equal( obj2 );
+			expect( spy.firstCall.args[ 1 ][ 4 ] ).to.equal( obj3 );
+		} );
+
 		it( 'should insert content (item)', () => {
 			schema.register( 'paragraph', { inheritAllFrom: '$block' } );
 
@@ -747,6 +765,33 @@ describe( 'Model', () => {
 			expect( args[ 0 ] ).to.equal( element );
 			expect( args[ 1 ] ).to.equal( model.document.selection );
 			expect( args[ 2 ] ).to.equal( options );
+		} );
+
+		it( 'should be decorated and pass all parameters in the event data', () => {
+			const spy = sinon.spy();
+			const element = new ModelElement( 'blockWidget' );
+			const options = {
+				findOptimalPosition: 'after',
+				setSelection: 'on'
+			};
+			const obj1 = { foo: 'bar' };
+			const obj2 = { baz: 7 };
+			const obj3 = { abc: true };
+
+			model.on( 'insertObject', spy );
+
+			model.insertObject( element, model.document.selection, null, options, obj1, obj2, obj3 );
+
+			const args = spy.firstCall.args[ 1 ];
+
+			expect( spy.calledOnce ).to.be.true;
+			expect( args[ 0 ] ).to.equal( element );
+			expect( args[ 1 ] ).to.equal( model.document.selection );
+			expect( args[ 2 ] ).to.equal( options );
+			expect( args[ 3 ] ).to.equal( options );
+			expect( args[ 4 ] ).to.equal( obj1 );
+			expect( args[ 5 ] ).to.equal( obj2 );
+			expect( args[ 6 ] ).to.equal( obj3 );
 		} );
 
 		it( 'should insert inline object at the document selection position', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (engine): `Model#insertContent()` and `Model#insertObject()` should pass all parameters to the event as it would be a decorated method. Closes #13379.

---

### Additional information

