### PR TITLE
Generate `.d.ts` files for all packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,5 +81,7 @@ packages/ckeditor5-watchdog/src/**/*.js
 packages/ckeditor5-widget/src/**/*.js
 packages/ckeditor5-word-count/src/**/*.js
 packages/*/src/**/*.d.ts
+packages/*/src/**/*.js.map
 src/**/*.js
+src/**/*.js.map
 src/**/*.d.ts

--- a/packages/ckeditor5-engine/tsconfig.release.json
+++ b/packages/ckeditor5-engine/tsconfig.release.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.release.json",
   "include": [
     "./src/",
+    "../../typings/"
   ],
   "exclude": [
     "./tests/"

--- a/packages/ckeditor5-utils/tsconfig.release.json
+++ b/packages/ckeditor5-utils/tsconfig.release.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.release.json",
   "include": [
     "./src/",
+    "../../typings/"
   ],
   "exclude": [
     "./tests/"

--- a/scripts/release/clean.js
+++ b/scripts/release/clean.js
@@ -38,7 +38,7 @@ async function cleanReleaseArtifacts( options ) {
 
 	const removePatterns = [
 		...typeScriptPatterns,
-		'src/**/*.@(js|d.ts)'
+		'src/**/*.@(js|js.map|d.ts)'
 	];
 
 	for ( const pattern of removePatterns ) {

--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -45,6 +45,7 @@ require( '@ckeditor/ckeditor5-dev-release-tools' )
 				// automated/manual tests, translations, documentation, content styles.
 				// If you need to release anything from the directory, type a full path to the file/directory.
 				'src/*.js',
+				'src/*.d.ts',
 				'build/ckeditor5-dll.js',
 				'build/ckeditor5-dll.manifest.json',
 				'build/translations/*.js',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": [
-      "DOM", 
+      "DOM",
       "DOM.Iterable"
     ],
     "noImplicitAny": true,
@@ -11,7 +11,8 @@
     "target": "es2020",
     "sourceMap": true,
     "allowJs": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "skipLibCheck": true
   },
   "include": [
     "./typings/"

--- a/tsconfig.release.json
+++ b/tsconfig.release.json
@@ -1,8 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "sourceMap": false,
-    "declaration": false
+    "sourceMap": true,
+    "declaration": true
   },
   "include": [
     "./typings/"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Internal: Generate `.d.ts` files for all packages. Closes #11722.