### PR TITLE
Docs: unifying demos toolbars Batch Five

### DIFF
--- a/docs/_snippets/features/toolbar-breakpoint.js
+++ b/docs/_snippets/features/toolbar-breakpoint.js
@@ -11,17 +11,13 @@ ClassicEditor
 	.create( document.querySelector( '#toolbar-breakpoint' ), {
 		toolbar: {
 			items: [
-				'heading', '|',
-				'alignment', '|',
-				'bold', 'italic', 'strikethrough', 'underline', 'subscript', 'superscript', '|',
-				'link', '|',
-				'bulletedList', 'numberedList', 'todoList', '-',
-				'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor', '|',
-				'code', 'codeBlock', '|',
-				'insertTable', '|',
-				'outdent', 'indent', '|',
-				'uploadImage', 'blockQuote', '|',
-				'undo', 'redo'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor',
+				'|', 'bold', 'italic', 'strikethrough', 'subscript', 'superscript', 'code',
+				'-', // break point
+				'link', 'uploadImage', 'blockQuote', 'codeBlock',
+				'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
 			],
 			shouldNotGroupWhenFull: true
 		},

--- a/docs/_snippets/features/toolbar-breakpoint.js
+++ b/docs/_snippets/features/toolbar-breakpoint.js
@@ -17,6 +17,7 @@ ClassicEditor
 				'|', 'bold', 'italic', 'strikethrough', 'subscript', 'superscript', 'code',
 				'-', // break point
 				'link', 'uploadImage', 'blockQuote', 'codeBlock',
+				'|', 'alignment',
 				'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
 			],
 			shouldNotGroupWhenFull: true

--- a/docs/_snippets/features/toolbar-grouping.js
+++ b/docs/_snippets/features/toolbar-grouping.js
@@ -11,14 +11,12 @@ ClassicEditor
 	.create( document.querySelector( '#toolbar-grouping' ), {
 		toolbar: {
 			items: [
-				'heading', '|',
-				'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor', '|',
-				'bold', 'italic', 'strikethrough', 'subscript', 'superscript', 'link', '|',
-				'bulletedList', 'numberedList', 'todoList', '|',
-				'code', 'codeBlock', '|',
-				'outdent', 'indent', '|',
-				'uploadImage', 'blockQuote', '|',
-				'undo', 'redo'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor',
+				'|', 'bold', 'italic', 'strikethrough', 'subscript', 'superscript', 'code',
+				'|', 'link', 'uploadImage', 'blockQuote', 'codeBlock',
+				'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/docs/_snippets/features/toolbar-nested-icon.js
+++ b/docs/_snippets/features/toolbar-nested-icon.js
@@ -10,23 +10,13 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#toolbar-nested-icon' ), {
 		toolbar: [
+			'undo', 'redo', '|',
 			{
 				// This drop-down uses a default icon because none was specified.
 				label: 'Fonts',
 				items: [ 'fontSize', 'fontFamily', 'fontColor', 'fontBackgroundColor' ]
 			},
-			{
-				// This drop-down has the icon disabled and a text label instead.
-				label: 'Lists',
-				icon: false,
-				items: [ 'bulletedList', 'numberedList', 'todoList' ]
-			},
-			{
-				// A "plus" sign icon works best for content insertion tools.
-				label: 'Insert',
-				icon: 'plus',
-				items: [ 'uploadImage', 'insertTable' ]
-			},
+			'|',
 			{
 				label: 'A drop-down with a custom icon',
 				// If you want your icon to change the color dynamically (e.g. when opened)
@@ -37,7 +27,19 @@ ClassicEditor
 				items: [ 'bold', 'italic', 'strikethrough', 'superscript', 'subscript' ]
 			},
 			'|',
-			'undo', 'redo'
+			{
+				// A "plus" sign icon works best for content insertion tools.
+				label: 'Insert',
+				icon: 'plus',
+				items: [ 'uploadImage', 'insertTable' ]
+			},
+			'|',
+			{
+				// This drop-down has the icon disabled and a text label instead.
+				label: 'Lists',
+				icon: false,
+				items: [ 'bulletedList', 'numberedList', 'todoList' ]
+			}
 		],
 		image: {
 			toolbar: [ 'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|', 'toggleImageCaption', 'imageTextAlternative' ]

--- a/docs/_snippets/features/toolbar-nested-label.js
+++ b/docs/_snippets/features/toolbar-nested-label.js
@@ -10,12 +10,7 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#toolbar-nested-label' ), {
 		toolbar: [
-			{
-				label: 'Basic styles',
-				withText: true,
-				items: [ 'bold', 'italic', 'strikethrough', 'superscript', 'subscript' ]
-			},
-			'|',
+			'undo', 'redo', '|',
 			{
 				label: 'Fonts',
 				icon: 'text',
@@ -23,7 +18,11 @@ ClassicEditor
 				items: [ 'fontSize', 'fontFamily', 'fontColor', 'fontBackgroundColor' ]
 			},
 			'|',
-			'undo', 'redo'
+			{
+				label: 'Basic styles',
+				withText: true,
+				items: [ 'bold', 'italic', 'strikethrough', 'superscript', 'subscript' ]
+			}
 		],
 		cloudServices: CS_CONFIG,
 		ui: {

--- a/docs/_snippets/features/toolbar-nested-simple.js
+++ b/docs/_snippets/features/toolbar-nested-simple.js
@@ -10,6 +10,7 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#toolbar-nested-simple' ), {
 		toolbar: [
+			'undo', 'redo', '|',
 			'heading', '|',
 			{
 				label: 'Fonts',
@@ -22,16 +23,13 @@ ClassicEditor
 				icon: 'threeVerticalDots',
 				items: [ 'strikethrough', 'superscript', 'subscript' ]
 			},
-			'|',
+			'|', 'alignment', '|',
 			{
 				label: 'Lists',
 				withText: true,
 				icon: false,
 				items: [ 'bulletedList', 'numberedList', 'todoList' ]
-			},
-			'alignment',
-			'|',
-			'undo', 'redo'
+			}
 		],
 		cloudServices: CS_CONFIG,
 		ui: {

--- a/docs/_snippets/features/toolbar-nested-tooltip.js
+++ b/docs/_snippets/features/toolbar-nested-tooltip.js
@@ -10,6 +10,7 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#toolbar-nested-tooltip' ), {
 		toolbar: [
+			'undo', 'redo', '|',
 			{
 				label: 'Formatting',
 				tooltip: 'Basic formatting features',
@@ -21,9 +22,7 @@ ClassicEditor
 				icon: 'plus',
 				tooltip: 'Insert media',
 				items: [ 'uploadImage', 'insertTable' ]
-			},
-			'|',
-			'undo', 'redo'
+			}
 		],
 		cloudServices: CS_CONFIG,
 		ui: {

--- a/docs/_snippets/features/toolbar-separator.js
+++ b/docs/_snippets/features/toolbar-separator.js
@@ -10,7 +10,13 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#toolbar-separator' ), {
 		toolbar: {
-			items: [ 'bold', 'italic', '|', 'undo', 'redo', '|', 'numberedList', 'bulletedList' ]
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
 		},
 		cloudServices: CS_CONFIG,
 		ui: {

--- a/docs/_snippets/features/toolbar-wrapping.js
+++ b/docs/_snippets/features/toolbar-wrapping.js
@@ -11,20 +11,14 @@ ClassicEditor
 	.create( document.querySelector( '#toolbar-wrapping' ), {
 		toolbar: {
 			items: [
-				'heading', '|',
-				'fontfamily', 'fontsize', '|',
-				'alignment', '|',
-				'fontColor', 'fontBackgroundColor', '|',
-				'bold', 'italic', 'strikethrough', 'underline', 'subscript', 'superscript', '|',
-				'link', '|',
-				'outdent', 'indent', '|',
-				'bulletedList', 'numberedList', 'todoList', '|',
-				'code', 'codeBlock', '|',
-				'insertTable', '|',
-				'uploadImage', 'blockQuote', '|',
-				'undo', 'redo'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor',
+				'|', 'bold', 'italic', 'strikethrough', 'subscript', 'superscript', 'code',
+				'|', 'link', 'uploadImage', 'blockQuote', 'codeBlock',
+				'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
 			],
-			shouldNotGroupWhenFull: true
+			shouldNotGroupWhenFull: false
 		},
 		ui: {
 			viewportOffset: {

--- a/docs/_snippets/features/toolbar-wrapping.js
+++ b/docs/_snippets/features/toolbar-wrapping.js
@@ -16,9 +16,10 @@ ClassicEditor
 				'|', 'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor',
 				'|', 'bold', 'italic', 'strikethrough', 'subscript', 'superscript', 'code',
 				'|', 'link', 'uploadImage', 'blockQuote', 'codeBlock',
+				'|', 'alignment',
 				'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
 			],
-			shouldNotGroupWhenFull: false
+			shouldNotGroupWhenFull: true
 		},
 		ui: {
 			viewportOffset: {

--- a/docs/features/toolbar.md
+++ b/docs/features/toolbar.md
@@ -117,6 +117,7 @@ toolbar: {
 		'|', 'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor',
 		'|', 'bold', 'italic', 'strikethrough', 'subscript', 'superscript', 'code',
 		'|', 'link', 'uploadImage', 'blockQuote', 'codeBlock',
+		'|', 'alignment',
 		'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
 	],
 	shouldNotGroupWhenFull: true
@@ -139,6 +140,7 @@ toolbar: {
 		'|', 'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor',
 		'|', 'bold', 'italic', 'strikethrough', 'subscript', 'superscript', 'code',
 		'-', // break point
+		'|', 'alignment',
 		'link', 'uploadImage', 'blockQuote', 'codeBlock',
 		'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
 	],

--- a/docs/features/toolbar.md
+++ b/docs/features/toolbar.md
@@ -11,7 +11,7 @@ The toolbar is the most basic user interface element of CKEditor 5 that gives yo
 
 ## Demo
 
-This is how a simplified toolbar from the snippet above looks in the CKEditor 5 WYSIWYG editor user interface. Toolbar items can be easily added or removed thanks to this configuration.
+Below is a sample toolbar with a basic set of features. Toolbar items can be easily added or removed which will be presented further.
 
 {@snippet features/toolbar-basic}
 
@@ -25,14 +25,14 @@ This is how a simplified toolbar from the snippet above looks in the CKEditor 5 
 	Toolbar configuration is a strict UI-related setting. Removing a toolbar item does not remove the feature from the editor internals. If your goal with the toolbar configuration is to remove features, the right solution is to also remove their respective plugins. Check {@link installation/getting-started/configuration#removing-features removing features} for more information.
 </info-box>
 
-In the builds that contain toolbars, an optimal default configuration is defined for it. You may need a different toolbar arrangement, though, and this can be achieved through configuration.
+In the builds that contain toolbars, an optimal default tollbar set is defined for it. You may need a different toolbar arrangement, though, and this can be achieved through configuration.
 
 Each editor may have a different toolbar configuration scheme, so it is recommended to check its documentation. In any case, the following example may give you a general idea:
 
 ```js
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
-		toolbar: [ 'bold', 'italic', 'link', 'undo', 'redo', 'numberedList', 'bulletedList' ]
+		toolbar: [ 'undo', 'redo', 'bold', 'italic', 'numberedList', 'bulletedList' ]
 	} )
 	.catch( error => {
 		console.log( error );
@@ -41,21 +41,7 @@ ClassicEditor
 
 ## Separating toolbar items
 
-You can use `'|'` to create a separator between groups of toolbar items. It works in both the basic and [extended](#extended-toolbar-configuration-format) configuration formats:
-
-Basic:
-
-```js
-toolbar: [ 'bold', 'italic', '|', 'undo', 'redo', '|', 'numberedList', 'bulletedList' ]
-```
-
-Extended:
-
-```js
-toolbar: {
-	items: [ 'bold', 'italic', '|', 'undo', 'redo', '|', 'numberedList', 'bulletedList' ]
-}
-```
+You can use `'|'` to create a separator between groups of toolbar items. It works in both the basic and extended configuration formats:
 
 Below you can find an example of a simple toolbar with button grouping. The group separators (`'|'`) set in the configuration help organize the toolbar.
 
@@ -63,12 +49,35 @@ Below you can find an example of a simple toolbar with button grouping. The grou
 
 ## Extended toolbar configuration format
 
+There are two available toolbar configuration formats:
+
+Basic, as presented above:
+
+```js
+toolbar: [ 'bold', 'italic', '|', 'undo', 'redo', '|', 'numberedList', 'bulletedList' ]
+```
+
+And extended:
+
+```js
+toolbar: {
+	items: [ 'bold', 'italic', '|', 'undo', 'redo', '|', 'numberedList', 'bulletedList' ]
+}
+```
+
 You can use the extended {@link module:core/editor/editorconfig~EditorConfig#toolbar toolbar configuration} format to access additional options:
 
 ```js
 toolbar: {
-	items: [ 'bold', 'italic', '|', 'undo', 'redo', '-', 'numberedList', 'bulletedList' ],
-	shouldNotGroupWhenFull: true
+	items: [
+		'undo', 'redo',
+		'|', 'heading',
+		'|', 'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor',
+		'|', 'bold', 'italic', 'strikethrough', 'subscript', 'superscript', 'code',
+		'|', 'link', 'uploadImage', 'blockQuote', 'codeBlock',
+		'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
+	],
+	shouldNotGroupWhenFull: false
 }
 ```
 
@@ -81,6 +90,63 @@ toolbar: {
 The demo below presents the "regular" toolbar look with `shouldNotGroupWhenFull` set to `false`. If there are excess toolbar items for the display width, the toolbar gets grouped and some of the items are accessible via the clickable "Show more items" (⋮) button.
 
 {@snippet features/toolbar-grouping}
+
+## Multiline (wrapping) toolbar
+
+In the [extended toolbar configuration format](#extended-toolbar-configuration-format) it is also possible to arrange toolbar items into multiple lines. Here is how to achieve this:
+
+* Set the `shouldNotGroupWhenFull` option to `true`, so items will not be grouped when the toolbar overflows but will wrap to the new line instead.
+* Additionally, the `'-'` separator can be used inside the items list to set the breaking point explicitly.
+
+```js
+toolbar: {
+	items: [ 'bold', 'italic', '|', 'undo', 'redo', '-', 'numberedList', 'bulletedList' ],
+	shouldNotGroupWhenFull: true
+}
+```
+
+### Automatic toolbar wrapping
+
+When `shouldNotGroupWhenFull` is set to `true`, by default the toolbar items are automatically wrapped into a new line once they do not fit the editor width. The mechanism is automatic and only wraps excess items. Notice that while the toolbar group separators `'|'` are preserved, the groups may be split when they overflow.
+
+```js
+toolbar: {
+	items: [
+		'undo', 'redo',
+		'|', 'heading',
+		'|', 'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor',
+		'|', 'bold', 'italic', 'strikethrough', 'subscript', 'superscript', 'code',
+		'|', 'link', 'uploadImage', 'blockQuote', 'codeBlock',
+		'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
+	],
+	shouldNotGroupWhenFull: true
+}
+```
+
+See how it works in practice. You may play with the browser window width to see how the buttons behave when the toolbar gets wrapped into multiple lines.
+
+{@snippet features/toolbar-wrapping}
+
+### Explicit wrapping breakpoint
+
+Setting an explicit break point in the toolbar configuration with `'-'` lets you create your own predefined multiline toolbar configuration. Toolbar items will then be grouped and put in lines as declared in the configuration.
+
+```js
+toolbar: {
+	items: [
+		'undo', 'redo',
+		'|', 'heading',
+		'|', 'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor',
+		'|', 'bold', 'italic', 'strikethrough', 'subscript', 'superscript', 'code',
+		'-', // break point
+		'link', 'uploadImage', 'blockQuote', 'codeBlock',
+		'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
+	],
+	shouldNotGroupWhenFull: true
+}
+```
+
+{@snippet features/toolbar-breakpoint}
 
 ## Grouping toolbar items in drop-downs (nested toolbars)
 
@@ -147,34 +213,37 @@ Here is an example:
 
 ```js
 toolbar: [
+	'undo', 'redo', '|',
 	{
 		// This drop-down uses a default icon because none was specified.
 		label: 'Fonts',
 		items: [ 'fontSize', 'fontFamily', 'fontColor', 'fontBackgroundColor' ]
 	},
+	'|',
 	{
-				// This drop-down has the icon disabled and a text label instead.
-		label: 'Lists',
-		icon: false,
-		items: [ 'bulletedList', 'numberedList', 'todoList' ]
+		label: 'A drop-down with a custom icon',
+		// If you want your icon to change the color dynamically (e.g. when opened)
+		// avoid fill="..." and stroke="..." styling attributes.
+		// Use solid shapes and avoid paths with strokes.
+		// eslint-disable-next-line max-len
+		icon: '<svg viewBox="0 0 68 64" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M43.71 11.025a11.508 11.508 0 0 0-1.213 5.159c0 6.42 5.244 11.625 11.713 11.625.083 0 .167 0 .25-.002v16.282a5.464 5.464 0 0 1-2.756 4.739L30.986 60.7a5.548 5.548 0 0 1-5.512 0L4.756 48.828A5.464 5.464 0 0 1 2 44.089V20.344c0-1.955 1.05-3.76 2.756-4.738L25.474 3.733a5.548 5.548 0 0 1 5.512 0l12.724 7.292z" fill="#FFF"/><path d="M45.684 8.79a12.604 12.604 0 0 0-1.329 5.65c0 7.032 5.744 12.733 12.829 12.733.091 0 .183-.001.274-.003v17.834a5.987 5.987 0 0 1-3.019 5.19L31.747 63.196a6.076 6.076 0 0 1-6.037 0L3.02 50.193A5.984 5.984 0 0 1 0 45.003V18.997c0-2.14 1.15-4.119 3.019-5.19L25.71.804a6.076 6.076 0 0 1 6.037 0L45.684 8.79zm-29.44 11.89c-.834 0-1.51.671-1.51 1.498v.715c0 .828.676 1.498 1.51 1.498h25.489c.833 0 1.51-.67 1.51-1.498v-.715c0-.827-.677-1.498-1.51-1.498h-25.49.001zm0 9.227c-.834 0-1.51.671-1.51 1.498v.715c0 .828.676 1.498 1.51 1.498h18.479c.833 0 1.509-.67 1.509-1.498v-.715c0-.827-.676-1.498-1.51-1.498H16.244zm0 9.227c-.834 0-1.51.671-1.51 1.498v.715c0 .828.676 1.498 1.51 1.498h25.489c.833 0 1.51-.67 1.51-1.498v-.715c0-.827-.677-1.498-1.51-1.498h-25.49.001zm41.191-14.459c-5.835 0-10.565-4.695-10.565-10.486 0-5.792 4.73-10.487 10.565-10.487C63.27 3.703 68 8.398 68 14.19c0 5.791-4.73 10.486-10.565 10.486v-.001z" fill="#1EBC61" fill-rule="nonzero"/><path d="M60.857 15.995c0-.467-.084-.875-.251-1.225a2.547 2.547 0 0 0-.686-.88 2.888 2.888 0 0 0-1.026-.531 4.418 4.418 0 0 0-1.259-.175c-.134 0-.283.006-.447.018-.15.01-.3.034-.446.07l.075-1.4h3.587v-1.8h-5.462l-.214 5.06c.319-.116.682-.21 1.089-.28.406-.071.77-.107 1.088-.107.218 0 .437.021.655.063.218.041.413.114.585.218s.313.244.422.419c.109.175.163.391.163.65 0 .424-.132.745-.396.961a1.434 1.434 0 0 1-.938.325c-.352 0-.656-.1-.912-.3-.256-.2-.43-.453-.523-.762l-1.925.588c.1.35.258.664.472.943.214.279.47.514.767.706.298.191.63.339.995.443.365.104.749.156 1.151.156.437 0 .86-.064 1.272-.193.41-.13.778-.323 1.1-.581a2.8 2.8 0 0 0 .775-.981c.193-.396.29-.864.29-1.405h-.001z" fill="#FFF" fill-rule="nonzero"/></g></svg>',
+		items: [ 'bold', 'italic', 'strikethrough', 'superscript', 'subscript' ]
 	},
+	'|',
 	{
 		// A "plus" sign icon works best for content insertion tools.
 		label: 'Insert',
 		icon: 'plus',
 		items: [ 'uploadImage', 'insertTable' ]
 	},
-	{
-		label: 'A drop-down with a custom icon',
-		// If you want your icon to change the color dynamically (e.g. when opened)
-		// avoid fill="..." and stroke="..." styling attributes.
-		// Use solid shapes and avoid paths with strokes.
-		icon: '<svg viewBox="0 0 68 64" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M43.71 11.025a11.508 11.508 0 0 0-1.213 5.159c0 6.42 5.244 11.625 11.713 11.625.083 0 .167 0 .25-.002v16.282a5.464 5.464 0 0 1-2.756 4.739L30.986 60.7a5.548 5.548 0 0 1-5.512 0L4.756 48.828A5.464 5.464 0 0 1 2 44.089V20.344c0-1.955 1.05-3.76 2.756-4.738L25.474 3.733a5.548 5.548 0 0 1 5.512 0l12.724 7.292z" fill="#FFF"/><path d="M45.684 8.79a12.604 12.604 0 0 0-1.329 5.65c0 7.032 5.744 12.733 12.829 12.733.091 0 .183-.001.274-.003v17.834a5.987 5.987 0 0 1-3.019 5.19L31.747 63.196a6.076 6.076 0 0 1-6.037 0L3.02 50.193A5.984 5.984 0 0 1 0 45.003V18.997c0-2.14 1.15-4.119 3.019-5.19L25.71.804a6.076 6.076 0 0 1 6.037 0L45.684 8.79zm-29.44 11.89c-.834 0-1.51.671-1.51 1.498v.715c0 .828.676 1.498 1.51 1.498h25.489c.833 0 1.51-.67 1.51-1.498v-.715c0-.827-.677-1.498-1.51-1.498h-25.49.001zm0 9.227c-.834 0-1.51.671-1.51 1.498v.715c0 .828.676 1.498 1.51 1.498h18.479c.833 0 1.509-.67 1.509-1.498v-.715c0-.827-.676-1.498-1.51-1.498H16.244zm0 9.227c-.834 0-1.51.671-1.51 1.498v.715c0 .828.676 1.498 1.51 1.498h25.489c.833 0 1.51-.67 1.51-1.498v-.715c0-.827-.677-1.498-1.51-1.498h-25.49.001zm41.191-14.459c-5.835 0-10.565-4.695-10.565-10.486 0-5.792 4.73-10.487 10.565-10.487C63.27 3.703 68 8.398 68 14.19c0 5.791-4.73 10.486-10.565 10.486v-.001z" fill="#1EBC61" fill-rule="nonzero"/><path d="M60.857 15.995c0-.467-.084-.875-.251-1.225a2.547 2.547 0 0 0-.686-.88 2.888 2.888 0 0 0-1.026-.531 4.418 4.418 0 0 0-1.259-.175c-.134 0-.283.006-.447.018-.15.01-.3.034-.446.07l.075-1.4h3.587v-1.8h-5.462l-.214 5.06c.319-.116.682-.21 1.089-.28.406-.071.77-.107 1.088-.107.218 0 .437.021.655.063.218.041.413.114.585.218s.313.244.422.419c.109.175.163.391.163.65 0 .424-.132.745-.396.961a1.434 1.434 0 0 1-.938.325c-.352 0-.656-.1-.912-.3-.256-.2-.43-.453-.523-.762l-1.925.588c.1.35.258.664.472.943.214.279.47.514.767.706.298.191.63.339.995.443.365.104.749.156 1.151.156.437 0 .86-.064 1.272-.193.41-.13.778-.323 1.1-.581a2.8 2.8 0 0 0 .775-.981c.193-.396.29-.864.29-1.405h-.001z" fill="#FFF" fill-rule="nonzero"/></g></svg>',
-		items: [ 'bold', 'italic' ]
-	},
 	'|',
-	'undo', 'redo'
-]
+	{
+		// This drop-down has the icon disabled and a text label instead.
+		label: 'Lists',
+		icon: false,
+		items: [ 'bulletedList', 'numberedList', 'todoList' ]
+	}
+],
 ```
 And here is the effect:
 
@@ -197,74 +266,6 @@ toolbar: [
 ```
 
 {@snippet features/toolbar-nested-tooltip}
-
-## Multiline (wrapping) toolbar
-
-In the [extended toolbar configuration format](#extended-toolbar-configuration-format) it is also possible to arrange toolbar items into multiple lines. Here is how to achieve this:
-
-* Set the `shouldNotGroupWhenFull` option to `true`, so items will not be grouped when the toolbar overflows but will wrap to the new line instead.
-* Additionally, the `'-'` separator can be used inside the items list to set the breaking point explicitly.
-
-```js
-toolbar: {
-	[ 'bold', 'italic', '|', 'undo', 'redo', '-', 'numberedList', 'bulletedList' ],
-	shouldNotGroupWhenFull: true
-}
-```
-
-### Automatic toolbar wrapping
-
-When `shouldNotGroupWhenFull` is set to `true`, by default the toolbar items are automatically wrapped into a new line once they do not fit the editor width. The mechanism is automatic and only wraps excess items. Notice that while the toolbar group separators `'|'` are preserved, the groups may be split when they overflow.
-
-```js
-toolbar: {
-	items: [
-		'heading', '|',
-		'fontfamily', 'fontsize', '|',
-		'alignment', '|',
-		'fontColor', 'fontBackgroundColor', '|',
-		'bold', 'italic', 'strikethrough', 'underline', 'subscript', 'superscript', '|',
-		'link', '|',
-		'outdent', 'indent', '|',
-		'bulletedList', 'numberedList', 'todoList', '|',
-		'code', 'codeBlock', '|',
-		'insertTable', '|',
-		'uploadImage', 'blockQuote', '|',
-		'undo', 'redo'
-	],
-	shouldNotGroupWhenFull: true
-}
-```
-
-See how it works in practice. You may play with the browser window width to see how the buttons behave when the toolbar gets wrapped into multiple lines.
-
-{@snippet features/toolbar-wrapping}
-
-### Explicit wrapping breakpoint
-
-Setting an explicit break point in the toolbar configuration with `'-'` lets you create your own predefined multiline toolbar configuration. Toolbar items will then be grouped and put in lines as declared in the configuration.
-
-```js
-toolbar: {
-	items: [
-		'heading', '|',
-		'alignment', '|',
-		'bold', 'italic', 'strikethrough', 'underline', 'subscript', 'superscript', '|',
-		'link', '|',
-		'bulletedList', 'numberedList', 'todoList',
-		'-', // break point
-		'fontfamily', 'fontsize', 'fontColor', 'fontBackgroundColor', '|',
-		'code', 'codeBlock', '|',
-		'insertTable', '|',
-		'outdent', 'indent', '|',
-		'uploadImage', 'blockQuote', '|',
-		'undo', 'redo'
-	],
-	shouldNotGroupWhenFull: true
-}
-```
-
-{@snippet features/toolbar-breakpoint}
 
 ## Listing available items
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: comprehensive toolbar guide demo tollbars refactor.
Closes: cksource/ckeditor5-internal#2878
Also closes: https://github.com/cksource/ckeditor5-internal/issues/2797

---

### Additional information

_The fifth batch of toolbars. Part of_ cksource/ckeditor5-internal#2797

Based on the "Editor toolbar with few features" setup as described here: [https://www.notion.so/WIP-Toolbar-composition-guidelines-5196b3852e70462b98b8023d4d0f6cd7?pvs=4#a78453199acb480ab776e2b9907b1eed](https://www.notion.so/WIP-Toolbar-composition-guidelines-5196b3852e70462b98b8023d4d0f6cd7?pvs=4#a78453199acb480ab776e2b9907b1eed)

All basic features in the setup are available in the editor builds (hence underline was removed).

Batch Five contains the following guides:

*   editor toolbar