### PR TITLE
Docs: unifying demos toolbars Batch Three

### DIFF
--- a/docs/_snippets/features/read-only-hide-toolbar.js
+++ b/docs/_snippets/features/read-only-hide-toolbar.js
@@ -10,6 +10,15 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-read-only-toolbar' ), {
 		cloudServices: CS_CONFIG,
+		toolbar: {
+			items: [
+				'exportPdf', 'exportWord', 'findAndReplace',
+				'|', 'undo', 'redo', '|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/read-only.js
+++ b/docs/_snippets/features/read-only.js
@@ -12,26 +12,11 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'exportPdf',
-				'exportWord',
-				'|',
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'link',
-				'numberedList',
-				'bulletedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'uploadImage',
-				'blockQuote',
-				'insertTable',
-				'findAndReplace',
-				'undo',
-				'redo'
+				'exportPdf', 'exportWord', 'findAndReplace',
+				'|', 'undo', 'redo', '|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/drag-drop.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/drag-drop.js
@@ -237,21 +237,10 @@ ClassicEditor
 		],
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'alignment',
-				'|',
-				'bold',
-				'italic',
-				'underline',
-				'|',
-				'link',
-				'uploadImage',
-				'insertTable',
-				'horizontalLine',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo', '|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed', 'horizontalLine',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/paste-plain-text.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/paste-plain-text.js
@@ -11,20 +11,11 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-paste-plain-text' ), {
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'fontSize',
-				'fontFamily',
-				'fontColor',
-				'fontBackgroundColor',
-				'|',
-				'bold',
-				'italic',
-				'underline',
-				'strikethrough',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo', '|', 'heading',
+				'|', 'fontSize', 'fontFamily', 'fontColor', 'fontBackgroundColor',
+				'|', 'bold', 'italic', 'underline', 'strikethrough',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
+++ b/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
@@ -9,7 +9,7 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-findandreplace' ), {
 		toolbar: {
 			items: [
-				'undo', 'redo', '|', 'heading',
+				'undo', 'redo', '|', 'findAndReplace', '|', 'heading',
 				'|', 'bold', 'italic',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
@@ -28,7 +28,10 @@ ClassicEditor
 			target: window.findToolbarItem( editor.ui.view.toolbar,
 				item => item.buttonView && item.buttonView.label === 'Find and replace' ),
 			text: 'Click here to search.',
-			editor
+			editor,
+			tippyOptions: {
+				placement: 'bottom-start'
+			}
 		} );
 	} )
 	.catch( err => {

--- a/packages/ckeditor5-minimap/docs/_snippets/features/minimap.js
+++ b/packages/ckeditor5-minimap/docs/_snippets/features/minimap.js
@@ -113,7 +113,7 @@ DecoupledEditor
 			text: 'Use the minimap for quick navigation',
 			editor,
 			tippyOptions: {
-				placement: 'bottom'
+				placement: 'bottom-end'
 			}
 		} );
 	} );

