### PR TITLE
Docs: unifying demos toolbars Batch Eight

### DIFF
--- a/docs/_snippets/examples/balloon-block-editor.html
+++ b/docs/_snippets/examples/balloon-block-editor.html
@@ -11,9 +11,9 @@
 
 	<p>Tourists frequently admit that Taj Mahal "simply cannot be described with words". And that’s probably true. The more you try the more speechless you become. Words give only a semblance of truth. The real truth about its beauty is revealed when you adore <strong>different shades of “Taj” depending on the time of the day</strong> or when you admire the exquisite inlay work in different corners of the façade.</p>
 
-	<h3>Masterpiece of the world’s heritage</h3>
+	<h3>A masterpiece of the world’s heritage</h3>
 
-	<p>Taj Mahal is a mausoleum built in Agra between 1631 and 1648 by Emperor Shah Jahan <strong>in the memory of his beloved wife</strong>, Mumtaz Mahal, whose body lies there. It took 20 000 workers to complete and the excellence of this building is visible in every brick.</p>
+	<p>Taj Mahal is a mausoleum built in Agra between 1631 and 1648 by Emperor Shah Jahan <strong>in memory of his beloved wife</strong>, Mumtaz Mahal, whose body lies there. It took 20 000 workers to complete and the excellence of this building is visible in every brick.</p>
 
 	<p>In 1983, Taj Mahal was appointed <a href="https://en.wikipedia.org/wiki/World_Heritage_Site">UNESCO World Heritage Site</a> for being "the jewel of Muslim art in India and one of the universally admired masterpieces of the world's heritage".</p>
 

--- a/docs/_snippets/examples/balloon-block-editor.js
+++ b/docs/_snippets/examples/balloon-block-editor.js
@@ -12,6 +12,13 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 BalloonEditor
 	.create( document.querySelector( '#snippet-balloon-block-editor' ), {
 		cloudServices: CS_CONFIG,
+		blockToolbar: [
+			'undo', 'redo',
+			'|', 'heading',
+			'|', 'uploadImage', 'insertTable', 'mediaEmbed',
+			'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+		],
+		toolbar: [ 'bold', 'italic', 'link' ],
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/examples/balloon-editor.js
+++ b/docs/_snippets/examples/balloon-editor.js
@@ -12,6 +12,15 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 BalloonEditor
 	.create( document.querySelector( '#snippet-balloon-editor' ), {
 		cloudServices: CS_CONFIG,
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/examples/bottom-toolbar-editor.js
+++ b/docs/_snippets/examples/bottom-toolbar-editor.js
@@ -174,6 +174,9 @@ DecoupledEditor
 			FormattingOptions
 		],
 		toolbar: [
+			'undo',
+			'redo',
+			'|',
 			'formattingOptions',
 			'|',
 			'link',
@@ -187,10 +190,7 @@ DecoupledEditor
 				label: 'Lists',
 				icon: false,
 				items: [ 'bulletedList', 'numberedList', '|', 'outdent', 'indent' ]
-			},
-			'|',
-			'undo',
-			'redo'
+			}
 		],
 
 		// Configuration of the formatting dropdown.

--- a/docs/_snippets/examples/classic-editor.js
+++ b/docs/_snippets/examples/classic-editor.js
@@ -10,6 +10,15 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-classic-editor' ), {
 		cloudServices: CS_CONFIG,
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/examples/document-editor.js
+++ b/docs/_snippets/examples/document-editor.js
@@ -15,6 +15,15 @@ DecoupledEditor
 			TableColumnResize
 		],
 		cloudServices: CS_CONFIG,
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/examples/inline-editor.js
+++ b/docs/_snippets/examples/inline-editor.js
@@ -17,7 +17,15 @@ Array.from( inlineInjectElements ).forEach( inlineElement => {
 				top: window.getViewportTopOffsetConfig()
 			}
 		},
-		toolbar: {},
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		cloudServices: CS_CONFIG
 	};
 

