### PR TITLE
Added post-checkout hook for removing empty package leftovers

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+# For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+
+BRANCH_CHANGED=$3
+
+node scripts/post-checkout.js $BRANCH_CHANGED $PWD

--- a/scripts/dll/build-dlls.js
+++ b/scripts/dll/build-dlls.js
@@ -9,6 +9,7 @@
 
 const chalk = require( 'chalk' );
 const childProcess = require( 'child_process' );
+const fs = require( 'fs' );
 const minimist = require( 'minimist' );
 const path = require( 'path' );
 
@@ -90,6 +91,11 @@ function isNotBaseDll( name ) {
  */
 function hasDLLBuildScript( name ) {
 	const packageJsonPath = path.join( ROOT_DIRECTORY, 'packages', name, 'package.json' );
+
+	if ( !fs.existsSync( packageJsonPath ) ) {
+		return false;
+	}
+
 	const scripts = require( packageJsonPath ).scripts;
 
 	return Boolean( scripts && scripts[ 'dll:build' ] );

--- a/scripts/post-checkout.js
+++ b/scripts/post-checkout.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* eslint-env node */
+
+'use strict';
+
+const fs = require( 'fs' );
+const glob = require( 'glob' );
+const path = require( 'path' );
+
+/**
+ * When package only exist on some branches, switching them can leave behind
+ * some files which are not tracked by git, such as node_modules.
+ *
+ * See: https://github.com/ckeditor/ckeditor5/issues/13692.
+ */
+
+const branchChanged = process.argv[ 2 ] === '1';
+const cwd = process.argv[ 3 ];
+
+if ( !branchChanged ) {
+	process.exit();
+}
+
+const packagesPattern = path.join( cwd, 'packages', '*' );
+const packagesDirectories = glob.sync( packagesPattern );
+const emptyPackages = packagesDirectories.filter( packageDir => {
+	const pkgJsonPath = path.join( packageDir, 'package.json' );
+
+	return !fs.existsSync( pkgJsonPath );
+} );
+
+if ( !emptyPackages.length ) {
+	process.exit();
+}
+
+console.log( '\nPost checkout hook - removing empty packages:' );
+console.log( emptyPackages.map( pkgName => ` - ${ pkgName }` ).join( '\n' ) );
+
+emptyPackages.forEach( packageDir => fs.rmSync( packageDir, { recursive: true, force: true } ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix: Manual tests script will no longer throw an error when it encounters a package directory without `package.json` file while building DLLs. Closes #13692.

Other: Added post-checkout hook for removing empty package leftovers. See #13692.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
