### PR TITLE
check-maunal-tests should not build DLL

### DIFF
--- a/scripts/check-manual-tests.sh
+++ b/scripts/check-manual-tests.sh
@@ -29,7 +29,7 @@ fi
 echo "Starting the manual test server..."
 
 # `yarn run` does not forward SIGTERM to process, so we need to use the command directly.
-node --max_old_space_size=8192 node_modules/@ckeditor/ckeditor5-dev-tests/bin/testmanual.js --tsconfig ./tsconfig.test.json $MANUAL_TEST_SERVER_OPTIONS &
+node --max_old_space_size=8192 node_modules/@ckeditor/ckeditor5-dev-tests/bin/testmanual.js --tsconfig ./tsconfig.test.json --no-dll $MANUAL_TEST_SERVER_OPTIONS &
 
 MANUAL_TEST_SERVER_PROCESS_ID=$!
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: The `check-manual-tests` should not produce DLL builds. An integrator should provide them before calling the checker script.
