### PR TITLE
Docs: Created File management category for CKBox and CKFinder.

### DIFF
--- a/docs/_snippets/installation/plugins-mapping/plugins-mapping.html
+++ b/docs/_snippets/installation/plugins-mapping/plugins-mapping.html
@@ -110,7 +110,7 @@
                <p style="margin-left:0px;"><a href="https://ckeditor.com/cke4/addon/ckfinder">ckfinder</a></p>
             </td>
             <td>
-               <p style="margin-left:0px;"><a href="https://ckeditor.com/docs/ckeditor5/latest/features/images/image-upload/ckfinder.html">CKFinder</a></p>
+               <p style="margin-left:0px;"><a href="https://ckeditor.com/docs/ckeditor5/latest/features/file-management/ckfinder.html">CKFinder</a></p>
             </td>
          </tr>
          <tr>

--- a/docs/features/image-upload.md
+++ b/docs/features/image-upload.md
@@ -8,11 +8,11 @@ order: 10
 
 Inserting {@link features/images-overview images} into content created with CKEditor 5 is a very common task. In a properly configured rich-text editor, there are several ways for the end user to insert images:
 
-* **Pasting** an image from the clipboard.
-* **Dragging** a file from the file system.
-* Selecting an image through a **file system dialog**.
-* Selecting an image from a **media management tool** in your application.
-* **Pasting** and URL to an image, either into the editor dialog or directly into the content.
+* **Pasting** an image from the clipboard
+* **Dragging** a file from the file system
+* Selecting an image through a **file system dialog**
+* Selecting an image from a **media management tool** in your application
+* **Pasting** a URL to an image, either into the editor dialog or directly into the content
 
 With the exception of pasting URLs, all other solutions require the image to be uploaded to a server. The server will then be responsible for providing the image URL used by CKEditor 5 to display the image in the document.
 
