### PR TITLE
Add missing config import in DocumentList plugin

### DIFF
--- a/packages/ckeditor5-list/src/documentlist.ts
+++ b/packages/ckeditor5-list/src/documentlist.ts
@@ -11,6 +11,8 @@ import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
 import DocumentListEditing from './documentlist/documentlistediting';
 import ListUI from './list/listui';
 
+import './listconfig';
+
 /**
  * The document list feature.
  *

--- a/packages/ckeditor5-list/src/documentlistproperties.ts
+++ b/packages/ckeditor5-list/src/documentlistproperties.ts
@@ -11,6 +11,8 @@ import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
 import DocumentListPropertiesEditing from './documentlistproperties/documentlistpropertiesediting';
 import ListPropertiesUI from './listproperties/listpropertiesui';
 
+import './listconfig';
+
 /**
  * The document list properties feature.
  *


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (list): Load the plugin configuration in `DocumentList` and `DocumentListProperties` plugins to enable module augmentation and proper editor config suggestions
