### PR TITLE
Docs: unifying demos toolbars Batch One

### DIFF
--- a/docs/_snippets/features/placeholder-custom.js
+++ b/docs/_snippets/features/placeholder-custom.js
@@ -10,6 +10,12 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-placeholder-custom' ), {
 		cloudServices: CS_CONFIG,
+		toolbar: [
+			'undo', 'redo', 'heading',
+			'|', 'bold', 'italic',
+			'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+			'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+		],
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/placeholder.js
+++ b/docs/_snippets/features/placeholder.js
@@ -11,7 +11,7 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-placeholder' ), {
 		cloudServices: CS_CONFIG,
 		toolbar: [
-			'undo', 'redo', 'heading',
+			'undo', '|', 'redo', 'heading',
 			'|', 'bold', 'italic',
 			'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 			'|', 'bulletedList', 'numberedList', 'outdent', 'indent'

--- a/docs/_snippets/features/placeholder.js
+++ b/docs/_snippets/features/placeholder.js
@@ -14,7 +14,7 @@ ClassicEditor
 			'undo', 'redo', 'heading',
 			'|', 'bold', 'italic',
 			'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
-			'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+			'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 		],
 		ui: {
 			viewportOffset: {

--- a/docs/_snippets/features/placeholder.js
+++ b/docs/_snippets/features/placeholder.js
@@ -10,6 +10,12 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-placeholder' ), {
 		cloudServices: CS_CONFIG,
+		toolbar: [
+			'undo', 'redo', 'heading',
+			'|', 'bold', 'italic',
+			'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+			'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+		],
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.js
+++ b/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.js
@@ -24,7 +24,7 @@ ClassicEditor
 		] ),
 		toolbar: {
 			items: [
-				'undo', 'redo', 'heading',
+				'undo', '|', 'redo', 'heading',
 				'|', 'bold', 'italic', 'underline', 'strikethrough', 'code',
 				'|', 'link', 'uploadImage', 'insertTable', 'blockQuote', 'mediaEmbed', 'codeBlock', 'horizontalLine',
 				'|', 'bulletedList', 'numberedList', 'todolist', 'outdent', 'indent'

--- a/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.js
+++ b/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.js
@@ -24,27 +24,10 @@ ClassicEditor
 		] ),
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'strikethrough',
-				'code',
-				'link',
-				'|',
-				'bulletedList',
-				'numberedList',
-				'todolist',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'blockQuote',
-				'codeBlock',
-				'horizontalLine',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo', 'heading',
+				'|', 'bold', 'italic', 'underline', 'strikethrough', 'code',
+				'|', 'link', 'uploadImage', 'insertTable', 'blockQuote', 'mediaEmbed', 'codeBlock', 'horizontalLine',
+				'|', 'bulletedList', 'numberedList', 'todolist', '|', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.js
+++ b/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.js
@@ -27,7 +27,7 @@ ClassicEditor
 				'undo', 'redo', 'heading',
 				'|', 'bold', 'italic', 'underline', 'strikethrough', 'code',
 				'|', 'link', 'uploadImage', 'insertTable', 'blockQuote', 'mediaEmbed', 'codeBlock', 'horizontalLine',
-				'|', 'bulletedList', 'numberedList', 'todolist', '|', 'outdent', 'indent'
+				'|', 'bulletedList', 'numberedList', 'todolist', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-basic-styles/docs/_snippets/features/basic-styles.js
+++ b/packages/ckeditor5-basic-styles/docs/_snippets/features/basic-styles.js
@@ -14,7 +14,7 @@ ClassicEditor
 				'undo', 'redo', 'heading',
 				'|', 'bold', 'italic', 'underline', 'strikethrough', 'subscript', 'superscript', 'code', '|', 'removeFormat',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