--- a/packages/ckeditor5-paste-from-office/docs/_snippets/features/paste-from-office.js
+++ b/packages/ckeditor5-paste-from-office/docs/_snippets/features/paste-from-office.js
@@ -12,35 +12,13 @@ ClassicEditor
 		extraPlugins: [ ListProperties ],
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'fontSize',
-				'fontFamily',
-				'fontColor',
-				'fontBackgroundColor',
-				'|',
-				'bold',
-				'italic',
-				'underline',
-				'strikethrough',
-				'-',
-				'alignment',
-				'|',
-				'numberedList',
-				'bulletedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'link',
-				'uploadImage',
-				'insertTable',
-				'horizontalLine',
-				'|',
-				'undo',
-				'redo'
-			],
-			shouldNotGroupWhenFull: true
+				'undo', 'redo', '|', 'heading',
+				'|', 'fontSize', 'fontFamily', 'fontColor', 'fontBackgroundColor',
+				'|', 'bold', 'italic', 'underline', 'strikethrough',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'alignment',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
 		},
 		ui: {
 			viewportOffset: {

--- a/packages/ckeditor5-remove-format/docs/_snippets/features/remove-format.js
+++ b/packages/ckeditor5-remove-format/docs/_snippets/features/remove-format.js
@@ -9,25 +9,15 @@ ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		toolbar: {
 			items: [
-				'bold',
-				'italic',
-				'underline',
-				'strikethrough',
-				'code',
-				'subscript',
-				'superscript',
-				'|',
-				'fontSize',
-				'fontFamily',
-				'|',
-				'alignment',
-				'link',
-				'|',
-				'undo',
-				'redo',
-				'|',
-				'removeformat'
-			]
+				'undo', 'redo', '|', 'heading',
+				'|', 'fontSize', 'fontFamily',
+				'|', 'bold', 'italic', 'underline', 'strikethrough', 'code', 'subscript', 'superscript',
+				'|', 'removeformat',
+				'-', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'alignment',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			],
+			shouldNotGroupWhenFull: true
 		},
 		ui: {
 			viewportOffset: {

--- a/packages/ckeditor5-restricted-editing/docs/_snippets/features/restricted-editing.js
+++ b/packages/ckeditor5-restricted-editing/docs/_snippets/features/restricted-editing.js
@@ -38,11 +38,14 @@ async function startMode( selectedMode ) {
 async function startStandardEditingMode() {
 	await reloadEditor( {
 		removePlugins: [ 'RestrictedEditingMode' ],
-		toolbar: [
-			'restrictedEditingException', '|', 'heading', '|', 'bold', 'italic', 'link', '|',
-			'bulletedList', 'numberedList', 'blockQuote', 'insertTable', '|',
-			'undo', 'redo'
-		],
+		toolbar: {
+			items: [
+				'undo', 'redo', '|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'restrictedEditingException', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		table: {
 			contentToolbar: [
 				'tableColumn',

--- a/packages/ckeditor5-select-all/docs/_snippets/features/select-all.js
+++ b/packages/ckeditor5-select-all/docs/_snippets/features/select-all.js
@@ -9,18 +9,10 @@ ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'underline',
-				'link',
-				'insertTable',
-				'|',
-				'undo',
-				'redo',
-				'|',
-				'selectAll'
+				'undo', 'redo', '|', 'selectAll', '|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {
@@ -35,7 +27,10 @@ ClassicEditor
 		window.attachTourBalloon( {
 			target: window.findToolbarItem( editor.ui.view.toolbar, item => item.label && item.label === 'Select all' ),
 			text: 'Click to select everything.',
-			editor
+			editor,
+			tippyOptions: {
+				placement: 'bottom-start'
+			}
 		} );
 	} )
 	.catch( err => {

--- a/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-imports.js
+++ b/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-imports.js
@@ -34,23 +34,12 @@ ClassicEditor.defaultConfig = {
 	cloudServices: CS_CONFIG,
 	toolbar: {
 		items: [
-			'sourceEditing',
-			'|',
-			'heading',
-			'|',
-			'bold',
-			'italic',
-			'link',
-			'bulletedList',
-			'numberedList',
-			'|',
-			'uploadImage',
-			'blockQuote',
-			'insertTable',
-			'mediaEmbed',
-			'|',
-			'undo',
-			'redo'
+			'undo', 'redo',
+			'|', 'sourceEditing',
+			'|', 'heading',
+			'|', 'bold', 'italic',
+			'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+			'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 		]
 	},
 	ui: {

--- a/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-with-markdown.js
+++ b/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-with-markdown.js
@@ -10,25 +10,13 @@ ClassicEditor
 		extraPlugins: [ Markdown ],
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'link',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'uploadImage',
-				'blockQuote',
-				'insertTable',
-				'mediaEmbed',
-				'|',
-				'undo',
-				'redo',
-				'|',
-				'sourceEditing'
-			],
-			shouldNotGroupWhenFull: true
+				'undo', 'redo',
+				'|', 'sourceEditing',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
 		},
 		table: {
 			contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ]
@@ -76,7 +64,10 @@ ClassicEditor
 			target: window.findToolbarItem( editor.ui.view.toolbar,
 				item => item.label && item.label === 'Source' ),
 			text: 'Switch to the source mode to edit the Markdown source.',
-			editor
+			editor,
+			tippyOptions: {
+				placement: 'bottom-start'
+			}
 		} );
 	} )
 	.catch( err => {

--- a/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing.js
+++ b/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing.js
@@ -11,35 +11,13 @@ ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'alignment',
-				'outdent',
-				'indent',
-				'|',
-				'bold',
-				'italic',
-				'underline',
-				'strikethrough',
-				'subscript',
-				'superscript',
-				'code',
-				'-',
-				'codeBlock',
-				'blockQuote',
-				'link',
-				'uploadImage',
-				'insertTable',
-				'mediaEmbed',
-				'|',
-				'bulletedList',
-				'numberedList',
-				'todoList',
-				'|',
-				'undo',
-				'redo',
-				'|',
-				'sourceEditing'
+				'undo', 'redo',
+				'|', 'sourceEditing',
+				'|', 'heading',
+				'|', 'bold', 'italic', 'underline', 'strikethrough', 'subscript', 'superscript', 'code',
+				'-', 'link', 'uploadImage', 'insertTable', 'blockQuote', 'mediaEmbed', 'codeBlock',
+				'|', 'alignment',
+				'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
 			],
 			shouldNotGroupWhenFull: true
 		},
@@ -93,7 +71,10 @@ ClassicEditor
 			target: window.findToolbarItem( editor.ui.view.toolbar,
 				item => item.label && item.label === 'Source' ),
 			text: 'Switch to the source mode to edit the HTML source.',
-			editor
+			editor,
+			tippyOptions: {
+				placement: 'bottom-start'
+			}
 		} );
 	} )
 	.catch( err => {

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-extended-category.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-extended-category.js
@@ -20,26 +20,10 @@ ClassicEditor
 		extraPlugins: [ SpecialCharactersEssentials, SpecialCharactersExtended ],
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'fontColor',
-				'fontBackgroundColor',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'specialCharacters',
-				'link',
-				'uploadImage',
-				'insertTable',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo', '|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed', 'specialCharacters',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-limited-categories.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-limited-categories.js
@@ -12,23 +12,10 @@ ClassicEditor
 		extraPlugins: [ SpecialCharactersCurrency, SpecialCharactersMathematical ],
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'specialCharacters',
-				'link',
-				'uploadImage',
-				'insertTable',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo', '|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed', 'specialCharacters',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-new-category.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-new-category.js
@@ -22,23 +22,10 @@ ClassicEditor
 		extraPlugins: [ SpecialCharactersEssentials, SpecialCharactersEmoji ],
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'specialCharacters',
-				'link',
-				'uploadImage',
-				'insertTable',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo', '|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed', 'specialCharacters',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters.js
@@ -12,23 +12,10 @@ ClassicEditor
 		extraPlugins: [ SpecialCharactersEssentials ],
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'specialCharacters',
-				'link',
-				'uploadImage',
-				'insertTable',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo', '|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed', 'specialCharacters',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: unifying demos toolbars.

---

### Additional information

_The third batch of toolbars. Part of_ cksource/ckeditor5-internal#2797

Based on the "Editor toolbar with few features" setup as described here: [https://www.notion.so/WIP-Toolbar-composition-guidelines-5196b3852e70462b98b8023d4d0f6cd7?pvs=4#a78453199acb480ab776e2b9907b1eed](https://www.notion.so/WIP-Toolbar-composition-guidelines-5196b3852e70462b98b8023d4d0f6cd7?pvs=4#a78453199acb480ab776e2b9907b1eed)

All basic features in the setup are available in the editor builds (hence underline was removed).

Batch Three contains the following guides:

*   paste from Google Docs
*   paste from Office
*   paste plain text
*   drag and drop
*   read-only support
*   remove formatting
*   restricted editing
*   select all
*   source editing
*   special characters