### PR TITLE
Other (engine, core): Changes in TS typings

### DIFF
--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -62,6 +62,9 @@ export { default as HtmlDataProcessor } from './dataprocessor/htmldataprocessor'
 // Model / Operation.
 export type { default as Operation } from './model/operation/operation';
 export { default as InsertOperation } from './model/operation/insertoperation';
+export { default as MoveOperation } from './model/operation/moveoperation';
+export { default as MergeOperation } from './model/operation/mergeoperation';
+export { default as SplitOperation } from './model/operation/splitoperation';
 export { default as MarkerOperation } from './model/operation/markeroperation';
 export { default as OperationFactory } from './model/operation/operationfactory';
 export type { default as AttributeOperation } from './model/operation/attributeoperation';


### PR DESCRIPTION
Minor changes in typings needed for CF revision history TS migration.

`documentfragment.markers` - Should this field be `readonly`? While the change in revision history can be fixed using pure TS changes, I'm not sure why it is readonly. From what I can see, it is not possible to pass markers via constructor so setting markers for document fragment (assuming we just want to create document fragment without attaching in to the model) seems difficult.