### PR TITLE
Node version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@typescript-eslint/eslint-plugin": "~5.43.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-adapter-ckfinder/package.json
+++ b/packages/ckeditor5-adapter-ckfinder/package.json
@@ -34,7 +34,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-alignment/package.json
+++ b/packages/ckeditor5-alignment/package.json
@@ -32,7 +32,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-autoformat/package.json
+++ b/packages/ckeditor5-autoformat/package.json
@@ -35,7 +35,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-autosave/package.json
+++ b/packages/ckeditor5-autosave/package.json
@@ -27,7 +27,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-basic-styles/package.json
+++ b/packages/ckeditor5-basic-styles/package.json
@@ -29,7 +29,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-block-quote/package.json
+++ b/packages/ckeditor5-block-quote/package.json
@@ -33,7 +33,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-build-balloon-block/package.json
+++ b/packages/ckeditor5-build-balloon-block/package.json
@@ -66,7 +66,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-build-balloon/package.json
+++ b/packages/ckeditor5-build-balloon/package.json
@@ -65,7 +65,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-build-classic/package.json
+++ b/packages/ckeditor5-build-classic/package.json
@@ -65,7 +65,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-build-decoupled-document/package.json
+++ b/packages/ckeditor5-build-decoupled-document/package.json
@@ -67,7 +67,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-build-inline/package.json
+++ b/packages/ckeditor5-build-inline/package.json
@@ -65,7 +65,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-build-multi-root/package.json
+++ b/packages/ckeditor5-build-multi-root/package.json
@@ -65,7 +65,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-ckbox/package.json
+++ b/packages/ckeditor5-ckbox/package.json
@@ -34,7 +34,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-ckfinder/package.json
+++ b/packages/ckeditor5-ckfinder/package.json
@@ -32,7 +32,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-clipboard/package.json
+++ b/packages/ckeditor5-clipboard/package.json
@@ -41,7 +41,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-cloud-services/package.json
+++ b/packages/ckeditor5-cloud-services/package.json
@@ -24,7 +24,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-code-block/package.json
+++ b/packages/ckeditor5-code-block/package.json
@@ -38,7 +38,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-core/package.json
+++ b/packages/ckeditor5-core/package.json
@@ -47,7 +47,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-easy-image/package.json
+++ b/packages/ckeditor5-easy-image/package.json
@@ -30,7 +30,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-editor-balloon/package.json
+++ b/packages/ckeditor5-editor-balloon/package.json
@@ -33,7 +33,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-editor-classic/package.json
+++ b/packages/ckeditor5-editor-classic/package.json
@@ -33,7 +33,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-editor-decoupled/package.json
+++ b/packages/ckeditor5-editor-decoupled/package.json
@@ -33,7 +33,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-editor-inline/package.json
+++ b/packages/ckeditor5-editor-inline/package.json
@@ -33,7 +33,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-editor-multi-root/package.json
+++ b/packages/ckeditor5-editor-multi-root/package.json
@@ -32,7 +32,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-engine/package.json
+++ b/packages/ckeditor5-engine/package.json
@@ -52,7 +52,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-enter/package.json
+++ b/packages/ckeditor5-enter/package.json
@@ -28,7 +28,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-essentials/package.json
+++ b/packages/ckeditor5-essentials/package.json
@@ -30,7 +30,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-find-and-replace/package.json
+++ b/packages/ckeditor5-find-and-replace/package.json
@@ -40,7 +40,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-font/package.json
+++ b/packages/ckeditor5-font/package.json
@@ -30,7 +30,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-heading/package.json
+++ b/packages/ckeditor5-heading/package.json
@@ -37,7 +37,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-highlight/package.json
+++ b/packages/ckeditor5-highlight/package.json
@@ -33,7 +33,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-horizontal-line/package.json
+++ b/packages/ckeditor5-horizontal-line/package.json
@@ -31,7 +31,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-html-embed/package.json
+++ b/packages/ckeditor5-html-embed/package.json
@@ -34,7 +34,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-html-support/package.json
+++ b/packages/ckeditor5-html-support/package.json
@@ -57,7 +57,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-image/package.json
+++ b/packages/ckeditor5-image/package.json
@@ -51,7 +51,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-indent/package.json
+++ b/packages/ckeditor5-indent/package.json
@@ -28,7 +28,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-language/package.json
+++ b/packages/ckeditor5-language/package.json
@@ -27,7 +27,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-link/package.json
+++ b/packages/ckeditor5-link/package.json
@@ -41,7 +41,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-list/package.json
+++ b/packages/ckeditor5-list/package.json
@@ -55,7 +55,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-markdown-gfm/package.json
+++ b/packages/ckeditor5-markdown-gfm/package.json
@@ -33,7 +33,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-media-embed/package.json
+++ b/packages/ckeditor5-media-embed/package.json
@@ -38,7 +38,7 @@
     "lodash-es": "^4.17.15"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-mention/package.json