-				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-basic-styles/docs/_snippets/features/basic-styles.js
+++ b/packages/ckeditor5-basic-styles/docs/_snippets/features/basic-styles.js
@@ -11,7 +11,7 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-basic-styles' ), {
 		toolbar: {
 			items: [
-				'undo', 'redo', 'heading',
+				'undo', '|', 'redo', 'heading',
 				'|', 'bold', 'italic', 'underline', 'strikethrough', 'subscript', 'superscript', 'code', '|', 'removeFormat',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'

--- a/packages/ckeditor5-basic-styles/docs/_snippets/features/basic-styles.js
+++ b/packages/ckeditor5-basic-styles/docs/_snippets/features/basic-styles.js
@@ -11,7 +11,10 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-basic-styles' ), {
 		toolbar: {
 			items: [
-				'bold', 'italic', 'underline', 'strikethrough', 'subscript', 'superscript', 'code', '|', 'removeFormat', '|', 'undo', 'redo'
+				'undo', 'redo', 'heading',
+				'|', 'bold', 'italic', 'underline', 'strikethrough', 'subscript', 'superscript', 'code', '|', 'removeFormat',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote-source.js
+++ b/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote-source.js
@@ -13,19 +13,10 @@ ClassicEditor.defaultConfig = {
 	cloudServices: CS_CONFIG,
 	toolbar: {
 		items: [
-			'heading',
-			'|',
-			'bold',
-			'italic',
-			'link',
-			'|',
-			'bulletedList',
-			'numberedList',
-			'|',
-			'blockQuote',
-			'|',
-			'undo',
-			'redo'
+			'undo', 'redo', 'heading',
+			'|', 'bold', 'italic',
+			'|', 'link', 'uploadImage', 'insertTable', 'blockQuote', 'mediaEmbed',
+			'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
 		]
 	},
 	ui: {

--- a/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote-source.js
+++ b/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote-source.js
@@ -16,7 +16,7 @@ ClassicEditor.defaultConfig = {
 			'undo', 'redo', 'heading',
 			'|', 'bold', 'italic',
 			'|', 'link', 'uploadImage', 'insertTable', 'blockQuote', 'mediaEmbed',
-			'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+			'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 		]
 	},
 	ui: {

--- a/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote-source.js
+++ b/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote-source.js
@@ -13,7 +13,7 @@ ClassicEditor.defaultConfig = {
 	cloudServices: CS_CONFIG,
 	toolbar: {
 		items: [
-			'undo', 'redo', 'heading',
+			'undo', '|', 'redo', 'heading',
 			'|', 'bold', 'italic',
 			'|', 'link', 'uploadImage', 'insertTable', 'blockQuote', 'mediaEmbed',
 			'|', 'bulletedList', 'numberedList', 'outdent', 'indent'

--- a/packages/ckeditor5-code-block/docs/_snippets/features/code-block-custom-languages.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/code-block-custom-languages.js
@@ -12,19 +12,10 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'code',
-				'codeBlock',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo', 'heading',
+				'|', 'bold', 'italic', 'code',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed', 'codeBlock',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-code-block/docs/_snippets/features/code-block-custom-languages.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/code-block-custom-languages.js
@@ -12,7 +12,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'undo', 'redo', 'heading',
+				'undo', '|', 'redo', 'heading',
 				'|', 'bold', 'italic', 'code',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed', 'codeBlock',
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'

--- a/packages/ckeditor5-code-block/docs/_snippets/features/code-block.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/code-block.js
@@ -15,7 +15,7 @@ ClassicEditor
 				'undo', 'redo', 'heading',
 				'|', 'bold', 'italic', 'code',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed', 'codeBlock',
-				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-code-block/docs/_snippets/features/code-block.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/code-block.js
@@ -12,19 +12,10 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'code',
-				'codeBlock',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo', 'heading',
+				'|', 'bold', 'italic', 'code',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed', 'codeBlock',
+				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-code-block/docs/_snippets/features/code-block.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/code-block.js
@@ -12,7 +12,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'undo', 'redo', 'heading',
+				'undo', '|', 'redo', 'heading',
 				'|', 'bold', 'italic', 'code',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed', 'codeBlock',
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'

--- a/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
+++ b/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
@@ -12,7 +12,7 @@ ClassicEditor
 				'undo', 'redo', 'heading',
 				'|', 'bold', 'italic',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
-				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
+++ b/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
@@ -9,7 +9,7 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-findandreplace' ), {
 		toolbar: {
 			items: [
-				'undo', 'redo', 'heading',
+				'undo', '|', 'redo', 'heading',
 				'|', 'bold', 'italic',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'

--- a/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
+++ b/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
@@ -9,18 +9,10 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-findandreplace' ), {
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'underline',
-				'link',
-				'insertTable',
-				'|',
-				'undo',
-				'redo',
-				'|',
-				'findAndReplace'
+				'undo', 'redo', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
@@ -16,7 +16,7 @@ ClassicEditor
 				'|',
 				'|', 'bold', 'italic',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
-				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			],
 			shouldNotGroupWhenFull: true
 		},

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
@@ -11,7 +11,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'undo', 'redo', 'heading',
+				'undo', '|', 'redo', 'heading',
 				'|', 'fontColor', 'fontBackgroundColor',
 				'|',
 				'|', 'bold', 'italic',

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
@@ -11,20 +11,14 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'heading',
+				'undo', 'redo', 'heading',
+				'|', 'fontColor', 'fontBackgroundColor',
 				'|',
-				'fontColor',
-				'fontBackgroundColor',
-				'|',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'undo',
-				'redo'
-			]
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+			],
+			shouldNotGroupWhenFull: true
 		},
 		ui: {
 			viewportOffset: {

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-family-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-family-options.js
@@ -11,7 +11,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'undo', 'redo', 'heading',
+				'undo', '|', 'redo', 'heading',
 				'|', 'fontFamily',
 				'|',
 				'|', 'bold', 'italic',

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-family-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-family-options.js
@@ -16,7 +16,7 @@ ClassicEditor
 				'|',
 				'|', 'bold', 'italic',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
-				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			],
 			shouldNotGroupWhenFull: true
 		},

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-family-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-family-options.js
@@ -11,19 +11,14 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'heading',
+				'undo', 'redo', 'heading',
+				'|', 'fontFamily',
 				'|',
-				'fontFamily',
-				'|',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'undo',
-				'redo'
-			]
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+			],
+			shouldNotGroupWhenFull: true
 		},
 		ui: {
 			viewportOffset: {

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-named-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-named-options.js
@@ -17,7 +17,7 @@ ClassicEditor
 				'|',
 				'|', 'bold', 'italic',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
-				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			],
 			shouldNotGroupWhenFull: true
 		},

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-named-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-named-options.js
@@ -12,7 +12,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'undo', 'redo', 'heading',
+				'undo', '|', 'redo', 'heading',
 				'|', 'fontSize',
 				'|',
 				'|', 'bold', 'italic',

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-named-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-named-options.js
@@ -12,8 +12,14 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'heading', '|', 'fontSize', 'bulletedList', 'numberedList', 'undo', 'redo'
-			]
+				'undo', 'redo', 'heading',
+				'|', 'fontSize',
+				'|',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+			],
+			shouldNotGroupWhenFull: true
 		},
 		ui: {
 			viewportOffset: {

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-numeric-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-numeric-options.js
@@ -17,7 +17,7 @@ ClassicEditor
 				'|',
 				'|', 'bold', 'italic',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
-				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			],
 			shouldNotGroupWhenFull: true
 		},

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-numeric-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-numeric-options.js
@@ -12,7 +12,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'undo', 'redo', 'heading',
+				'undo', '|', 'redo', 'heading',
 				'|', 'fontSize',
 				'|',
 				'|', 'bold', 'italic',

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-numeric-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-numeric-options.js
@@ -12,19 +12,14 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'heading',
+				'undo', 'redo', 'heading',
+				'|', 'fontSize',
 				'|',
