### PR TITLE
Docs: adding missing contribute links.

### DIFF
--- a/docs/features/editor-placeholder.md
+++ b/docs/features/editor-placeholder.md
@@ -80,3 +80,7 @@ The editor placeholder text is displayed using a CSS pseudo–element (`::before
 {@snippet features/placeholder-custom}
 
 **Note**: The `.ck-placeholder` class is also used to display placeholders in other places, for instance, {@link features/images-captions image captions}. Make sure your custom styles apply to the right subset of placeholders.
+
+## Contribute
+
+The source code of the feature is available on GitHub in [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-core](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-core).

--- a/docs/features/read-only.md
+++ b/docs/features/read-only.md
@@ -82,3 +82,7 @@ There are more features that help control user permissions in the WYSIWYG editor
 
 * {@link features/restricted-editing Restricted editing} &ndash; Define editable areas of the document for users with restricted editing rights.
 * {@link features/comments-only-mode Comments-only mode} &ndash; Users can add comments to any part of the content instead of editing it directly.
+
+## Contribute
+
+The source code of the feature is available on GitHub in [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-core](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-core).

--- a/docs/features/toolbar.md
+++ b/docs/features/toolbar.md
@@ -281,3 +281,7 @@ Refer to the {@link framework/guides/creating-simple-plugin-timestamp Creating a
 ## Block toolbar
 
 The {@link features/blocktoolbar BlockToolbar} feature provides an additional configurable toolbar on the left-hand side of the content area, useful when the main toolbar is not accessible (e.g. in certain {@link installation/getting-started/predefined-builds#balloon-block-editor balloon block editor} scenarios).
+
+## Contribute
+
+The source code of the feature is available on GitHub in [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-ui](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-ui).

--- a/docs/features/ui-language.md
+++ b/docs/features/ui-language.md
@@ -351,3 +351,7 @@ ClassicEditor
 There are other CKEditor 5 features that will help you control the content language:
 
 * {@link features/language Text part Language}  &ndash; Set the language of the selected content part to support multilingual texts.
+
+## Contribute
+
+The source code of the feature is available on GitHub in [https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-translations](https://github.com/ckeditor/ckeditor5-dev/tree/master/packages/ckeditor5-dev-translations).

--- a/packages/ckeditor5-clipboard/docs/features/drag-drop.md
+++ b/packages/ckeditor5-clipboard/docs/features/drag-drop.md
@@ -67,3 +67,6 @@ The {@link module:clipboard/dragdrop~DragDrop `DragDrop`} plugin will activate a
 
 At the moment, the drag and drop feature supports textual content as well as widgets. Bringing support for any types of blocks is tracked in [issue #7731](https://github.com/ckeditor/ckeditor5/issues/7731). If you  would like to see this feature implemented, make sure you add a 👍 &nbsp; to the issue on GitHub.
 
+## Contribute
+
+The source code of the feature is available on GitHub in [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-clipboard](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-clipboard).

--- a/packages/ckeditor5-clipboard/docs/features/paste-plain-text.md
+++ b/packages/ckeditor5-clipboard/docs/features/paste-plain-text.md
@@ -73,3 +73,7 @@ If you think that support for any of the applications needs improvements, please
 * [Support pasting from Pages](https://github.com/ckeditor/ckeditor5/issues/2527).
 
 Feel free to open a [new feature request](https://github.com/ckeditor/ckeditor5/issues/new/choose) for other similar applications, too!
+
+## Contribute
+
+The source code of the feature is available on GitHub in [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-clipboard](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-clipboard).

--- a/packages/ckeditor5-minimap/docs/features/minimap.md
+++ b/packages/ckeditor5-minimap/docs/features/minimap.md
@@ -193,3 +193,7 @@ The minimap feature uses `<iframe>` internally. For a proper look and operation,
 <info-box>
 	We recommend using the official {@link framework/guides/development-tools#ckeditor-5-inspector CKEditor 5 inspector} for development and debugging. It will give you tons of useful information about the state of the editor such as internal data structures, selection, commands, and many more.
 </info-box>
+
+## Contribute
+
+The source code of the feature is available on GitHub in [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-minimap](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-minimap).

--- a/packages/ckeditor5-paste-from-office/docs/features/paste-from-google-docs.md
+++ b/packages/ckeditor5-paste-from-office/docs/features/paste-from-google-docs.md
@@ -90,3 +90,6 @@ If you think that support for any of the applications needs improvements, please
 
 Feel free to open a [new feature request](https://github.com/ckeditor/ckeditor5/issues/new/choose) for other similar applications, too!
 
+## Contribute
+
+The source code of the feature is available on GitHub in [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-paste-from-office](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-paste-from-office).

--- a/packages/ckeditor5-paste-from-office/docs/features/paste-from-word.md
+++ b/packages/ckeditor5-paste-from-office/docs/features/paste-from-word.md
@@ -97,3 +97,7 @@ If the pasted document contains both images and styled text (e.g. headings), it 
 It is advised to try and paste the image separately from the body of the text if this error occurs.
 
 If the image is represented in the Word content by the VML syntax (like this one: `<v:shape><v:imagedata src="...."/></v:shape>`), it will not be pasted either as this notation is not supported by CKEditor 5. If you'd like to see this feature implemented, add a 👍&nbsp; reaction to [this GitHub issue](https://github.com/ckeditor/ckeditor5/issues/9245).
+
+## Contribute
+
+The source code of the feature is available on GitHub in [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-paste-from-office](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-paste-from-office).

--- a/packages/ckeditor5-undo/docs/features/undo-redo.md
+++ b/packages/ckeditor5-undo/docs/features/undo-redo.md
@@ -87,8 +87,10 @@ The `UndoEditing` feature registers the following commands:
 
 The {@link module:undo/undoui~UndoUI} feature introduces the `undo` and `redo` buttons to the editor toolbar.
 
-
-
 <info-box>
 	We recommend using the official {@link framework/guides/development-tools#ckeditor-5-inspector CKEditor 5 inspector} for development and debugging. It will give you tons of useful information about the state of the editor such as internal data structures, selection, commands, and many more.
 </info-box>
+
+## Contribute
+
+The source code of the feature is available on GitHub in [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-undo](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-undo).


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: adding missing contribute links. Closes cksource/ckeditor5-internal#2672

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._