### PR TITLE
Added docs for eslint rule `ckeditor5-rules/non-public-members-as-internal`.

### DIFF
--- a/docs/framework/guides/contributing/code-style.md
+++ b/docs/framework/guides/contributing/code-style.md
@@ -460,7 +460,7 @@ You can use ES6 getters to simplify class API:
 class Position {
 	// More methods.
 	// ...
-	
+
 	get offset() {
 		return this.path[ this.path.length - 1 ];
 	}
@@ -1003,3 +1003,32 @@ To create a code executed only in the debug mode, follow the description of the 
 ```
 
 [History of the change.](https://github.com/ckeditor/ckeditor5/issues/12479)
+
+### Non public members marked as @internal : `ckeditor5-rules/non-public-members-as-internal`
+
+**This rule should only be used on `.ts` files.**
+
+In order to remove non public members from typings, the `@internal` tag has to be used in member's JSDoc.
+
+Then option `"stripInternal": true` in `tsconfig.json` can be used to remove them from declaration types.
+
+👎&nbsp; Examples of incorrect code for this rule:
+
+```ts
+class ClassWithSecrets {
+    private _shouldNotBeEmitted: string;
+}
+```
+
+👍&nbsp; Examples of correct code for this rule:
+
+```ts
+class ClassWithSecrets {
+	/**
+	 * @internal
+	 */
+	private _shouldNotBeEmitted: string;
+}
+```
+
+[History of the change.](https://github.com/cksource/ckeditor5-internal/issues/2643)

--- a/docs/framework/guides/contributing/code-style.md
+++ b/docs/framework/guides/contributing/code-style.md
@@ -1029,6 +1029,3 @@ class ClassWithSecrets {
 	 */
 	private _shouldNotBeEmitted: string;
 }
-```
-
-[History of the change.](https://github.com/cksource/ckeditor5-internal/issues/2643)

--- a/docs/framework/guides/contributing/code-style.md
+++ b/docs/framework/guides/contributing/code-style.md
@@ -1016,7 +1016,7 @@ Then option `"stripInternal": true` in `tsconfig.json` can be used to remove the
 
 ```ts
 class ClassWithSecrets {
-    private _shouldNotBeEmitted: string;
+	private _shouldNotBeEmitted: string;
 }
 ```
 
@@ -1029,3 +1029,4 @@ class ClassWithSecrets {
 	 */
 	private _shouldNotBeEmitted: string;
 }
+```


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/guides/contributing/git-commit-message-convention.html))

Docs: Added docs for eslint rule `ckeditor5-rules/non-public-members-as-internal`.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
