### PR TITLE
Docs: Removed suffixes from articles in File management category.

### DIFF
--- a/packages/ckeditor5-ckbox/docs/features/ckbox.md
+++ b/packages/ckeditor5-ckbox/docs/features/ckbox.md
@@ -1,6 +1,6 @@
 ---
 category: features-file-management
-menu-title: CKBox file manager
+menu-title: CKBox
 modified_at: 2022-06-20
 order: 10
 badges: [ premium ]
@@ -8,7 +8,7 @@ badges: [ premium ]
 
 {@snippet features/build-ckbox-source}
 
-# CKBox file manager
+# CKBox
 
 This CKBox integration feature allows you to effortlessly and intuitively insert images as well as links to other files into the rich-text editor content. CKBox is a file manager and a file uploader that acts as a convenient interface for the cloud storage service. The CKBox feature provides a simple integration with this service for the CKEditor 5 WYSIWYG editor. To find out more about CKBox, the brand-new file manager, visit the [CKBox website](https://ckeditor.com/ckbox/) and read the dedicated [CKBox documentation page](https://ckeditor.com/docs/ckbox/latest/guides/index.html).
 

--- a/packages/ckeditor5-ckfinder/docs/features/ckfinder.md
+++ b/packages/ckeditor5-ckfinder/docs/features/ckfinder.md
@@ -1,13 +1,13 @@
 ---
 category: features-file-management
-menu-title: CKFinder file manager
+menu-title: CKFinder
 order: 20
 badges: [ premium ]
 ---
 
 {@snippet features/build-ckfinder-source}
 
-# CKFinder file manager integration
+# CKFinder
 
 This CKFinder integration feature allows you to insert images as well as links to files into the rich-text editor content. It is a bridge between the CKEditor 5 WYSIWYG editor and the [CKFinder](https://ckeditor.com/ckfinder) file manager and uploader. CKFinder is a commercial application that was designed with CKEditor compatibility in mind. It is currently available as version 3.x for PHP, ASP.NET, and Java and version 2.x for ASP and ColdFusion.
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Removed suffixes from articles in File management category. Closes [#2759](https://github.com/cksource/ckeditor5-internal/issues/2759).

---

### Additional information

I've removed the "file manager" suffixes from the articles in the _File management_ category.
