### PR TITLE
Internal: Add missing export in `hightlight` plugin

### DIFF
--- a/packages/ckeditor5-highlight/src/index.ts
+++ b/packages/ckeditor5-highlight/src/index.ts
@@ -11,6 +11,6 @@ export { default as Highlight } from './highlight';
 export { default as HighlightEditing } from './highlightediting';
 export { default as HighlightUI } from './highlightui';
 export type { default as HighlightCommand } from './highlightcommand';
-export type { HighlightConfig } from './highlightconfig';
+export type { HighlightOption, HighlightConfig } from './highlightconfig';
 
 import './augmentation';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Add missing export in `hightlight` plugin