### PR TITLE
Docs: unifying demos toolbars Batch Four

### DIFF
--- a/docs/_snippets/features/toolbar-basic.js
+++ b/docs/_snippets/features/toolbar-basic.js
@@ -10,7 +10,13 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#toolbar-basic' ), {
 		toolbar: {
-			items: [ 'bold', 'italic', 'link', 'undo', 'redo', 'numberedList', 'bulletedList' ]
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
 		},
 		cloudServices: CS_CONFIG,
 		ui: {

--- a/docs/_snippets/features/ui-language-content.js
+++ b/docs/_snippets/features/ui-language-content.js
@@ -13,6 +13,15 @@ ClassicEditor
 			content: 'ar'
 		},
 		cloudServices: CS_CONFIG,
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/ui-language-rtl.js
+++ b/docs/_snippets/features/ui-language-rtl.js
@@ -11,6 +11,15 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-ui-language-rtl' ), {
 		language: 'ar',
 		cloudServices: CS_CONFIG,
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/ui-language.js
+++ b/docs/_snippets/features/ui-language.js
@@ -11,6 +11,15 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-ui-language' ), {
 		language: 'es',
 		cloudServices: CS_CONFIG,
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/wproofreader.js
+++ b/docs/_snippets/features/wproofreader.js
@@ -25,25 +25,12 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'blockQuote',
-				'link',
-				'mediaEmbed',
-				'insertTable',
-				'|',
-				'wproofreader',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo',
+				'|', 'wproofreader',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-options.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-options.js
@@ -11,17 +11,12 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-custom-text-alignment-options' ), {
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'alignment',
-				'undo',
-				'redo'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'alignment',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-toolbar.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-toolbar.js
@@ -11,7 +11,12 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-custom-text-alignment-toolbar' ), {
 		toolbar: {
 			items: [
-				'heading', '|', 'alignment:left', 'alignment:right', 'alignment:center', 'alignment:justify'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'alignment:left', 'alignment:right', 'alignment:center', 'alignment:justify',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js
@@ -11,17 +11,12 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-text-alignment' ), {
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'alignment',
-				'undo',
-				'redo'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'alignment',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-ckbox/docs/_snippets/features/ckbox.js
+++ b/packages/ckeditor5-ckbox/docs/_snippets/features/ckbox.js
@@ -11,17 +11,11 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-ckbox' ), {
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'link',
-				'insertTable',
-				'|',
-				'undo',
-				'redo',
-				'|',
-				'ckbox'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'ckbox', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		image: {

--- a/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder-options.js
+++ b/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder-options.js
@@ -9,7 +9,11 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-ckfinder-options' ), {
 		toolbar: {
 			items: [
-				'heading', '|', 'bold', 'italic', '|', 'undo', 'redo', '|', 'ckfinder'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'ckfinder', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder-upload-only.js
+++ b/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder-upload-only.js
@@ -9,7 +9,11 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-ckfinder-upload-only' ), {
 		toolbar: {
 			items: [
-				'heading', '|', 'bold', 'italic', '|', 'undo', 'redo', '|', 'uploadImage'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		image: {

--- a/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder.js
+++ b/packages/ckeditor5-ckfinder/docs/_snippets/features/ckfinder.js
@@ -9,7 +9,11 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-ckfinder' ), {
 		toolbar: {
 			items: [
-				'heading', '|', 'bold', 'italic', '|', 'undo', 'redo', '|', 'ckfinder'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'ckfinder', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		image: {

--- a/packages/ckeditor5-ckfinder/docs/api/ckfinder.md
+++ b/packages/ckeditor5-ckfinder/docs/api/ckfinder.md
@@ -10,7 +10,7 @@ This package implements the {@link features/ckfinder CKFinder feature}. This fea
 
 ## Demo
 
-Check out the {@link features/ckfinder#demo demos} in the integration guide.
+Check out the {@link features/ckfinder#demos demos} in the integration guide.
 
 ## Documentation
 

--- a/packages/ckeditor5-ckfinder/docs/features/ckfinder.md
+++ b/packages/ckeditor5-ckfinder/docs/features/ckfinder.md
@@ -19,7 +19,7 @@ The CKFinder feature lets you insert images and links to files into your content
 	This feature is enabled by default in all [predefined builds](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/predefined-builds.html) for convenience, but the editor will still work properly without activating it.
 </info-box>
 
-## Demo
+## Demos
 
 ### Image upload only
 
@@ -30,10 +30,6 @@ This demo shows the integration where the file manager's server connector handle
 
 {@snippet features/ckfinder-upload-only}
 
-<info-box info>
-	This demo only presents a limited set of features. Visit the {@link examples/builds/full-featured-editor full-featured editor example} to see more in action.
-</info-box>
-
 ### Full integration
 
 This demo shows the [full integration](#configuring-the-full-integration) with the CKFinder file uploader:
@@ -43,6 +39,9 @@ This demo shows the [full integration](#configuring-the-full-integration) with t
 
 {@snippet features/ckfinder}
 
+<info-box info>
+	These demos only presents a limited set of features. Visit the {@link examples/builds/full-featured-editor full-featured editor example} to see more in action.
+</info-box>
 ## Additional feature information
 
 The CKFinder integration feature is a bridge between the CKEditor 5 WYSIWYG editor and the [CKFinder](https://ckeditor.com/ckfinder) file manager and uploader. CKFinder is a commercial application that was designed with CKEditor compatibility in mind. It is currently available as version 3.x for PHP, ASP.NET, and Java and version 2.x for ASP and ColdFusion.

--- a/packages/ckeditor5-font/docs/_snippets/features/font.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/font.js
@@ -12,7 +12,7 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'undo', 'redo', 'heading',
+				'undo', 'redo', '|', 'heading',
 				'|', 'fontSize', 'fontFamily', 'fontColor', 'fontBackgroundColor',
 				'|',
 				'|', 'bold', 'italic',

--- a/packages/ckeditor5-image/docs/_snippets/features/image-caption.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-caption.js
@@ -10,6 +10,15 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-caption' ), {
 		removePlugins: [ 'LinkImage', 'AutoImage' ],
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		image: {
 			toolbar: [
 				'imageTextAlternative',

--- a/packages/ckeditor5-image/docs/_snippets/features/image-full.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-full.js
@@ -11,23 +11,11 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-image-full' ), {
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'link',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'uploadImage',
-				'blockQuote',
-				'insertTable',
-				'mediaEmbed',
-				'undo',
-				'redo'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-image/docs/_snippets/features/image-insert-via-pasting-url-into-editor.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-insert-via-pasting-url-into-editor.js
@@ -11,6 +11,15 @@ ClassicEditor
 	.create( document.querySelector( '#snippet-image-insert-via-pasting-url-into-editor' ), {
 		removePlugins: [ 'ImageToolbar', 'ImageCaption', 'ImageStyle', 'ImageResize', 'LinkImage' ],
 		cloudServices: CS_CONFIG,
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-insert-via-url.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-insert-via-url.js
@@ -7,15 +7,21 @@
 
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config.js';
 
-const toolbarItems = [ ...ClassicEditor.defaultConfig.toolbar.items ];
+// const toolbarItems = [ ...ClassicEditor.defaultConfig.toolbar.items ];
 
-toolbarItems.splice( toolbarItems.indexOf( 'uploadImage' ), 1, 'insertImage' );
+// toolbarItems.splice( toolbarItems.indexOf( 'uploadImage' ), 1, 'insertImage' );
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-insert-via-url' ), {
 		removePlugins: [ 'ImageToolbar', 'ImageCaption', 'ImageStyle', 'ImageResize', 'LinkImage', 'AutoImage' ],
 		toolbar: {
-			items: toolbarItems
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'insertImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
 		},
 		ui: {
 			viewportOffset: {

--- a/packages/ckeditor5-image/docs/_snippets/features/image-link.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-link.js
@@ -10,6 +10,15 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-link' ), {
 		removePlugins: [ 'AutoImage' ],
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons-dropdown.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons-dropdown.js
@@ -10,6 +10,15 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-resize-buttons-dropdown' ), {
 		removePlugins: [ 'LinkImage', 'AutoImage' ],
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons.js
@@ -10,6 +10,15 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-resize-buttons' ), {
 		removePlugins: [ 'LinkImage', 'AutoImage' ],
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize-px.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize-px.js
@@ -10,6 +10,15 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-resize-px' ), {
 		removePlugins: [ 'LinkImage', 'AutoImage' ],
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		image: {
 			resizeUnit: 'px',
 			resizeOptions: [

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize.js
@@ -10,6 +10,15 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-resize' ), {
 		removePlugins: [ 'LinkImage', 'AutoImage' ],
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-semantical-style.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-semantical-style.js
@@ -16,6 +16,15 @@ ClassicEditor
 			}
 		},
 		cloudServices: CS_CONFIG,
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		image: {
 			toolbar: [ 'imageStyle:inline', 'imageStyle:block', 'imageStyle:side' ]
 		}

--- a/packages/ckeditor5-image/docs/_snippets/features/image-style-custom.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-style-custom.js
@@ -21,6 +21,15 @@ ClassicEditor
 			}
 		},
 		cloudServices: CS_CONFIG,
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		image: {
 			styles: {
 				options: [ {

--- a/packages/ckeditor5-image/docs/_snippets/features/image-style-presentational.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-style-presentational.js
@@ -10,6 +10,15 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-presentational-image-style-default' ), {
 		removePlugins: [ 'LinkImage', 'AutoImage', 'imageCaption' ],
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		image: {
 			resizeUnit: '%',
 			resizeOptions: [

--- a/packages/ckeditor5-image/docs/_snippets/features/image-text-alternative.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-text-alternative.js
@@ -10,6 +10,15 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-text-alternative' ), {
 		removePlugins: [ 'LinkImage', 'AutoImage' ],
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		image: {
 			toolbar: [
 				'imageTextAlternative',

--- a/packages/ckeditor5-language/docs/_snippets/features/textpartlanguage.js
+++ b/packages/ckeditor5-language/docs/_snippets/features/textpartlanguage.js
@@ -23,23 +23,12 @@ ClassicEditor
 		},
 		toolbar: {
 			items: [
-				'textPartLanguage',
-				'|',
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'link',
-				'|',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'blockQuote',
-				'outdent',
-				'indent',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'textPartLanguage',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.js
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.js
@@ -26,20 +26,12 @@ ClassicEditor
 		],
 		toolbar: {
 			items: [
-				'style',
-				'|',
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'strikethrough',
-				'link',
-				'|',
-				'highlight',
-				'code',
-				'codeBlock',
-				'blockQuote',
-				'horizontalLine'
+				'undo', 'redo',
+				'|', 'style', '|', 'heading',
+				'|', 'bold', 'italic', 'strikethrough', 'code',
+				'-', 'link', 'uploadImage', 'insertTable', 'highlight', 'codeBlock',
+				'blockQuote', 'mediaEmbed', 'codeBlock', 'horizontalLine',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			],
 			shouldNotGroupWhenFull: true
 		},

--- a/packages/ckeditor5-table/docs/_snippets/features/build-table-source.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/build-table-source.js
@@ -24,21 +24,12 @@ ClassicEditor.defaultConfig = {
 	cloudServices: CS_CONFIG,
 	toolbar: {
 		items: [
-			'insertTable',
-			'|',
-			'fontFamily', 'fontSize',
-			'|',
-			'bold', 'italic',
-			'|',
-			'alignment:left', 'alignment:center', 'alignment:right', 'alignment:justify',
-			'|',
-			'bulletedList', 'numberedList',
-			'|',
-			'outdent', 'indent',
-			'|',
-			'link', 'blockQuote',
-			'|',
-			'undo', 'redo'
+			'undo', 'redo',
+			'|', 'heading', '|', 'fontFamily', 'fontSize',
+			'|', 'bold', 'italic',
+			'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+			'|', 'aligmnet',
+			'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 		]
 	},
 	ui: {

--- a/packages/ckeditor5-undo/docs/_snippets/features/undo-redo.js
+++ b/packages/ckeditor5-undo/docs/_snippets/features/undo-redo.js
@@ -21,24 +21,11 @@ ClassicEditor
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'blockQuote',
-				'link',
-				'ckbox',
-				'mediaEmbed',
-				'insertTable',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-word-count/docs/_snippets/features/word-count-update.js
+++ b/packages/ckeditor5-word-count/docs/_snippets/features/word-count-update.js
@@ -21,24 +21,11 @@ BalloonEditor
 	.create( document.querySelector( '#demo-update__editor' ), {
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'blockQuote',
-				'link',
-				'|',
-				'mediaEmbed',
-				'insertTable',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-word-count/docs/_snippets/features/word-count.js
+++ b/packages/ckeditor5-word-count/docs/_snippets/features/word-count.js
@@ -9,24 +9,11 @@ ClassicEditor
 	.create( document.querySelector( '#demo-editor' ), {
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'blockQuote',
-				'link',
-				'|',
-				'mediaEmbed',
-				'insertTable',
-				'|',
-				'undo',
-				'redo'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: unifying demos toolbars.

---

### Additional information

_The fourth batch of toolbars. Part of_ cksource/ckeditor5-internal#2797

Based on the "Editor toolbar with few features" setup as described here: [https://www.notion.so/WIP-Toolbar-composition-guidelines-5196b3852e70462b98b8023d4d0f6cd7?pvs=4#a78453199acb480ab776e2b9907b1eed](https://www.notion.so/WIP-Toolbar-composition-guidelines-5196b3852e70462b98b8023d4d0f6cd7?pvs=4#a78453199acb480ab776e2b9907b1eed)

All basic features in the setup are available in the editor builds (hence underline was removed).

Batch Four contains the following guides:

*   CKBox
*   CKFinder
*   images
*   spell and grammar checker
*   tables
*   text alignment
*   text part language
*   toolbar
*   UI language
*   undo
*   word count

This Batch concludes the main repo features.