### PR TITLE
Ability to specify the npm tag when publishing

### DIFF
--- a/scripts/release/publish.js
+++ b/scripts/release/publish.js
@@ -11,6 +11,13 @@
 
 const fs = require( 'fs' );
 const path = require( 'path' );
+const minimist = require( 'minimist' );
+
+const argv = minimist( process.argv.slice( 2 ), {
+	string: [
+		'npm-tag'
+	]
+} );
 
 // This scripts publish changes.
 //
@@ -29,6 +36,7 @@ require( '@ckeditor/ckeditor5-dev-release-tools' )
 		cwd: process.cwd(),
 		packages: 'packages',
 		releaseBranch: 'release',
+		npmTag: argv[ 'npm-tag' ],
 		customReleases: [
 			'ckeditor5'
 		],


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Ability to specify the npm tag when publishing. See #13533.

---

### Additional information

Requires: https://github.com/ckeditor/ckeditor5-dev/pull/844.
