### PR TITLE
Adopt Github conventions in HTML -> MD conversion

### DIFF
--- a/packages/ckeditor5-markdown-gfm/src/html2markdown/html2markdown.ts
+++ b/packages/ckeditor5-markdown-gfm/src/html2markdown/html2markdown.ts
@@ -62,7 +62,11 @@ TurndownService.prototype.escape = function( string: string ): string {
 const turndownService = new TurndownService( {
 	codeBlockStyle: 'fenced',
 	hr: '---',
-	headingStyle: 'atx'
+	headingStyle: 'atx',
+	bulletListMarker: '-',
+	codeBlockStyle: 'fenced',
+	emDelimiter: '*',
+	br: '\n'
 } );
 
 turndownService.use( [

--- a/packages/ckeditor5-markdown-gfm/src/html2markdown/html2markdown.ts
+++ b/packages/ckeditor5-markdown-gfm/src/html2markdown/html2markdown.ts
@@ -64,7 +64,6 @@ const turndownService = new TurndownService( {
 	hr: '---',
 	headingStyle: 'atx',
 	bulletListMarker: '-',
-	codeBlockStyle: 'fenced',
 	emDelimiter: '*',
 	br: '\n'
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Closes ckeditor/github-writer#438.
Adopt Github conventions in HTML -> MD conversion.

---

### Additional information

[CommonMark](https://commonmark.org/help/) is so popular compared to [Josh Gruber's original Markdown spec](https://daringfireball.net/projects/markdown/syntax) that we should favor it.