### PR TITLE
Clean-up docs for `ckeditor5-undo`

### DIFF
--- a/packages/ckeditor5-undo/src/basecommand.ts
+++ b/packages/ckeditor5-undo/src/basecommand.ts
@@ -27,21 +27,18 @@ export default abstract class BaseCommand extends Command {
 	 * * {@link module:engine/model/batch~Batch batch} saved by the command,
 	 * * {@link module:engine/model/selection~Selection selection} state at the moment of saving the batch.
 	 */
-	protected _stack: Array<{ batch: Batch; selection: { ranges: Array<Range>; isBackward: boolean } }>;
+	protected _stack: Array<{ batch: Batch; selection: { ranges: Array<Range>; isBackward: boolean } }> = [];
 
 	/**
 	 * Stores all batches that were created by this command.
 	 */
-	protected _createdBatches: WeakSet<Batch>;
+	protected _createdBatches = new WeakSet<Batch>();
 
 	/**
 	 * @inheritDoc
 	 */
 	constructor( editor: Editor ) {
 		super( editor );
-
-		this._stack = [];
-		this._createdBatches = new WeakSet();
 
 		// Refresh state, so the command is inactive right after initialization.
 		this.refresh();

--- a/packages/ckeditor5-undo/src/basecommand.ts
+++ b/packages/ckeditor5-undo/src/basecommand.ts
@@ -19,38 +19,28 @@ import {
 
 /**
  * Base class for the undo feature commands: {@link module:undo/undocommand~UndoCommand} and {@link module:undo/redocommand~RedoCommand}.
- *
- * @protected
- * @extends module:core/command~Command
  */
 export default abstract class BaseCommand extends Command {
+	/**
+	 * Stack of items stored by the command. These are pairs of:
+	 *
+	 * * {@link module:engine/model/batch~Batch batch} saved by the command,
+	 * * {@link module:engine/model/selection~Selection selection} state at the moment of saving the batch.
+	 */
 	protected _stack: Array<{ batch: Batch; selection: { ranges: Array<Range>; isBackward: boolean } }>;
 
 	/**
-	 * @internal
+	 * Stores all batches that were created by this command.
 	 */
-	public _createdBatches: WeakSet<Batch>;
+	protected _createdBatches: WeakSet<Batch>;
 
+	/**
+	 * @inheritDoc
+	 */
 	constructor( editor: Editor ) {
 		super( editor );
 
-		/**
-		 * Stack of items stored by the command. These are pairs of:
-		 *
-		 * * {@link module:engine/model/batch~Batch batch} saved by the command,
-		 * * {@link module:engine/model/selection~Selection selection} state at the moment of saving the batch.
-		 *
-		 * @protected
-		 * @member {Array} #_stack
-		 */
 		this._stack = [];
-
-		/**
-		 * Stores all batches that were created by this command.
-		 *
-		 * @protected
-		 * @member {WeakSet.<module:engine/model/batch~Batch>} #_createdBatches
-		 */
 		this._createdBatches = new WeakSet();
 
 		// Refresh state, so the command is inactive right after initialization.
@@ -91,10 +81,17 @@ export default abstract class BaseCommand extends Command {
 	}
 
 	/**
+	 * Returns all batches created by this command.
+	 */
+	public get createdBatches(): WeakSet<Batch> {
+		return this._createdBatches;
+	}
+
+	/**
 	 * Stores a batch in the command, together with the selection state of the {@link module:engine/model/document~Document document}
 	 * created by the editor which this command is registered to.
 	 *
-	 * @param {module:engine/model/batch~Batch} batch The batch to add.
+	 * @param batch The batch to add.
 	 */
 	public addBatch( batch: Batch ): void {
 		const docSelection = this.editor.model.document.selection;
@@ -119,11 +116,9 @@ export default abstract class BaseCommand extends Command {
 	/**
 	 * Restores the {@link module:engine/model/document~Document#selection document selection} state after a batch was undone.
 	 *
-	 * @protected
-	 * @param {Array.<module:engine/model/range~Range>} ranges Ranges to be restored.
-	 * @param {Boolean} isBackward A flag describing whether the restored range was selected forward or backward.
-	 * @param {Array.<module:engine/model/operation/operation~Operation>} operations Operations which has been applied
-	 * since selection has been stored.
+	 * @param ranges Ranges to be restored.
+	 * @param isBackward A flag describing whether the restored range was selected forward or backward.
+	 * @param operations Operations which has been applied since selection has been stored.
 	 */
 	protected _restoreSelection(
 		ranges: Array<Range>,
@@ -175,9 +170,8 @@ export default abstract class BaseCommand extends Command {
 	 * Undoes a batch by reversing that batch, transforming reversed batch and finally applying it.
 	 * This is a helper method for {@link #execute}.
 	 *
-	 * @protected
-	 * @param {module:engine/model/batch~Batch} batchToUndo The batch to be undone.
-	 * @param {module:engine/model/batch~Batch} undoingBatch The batch that will contain undoing changes.
+	 * @param batchToUndo The batch to be undone.
+	 * @param undoingBatch The batch that will contain undoing changes.
 	 */
 	protected _undo( batchToUndo: Batch, undoingBatch: Batch ): void {
 		const model = this.editor.model;
@@ -220,11 +214,12 @@ export default abstract class BaseCommand extends Command {
 	}
 }
 
-// Normalizes list of ranges by joining intersecting or "touching" ranges.
-//
-// @param {Array.<module:engine/model/range~Range>} ranges
-//
-function normalizeRanges( ranges: Array<Range> ) {
+/**
+ * Normalizes list of ranges by joining intersecting or "touching" ranges.
+ *
+ * @param ranges Ranges to be normalized.
+ */
+function normalizeRanges( ranges: Array<Range> ): void {
 	ranges.sort( ( a, b ) => a.start.isBefore( b.start ) ? -1 : 1 );
 
 	for ( let i = 1; i < ranges.length; i++ ) {
@@ -239,6 +234,6 @@ function normalizeRanges( ranges: Array<Range> ) {
 	}
 }
 
-function isRangeContainedByAnyOtherRange( range: Range, ranges: Array<Range> ) {
+function isRangeContainedByAnyOtherRange( range: Range, ranges: Array<Range> ): boolean {
 	return ranges.some( otherRange => otherRange !== range && otherRange.containsRange( range, true ) );
 }

--- a/packages/ckeditor5-undo/src/redocommand.ts
+++ b/packages/ckeditor5-undo/src/redocommand.ts
@@ -16,8 +16,6 @@ import BaseCommand from './basecommand';
  * {@link module:engine/model/document~Document#history history} that happened after the reversed undo batch.
  *
  * The redo command also takes care of restoring the {@link module:engine/model/document~Document#selection document selection}.
- *
- * @extends module:undo/basecommand~BaseCommand
  */
 export default class RedoCommand extends BaseCommand {
 	/**

--- a/packages/ckeditor5-undo/src/undo.ts
+++ b/packages/ckeditor5-undo/src/undo.ts
@@ -28,15 +28,17 @@ import UndoUI from './undoui';
  *
  * After changes happen to the document, the `History` and `UndoCommand` stack can be represented as follows:
  *
- *		    History                            Undo stack
- *		==============             ==================================
- *		[operation A1]                         [batch A]
- *		[operation B1]                         [batch B]
- *		[operation B2]                         [batch C]
- *		[operation C1]
- *		[operation C2]
- *		[operation B3]
- *		[operation C3]
+ * ```
+ *    History                            Undo stack
+ * ==============             ==================================
+ * [operation A1]                      [  batch A  ]
+ * [operation B1]                      [  batch B  ]
+ * [operation B2]                      [  batch C  ]
+ * [operation C1]
+ * [operation C2]
+ * [operation B3]
+ * [operation C3]
+ * ```
  *
  * Where operations starting with the same letter are from same batch.
  *
@@ -50,33 +52,37 @@ import UndoUI from './undoui';
  * one needs to make sure if they are ready to be applied. In the scenario above, operation `C3` is the last operation and `C3r`
  * bases on up-to-date document state, so it can be applied to the document.
  *
- *		     History                             Undo stack
- *		=================             ==================================
- *		[ operation A1  ]                      [  batch A  ]
- *		[ operation B1  ]                      [  batch B  ]
- *		[ operation B2  ]             [   processing undoing batch C   ]
- *		[ operation C1  ]
- *		[ operation C2  ]
- *		[ operation B3  ]
- *		[ operation C3  ]
- *		[ operation C3r ]
+ * ```
+ *      History                             Undo stack
+ * =================             ==================================
+ * [ operation A1  ]                      [  batch A  ]
+ * [ operation B1  ]                      [  batch B  ]
+ * [ operation B2  ]             [   processing undoing batch C   ]
+ * [ operation C1  ]
+ * [ operation C2  ]
+ * [ operation B3  ]
+ * [ operation C3  ]
+ * [ operation C3r ]
+ * ```
  *
  * Next is operation `C2`, reversed to `C2r`. `C2r` bases on `C2`, so it bases on the wrong document state. It needs to be
  * transformed by operations from history that happened after it, so it "knows" about them. Let us assume that `C2' = C2r * B3 * C3 * C3r`,
  * where `*` means "transformed by". Rest of operations from that batch are processed in the same fashion.
  *
- *		     History                             Undo stack                                      Redo stack
- *		=================             ==================================             ==================================
- *		[ operation A1  ]                      [  batch A  ]                                    [ batch Cr ]
- *		[ operation B1  ]                      [  batch B  ]
- *		[ operation B2  ]
- *		[ operation C1  ]
- *		[ operation C2  ]
- *		[ operation B3  ]
- *		[ operation C3  ]
- *		[ operation C3r ]
- *		[ operation C2' ]
- *		[ operation C1' ]
+ * ```
+ *      History                             Undo stack                                      Redo stack
+ * =================             ==================================             ==================================
+ * [ operation A1  ]                      [  batch A  ]                                    [ batch Cr ]
+ * [ operation B1  ]                      [  batch B  ]
+ * [ operation B2  ]
+ * [ operation C1  ]
+ * [ operation C2  ]
+ * [ operation B3  ]
+ * [ operation C3  ]
+ * [ operation C3r ]
+ * [ operation C2' ]
+ * [ operation C1' ]
+ * ```
  *
  * Selective undo works on the same basis, however, instead of undoing the last batch in the undo stack, any batch can be undone.
  * The same algorithm applies: operations from a batch (i.e. `A1`) are reversed and then transformed by operations stored in history.
@@ -84,23 +90,23 @@ import UndoUI from './undoui';
  * Redo also is very similar to undo. It has its own stack that is filled with undoing (reversed batches). Operations from
  * the batch that is re-done are reversed-back, transformed in proper order and applied to the document.
  *
- *		     History                             Undo stack                                      Redo stack
- *		=================             ==================================             ==================================
- *		[ operation A1  ]                      [  batch A  ]
- *		[ operation B1  ]                      [  batch B  ]
- *		[ operation B2  ]                      [ batch Crr ]
- *		[ operation C1  ]
- *		[ operation C2  ]
- *		[ operation B3  ]
- *		[ operation C3  ]
- *		[ operation C3r ]
- *		[ operation C2' ]
- *		[ operation C1' ]
- *		[ operation C1'r]
- *		[ operation C2'r]
- *		[ operation C3rr]
- *
- * @extends module:core/plugin~Plugin
+ * ```
+ *      History                             Undo stack                                      Redo stack
+ * =================             ==================================             ==================================
+ * [ operation A1  ]                      [  batch A  ]
+ * [ operation B1  ]                      [  batch B  ]
+ * [ operation B2  ]                      [ batch Crr ]
+ * [ operation C1  ]
+ * [ operation C2  ]
+ * [ operation B3  ]
+ * [ operation C3  ]
+ * [ operation C3r ]
+ * [ operation C2' ]
+ * [ operation C1' ]
+ * [ operation C1'r]
+ * [ operation C2'r]
+ * [ operation C3rr]
+ * ```
  */
 export default class Undo extends Plugin {
 	/**

--- a/packages/ckeditor5-undo/src/undocommand.ts
+++ b/packages/ckeditor5-undo/src/undocommand.ts
@@ -16,8 +16,6 @@ import type { Batch } from '@ckeditor/ckeditor5-engine';
  * batches from {@link module:engine/model/document~Document#history history} that happened after the reversed batch.
  *
  * The undo command also takes care of restoring the {@link module:engine/model/document~Document#selection document selection}.
- *
- * @extends module:undo/basecommand~BaseCommand
  */
 export default class UndoCommand extends BaseCommand {
 	/**
@@ -27,7 +25,7 @@ export default class UndoCommand extends BaseCommand {
 	 *
 	 * @fires execute
 	 * @fires revert
-	 * @param {module:engine/model/batch~Batch} [batch] A batch that should be undone. If not set, the last added batch will be undone.
+	 * @param batch A batch that should be undone. If not set, the last added batch will be undone.
 	 */
 	public override execute( batch: Batch | null = null ): void {
 		// If batch is not given, set `batchIndex` to the last index in command stack.
@@ -54,7 +52,7 @@ export default class UndoCommand extends BaseCommand {
 /**
  * Fired when execution of the command reverts some batch.
  *
- * @event revert
+ * @eventName revert
  */
 export type UndoCommandRevertEvent = {
 	name: 'revert';

--- a/packages/ckeditor5-undo/src/undoediting.ts
+++ b/packages/ckeditor5-undo/src/undoediting.ts
@@ -21,12 +21,23 @@ import type {
  * The undo engine feature.
  *
  * It introduces the `'undo'` and `'redo'` commands to the editor.
- *
- * @extends module:core/plugin~Plugin
  */
 export default class UndoEditing extends Plugin {
+	/**
+	 * The command that manages the undo {@link module:engine/model/batch~Batch batches} stack (history).
+	 * Created and registered during the {@link #init feature initialization}.
+	 */
 	private _undoCommand!: UndoCommand;
+
+	/**
+	 * The command that manages the redo {@link module:engine/model/batch~Batch batches} stack (history).
+	 * Created and registered during the {@link #init feature initialization}.
+	 */
 	private _redoCommand!: RedoCommand;
+
+	/**
+	 * Keeps track of which batches were registered in undo.
+	 */
 	private _batchRegistry: WeakSet<Batch>;
 
 	/**
@@ -42,28 +53,6 @@ export default class UndoEditing extends Plugin {
 	constructor( editor: Editor ) {
 		super( editor );
 
-		/**
-		 * The command that manages the undo {@link module:engine/model/batch~Batch batches} stack (history).
-		 * Created and registered during the {@link #init feature initialization}.
-		 *
-		 * @private
-		 * @member {module:undo/undocommand~UndoCommand} #_undoCommand
-		 */
-
-		/**
-		 * The command that manages the redo {@link module:engine/model/batch~Batch batches} stack (history).
-		 * Created and registered during the {@link #init feature initialization}.
-		 *
-		 * @private
-		 * @member {module:undo/undocommand~UndoCommand} #_redoCommand
-		 */
-
-		/**
-		 * Keeps track of which batches were registered in undo.
-		 *
-		 * @private
-		 * @member {WeakSet.<module:engine/model/batch~Batch>}
-		 */
 		this._batchRegistry = new WeakSet();
 	}
 
@@ -95,8 +84,8 @@ export default class UndoEditing extends Plugin {
 
 			const batch = operation.batch!;
 
-			const isRedoBatch = this._redoCommand._createdBatches.has( batch );
-			const isUndoBatch = this._undoCommand._createdBatches.has( batch );
+			const isRedoBatch = this._redoCommand.createdBatches.has( batch );
+			const isUndoBatch = this._undoCommand.createdBatches.has( batch );
 			const wasProcessed = this._batchRegistry.has( batch );
 
 			// Skip the batch if it was already processed.

--- a/packages/ckeditor5-undo/src/undoediting.ts
+++ b/packages/ckeditor5-undo/src/undoediting.ts
@@ -38,22 +38,13 @@ export default class UndoEditing extends Plugin {
 	/**
 	 * Keeps track of which batches were registered in undo.
 	 */
-	private _batchRegistry: WeakSet<Batch>;
+	private _batchRegistry = new WeakSet<Batch>();
 
 	/**
 	 * @inheritDoc
 	 */
 	public static get pluginName(): 'UndoEditing' {
 		return 'UndoEditing';
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	constructor( editor: Editor ) {
-		super( editor );
-
-		this._batchRegistry = new WeakSet();
 	}
 
 	/**

--- a/packages/ckeditor5-undo/src/undoui.ts
+++ b/packages/ckeditor5-undo/src/undoui.ts
@@ -15,8 +15,6 @@ import redoIcon from '../theme/icons/redo.svg';
 
 /**
  * The undo UI feature. It introduces the `'undo'` and `'redo'` buttons to the editor.
- *
- * @extends module:core/plugin~Plugin
  */
 export default class UndoUI extends Plugin {
 	/**
@@ -44,11 +42,10 @@ export default class UndoUI extends Plugin {
 	/**
 	 * Creates a button for the specified command.
 	 *
-	 * @private
-	 * @param {String} name Command name.
-	 * @param {String} label Button label.
-	 * @param {String} keystroke Command keystroke.
-	 * @param {String} Icon Source of the icon.
+	 * @param name Command name.
+	 * @param label Button label.
+	 * @param keystroke Command keystroke.
+	 * @param Icon Source of the icon.
 	 */
 	private _addButton( name: 'undo' | 'redo', label: string, keystroke: string, Icon: string ) {
 		const editor = this.editor;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal (undo): Clean-up docs for `ckeditor5-undo`. Closes #12707 .