+++ b/packages/ckeditor5-mention/package.json
@@ -40,7 +40,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-minimap/package.json
+++ b/packages/ckeditor5-minimap/package.json
@@ -34,7 +34,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-page-break/package.json
+++ b/packages/ckeditor5-page-break/package.json
@@ -31,7 +31,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-paragraph/package.json
+++ b/packages/ckeditor5-paragraph/package.json
@@ -31,7 +31,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-paste-from-office/package.json
+++ b/packages/ckeditor5-paste-from-office/package.json
@@ -40,7 +40,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-remove-format/package.json
+++ b/packages/ckeditor5-remove-format/package.json
@@ -35,7 +35,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-restricted-editing/package.json
+++ b/packages/ckeditor5-restricted-editing/package.json
@@ -34,7 +34,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-select-all/package.json
+++ b/packages/ckeditor5-select-all/package.json
@@ -30,7 +30,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-source-editing/package.json
+++ b/packages/ckeditor5-source-editing/package.json
@@ -32,7 +32,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-special-characters/package.json
+++ b/packages/ckeditor5-special-characters/package.json
@@ -30,7 +30,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-style/package.json
+++ b/packages/ckeditor5-style/package.json
@@ -54,7 +54,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-table/package.json
+++ b/packages/ckeditor5-table/package.json
@@ -46,7 +46,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-theme-lark/package.json
+++ b/packages/ckeditor5-theme-lark/package.json
@@ -39,7 +39,7 @@
     "ckeditor5": "^36.0.1"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-typing/package.json
+++ b/packages/ckeditor5-typing/package.json
@@ -40,7 +40,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-ui/package.json
+++ b/packages/ckeditor5-ui/package.json
@@ -39,7 +39,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-undo/package.json
+++ b/packages/ckeditor5-undo/package.json
@@ -31,7 +31,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-upload/package.json
+++ b/packages/ckeditor5-upload/package.json
@@ -21,7 +21,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-utils/package.json
+++ b/packages/ckeditor5-utils/package.json
@@ -25,7 +25,7 @@
     "typescript"
   ],
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-watchdog/package.json
+++ b/packages/ckeditor5-watchdog/package.json
@@ -26,7 +26,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-widget/package.json
+++ b/packages/ckeditor5-widget/package.json
@@ -39,7 +39,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",

--- a/packages/ckeditor5-word-count/package.json
+++ b/packages/ckeditor5-word-count/package.json
@@ -35,7 +35,7 @@
     "webpack-cli": "^4.9.0"
   },
   "engines": {
-    "node": ">=14.0.0",
+    "node": ">=16.0.0",
     "npm": ">=5.7.1"
   },
   "author": "CKSource (http://cksource.com/)",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other: Updated the required version of Node.js to 16. See #13671.

MAJOR BREAKING CHANGE: Upgraded the minimal versions of Node.js to `16.0.0` due to the end of LTS.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
