### PR TITLE
Re-export some view types. Add `DOM.Iterable` to TS config.

### DIFF
--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -17,6 +17,7 @@ export { default as DataController, type DataControllerSetEvent } from './contro
 export { default as Conversion } from './conversion/conversion';
 export type {
 	default as DowncastDispatcher,
+	DowncastAddMarkerEvent,
 	DowncastAttributeEvent,
 	DowncastConversionApi,
 	DowncastInsertEvent,
@@ -156,6 +157,7 @@ export type {
 	ViewDocumentMouseOutEvent
 } from './view/observer/mouseobserver';
 export type { ViewDocumentTabEvent } from './view/observer/tabobserver';
+export type { ViewRenderEvent } from './view/view';
 
 // View / Styles.
 export { StylesProcessor } from './view/stylesmap';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": [
-      "DOM"
+      "DOM", "DOM.Iterable"
     ],
     "noImplicitAny": true,
     "noImplicitOverride": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "lib": [
-      "DOM", "DOM.Iterable"
+      "DOM", 
+      "DOM.Iterable"
     ],
     "noImplicitAny": true,
     "noImplicitOverride": true,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (engine): Added `DowncastAddMarkerEvent` and `ViewRenderEvent` types to the package exports.

Internal: Added `DOM.Iterable` library to known type definitions in TypeScript configuration.

---

### Additional information

The `DOM.Iterable` adds `[Symbol.iterator]()` for allowed DOM types. Therefore, the following code is not reported as incorrect by TypeScript:

```ts
const editor = this.editor;
const view = editor.editing.view;
const domRoot = view.getDomRoot()!;

const classes = [
    'ck-foo',
    'ck-bar',

    // Clone all editing root classes.
    ...domRoot.classList
];
```