@@ -29,7 +29,7 @@ Read our comprehensive blog post about [Managing images with CKEditor 5](https:/
 
 ## Demo
 
-The demo below uses the {@link installation/getting-started/predefined-builds#classic-editor Classic editor} configured to use the {@link features/easy-image Easy Image} service provided by [CKEditor Cloud Services](https://ckeditor.com/ckeditor-cloud-services) and the `AutoImage` plugin, which allows to {@link features/images-inserting paste image URLs directly}:
+The demo below uses the {@link installation/getting-started/predefined-builds#classic-editor Classic editor} configured to use the {@link features/easy-image Easy Image} service provided by [CKEditor Cloud Services](https://ckeditor.com/ckeditor-cloud-services) and the `AutoImage` plugin, which allows you to {@link features/images-inserting paste image URLs directly}:
 
 {@snippet build-classic-source}
 
@@ -39,11 +39,11 @@ The demo below uses the {@link installation/getting-started/predefined-builds#cl
 
 ### CKBox
 
-CKBox is a modern SaaS file management platform with a clean interface, responsive images and top-notch UX. We keep expanding and updating it constantly, adding new features and functions. If you are a part of an organization with many different files to manage, such as images or documents, and regularly have issues finding the right files for the task at hand, CKBox is the right solution.
+CKBox is a modern SaaS file management platform with a clean interface, responsive images, and top-notch UX. We keep expanding and updating it constantly, adding new features and functions. If you are a part of an organization with many different files to manage, such as images or documents, and regularly have issues finding the right files for the task at hand, CKBox is the right solution.
 
 CKBox is a part of the commercial [CKEditor Cloud Services](https://ckeditor.com/ckeditor-cloud-services/) offer.
 
-With the CKBox platform, users can upload files and categorize them into different groups. They can also change the way the files are organized as various interface modification options exist. For example, you can modify the image thumbnail sizes or decide how many files are displayed within the navigation that users can view. Files can be uploaded, deleted, renamed, and tagged. File properties like dimensions, upload date or size are also easily accessible and can be used to sort the files view alonside a regular search.
+With the CKBox platform, users can upload files and categorize them into different groups. They can also change the way the files are organized as various interface modification options exist. For example, you can modify the image thumbnail sizes or decide how many files are displayed within the navigation that users can view. Files can be uploaded, deleted, renamed, and tagged. File properties like dimensions, upload date or size are also easily accessible and can be used to sort the files view alongside a regular search.
 
 {@link features/ckbox **Learn how to use CKBox in your project**}.
 
@@ -57,7 +57,7 @@ Easy Image is part of the commercial [CKEditor Cloud Services](https://ckeditor.
 
 ### CKFinder
 
-The {@link features/ckfinder CKFinder feature} provides a bridge between the rich-text editor and [CKFinder](https://ckeditor.com/ckfinder/), a browser-based commercial file uploader with its server-side connectors (PHP, Java and ASP.NET).
+The {@link features/ckfinder CKFinder feature} provides a bridge between the rich-text editor and [CKFinder](https://ckeditor.com/ckfinder/), a browser-based commercial file uploader with its server-side connectors (PHP, Java, and ASP.NET).
 
 There are two ways you can integrate CKEditor 5 with the CKFinder file manager:
 
@@ -66,10 +66,10 @@ There are two ways you can integrate CKEditor 5 with the CKFinder file manager:
 
 	But there are more cool features available, for instance:
 
-	* **uploading** using the full user interface,
-	* **browsing** previously uploaded images,
-	* **editing** images (cropping, resizing, etc.),
-	* **organizing** or deleting images.
+	* **Uploading** using the full user interface
+	* **Browsing** previously uploaded images
+	* **Editing** images (cropping, resizing, etc.)
+	* **Organizing** or deleting images
 
 {@link features/ckfinder **Learn how to integrate CKEditor 5 with CKFinder in your project**}.
 
@@ -91,12 +91,12 @@ The {@link features/base64-upload-adapter Base64 upload feature} converts images
 
 ## Implementing your own upload adapter
 
-CKEditor 5 provides an open API that allows you to develop your own upload adapters. Tailored to your project, a custom adapter will allow you to take the **full control** over the process of sending the files to the server as well as passing the response from the server (e.g. the URL to the saved file) back to the WYSIWYG editor.
+CKEditor 5 provides an open API that allows you to develop your own upload adapters. Tailored to your project, a custom adapter will allow you to take **full control** over the process of sending the files to the server as well as passing the response from the server (e.g. the URL to the saved file) back to the WYSIWYG editor.
 
 {@link framework/guides/deep-dive/upload-adapter **Learn how to develop your own upload adapter for CKEditor 5**}.
 
 ## Inserting images via URL
 
-CKEditor 5 supports inserting images into the document via pasting URLs. These may be pasted both into the image insertion dialog or, thanks to the `AutoImage` function, directly into content.
+CKEditor 5 supports inserting images into the document via pasting URLs. These may be pasted both into the image insertion dialog or, thanks to the `AutoImage` function, directly into the content.
 
 {@link features/images-inserting **Learn how to paste images into CKEditor 5 using URLs**}.

--- a/docs/features/using-file-managers.md
+++ b/docs/features/using-file-managers.md
@@ -7,13 +7,15 @@ badges: [ premium ]
 
 # Using file managers
 
-One way to upload and insert images in CKEditor is by using file managers. [CKBox](https://ckeditor.com/ckbox/) and [CKFinder](https://ckeditor.com/ckfinder/) are our official file managers and file uploaders that let you upload, manage, and insert images and other files.
+The most con venient way to upload, manage, and insert images into content in CKEditor is by using file managers. [CKBox](https://ckeditor.com/ckbox/) and [CKFinder](https://ckeditor.com/ckfinder/) are our official file managers and file uploaders that let you upload, manage, and insert images and other files.
 
-CKBox and CKFinder are both premium features. [Contact us](https://ckeditor.com/contact/?sales=true#contact-form) to receive an offer tailored to your needs.
+<info-box>
+	CKBox and CKFinder are both premium features. [Contact us](https://ckeditor.com/contact/?sales=true#contact-form) to receive an offer tailored to your needs.
+</info-box>
 
 ## CKBox file manager
 
-[CKBox](https://ckeditor.com/ckbox/) is a modern file management platform with a clean UI and a top-notch UX.
+CKBox is a modern file management platform with a clean UI and a top-notch UX.
 
 With CKBox you can:
 - Organize images and other files into customizable categories.
@@ -27,7 +29,7 @@ With CKBox you can:
 
 ## CKFinder file manager
 
-[CKFinder](https://ckeditor.com/ckfinder/) is a powerful file manager with various image editing and image upload options.
+CKFinder is a powerful file manager with various image editing and image upload options.
 
 With CKFinder you can:
 - Group images and other files into folders and subfolders.

--- a/docs/features/using-file-managers.md
+++ b/docs/features/using-file-managers.md
@@ -1,0 +1,39 @@
+---
+category: features-image-upload
+menu-title: Using file managers
+order: 20
+badges: [ premium ]
+---
+
+# Using file managers
+
+One way to upload and insert images in CKEditor is by using file managers. [CKBox](https://ckeditor.com/ckbox/) and [CKFinder](https://ckeditor.com/ckfinder/) are our official file managers and file uploaders that let you upload, manage, and insert images and other files.
+
+CKBox and CKFinder are both premium features. [Contact us](https://ckeditor.com/contact/?sales=true#contact-form) to receive an offer tailored to your needs.
+
+## CKBox file manager
+
+[CKBox](https://ckeditor.com/ckbox/) is a modern file management platform with a clean UI and a top-notch UX.
+
+With CKBox you can:
+- Organize images and other files into customizable categories.
+- Delete, rename, and tag files.
+- Search files and filter results by numerous properties.
+- Easily access recently used files.
+- View images in high-resolution full-page preview.
+- Define and reuse alternative text for images.
+
+{@link features/ckbox **Read a separate guide on CKBox**} to learn about its installation and configuration. The guide also lets you try CKBox in action.
+
+## CKFinder file manager
+
+[CKFinder](https://ckeditor.com/ckfinder/) is a powerful file manager with various image editing and image upload options.
+
+With CKFinder you can:
+- Group images and other files into folders and subfolders.
+- Move or copy files between folders.
+- Easily filter files.
+- Drag and drop images and paste them from the clipboard into the editor.
+- Crop, rotate, edit, and resize images.
+
+{@link features/ckfinder **Read a separate guide on CKFinder**} to learn about its installation and configuration. The guide also lets you try CKFinder in action.

--- a/docs/features/using-file-managers.md
+++ b/docs/features/using-file-managers.md
@@ -19,6 +19,7 @@ CKBox is a modern file management platform with a clean UI and a top-notch UX.
 
 With CKBox you can:
 - Organize images and other files into customizable categories.
+- Create, rename, and delete folders.
 - Delete, rename, and tag files.
 - Search files and filter results by numerous properties.
 - Easily access recently used files.

--- a/docs/installation/getting-started/predefined-builds.md
+++ b/docs/installation/getting-started/predefined-builds.md
@@ -560,7 +560,7 @@ The table below presents the list of all plugins included in various builds.
 				<td style="text-align:center; width:70px">✅</td>
 			</tr>
 			<tr>
-				<td><a href="https://ckeditor.com/docs/ckeditor5/latest/features/images/image-upload/ckbox.html">CKBox</a></td>
+				<td><a href="https://ckeditor.com/docs/ckeditor5/latest/features/file-management/ckbox.html">CKBox</a></td>
 				<td style="text-align:center; width:70px">✅</td>
 				<td style="text-align:center; width:70px">✅</td>
 				<td style="text-align:center; width:70px">✅</td>
@@ -569,7 +569,7 @@ The table below presents the list of all plugins included in various builds.
 				<td style="text-align:center; width:70px">✅</td>
 			</tr>
 			<tr>
-				<td><a href="https://ckeditor.com/docs/ckeditor5/latest/features/images/image-upload/ckfinder.html">CKFinder</a></td>
+				<td><a href="https://ckeditor.com/docs/ckeditor5/latest/features/file-management/ckfinder.html">CKFinder</a></td>
 				<td style="text-align:center; width:70px">✅</td>
 				<td style="text-align:center; width:70px">✅</td>
 				<td style="text-align:center; width:70px">✅</td>

--- a/docs/umberto.json
+++ b/docs/umberto.json
@@ -81,7 +81,7 @@
 		"builds/guides/integration/advanced-setup.html#creating-super-builds": "installation/advanced/using-two-editors.html#creating-super-builds",
 		"features/toolbar.html": "features/toolbar/toolbar.html",
 		"features/blocktoolbar.html": "features/toolbar/blocktoolbar.html",
-		"features/ckfinder.html": "features/images/image-upload/ckfinder.html",
+		"features/ckfinder.html": "features/file-management/ckfinder.html",
 		"features/collaboration/annotation-customization/annotations-custom-configuration.html": "features/collaboration/annotations/annotations-custom-configuration.html",
 		"features/collaboration/annotation-customization/annotations-custom-template.html": "features/collaboration/annotations/annotations-custom-template.html",
 		"features/collaboration/annotation-customization/annotations-custom-theme.html": "features/collaboration/annotations/annotations-custom-theme.html",
@@ -103,7 +103,7 @@
 		"features/easy-image.html": "features/images/image-upload/easy-image.html",
 		"features/image-upload/image-upload.html": "features/images/image-upload/image-upload.html",
 		"features/image-upload/easy-image.html": "features/images/image-upload/easy-image.html",
-		"features/image-upload/ckfinder.html": "features/images/image-upload/ckfinder.html",
+		"features/image-upload/ckfinder.html": "features/file-management/ckfinder.html",
 		"features/image-upload/base64-upload-adapter.html": "features/images/image-upload/base64-upload-adapter.html",
 		"features/image-upload/simple-upload-adapter.html": "features/images/image-upload/simple-upload-adapter.html",
 		"features/lists.html": "features/lists/lists.html",
@@ -112,6 +112,8 @@
 		"features/iframe-embed.html": "features/media-embed.html",
 		"features/video.html": "features/media-embed.html",
 		"features/video-upload.html": "features/media-embed.html",
+		"features/images/image-upload/ckbox.html": "features/file-management/ckbox.html",
+		"features/images/image-upload/ckfinder.html": "features/file-management/ckfinder.html",
 		"features/images/overview.html": "features/images/images-overview.html",
 		"features/mathtype.html": "features/math-equations.html",
 		"features/pagination.html": "features/pagination/pagination.html",
@@ -120,7 +122,7 @@
 		"features/import-word.html": "features/import-word/import-word.html",
 		"features/spell-checker.html": "features/spelling-and-grammar-checking.html",
 		"features/collaboration/comments/comments-api.html": "api/comments.html",
-		"features/ckbox.html": "features/images/image-upload/ckbox.html",
+		"features/ckbox.html": "features/file-management/ckbox.html",
 		"framework/guides/ui/document-editor.html": "framework/guides/deep-dive/ui/document-editor.html",
 		"framework/guides/ui/external-ui.html": "framework/guides/deep-dive/ui/external-ui.html",
 		"framework/guides/ui/theme-customization.html": "framework/guides/deep-dive/ui/theme-customization.html",
@@ -365,6 +367,11 @@
 							"order": 500
 						}
 					]
+				},
+				{
+					"name": "File management",
+					"id": "features-file-management",
+					"slug": "file-management"
 				},
 				{
 					"name": "Images",

--- a/packages/ckeditor5-adapter-ckfinder/_src/uploadadapter.js
+++ b/packages/ckeditor5-adapter-ckfinder/_src/uploadadapter.js
@@ -17,7 +17,7 @@ import { getCsrfToken } from './utils';
 /**
  * A plugin that enables file uploads in CKEditor 5 using the CKFinder server–side connector.
  *
- * See the {@glink features/images/image-upload/ckfinder "CKFinder file manager integration" guide} to learn how to configure
+ * See the {@glink features/file-management/ckfinder "CKFinder file manager integration" guide} to learn how to configure
  * and use this feature as well as find out more about the full integration with the file manager
  * provided by the {@link module:ckfinder/ckfinder~CKFinder} plugin.
  *

--- a/packages/ckeditor5-adapter-ckfinder/src/uploadadapter.ts
+++ b/packages/ckeditor5-adapter-ckfinder/src/uploadadapter.ts
@@ -23,7 +23,7 @@ import { getCsrfToken } from './utils';
 /**
  * A plugin that enables file uploads in CKEditor 5 using the CKFinder server–side connector.
  *
- * See the {@glink features/images/image-upload/ckfinder "CKFinder file manager integration"} guide to learn how to configure
+ * See the {@glink features/file-management/ckfinder "CKFinder file manager integration"} guide to learn how to configure
  * and use this feature as well as find out more about the full integration with the file manager
  * provided by the {@link module:ckfinder/ckfinder~CKFinder} plugin.
  *

--- a/packages/ckeditor5-ckbox/ckeditor5-metadata.json
+++ b/packages/ckeditor5-ckbox/ckeditor5-metadata.json
@@ -4,7 +4,7 @@
 			"name": "CKBox",
 			"className": "CKBox",
 			"description": "Allows inserting images as well as links to files into the rich-text editor content.",
-			"docs": "features/images/image-upload/ckbox.html",
+			"docs": "features/file-management/ckbox.html",
 			"path": "src/ckbox.js",
 			"requires": [
 				"CloudServices",

--- a/packages/ckeditor5-ckbox/docs/features/ckbox.md
+++ b/packages/ckeditor5-ckbox/docs/features/ckbox.md
@@ -13,7 +13,7 @@ badges: [ premium ]
 This CKBox integration feature allows you to effortlessly and intuitively insert images as well as links to other files into the rich-text editor content. CKBox is a file manager and a file uploader that acts as a convenient interface for the cloud storage service. The CKBox feature provides a simple integration with this service for the CKEditor 5 WYSIWYG editor. To find out more about CKBox, the brand-new file manager, visit the [CKBox website](https://ckeditor.com/ckbox/) and read the dedicated [CKBox documentation page](https://ckeditor.com/docs/ckbox/latest/guides/index.html).
 
 <info-box>
-	This is a premium feature and you need a subscription to use it. You can [purchase it here](https://ckeditor.com/pricing/) for your open source CKEditor implementation. [Contact us](https://ckeditor.com/contact/?sales=true#contact-form) if:
+	This is a premium feature and you need a subscription to use it. You can [purchase it here](https://ckeditor.com/pricing/) for your open-source CKEditor implementation. [Contact us](https://ckeditor.com/contact/?sales=true#contact-form) if:
 	* CKEditor commercial license is needed for your application.
 	* You need on-premises (self-hosted) version of the service.
 	* You have other licensing questions.
@@ -25,11 +25,11 @@ This CKBox integration feature allows you to effortlessly and intuitively insert
 
 ## Demo
 
-Try CKBox in action. Use the Open file manager toolbar button {@icon @ckeditor/ckeditor5-ckbox/theme/icons/browse-files.svg Open file manager} to invoke the CKBox dialog window. After the dialog is opened, find an interesting image and click on the Choose button. The selected image should be inserted into the editor content. You can choose more than one file at once. Play around with these, changing the alignment and size.
+Try CKBox in action. Use the Open file manager toolbar button {@icon @ckeditor/ckeditor5-ckbox/theme/icons/browse-files.svg Open file manager} to invoke the CKBox dialog window. After the dialog opens, find an interesting image and click the Choose button. The selected image will be inserted into the editor content. You can choose more than one file at once. Play around with these, changing the alignment and size.
 
 Non-embeddable files (e.g. PDF files) will be inserted into editor content as links. To test it, open the CKBox dialog again and choose any PDF file. It should be inserted as a link in the editor content. After clicking this link, it is automatically downloaded.
 
-The CKBox feature also supports uploading images. Drag any image into the editor content and it will be uploaded into the CKBox cloud storage. The uploaded file is then automatically inserted in the editor content. If you want to upload a non-image file type (such as a PDF or a text file) to the cloud storage, just open the CKBox dialog and use the Upload button.
+The CKBox feature also supports uploading images. Drag any image into the editor content and it will be uploaded into the CKBox cloud storage. The uploaded file is then automatically inserted into the editor content. If you want to upload a non-image file type (such as a PDF or a text file) to the cloud storage, just open the CKBox dialog and use the Upload button.
 
 {@snippet features/ckbox}
 
@@ -59,9 +59,9 @@ npm install --save @ckeditor/ckeditor5-ckbox
 
 The CKBox feature requires one of the following plugins to be loaded to work correctly:
 
-* {@link module:image/imageblock~ImageBlock the `ImageBlock` feature},
-* {@link module:image/imageinline~ImageInline the `ImageInline` feature},
-* {@link module:image/image~Image the `Image` feature} (a glue plugin that loads both the `ImageBlock` and `ImageInline` features).
+* {@link module:image/imageblock~ImageBlock The `ImageBlock` feature}
+* {@link module:image/imageinline~ImageInline The `ImageInline` feature}
+* {@link module:image/image~Image The `Image` feature} (a glue plugin that loads both the `ImageBlock` and `ImageInline` features)
 
 If you do not have any of them in your editor, install one and add it to your plugin list.
 
@@ -98,14 +98,14 @@ The feature can be configured via the {@link module:ckbox/ckbox~CKBoxConfig `con
 </info-box>
 
 <info-box>
-	There is a [free personal plan than still requires sign-up](https://ckeditor.com/pricing/#plan-ckbox), however.
+	There is a [free personal plan](https://ckeditor.com/pricing/#plan-ckbox). However, it still requires a sign-up.
 </info-box>
 
 After you purchase a license, log into the CKEditor Ecosystem customer dashboard to create access credentials, as explained in the {@link @ckbox guides/configuration/authentication CKBox configuration guide}.
 
 ### Defining upload categories
 
-By default, CKBox feature maps the uploaded image type to the category configured on the cloud service. You can override this behavior and provide your own mappings via the {@link module:ckbox/ckbox~CKBoxConfig#defaultUploadCategories `config.ckbox.defaultUploadCategories`} configuration option. It is an object, where the keys define categories and their values are the types of images that will be uploaded to these categories. The categories might be referenced either by their name or by their ID. Referencing by ID is future-proof, because it will not require configuration changes when a category name is changed.
+By default, the CKBox feature maps the uploaded image type to the category configured on the cloud service. You can override this behavior and provide your own mappings via the {@link module:ckbox/ckbox~CKBoxConfig#defaultUploadCategories `config.ckbox.defaultUploadCategories`} configuration option. It is an object, where the keys define categories and their values are the types of images that will be uploaded to these categories. The categories might be referenced either by their name or by their ID. Referencing by ID is future-proof, because it will not require configuration changes when a category name is changed.
 
 ```js
 import CKBox from '@ckeditor/ckeditor5-ckbox/src/ckbox';
@@ -131,10 +131,10 @@ ClassicEditor
 Please keep in mind that if you define your own upload category mappings for a particular image type, only your first found category will be taken into account while finding the appropriate category for the uploaded image. Category mappings configured on the server will not be searched in that case. The image will not be uploaded (and hence inserted into the editor) in the following cases:
 
 * If you have defined your own category mapping in `defaultUploadCategories` for the uploaded image type:
-   * the category does not exist on the server,
-   * the category exists on the server, but the server configuration does not allow the uploaded image type.
+   * The category does not exist on the server.
+   * The category exists on the server, but the server configuration does not allow the uploaded image type.
 * If you have not defined your own category mapping in `defaultUploadCategories` for the uploaded image type:
-   * there is no category mapping for the uploaded image type on the server.
+   * There is no category mapping for the uploaded image type on the server.
 
 ### Adding the ID for inserted assets
 
@@ -202,7 +202,7 @@ ClassicEditor
 
 ### Configuring the API service and assets origin
 
-If the cloud service is hosted in your own environment you should configure the base URL of the API service via the {@link module:ckbox/ckbox~CKBoxConfig#serviceOrigin `config.ckbox.serviceOrigin`}, and {@link module:ckbox/ckbox~CKBoxConfig#assetsOrigin `config.ckbox.assetsOrigin`} options:
+If the cloud service is hosted in your own environment, you should configure the base URL of the API service via the {@link module:ckbox/ckbox~CKBoxConfig#serviceOrigin `config.ckbox.serviceOrigin`} and {@link module:ckbox/ckbox~CKBoxConfig#assetsOrigin `config.ckbox.assetsOrigin`} options:
 
 ```js
 import CKBox from '@ckeditor/ckeditor5-ckbox/src/ckbox';
@@ -224,8 +224,8 @@ ClassicEditor
 
 The {@link module:ckbox/ckbox~CKBox} plugin registers:
 
-* The `'ckbox'` UI button component.
-* The `'ckbox'` command implemented by the {@link module:ckbox/ckboxcommand~CKBoxCommand}.
+* The `'ckbox'` UI button component
+* The `'ckbox'` command implemented by the {@link module:ckbox/ckboxcommand~CKBoxCommand}
 
 	You can open CKBox by executing the following code:
 
@@ -245,4 +245,4 @@ See the {@link features/images-overview image feature} guide to find out more ab
 
 ## Contribute
 
-The source code of the feature is available on GitHub in [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-ckbox](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-ckbox).
+The source code of the feature is available on GitHub at [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-ckbox](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-ckbox).

--- a/packages/ckeditor5-ckbox/docs/features/ckbox.md
+++ b/packages/ckeditor5-ckbox/docs/features/ckbox.md
@@ -1,8 +1,8 @@
 ---
-category: features-image-upload
+category: features-file-management
 menu-title: CKBox file manager
 modified_at: 2022-06-20
-order: 20
+order: 10
 badges: [ premium ]
 ---
 

--- a/packages/ckeditor5-ckbox/src/ckbox.js
+++ b/packages/ckeditor5-ckbox/src/ckbox.js
@@ -20,7 +20,7 @@ import CKBoxEditing from './ckboxediting';
  * * {@link module:ckbox/ckboxediting~CKBoxEditing},
  * * {@link module:ckbox/ckboxui~CKBoxUI},
  *
- * See the {@glink features/images/image-upload/ckbox CKBox integration} guide to learn how to configure and use this feature.
+ * See the {@glink features/file-management/ckbox CKBox integration} guide to learn how to configure and use this feature.
  *
  * Check out the {@glink features/images/image-upload/image-upload Image upload} guide to learn about other ways to upload
  * images into CKEditor 5.

--- a/packages/ckeditor5-ckbox/src/ckboxuploadadapter.js
+++ b/packages/ckeditor5-ckbox/src/ckboxuploadadapter.js
@@ -17,7 +17,7 @@ import { getImageUrls } from './utils';
 
 /**
  * A plugin that enables file uploads in CKEditor 5 using the CKBox server–side connector.
- * See the {@glink features/images/image-upload/ckbox CKBox file manager integration} guide to learn how to configure
+ * See the {@glink features/file-management/ckbox CKBox file manager integration} guide to learn how to configure
  * and use this feature as well as find out more about the full integration with the file manager
  * provided by the {@link module:ckbox/ckbox~CKBox} plugin.
  *

--- a/packages/ckeditor5-ckfinder/ckeditor5-metadata.json
+++ b/packages/ckeditor5-ckfinder/ckeditor5-metadata.json
@@ -4,7 +4,7 @@
 			"name": "CKFinder",
 			"className": "CKFinder",
 			"description": "An image upload tool. It provides a full, server-side and client-side integration with CKFinder and all its features, including multiple file uploads, image editor and file management.",
-			"docs": "features/images/image-upload/ckfinder.html",
+			"docs": "features/file-management/ckfinder.html",
 			"path": "src/ckfinder.js",
 			"requires": [
 				"CKFinderUploadAdapter",

--- a/packages/ckeditor5-ckfinder/docs/features/ckfinder.md
+++ b/packages/ckeditor5-ckfinder/docs/features/ckfinder.md
@@ -1,7 +1,7 @@
 ---
-category: features-image-upload
+category: features-file-management
 menu-title: CKFinder file manager
-order: 40
+order: 20
 badges: [ premium ]
 ---
 

--- a/packages/ckeditor5-ckfinder/docs/features/ckfinder.md
+++ b/packages/ckeditor5-ckfinder/docs/features/ckfinder.md
@@ -9,7 +9,7 @@ badges: [ premium ]
 
 # CKFinder file manager integration
 
-This CKFinder integration feature allows you to insert images as well as links to files into the rich-text editor content. It is a bridge between the CKEditor 5 WYSIWYG editor and the [CKFinder](https://ckeditor.com/ckfinder) file manager and uploader. CKFinder is a commercial application that was designed with CKEditor compatibility in mind. It is currently available as version 3.x for PHP, ASP.NET and Java and version 2.x for ASP and ColdFusion.
+This CKFinder integration feature allows you to insert images as well as links to files into the rich-text editor content. It is a bridge between the CKEditor 5 WYSIWYG editor and the [CKFinder](https://ckeditor.com/ckfinder) file manager and uploader. CKFinder is a commercial application that was designed with CKEditor compatibility in mind. It is currently available as version 3.x for PHP, ASP.NET, and Java and version 2.x for ASP and ColdFusion.
 
 <info-box info>
 	This is a premium feature and you need a license for it on top of your CKEditor 5 commercial license. [Contact us](https://ckeditor.com/contact/?sales=true#contact-form) to receive an offer tailored to your needs.
@@ -21,16 +21,16 @@ This CKFinder integration feature allows you to insert images as well as links t
 
 This feature can be used in the rich-text editor in two different ways:
 
-* [**As a server-side connector only**](#configuring-the-image-upload-only) ([demo](#image-upload-only)). In this scenario, images which are dropped or pasted into the editor are uploaded to the CKFinder server-side connector running on your server.
-* [**As a server and client-side file manager integration**](#configuring-the-full-integration) ([demo](#full-integration)). Images dropped and pasted directly into the editor are uploaded to the server (just like in the first option).
+* [**As a server-side connector only**](#configuring-the-image-upload-only) ([demo](#image-upload-only)). In this scenario, images dropped or pasted into the editor are uploaded to the CKFinder server-side connector running on your server.
+* [**As a server and client-side file manager integration**](#configuring-the-full-integration) ([demo](#full-integration)). Images dropped or pasted directly into the editor are uploaded to the server (just like in the first option).
 
 	But there are more cool features available, for instance:
 
-	* **uploading** using the full user interface,
-	* uploading **multiple files** at once,
-	* **browsing** previously uploaded images,
-	* **editing** images (cropping, resizing, etc.),
-	* **organizing** or deleting images.
+	* **Uploading** using the full user interface
+	* Uploading **multiple files** at once
+	* **Browsing** previously uploaded images
+	* **Editing** images (cropping, resizing, etc.)
+	* **Organizing** or deleting images
 
 	Check out the [CKFinder file manager website](https://ckeditor.com/ckfinder/) to learn more about the features you can use in your project.
 
@@ -106,7 +106,7 @@ Then:
 * In order to display the toolbar button that opens the CKFinder file manager UI allowing the users to choose the files on the server, make sure that `'ckfinder'` is present in your {@link module:core/editor/editorconfig~EditorConfig#toolbar `config.toolbar`}.
 * Additionally, you can use {@link module:ckfinder/ckfinder~CKFinderConfig#options `config.ckfinder.options`} to define [CKFinder's options](https://ckeditor.com/docs/ckfinder/ckfinder3/#!/api/CKFinder.Config). For example:
 	* You can define [`options.resourceType`](https://ckeditor.com/docs/ckfinder/ckfinder3/#!/api/CKFinder.Config-cfg-resourceType) to tell CKFinder the specified resource type can be browsed when the user clicks the button.
-	* You can define [`options.language`](https://ckeditor.com/docs/ckfinder/ckfinder3/#!/api/CKFinder.Config-cfg-language) to set the UI language of CKFinder. By default it will be set to the UI language of the editor.
+	* You can define [`options.language`](https://ckeditor.com/docs/ckfinder/ckfinder3/#!/api/CKFinder.Config-cfg-language) to set the UI language of CKFinder. By default, it will be set to the UI language of the editor.
 
 ```js
 import CKFinder from '@ckeditor/ckeditor5-ckfinder/src/ckfinder';
@@ -158,16 +158,16 @@ ClassicEditor
 
 ### Configuring allowed file types
 
-The allowed file types that can be uploaded should actually be configured in two places:
+The allowed file types that can be uploaded should be configured in two places:
 
-* On the client side, in CKEditor 5, restricting image upload through the CKEditor 5 UI and commands.
-* On the server side, in CKFinder, restricting the file formats that are accepted in CKFinder.
+* On the client side, in CKEditor 5, restricting image upload through the CKEditor 5 UI and commands
+* On the server side, in CKFinder, restricting the file formats that are accepted in CKFinder
 
 #### Client-side configuration
 
 Use the {@link module:image/imageupload~ImageUploadConfig#types `image.upload.types`} configuration option to define the allowed image MIME types that can be uploaded to CKEditor 5.
 
-By default, users are allowed to upload `jpeg`, `png`, `gif`, `bmp`, `webp` and `tiff` files, but you can customize this behavior to accept, for example, SVG files.
+By default, users are allowed to upload `jpeg`, `png`, `gif`, `bmp`, `webp`, and `tiff` files, but you can customize this behavior to accept, for example, SVG files.
 
 #### Server-side configuration
 
@@ -207,8 +207,8 @@ ClassicEditor
 
 The {@link module:ckfinder/ckfinder~CKFinder} plugin registers:
 
-* The `'ckfinder'` UI button component.
-* The `'ckfinder'` command implemented by the {@link module:ckfinder/ckfindercommand~CKFinderCommand}.
+* The `'ckfinder'` UI button component
+* The `'ckfinder'` command implemented by the {@link module:ckfinder/ckfindercommand~CKFinderCommand}
 
 	You can open CKFinder by executing the following code:
 
@@ -218,8 +218,8 @@ The {@link module:ckfinder/ckfinder~CKFinder} plugin registers:
 
 Additionally, in the "image upload only" integration, you can use the following button and command registered by the {@link module:image/imageupload~ImageUpload} plugin:
 
-* The `'uploadImage'` UI button component.
-* The `'uploadImage'` command implemented by the {@link module:image/imageupload/uploadimagecommand~UploadImageCommand}.
+* The `'uploadImage'` UI button component
+* The `'uploadImage'` command implemented by the {@link module:image/imageupload/uploadimagecommand~UploadImageCommand}
 
 <info-box>
 	We recommend using the official {@link framework/guides/development-tools#ckeditor-5-inspector CKEditor 5 inspector} for development and debugging. It will give you tons of useful information about the state of the editor such as internal data structures, selection, commands, and many more.
@@ -233,4 +233,4 @@ See the {@link features/images-overview image feature guide} to find out more ab
 
 ## Contribute
 
-The source code of the feature is available on GitHub in [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-ckfinder](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-ckfinder).
+The source code of the feature is available on GitHub at [https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-ckfinder](https://github.com/ckeditor/ckeditor5/tree/master/packages/ckeditor5-ckfinder).

--- a/packages/ckeditor5-ckfinder/src/ckfinder.js
+++ b/packages/ckeditor5-ckfinder/src/ckfinder.js
@@ -22,7 +22,7 @@ import CKFinderEditing from './ckfinderediting';
  * * {@link module:ckfinder/ckfinderui~CKFinderUI},
  * * {@link module:adapter-ckfinder/uploadadapter~CKFinderUploadAdapter}.
  *
- * See the {@glink features/images/image-upload/ckfinder "CKFinder integration" guide} to learn how to configure
+ * See the {@glink features/file-management/ckfinder "CKFinder integration" guide} to learn how to configure
  * and use this feature.
  *
  * Check out the {@glink features/images/image-upload/image-upload comprehensive "Image upload" guide} to learn about


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Created File management category for CKBox and CKFinder. Closes [#2662](https://github.com/cksource/ckeditor5-internal/issues/2662).

---

### Additional information

For this task, I've done the following things:

1. Created a new _File management_ section for the CKBox and CKFinder guides.
2. In the _Image upload_ section, added a new document _Using file managers_. It's basically a CTA to go to one of the two guides that have been moved.
3. Added some minor linguistic corrections to a couple of documents.