-				'fontSize',
-				'|',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'undo',
-				'redo'
-			]
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+			],
+			shouldNotGroupWhenFull: true
 		},
 		ui: {
 			viewportOffset: {

--- a/packages/ckeditor5-font/docs/_snippets/features/font.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/font.js
@@ -12,21 +12,12 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'heading',
+				'undo', 'redo', 'heading',
+				'|', 'fontSize', 'fontFamily', 'fontColor', 'fontBackgroundColor',
 				'|',
-				'fontSize',
-				'fontFamily',
-				'fontColor',
-				'fontBackgroundColor',
-				'|',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'undo',
-				'redo'
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-indent/docs/_snippets/features/custom-indent-block-classes.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/custom-indent-block-classes.js
@@ -15,7 +15,7 @@ ClassicEditor
 				'undo', 'redo', 'heading',
 				'|', 'bold', 'italic', 'code',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
-				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-indent/docs/_snippets/features/custom-indent-block-classes.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/custom-indent-block-classes.js
@@ -12,18 +12,10 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'code',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo', 'heading',
+				'|', 'bold', 'italic', 'code',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-indent/docs/_snippets/features/custom-indent-block-classes.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/custom-indent-block-classes.js
@@ -12,7 +12,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'undo', 'redo', 'heading',
+				'undo', '|', 'redo', 'heading',
 				'|', 'bold', 'italic', 'code',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'

--- a/packages/ckeditor5-indent/docs/_snippets/features/indent.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/indent.js
@@ -12,7 +12,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'undo', 'redo', 'heading',
+				'undo', '|', 'redo', 'heading',
 				'|', 'bold', 'italic',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'

--- a/packages/ckeditor5-indent/docs/_snippets/features/indent.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/indent.js
@@ -12,16 +12,10 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-indent/docs/_snippets/features/indent.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/indent.js
@@ -15,7 +15,7 @@ ClassicEditor
 				'undo', 'redo', 'heading',
 				'|', 'bold', 'italic',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
-				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-minimap/docs/_snippets/features/minimap.js
+++ b/packages/ckeditor5-minimap/docs/_snippets/features/minimap.js
@@ -50,7 +50,7 @@ const config = {
 		EasyImage
 	],
 	toolbar: [
-		'undo', 'redo', 'heading',
+		'undo', '|', 'redo', 'heading',
 		'|', 'bold', 'italic',
 		'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 		'|', 'bulletedList', 'numberedList', 'outdent', 'indent'

--- a/packages/ckeditor5-minimap/docs/_snippets/features/minimap.js
+++ b/packages/ckeditor5-minimap/docs/_snippets/features/minimap.js
@@ -53,7 +53,7 @@ const config = {
 		'undo', 'redo', 'heading',
 		'|', 'bold', 'italic',
 		'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
-		'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+		'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 	],
 	image: {
 		toolbar: [

--- a/packages/ckeditor5-minimap/docs/_snippets/features/minimap.js
+++ b/packages/ckeditor5-minimap/docs/_snippets/features/minimap.js
@@ -50,15 +50,10 @@ const config = {
 		EasyImage
 	],
 	toolbar: [
-		'heading', '|',
-		'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor', '|',
-		'bold', 'italic', 'blockQuote', '|',
-		'codeBlock',
-		'alignment', '|',
-		'indent', 'outdent', '|',
-		'subscript', 'superscript', '|',
-		'insertTable', 'imageUpload', 'pageBreak', '|',
-		'undo', 'redo'
+		'undo', 'redo', 'heading',
+		'|', 'bold', 'italic',
+		'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+		'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
 	],
 	image: {
 		toolbar: [

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.js
@@ -13,7 +13,7 @@ ClassicEditor
 		placeholder: 'Type here...',
 		toolbar: {
 			items: [
-				'undo', 'redo', 'heading',
+				'undo', '|', 'redo', 'heading',
 				'|', 'bold', 'italic',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.js
@@ -11,6 +11,14 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-text-transformation-extended' ), {
 		cloudServices: CS_CONFIG,
 		placeholder: 'Type here...',
+		toolbar: {
+			items: [
+				'undo', 'redo', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
@@ -13,7 +13,7 @@ ClassicEditor
 		placeholder: 'Type here...',
 		toolbar: {
 			items: [
-				'undo', 'redo', 'heading',
+				'undo', '|', 'redo', 'heading',
 				'|', 'bold', 'italic',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
@@ -11,6 +11,14 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-text-transformation' ), {
 		cloudServices: CS_CONFIG,
 		placeholder: 'Type here...',
+		toolbar: {
+			items: [
+				'undo', 'redo', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
@@ -16,7 +16,7 @@ ClassicEditor
 				'undo', 'redo', 'heading',
 				'|', 'bold', 'italic',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
-				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: unifying demos toolbars.

---

### Additional information

_The first batch of toolbars. Part of_ cksource/ckeditor5-internal#2797

Based on the "Editor toolbar with few features" setup as described here: [https://www.notion.so/WIP-Toolbar-composition-guidelines-5196b3852e70462b98b8023d4d0f6cd7?pvs=4#a78453199acb480ab776e2b9907b1eed](https://www.notion.so/WIP-Toolbar-composition-guidelines-5196b3852e70462b98b8023d4d0f6cd7?pvs=4#a78453199acb480ab776e2b9907b1eed)

All basic features in the setup are available in the editor builds (hence underline was removed).

Batch One contains the following guides:

*   autoformatting
*   automatic text transformations
*   basic text styles
*   block indent
*   block quote
*   code block
*   content minimap
*   editor placeholder
*   find and replace
*   font: family, size, color, background color