### PR TITLE
Make a `text` property optional in `MentionFeedObjectItem` type

### DIFF
--- a/packages/ckeditor5-mention/src/mentionconfig.ts
+++ b/packages/ckeditor5-mention/src/mentionconfig.ts
@@ -278,7 +278,7 @@ export type MentionFeedObjectItem = {
 	/**
 	 * Text inserted into the editor when creating a mention.
 	 */
-	text: string;
+	text?: string;
 };
 
 declare module '@ckeditor/ckeditor5-core' {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (mention): Make a `text` property optional in `MentionFeedObjectItem` type. Closes #13550.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._