### PR TITLE
Ck/12705 cleanup docs for typing

### DIFF
--- a/packages/ckeditor5-typing/src/delete.ts
+++ b/packages/ckeditor5-typing/src/delete.ts
@@ -14,15 +14,10 @@ import DeleteObserver, { type ViewDocumentDeleteEvent } from './deleteobserver';
 /**
  * The delete and backspace feature. Handles keys such as <kbd>Delete</kbd> and <kbd>Backspace</kbd>, other
  * keystrokes and user actions that result in deleting content in the editor.
- *
- * @extends module:core/plugin~Plugin
  */
 export default class Delete extends Plugin {
 	/**
 	 * Whether pressing backspace should trigger undo action
-	 *
-	 * @private
-	 * @member {Boolean} #_undoOnBackspace
 	 */
 	private _undoOnBackspace!: boolean;
 

--- a/packages/ckeditor5-typing/src/deletecommand.ts
+++ b/packages/ckeditor5-typing/src/deletecommand.ts
@@ -19,47 +19,34 @@ import './typingconfig';
 /**
  * The delete command. Used by the {@link module:typing/delete~Delete delete feature} to handle the <kbd>Delete</kbd> and
  * <kbd>Backspace</kbd> keys.
- *
- * @extends module:core/command~Command
  */
 export default class DeleteCommand extends Command {
+	/**
+	 * The directionality of the delete describing in what direction it should
+	 * consume the content when the selection is collapsed.
+	 */
 	public readonly direction: 'forward' | 'backward';
 
+	/**
+	 * Delete's change buffer used to group subsequent changes into batches.
+	 */
 	private readonly _buffer: ChangeBuffer;
 
 	/**
 	 * Creates an instance of the command.
 	 *
-	 * @param {module:core/editor/editor~Editor} editor
-	 * @param {'forward'|'backward'} direction The directionality of the delete describing in what direction it
+	 * @param direction The directionality of the delete describing in what direction it
 	 * should consume the content when the selection is collapsed.
 	 */
 	constructor( editor: Editor, direction: 'forward' | 'backward' ) {
 		super( editor );
 
-		/**
-		 * The directionality of the delete describing in what direction it should
-		 * consume the content when the selection is collapsed.
-		 *
-		 * @readonly
-		 * @member {'forward'|'backward'} #direction
-		 */
 		this.direction = direction;
-
-		/**
-		 * Delete's change buffer used to group subsequent changes into batches.
-		 *
-		 * @readonly
-		 * @private
-		 * @type {module:typing/utils/changebuffer~ChangeBuffer}
-		 */
 		this._buffer = new ChangeBuffer( editor.model, editor.config.get( 'typing.undoStep' ) );
 	}
 
 	/**
 	 * The current change buffer.
-	 *
-	 * @type {module:typing/utils/changebuffer~ChangeBuffer}
 	 */
 	public get buffer(): ChangeBuffer {
 		return this._buffer;
@@ -70,13 +57,11 @@ export default class DeleteCommand extends Command {
 	 * or a piece of content in the {@link #direction defined direction}.
 	 *
 	 * @fires execute
-	 * @param {Object} [options] The command options.
-	 * @param {'character'|'codePoint'|'word'} [options.unit='character']
-	 * See {@link module:engine/model/utils/modifyselection~modifySelection}'s options.
-	 * @param {Number} [options.sequence=1] A number describing which subsequent delete event it is without the key being released.
+	 * @param options The command options.
+	 * @param options.unit See {@link module:engine/model/utils/modifyselection~modifySelection}'s options.
+	 * @param options.sequence A number describing which subsequent delete event it is without the key being released.
 	 * See the {@link module:engine/view/document~Document#event:delete} event data.
-	 * @param {module:engine/model/selection~Selection} [options.selection] Selection to remove. If not set, current model selection
-	 * will be used.
+	 * @param options.selection Selection to remove. If not set, current model selection will be used.
 	 */
 	public override execute( options: {
 		unit?: 'character' | 'codePoint' | 'word';
@@ -170,9 +155,7 @@ export default class DeleteCommand extends Command {
 	 *
 	 * See https://github.com/ckeditor/ckeditor5-typing/issues/61.
 	 *
-	 * @private
-	 * @param {Number} sequence A number describing which subsequent delete event it is without the key being released.
-	 * @returns {Boolean}
+	 * @param sequence A number describing which subsequent delete event it is without the key being released.
 	 */
 	private _shouldEntireContentBeReplacedWithParagraph( sequence: number ): boolean {
 		// Does nothing if user pressed and held the "Backspace" or "Delete" key.
@@ -212,8 +195,7 @@ export default class DeleteCommand extends Command {
 	/**
 	 * The entire content is replaced with the paragraph. Selection is moved inside the paragraph.
 	 *
-	 * @private
-	 * @param {module:engine/model/writer~Writer} writer The model writer.
+	 * @param writer The model writer.
 	 */
 	private _replaceEntireContentWithParagraph( writer: Writer ): void {
 		const model = this.editor.model;
@@ -232,10 +214,8 @@ export default class DeleteCommand extends Command {
 	 * Checks if the selection is inside an empty element that is the first child of the limit element
 	 * and should be replaced with a paragraph.
 	 *
-	 * @private
-	 * @param {module:engine/model/selection~Selection} selection The selection.
-	 * @param {Number} sequence A number describing which subsequent delete event it is without the key being released.
-	 * @returns {Boolean}
+	 * @param selection The selection.
+	 * @param sequence A number describing which subsequent delete event it is without the key being released.
 	 */
 	private _shouldReplaceFirstBlockWithParagraph( selection: Selection, sequence: number ): boolean {
 		const model = this.editor.model;

--- a/packages/ckeditor5-typing/src/deleteobserver.ts
+++ b/packages/ckeditor5-typing/src/deleteobserver.ts
@@ -119,8 +119,6 @@ const DELETE_EVENT_TYPES: Record<string, DeleteEventSpec> = {
 
 /**
  * Delete observer introduces the {@link module:engine/view/document~Document#event:delete} event.
- *
- * @extends module:engine/view/observer/observer~Observer
  */
 export default class DeleteObserver extends Observer {
 	/**
@@ -217,15 +215,8 @@ export default class DeleteObserver extends Observer {
  * Note: This event is fired by the {@link module:typing/deleteobserver~DeleteObserver delete observer}
  * (usually registered by the {@link module:typing/delete~Delete delete feature}).
  *
- * @event module:engine/view/document~Document#event:delete
- * @param {module:engine/view/observer/domeventdata~DomEventData} data
- * @param {'forward'|'backward'} data.direction The direction in which the deletion should happen.
- * @param {'character'|'word'|'codePoint'|'selection'} data.unit The "amount" of content that should be deleted.
- * @param {Number} data.sequence A number describing which subsequent delete event it is without the key being released.
- * If it's 2 or more it means that the key was pressed and hold.
- * @param {module:engine/view/selection~Selection} [data.selectionToRemove] View selection which content should be removed. If not set,
- * current selection should be used.
- * @param {String} data.inputType The `beforeinput` event type that caused the deletion.
+ * @eventName delete
+ * @param data The event data.
  */
 export type ViewDocumentDeleteEvent = BubblingEvent<{
 	name: 'delete';
@@ -233,13 +224,33 @@ export type ViewDocumentDeleteEvent = BubblingEvent<{
 }>;
 
 export interface DeleteEventData extends DomEventData<InputEvent> {
+
+	/**
+	 * The direction in which the deletion should happen.
+	 */
 	direction: 'backward' | 'forward';
+
+	/**
+	 * The "amount" of content that should be deleted.
+	 */
 	unit: 'selection' | 'codePoint' | 'character' | 'word';
+
+	/**
+	 * A number describing which subsequent delete event it is without the key being released.
+	 * If it's 2 or more it means that the key was pressed and hold.
+	 */
 	sequence: number;
+
+	/**
+	 * View selection which content should be removed. If not set,
+	 * current selection should be used.
+	 */
 	selectionToRemove?: ViewSelection | ViewDocumentSelection;
 }
 
-// Enables workaround for the issue https://github.com/ckeditor/ckeditor5/issues/11904.
+/**
+ * Enables workaround for the issue https://github.com/ckeditor/ckeditor5/issues/11904.
+ */
 function enableChromeWorkaround( observer: DeleteObserver ) {
 	const view = observer.view;
 	const document = view.document;

--- a/packages/ckeditor5-typing/src/input.ts
+++ b/packages/ckeditor5-typing/src/input.ts
@@ -20,8 +20,6 @@ import './typingconfig';
 
 /**
  * Handles text input coming from the keyboard or other input methods.
- *
- * @extends module:core/plugin~Plugin
  */
 export default class Input extends Plugin {
 	/**

--- a/packages/ckeditor5-typing/src/inserttextcommand.ts
+++ b/packages/ckeditor5-typing/src/inserttextcommand.ts
@@ -15,36 +15,28 @@ import type { DocumentSelection, Range, Selection } from '@ckeditor/ckeditor5-en
 
 /**
  * The insert text command. Used by the {@link module:typing/input~Input input feature} to handle typing.
- *
- * @extends module:core/command~Command
  */
 export default class InsertTextCommand extends Command {
+	/**
+	 * Typing's change buffer used to group subsequent changes into batches.
+	 */
 	private readonly _buffer: ChangeBuffer;
 
 	/**
 	 * Creates an instance of the command.
 	 *
-	 * @param {module:core/editor/editor~Editor} editor
-	 * @param {Number} undoStepSize The maximum number of atomic changes
+	 * @param editor
+	 * @param undoStepSize The maximum number of atomic changes
 	 * which can be contained in one batch in the command buffer.
 	 */
 	constructor( editor: Editor, undoStepSize: number ) {
 		super( editor );
 
-		/**
-		 * Typing's change buffer used to group subsequent changes into batches.
-		 *
-		 * @readonly
-		 * @private
-		 * @member {module:typing/utils/changebuffer~ChangeBuffer} #_buffer
-		 */
 		this._buffer = new ChangeBuffer( editor.model, undoStepSize );
 	}
 
 	/**
 	 * The current change buffer.
-	 *
-	 * @type {module:typing/utils/changebuffer~ChangeBuffer}
 	 */
 	public get buffer(): ChangeBuffer {
 		return this._buffer;
@@ -65,17 +57,7 @@ export default class InsertTextCommand extends Command {
 	 * at the beginning of the range (which after the removal is a collapsed range).
 	 *
 	 * @fires execute
-	 * @param {Object} [options] The command options.
-	 * @param {String} [options.text=''] The text to be inserted.
-	 * @param {module:engine/model/selection~Selection} [options.selection] The selection in which the text is inserted.
-	 * Inserting a text into a selection deletes the current content within selection ranges. If the selection is not specified,
-	 * the current selection in the model will be used instead.
-	 * // TODO note that those 2 options are exclusive (either selection or range)
-	 * @param {module:engine/model/range~Range} [options.range] The range in which the text is inserted. Defaults
-	 * to the first range in the current selection.
-	 * @param {module:engine/model/range~Range} [options.resultRange] The range where the selection
-	 * should be placed after the insertion. If not specified, the selection will be placed right after
-	 * the inserted text.
+	 * @param options The command options.
 	 */
 	public override execute( options: InsertTextCommandOptions = {} ): void {
 		const model = this.editor.model;
@@ -116,9 +98,28 @@ export default class InsertTextCommand extends Command {
 }
 
 export interface InsertTextCommandOptions {
+
+	/**
+	 * The text to be inserted.
+	 */
 	text?: string;
+	// TODO note that those 2 options are exclusive (either selection or range)
+	/**
+	 * The selection in which the text is inserted.
+	 * Inserting a text into a selection deletes the current content within selection ranges. If the selection is not specified,
+	 * the current selection in the model will be used instead.
+	 */
 	selection?: Selection | DocumentSelection;
+
+	/**
+	 * The range in which the text is inserted. Defaults to the first range in the current selection.
+	 */
 	range?: Range;
+
+	/**
+	 * The range where the selection should be placed after the insertion.
+	 * If not specified, the selection will be placed right after the inserted text.
+	 */
 	resultRange?: Range;
 }
 

--- a/packages/ckeditor5-typing/src/inserttextcommand.ts
+++ b/packages/ckeditor5-typing/src/inserttextcommand.ts
@@ -97,13 +97,19 @@ export default class InsertTextCommand extends Command {
 	}
 }
 
+/**
+ * Interface with parameters for executing InsertTextCommand.
+ *
+ * Both `range` and `selection` parameters are used for defining selection but should not be used together.
+ * If both are defined, only `selection` will be considered.
+ */
 export interface InsertTextCommandOptions {
 
 	/**
 	 * The text to be inserted.
 	 */
 	text?: string;
-	// TODO note that those 2 options are exclusive (either selection or range)
+
 	/**
 	 * The selection in which the text is inserted.
 	 * Inserting a text into a selection deletes the current content within selection ranges. If the selection is not specified,

--- a/packages/ckeditor5-typing/src/inserttextcommand.ts
+++ b/packages/ckeditor5-typing/src/inserttextcommand.ts
@@ -25,7 +25,6 @@ export default class InsertTextCommand extends Command {
 	/**
 	 * Creates an instance of the command.
 	 *
-	 * @param editor
 	 * @param undoStepSize The maximum number of atomic changes
 	 * which can be contained in one batch in the command buffer.
 	 */

--- a/packages/ckeditor5-typing/src/inserttextobserver.ts
+++ b/packages/ckeditor5-typing/src/inserttextobserver.ts
@@ -36,8 +36,6 @@ const TYPING_INPUT_TYPES = [
 
 /**
  * Text insertion observer introduces the {@link module:engine/view/document~Document#event:insertText} event.
- *
- * @extends module:engine/view/observer/observer~Observer
  */
 export default class InsertTextObserver extends Observer {
 	/**
@@ -139,12 +137,8 @@ export default class InsertTextObserver extends Observer {
  *
  * **Note**: This event is fired by the {@link module:typing/inserttextobserver~InsertTextObserver input feature}.
  *
- * @event module:engine/view/document~Document#event:insertText
- * @param {module:engine/view/observer/domeventdata~DomEventData} data
- * @param {String} data.text The text to be inserted.
- * @param {module:engine/view/selection~Selection} [data.selection] The selection into which the text should be inserted.
- * If not specified, the insertion should occur at the current view selection.
- * @param {module:engine/view/range~Range} [data.resultRange] The range that view selection should be set to after insertion.
+ * @eventName module:engine/view/document~Document#event:insertText
+ * @param data The event data.
  */
 export type ViewDocumentInsertTextEvent = {
 	name: 'insertText';
@@ -152,7 +146,20 @@ export type ViewDocumentInsertTextEvent = {
 };
 
 export interface InsertTextEventData extends DomEventData {
+
+	/**
+	 *  The text to be inserted.
+	 */
 	text: string;
+
+	/**
+	 * The selection into which the text should be inserted.
+	 * If not specified, the insertion should occur at the current view selection.
+	 */
 	selection: ViewSelection | ViewDocumentSelection;
+
+	/**
+	 * The range that view selection should be set to after insertion.
+	 */
 	resultRange?: ViewRange;
 }

--- a/packages/ckeditor5-typing/src/texttransformation.ts
+++ b/packages/ckeditor5-typing/src/texttransformation.ts
@@ -225,8 +225,6 @@ function normalizeTo( to: TextTransformationDescription[ 'to' ] ) {
 /**
  * For given `position` returns attributes for the text that is after that position.
  * The text can be in the same text node as the position (`foo[]bar`) or in the next text node (`foo[]<$text bold="true">bar</$text>`).
- * @param position
- * @returns
  */
 function getTextAttributesAfterPosition( position: Position ) {
 	const textNode = position.textNode ? position.textNode : position.nodeAfter;

--- a/packages/ckeditor5-typing/src/texttransformation.ts
+++ b/packages/ckeditor5-typing/src/texttransformation.ts
@@ -80,8 +80,6 @@ const DEFAULT_TRANSFORMATIONS = [
 
 /**
  * The text transformation plugin.
- *
- * @extends module:core/plugin~Plugin
  */
 export default class TextTransformation extends Plugin {
 	/**
@@ -128,8 +126,6 @@ export default class TextTransformation extends Plugin {
 
 	/**
 	 * Create new TextWatcher listening to the editor for typing and selection events.
-	 *
-	 * @private
 	 */
 	private _enableTransformationWatchers(): void {
 		const editor = this.editor;
@@ -196,13 +192,12 @@ export default class TextTransformation extends Plugin {
 	}
 }
 
-// Normalizes the configuration `from` parameter value.
-// The normalized value for the `from` parameter is a RegExp instance. If the passed `from` is already a RegExp instance,
-// it is returned unchanged.
-//
-// @param {String|RegExp} from
-// @returns {RegExp}
-function normalizeFrom( from: string | RegExp ) {
+/**
+ * Normalizes the configuration `from` parameter value.
+ * The normalized value for the `from` parameter is a RegExp instance. If the passed `from` is already a RegExp instance,
+ * it is returned unchanged.
+ */
+function normalizeFrom( from: string | RegExp ): RegExp {
 	if ( typeof from == 'string' ) {
 		return new RegExp( `(${ escapeRegExp( from ) })$` );
 	}
@@ -211,12 +206,11 @@ function normalizeFrom( from: string | RegExp ) {
 	return from;
 }
 
-// Normalizes the configuration `to` parameter value.
-// The normalized value for the `to` parameter is a function that takes an array and returns an array. See more in the
-// configuration description. If the passed `to` is already a function, it is returned unchanged.
-//
-// @param {String|Array.<null|String>|Function} to
-// @returns {Function}
+/**
+ * Normalizes the configuration `to` parameter value.
+ * The normalized value for the `to` parameter is a function that takes an array and returns an array. See more in the
+ * configuration description. If the passed `to` is already a function, it is returned unchanged.
+ */
 function normalizeTo( to: TextTransformationDescription[ 'to' ] ) {
 	if ( typeof to == 'string' ) {
 		return () => [ to ];
@@ -228,29 +222,30 @@ function normalizeTo( to: TextTransformationDescription[ 'to' ] ) {
 	return to;
 }
 
-// For given `position` returns attributes for the text that is after that position.
-// The text can be in the same text node as the position (`foo[]bar`) or in the next text node (`foo[]<$text bold="true">bar</$text>`).
-//
-// @param {module:engine/model/position~Position} position
-// @returns {Iterable.<*>}
+/**
+ * For given `position` returns attributes for the text that is after that position.
+ * The text can be in the same text node as the position (`foo[]bar`) or in the next text node (`foo[]<$text bold="true">bar</$text>`).
+ * @param position
+ * @returns
+ */
 function getTextAttributesAfterPosition( position: Position ) {
 	const textNode = position.textNode ? position.textNode : position.nodeAfter;
 
 	return textNode!.getAttributes();
 }
 
-// Returns a RegExp pattern string that detects a sentence inside a quote.
-//
-// @param {String} quoteCharacter The character to create a pattern for.
-// @returns {String}
-function buildQuotesRegExp( quoteCharacter: string ) {
+/**
+ * Returns a RegExp pattern string that detects a sentence inside a quote.
+ *
+ * @param quoteCharacter The character to create a pattern for.
+ */
+function buildQuotesRegExp( quoteCharacter: string ): RegExp {
 	return new RegExp( `(^|\\s)(${ quoteCharacter })([^${ quoteCharacter }]*)(${ quoteCharacter })$` );
 }
 
-// Reads text transformation config and returns normalized array of transformations objects.
-//
-// @param {module:typing/texttransformation~TextTransformationDescription} config
-// @returns {Array.<{from:String,to:Function}>}
+/**
+ * Reads text transformation config and returns normalized array of transformations objects.
+ */
 function normalizeTransformations( config: TextTransformationConfig ): Array<NormalizedTransformationConfig> {
 	const extra = config.extra || [];
 	const remove = config.remove || [];
@@ -271,11 +266,10 @@ function normalizeTransformations( config: TextTransformationConfig ): Array<Nor
 		} ) );
 }
 
-// Reads definitions and expands named groups if needed to transformation names.
-// This method also removes duplicated named transformations if any.
-//
-// @param {Array.<String|Object>} definitions
-// @returns {Array.<String|Object>}
+/**
+ * Reads definitions and expands named groups if needed to transformation names.
+ * This method also removes duplicated named transformations if any.
+ */
 function expandGroupsAndRemoveDuplicates(
 	definitions: Array<TextTransformationDescription | string>
 ): Array<TextTransformationDescription | string> {

--- a/packages/ckeditor5-typing/src/textwatcher.ts
+++ b/packages/ckeditor5-typing/src/textwatcher.ts
@@ -44,8 +44,6 @@ export default class TextWatcher extends ObservableMixin() {
 
 	/**
 	 * Whether there is a match currently.
-	 *
-	 * @readonly
 	 */
 	private _hasMatch: boolean;
 

--- a/packages/ckeditor5-typing/src/textwatcher.ts
+++ b/packages/ckeditor5-typing/src/textwatcher.ts
@@ -155,7 +155,7 @@ export default class TextWatcher extends ObservableMixin() {
 		const testResult = this.testCallback( text );
 
 		if ( !testResult && this.hasMatch ) {
-			this.fire( 'unmatched' );
+			this.fire<TextWatcherUnmatchedEvent>( 'unmatched' );
 		}
 
 		this._hasMatch = !!testResult;
@@ -168,7 +168,7 @@ export default class TextWatcher extends ObservableMixin() {
 				Object.assign( eventData, testResult );
 			}
 
-			this.fire( `matched:${ suffix }`, eventData );
+			this.fire<TextWatcherMatchedEvent>( `matched:${ suffix }`, eventData );
 		}
 	}
 }
@@ -237,5 +237,9 @@ export interface TextWatcherMatchedSelectionEventData {
 /**
  * Fired whenever the text does not match anymore. Fired only when the text watcher found a match.
  *
- * @event unmatched
+ * @eventName unmatched
  */
+export type TextWatcherUnmatchedEvent = {
+	name: 'unmatched';
+	args: [];
+};

--- a/packages/ckeditor5-typing/src/textwatcher.ts
+++ b/packages/ckeditor5-typing/src/textwatcher.ts
@@ -24,71 +24,58 @@ import type {
  * Fires the {@link module:typing/textwatcher~TextWatcher#event:matched:data `matched:data`},
  * {@link module:typing/textwatcher~TextWatcher#event:matched:selection `matched:selection`} and
  * {@link module:typing/textwatcher~TextWatcher#event:unmatched `unmatched`} events on typing or selection changes.
- *
- * @private
- * @mixes module:utils/observablemixin~ObservableMixin
  */
 export default class TextWatcher extends ObservableMixin() {
+	/**
+	 * The editor's model.
+	 */
 	public readonly model: Model;
+
+	/**
+	 * The function used to match the text.
+	 *
+	 * The test callback can return 3 values:
+	 *
+	 * * `false` if there is no match,
+	 * * `true` if there is a match,
+	 * * an object if there is a match and we want to pass some additional information to the {@link #event:matched:data} event.
+	 */
 	public testCallback: ( text: string ) => unknown;
 
+	/**
+	 * Whether there is a match currently.
+	 *
+	 * @readonly
+	 */
 	private _hasMatch: boolean;
 
+	/**
+	 * Flag indicating whether the `TextWatcher` instance is enabled or disabled.
+	 * A disabled TextWatcher will not evaluate text.
+	 *
+	 * To disable TextWatcher:
+	 *
+	 * ```ts
+	 * const watcher = new TextWatcher( editor.model, testCallback );
+	 *
+	 * // After this a testCallback will not be called.
+	 * watcher.isEnabled = false;
+	 * ```
+	 */
 	declare public isEnabled: boolean;
 
 	/**
 	 * Creates a text watcher instance.
 	 *
-	 * @param {module:engine/model/model~Model} model
-	 * @param {Function} testCallback See {@link module:typing/textwatcher~TextWatcher#testCallback}.
+	 * @param testCallback See {@link module:typing/textwatcher~TextWatcher#testCallback}.
 	 */
 	constructor( model: Model, testCallback: ( text: string ) => unknown ) {
 		super();
 
-		/**
-		 * The editor's model.
-		 *
-		 * @readonly
-		 * @member {module:engine/model/model~Model}
-		 */
 		this.model = model;
-
-		/**
-		 * The function used to match the text.
-		 *
-		 * The test callback can return 3 values:
-		 *
-		 * * `false` if there is no match,
-		 * * `true` if there is a match,
-		 * * an object if there is a match and we want to pass some additional information to the {@link #event:matched:data} event.
-		 *
-		 * @member {Function} #testCallback
-		 * @returns {Object} testResult
-		 */
 		this.testCallback = testCallback;
-
-		/**
-		 * Whether there is a match currently.
-		 *
-		 * @readonly
-		 * @member {Boolean}
-		 */
 		this._hasMatch = false;
 
-		/**
-		 * Flag indicating whether the `TextWatcher` instance is enabled or disabled.
-		 * A disabled TextWatcher will not evaluate text.
-		 *
-		 * To disable TextWatcher:
-		 *
-		 *		const watcher = new TextWatcher( editor.model, testCallback );
-		 *
-		 *		// After this a testCallback will not be called.
-		 *		watcher.isEnabled = false;
-		 *
-		 * @observable
-		 * @member {Boolean} #isEnabled
-		 */
 		this.set( 'isEnabled', true );
 
 		// Toggle text watching on isEnabled state change.
@@ -105,7 +92,7 @@ export default class TextWatcher extends ObservableMixin() {
 	}
 
 	/**
-	 * TODO
+	 * Flag indicating whether there is a match currently.
 	 */
 	public get hasMatch(): boolean {
 		return this._hasMatch;
@@ -113,8 +100,6 @@ export default class TextWatcher extends ObservableMixin() {
 
 	/**
 	 * Starts listening to the editor for typing and selection events.
-	 *
-	 * @private
 	 */
 	private _startListening(): void {
 		const model = this.model;
@@ -155,9 +140,8 @@ export default class TextWatcher extends ObservableMixin() {
 	 * @fires matched:selection
 	 * @fires unmatched
 	 *
-	 * @private
-	 * @param {'data'|'selection'} suffix A suffix used for generating the event name.
-	 * @param {Object} data Data object for event.
+	 * @param suffix A suffix used for generating the event name.
+	 * @param data Data object for event.
 	 */
 	private _evaluateTextBeforeSelection( suffix: 'data' | 'selection', data: { batch?: Batch } = {} ): void {
 		const model = this.model;
@@ -201,37 +185,54 @@ export type TextWatcherMatchedEvent<TCallbackResult extends Record<string, unkno
 /**
  * Fired whenever the text watcher found a match for data changes.
  *
- * @event matched:data
- * @param {Object} data Event data.
- * @param {String} data.text The full text before selection to which the regexp was applied.
- * @param {module:engine/model/range~Range} data.range The range representing the position of the `data.text`.
- * @param {Object} [data.testResult] The additional data returned from the {@link module:typing/textwatcher~TextWatcher#testCallback}.
+ * @eventName matched:data
+ * @param data Event data.
+ * @param data.testResult The additional data returned from the {@link module:typing/textwatcher~TextWatcher#testCallback}.
  */
 export type TextWatcherMatchedDataEvent<TCallbackResult extends Record<string, unknown>> = {
 	name: 'matched:data';
-	args: [ {
-		text: string;
-		range: Range;
-		batch: Batch;
-	} & TCallbackResult ];
+	args: [ data: TextWatcherMatchedDataEventData & TCallbackResult ];
 };
+
+export interface TextWatcherMatchedDataEventData {
+
+	/**
+	 * The full text before selection to which the regexp was applied.
+	 */
+	text: string;
+
+	/**
+	 * The range representing the position of the `data.text`.
+	 */
+	range: Range;
+
+	batch: Batch;
+}
 
 /**
  * Fired whenever the text watcher found a match for selection changes.
  *
- * @event matched:selection
- * @param {Object} data Event data.
- * @param {String} data.text The full text before selection.
- * @param {module:engine/model/range~Range} data.range The range representing the position of the `data.text`.
- * @param {Object} [data.testResult] The additional data returned from the {@link module:typing/textwatcher~TextWatcher#testCallback}.
+ * @eventName matched:selection
+ * @param data Event data.
+ * @param data.testResult The additional data returned from the {@link module:typing/textwatcher~TextWatcher#testCallback}.
  */
 export type TextWatcherMatchedSelectionEvent<TCallbackResult extends Record<string, unknown>> = {
 	name: 'matched:selection';
-	args: [ {
-		text: string;
-		range: Range;
-	} & TCallbackResult ];
+	args: [ data: TextWatcherMatchedSelectionEventData & TCallbackResult ];
 };
+
+export interface TextWatcherMatchedSelectionEventData {
+
+	/**
+	 * The full text before selection.
+	 */
+	text: string;
+
+	/**
+	 * The range representing the position of the `data.text`.
+	 */
+	range: Range;
+}
 
 /**
  * Fired whenever the text does not match anymore. Fired only when the text watcher found a match.

--- a/packages/ckeditor5-typing/src/twostepcaretmovement.ts
+++ b/packages/ckeditor5-typing/src/twostepcaretmovement.ts
@@ -41,25 +41,25 @@ import type {
  *
  * * When enabled:
  *
- * ```html
+ * ```xml
  * 		foo{}<$text a="true">bar</$text>
  * ```
  *
  * 	<kbd>→</kbd>
  *
- * ```html
+ * ```xml
  * 		foo<$text a="true">{}bar</$text>
  * ```
  *
  * * When disabled:
  *
- * ```html
+ * ```xml
  * 		foo{}<$text a="true">bar</$text>
  * ```
  *
  * 	<kbd>→</kbd>
  *
- * ```html
+ * ```xml
  * 		foo<$text a="true">b{}ar</$text>
  * ```
  *
@@ -68,25 +68,25 @@ import type {
  *
  * * When enabled:
  *
- * ```html
+ * ```xml
  * 		<$text a="true">bar{}</$text>baz
  * ```
  *
  * 	<kbd>→</kbd>
  *
- * ```html
+ * ```xml
  * 		<$text a="true">bar</$text>{}baz
  * ```
  *
  * * When disabled:
  *
- * ```html
+ * ```xml
  * 		<$text a="true">bar{}</$text>baz
  * ```
  *
  * 	<kbd>→</kbd>
  *
- * ```html
+ * ```xml
  * 		<$text a="true">bar</$text>b{}az
  * ```
  *
@@ -94,23 +94,25 @@ import type {
  *
  * * When enabled:
  *
- * ```html
+ * ```xml
  * 		<$text a="true">bar</$text>{}baz
  * ```
  *
  * 	<kbd>←</kbd>
  *
- * ```html
+ * ```xml
  * 		<$text a="true">bar{}</$text>baz
  * ```
  *
  * * When disabled:
  *
- * ```html
+ * ```xml
  * 		<$text a="true">bar</$text>{}baz
+ * ```
  *
  * 	<kbd>←</kbd>
  *
+ * ```xml
  * 		<$text a="true">ba{}r</$text>b{}az
  * ```
  *
@@ -118,21 +120,25 @@ import type {
  *
  * * When enabled and many attributes starts or ends at the same position:
  *
- * ```html
+ * ```xml
  * 		<$text a="true" b="true">bar</$text>{}baz
+ * ```
  *
  * 	<kbd>←</kbd>
  *
+ * ```xml
  * 		<$text a="true" b="true">bar{}</$text>baz
  * ```
  *
  * * When enabled and one procedes another:
  *
- * ```html
+ * ```xml
  * 		<$text a="true">bar</$text><$text b="true">{}bar</$text>
+ * ```
  *
  * 	<kbd>←</kbd>
  *
+ * ```xml
  * 		<$text a="true">bar{}</$text><$text b="true">bar</$text>
  * ```
  *

--- a/packages/ckeditor5-typing/src/twostepcaretmovement.ts
+++ b/packages/ckeditor5-typing/src/twostepcaretmovement.ts
@@ -13,6 +13,7 @@ import { keyCodes } from '@ckeditor/ckeditor5-utils';
 
 import type {
 	DocumentSelection,
+	DocumentSelectionChangeEvent,
 	DomEventData,
 	Model,
 	Position,
@@ -40,79 +41,110 @@ import type {
  *
  * * When enabled:
  *
- *   		foo{}<$text a="true">bar</$text>
+ * ```html
+ * 		foo{}<$text a="true">bar</$text>
  *
- *    <kbd>→</kbd>
+ * 	<kbd>→</kbd>
  *
- *   		foo<$text a="true">{}bar</$text>
+ * 		foo<$text a="true">{}bar</$text>
+ * ```
  *
  * * When disabled:
  *
- *   		foo{}<$text a="true">bar</$text>
+ * ```html
+ * 		foo{}<$text a="true">bar</$text>
  *
- *   <kbd>→</kbd>
+ * 	<kbd>→</kbd>
  *
- *   		foo<$text a="true">b{}ar</$text>
+ * 		foo<$text a="true">b{}ar</$text>
+ * ```html
  *
  *
  * ## "Leaving" an attribute:
  *
  * * When enabled:
  *
- *   		<$text a="true">bar{}</$text>baz
+ * ```html
+ * 		<$text a="true">bar{}</$text>baz
  *
- *    <kbd>→</kbd>
+ * 	<kbd>→</kbd>
  *
- *   		<$text a="true">bar</$text>{}baz
+ * 		<$text a="true">bar</$text>{}baz
+ * ```
  *
  * * When disabled:
  *
- *   		<$text a="true">bar{}</$text>baz
+ * ```html
+ * 		<$text a="true">bar{}</$text>baz
  *
- *   <kbd>→</kbd>
+ * 	<kbd>→</kbd>
  *
- *   		<$text a="true">bar</$text>b{}az
+ * 		<$text a="true">bar</$text>b{}az
+ * ```
  *
  * # Backward movement
  *
  * * When enabled:
  *
- *   		<$text a="true">bar</$text>{}baz
+ * ```html
+ * 		<$text a="true">bar</$text>{}baz
  *
- *    <kbd>←</kbd>
+ * 	<kbd>←</kbd>
  *
- *   		<$text a="true">bar{}</$text>baz
+ * 		<$text a="true">bar{}</$text>baz
+ * ```
  *
  * * When disabled:
  *
- *   		<$text a="true">bar</$text>{}baz
+ * ```html
+ * 		<$text a="true">bar</$text>{}baz
  *
- *   <kbd>←</kbd>
+ * 	<kbd>←</kbd>
  *
- *   		<$text a="true">ba{}r</$text>b{}az
+ * 		<$text a="true">ba{}r</$text>b{}az
+ * ```
  *
  * # Multiple attributes
  *
  * * When enabled and many attributes starts or ends at the same position:
  *
- *   		<$text a="true" b="true">bar</$text>{}baz
+ * ```html
+ * 		<$text a="true" b="true">bar</$text>{}baz
  *
- *    <kbd>←</kbd>
+ * 	<kbd>←</kbd>
  *
- *   		<$text a="true" b="true">bar{}</$text>baz
+ * 		<$text a="true" b="true">bar{}</$text>baz
+ * ```
  *
  * * When enabled and one procedes another:
  *
- *   		<$text a="true">bar</$text><$text b="true">{}bar</$text>
+ * ```html
+ * 		<$text a="true">bar</$text><$text b="true">{}bar</$text>
  *
- *    <kbd>←</kbd>
+ * 	<kbd>←</kbd>
  *
- *   		<$text a="true">bar{}</$text><$text b="true">bar</$text>
+ * 		<$text a="true">bar{}</$text><$text b="true">bar</$text>
+ * ```
  *
  */
 export default class TwoStepCaretMovement extends Plugin {
+	/**
+	 * A set of attributes to handle.
+	 */
 	private attributes: Set<string>;
+
+	/**
+	 * The current UID of the overridden gravity, as returned by
+	 * {@link module:engine/model/writer~Writer#overrideSelectionGravity}.
+	 */
 	private _overrideUid: string | null;
+
+	/**
+	 * A flag indicating that the automatic gravity restoration should not happen upon the next
+	 * gravity restoration.
+	 * {@link module:engine/model/selection~Selection#event:change:range} event.
+	 */
+
 	private _isNextGravityRestorationSkipped!: boolean;
 
 	/**
@@ -128,21 +160,7 @@ export default class TwoStepCaretMovement extends Plugin {
 	constructor( editor: Editor ) {
 		super( editor );
 
-		/**
-		 * A set of attributes to handle.
-		 *
-		 * @protected
-		 * @property {module:typing/twostepcaretmovement~TwoStepCaretMovement}
-		 */
 		this.attributes = new Set();
-
-		/**
-		 * The current UID of the overridden gravity, as returned by
-		 * {@link module:engine/model/writer~Writer#overrideSelectionGravity}.
-		 *
-		 * @private
-		 * @member {String}
-		 */
 		this._overrideUid = null;
 	}
 
@@ -194,18 +212,10 @@ export default class TwoStepCaretMovement extends Plugin {
 			}
 		}, { context: '$text', priority: 'highest' } );
 
-		/**
-		 * A flag indicating that the automatic gravity restoration should not happen upon the next
-		 * gravity restoration.
-		 * {@link module:engine/model/selection~Selection#event:change:range} event.
-		 *
-		 * @private
-		 * @member {String}
-		 */
 		this._isNextGravityRestorationSkipped = false;
 
 		// The automatic gravity restoration logic.
-		this.listenTo( modelSelection, 'change:range', ( evt, data ) => {
+		this.listenTo<DocumentSelectionChangeEvent>( modelSelection, 'change:range', ( evt, data ) => {
 			// Skipping the automatic restoration is needed if the selection should change
 			// but the gravity must remain overridden afterwards. See the #handleBackwardMovement
 			// to learn more.
@@ -235,7 +245,7 @@ export default class TwoStepCaretMovement extends Plugin {
 	/**
 	 * Registers a given attribute for the two-step caret movement.
 	 *
-	 * @param {String} attribute Name of the attribute to handle.
+	 * @param attribute Name of the attribute to handle.
 	 */
 	public registerAttribute( attribute: string ): void {
 		this.attributes.add( attribute );
@@ -245,8 +255,7 @@ export default class TwoStepCaretMovement extends Plugin {
 	 * Updates the document selection and the view according to the two–step caret movement state
 	 * when moving **forwards**. Executed upon `keypress` in the {@link module:engine/view/view~View}.
 	 *
-	 * @private
-	 * @param {module:engine/view/observer/domeventdata~DomEventData} data Data of the key press.
+	 * @param data Data of the key press.
 	 * @returns {Boolean} `true` when the handler prevented caret movement
 	 */
 	private _handleForwardMovement( data: DomEventData ): boolean {
@@ -300,9 +309,8 @@ export default class TwoStepCaretMovement extends Plugin {
 	 * Updates the document selection and the view according to the two–step caret movement state
 	 * when moving **backwards**. Executed upon `keypress` in the {@link module:engine/view/view~View}.
 	 *
-	 * @private
-	 * @param {module:engine/view/observer/domeventdata~DomEventData} data Data of the key press.
-	 * @returns {Boolean} `true` when the handler prevented caret movement
+	 * @param data Data of the key press.
+	 * @returns `true` when the handler prevented caret movement
 	 */
 	private _handleBackwardMovement( data: DomEventData ): boolean {
 		const attributes = this.attributes;
@@ -384,10 +392,6 @@ export default class TwoStepCaretMovement extends Plugin {
 
 	/**
 	 * `true` when the gravity is overridden for the plugin.
-	 *
-	 * @readonly
-	 * @private
-	 * @type {Boolean}
 	 */
 	private get _isGravityOverridden(): boolean {
 		return !!this._overrideUid;
@@ -398,8 +402,6 @@ export default class TwoStepCaretMovement extends Plugin {
 	 * and stores the information about this fact in the {@link #_overrideUid}.
 	 *
 	 * A shorthand for {@link module:engine/model/writer~Writer#overrideSelectionGravity}.
-	 *
-	 * @private
 	 */
 	private _overrideGravity(): void {
 		this._overrideUid = this.editor.model.change( writer => {
@@ -411,8 +413,6 @@ export default class TwoStepCaretMovement extends Plugin {
 	 * Restores the gravity using the {@link module:engine/model/writer~Writer model writer}.
 	 *
 	 * A shorthand for {@link module:engine/model/writer~Writer#restoreSelectionGravity}.
-	 *
-	 * @private
 	 */
 	private _restoreGravity(): void {
 		this.editor.model.change( writer => {
@@ -422,11 +422,10 @@ export default class TwoStepCaretMovement extends Plugin {
 	}
 }
 
-// Checks whether the selection has any of given attributes.
-//
-// @param {module:engine/model/documentselection~DocumentSelection} selection
-// @param {Iterable.<String>} attributes
-function hasAnyAttribute( selection: DocumentSelection, attributes: Set<string> ) {
+/**
+ * Checks whether the selection has any of given attributes.
+ */
+function hasAnyAttribute( selection: DocumentSelection, attributes: Set<string> ): boolean {
 	for ( const observedAttribute of attributes ) {
 		if ( selection.hasAttribute( observedAttribute ) ) {
 			return true;
@@ -436,13 +435,11 @@ function hasAnyAttribute( selection: DocumentSelection, attributes: Set<string> 
 	return false;
 }
 
-// Applies the given attributes to the current selection using using the
-// values from the node before the current position. Uses
-// the {@link module:engine/model/writer~Writer model writer}.
-//
-// @param {module:engine/model/model~Model}
-// @param {Iterable.<String>} attributess
-// @param {module:engine/model/position~Position} position
+/**
+ * Applies the given attributes to the current selection using using the
+ * values from the node before the current position. Uses
+ * the {@link module:engine/model/writer~Writer model writer}.
+ */
 function setSelectionAttributesFromTheNodeBefore( model: Model, attributes: Set<string>, position: Position ) {
 	const nodeBefore = position.nodeBefore;
 	model.change( writer => {
@@ -454,27 +451,27 @@ function setSelectionAttributesFromTheNodeBefore( model: Model, attributes: Set<
 	} );
 }
 
-// Prevents the caret movement in the view by calling `preventDefault` on the event data.
-//
-// @alias data.preventDefault
+/**
+ * Prevents the caret movement in the view by calling `preventDefault` on the event data.
+ *
+ * @alias data.preventDefault
+ */
 function preventCaretMovement( data: DomEventData ) {
 	data.preventDefault();
 }
 
-// Checks whether the step before `isBetweenDifferentAttributes()`.
-//
-// @param {module:engine/model/position~Position} position
-// @param {String} attribute
-function isStepAfterAnyAttributeBoundary( position: Position, attributes: Set<string> ) {
+/**
+ * Checks whether the step before `isBetweenDifferentAttributes()`.
+ */
+function isStepAfterAnyAttributeBoundary( position: Position, attributes: Set<string> ): boolean {
 	const positionBefore = position.getShiftedBy( -1 );
 	return isBetweenDifferentAttributes( positionBefore, attributes );
 }
 
-// Checks whether the given position is between different values of given attributes.
-//
-// @param {module:engine/model/position~Position} position
-// @param {Iterable.<String>} attributes
-function isBetweenDifferentAttributes( position: Position, attributes: Set<string> ) {
+/**
+ * Checks whether the given position is between different values of given attributes.
+ */
+function isBetweenDifferentAttributes( position: Position, attributes: Set<string> ): boolean {
 	const { nodeBefore, nodeAfter } = position;
 	for ( const observedAttribute of attributes ) {
 		const attrBefore = nodeBefore ? nodeBefore.getAttribute( observedAttribute ) : undefined;

--- a/packages/ckeditor5-typing/src/twostepcaretmovement.ts
+++ b/packages/ckeditor5-typing/src/twostepcaretmovement.ts
@@ -43,9 +43,11 @@ import type {
  *
  * ```html
  * 		foo{}<$text a="true">bar</$text>
+ * ```
  *
  * 	<kbd>→</kbd>
  *
+ * ```html
  * 		foo<$text a="true">{}bar</$text>
  * ```
  *
@@ -53,11 +55,13 @@ import type {
  *
  * ```html
  * 		foo{}<$text a="true">bar</$text>
+ * ```
  *
  * 	<kbd>→</kbd>
  *
- * 		foo<$text a="true">b{}ar</$text>
  * ```html
+ * 		foo<$text a="true">b{}ar</$text>
+ * ```
  *
  *
  * ## "Leaving" an attribute:
@@ -66,9 +70,11 @@ import type {
  *
  * ```html
  * 		<$text a="true">bar{}</$text>baz
+ * ```
  *
  * 	<kbd>→</kbd>
  *
+ * ```html
  * 		<$text a="true">bar</$text>{}baz
  * ```
  *
@@ -76,9 +82,11 @@ import type {
  *
  * ```html
  * 		<$text a="true">bar{}</$text>baz
+ * ```
  *
  * 	<kbd>→</kbd>
  *
+ * ```html
  * 		<$text a="true">bar</$text>b{}az
  * ```
  *
@@ -88,9 +96,11 @@ import type {
  *
  * ```html
  * 		<$text a="true">bar</$text>{}baz
+ * ```
  *
  * 	<kbd>←</kbd>
  *
+ * ```html
  * 		<$text a="true">bar{}</$text>baz
  * ```
  *
@@ -256,7 +266,7 @@ export default class TwoStepCaretMovement extends Plugin {
 	 * when moving **forwards**. Executed upon `keypress` in the {@link module:engine/view/view~View}.
 	 *
 	 * @param data Data of the key press.
-	 * @returns {Boolean} `true` when the handler prevented caret movement
+	 * @returns `true` when the handler prevented caret movement.
 	 */
 	private _handleForwardMovement( data: DomEventData ): boolean {
 		const attributes = this.attributes;

--- a/packages/ckeditor5-typing/src/twostepcaretmovement.ts
+++ b/packages/ckeditor5-typing/src/twostepcaretmovement.ts
@@ -42,25 +42,25 @@ import type {
  * * When enabled:
  *
  * ```xml
- * 		foo{}<$text a="true">bar</$text>
+ * foo{}<$text a="true">bar</$text>
  * ```
  *
  * 	<kbd>→</kbd>
  *
  * ```xml
- * 		foo<$text a="true">{}bar</$text>
+ * foo<$text a="true">{}bar</$text>
  * ```
  *
  * * When disabled:
  *
  * ```xml
- * 		foo{}<$text a="true">bar</$text>
+ * foo{}<$text a="true">bar</$text>
  * ```
  *
  * 	<kbd>→</kbd>
  *
  * ```xml
- * 		foo<$text a="true">b{}ar</$text>
+ * foo<$text a="true">b{}ar</$text>
  * ```
  *
  *
@@ -69,25 +69,25 @@ import type {
  * * When enabled:
  *
  * ```xml
- * 		<$text a="true">bar{}</$text>baz
+ * <$text a="true">bar{}</$text>baz
  * ```
  *
  * 	<kbd>→</kbd>
  *
  * ```xml
- * 		<$text a="true">bar</$text>{}baz
+ * <$text a="true">bar</$text>{}baz
  * ```
  *
  * * When disabled:
  *
  * ```xml
- * 		<$text a="true">bar{}</$text>baz
+ * <$text a="true">bar{}</$text>baz
  * ```
  *
  * 	<kbd>→</kbd>
  *
  * ```xml
- * 		<$text a="true">bar</$text>b{}az
+ * <$text a="true">bar</$text>b{}az
  * ```
  *
  * # Backward movement
@@ -95,25 +95,25 @@ import type {
  * * When enabled:
  *
  * ```xml
- * 		<$text a="true">bar</$text>{}baz
+ * <$text a="true">bar</$text>{}baz
  * ```
  *
  * 	<kbd>←</kbd>
  *
  * ```xml
- * 		<$text a="true">bar{}</$text>baz
+ * <$text a="true">bar{}</$text>baz
  * ```
  *
  * * When disabled:
  *
  * ```xml
- * 		<$text a="true">bar</$text>{}baz
+ * <$text a="true">bar</$text>{}baz
  * ```
  *
  * 	<kbd>←</kbd>
  *
  * ```xml
- * 		<$text a="true">ba{}r</$text>b{}az
+ * <$text a="true">ba{}r</$text>b{}az
  * ```
  *
  * # Multiple attributes
@@ -121,25 +121,25 @@ import type {
  * * When enabled and many attributes starts or ends at the same position:
  *
  * ```xml
- * 		<$text a="true" b="true">bar</$text>{}baz
+ * <$text a="true" b="true">bar</$text>{}baz
  * ```
  *
  * 	<kbd>←</kbd>
  *
  * ```xml
- * 		<$text a="true" b="true">bar{}</$text>baz
+ * <$text a="true" b="true">bar{}</$text>baz
  * ```
  *
  * * When enabled and one procedes another:
  *
  * ```xml
- * 		<$text a="true">bar</$text><$text b="true">{}bar</$text>
+ * <$text a="true">bar</$text><$text b="true">{}bar</$text>
  * ```
  *
  * 	<kbd>←</kbd>
  *
  * ```xml
- * 		<$text a="true">bar{}</$text><$text b="true">bar</$text>
+ * <$text a="true">bar{}</$text><$text b="true">bar</$text>
  * ```
  *
  */

--- a/packages/ckeditor5-typing/src/typing.ts
+++ b/packages/ckeditor5-typing/src/typing.ts
@@ -16,8 +16,6 @@ import Delete from './delete';
  *
  * This is a "glue" plugin which loads the {@link module:typing/input~Input} and {@link module:typing/delete~Delete}
  * plugins.
- *
- * @extends module:core/plugin~Plugin
  */
 export default class Typing extends Plugin {
 	public static get requires(): PluginDependencies {

--- a/packages/ckeditor5-typing/src/typingconfig.ts
+++ b/packages/ckeditor5-typing/src/typingconfig.ts
@@ -35,8 +35,6 @@ export interface TypingConfig {
 	 * The configuration of the {@link module:typing/texttransformation~TextTransformation} feature.
 	 *
 	 * Read more in {@link module:typing/typingconfig~TextTransformationConfig}.
-	 *
-	 * @member {module:typing/typingconfig~TextTransformationConfig} module:typing/typingconfig~TypingConfig#transformations
 	 */
 	transformations: TextTransformationConfig;
 }
@@ -146,12 +144,14 @@ export interface TextTransformationConfig {
 	 * {@link module:typing/typingconfig~TextTransformationConfig#include `transformations.include`} or
 	 * {@link module:typing/typingconfig~TextTransformationConfig#extra `transformations.extra`}.
 	 *
-	 *		const transformationsConfig = {
-	 *			remove: [
-	 *				'ellipsis',    // Remove only 'ellipsis' from the 'typography' group.
-	 *				'mathematical' // Remove all transformations from the 'mathematical' group.
-	 *			]
-	 *		}
+	 * ```ts
+	 * const transformationsConfig = {
+	 * 	remove: [
+	 * 		'ellipsis',    // Remove only 'ellipsis' from the 'typography' group.
+	 * 		'mathematical' // Remove all transformations from the 'mathematical' group.
+	 * 	]
+	 * }
+	 * ```
 	 */
 	remove?: Array<TextTransformationDescription | string>;
 }

--- a/packages/ckeditor5-typing/src/utils/changebuffer.ts
+++ b/packages/ckeditor5-typing/src/utils/changebuffer.ts
@@ -27,61 +27,64 @@ import type { EventInfo } from '@ckeditor/ckeditor5-utils';
  *
  * To use the change buffer you need to let it know about the number of changes that were added to the batch:
  *
- *		const buffer = new ChangeBuffer( model, LIMIT );
+ * ```ts
+ * const buffer = new ChangeBuffer( model, LIMIT );
  *
- *		// Later on in your feature:
- *		buffer.batch.insert( pos, insertedCharacters );
- *		buffer.input( insertedCharacters.length );
- *
+ * // Later on in your feature:
+ * buffer.batch.insert( pos, insertedCharacters );
+ * buffer.input( insertedCharacters.length );
+ * ```
  */
 export default class ChangeBuffer {
+	/**
+	 * The model instance.
+	 */
 	public readonly model: Model;
+
+	/**
+	 * The maximum number of atomic changes which can be contained in one batch.
+	 */
 	public readonly limit: number;
 
+	/**
+	 * Whether the buffer is locked. A locked buffer cannot be reset unless it gets unlocked.
+	 *
+	 * @readonly
+	 */
 	private _isLocked: boolean;
+
+	/**
+	 * The number of atomic changes in the buffer. Once it exceeds the {@link #limit},
+	 * the {@link #batch batch} is set to a new one.
+	 *
+	 * @readonly
+	 */
 	private _size: number;
+
+	/**
+	 * The current batch instance.
+	 */
 	private _batch: Batch | null = null;
+
+	/**
+	 * The callback to document the change event which later needs to be removed.
+	 */
 	private readonly _changeCallback: ( evt: EventInfo, batch: Batch ) => void;
+
+	/**
+	 * The callback to document selection `change:attribute` and `change:range` events which resets the buffer.
+	 */
 	private readonly _selectionChangeCallback: () => void;
 
 	/**
 	 * Creates a new instance of the change buffer.
 	 *
-	 * @param {module:engine/model/model~Model} model
-	 * @param {Number} [limit=20] The maximum number of atomic changes which can be contained in one batch.
+	 * @param limit The maximum number of atomic changes which can be contained in one batch.
 	 */
 	constructor( model: Model, limit: number = 20 ) {
-		/**
-		 * The model instance.
-		 *
-		 * @readonly
-		 * @member {module:engine/model/model~Model} #model
-		 */
 		this.model = model;
-
-		/**
-		 * The number of atomic changes in the buffer. Once it exceeds the {@link #limit},
-		 * the {@link #batch batch} is set to a new one.
-		 *
-		 * @readonly
-		 * @member {Number} #size
-		 */
 		this._size = 0;
-
-		/**
-		 * The maximum number of atomic changes which can be contained in one batch.
-		 *
-		 * @readonly
-		 * @member {Number} #limit
-		 */
 		this.limit = limit;
-
-		/**
-		 * Whether the buffer is locked. A locked buffer cannot be reset unless it gets unlocked.
-		 *
-		 * @readonly
-		 * @member {Boolean} #isLocked
-		 */
 		this._isLocked = false;
 
 		// The function to be called in order to notify the buffer about batches which appeared in the document.
@@ -104,34 +107,11 @@ export default class ChangeBuffer {
 
 		this.model.document.selection.on<DocumentSelectionChangeEvent>( 'change:range', this._selectionChangeCallback );
 		this.model.document.selection.on<DocumentSelectionChangeEvent>( 'change:attribute', this._selectionChangeCallback );
-
-		/**
-		 * The current batch instance.
-		 *
-		 * @private
-		 * @member #_batch
-		 */
-
-		/**
-		 * The callback to document the change event which later needs to be removed.
-		 *
-		 * @private
-		 * @member #_changeCallback
-		 */
-
-		/**
-		 * The callback to document selection `change:attribute` and `change:range` events which resets the buffer.
-		 *
-		 * @private
-		 * @member #_selectionChangeCallback
-		 */
 	}
 
 	/**
 	 * The current batch to which a feature should add its operations. Once the {@link #size}
 	 * is reached or exceeds the {@link #limit}, the batch is set to a new instance and the size is reset.
-	 *
-	 * @type {module:engine/model/batch~Batch}
 	 */
 	public get batch(): Batch {
 		if ( !this._batch ) {
@@ -153,7 +133,7 @@ export default class ChangeBuffer {
 	 * The input number of changes into the buffer. Once the {@link #size} is
 	 * reached or exceeds the {@link #limit}, the batch is set to a new instance and the size is reset.
 	 *
-	 * @param {Number} changeCount The number of atomic changes to input.
+	 * @param changeCount The number of atomic changes to input.
 	 */
 	public input( changeCount: number ): void {
 		this._size += changeCount;
@@ -196,8 +176,7 @@ export default class ChangeBuffer {
 	/**
 	 * Resets the change buffer.
 	 *
-	 * @private
-	 * @param {Boolean} [ignoreLock] Whether internal lock {@link #isLocked} should be ignored.
+	 * @param ignoreLock Whether internal lock {@link #isLocked} should be ignored.
 	 */
 	private _reset( ignoreLock: boolean = false ): void {
 		if ( !this.isLocked || ignoreLock ) {

--- a/packages/ckeditor5-typing/src/utils/changebuffer.ts
+++ b/packages/ckeditor5-typing/src/utils/changebuffer.ts
@@ -48,16 +48,12 @@ export default class ChangeBuffer {
 
 	/**
 	 * Whether the buffer is locked. A locked buffer cannot be reset unless it gets unlocked.
-	 *
-	 * @readonly
 	 */
 	private _isLocked: boolean;
 
 	/**
 	 * The number of atomic changes in the buffer. Once it exceeds the {@link #limit},
 	 * the {@link #batch batch} is set to a new one.
-	 *
-	 * @readonly
 	 */
 	private _size: number;
 

--- a/packages/ckeditor5-typing/src/utils/findattributerange.ts
+++ b/packages/ckeditor5-typing/src/utils/findattributerange.ts
@@ -16,11 +16,11 @@ import type { Position, Model, Range } from '@ckeditor/ckeditor5-engine';
  * It can be used e.g. to get the entire range on which the `linkHref` attribute needs to be changed when having a
  * selection inside a link.
  *
- * @param {module:engine/model/position~Position} position The start position.
- * @param {String} attributeName The attribute name.
- * @param {String} value The attribute value.
- * @param {module:engine/model/model~Model} model The model instance.
- * @returns {module:engine/model/range~Range} The link range.
+ * @param position The start position.
+ * @param attributeName The attribute name.
+ * @param value The attribute value.
+ * @param model The model instance.
+ * @returns The link range.
  */
 export default function findAttributeRange(
 	position: Position,
@@ -34,14 +34,16 @@ export default function findAttributeRange(
 	);
 }
 
-// Walks forward or backward (depends on the `lookBack` flag), node by node, as long as they have the same attribute value
-// and returns a position just before or after (depends on the `lookBack` flag) the last matched node.
-//
-// @param {module:engine/model/position~Position} position The start position.
-// @param {String} attributeName The attribute name.
-// @param {String} value The attribute value.
-// @param {Boolean} lookBack Whether the walk direction is forward (`false`) or backward (`true`).
-// @returns {module:engine/model/position~Position} The position just before the last matched node.
+/**
+ * Walks forward or backward (depends on the `lookBack` flag), node by node, as long as they have the same attribute value
+ * and returns a position just before or after (depends on the `lookBack` flag) the last matched node.
+ *
+ * @param position The start position.
+ * @param attributeName The attribute name.
+ * @param value The attribute value.
+ * @param lookBack Whether the walk direction is forward (`false`) or backward (`true`).
+ * @returns The position just before the last matched node.
+ */
 function _findBound(
 	position: Position,
 	attributeName: string,

--- a/packages/ckeditor5-typing/src/utils/getlasttextline.ts
+++ b/packages/ckeditor5-typing/src/utils/getlasttextline.ts
@@ -15,25 +15,26 @@ import type { Model, Range } from '@ckeditor/ckeditor5-engine';
  * "The last text line" is understood as text (from one or more text nodes) which is limited either by a parent block
  * or by inline elements (e.g. `<softBreak>`).
  *
- *		const rangeToCheck = model.createRange(
- *			model.createPositionAt( paragraph, 0 ),
- *			model.createPositionAt( paragraph, 'end' )
- *		);
+ * ```ts
+ * const rangeToCheck = model.createRange(
+ * 	model.createPositionAt( paragraph, 0 ),
+ * 	model.createPositionAt( paragraph, 'end' )
+ * );
  *
- *		const { text, range } = getLastTextLine( rangeToCheck, model );
+ * const { text, range } = getLastTextLine( rangeToCheck, model );
+ * ```
  *
  * For model below, the returned `text` will be "Foo bar baz" and `range` will be set on whole `<paragraph>` content:
  *
- *		<paragraph>Foo bar baz<paragraph>
+ * ```html
+ * <paragraph>Foo bar baz<paragraph>
+ * ```
  *
  * However, in below case, `text` will be set to "baz" and `range` will be set only on "baz".
  *
- *		<paragraph>Foo<softBreak></softBreak>bar<softBreak></softBreak>baz<paragraph>
- *
- * @protected
- * @param {module:engine/model/range~Range} range
- * @param {module:engine/model/model~Model} model
- * @returns {module:typing/utils/getlasttextline~LastTextLineData}
+ * ```html
+ * <paragraph>Foo<softBreak></softBreak>bar<softBreak></softBreak>baz<paragraph>
+ * ```
  */
 export default function getLastTextLine( range: Range, model: Model ): LastTextLineData {
 	let start = range.start;
@@ -54,13 +55,16 @@ export default function getLastTextLine( range: Range, model: Model ): LastTextL
 
 /**
  * The value returned by {@link module:typing/utils/getlasttextline~getLastTextLine}.
- *
- * @typedef {Object} module:typing/utils/getlasttextline~LastTextLineData
- *
- * @property {String} text The text from the text nodes in the last text line.
- * @property {module:engine/model/range~Range} range The range set on the text nodes in the last text line.
  */
 export type LastTextLineData = {
+
+	/**
+	 * The text from the text nodes in the last text line.
+	 */
 	text: string;
+
+	/**
+	 * The range set on the text nodes in the last text line.
+	 */
 	range: Range;
 };

--- a/packages/ckeditor5-typing/src/utils/getlasttextline.ts
+++ b/packages/ckeditor5-typing/src/utils/getlasttextline.ts
@@ -26,13 +26,13 @@ import type { Model, Range } from '@ckeditor/ckeditor5-engine';
  *
  * For model below, the returned `text` will be "Foo bar baz" and `range` will be set on whole `<paragraph>` content:
  *
- * ```html
+ * ```xml
  * <paragraph>Foo bar baz<paragraph>
  * ```
  *
  * However, in below case, `text` will be set to "baz" and `range` will be set only on "baz".
  *
- * ```html
+ * ```xml
  * <paragraph>Foo<softBreak></softBreak>bar<softBreak></softBreak>baz<paragraph>
  * ```
  */

--- a/packages/ckeditor5-typing/src/utils/inlinehighlight.ts
+++ b/packages/ckeditor5-typing/src/utils/inlinehighlight.ts
@@ -25,16 +25,18 @@ import type { ViewElement } from '@ckeditor/ckeditor5-engine';
  *
  * Usage:
  *
- *		import inlineHighlight from '@ckeditor/ckeditor5-typing/src/utils/inlinehighlight';
+ * ```ts
+ * import inlineHighlight from '@ckeditor/ckeditor5-typing/src/utils/inlinehighlight';
  *
- *		// Make `ck-link_selected` class be applied on an `a` element
- *		// whenever the corresponding `linkHref` attribute element is selected.
- *		inlineHighlight( editor, 'linkHref', 'a', 'ck-link_selected' );
+ * // Make `ck-link_selected` class be applied on an `a` element
+ * // whenever the corresponding `linkHref` attribute element is selected.
+ * inlineHighlight( editor, 'linkHref', 'a', 'ck-link_selected' );
+ * ```
  *
- * @param {module:core/editor/editor~Editor} editor The editor instance.
- * @param {String} attributeName The attribute name to check.
- * @param {String} tagName The tagName of a view item.
- * @param {String} className The class name to apply in the view.
+ * @param editor The editor instance.
+ * @param attributeName The attribute name to check.
+ * @param tagName The tagName of a view item.
+ * @param className The class name to apply in the view.
  */
 export default function inlineHighlight(
 	editor: Editor,


### PR DESCRIPTION
### Other (typing): Cleanup docs in `ckeditor5-typing`. Closes #12705.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
