### PR TITLE
Allow for adding and detaching model roots after the editor was initialized

### DIFF
--- a/packages/ckeditor5-core/src/editor/utils/dataapimixin.ts
+++ b/packages/ckeditor5-core/src/editor/utils/dataapimixin.ts
@@ -87,6 +87,9 @@ export interface DataApi {
 	 * By default the editor outputs HTML. This can be controlled by injecting a different data processor.
 	 * See the {@glink features/markdown Markdown output} guide for more details.
 	 *
+	 * A warning is logged when you try to retrieve data for a detached root, as most probably this is a mistake. A detached root should
+	 * be treated like it is removed, and you should not save its data. Note, that the detached root data is always an empty string.
+	 *
 	 * @param options Additional configuration for the retrieved data.
 	 * Editor features may introduce more configuration options that can be set through this parameter.
 	 * @param options.rootName Root name. Default to `'main'`.

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -251,11 +251,11 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	 * ```
 	 *
 	 * @param rootName Name of the root to add.
-	 * @param isUndoable Whether creating the root can be undone (using the undo feature) or not.
 	 * @param data Initial data for the root.
 	 * @param elementName Element name for the root element in the model. It can be used to set different schema rules for different roots.
+	 * @param isUndoable Whether creating the root can be undone (using the undo feature) or not.
 	 */
-	public addRoot( rootName: string, isUndoable = false, data = '', elementName = '$root' ): void {
+	public addRoot( { rootName, data, elementName }: RootData, isUndoable: boolean ): void {
 		const dataController = this.data;
 
 		if ( isUndoable ) {
@@ -267,7 +267,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 		function _addRoot( writer: Writer ) {
 			const root = writer.addRoot( rootName, elementName );
 
-			if ( data !== '' ) {
+			if ( data ) {
 				writer.insert( dataController.parse( data, root ), root, 0 );
 			}
 		}
@@ -569,3 +569,9 @@ export type DetachRootEvent = {
 	name: 'detachRoot';
 	args: [ root: RootElement ];
 };
+
+interface RootData {
+	rootName: string;
+	data?: string;
+	elementName?: string;
+}

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -127,8 +127,6 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 
 		this.ui = new MultiRootEditorUI( this, view );
 
-		// This can be improved if `$isVirtual` attribute for root is introduced.
-		// Multi-root editor will create (or not) the editable based on the attribute value. The events will be editable-related.
 		this.model.document.on( 'change:data', () => {
 			const changedRoots = this.model.document.differ.getChangedRoots();
 
@@ -341,13 +339,16 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	 * The new DOM editable is attached to the model root and can be used to modify the root content.
 	 *
 	 * @param root Root for which the editable element should be created.
+	 * @param placeholder Placeholder for the editable element. If not set, placeholder value from the
+	 * {@link module:core/editor/editorconfig~EditorConfig#placeholder editor configuration} will be used (if it was provided).
 	 * @returns The created DOM element. Append it in a desired place in your application.
 	 */
-	public createEditable( root: RootElement ): HTMLElement {
-		// After introducing `$isVirtual` root attribute, this method will be fired automatically by the multi-root editor instance.
+	public createEditable( root: RootElement, placeholder?: string ): HTMLElement {
 		const editable = this.ui.view.createEditable( root.rootName );
 
-		this.ui.addEditable( editable );
+		this.ui.addEditable( editable, placeholder );
+
+		this.editing.view.forceRender();
 
 		return editable.element!;
 	}

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -539,8 +539,8 @@ function isElement( value: any ): value is Element {
 /**
  * Fired whenever a root is {@link ~MultiRootEditor#addRoot added or re-added} to the editor model.
  *
- * Use this event to {@link ~MultiRootEditor#createEditable create a DOM editable} for the added root and append the DOM element in a desired place
- * in your application.
+ * Use this event to {@link ~MultiRootEditor#createEditable create a DOM editable} for the added root and append the DOM element
+ * in a desired place in your application.
  *
  * The event is fired after all changes from a given batch are applied. The event is not fired, if the root was added and detached
  * in the same batch.

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -197,7 +197,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	 * Adds a new root to the editor.
 	 *
 	 * ```ts
-	 * editor.addRoot( 'myRoot' );
+	 * editor.addRoot( 'myRoot', { data: '<p>Initial root data.</p>' } );
 	 * ```
 	 *
 	 * After a root is added, you will be able to modify and retrieve its data.
@@ -242,9 +242,9 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	 * let rowId = 0;
 	 *
 	 * editor.model.change( () => {
-	 * 	editor.addRoot( 'left-row-' + rowId, true );
-	 * 	editor.addRoot( 'center-row-' + rowId, true );
-	 * 	editor.addRoot( 'right-row-' + rowId, true );
+	 * 	editor.addRoot( 'left-row-' + rowId, { isUndoable: true } );
+	 * 	editor.addRoot( 'center-row-' + rowId, { isUndoable: true } );
+	 * 	editor.addRoot( 'right-row-' + rowId, { isUndoable: true } );
 	 *
 	 * 	rowId++;
 	 * } );
@@ -255,7 +255,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	 * @param elementName Element name for the root element in the model. It can be used to set different schema rules for different roots.
 	 * @param isUndoable Whether creating the root can be undone (using the undo feature) or not.
 	 */
-	public addRoot( { rootName, data, elementName }: RootData, isUndoable: boolean ): void {
+	public addRoot( rootName: string, { data = '', elementName = '$root', isUndoable = false } = {} ): void {
 		const dataController = this.data;
 
 		if ( isUndoable ) {
@@ -318,9 +318,9 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	 *
 	 * ```ts
 	 * editor.model.change( () => {
-	 * 	editor.addRoot( 'left-row-3', true );
-	 * 	editor.addRoot( 'center-row-3', true );
-	 * 	editor.addRoot( 'right-row-3', true );
+	 * 	editor.detachRoot( 'left-row-3', true );
+	 * 	editor.detachRoot( 'center-row-3', true );
+	 * 	editor.detachRoot( 'right-row-3', true );
 	 * } );
 	 * ```
 	 *
@@ -569,9 +569,3 @@ export type DetachRootEvent = {
 	name: 'detachRoot';
 	args: [ root: RootElement ];
 };
-
-interface RootData {
-	rootName: string;
-	data?: string;
-	elementName?: string;
-}

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -249,11 +249,9 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	 * ```
 	 *
 	 * @param rootName Name of the root to add.
-	 * @param data Initial data for the root.
-	 * @param elementName Element name for the root element in the model. It can be used to set different schema rules for different roots.
-	 * @param isUndoable Whether creating the root can be undone (using the undo feature) or not.
+	 * @param options Additional options for the added root.
 	 */
-	public addRoot( rootName: string, { data = '', elementName = '$root', isUndoable = false } = {} ): void {
+	public addRoot( rootName: string, { data = '', elementName = '$root', isUndoable = false }: AddRootOptions = {} ): void {
 		const dataController = this.data;
 
 		if ( isUndoable ) {
@@ -557,7 +555,7 @@ export type AddRootEvent = {
 /**
  * Fired whenever a root is {@link ~MultiRootEditor#detachRoot detached} from the editor model.
  *
- * Use this event to {@link ~MultiRootEditor#removeEditable destroy a DOM editable} for the detached root and remove the DOM element
+ * Use this event to {@link ~MultiRootEditor#detachEditable destroy a DOM editable} for the detached root and remove the DOM element
  * from your application.
  *
  * The event is fired after all changes from a given batch are applied. The event is not fired, if the root was detached and re-added
@@ -569,4 +567,17 @@ export type AddRootEvent = {
 export type DetachRootEvent = {
 	name: 'detachRoot';
 	args: [ root: RootElement ];
+};
+
+/**
+ * Additional options available when adding a root.
+ *
+ * @param data Initial data for the root.
+ * @param elementName Element name for the root element in the model. It can be used to set different schema rules for different roots.
+ * @param isUndoable Whether creating the root can be undone (using the undo feature) or not.
+ */
+export type AddRootOptions = {
+	data?: string;
+	elementName?: string;
+	isUndoable?: boolean;
 };

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditorui.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditorui.ts
@@ -96,8 +96,10 @@ export default class MultiRootEditorUI extends EditorUI {
 	 * changing its content will be reflected in the editor model. Keystrokes, focus handling and placeholder are initialized.
 	 *
 	 * @param editable The editable instance to add.
+	 * @param placeholder Placeholder for the editable element. If not set, placeholder value from the
+	 * {@link module:core/editor/editorconfig~EditorConfig#placeholder editor configuration} will be used (if it was provided).
 	 */
-	public addEditable( editable: InlineEditableUIView ): void {
+	public addEditable( editable: InlineEditableUIView, placeholder?: string ): void {
 		// The editable UI element in DOM is available for sure only after the editor UI view has been rendered.
 		// But it can be available earlier if a DOM element has been passed to `MultiRootEditor.create()`.
 		const editableElement = editable.element!;
@@ -140,7 +142,7 @@ export default class MultiRootEditorUI extends EditorUI {
 				}
 			} );
 
-		this._initPlaceholder( editable );
+		this._initPlaceholder( editable, placeholder );
 	}
 
 	/**
@@ -190,17 +192,19 @@ export default class MultiRootEditorUI extends EditorUI {
 	 * Enables the placeholder text on a given editable, if the placeholder was configured.
 	 *
 	 * @param editable Editable on which the placeholder should be set.
+	 * @param placeholder Placeholder for the editable element. If not set, placeholder value from the
+	 * {@link module:core/editor/editorconfig~EditorConfig#placeholder editor configuration} will be used (if it was provided).
 	 */
-	private _initPlaceholder( editable: InlineEditableUIView ): void {
-		const placeholder = this.editor.config.get( 'placeholder' );
-
+	private _initPlaceholder( editable: InlineEditableUIView, placeholder?: string ): void {
 		if ( !placeholder ) {
-			return;
+			const configPlaceholder = this.editor.config.get( 'placeholder' );
+
+			if ( configPlaceholder ) {
+				placeholder = typeof configPlaceholder === 'string' ? configPlaceholder : configPlaceholder[ editable.name! ];
+			}
 		}
 
-		const placeholderText = typeof placeholder === 'string' ? placeholder : placeholder[ editable.name! ];
-
-		if ( !placeholderText ) {
+		if ( !placeholder ) {
 			return;
 		}
 
@@ -210,7 +214,7 @@ export default class MultiRootEditorUI extends EditorUI {
 		enablePlaceholder( {
 			view: editingView,
 			element: editingRoot,
-			text: placeholderText,
+			text: placeholder,
 			isDirectHost: false,
 			keepOnFocus: true
 		} );

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditorui.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditorui.ts
@@ -13,7 +13,8 @@ import {
 
 import {
 	EditorUI,
-	type EditorUIReadyEvent
+	type EditorUIReadyEvent,
+	type InlineEditableUIView
 } from 'ckeditor5/src/ui';
 
 import { enablePlaceholder } from 'ckeditor5/src/engine';
@@ -30,6 +31,11 @@ export default class MultiRootEditorUI extends EditorUI {
 	public readonly view: MultiRootEditorUIView;
 
 	/**
+	 * The editable element that was focused the last time when any of the editables had focus.
+	 */
+	private _lastFocusedEditableElement: HTMLElement | null;
+
+	/**
 	 * Creates an instance of the multi-root editor UI class.
 	 *
 	 * @param editor The editor instance.
@@ -39,6 +45,7 @@ export default class MultiRootEditorUI extends EditorUI {
 		super( editor );
 
 		this.view = view;
+		this._lastFocusedEditableElement = null;
 	}
 
 	/**
@@ -46,14 +53,6 @@ export default class MultiRootEditorUI extends EditorUI {
 	 */
 	public init(): void {
 		const view = this.view;
-		const editor = this.editor;
-		const editingView = editor.editing.view;
-
-		let lastFocusedEditableElement: HTMLElement | null;
-
-		for ( const editableName of Object.keys( view.editables ) ) {
-			view.editables[ editableName ].name = editableName;
-		}
 
 		view.render();
 
@@ -65,7 +64,7 @@ export default class MultiRootEditorUI extends EditorUI {
 		this.focusTracker.on( 'change:focusedElement', ( evt, name, focusedElement ) => {
 			for ( const editable of Object.values( this.view.editables ) ) {
 				if ( focusedElement === editable.element ) {
-					lastFocusedEditableElement = editable.element;
+					this._lastFocusedEditableElement = editable.element;
 				}
 			}
 		} );
@@ -76,57 +75,88 @@ export default class MultiRootEditorUI extends EditorUI {
 		// to another within the editor UI.
 		this.focusTracker.on( 'change:isFocused', ( evt, name, isFocused ) => {
 			if ( !isFocused ) {
-				lastFocusedEditableElement = null;
+				this._lastFocusedEditableElement = null;
 			}
 		} );
 
 		for ( const editable of Object.values( this.view.editables ) ) {
-			// The editable UI element in DOM is available for sure only after the editor UI view has been rendered.
-			// But it can be available earlier if a DOM element has been passed to `MultiRootEditor.create()`.
-			const editableElement = editable.element!;
-
-			// Register each editable UI view in the editor.
-			this.setEditableElement( editable.name!, editableElement );
-
-			// Let the editable UI element respond to the changes in the global editor focus
-			// tracker. It has been added to the same tracker a few lines above but, in reality, there are
-			// many focusable areas in the editor, like balloons, toolbars or dropdowns and as long
-			// as they have focus, the editable should act like it is focused too (although technically
-			// it isn't), e.g. by setting the proper CSS class, visually announcing focus to the user.
-			// Doing otherwise will result in editable focus styles disappearing, once e.g. the
-			// toolbar gets focused.
-			editable.bind( 'isFocused' ).to( this.focusTracker, 'isFocused', this.focusTracker, 'focusedElement',
-				( isFocused: boolean, focusedElement: Element | null ) => {
-					// When the focus tracker is blurred, it means the focus moved out of the editor UI.
-					// No editable will maintain focus then.
-					if ( !isFocused ) {
-						return false;
-					}
-
-					// If the focus tracker says the editor UI is focused and currently focused element
-					// is the editable, then the editable should be visually marked as focused too.
-					if ( focusedElement === editableElement ) {
-						return true;
-					}
-					// If the focus tracker says the editor UI is focused but the focused element is
-					// not an editable, it is possible that the editable is still (context–)focused.
-					// For instance, the focused element could be an input inside of a balloon attached
-					// to the content in the editable. In such case, the editable should remain _visually_
-					// focused even though technically the focus is somewhere else. The focus moved from
-					// the editable to the input but the focus context remained the same.
-					else {
-						return lastFocusedEditableElement === editableElement;
-					}
-				} );
-
-			// Bind the editable UI element to the editing view, making it an end– and entry–point
-			// of the editor's engine. This is where the engine meets the UI.
-			editingView.attachDomRoot( editableElement, editable.name! );
+			this.addEditable( editable );
 		}
 
-		this._initPlaceholder();
 		this._initToolbar();
 		this.fire<EditorUIReadyEvent>( 'ready' );
+	}
+
+	/**
+	 * Adds the editable to the editor UI.
+	 *
+	 * After the editable is added to the editor UI it can be considered "active".
+	 *
+	 * The editable is attached to the editor editing pipeline, which means that it will be updated as the editor model updates and
+	 * changing its content will be reflected in the editor model. Keystrokes, focus handling and placeholder are initialized.
+	 *
+	 * @param editable The editable instance to add.
+	 */
+	public addEditable( editable: InlineEditableUIView ): void {
+		// The editable UI element in DOM is available for sure only after the editor UI view has been rendered.
+		// But it can be available earlier if a DOM element has been passed to `MultiRootEditor.create()`.
+		const editableElement = editable.element!;
+
+		// Bind the editable UI element to the editing view, making it an end– and entry–point
+		// of the editor's engine. This is where the engine meets the UI.
+		this.editor.editing.view.attachDomRoot( editableElement, editable.name! );
+
+		// Register each editable UI view in the editor.
+		this.setEditableElement( editable.name!, editableElement );
+
+		// Let the editable UI element respond to the changes in the global editor focus
+		// tracker. It has been added to the same tracker a few lines above but, in reality, there are
+		// many focusable areas in the editor, like balloons, toolbars or dropdowns and as long
+		// as they have focus, the editable should act like it is focused too (although technically
+		// it isn't), e.g. by setting the proper CSS class, visually announcing focus to the user.
+		// Doing otherwise will result in editable focus styles disappearing, once e.g. the
+		// toolbar gets focused.
+		editable.bind( 'isFocused' ).to( this.focusTracker, 'isFocused', this.focusTracker, 'focusedElement',
+			( isFocused: boolean, focusedElement: Element | null ) => {
+				// When the focus tracker is blurred, it means the focus moved out of the editor UI.
+				// No editable will maintain focus then.
+				if ( !isFocused ) {
+					return false;
+				}
+
+				// If the focus tracker says the editor UI is focused and currently focused element
+				// is the editable, then the editable should be visually marked as focused too.
+				if ( focusedElement === editableElement ) {
+					return true;
+				}
+				// If the focus tracker says the editor UI is focused but the focused element is
+				// not an editable, it is possible that the editable is still (context–)focused.
+				// For instance, the focused element could be an input inside of a balloon attached
+				// to the content in the editable. In such case, the editable should remain _visually_
+				// focused even though technically the focus is somewhere else. The focus moved from
+				// the editable to the input but the focus context remained the same.
+				else {
+					return this._lastFocusedEditableElement === editableElement;
+				}
+			} );
+
+		this._initPlaceholder( editable );
+	}
+
+	/**
+	 * Removes the editable instance from the editor UI.
+	 *
+	 * Removed editable can be considered "deactivated".
+	 *
+	 * The editable is detached from the editing pipeline, so model changes are no longer reflected in it. All handling added in
+	 * {@link #addEditable} is removed.
+	 *
+	 * @param editable Editable to remove from the editor UI.
+	 */
+	public removeEditable( editable: InlineEditableUIView ): void {
+		this.editor.editing.view.detachDomRoot( editable.name! );
+		editable.unbind( 'isFocused' );
+		this.removeEditableElement( editable.name! );
 	}
 
 	/**
@@ -135,14 +165,11 @@ export default class MultiRootEditorUI extends EditorUI {
 	public override destroy(): void {
 		super.destroy();
 
-		const view = this.view;
-		const editingView = this.editor.editing.view;
-
 		for ( const editable of Object.values( this.view.editables ) ) {
-			editingView.detachDomRoot( editable.name! );
+			this.removeEditable( editable );
 		}
 
-		view.destroy();
+		this.view.destroy();
 	}
 
 	/**
@@ -155,35 +182,37 @@ export default class MultiRootEditorUI extends EditorUI {
 
 		toolbar.fillFromConfig( editor.config.get( 'toolbar' ), this.componentFactory );
 
-		// Register the toolbar so it becomes available for Alt+F10 and Esc navigation.
+		// Register the toolbar, so it becomes available for Alt+F10 and Esc navigation.
 		this.addToolbar( view.toolbar );
 	}
 
 	/**
-	 * Enable the placeholder text on the editing roots, if any was configured.
+	 * Enables the placeholder text on a given editable, if the placeholder was configured.
+	 *
+	 * @param editable Editable on which the placeholder should be set.
 	 */
-	private _initPlaceholder(): void {
-		const editor = this.editor;
-		const editingView = editor.editing.view;
-		const placeholder = editor.config.get( 'placeholder' );
+	private _initPlaceholder( editable: InlineEditableUIView ): void {
+		const placeholder = this.editor.config.get( 'placeholder' );
 
 		if ( !placeholder ) {
 			return;
 		}
 
-		for ( const editable of Object.values( this.view.editables ) ) {
-			const editingRoot = editingView.document.getRoot( editable.name! )!;
-			const placeholderText = typeof placeholder === 'string' ? placeholder : placeholder[ editable.name! ];
+		const placeholderText = typeof placeholder === 'string' ? placeholder : placeholder[ editable.name! ];
 
-			if ( placeholderText ) {
-				enablePlaceholder( {
-					view: editingView,
-					element: editingRoot,
-					text: placeholderText,
-					isDirectHost: false,
-					keepOnFocus: true
-				} );
-			}
+		if ( !placeholderText ) {
+			return;
 		}
+
+		const editingView = this.editor.editing.view;
+		const editingRoot = editingView.document.getRoot( editable.name! )!;
+
+		enablePlaceholder( {
+			view: editingView,
+			element: editingRoot,
+			text: placeholderText,
+			isDirectHost: false,
+			keepOnFocus: true
+		} );
 	}
 }

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditoruiview.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditoruiview.ts
@@ -133,7 +133,9 @@ export default class MultiRootEditorUIView extends EditorUIView {
 	public removeEditable( editableName: string ): void {
 		const editable = this.editables[ editableName ];
 
-		this.deregisterChild( editable );
+		if ( this.isRendered ) {
+			this.deregisterChild( editable );
+		}
 
 		delete this.editables[ editableName ];
 

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditoruiview.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditoruiview.ts
@@ -118,8 +118,9 @@ export default class MultiRootEditorUIView extends EditorUIView {
 		this.editables[ editableName ] = editable;
 		editable.name = editableName;
 
-		// This will render `editable` as `this` is already rendered.
-		this.registerChild( editable );
+		if ( this.isRendered ) {
+			this.registerChild( editable );
+		}
 
 		return editable;
 	}
@@ -145,6 +146,7 @@ export default class MultiRootEditorUIView extends EditorUIView {
 	public override render(): void {
 		super.render();
 
+		this.registerChild( Object.values( this.editables ) );
 		this.registerChild( this.toolbar );
 	}
 }

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditoruiview.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditoruiview.ts
@@ -34,6 +34,11 @@ export default class MultiRootEditorUIView extends EditorUIView {
 	public readonly editable: InlineEditableUIView;
 
 	/**
+	 * The editing view instance this view is related to.
+	 */
+	private readonly _editingView: View;
+
+	/**
 	 * Creates an instance of the multi-root editor UI view.
 	 *
 	 * @param locale The {@link module:core/editor/editor~Editor#locale} instance.
@@ -59,7 +64,7 @@ export default class MultiRootEditorUIView extends EditorUIView {
 	) {
 		super( locale );
 
-		const t = locale.t;
+		this._editingView = editingView;
 
 		this.toolbar = new ToolbarView( locale, {
 			shouldGroupWhenFull: options.shouldToolbarGroupWhenFull
@@ -69,18 +74,9 @@ export default class MultiRootEditorUIView extends EditorUIView {
 
 		// Create `InlineEditableUIView` instance for each editable.
 		for ( const editableName of editableNames ) {
-			const editable = new InlineEditableUIView(
-				locale,
-				editingView,
-				options.editableElements ? options.editableElements[ editableName ] : undefined,
-				{
-					label: editable => {
-						return t( 'Rich Text Editor. Editing area: %0', editable.name! );
-					}
-				}
-			);
+			const editableElement = options.editableElements ? options.editableElements[ editableName ] : undefined;
 
-			this.editables[ editableName ] = editable;
+			this.createEditable( editableName, editableElement );
 		}
 
 		this.editable = Object.values( this.editables )[ 0 ];
@@ -101,12 +97,54 @@ export default class MultiRootEditorUIView extends EditorUIView {
 	}
 
 	/**
+	 * Creates an editable instance with given name and registers it in the editor UI view.
+	 *
+	 * If `editableElement` is provided, the editable instance will be created on top of it. Otherwise, the editor will create a new
+	 * DOM element and use it instead.
+	 *
+	 * @param editableName The name for the editable.
+	 * @param editableElement DOM element for which the editable should be created.
+	 * @returns The created editable instance.
+	 */
+	public createEditable( editableName: string, editableElement?: HTMLElement ): InlineEditableUIView {
+		const t = this.locale.t;
+
+		const editable = new InlineEditableUIView( this.locale, this._editingView, editableElement, {
+			label: editable => {
+				return t( 'Rich Text Editor. Editing area: %0', editable.name! );
+			}
+		} );
+
+		this.editables[ editableName ] = editable;
+		editable.name = editableName;
+
+		// This will render `editable` as `this` is already rendered.
+		this.registerChild( editable );
+
+		return editable;
+	}
+
+	/**
+	 * Destroys and removes the editable from the editor UI view.
+	 *
+	 * @param editableName The name of the editable that should be removed.
+	 */
+	public removeEditable( editableName: string ): void {
+		const editable = this.editables[ editableName ];
+
+		this.deregisterChild( editable );
+
+		delete this.editables[ editableName ];
+
+		editable.destroy();
+	}
+
+	/**
 	 * @inheritDoc
 	 */
 	public override render(): void {
 		super.render();
 
-		this.registerChild( Object.values( this.editables ) );
-		this.registerChild( [ this.toolbar ] );
+		this.registerChild( this.toolbar );
 	}
 }

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
@@ -352,7 +352,7 @@ describe( 'MultiRootEditor', () => {
 
 		afterEach( async () => {
 			await editor.destroy();
-		} )
+		} );
 
 		it( 'should add a model root with given root name using operations', () => {
 			const document = editor.model.document;
@@ -360,7 +360,7 @@ describe( 'MultiRootEditor', () => {
 
 			editor.addRoot( 'bar' );
 
-			const root = document.getRoot( 'bar' )
+			const root = document.getRoot( 'bar' );
 
 			expect( root ).not.to.be.null;
 			expect( root.isAttached() ).to.be.true;
@@ -396,7 +396,7 @@ describe( 'MultiRootEditor', () => {
 
 			editor.execute( 'undo' );
 
-			const root = editor.model.document.getRoot( 'bar' )
+			const root = editor.model.document.getRoot( 'bar' );
 
 			expect( root ).not.to.be.null;
 			expect( root.isAttached() ).to.be.false;
@@ -410,14 +410,14 @@ describe( 'MultiRootEditor', () => {
 
 		afterEach( async () => {
 			await editor.destroy();
-		} )
+		} );
 
 		it( 'should detach given model root using operations', () => {
 			const document = editor.model.document;
 
 			editor.detachRoot( 'bar' );
 
-			const root = document.getRoot( 'bar' )
+			const root = document.getRoot( 'bar' );
 
 			expect( root ).not.to.be.null;
 			expect( root.isAttached() ).to.be.false;
@@ -462,7 +462,7 @@ describe( 'MultiRootEditor', () => {
 
 		afterEach( async () => {
 			await editor.destroy();
-		} )
+		} );
 
 		it( 'should return an HTMLElement which is updated with the downcasted model data', () => {
 			editor.addRoot( 'new' );
@@ -525,7 +525,7 @@ describe( 'MultiRootEditor', () => {
 
 		afterEach( async () => {
 			await editor.destroy();
-		} )
+		} );
 
 		it( 'should detach the editable element from the model root and return the editable DOM element', () => {
 			const editableElement = editor.ui.view.editables.foo.element;

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditoruiview.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditoruiview.js
@@ -57,7 +57,7 @@ describe( 'MultiRootEditorUIView', () => {
 
 				it( 'should be controlled via options.shouldToolbarGroupWhenFull', () => {
 					const editingView = new EditingView();
-					const editingViewRoot = createRoot( editingView.document, 'foo' );
+					const editingViewRoot = createRoot( editingView.document, 'div', 'foo' );
 					const view = new MultiRootEditorUIView( locale, editingView, [ 'foo' ], {
 						shouldToolbarGroupWhenFull: true
 					} );

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditoruiview.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditoruiview.js
@@ -115,6 +115,72 @@ describe( 'MultiRootEditorUIView', () => {
 		} );
 	} );
 
+	describe( 'createEditable()', () => {
+		it( 'adds editable', () => {
+			const editable = view.createEditable( 'new' );
+
+			expect( view.editables.new ).to.equal( editable );
+		} );
+
+		it( 'uses given HTML element inside editable', () => {
+			createRoot( editingView.document, 'div', 'new' );
+
+			const domElement = document.createElement( 'div' );
+			const editable = view.createEditable( 'new', domElement );
+			view.editables.new.name = 'new';
+
+			view.render();
+
+			expect( view.editables.new ).to.equal( editable );
+			expect( editable.element ).to.equal( domElement );
+
+			view.destroy();
+		} );
+
+		it( 'passed locale object to editable', () => {
+			view.createEditable( 'new' );
+
+			expect( view.editables.new.locale ).to.equal( locale );
+		} );
+
+		it( 'new editable is not rendered', () => {
+			view.createEditable( 'new' );
+
+			expect( view.editables.new.isRendered ).to.be.false;
+		} );
+
+		it( 'new editable is given an accessible aria label', () => {
+			const newViewRoot = createRoot( editingView.document, 'div', 'new' );
+
+			view.createEditable( 'new' );
+			view.editables.new.name = 'new';
+
+			view.render();
+
+			expect( newViewRoot.getAttribute( 'aria-label' ) ).to.equal( 'Rich Text Editor. Editing area: new' );
+
+			view.destroy();
+		} );
+	} );
+
+	describe( 'removeEditable()', () => {
+		it( 'removes the editable from the editables list (before view was rendered)', () => {
+			view.removeEditable( 'foo' );
+
+			expect( view.editables.foo ).to.be.undefined;
+		} );
+
+		it( 'removes the editable from the editables list (after view was rendered)', () => {
+			view.render();
+
+			view.removeEditable( 'foo' );
+
+			expect( view.editables.foo ).to.be.undefined;
+
+			view.destroy();
+		} );
+	} );
+
 	describe( 'render()', () => {
 		beforeEach( () => {
 			view.render();

--- a/packages/ckeditor5-engine/src/controller/datacontroller.ts
+++ b/packages/ckeditor5-engine/src/controller/datacontroller.ts
@@ -537,7 +537,7 @@ export default class DataController extends EmitterMixin() {
 	 */
 	private _checkIfRootsExists( rootNames: Array<string> ): boolean {
 		for ( const rootName of rootNames ) {
-			if ( !this.model.document.getRootNames().includes( rootName ) ) {
+			if ( !this.model.document.getRoot( rootName ) ) {
 				return false;
 			}
 		}

--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -67,8 +67,8 @@ export { default as MergeOperation } from './model/operation/mergeoperation';
 export { default as SplitOperation } from './model/operation/splitoperation';
 export { default as MarkerOperation } from './model/operation/markeroperation';
 export { default as OperationFactory } from './model/operation/operationfactory';
-export type { default as AttributeOperation } from './model/operation/attributeoperation';
-export type { default as RenameOperation } from './model/operation/renameoperation';
+export { default as AttributeOperation } from './model/operation/attributeoperation';
+export { default as RenameOperation } from './model/operation/renameoperation';
 export { transformSets } from './model/operation/transform';
 
 // Model.

--- a/packages/ckeditor5-engine/src/model/differ.ts
+++ b/packages/ckeditor5-engine/src/model/differ.ts
@@ -244,7 +244,7 @@ export default class Differ {
 
 				break;
 			}
-			case 'removeRoot':
+			case 'detachRoot':
 			case 'addRoot': {
 				this._bufferRootChange( operation.rootName, operation.isAdd );
 

--- a/packages/ckeditor5-engine/src/model/document.ts
+++ b/packages/ckeditor5-engine/src/model/document.ts
@@ -178,6 +178,8 @@ export default class Document extends EmitterMixin() {
 			for ( const marker of this.model.markers ) {
 				if ( !marker.getRange().root.isAttached() ) {
 					writer.removeMarker( marker );
+
+					result = true;
 				}
 			}
 

--- a/packages/ckeditor5-engine/src/model/documentfragment.ts
+++ b/packages/ckeditor5-engine/src/model/documentfragment.ts
@@ -133,6 +133,13 @@ export default class DocumentFragment extends TypeCheckable implements Iterable<
 	}
 
 	/**
+	 * Returns `false` as `DocumentFragment` by definition is not attached to a document. Added for compatibility reasons.
+	 */
+	public isAttached(): false {
+		return false;
+	}
+
+	/**
 	 * Returns empty array. Added for compatibility reasons.
 	 */
 	public getAncestors(): Array<never> {

--- a/packages/ckeditor5-engine/src/model/node.ts
+++ b/packages/ckeditor5-engine/src/model/node.ts
@@ -187,7 +187,11 @@ export default abstract class Node extends TypeCheckable {
 	 * Returns `true` if the node is inside a document root that is attached to the document.
 	 */
 	public isAttached(): boolean {
-		return this.root.isAttached();
+		// If the node has no parent it means that it is a root.
+		// But this is not a `RootElement`, so it means that it is not attached.
+		//
+		// If this is not the root, check if this element's root is attached.
+		return this.parent === null ? false : this.root.isAttached();
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/model/node.ts
+++ b/packages/ckeditor5-engine/src/model/node.ts
@@ -184,10 +184,10 @@ export default abstract class Node extends TypeCheckable {
 	}
 
 	/**
-	 * Returns true if the node is in a tree rooted in the document (is a descendant of one of its roots).
+	 * Returns `true` if the node is inside a document root that is attached to the document.
 	 */
 	public isAttached(): boolean {
-		return this.root.is( 'rootElement' );
+		return this.root.isAttached();
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/model/operation/attributeoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/attributeoperation.ts
@@ -184,7 +184,7 @@ export default class AttributeOperation extends Operation {
 	}
 
 	/**
-	 * Creates `AttributeOperation` object from deserilized object, i.e. from parsed JSON string.
+	 * Creates `AttributeOperation` object from deserialized object, i.e. from parsed JSON string.
 	 *
 	 * @param json Deserialized JSON object.
 	 * @param document Document on which this operation will be applied.

--- a/packages/ckeditor5-engine/src/model/operation/insertoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/insertoperation.ts
@@ -152,7 +152,7 @@ export default class InsertOperation extends Operation {
 	}
 
 	/**
-	 * Creates `InsertOperation` object from deserilized object, i.e. from parsed JSON string.
+	 * Creates `InsertOperation` object from deserialized object, i.e. from parsed JSON string.
 	 *
 	 * @param json Deserialized JSON object.
 	 * @param document Document on which this operation will be applied.

--- a/packages/ckeditor5-engine/src/model/operation/mergeoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/mergeoperation.ts
@@ -192,7 +192,7 @@ export default class MergeOperation extends Operation {
 	}
 
 	/**
-	 * Creates `MergeOperation` object from deserilized object, i.e. from parsed JSON string.
+	 * Creates `MergeOperation` object from deserialized object, i.e. from parsed JSON string.
 	 *
 	 * @param json Deserialized JSON object.
 	 * @param document Document on which this operation will be applied.

--- a/packages/ckeditor5-engine/src/model/operation/moveoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/moveoperation.ts
@@ -185,7 +185,7 @@ export default class MoveOperation extends Operation {
 	}
 
 	/**
-	 * Creates `MoveOperation` object from deserilized object, i.e. from parsed JSON string.
+	 * Creates `MoveOperation` object from deserialized object, i.e. from parsed JSON string.
 	 *
 	 * @param json Deserialized JSON object.
 	 * @param document Document on which this operation will be applied.

--- a/packages/ckeditor5-engine/src/model/operation/operation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/operation.ts
@@ -117,7 +117,7 @@ export default abstract class Operation {
 	}
 
 	/**
-	 * Creates Operation object from deserilized object, i.e. from parsed JSON string.
+	 * Creates `Operation` object from deserialized object, i.e. from parsed JSON string.
 	 *
 	 * @param json Deserialized JSON object.
 	 * @param doc Document on which this operation will be applied.

--- a/packages/ckeditor5-engine/src/model/operation/operationfactory.ts
+++ b/packages/ckeditor5-engine/src/model/operation/operationfactory.ts
@@ -15,6 +15,7 @@ import NoOperation from './nooperation';
 import Operation from './operation';
 import RenameOperation from './renameoperation';
 import RootAttributeOperation from './rootattributeoperation';
+import RootOperation from './rootoperation';
 import SplitOperation from './splitoperation';
 import MergeOperation from './mergeoperation';
 
@@ -34,6 +35,7 @@ operations[ NoOperation.className ] = NoOperation;
 operations[ Operation.className ] = Operation;
 operations[ RenameOperation.className ] = RenameOperation;
 operations[ RootAttributeOperation.className ] = RootAttributeOperation;
+operations[ RootOperation.className ] = RootOperation;
 operations[ SplitOperation.className ] = SplitOperation;
 operations[ MergeOperation.className ] = MergeOperation;
 
@@ -48,6 +50,12 @@ export default abstract class OperationFactory {
 	 * @param document Document on which this operation will be applied.
 	 */
 	public static fromJSON( json: any, document: Document ): Operation {
+		// TODO: Temporary solution to be able to pass `RootOperation` data to remote clients.
+		// TODO: The `RootOperation` is currently not handled by operations compressor, so it is compressed as a `RootAttributeOperation`.
+		if ( json.__className === 'RootAttributeOperation' && json.key.startsWith( '$$' ) ) {
+			return operations[ 'RootOperation' ].fromJSON( json, document );
+		}
+
 		return operations[ json.__className ].fromJSON( json, document );
 	}
 }

--- a/packages/ckeditor5-engine/src/model/operation/operationfactory.ts
+++ b/packages/ckeditor5-engine/src/model/operation/operationfactory.ts
@@ -53,7 +53,7 @@ export default abstract class OperationFactory {
 		// TODO: Temporary solution to be able to pass `RootOperation` data to remote clients.
 		// TODO: The `RootOperation` is currently not handled by operations compressor, so it is compressed as a `RootAttributeOperation`.
 		if ( json.__className === 'RootAttributeOperation' && json.key.startsWith( '$$' ) ) {
-			return operations[ 'RootOperation' ].fromJSON( json, document );
+			return operations.RootOperation.fromJSON( json, document );
 		}
 
 		return operations[ json.__className ].fromJSON( json, document );

--- a/packages/ckeditor5-engine/src/model/operation/operationfactory.ts
+++ b/packages/ckeditor5-engine/src/model/operation/operationfactory.ts
@@ -50,12 +50,6 @@ export default abstract class OperationFactory {
 	 * @param document Document on which this operation will be applied.
 	 */
 	public static fromJSON( json: any, document: Document ): Operation {
-		// TODO: Temporary solution to be able to pass `RootOperation` data to remote clients.
-		// TODO: The `RootOperation` is currently not handled by operations compressor, so it is compressed as a `RootAttributeOperation`.
-		if ( json.__className === 'RootAttributeOperation' && json.key.startsWith( '$$' ) ) {
-			return operations.RootOperation.fromJSON( json, document );
-		}
-
 		return operations[ json.__className ].fromJSON( json, document );
 	}
 }

--- a/packages/ckeditor5-engine/src/model/operation/rootattributeoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/rootattributeoperation.ts
@@ -131,7 +131,7 @@ export default class RootAttributeOperation extends Operation {
 
 		if ( this.oldValue !== null && this.root.getAttribute( this.key ) !== this.oldValue ) {
 			/**
-			 * The attribute which should be removed does not exists for the given node.
+			 * The attribute which should be removed does not exist for the given node.
 			 *
 			 * @error rootattribute-operation-wrong-old-value
 			 * @param root
@@ -192,7 +192,7 @@ export default class RootAttributeOperation extends Operation {
 	}
 
 	/**
-	 * Creates RootAttributeOperation object from deserilized object, i.e. from parsed JSON string.
+	 * Creates `RootAttributeOperation` object from deserialized object, i.e. from parsed JSON string.
 	 *
 	 * @param json Deserialized JSON object.
 	 * @param document Document on which this operation will be applied.

--- a/packages/ckeditor5-engine/src/model/operation/rootoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/rootoperation.ts
@@ -71,18 +71,30 @@ export default class RootOperation extends Operation {
 		}
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public override get type(): 'addRoot' | 'removeRoot' {
 		return this.isAdd ? 'addRoot' : 'removeRoot';
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public override clone(): RootOperation {
 		return new RootOperation( this.rootName, this.elementName, this.isAdd, this._document, this.baseVersion );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public override getReversed(): RootOperation {
 		return new RootOperation( this.rootName, this.elementName, !this.isAdd, this._document, this.baseVersion! + 1 );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public override _validate(): void {
 		const root = this._document.getRoot( this.rootName )!;
 
@@ -109,10 +121,16 @@ export default class RootOperation extends Operation {
 		}
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public override _execute(): void {
 		this._document.getRoot( this.rootName )!._isAttached = this.isAdd;
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public override toJSON(): unknown {
 		const json: any = super.toJSON();
 
@@ -129,6 +147,9 @@ export default class RootOperation extends Operation {
 		return json;
 	}
 
+	/**
+	 * @inheritDoc
+	 */
 	public static override get className(): string {
 		return 'RootOperation';
 	}

--- a/packages/ckeditor5-engine/src/model/operation/rootoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/rootoperation.ts
@@ -1,0 +1,154 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module engine/model/operation/rootoperation
+ */
+
+import Operation from './operation';
+
+import type Document from '../document';
+import { CKEditorError } from '@ckeditor/ckeditor5-utils';
+
+/**
+ * Operation that creates or removes a root element.
+ */
+export default class RootOperation extends Operation {
+	/**
+	 * Root name to create or remove.
+	 */
+	public readonly rootName: string;
+
+	/**
+	 * Root element to create or remove.
+	 */
+	public readonly elementName: string;
+
+	/**
+	 * Specifies whether the operation adds (`true`) or removes the root (`false`).
+	 */
+	public readonly isAdd: boolean;
+
+	/**
+	 * Document for which the root should be created.
+	 */
+	private readonly _document: Document;
+
+	/**
+	 * Creates an operation that creates or removes a root element.
+	 *
+	 * @param rootName Root name.
+	 * @param elementName Root element name.
+	 * @param isAdd Specifies whether the operation adds (`true`) or removes the root (`false`).
+	 * @param document Document for which the root should be created.
+	 * @param baseVersion Document {@link module:engine/model/document~Document#version} on which operation
+	 * can be applied or `null` if the operation operates on detached (non-document) tree.
+	 */
+	constructor(
+		rootName: string,
+		elementName: string,
+		isAdd: boolean,
+		document: Document,
+		baseVersion: number | null
+	) {
+		super( baseVersion );
+
+		this.rootName = rootName;
+		this.elementName = elementName;
+		this.isAdd = isAdd;
+		this._document = document;
+
+		// Make sure that the root exists ASAP, this is important for RTC.
+		// If the root was dynamically added, there will be more operations that operate on/in this root.
+		// These operations will require root element instance (in operation property or in position instance).
+		// If the root is not created ahead of time, instantiating such operations may fail.
+		if ( !this._document.getRoot( this.rootName ) ) {
+			const root = this._document.createRoot( this.elementName, this.rootName );
+
+			root._isAttached = false;
+		}
+	}
+
+	public override get type(): 'addRoot' | 'removeRoot' {
+		return this.isAdd ? 'addRoot' : 'removeRoot';
+	}
+
+	public override clone(): RootOperation {
+		return new RootOperation( this.rootName, this.elementName, this.isAdd, this._document, this.baseVersion );
+	}
+
+	public override getReversed(): RootOperation {
+		return new RootOperation( this.rootName, this.elementName, !this.isAdd, this._document, this.baseVersion! + 1 );
+	}
+
+	public override _validate(): void {
+		const root = this._document.getRoot( this.rootName )!;
+
+		if ( root.isAttached() && this.isAdd ) {
+			/**
+			 * Trying to attach a root that is already attached.
+			 *
+			 * @error root-operation-root-attached
+			 */
+			throw new CKEditorError(
+				'root-operation-root-attached',
+				this
+			);
+		} else if ( !root.isAttached() && !this.isAdd ) {
+			/**
+			 * Trying to detach a root that is already detached.
+			 *
+			 * @error root-operation-root-detached
+			 */
+			throw new CKEditorError(
+				'root-operation-root-detached',
+				this
+			);
+		}
+	}
+
+	public override _execute(): void {
+		this._document.getRoot( this.rootName )!._isAttached = this.isAdd;
+	}
+
+	public override toJSON(): unknown {
+		const json: any = super.toJSON();
+
+		// TODO: Temporary solution. To allow compressing `RootOperation`, it stored as `RootAttributeOperation` until changes are
+		// TODO: introduced in operations compressor.
+		json.__className = 'RootAttributeOperation';
+		json.root = this.rootName;
+		json.key = '$$' + this.type;
+		json.oldValue = null;
+		json.newValue = this.elementName;
+
+		delete json._document;
+
+		return json;
+	}
+
+	public static override get className(): string {
+		return 'RootOperation';
+	}
+
+	/**
+	 * Creates `RootOperation` object from deserialized object, i.e. from parsed JSON string.
+	 *
+	 * @param json Deserialized JSON object.
+	 * @param document Document on which this operation will be applied.
+	 */
+	public static override fromJSON( json: any, document: Document ): RootOperation {
+		// TODO: Temporary solution. To allow compressing `RootOperation`, it stored as `RootAttributeOperation` until changes are
+		// TODO: introduced in operations compressor.
+		const type = json.key.substring( 2 );
+
+		return new RootOperation( json.root, json.newValue, type === 'addRoot', document, json.baseVersion );
+	}
+
+	// @if CK_DEBUG_ENGINE // public override toString(): string {
+	// @if CK_DEBUG_ENGINE // 	return `RootOperation( ${ this.baseVersion } ): ` +
+	// @if CK_DEBUG_ENGINE //		`${ this.type } -> "${ this.rootName }" (${ this.elementName })`;
+	// @if CK_DEBUG_ENGINE // }
+}

--- a/packages/ckeditor5-engine/src/model/operation/splitoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/splitoperation.ts
@@ -226,7 +226,7 @@ export default class SplitOperation extends Operation {
 	}
 
 	/**
-	 * Creates `SplitOperation` object from deserilized object, i.e. from parsed JSON string.
+	 * Creates `SplitOperation` object from deserialized object, i.e. from parsed JSON string.
 	 *
 	 * @param json Deserialized JSON object.
 	 * @param document Document on which this operation will be applied.

--- a/packages/ckeditor5-engine/src/model/operation/transform.ts
+++ b/packages/ckeditor5-engine/src/model/operation/transform.ts
@@ -9,6 +9,7 @@ import RenameOperation from './renameoperation';
 import MarkerOperation from './markeroperation';
 import MoveOperation from './moveoperation';
 import RootAttributeOperation from './rootattributeoperation';
+import RootOperation from './rootoperation';
 import MergeOperation from './mergeoperation';
 import SplitOperation from './splitoperation';
 import NoOperation from './nooperation';
@@ -1969,6 +1970,16 @@ setTransformation( RootAttributeOperation, RootAttributeOperation, ( a, b, conte
 		} else {
 			a.oldValue = b.newValue;
 		}
+	}
+
+	return [ a ];
+} );
+
+// -----------------------
+
+setTransformation( RootOperation, RootOperation, ( a, b, context ) => {
+	if ( a.rootName === b.rootName && a.isAdd === b.isAdd && !context.bWasUndone ) {
+		return [ new NoOperation( 0 ) ];
 	}
 
 	return [ a ];

--- a/packages/ckeditor5-engine/src/model/rootelement.ts
+++ b/packages/ckeditor5-engine/src/model/rootelement.ts
@@ -26,6 +26,11 @@ export default class RootElement extends Element {
 	private readonly _document: Document;
 
 	/**
+	 * @internal
+	 */
+	public _isAttached = true;
+
+	/**
 	 * Creates root element.
 	 *
 	 * @param document Document that is an owner of this root.
@@ -47,7 +52,20 @@ export default class RootElement extends Element {
 	}
 
 	/**
-	 * Converts `RootElement` instance to `string` containing it's name.
+	 * Informs if the root element is currently attached to the document, or not.
+	 *
+	 * A detached root is equivalent to being removed and cannot contain any children or markers.
+	 *
+	 * By default, a newly added root is attached. It can be detached using
+	 * {@link module:engine/model/writer~Writer#detachRoot `Writer#detachRoot`}. A detached root can be re-attached again using
+	 * {@link module:engine/model/writer~Writer#addRoot `Writer#addRoot`}.
+	 */
+	public override isAttached(): boolean {
+		return this._isAttached;
+	}
+
+	/**
+	 * Converts `RootElement` instance to `string` containing its name.
 	 *
 	 * @returns `RootElement` instance converted to `string`.
 	 */

--- a/packages/ckeditor5-engine/src/model/writer.ts
+++ b/packages/ckeditor5-engine/src/model/writer.ts
@@ -1333,6 +1333,8 @@ export default class Writer {
 	 * @returns The added root element.
 	 */
 	public addRoot( rootName: string, elementName = '$root' ): RootElement {
+		this._assertWriterUsedCorrectly();
+
 		const root = this.model.document.getRoot( rootName );
 
 		if ( root && root.isAttached() ) {
@@ -1369,6 +1371,8 @@ export default class Writer {
 	 * @param rootName Name of the detached root.
 	 */
 	public detachRoot( rootName: string ): void {
+		this._assertWriterUsedCorrectly();
+
 		const root = this.model.document.getRoot( rootName );
 
 		if ( !root || !root.isAttached() ) {

--- a/packages/ckeditor5-engine/src/model/writer.ts
+++ b/packages/ckeditor5-engine/src/model/writer.ts
@@ -1368,12 +1368,12 @@ export default class Writer {
 	 *
 	 * Throws an error if the root does not exist or the root is already detached.
 	 *
-	 * @param rootName Name of the detached root.
+	 * @param rootOrName Name of the detached root.
 	 */
-	public detachRoot( rootName: string ): void {
+	public detachRoot( rootOrName: string | RootElement ): void {
 		this._assertWriterUsedCorrectly();
 
-		const root = this.model.document.getRoot( rootName );
+		const root = typeof rootOrName == 'string' ? this.model.document.getRoot( rootOrName ) : rootOrName;
 
 		if ( !root || !root.isAttached() ) {
 			/**
@@ -1397,7 +1397,7 @@ export default class Writer {
 
 		// Finally, detach the root.
 		const document = this.model.document;
-		const operation = new RootOperation( rootName, root.name, false, document, document.version );
+		const operation = new RootOperation( root.rootName, root.name, false, document, document.version );
 
 		this.batch.addOperation( operation );
 		this.model.applyOperation( operation );

--- a/packages/ckeditor5-engine/src/view/observer/arrowkeysobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/arrowkeysobserver.ts
@@ -44,6 +44,11 @@ export default class ArrowKeysObserver extends Observer {
 	 * @inheritDoc
 	 */
 	public override observe(): void {}
+
+	/**
+	 * @inheritDoc
+	 */
+	public override stopObserving(): void {}
 }
 
 /**

--- a/packages/ckeditor5-engine/src/view/observer/domeventobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/domeventobserver.ts
@@ -80,6 +80,13 @@ export default abstract class DomEventObserver<
 	}
 
 	/**
+	 * @inheritDoc
+	 */
+	public override stopObserving( domElement: HTMLElement ): void {
+		this.stopListening( domElement );
+	}
+
+	/**
 	 * Calls `Document#fire()` if observer {@link #isEnabled is enabled}.
 	 *
 	 * @see module:utils/emittermixin~Emitter#fire

--- a/packages/ckeditor5-engine/src/view/observer/fakeselectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/fakeselectionobserver.ts
@@ -70,6 +70,11 @@ export default class FakeSelectionObserver extends Observer {
 	/**
 	 * @inheritDoc
 	 */
+	public override stopObserving(): void {}
+
+	/**
+	 * @inheritDoc
+	 */
 	public override destroy(): void {
 		super.destroy();
 

--- a/packages/ckeditor5-engine/src/view/observer/mutationobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/mutationobserver.ts
@@ -97,7 +97,7 @@ export default class MutationObserver extends Observer {
 	/**
 	 * @inheritDoc
 	 */
-	public override stopObserving( domElement: HTMLElement ) {
+	public override stopObserving( domElement: HTMLElement ): void {
 		this._domElements.delete( domElement );
 
 		if ( this.isEnabled ) {

--- a/packages/ckeditor5-engine/src/view/observer/observer.ts
+++ b/packages/ckeditor5-engine/src/view/observer/observer.ts
@@ -108,12 +108,17 @@ export default abstract class Observer extends DomEmitterMixin() {
 	}
 
 	/**
-	 * Starts observing the given root element.
+	 * Starts observing given DOM element.
 	 *
-	 * @param name The name of the root element.
+	 * @param domElement DOM element to observe.
+	 * @param name The name of the related root element.
 	 */
-
 	public abstract observe( domElement: HTMLElement, name: string ): void;
+
+	/**
+	 * Stops observing given DOM element.
+	 */
+	public abstract stopObserving( domElement: HTMLElement ): void;
 }
 
 /**

--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -194,6 +194,13 @@ export default class SelectionObserver extends Observer {
 	/**
 	 * @inheritDoc
 	 */
+	public override stopObserving( domElement: HTMLElement ): void {
+		this.stopListening( domElement );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
 	public override destroy(): void {
 		super.destroy();
 

--- a/packages/ckeditor5-engine/src/view/observer/tabobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/tabobserver.ts
@@ -53,6 +53,11 @@ export default class TabObserver extends Observer {
 	 * @inheritDoc
 	 */
 	public override observe(): void {}
+
+	/**
+	 * @inheritDoc
+	 */
+	public override stopObserving(): void {}
 }
 
 /**

--- a/packages/ckeditor5-engine/src/view/placeholder.ts
+++ b/packages/ckeditor5-engine/src/view/placeholder.ts
@@ -80,11 +80,11 @@ export function enablePlaceholder( { view, element, text, isDirectHost = true, k
 export function disablePlaceholder( view: View, element: Element ): void {
 	const doc = element.document;
 
-	view.change( writer => {
-		if ( !documentPlaceholders.has( doc ) ) {
-			return;
-		}
+	if ( !documentPlaceholders.has( doc ) ) {
+		return;
+	}
 
+	view.change( writer => {
 		const placeholders = documentPlaceholders.get( doc )!;
 		const config = placeholders.get( element )!;
 

--- a/packages/ckeditor5-engine/src/view/view.ts
+++ b/packages/ckeditor5-engine/src/view/view.ts
@@ -310,6 +310,10 @@ export default class View extends ObservableMixin() {
 
 		this.domRoots.delete( name );
 		this.domConverter.unbindDomElement( domRoot );
+
+		for ( const observer of this._observers.values() ) {
+			observer.stopObserving( domRoot );
+		}
 	}
 
 	/**

--- a/packages/ckeditor5-engine/tests/controller/datacontroller.js
+++ b/packages/ckeditor5-engine/tests/controller/datacontroller.js
@@ -571,6 +571,23 @@ describe( 'DataController', () => {
 			setData( model, '<paragraph>foo</paragraph>' );
 			data.get();
 		} );
+
+		it( 'should return empty string and log a warning when asked for data from a detached root', () => {
+			setData( model, '<paragraph>foo</paragraph>' );
+
+			model.change( writer => {
+				writer.detachRoot( 'main' );
+			} );
+
+			const stub = sinon.stub( console, 'warn' );
+
+			const result = data.get( { rootName: 'main' } );
+
+			expect( result ).to.equal( '' );
+			sinon.assert.calledWithMatch( stub, 'datacontroller-get-detached-root' );
+
+			console.warn.restore();
+		} );
 	} );
 
 	describe( 'stringify()', () => {

--- a/packages/ckeditor5-engine/tests/controller/datacontroller.js
+++ b/packages/ckeditor5-engine/tests/controller/datacontroller.js
@@ -23,6 +23,8 @@ import DowncastHelpers from '../../src/conversion/downcasthelpers';
 import { expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 import { StylesProcessor } from '../../src/view/stylesmap';
 
+/* global console */
+
 describe( 'DataController', () => {
 	let model, modelDocument, data, schema, upcastHelpers, downcastHelpers, viewDocument;
 

--- a/packages/ckeditor5-engine/tests/model/document.js
+++ b/packages/ckeditor5-engine/tests/model/document.js
@@ -131,12 +131,31 @@ describe( 'Document', () => {
 
 			expect( Array.from( doc.getRootNames() ) ).to.deep.equal( [ 'a', 'b' ] );
 		} );
+
+		it( 'should return only attached roots', () => {
+			doc.createRoot( '$root', 'a' );
+			const rootB = doc.createRoot( '$root', 'b' );
+
+			rootB._isAttached = false;
+
+			expect( Array.from( doc.getRootNames() ) ).to.deep.equal( [ 'a' ] );
+		} );
+
+		it( 'should return detached roots when `includeDetached` flag is set to `true`', () => {
+			doc.createRoot( '$root', 'a' );
+			const rootB = doc.createRoot( '$root', 'b' );
+
+			rootB._isAttached = false;
+
+			expect( Array.from( doc.getRootNames( true ) ) ).to.deep.equal( [ 'a', 'b' ] );
+		} );
 	} );
 
 	describe( 'createRoot()', () => {
-		it( 'should create a new RootElement with default element and root names, add it to roots map and return it', () => {
+		it( 'should create a new RootElement, attached, with default element and root names, add it to roots map and return it', () => {
 			const root = doc.createRoot();
 
+			expect( root.isAttached() ).to.be.true;
 			expect( doc.roots.length ).to.equal( 2 );
 			expect( root ).to.be.instanceof( RootElement );
 			expect( root.maxOffset ).to.equal( 0 );
@@ -144,9 +163,10 @@ describe( 'Document', () => {
 			expect( root ).to.have.property( 'rootName', 'main' );
 		} );
 
-		it( 'should create a new RootElement with custom element and root names, add it to roots map and return it', () => {
+		it( 'should create a new RootElement, attached, with custom element and root names, add it to roots map and return it', () => {
 			const root = doc.createRoot( 'customElementName', 'customRootName' );
 
+			expect( root.isAttached() ).to.be.true;
 			expect( doc.roots.length ).to.equal( 2 );
 			expect( root ).to.be.instanceof( RootElement );
 			expect( root.maxOffset ).to.equal( 0 );
@@ -179,6 +199,14 @@ describe( 'Document', () => {
 		it( 'should return null when trying to get non-existent root', () => {
 			expect( doc.getRoot( 'not-existing' ) ).to.null;
 		} );
+
+		it( 'should return a detached root', () => {
+			const root = doc.createRoot( '$root', 'a' );
+
+			root._isAttached = false;
+
+			expect( doc.getRoot( 'a' ) ).to.equal( root );
+		} );
 	} );
 
 	describe( '_getDefaultRoot()', () => {
@@ -193,6 +221,33 @@ describe( 'Document', () => {
 
 			expect( doc._getDefaultRoot() ).to.equal( rootA );
 		} );
+	} );
+
+	it( 'should automatically remove elements or markers when added to a detached root', () => {
+		let root, p;
+
+		model.change( writer => {
+			root = writer.addRoot( 'new' );
+			writer.detachRoot( 'new' );
+		} );
+
+		model.change( writer => {
+			p = writer.createElement( 'paragraph' );
+			writer.insert( p, root, 0 );
+		} );
+
+		expect( root.isEmpty ).to.be.true;
+		expect( p.parent.rootName ).to.equal( '$graveyard' );
+
+		model.change( writer => {
+			writer.addMarker( 'newMarker', {
+				usingOperation: true,
+				affectsData: true,
+				range: writer.createRangeIn( root )
+			} );
+		} );
+
+		expect( model.markers.get( 'newMarker' ) ).to.be.null;
 	} );
 
 	describe( 'destroy()', () => {

--- a/packages/ckeditor5-engine/tests/model/documentfragment.js
+++ b/packages/ckeditor5-engine/tests/model/documentfragment.js
@@ -107,6 +107,14 @@ describe( 'DocumentFragment', () => {
 		} );
 	} );
 
+	describe( 'isAttached()', () => {
+		it( 'returns false', () => {
+			const frag = new DocumentFragment();
+
+			expect( frag.isAttached() ).to.be.false;
+		} );
+	} );
+
 	describe( 'offsetToIndex', () => {
 		let frag;
 

--- a/packages/ckeditor5-engine/tests/model/node.js
+++ b/packages/ckeditor5-engine/tests/model/node.js
@@ -141,7 +141,7 @@ describe( 'Node', () => {
 		it( 'should throw if node does not have a parent', () => {
 			expect( () => {
 				node._remove();
-			} ).to.throw;
+			} ).to.throw();
 		} );
 	} );
 

--- a/packages/ckeditor5-engine/tests/model/operation/rootoperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/rootoperation.js
@@ -4,8 +4,6 @@
  */
 
 import Model from '../../../src/model/model';
-import DocumentFragment from '../../../src/model/documentfragment';
-import Element from '../../../src/model/element';
 import RootOperation from '../../../src/model/operation/rootoperation';
 import { expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 
@@ -34,6 +32,7 @@ describe( 'RootOperation', () => {
 	it( 'should create a detached root in the model as the operation is created, if the model does not have such root', () => {
 		expect( model.document.getRoot( 'new' ) ).to.be.null;
 
+		// eslint-disable-next-line
 		new RootOperation( 'new', '$root', true, doc, doc.version );
 
 		const root = model.document.getRoot( 'new' );
@@ -42,6 +41,7 @@ describe( 'RootOperation', () => {
 
 		expect( () => {
 			// Should not throw because the operation should not try to create the root again.
+			// eslint-disable-next-line
 			new RootOperation( 'new', '$root', true, doc, doc.version );
 		} ).not.to.throw();
 	} );

--- a/packages/ckeditor5-engine/tests/model/operation/rootoperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/rootoperation.js
@@ -1,0 +1,142 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import Model from '../../../src/model/model';
+import DocumentFragment from '../../../src/model/documentfragment';
+import Element from '../../../src/model/element';
+import RootOperation from '../../../src/model/operation/rootoperation';
+import { expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
+
+describe( 'RootOperation', () => {
+	let model, doc;
+
+	beforeEach( () => {
+		model = new Model();
+		doc = model.document;
+	} );
+
+	describe( 'type', () => {
+		it( 'should be addRoot for adding a root', () => {
+			const op = new RootOperation( 'new', '$root', true, doc, doc.version );
+
+			expect( op.type ).to.equal( 'addRoot' );
+		} );
+
+		it( 'should be detachRoot for detaching a root', () => {
+			const op = new RootOperation( 'new', '$root', false, doc, doc.version );
+
+			expect( op.type ).to.equal( 'detachRoot' );
+		} );
+	} );
+
+	it( 'should create a detached root in the model as the operation is created, if the model does not have such root', () => {
+		expect( model.document.getRoot( 'new' ) ).to.be.null;
+
+		new RootOperation( 'new', '$root', true, doc, doc.version );
+
+		const root = model.document.getRoot( 'new' );
+		expect( root ).not.to.be.null;
+		expect( root.isAttached() ).to.be.false;
+
+		expect( () => {
+			// Should not throw because the operation should not try to create the root again.
+			new RootOperation( 'new', '$root', true, doc, doc.version );
+		} ).not.to.throw();
+	} );
+
+	it( 'should attach a model in the root', () => {
+		const op = new RootOperation( 'new', '$root', true, doc, doc.version );
+		const root = model.document.getRoot( 'new' );
+
+		expect( root.isAttached() ).to.be.false;
+
+		model.applyOperation( op );
+
+		expect( root.isAttached() ).to.be.true;
+	} );
+
+	it( 'should detach a model in the root', () => {
+		const root = doc.createRoot( '$root', 'new' );
+
+		expect( root.isAttached() ).to.be.true;
+
+		const op = new RootOperation( 'new', '$root', false, doc, doc.version );
+
+		model.applyOperation( op );
+
+		expect( root.isAttached() ).to.be.false;
+	} );
+
+	it( 'should create a RootOperation as a reverse', () => {
+		const operation = new RootOperation( 'new', '$root', true, doc, doc.version );
+		const reverse = operation.getReversed();
+
+		expect( reverse ).to.be.an.instanceof( RootOperation );
+		expect( reverse.baseVersion ).to.equal( doc.version + 1 );
+		expect( reverse.rootName ).to.equal( 'new' );
+		expect( reverse.elementName ).to.equal( '$root' );
+		expect( reverse.isAdd ).to.equal( false );
+	} );
+
+	it( 'should create a correct operation when cloned', () => {
+		const operation = new RootOperation( 'new', '$root', true, doc, doc.version );
+		const clone = operation.clone();
+
+		expect( clone ).to.be.an.instanceof( RootOperation );
+		expect( clone.baseVersion ).to.equal( doc.version );
+		expect( clone.rootName ).to.equal( 'new' );
+		expect( clone.elementName ).to.equal( '$root' );
+		expect( clone.isAdd ).to.equal( true );
+	} );
+
+	describe( '_validate()', () => {
+		it( 'should throw an error when trying to add an existing and attached root', () => {
+			doc.createRoot( '$root', 'new' );
+
+			expectToThrowCKEditorError( () => {
+				const op = new RootOperation( 'new', '$root', true, doc, doc.version );
+
+				op._validate();
+			}, /root-operation-root-attached/ );
+		} );
+
+		it( 'should throw an error when trying to detach a detached root', () => {
+			const root = doc.createRoot( '$root', 'new' );
+			root._isAttached = false;
+
+			expectToThrowCKEditorError( () => {
+				const op = new RootOperation( 'new', '$root', false, doc, doc.version );
+
+				op._validate();
+			}, /root-operation-root-detached/ );
+		} );
+	} );
+
+	describe( 'toJSON', () => {
+		it( 'should create proper serialized object', () => {
+			const op = new RootOperation( 'new', '$root', true, doc, doc.version );
+			const serialized = op.toJSON();
+
+			expect( serialized.__className ).to.equal( 'RootOperation' );
+			expect( serialized ).to.deep.equal( {
+				__className: 'RootOperation',
+				baseVersion: 0,
+				rootName: 'new',
+				elementName: '$root',
+				isAdd: true
+			} );
+		} );
+	} );
+
+	describe( 'fromJSON', () => {
+		it( 'should create proper RootOperation from json object', () => {
+			const op = new RootOperation( 'new', '$root', false, doc, doc.version );
+			const serialized = op.toJSON();
+			const deserialized = RootOperation.fromJSON( serialized, doc );
+
+			expect( deserialized ).to.deep.equal( op );
+		} );
+	} );
+} );

--- a/packages/ckeditor5-engine/tests/model/operation/transform/root.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/root.js
@@ -1,0 +1,85 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import { Client, syncClients, clearBuffer } from './utils.js';
+
+describe( 'transform', () => {
+	let john, kate;
+
+	beforeEach( () => {
+		return Promise.all( [
+			Client.get( 'john' ).then( client => ( john = client ) ),
+			Client.get( 'kate' ).then( client => ( kate = client ) )
+		] );
+	} );
+
+	afterEach( () => {
+		clearBuffer();
+
+		return Promise.all( [ john.destroy(), kate.destroy() ] );
+	} );
+
+	describe( 'add root', () => {
+		describe( 'by add root', () => {
+			it( 'with a different name', () => {
+				john.addRoot( 'foo' );
+				kate.addRoot( 'bar' );
+
+				syncClients();
+
+				expect( john.document.getRoot( 'foo' ) ).not.to.be.null;
+				expect( john.document.getRoot( 'bar' ) ).not.to.be.null;
+				expect( kate.document.getRoot( 'foo' ) ).not.to.be.null;
+				expect( kate.document.getRoot( 'bar' ) ).not.to.be.null;
+			} );
+
+			it( 'with the same name', () => {
+				john.addRoot( 'new' );
+				kate.addRoot( 'new' );
+
+				syncClients();
+
+				expect( john.document.getRoot( 'new' ) ).not.to.be.null;
+				expect( kate.document.getRoot( 'new' ) ).not.to.be.null;
+			} );
+		} );
+	} );
+
+	describe( 'detach root', () => {
+		describe( 'by detach root', () => {
+			it( 'with a different name', () => {
+				john.addRoot( 'foo' );
+				kate.addRoot( 'bar' );
+
+				syncClients();
+
+				john.detachRoot( 'bar' );
+				kate.detachRoot( 'foo' );
+
+				syncClients();
+
+				expect( john.document.getRoot( 'foo' ).isAttached() ).to.be.false;
+				expect( john.document.getRoot( 'bar' ).isAttached() ).to.be.false;
+				expect( kate.document.getRoot( 'foo' ).isAttached() ).to.be.false;
+				expect( kate.document.getRoot( 'bar' ).isAttached() ).to.be.false;
+			} );
+
+			it( 'with the same name', () => {
+				john.addRoot( 'new' );
+				kate.addRoot( 'new' );
+
+				syncClients();
+
+				john.detachRoot( 'new' );
+				kate.detachRoot( 'new' );
+
+				syncClients();
+
+				expect( john.document.getRoot( 'new' ).isAttached() ).to.be.false;
+				expect( kate.document.getRoot( 'new' ).isAttached() ).to.be.false;
+			} );
+		} );
+	} );
+} );

--- a/packages/ckeditor5-engine/tests/model/operation/transform/utils.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/utils.js
@@ -197,6 +197,14 @@ export class Client {
 		this._processAction( 'split', pos );
 	}
 
+	addRoot( rootName ) {
+		this._processAction( 'addRoot', rootName );
+	}
+
+	detachRoot( rootName ) {
+		this._processAction( 'detachRoot', rootName );
+	}
+
 	undo() {
 		this._processExecute( 'undo' );
 	}

--- a/packages/ckeditor5-engine/tests/model/rootelement.js
+++ b/packages/ckeditor5-engine/tests/model/rootelement.js
@@ -10,12 +10,13 @@ import count from '@ckeditor/ckeditor5-utils/src/count';
 
 describe( 'RootElement', () => {
 	describe( 'constructor()', () => {
-		it( 'should create root element without attributes', () => {
+		it( 'should create attached root element without attributes', () => {
 			const model = new Model();
 			const doc = model.document;
 			const root = new RootElement( doc );
 
 			expect( root ).to.be.an.instanceof( Element );
+			expect( root.isAttached() ).to.be.true;
 			expect( root ).to.have.property( 'document' ).that.equals( doc );
 			expect( count( root.getAttributes() ) ).to.equal( 0 );
 			expect( root.childCount ).to.equal( 0 );

--- a/packages/ckeditor5-engine/tests/view/observer/arrowkeysobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/arrowkeysobserver.js
@@ -96,4 +96,10 @@ describe( 'ArrowKeysObserver', () => {
 			observer.observe();
 		} ).to.not.throw();
 	} );
+
+	it( 'should implement empty #stopOvserving() method', () => {
+		expect( () => {
+			observer.stopObserving();
+		} ).to.not.throw();
+	} );
 } );

--- a/packages/ckeditor5-engine/tests/view/observer/arrowkeysobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/arrowkeysobserver.js
@@ -97,7 +97,7 @@ describe( 'ArrowKeysObserver', () => {
 		} ).to.not.throw();
 	} );
 
-	it( 'should implement empty #stopOvserving() method', () => {
+	it( 'should implement empty #stopObserving() method', () => {
 		expect( () => {
 			observer.stopObserving();
 		} ).to.not.throw();

--- a/packages/ckeditor5-engine/tests/view/observer/domeventobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/domeventobserver.js
@@ -253,4 +253,23 @@ describe( 'DomEventObserver', () => {
 			expect( fireSpy.calledOnce ).to.be.true;
 		} );
 	} );
+
+	describe( 'stopListening()', () => {
+		it( 'should stop listening to events fired by DOM element', () => {
+			const domElement = document.createElement( 'p' );
+			const domEvent = new MouseEvent( 'click' );
+			const evtSpy = sinon.spy();
+
+			createViewRoot( viewDocument );
+			view.attachDomRoot( domElement );
+			view.addObserver( ClickObserver );
+			viewDocument.on( 'click', evtSpy );
+
+			view.getObserver( ClickObserver ).stopListening( domElement );
+
+			domElement.dispatchEvent( domEvent );
+
+			expect( evtSpy.called ).to.be.false;
+		} );
+	} );
 } );

--- a/packages/ckeditor5-engine/tests/view/observer/fakeselectionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/fakeselectionobserver.js
@@ -148,6 +148,12 @@ describe( 'FakeSelectionObserver', () => {
 		sinon.assert.notCalled( spy );
 	} );
 
+	it( 'should implement empty #stopOvserving() method', () => {
+		expect( () => {
+			observer.stopObserving();
+		} ).to.not.throw();
+	} );
+
 	// Checks if preventDefault method was called by FakeSelectionObserver for specified key code.
 	//
 	// @param {Number} keyCode

--- a/packages/ckeditor5-engine/tests/view/observer/fakeselectionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/fakeselectionobserver.js
@@ -148,7 +148,7 @@ describe( 'FakeSelectionObserver', () => {
 		sinon.assert.notCalled( spy );
 	} );
 
-	it( 'should implement empty #stopOvserving() method', () => {
+	it( 'should implement empty #stopObserving() method', () => {
 		expect( () => {
 			observer.stopObserving();
 		} ).to.not.throw();

--- a/packages/ckeditor5-engine/tests/view/observer/mutationobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/mutationobserver.js
@@ -66,6 +66,23 @@ describe( 'MutationObserver', () => {
 		expect( domAdditionalRoot.childNodes[ 0 ].data ).to.equal( 'foobar' );
 	} );
 
+	it( 'should allow to stop observing a DOM element', () => {
+		const { domRoot: domAdditionalRoot } = setupRoot( 'additional' );
+
+		mutationObserver.stopObserving( domRoot );
+
+		domAdditionalRoot.innerHTML = 'foobar';
+		domRoot.innerHTML = 'abcabc';
+
+		mutationObserver.flush();
+
+		// Explanation:
+		// Mutation observer is listening on `domAdditionalRoot`. Because of that, the changes done to it are reverted.
+		// Mutation observer was disabled for `domRoot`. Because of that, changes done to it are kept.
+		expect( domAdditionalRoot.innerHTML ).to.equal( '<br data-cke-filler="true">' );
+		expect( domRoot.innerHTML ).to.equal( 'abcabc' );
+	} );
+
 	it( 'should handle bold', () => {
 		const domB = document.createElement( 'b' );
 

--- a/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
@@ -426,6 +426,20 @@ describe( 'SelectionObserver', () => {
 		sel.collapse( domText, 3 );
 	} );
 
+	describe( 'stopListening()', () => {
+		it( 'should not fire selectionChange after stopped observing a DOM element', () => {
+			const spy = sinon.spy();
+
+			viewDocument.on( 'selectionChange', spy );
+
+			selectionObserver.stopListening( domMain );
+
+			changeDomSelection();
+
+			expect( spy.called ).to.be.false;
+		} );
+	} );
+
 	describe( 'Management of view Document#isSelecting', () => {
 		it( 'should not set #isSelecting to true upon the "selectstart" event outside the DOM root', () => {
 			const selectStartChangedSpy = sinon.spy();

--- a/packages/ckeditor5-engine/tests/view/observer/tabobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/tabobserver.js
@@ -96,4 +96,10 @@ describe( 'TabObserver', () => {
 			sinon.assert.notCalled( tabSpy );
 		} );
 	} );
+
+	it( 'should implement empty #stopOvserving() method', () => {
+		expect( () => {
+			view.getObserver( TabObserver ).stopObserving();
+		} ).to.not.throw();
+	} );
 } );

--- a/packages/ckeditor5-engine/tests/view/observer/tabobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/tabobserver.js
@@ -97,7 +97,7 @@ describe( 'TabObserver', () => {
 		} );
 	} );
 
-	it( 'should implement empty #stopOvserving() method', () => {
+	it( 'should implement empty #stopObserving() method', () => {
 		expect( () => {
 			view.getObserver( TabObserver ).stopObserving();
 		} ).to.not.throw();

--- a/packages/ckeditor5-engine/tests/view/view/view.js
+++ b/packages/ckeditor5-engine/tests/view/view/view.js
@@ -54,6 +54,7 @@ describe( 'view', () => {
 				this.enable = sinon.spy();
 				this.disable = sinon.spy();
 				this.observe = sinon.spy();
+				this.stopObserving = sinon.spy();
 				this.destroy = sinon.spy();
 			}
 		};
@@ -256,6 +257,23 @@ describe( 'view', () => {
 			view.detachDomRoot( 'main' );
 
 			expect( domDiv.classList.contains( 'ck-read-only' ) ).to.be.false;
+
+			domDiv.remove();
+		} );
+
+		it( 'should detach observers from the DOM element', () => {
+			const observerMock = view.addObserver( ObserverMock );
+
+			const domDiv = document.createElement( 'div' );
+			createViewRoot( viewDocument, 'div', 'main' );
+
+			view.attachDomRoot( domDiv );
+
+			expect( observerMock.stopObserving.calledOnce ).to.be.false;
+
+			view.detachDomRoot( 'main' );
+
+			expect( observerMock.stopObserving.calledOnce ).to.be.true;
 
 			domDiv.remove();
 		} );

--- a/packages/ckeditor5-enter/src/enterobserver.ts
+++ b/packages/ckeditor5-enter/src/enterobserver.ts
@@ -63,6 +63,11 @@ export default class EnterObserver extends Observer {
 	 * @inheritDoc
 	 */
 	public observe(): void {}
+
+	/**
+	 * @inheritDoc
+	 */
+	public stopObserving(): void {}
 }
 
 /**

--- a/packages/ckeditor5-enter/tests/enterobserver.js
+++ b/packages/ckeditor5-enter/tests/enterobserver.js
@@ -130,4 +130,10 @@ describe( 'EnterObserver', () => {
 
 		expect( interceptedEventInfo.stop.called ).to.be.undefined;
 	} );
+
+	it( 'should implement empty #stopOvserving() method', () => {
+		expect( () => {
+			view.getObserver( EnterObserver ).stopObserving();
+		} ).to.not.throw();
+	} );
 } );

--- a/packages/ckeditor5-enter/tests/enterobserver.js
+++ b/packages/ckeditor5-enter/tests/enterobserver.js
@@ -131,7 +131,7 @@ describe( 'EnterObserver', () => {
 		expect( interceptedEventInfo.stop.called ).to.be.undefined;
 	} );
 
-	it( 'should implement empty #stopOvserving() method', () => {
+	it( 'should implement empty #stopObserving() method', () => {
 		expect( () => {
 			view.getObserver( EnterObserver ).stopObserving();
 		} ).to.not.throw();

--- a/packages/ckeditor5-image/src/image/imageloadobserver.ts
+++ b/packages/ckeditor5-image/src/image/imageloadobserver.ts
@@ -37,6 +37,13 @@ export default class ImageLoadObserver extends Observer {
 	}
 
 	/**
+	 * @inheritDoc
+	 */
+	public override stopObserving( domRoot: HTMLElement ) {
+		this.stopListening( domRoot );
+	}
+
+	/**
 	 * Fires {@link module:engine/view/document~Document#event:layoutChanged} and
 	 * {@link module:engine/view/document~Document#event:imageLoaded}
 	 * if observer {@link #isEnabled is enabled}.

--- a/packages/ckeditor5-image/src/image/imageloadobserver.ts
+++ b/packages/ckeditor5-image/src/image/imageloadobserver.ts
@@ -39,7 +39,7 @@ export default class ImageLoadObserver extends Observer {
 	/**
 	 * @inheritDoc
 	 */
-	public override stopObserving( domRoot: HTMLElement ) {
+	public override stopObserving( domRoot: HTMLElement ): void {
 		this.stopListening( domRoot );
 	}
 

--- a/packages/ckeditor5-image/tests/image/imageloadobserver.js
+++ b/packages/ckeditor5-image/tests/image/imageloadobserver.js
@@ -172,6 +172,20 @@ describe( 'ImageLoadObserver', () => {
 		} ).to.not.throw();
 	} );
 
+	it( 'should stop listening to events on given DOM element', () => {
+		const spy = sinon.spy();
+
+		viewDocument.on( 'imageLoaded', spy );
+
+		setData( view, '<img src="/assets/sample.png" />' );
+
+		observer.stopObserving( domRoot );
+
+		domRoot.querySelector( 'img' ).dispatchEvent( new Event( 'load' ) );
+
+		sinon.assert.notCalled( spy );
+	} );
+
 	it( 'should stop observing images on destroy', () => {
 		const spy = sinon.spy();
 

--- a/packages/ckeditor5-typing/src/deleteobserver.ts
+++ b/packages/ckeditor5-typing/src/deleteobserver.ts
@@ -207,6 +207,11 @@ export default class DeleteObserver extends Observer {
 	 * @inheritDoc
 	 */
 	public observe(): void {}
+
+	/**
+	 * @inheritDoc
+	 */
+	public stopObserving(): void {}
 }
 
 /**

--- a/packages/ckeditor5-typing/src/inserttextobserver.ts
+++ b/packages/ckeditor5-typing/src/inserttextobserver.ts
@@ -125,6 +125,11 @@ export default class InsertTextObserver extends Observer {
 	 * @inheritDoc
 	 */
 	public observe(): void {}
+
+	/**
+	 * @inheritDoc
+	 */
+	public stopObserving(): void {}
 }
 
 /**

--- a/packages/ckeditor5-typing/tests/deleteobserver.js
+++ b/packages/ckeditor5-typing/tests/deleteobserver.js
@@ -16,7 +16,6 @@ import { getCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import { fireBeforeInputDomEvent } from './_utils/utils';
 import { setData as viewSetData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 import { StylesProcessor } from '@ckeditor/ckeditor5-engine/src/view/stylesmap';
-import EnterObserver from '@ckeditor/ckeditor5-enter/src/enterobserver';
 
 describe( 'Delete', () => {
 	describe( 'DeleteObserver', () => {

--- a/packages/ckeditor5-typing/tests/deleteobserver.js
+++ b/packages/ckeditor5-typing/tests/deleteobserver.js
@@ -16,6 +16,7 @@ import { getCode } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import { fireBeforeInputDomEvent } from './_utils/utils';
 import { setData as viewSetData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 import { StylesProcessor } from '@ckeditor/ckeditor5-engine/src/view/stylesmap';
+import EnterObserver from '@ckeditor/ckeditor5-enter/src/enterobserver';
 
 describe( 'Delete', () => {
 	describe( 'DeleteObserver', () => {
@@ -531,6 +532,12 @@ describe( 'Delete', () => {
 					sinon.assert.calledOnce( keydownSpy );
 				} );
 			} );
+		} );
+
+		it( 'should implement empty #stopOvserving() method', () => {
+			expect( () => {
+				view.getObserver( DeleteObserver ).stopObserving();
+			} ).to.not.throw();
 		} );
 	} );
 

--- a/packages/ckeditor5-typing/tests/deleteobserver.js
+++ b/packages/ckeditor5-typing/tests/deleteobserver.js
@@ -533,7 +533,7 @@ describe( 'Delete', () => {
 			} );
 		} );
 
-		it( 'should implement empty #stopOvserving() method', () => {
+		it( 'should implement empty #stopObserving() method', () => {
 			expect( () => {
 				view.getObserver( DeleteObserver ).stopObserving();
 			} ).to.not.throw();

--- a/packages/ckeditor5-typing/tests/inserttextobserver.js
+++ b/packages/ckeditor5-typing/tests/inserttextobserver.js
@@ -13,7 +13,6 @@ import createViewRoot from '@ckeditor/ckeditor5-engine/tests/view/_utils/creater
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import { setData as viewSetData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 import env from '@ckeditor/ckeditor5-utils/src/env';
-import DeleteObserver from '../src/deleteobserver';
 
 describe( 'InsertTextObserver', () => {
 	let view, viewDocument, insertTextEventSpy;

--- a/packages/ckeditor5-typing/tests/inserttextobserver.js
+++ b/packages/ckeditor5-typing/tests/inserttextobserver.js
@@ -13,6 +13,7 @@ import createViewRoot from '@ckeditor/ckeditor5-engine/tests/view/_utils/creater
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import { setData as viewSetData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 import env from '@ckeditor/ckeditor5-utils/src/env';
+import DeleteObserver from '../src/deleteobserver';
 
 describe( 'InsertTextObserver', () => {
 	let view, viewDocument, insertTextEventSpy;
@@ -242,5 +243,11 @@ describe( 'InsertTextObserver', () => {
 			expect( firstCallArgs.text ).to.equal( 'bar' );
 			expect( firstCallArgs.selection.isEqual( viewSelection ) ).to.be.true;
 		} );
+	} );
+
+	it( 'should implement empty #stopOvserving() method', () => {
+		expect( () => {
+			view.getObserver( InsertTextObserver ).stopObserving();
+		} ).to.not.throw();
 	} );
 } );

--- a/packages/ckeditor5-typing/tests/inserttextobserver.js
+++ b/packages/ckeditor5-typing/tests/inserttextobserver.js
@@ -244,7 +244,7 @@ describe( 'InsertTextObserver', () => {
 		} );
 	} );
 
-	it( 'should implement empty #stopOvserving() method', () => {
+	it( 'should implement empty #stopObserving() method', () => {
 		expect( () => {
 			view.getObserver( InsertTextObserver ).stopObserving();
 		} ).to.not.throw();

--- a/packages/ckeditor5-ui/src/editorui/editorui.ts
+++ b/packages/ckeditor5-ui/src/editorui/editorui.ts
@@ -233,6 +233,8 @@ export default abstract class EditorUI extends ObservableMixin() {
 			return;
 		}
 
+		this._editableElementsMap.delete( rootName );
+
 		this.editor.keystrokes.stopListening( domElement );
 		this.focusTracker.remove( domElement );
 

--- a/packages/ckeditor5-ui/src/editorui/editorui.ts
+++ b/packages/ckeditor5-ui/src/editorui/editorui.ts
@@ -171,6 +171,7 @@ export default abstract class EditorUI extends ObservableMixin() {
 		// Clean–up the references to the CKEditor instance stored in the native editable DOM elements.
 		for ( const domElement of this._editableElementsMap.values() ) {
 			( domElement as any ).ckeditorInstance = null;
+			this.editor.keystrokes.stopListening( domElement );
 		}
 
 		this._editableElementsMap = new Map();
@@ -197,7 +198,7 @@ export default abstract class EditorUI extends ObservableMixin() {
 			( domElement as any ).ckeditorInstance = this.editor;
 		}
 
-		// Register the element so it becomes available for Alt+F10 and Esc navigation.
+		// Register the element, so it becomes available for Alt+F10 and Esc navigation.
 		this.focusTracker.add( domElement );
 
 		const setUpKeystrokeHandler = () => {
@@ -218,6 +219,24 @@ export default abstract class EditorUI extends ObservableMixin() {
 		else {
 			this.once<EditorUIReadyEvent>( 'ready', setUpKeystrokeHandler );
 		}
+	}
+
+	/**
+	 * Removes the editable from the editor UI. Removes all handlers added by {@link #setEditableElement}.
+	 *
+	 * @param rootName The name of the editable element to remove.
+	 */
+	public removeEditableElement( rootName: string ): void {
+		const domElement = this._editableElementsMap.get( rootName );
+
+		if ( !domElement ) {
+			return;
+		}
+
+		this.editor.keystrokes.stopListening( domElement );
+		this.focusTracker.remove( domElement );
+
+		( domElement as any ).ckeditorInstance = null;
 	}
 
 	/**

--- a/packages/ckeditor5-utils/src/keystrokehandler.ts
+++ b/packages/ckeditor5-utils/src/keystrokehandler.ts
@@ -129,9 +129,16 @@ export default class KeystrokeHandler {
 	}
 
 	/**
+	 * Stops listening to `keydown` events from the given emitter.
+	 */
+	public stopListening( emitter?: Emitter | HTMLElement | Window ): void {
+		this._listener.stopListening( emitter );
+	}
+
+	/**
 	 * Destroys the keystroke handler.
 	 */
 	public destroy(): void {
-		this._listener.stopListening();
+		this.stopListening();
 	}
 }

--- a/packages/ckeditor5-utils/tests/keystrokehandler.js
+++ b/packages/ckeditor5-utils/tests/keystrokehandler.js
@@ -142,29 +142,48 @@ describe( 'KeystrokeHandler', () => {
 		} );
 	} );
 
-	describe( 'destroy()', () => {
-		it( 'detaches #keydown listener', () => {
-			const spy = sinon.spy( keystrokes, 'press' );
+	describe( 'stopListening()', () => {
+		it( 'detaches events from the given emitter', () => {
+			const spy = sinon.spy();
+			const newEmitter = new Emitter();
 
-			keystrokes.destroy();
+			keystrokes.listenTo( newEmitter );
 
-			emitter.fire( 'keydown', { keyCode: 1 } );
+			keystrokes.set( 'Ctrl+A', spy );
+			keystrokes.stopListening( emitter );
+
+			emitter.fire( 'keydown', getCtrlA() );
+
+			sinon.assert.notCalled( spy );
+
+			newEmitter.fire( 'keydown', getCtrlA() );
+
+			sinon.assert.called( spy );
+		} );
+
+		it( 'detaches events from all emitters', () => {
+			const spy = sinon.spy();
+			const newEmitter = new Emitter();
+
+			keystrokes.listenTo( newEmitter );
+
+			keystrokes.set( 'Ctrl+A', spy );
+			keystrokes.stopListening();
+
+			emitter.fire( 'keydown', getCtrlA() );
+			newEmitter.fire( 'keydown', getCtrlA() );
 
 			sinon.assert.notCalled( spy );
 		} );
+	} );
 
-		it( 'removes all keystrokes', () => {
-			const spy = sinon.spy();
-			const keystrokeHandler = keystrokes;
+	describe( 'destroy()', () => {
+		it( 'detaches events from all emitters', () => {
+			const spy = sinon.spy( keystrokes, 'stopListening' );
 
-			keystrokeHandler.set( 'Ctrl+A', spy );
+			keystrokes.destroy();
 
-			keystrokeHandler.destroy();
-
-			const wasHandled = keystrokeHandler.press( getCtrlA() );
-
-			expect( wasHandled ).to.be.false;
-			sinon.assert.notCalled( spy );
+			sinon.assert.calledWithExactly( spy );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-widget/tests/widgetresize.js
+++ b/packages/ckeditor5-widget/tests/widgetresize.js
@@ -173,7 +173,7 @@ describe( 'WidgetResize', () => {
 
 			expect( () => {
 				widgetResizePlugin.redrawSelectedResizer();
-			} ).not.to.throw;
+			} ).not.to.throw();
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (engine): Introduced `model.Writer#addRoot()` and `model.Writer#detachRoot()`. Model roots can now be dynamically added or detached from the document. All content gets removed from a detached root, and new content cannot be inserted, as long as the root is detached. Closes #13388.

Feature (engine): Introduced `Differ.getChangedRoots()` which returns roots added or detached since last differ reset. `Differ#isEmpty` and `Differ#hasDataChanges()` will return `true` if a root was added or detached.

Other: Introduced `Observer#stopObserving()` to allow for proper removal of DOM editable elements from the editor.

Other (ui): Introduced `EditorUI#removeEditableElement()`.

Other (engine): `model.Document#getRootNames()` now returns only attached roots by default. `includeDetached` parameter was introduced to enable returning detached roots as well.

Other (engine): Introduced `RootOperation`.

Other (engine): `model.DocumentFragment#isAttached` was introduced for compatibility reasons. It always returns `false`.

Internal (multi-root-editor): Introduced API which allows for adding and removing roots and editable areas.