### PR TITLE
Normalized path to classic editor sources for Windows to use slashes instead of backslashes

### DIFF
--- a/scripts/docs/build-content-styles.js
+++ b/scripts/docs/build-content-styles.js
@@ -303,7 +303,8 @@ function generateCKEditor5Source( ckeditor5Modules, cwd ) {
 		return { modulePath, pluginName };
 	} );
 
-	const classicEditorImportPath = path.join( cwd, 'node_modules', '@ckeditor', 'ckeditor5-editor-classic', 'src', 'classiceditor' );
+	const classicEditorImportPath = path.join( cwd, 'node_modules', '@ckeditor', 'ckeditor5-editor-classic', 'src', 'classiceditor' )
+		.replace( /\\/g, '/' );
 
 	const sourceFileContent = [
 		'/**',

--- a/scripts/docs/build-content-styles.js
+++ b/scripts/docs/build-content-styles.js
@@ -303,8 +303,7 @@ function generateCKEditor5Source( ckeditor5Modules, cwd ) {
 		return { modulePath, pluginName };
 	} );
 
-	const classicEditorImportPath = path.join( cwd, 'node_modules', '@ckeditor', 'ckeditor5-editor-classic', 'src', 'classiceditor' )
-		.replace( /\\/g, '/' );
+	const classicEditorImportPath = path.join( cwd, 'node_modules', '@ckeditor', 'ckeditor5-editor-classic', 'src', 'classiceditor' );
 
 	const sourceFileContent = [
 		'/**',
@@ -313,7 +312,7 @@ function generateCKEditor5Source( ckeditor5Modules, cwd ) {
 		' */',
 		'',
 		'// The editor creator to use.',
-		`import ClassicEditorBase from '${ classicEditorImportPath }';`,
+		`import ClassicEditorBase from '${ normalizePath( classicEditorImportPath ) }';`,
 		''
 	];
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Normalized path to classic editor sources for content styles to always use slashes instead of backslashes. Otherwise, generating content styles will end with an error on Windows.