--- a/docs/_snippets/framework/tutorials/external-data-widget.js
+++ b/docs/_snippets/framework/tutorials/external-data-widget.js
@@ -197,7 +197,7 @@ class ExternalDataWidgetEditing extends Plugin {
 ClassicEditor
 	.create( document.querySelector( '#snippet-external-data-widget' ), {
 		plugins: [ Essentials, Paragraph, Heading, List, Bold, Italic, ExternalDataWidget ],
-		toolbar: [ 'external', '|', 'heading', 'bold', 'italic', 'numberedList', 'bulletedList', '|', 'undo', 'redo' ]
+		toolbar: [ 'undo', 'redo', '|', 'external', '|', 'heading', '|', 'bold', 'italic', '|', 'numberedList', 'bulletedList' ]
 	} )
 	.then( editor => {
 		console.log( 'Editor was initialized', editor );

--- a/docs/_snippets/framework/tutorials/inline-widget.js
+++ b/docs/_snippets/framework/tutorials/inline-widget.js
@@ -209,7 +209,16 @@ class PlaceholderEditing extends Plugin {
 ClassicEditor
 	.create( document.querySelector( '#snippet-inline-widget' ), {
 		plugins: [ Essentials, Paragraph, Heading, List, Bold, Italic, Placeholder ],
-		toolbar: [ 'heading', '|', 'bold', 'italic', 'numberedList', 'bulletedList', '|', 'placeholder' ],
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'placeholder',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		placeholderConfig: {
 			types: [ 'date', 'color', 'first name', 'surname' ]
 		},

--- a/docs/_snippets/framework/tutorials/using-react-in-widget.html
+++ b/docs/_snippets/framework/tutorials/using-react-in-widget.html
@@ -233,14 +233,12 @@ class App extends React.Component {
 			],
 			toolbar: {
 				items: [
-					'heading',
-					'|',
-					'bold', 'italic', 'underline',
-					'|',
-					'link', 'insertTable',
-					'|',
-					'undo', 'redo'
-				]
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
 			},
 			ui: {
 				viewportOffset: {

--- a/docs/examples/builds/balloon-editor.md
+++ b/docs/examples/builds/balloon-editor.md
@@ -24,6 +24,15 @@ import BalloonEditor from '@ckeditor/ckeditor5-build-balloon/src/ckeditor';
 
 BalloonEditor
 	.create( document.querySelector( '#snippet-balloon-editor' ), {
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		cloudServices: {
 			// All predefined builds include the Easy Image feature.
 			// Provide correct configuration values to use it.

--- a/docs/examples/builds/classic-editor.md
+++ b/docs/examples/builds/classic-editor.md
@@ -33,7 +33,16 @@ ClassicEditor
 			uploadUrl: 'https://your-organization-id.cke-cs.com/easyimage/upload/'
 			// Read more about Easy Image - https://ckeditor.com/docs/ckeditor5/latest/features/images/image-upload/easy-image.html.
 			// For other image upload methods see the guide - https://ckeditor.com/docs/ckeditor5/latest/features/images/image-upload/image-upload.html.
-		}
+		},
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 	} )
 	.then( editor => {
 		window.editor = editor;

--- a/docs/examples/builds/classic-editor.md
+++ b/docs/examples/builds/classic-editor.md
@@ -26,14 +26,6 @@ import ClassicEditor from '@ckeditor/ckeditor5-build-classic/src/ckeditor';
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-classic-editor' ), {
-		cloudServices: {
-			// All predefined builds include the Easy Image feature.
-			// Provide correct configuration values to use it.
-			tokenUrl: 'https://example.com/cs-token-endpoint',
-			uploadUrl: 'https://your-organization-id.cke-cs.com/easyimage/upload/'
-			// Read more about Easy Image - https://ckeditor.com/docs/ckeditor5/latest/features/images/image-upload/easy-image.html.
-			// For other image upload methods see the guide - https://ckeditor.com/docs/ckeditor5/latest/features/images/image-upload/image-upload.html.
-		},
 		toolbar: {
 			items: [
 				'undo', 'redo',
@@ -43,6 +35,14 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		cloudServices: {
+			// All predefined builds include the Easy Image feature.
+			// Provide correct configuration values to use it.
+			tokenUrl: 'https://example.com/cs-token-endpoint',
+			uploadUrl: 'https://your-organization-id.cke-cs.com/easyimage/upload/'
+			// Read more about Easy Image - https://ckeditor.com/docs/ckeditor5/latest/features/images/image-upload/easy-image.html.
+			// For other image upload methods see the guide - https://ckeditor.com/docs/ckeditor5/latest/features/images/image-upload/image-upload.html.
+		}
 	} )
 	.then( editor => {
 		window.editor = editor;

--- a/docs/examples/builds/document-editor.md
+++ b/docs/examples/builds/document-editor.md
@@ -26,6 +26,15 @@ import DecoupledEditor from '@ckeditor/ckeditor5-build-decoupled-document/src/ck
 
 DecoupledEditor
 	.create( document.querySelector( '.document-editor__editable' ), {
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		cloudServices: {
 			// All predefined builds include the Easy Image feature.
 			// Provide correct configuration values to use it.

--- a/docs/examples/builds/inline-editor.md
+++ b/docs/examples/builds/inline-editor.md
@@ -28,7 +28,15 @@ const inlineInjectElements = document.querySelectorAll( '#snippet-inline-editor 
 
 Array.from( inlineInjectElements ).forEach( inlineElement => {
 	const config = {
-		toolbar: {},
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		cloudServices: {
 			// All predefined builds include the Easy Image feature.
 			// Provide correct configuration values to use it.

--- a/docs/examples/custom/bottom-toolbar-editor.md
+++ b/docs/examples/custom/bottom-toolbar-editor.md
@@ -192,6 +192,9 @@ DecoupledEditor
 			FormattingOptions
 		],
 		toolbar: [
+			'undo',
+			'redo',
+			'|',
 			'formattingOptions',
 			'|',
 			'link',
@@ -199,9 +202,14 @@ DecoupledEditor
 			'uploadImage',
 			'insertTable',
 			'mediaEmbed',
-			'horizontalLine'
+			'horizontalLine',
+			'|',
+			{
+				label: 'Lists',
+				icon: false,
+				items: [ 'bulletedList', 'numberedList', '|', 'outdent', 'indent' ]
+			}
 		],
-
 		// Configuration of the formatting dropdown.
 		formattingOptions: [
 			'undo',

--- a/docs/examples/framework/content-placeholder.md
+++ b/docs/examples/framework/content-placeholder.md
@@ -226,7 +226,16 @@ class PlaceholderEditing extends Plugin {
 ClassicEditor
 	.create( document.querySelector( '#snippet-inline-widget' ), {
 		plugins: [ Essentials, Paragraph, Heading, List, Bold, Italic, Placeholder ],
-		toolbar: [ 'heading', '|', 'bold', 'italic', 'numberedList', 'bulletedList', '|', 'placeholder' ],
+		toolbar: {
+			items: [
+				'undo', 'redo',
+				'|', 'placeholder',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
 		placeholderConfig: {
 			types: [ 'date', 'color', 'first name', 'surname' ]
 		},

--- a/docs/examples/framework/data-from-external-source.md
+++ b/docs/examples/framework/data-from-external-source.md
@@ -214,7 +214,7 @@ class ExternalDataWidgetEditing extends Plugin {
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [ Essentials, Paragraph, Heading, List, Bold, Italic, ExternalDataWidget ],
-		toolbar: [ 'external', '|', 'heading', 'bold', 'italic', 'numberedList', 'bulletedList', '|', 'undo', 'redo' ]
+		toolbar: [ 'undo', 'redo', '|', 'external', '|', 'heading', '|', 'bold', 'italic', '|', 'numberedList', 'bulletedList' ]
 	} )
 	.then( editor => {
 		console.log( 'Editor was initialized', editor );

--- a/docs/examples/framework/using-react-in-a-widget.md
+++ b/docs/examples/framework/using-react-in-a-widget.md
@@ -436,15 +436,12 @@ class App extends React.Component {
 			],
 			toolbar: {
 				items: [
-					'heading',
-					'|',
-					'bold', 'italic', 'underline',
-					'|',
-					'link', 'insertTable',
-					'|',
-					'undo', 'redo'
-				]
-			},
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
 			ui: {
 				viewportOffset: {
 					top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-mention/docs/examples/chat-with-mentions.md
+++ b/packages/ckeditor5-mention/docs/examples/chat-with-mentions.md
@@ -36,7 +36,10 @@ ClassicEditor
 		extraPlugins: [ Essentials, Paragraph, Mention, MentionLinks, Bold, Italic, Underline, Strikethrough, Link ],
 		toolbar: {
 			items: [
-				'bold', 'italic', 'underline', 'strikethrough', '|', 'link', '|', 'undo', 'redo'
+				'undo', 'redo', '|', 'heading',
+				'|', 'bold', 'italic', 'underline', 'strikethrough',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		mention: {

--- a/packages/ckeditor5-theme-lark/docs/_snippets/examples/theme-lark.js
+++ b/packages/ckeditor5-theme-lark/docs/_snippets/examples/theme-lark.js
@@ -18,20 +18,11 @@ ClassicEditor
 		plugins: [ ArticlePluginSet, EasyImage, ImageUpload, CloudServices ],
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'link',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'blockQuote',
-				'undo',
-				'redo'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-theme-lark/docs/examples/theme-customization.md
+++ b/packages/ckeditor5-theme-lark/docs/examples/theme-customization.md
@@ -61,20 +61,11 @@ ClassicEditor
 			CloudServices ],
 		toolbar: {
 			items: [
-				'heading',
-				'|',
-				'bold',
-				'italic',
-				'link',
-				'bulletedList',
-				'numberedList',
-				'|',
-				'outdent',
-				'indent',
-				'|',
-				'blockQuote',
-				'undo',
-				'redo'
+				'undo', 'redo',
+				'|', 'heading',
+				'|', 'bold', 'italic',
+				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
 		image: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: unifying demos toolbars.

---

### Additional information

_The eighth batch of toolbars. Part of_ cksource/ckeditor5-internal#2797

Based on the "Editor toolbar with few features" setup as described here: [https://www.notion.so/WIP-Toolbar-composition-guidelines-5196b3852e70462b98b8023d4d0f6cd7?pvs=4#a78453199acb480ab776e2b9907b1eed](https://www.notion.so/WIP-Toolbar-composition-guidelines-5196b3852e70462b98b8023d4d0f6cd7?pvs=4#a78453199acb480ab776e2b9907b1eed)

All basic features in the setup are available in the editor builds.

Batch Eight contains the following examples:

*   classic build
*   inline build
*   balloon build
*   balloon block build
*   document build
*   bottom toolbar editor
*   chat with mentions
*   theme customization
*   data from external source
*   react components
*   content placeholder