### PR TITLE
Clean-up docs for `ckeditor5-paragraph`

### DIFF
--- a/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
+++ b/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
@@ -14,27 +14,26 @@ import type { Element, Position } from '@ckeditor/ckeditor5-engine';
  * The insert paragraph command. It inserts a new paragraph at a specific
  * {@link module:engine/model/position~Position document position}.
  *
- *		// Insert a new paragraph before an element in the document.
- *		editor.execute( 'insertParagraph', {
- *			position: editor.model.createPositionBefore( element )
- *		} );
+ * ```ts
+ * // Insert a new paragraph before an element in the document.
+ * editor.execute( 'insertParagraph', {
+ *   position: editor.model.createPositionBefore( element )
+ * } );
+ * ```
  *
  * If a paragraph is disallowed in the context of the specific position, the command
  * will attempt to split position ancestors to find a place where it is possible
  * to insert a paragraph.
  *
  * **Note**: This command moves the selection to the inserted paragraph.
- *
- * @extends module:core/command~Command
  */
 export default class InsertParagraphCommand extends Command {
 	/**
 	 * Executes the command.
 	 *
-	 * @param {Object} options Options for the executed command.
-	 * @param {module:engine/model/position~Position} options.position The model position at which
-	 * the new paragraph will be inserted.
-	 * @param {Object} attributes Attributes keys and values to set on a inserted paragraph
+	 * @param options Options for the executed command.
+	 * @param options.position The model position at which the new paragraph will be inserted.
+	 * @param options.attributes Attributes keys and values to set on a inserted paragraph.
 	 * @fires execute
 	 */
 	public override execute( options: {

--- a/packages/ckeditor5-paragraph/src/paragraph.ts
+++ b/packages/ckeditor5-paragraph/src/paragraph.ts
@@ -23,8 +23,6 @@ import { Plugin } from '@ckeditor/ckeditor5-core';
  * blocks in the model selection into paragraphs.
  * * The {@link module:paragraph/insertparagraphcommand~InsertParagraphCommand `'insertParagraph'`} command
  * that inserts a new paragraph at a specified location in the model.
- *
- * @extends module:core/plugin~Plugin
  */
 export default class Paragraph extends Plugin {
 	/**
@@ -72,33 +70,35 @@ export default class Paragraph extends Plugin {
 	 * A list of element names which should be treated by the autoparagraphing algorithms as
 	 * paragraph-like. This means that e.g. the following content:
 	 *
-	 *		<h1>Foo</h1>
-	*		<table>
-	*			<tr>
-	*				<td>X</td>
-	*				<td>
-	*					<ul>
-	*						<li>Y</li>
-	*						<li>Z</li>
-	*					</ul>
-	*				</td>
-	*			</tr>
-	*		</table>
-	*
-	* contains five paragraph-like elements: `<h1>`, two `<td>`s and two `<li>`s.
-	* Hence, if none of the features is going to convert those elements the above content will be automatically handled
-	* by the paragraph feature and converted to:
-	*
-	*		<p>Foo</p>
-	*		<p>X</p>
-	*		<p>Y</p>
-	*		<p>Z</p>
-	*
-	* Note: The `<td>` containing two `<li>` elements was ignored as the innermost paragraph-like elements
-	* have a priority upon conversion.
-	*
-	* @member {Set.<String>} module:paragraph/paragraph~Paragraph.paragraphLikeElements
-	*/
+	 * ```html
+	 * <h1>Foo</h1>
+	 * <table>
+	 *   <tr>
+	 *     <td>X</td>
+	 *     <td>
+	 *       <ul>
+	 *         <li>Y</li>
+	 *         <li>Z</li>
+	 *       </ul>
+	 *     </td>
+	 *   </tr>
+	 * </table>
+	 * ```
+	 *
+	 * contains five paragraph-like elements: `<h1>`, two `<td>`s and two `<li>`s.
+	 * Hence, if none of the features is going to convert those elements the above content will be automatically handled
+	 * by the paragraph feature and converted to:
+	 *
+	 * ```html
+	 * <p>Foo</p>
+	 * <p>X</p>
+	 * <p>Y</p>
+	 * <p>Z</p>
+	 * ```
+	 *
+	 * Note: The `<td>` containing two `<li>` elements was ignored as the innermost paragraph-like elements
+	 * have a priority upon conversion.
+	 */
 	public static paragraphLikeElements = new Set( [
 		'blockquote',
 		'dd',

--- a/packages/ckeditor5-paragraph/src/paragraphbuttonui.ts
+++ b/packages/ckeditor5-paragraph/src/paragraphbuttonui.ts
@@ -22,15 +22,15 @@ const icon = icons.paragraph;
  * This plugin is not loaded automatically by the {@link module:paragraph/paragraph~Paragraph} plugin. It must
  * be added manually.
  *
- *		ClassicEditor
- *			.create( {
- *				plugins: [ ..., Heading, Paragraph, HeadingButtonsUI, ParagraphButtonUI ]
- *				toolbar: [ 'paragraph', 'heading1', 'heading2', 'heading3' ]
- *			} )
- *			.then( ... )
- *			.catch( ... );
- *
- * @extends module:core/plugin~Plugin
+ * ```ts
+ * ClassicEditor
+ *   .create( {
+ *     plugins: [ ..., Heading, Paragraph, HeadingButtonsUI, ParagraphButtonUI ]
+ *     toolbar: [ 'paragraph', 'heading1', 'heading2', 'heading3' ]
+ *   } )
+ *   .then( ... )
+ *   .catch( ... );
+ * ```
  */
 export default class ParagraphButtonUI extends Plugin {
 	/**

--- a/packages/ckeditor5-paragraph/src/paragraphcommand.ts
+++ b/packages/ckeditor5-paragraph/src/paragraphcommand.ts
@@ -14,8 +14,6 @@ import type { Schema, Selection, DocumentSelection, Element } from '@ckeditor/ck
 
 /**
  * The paragraph command.
- *
- * @extends module:core/command~Command
  */
 export default class ParagraphCommand extends Command {
 	/**
@@ -23,7 +21,6 @@ export default class ParagraphCommand extends Command {
 	 *
 	 * @readonly
 	 * @observable
-	 * @member {Boolean} #value
 	 */
 	declare public value: boolean;
 
@@ -44,10 +41,9 @@ export default class ParagraphCommand extends Command {
 	 * will be turned to paragraphs.
 	 *
 	 * @fires execute
-	 * @param {Object} [options] Options for the executed command.
-	 * @param {module:engine/model/selection~Selection|module:engine/model/documentselection~DocumentSelection} [options.selection]
-	 * The selection that the command should be applied to.
-	 * By default, if not provided, the command is applied to the {@link module:engine/model/document~Document#selection}.
+	 * @param options Options for the executed command.
+	 * @param options.selection The selection that the command should be applied to. By default,
+	 * if not provided, the command is applied to the {@link module:engine/model/document~Document#selection}.
 	 */
 	public override execute( options: {
 		selection?: Selection | DocumentSelection;
@@ -67,13 +63,13 @@ export default class ParagraphCommand extends Command {
 	}
 }
 
-// Checks whether the given block can be replaced by a paragraph.
-//
-// @private
-// @param {module:engine/model/element~Element} block A block to be tested.
-// @param {module:engine/model/schema~Schema} schema The schema of the document.
-// @returns {Boolean}
-function checkCanBecomeParagraph( block: Element, schema: Schema ) {
+/**
+ * Checks whether the given block can be replaced by a paragraph.
+ *
+ * @param block A block to be tested.
+ * @param schema The schema of the document.
+ */
+function checkCanBecomeParagraph( block: Element, schema: Schema ): boolean {
 	return schema.checkChild( block.parent as Element, 'paragraph' ) && !schema.isObject( block );
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (paragraph): Clean-up docs for `ckeditor5-paragraph`. Closes #12703.
