### PR TITLE
Remove return types from 'requires()' methods.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,17 @@ module.exports = {
 	},
 	overrides: [
 		{
+			files: [ '**/*.ts' ],
+			rules: {
+				'@typescript-eslint/explicit-module-boundary-types': [
+					'error',
+					{
+						'allowedNames': [ 'requires' ]
+					}
+				]
+			}
+		},
+		{
 			files: [ '**/tests/**/*.js' ],
 			rules: {
 				'no-unused-expressions': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,8 @@ module.exports = {
 				'@typescript-eslint/explicit-module-boundary-types': [
 					'error',
 					{
-						'allowedNames': [ 'requires' ]
+						'allowedNames': [ 'requires' ],
+						'allowArgumentsExplicitlyTypedAsAny': true
 					}
 				]
 			}

--- a/packages/ckeditor5-adapter-ckfinder/src/uploadadapter.ts
+++ b/packages/ckeditor5-adapter-ckfinder/src/uploadadapter.ts
@@ -9,7 +9,7 @@
  * @module adapter-ckfinder/uploadadapter
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import {
 	FileRepository,
 	type UploadAdapter as UploadAdapterInterface,
@@ -34,8 +34,8 @@ export default class CKFinderUploadAdapter extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ FileRepository ];
+	public static get requires() {
+		return [ FileRepository ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-alignment/src/alignment.ts
+++ b/packages/ckeditor5-alignment/src/alignment.ts
@@ -7,7 +7,7 @@
  * @module alignment/alignment
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import AlignmentEditing from './alignmentediting';
 import AlignmentUI from './alignmentui';
@@ -25,8 +25,8 @@ export default class Alignment extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ AlignmentEditing, AlignmentUI ];
+	public static get requires() {
+		return [ AlignmentEditing, AlignmentUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-autoformat/src/autoformat.ts
+++ b/packages/ckeditor5-autoformat/src/autoformat.ts
@@ -8,7 +8,7 @@
  */
 import type { HeadingCommand } from '@ckeditor/ckeditor5-heading';
 
-import { Plugin, type PluginDependencies, type Editor } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 import type { Range, Writer } from 'ckeditor5/src/engine';
 import { Delete } from 'ckeditor5/src/typing';
 
@@ -25,8 +25,8 @@ export default class Autoformat extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ Delete ];
+	public static get requires() {
+		return [ Delete ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-autosave/src/autosave.ts
+++ b/packages/ckeditor5-autosave/src/autosave.ts
@@ -10,7 +10,6 @@
 import {
 	Plugin,
 	PendingActions,
-	type PluginDependencies,
 	type Editor,
 	type PendingAction,
 	type EditorDestroyEvent,
@@ -136,8 +135,8 @@ export default class Autosave extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ PendingActions ];
+	public static get requires() {
+		return [ PendingActions ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-basic-styles/src/bold.ts
+++ b/packages/ckeditor5-basic-styles/src/bold.ts
@@ -7,7 +7,7 @@
  * @module basic-styles/bold
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import BoldEditing from './bold/boldediting';
 import BoldUI from './bold/boldui';
 
@@ -24,8 +24,8 @@ export default class Bold extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ BoldEditing, BoldUI ];
+	public static get requires() {
+		return [ BoldEditing, BoldUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-basic-styles/src/code.ts
+++ b/packages/ckeditor5-basic-styles/src/code.ts
@@ -7,7 +7,7 @@
  * @module basic-styles/code
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import CodeEditing from './code/codeediting';
 import CodeUI from './code/codeui';
 
@@ -26,8 +26,8 @@ export default class Code extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ CodeEditing, CodeUI ];
+	public static get requires() {
+		return [ CodeEditing, CodeUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-basic-styles/src/code/codeediting.ts
+++ b/packages/ckeditor5-basic-styles/src/code/codeediting.ts
@@ -7,7 +7,7 @@
  * @module basic-styles/code/codeediting
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { TwoStepCaretMovement, inlineHighlight } from 'ckeditor5/src/typing';
 
 import AttributeCommand from '../attributecommand';
@@ -32,8 +32,8 @@ export default class CodeEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TwoStepCaretMovement ];
+	public static get requires() {
+		return [ TwoStepCaretMovement ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-basic-styles/src/italic.ts
+++ b/packages/ckeditor5-basic-styles/src/italic.ts
@@ -7,7 +7,7 @@
  * @module basic-styles/italic
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import ItalicEditing from './italic/italicediting';
 import ItalicUI from './italic/italicui';
 
@@ -24,8 +24,8 @@ export default class Italic extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ItalicEditing, ItalicUI ];
+	public static get requires() {
+		return [ ItalicEditing, ItalicUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-basic-styles/src/strikethrough.ts
+++ b/packages/ckeditor5-basic-styles/src/strikethrough.ts
@@ -7,7 +7,7 @@
  * @module basic-styles/strikethrough
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import StrikethroughEditing from './strikethrough/strikethroughediting';
 import StrikethroughUI from './strikethrough/strikethroughui';
 
@@ -24,8 +24,8 @@ export default class Strikethrough extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ StrikethroughEditing, StrikethroughUI ];
+	public static get requires() {
+		return [ StrikethroughEditing, StrikethroughUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-basic-styles/src/subscript.ts
+++ b/packages/ckeditor5-basic-styles/src/subscript.ts
@@ -7,7 +7,7 @@
  * @module basic-styles/subscript
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import SubscriptEditing from './subscript/subscriptediting';
 import SubscriptUI from './subscript/subscriptui';
 
@@ -21,8 +21,8 @@ export default class Subscript extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ SubscriptEditing, SubscriptUI ];
+	public static get requires() {
+		return [ SubscriptEditing, SubscriptUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-basic-styles/src/superscript.ts
+++ b/packages/ckeditor5-basic-styles/src/superscript.ts
@@ -7,7 +7,7 @@
  * @module basic-styles/superscript
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import SuperscriptEditing from './superscript/superscriptediting';
 import SuperscriptUI from './superscript/superscriptui';
 
@@ -21,8 +21,8 @@ export default class Superscript extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ SuperscriptEditing, SuperscriptUI ];
+	public static get requires() {
+		return [ SuperscriptEditing, SuperscriptUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-basic-styles/src/underline.ts
+++ b/packages/ckeditor5-basic-styles/src/underline.ts
@@ -7,7 +7,7 @@
  * @module basic-styles/underline
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import UnderlineEditing from './underline/underlineediting';
 import UnderlineUI from './underline/underlineui';
 
@@ -24,8 +24,8 @@ export default class Underline extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ UnderlineEditing, UnderlineUI ];
+	public static get requires() {
+		return [ UnderlineEditing, UnderlineUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-block-quote/src/blockquote.ts
+++ b/packages/ckeditor5-block-quote/src/blockquote.ts
@@ -7,7 +7,7 @@
  * @module block-quote/blockquote
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import BlockQuoteEditing from './blockquoteediting';
 import BlockQuoteUI from './blockquoteui';
@@ -26,8 +26,8 @@ export default class BlockQuote extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ BlockQuoteEditing, BlockQuoteUI ];
+	public static get requires() {
+		return [ BlockQuoteEditing, BlockQuoteUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-block-quote/src/blockquoteediting.ts
+++ b/packages/ckeditor5-block-quote/src/blockquoteediting.ts
@@ -7,7 +7,7 @@
  * @module block-quote/blockquoteediting
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { Enter, type ViewDocumentEnterEvent } from 'ckeditor5/src/enter';
 import { Delete, type ViewDocumentDeleteEvent } from 'ckeditor5/src/typing';
 
@@ -31,8 +31,8 @@ export default class BlockQuoteEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ Enter, Delete ];
+	public static get requires() {
+		return [ Enter, Delete ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-ckbox/src/ckbox.ts
+++ b/packages/ckeditor5-ckbox/src/ckbox.ts
@@ -7,7 +7,7 @@
  * @module ckbox/ckbox
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import CKBoxUI from './ckboxui';
 import CKBoxEditing from './ckboxediting';
@@ -36,7 +36,7 @@ export default class CKBox extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ CKBoxEditing, CKBoxUI ];
+	public static get requires() {
+		return [ CKBoxEditing, CKBoxUI ] as const;
 	}
 }

--- a/packages/ckeditor5-ckbox/src/ckboxediting.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxediting.ts
@@ -10,7 +10,7 @@
  */
 
 import type { CloudServices, CloudServicesCore, InitializedToken } from '@ckeditor/ckeditor5-cloud-services';
-import { Plugin, type Editor, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 import {
 	Range,
 	type DocumentSelection,
@@ -50,8 +50,8 @@ export default class CKBoxEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ 'CloudServices', 'LinkEditing', 'PictureEditing', CKBoxUploadAdapter ];
+	public static get requires() {
+		return [ 'CloudServices', 'LinkEditing', 'PictureEditing', CKBoxUploadAdapter ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-ckbox/src/ckboxuploadadapter.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxuploadadapter.ts
@@ -9,7 +9,7 @@
  * @module ckbox/ckboxuploadadapter
  */
 
-import { Plugin, type Editor, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 import {
 	FileRepository,
 	type FileLoader,
@@ -37,8 +37,8 @@ export default class CKBoxUploadAdapter extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ 'ImageUploadEditing', 'ImageUploadProgress', FileRepository, CKBoxEditing ];
+	public static get requires() {
+		return [ 'ImageUploadEditing', 'ImageUploadProgress', FileRepository, CKBoxEditing ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-ckfinder/src/ckfinder.ts
+++ b/packages/ckeditor5-ckfinder/src/ckfinder.ts
@@ -7,7 +7,7 @@
  * @module ckfinder/ckfinder
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import CKFinderUI from './ckfinderui';
 import CKFinderEditing from './ckfinderediting';
@@ -39,7 +39,7 @@ export default class CKFinder extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ 'Link', 'CKFinderUploadAdapter', CKFinderEditing, CKFinderUI ];
+	public static get requires() {
+		return [ 'Link', 'CKFinderUploadAdapter', CKFinderEditing, CKFinderUI ] as const;
 	}
 }

--- a/packages/ckeditor5-ckfinder/src/ckfinderediting.ts
+++ b/packages/ckeditor5-ckfinder/src/ckfinderediting.ts
@@ -7,7 +7,7 @@
  * @module ckfinder/ckfinderediting
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { Notification } from 'ckeditor5/src/ui';
 import { CKEditorError } from 'ckeditor5/src/utils';
 
@@ -27,8 +27,8 @@ export default class CKFinderEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ Notification, 'LinkEditing' ];
+	public static get requires() {
+		return [ Notification, 'LinkEditing' ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-clipboard/src/clipboard.ts
+++ b/packages/ckeditor5-clipboard/src/clipboard.ts
@@ -7,7 +7,7 @@
  * @module clipboard/clipboard
  */
 
-import { Plugin, type PluginDependencies } from '@ckeditor/ckeditor5-core';
+import { Plugin } from '@ckeditor/ckeditor5-core';
 
 import ClipboardPipeline from './clipboardpipeline';
 import DragDrop from './dragdrop';
@@ -34,7 +34,7 @@ export default class Clipboard extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ClipboardPipeline, DragDrop, PastePlainText ];
+	public static get requires() {
+		return [ ClipboardPipeline, DragDrop, PastePlainText ] as const;
 	}
 }

--- a/packages/ckeditor5-clipboard/src/dragdrop.ts
+++ b/packages/ckeditor5-clipboard/src/dragdrop.ts
@@ -9,7 +9,7 @@
 
 /* globals setTimeout, clearTimeout */
 
-import { Plugin, type Editor, type PluginDependencies } from '@ckeditor/ckeditor5-core';
+import { Plugin, type Editor } from '@ckeditor/ckeditor5-core';
 
 import {
 	LiveRange,
@@ -168,8 +168,8 @@ export default class DragDrop extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ClipboardPipeline, Widget ];
+	public static get requires() {
+		return [ ClipboardPipeline, Widget ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-clipboard/src/pasteplaintext.ts
+++ b/packages/ckeditor5-clipboard/src/pasteplaintext.ts
@@ -7,7 +7,7 @@
  * @module clipboard/pasteplaintext
  */
 
-import { Plugin, type PluginDependencies } from '@ckeditor/ckeditor5-core';
+import { Plugin } from '@ckeditor/ckeditor5-core';
 
 import type { DocumentFragment, Schema, ViewDocumentKeyDownEvent } from '@ckeditor/ckeditor5-engine';
 
@@ -30,8 +30,8 @@ export default class PastePlainText extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ClipboardPipeline ];
+	public static get requires() {
+		return [ ClipboardPipeline ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-cloud-services/src/cloudservices.ts
+++ b/packages/ckeditor5-cloud-services/src/cloudservices.ts
@@ -7,7 +7,7 @@
  * @module cloud-services/cloudservices
  */
 
-import { ContextPlugin, type ContextPluginDependencies } from 'ckeditor5/src/core';
+import { ContextPlugin } from 'ckeditor5/src/core';
 import { CKEditorError } from 'ckeditor5/src/utils';
 import CloudServicesCore from './cloudservicescore';
 import type { CloudServicesConfig, TokenUrl } from './cloudservicesconfig';
@@ -72,8 +72,8 @@ export default class CloudServices extends ContextPlugin implements CloudService
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): ContextPluginDependencies {
-		return [ CloudServicesCore ];
+	public static get requires() {
+		return [ CloudServicesCore ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-code-block/src/codeblock.ts
+++ b/packages/ckeditor5-code-block/src/codeblock.ts
@@ -7,7 +7,7 @@
  * @module code-block/codeblock
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import CodeBlockEditing from './codeblockediting';
 import CodeBlockUI from './codeblockui';
@@ -25,8 +25,8 @@ export default class CodeBlock extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ CodeBlockEditing, CodeBlockUI ];
+	public static get requires() {
+		return [ CodeBlockEditing, CodeBlockUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-code-block/src/codeblockediting.ts
+++ b/packages/ckeditor5-code-block/src/codeblockediting.ts
@@ -7,7 +7,7 @@
  * @module code-block/codeblockediting
  */
 
-import { Plugin, type PluginDependencies, type Editor, type MultiCommand } from 'ckeditor5/src/core';
+import { Plugin, type Editor, type MultiCommand } from 'ckeditor5/src/core';
 import { ShiftEnter, type ViewDocumentEnterEvent } from 'ckeditor5/src/enter';
 
 import {
@@ -56,8 +56,8 @@ export default class CodeBlockEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ShiftEnter ];
+	public static get requires() {
+		return [ ShiftEnter ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -245,7 +245,7 @@ export default abstract class Editor extends ObservableMixin() {
 	 *
 	 * See also {@link module:core/editor/editor~Editor.defaultConfig}.
 	 */
-	public static builtinPlugins?: Array<PluginConstructor<Editor>>;
+	public static builtinPlugins?: ReadonlyArray<PluginConstructor<Editor>>;
 
 	/**
 	 * The editor UI instance.

--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -245,7 +245,7 @@ export default abstract class Editor extends ObservableMixin() {
 	 *
 	 * See also {@link module:core/editor/editor~Editor.defaultConfig}.
 	 */
-	public static builtinPlugins?: ReadonlyArray<PluginConstructor<Editor>>;
+	public static builtinPlugins?: Array<PluginConstructor<Editor>>;
 
 	/**
 	 * The editor UI instance.

--- a/packages/ckeditor5-core/src/plugin.ts
+++ b/packages/ckeditor5-core/src/plugin.ts
@@ -316,7 +316,7 @@ export interface PluginStaticMembers<TContext = Editor> {
 	readonly isContextPlugin?: boolean;
 }
 
-export type PluginDependencies<TContext = Editor> = Array<PluginConstructor<TContext> | string>;
+export type PluginDependencies<TContext = Editor> = ReadonlyArray<PluginConstructor<TContext> | string>;
 
 /**
  * An array of loaded plugins.

--- a/packages/ckeditor5-core/src/plugincollection.ts
+++ b/packages/ckeditor5-core/src/plugincollection.ts
@@ -170,9 +170,9 @@ export default class PluginCollection<TContext extends object> extends EmitterMi
 	 * @returns A promise which gets resolved once all plugins are loaded and available in the collection.
 	 */
 	public init(
-		plugins: Array<PluginConstructor<TContext> | string>,
-		pluginsToRemove: Array<PluginConstructor<TContext> | string> = [],
-		pluginsSubstitutions: Array<PluginConstructor<TContext>> = []
+		plugins: ReadonlyArray<PluginConstructor<TContext> | string>,
+		pluginsToRemove: ReadonlyArray<PluginConstructor<TContext> | string> = [],
+		pluginsSubstitutions: ReadonlyArray<PluginConstructor<TContext>> = []
 	): Promise<LoadedPlugins> {
 		// Plugin initialization procedure consists of 2 main steps:
 		// 1) collecting all available plugin constructors,
@@ -220,7 +220,7 @@ export default class PluginCollection<TContext extends object> extends EmitterMi
 
 		function isPluginRemoved(
 			plugin: PluginConstructor<TContext> | string,
-			pluginsToRemove: Array<PluginConstructor<TContext> | string>
+			pluginsToRemove: ReadonlyArray<PluginConstructor<TContext> | string>
 		) {
 			return pluginsToRemove.some( removedPlugin => {
 				if ( removedPlugin === plugin ) {
@@ -246,7 +246,7 @@ export default class PluginCollection<TContext extends object> extends EmitterMi
 		}
 
 		function findAvailablePluginConstructors(
-			plugins: Array<PluginConstructor<TContext> | string>,
+			plugins: ReadonlyArray<PluginConstructor<TContext> | string>,
 			processed = new Set<PluginConstructor<TContext>>()
 		) {
 			plugins.forEach( plugin => {
@@ -271,7 +271,7 @@ export default class PluginCollection<TContext extends object> extends EmitterMi
 		}
 
 		function getPluginConstructors(
-			plugins: Array<PluginConstructor<TContext> | string>,
+			plugins: ReadonlyArray<PluginConstructor<TContext> | string>,
 			processed = new Set<PluginConstructor<TContext>>()
 		) {
 			return plugins
@@ -298,7 +298,7 @@ export default class PluginCollection<TContext extends object> extends EmitterMi
 		}
 
 		function validatePlugins(
-			plugins: Array<PluginConstructor<TContext> | string>,
+			plugins: ReadonlyArray<PluginConstructor<TContext> | string>,
 			parentPluginConstructor: PluginConstructor<TContext> | null = null
 		) {
 			plugins
@@ -439,7 +439,7 @@ export default class PluginCollection<TContext extends object> extends EmitterMi
 			);
 		}
 
-		function loadPlugins( pluginConstructors: Array<PluginConstructor<TContext>> ) {
+		function loadPlugins( pluginConstructors: ReadonlyArray<PluginConstructor<TContext>> ) {
 			return pluginConstructors.map( PluginConstructor => {
 				let pluginInstance = that._contextPlugins.get( PluginConstructor ) as ( PluginInterface | undefined );
 
@@ -451,7 +451,7 @@ export default class PluginCollection<TContext extends object> extends EmitterMi
 			} );
 		}
 
-		function initPlugins( pluginInstances: Array<PluginInterface>, method: 'init' | 'afterInit' ) {
+		function initPlugins( pluginInstances: ReadonlyArray<PluginInterface>, method: 'init' | 'afterInit' ) {
 			return pluginInstances.reduce<Promise<unknown>>( ( promise, plugin ) => {
 				if ( !plugin[ method ] ) {
 					return promise;
@@ -470,7 +470,7 @@ export default class PluginCollection<TContext extends object> extends EmitterMi
 		 */
 		function substitutePlugins(
 			pluginConstructors: Array<PluginConstructor<TContext>>,
-			pluginsSubstitutions: Array<PluginConstructor<TContext>>
+			pluginsSubstitutions: ReadonlyArray<PluginConstructor<TContext>>
 		) {
 			for ( const pluginItem of pluginsSubstitutions ) {
 				if ( typeof pluginItem != 'function' ) {

--- a/packages/ckeditor5-easy-image/src/cloudservicesuploadadapter.ts
+++ b/packages/ckeditor5-easy-image/src/cloudservicesuploadadapter.ts
@@ -7,7 +7,7 @@
 * @module easy-image/cloudservicesuploadadapter
 */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { FileRepository, type FileLoader, type UploadAdapter } from 'ckeditor5/src/upload';
 import type { CloudServicesCore, CloudServices, UploadGateway, FileUploader } from '@ckeditor/ckeditor5-cloud-services';
 
@@ -32,8 +32,8 @@ export default class CloudServicesUploadAdapter extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ 'CloudServices', FileRepository ];
+	public static get requires() {
+		return [ 'CloudServices', FileRepository ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-easy-image/src/easyimage.ts
+++ b/packages/ckeditor5-easy-image/src/easyimage.ts
@@ -7,7 +7,7 @@
  * @module easy-image/easyimage
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { logWarning } from 'ckeditor5/src/utils';
 
 import CloudServicesUploadAdapter from './cloudservicesuploadadapter';
@@ -47,8 +47,8 @@ export default class EasyImage extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ CloudServicesUploadAdapter, 'ImageUpload' ];
+	public static get requires() {
+		return [ CloudServicesUploadAdapter, 'ImageUpload' ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-essentials/src/essentials.ts
+++ b/packages/ckeditor5-essentials/src/essentials.ts
@@ -7,7 +7,7 @@
  * @module essentials/essentials
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import { Clipboard } from 'ckeditor5/src/clipboard';
 import { Enter, ShiftEnter } from 'ckeditor5/src/enter';
@@ -35,8 +35,8 @@ export default class Essentials extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ Clipboard, Enter, SelectAll, ShiftEnter, Typing, Undo ];
+	public static get requires() {
+		return [ Clipboard, Enter, SelectAll, ShiftEnter, Typing, Undo ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-find-and-replace/src/findandreplace.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplace.ts
@@ -7,7 +7,7 @@
  * @module find-and-replace/findandreplace
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import FindAndReplaceUI, { type SearchResetedEvent } from './findandreplaceui';
 import FindAndReplaceEditing from './findandreplaceediting';
 import type { Marker } from 'ckeditor5/src/engine';
@@ -35,8 +35,8 @@ export default class FindAndReplace extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ FindAndReplaceEditing, FindAndReplaceUI ];
+	public static get requires() {
+		return [ FindAndReplaceEditing, FindAndReplaceUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceediting.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceediting.ts
@@ -7,7 +7,7 @@
  * @module find-and-replace/findandreplaceediting
  */
 
-import { Plugin, type Editor, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 import type { DiffItem, DiffItemAttribute, Element, Item, Node } from 'ckeditor5/src/engine';
 import type { Collection, GetCallback, ObservableChangeEvent } from 'ckeditor5/src/utils';
 // eslint-disable-next-line ckeditor5-rules/ckeditor-imports
@@ -95,8 +95,8 @@ export default class FindAndReplaceEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ FindAndReplaceUtils ];
+	public static get requires() {
+		return [ FindAndReplaceUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-font/src/font.ts
+++ b/packages/ckeditor5-font/src/font.ts
@@ -7,7 +7,7 @@
  * @module font/font
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import FontFamily from './fontfamily';
 import FontSize from './fontsize';
@@ -29,8 +29,8 @@ export default class Font extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ FontFamily, FontSize, FontColor, FontBackgroundColor ];
+	public static get requires() {
+		return [ FontFamily, FontSize, FontColor, FontBackgroundColor ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-font/src/fontbackgroundcolor.ts
+++ b/packages/ckeditor5-font/src/fontbackgroundcolor.ts
@@ -7,7 +7,7 @@
  * @module font/fontbackgroundcolor
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import FontBackgroundColorEditing from './fontbackgroundcolor/fontbackgroundcolorediting';
 import FontBackgroundColorUI from './fontbackgroundcolor/fontbackgroundcolorui';
 
@@ -25,8 +25,8 @@ export default class FontBackgroundColor extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ FontBackgroundColorEditing, FontBackgroundColorUI ];
+	public static get requires() {
+		return [ FontBackgroundColorEditing, FontBackgroundColorUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-font/src/fontcolor.ts
+++ b/packages/ckeditor5-font/src/fontcolor.ts
@@ -7,8 +7,7 @@
  * @module font/fontcolor
  */
 
-import type { ColorOption } from 'ckeditor5/src/ui';
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import FontColorEditing from './fontcolor/fontcolorediting';
 import FontColorUI from './fontcolor/fontcolorui';
 
@@ -25,8 +24,8 @@ export default class FontColor extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ FontColorEditing, FontColorUI ];
+	public static get requires() {
+		return [ FontColorEditing, FontColorUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-font/src/fontfamily.ts
+++ b/packages/ckeditor5-font/src/fontfamily.ts
@@ -7,8 +7,7 @@
  * @module font/fontfamily
  */
 
-import type { MatcherPattern, ViewElementDefinition } from 'ckeditor5/src/engine';
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import FontFamilyEditing from './fontfamily/fontfamilyediting';
 import FontFamilyUI from './fontfamily/fontfamilyui';
 
@@ -25,8 +24,8 @@ export default class FontFamily extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ FontFamilyEditing, FontFamilyUI ];
+	public static get requires() {
+		return [ FontFamilyEditing, FontFamilyUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-font/src/fontsize.ts
+++ b/packages/ckeditor5-font/src/fontsize.ts
@@ -7,7 +7,7 @@
  * @module font/fontsize
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import FontSizeEditing from './fontsize/fontsizeediting';
 import FontSizeUI from './fontsize/fontsizeui';
 import { normalizeOptions } from './fontsize/utils';
@@ -26,8 +26,8 @@ export default class FontSize extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ FontSizeEditing, FontSizeUI ];
+	public static get requires() {
+		return [ FontSizeEditing, FontSizeUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-heading/src/heading.ts
+++ b/packages/ckeditor5-heading/src/heading.ts
@@ -7,7 +7,7 @@
  * @module heading/heading
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import HeadingEditing from './headingediting';
 import HeadingUI from './headingui';
@@ -29,8 +29,8 @@ export default class Heading extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ HeadingEditing, HeadingUI ];
+	public static get requires() {
+		return [ HeadingEditing, HeadingUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-heading/src/headingediting.ts
+++ b/packages/ckeditor5-heading/src/headingediting.ts
@@ -7,7 +7,7 @@
  * @module heading/headingediting
  */
 
-import { Plugin, type Editor, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 import { Paragraph } from 'ckeditor5/src/paragraph';
 import { priorities } from 'ckeditor5/src/utils';
 import type { HeadingOption } from './headingconfig';
@@ -48,8 +48,8 @@ export default class HeadingEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ Paragraph ];
+	public static get requires() {
+		return [ Paragraph ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-heading/src/title.ts
+++ b/packages/ckeditor5-heading/src/title.ts
@@ -7,7 +7,7 @@
  * @module heading/title
  */
 
-import { Plugin, type Editor, type ElementApi, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, type Editor, type ElementApi } from 'ckeditor5/src/core';
 import { first, type GetCallback } from 'ckeditor5/src/utils';
 import {
 	DowncastWriter,
@@ -55,8 +55,8 @@ export default class Title extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ 'Paragraph' ];
+	public static get requires() {
+		return [ 'Paragraph' ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-highlight/src/highlight.ts
+++ b/packages/ckeditor5-highlight/src/highlight.ts
@@ -7,7 +7,7 @@
  * @module highlight/highlight
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import HighlightEditing from './highlightediting';
 import HighlightUI from './highlightui';
@@ -24,8 +24,8 @@ export default class Highlight extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ HighlightEditing, HighlightUI ];
+	public static get requires() {
+		return [ HighlightEditing, HighlightUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-horizontal-line/src/horizontalline.ts
+++ b/packages/ckeditor5-horizontal-line/src/horizontalline.ts
@@ -7,7 +7,7 @@
  * @module horizontal-line/horizontalline
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { Widget } from 'ckeditor5/src/widget';
 import HorizontalLineEditing from './horizontallineediting';
 import HorizontalLineUI from './horizontallineui';
@@ -23,8 +23,8 @@ export default class HorizontalLine extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ HorizontalLineEditing, HorizontalLineUI, Widget ];
+	public static get requires() {
+		return [ HorizontalLineEditing, HorizontalLineUI, Widget ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-html-embed/src/htmlembed.ts
+++ b/packages/ckeditor5-html-embed/src/htmlembed.ts
@@ -7,7 +7,7 @@
  * @module html-embed/htmlembed
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { Widget } from 'ckeditor5/src/widget';
 
 import HtmlEmbedEditing from './htmlembedediting';
@@ -24,8 +24,8 @@ export default class HtmlEmbed extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ HtmlEmbedEditing, HtmlEmbedUI, Widget ];
+	public static get requires() {
+		return [ HtmlEmbedEditing, HtmlEmbedUI, Widget ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-html-support/src/datafilter.ts
+++ b/packages/ckeditor5-html-support/src/datafilter.ts
@@ -9,7 +9,7 @@
 
 /* globals document */
 
-import { Plugin, type Editor, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 import {
 	Matcher,
 	type MatcherPattern,
@@ -149,8 +149,8 @@ export default class DataFilter extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ DataSchema, Widget ];
+	public static get requires() {
+		return [ DataSchema, Widget ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-html-support/src/generalhtmlsupport.ts
+++ b/packages/ckeditor5-html-support/src/generalhtmlsupport.ts
@@ -7,7 +7,7 @@
  * @module html-support/generalhtmlsupport
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { toArray, type ArrayOrItem } from 'ckeditor5/src/utils';
 
 import DataFilter from './datafilter';
@@ -46,7 +46,7 @@ export default class GeneralHtmlSupport extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
+	public static get requires() {
 		return [
 			DataFilter,
 			CodeBlockElementSupport,
@@ -59,7 +59,7 @@ export default class GeneralHtmlSupport extends Plugin {
 			StyleElementSupport,
 			DocumentListElementSupport,
 			CustomElementSupport
-		];
+		] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-html-support/src/integrations/codeblock.ts
+++ b/packages/ckeditor5-html-support/src/integrations/codeblock.ts
@@ -15,7 +15,7 @@ import type {
 	UpcastElementEvent,
 	ViewElement
 } from 'ckeditor5/src/engine';
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import { updateViewAttributes, type GHSViewAttributes } from '../conversionutils';
 import DataFilter, { type DataFilterRegisterEvent } from '../datafilter';
@@ -27,8 +27,8 @@ export default class CodeBlockElementSupport extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ DataFilter ];
+	public static get requires() {
+		return [ DataFilter ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-html-support/src/integrations/customelement.ts
+++ b/packages/ckeditor5-html-support/src/integrations/customelement.ts
@@ -9,7 +9,7 @@
 
 /* globals document */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { UpcastWriter, type ViewDocumentFragment, type ViewNode } from 'ckeditor5/src/engine';
 
 import DataSchema from '../dataschema';
@@ -23,8 +23,8 @@ export default class CustomElementSupport extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ DataFilter, DataSchema ];
+	public static get requires() {
+		return [ DataFilter, DataSchema ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-html-support/src/integrations/documentlist.ts
+++ b/packages/ckeditor5-html-support/src/integrations/documentlist.ts
@@ -8,7 +8,7 @@
  */
 
 import { isEqual } from 'lodash-es';
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import type { UpcastElementEvent } from 'ckeditor5/src/engine';
 import type { GetCallback } from 'ckeditor5/src/utils';
 import type {
@@ -28,8 +28,8 @@ export default class DocumentListElementSupport extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ DataFilter ];
+	public static get requires() {
+		return [ DataFilter ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-html-support/src/integrations/dualcontent.ts
+++ b/packages/ckeditor5-html-support/src/integrations/dualcontent.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ViewElement } from 'ckeditor5/src/engine';
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { priorities } from 'ckeditor5/src/utils';
 
 import {
@@ -39,8 +39,8 @@ export default class DualContentModelElementSupport extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ DataFilter ];
+	public static get requires() {
+		return [ DataFilter ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-html-support/src/integrations/heading.ts
+++ b/packages/ckeditor5-html-support/src/integrations/heading.ts
@@ -7,7 +7,7 @@
  * @module html-support/integrations/heading
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import type { HeadingOption } from '@ckeditor/ckeditor5-heading';
 
 import DataSchema from '../dataschema';
@@ -19,8 +19,8 @@ export default class HeadingElementSupport extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ DataSchema ];
+	public static get requires() {
+		return [ DataSchema ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-html-support/src/integrations/image.ts
+++ b/packages/ckeditor5-html-support/src/integrations/image.ts
@@ -7,7 +7,7 @@
  * @module html-support/integrations/image
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import type {
 	DowncastAttributeEvent,
 	DowncastDispatcher,
@@ -26,8 +26,8 @@ export default class ImageElementSupport extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ DataFilter ];
+	public static get requires() {
+		return [ DataFilter ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-html-support/src/integrations/mediaembed.ts
+++ b/packages/ckeditor5-html-support/src/integrations/mediaembed.ts
@@ -7,7 +7,7 @@
  * @module html-support/integrations/mediaembed
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import DataFilter, { type DataFilterRegisterEvent } from '../datafilter';
 import DataSchema from '../dataschema';
@@ -29,8 +29,8 @@ export default class MediaEmbedElementSupport extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ DataFilter ];
+	public static get requires() {
+		return [ DataFilter ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-html-support/src/integrations/script.ts
+++ b/packages/ckeditor5-html-support/src/integrations/script.ts
@@ -7,7 +7,7 @@
  * @module html-support/integrations/script
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import {
 	createObjectView,
 	modelToViewBlockAttributeConverter,
@@ -24,8 +24,8 @@ export default class ScriptElementSupport extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ DataFilter ];
+	public static get requires() {
+		return [ DataFilter ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-html-support/src/integrations/style.ts
+++ b/packages/ckeditor5-html-support/src/integrations/style.ts
@@ -7,7 +7,7 @@
  * @module html-support/integrations/style
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import {
 	createObjectView,
@@ -25,8 +25,8 @@ export default class StyleElementSupport extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ DataFilter ];
+	public static get requires() {
+		return [ DataFilter ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-html-support/src/integrations/table.ts
+++ b/packages/ckeditor5-html-support/src/integrations/table.ts
@@ -14,7 +14,7 @@ import type {
 	UpcastDispatcher,
 	UpcastElementEvent,
 	ViewElement } from 'ckeditor5/src/engine';
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { setViewAttributes, type GHSViewAttributes } from '../conversionutils';
 import DataFilter, { type DataFilterRegisterEvent } from '../datafilter';
 import { getDescendantElement } from './integrationutils';
@@ -26,8 +26,8 @@ export default class TableElementSupport extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ DataFilter ];
+	public static get requires() {
+		return [ DataFilter ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/autoimage.ts
+++ b/packages/ckeditor5-image/src/autoimage.ts
@@ -7,7 +7,7 @@
  * @module image/autoimage
  */
 
-import { Plugin, type PluginDependencies, type Editor } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 import { Clipboard, type ClipboardPipeline } from 'ckeditor5/src/clipboard';
 import { LivePosition, LiveRange } from 'ckeditor5/src/engine';
 import { Undo } from 'ckeditor5/src/undo';
@@ -30,8 +30,8 @@ export default class AutoImage extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ Clipboard, ImageUtils, Undo, Delete ];
+	public static get requires() {
+		return [ Clipboard, ImageUtils, Undo, Delete ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/image.ts
+++ b/packages/ckeditor5-image/src/image.ts
@@ -7,7 +7,7 @@
  * @module image/image
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import ImageBlock from './imageblock';
 import ImageInline from './imageinline';
 
@@ -30,8 +30,8 @@ export default class Image extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageBlock, ImageInline ];
+	public static get requires() {
+		return [ ImageBlock, ImageInline ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/image/imageblockediting.ts
+++ b/packages/ckeditor5-image/src/image/imageblockediting.ts
@@ -7,7 +7,7 @@
  * @module image/image/imageblockediting
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { ClipboardPipeline, type ClipboardInputTransformationEvent } from 'ckeditor5/src/clipboard';
 import { UpcastWriter, type ViewElement } from 'ckeditor5/src/engine';
 
@@ -40,8 +40,8 @@ export default class ImageBlockEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageEditing, ImageUtils, ClipboardPipeline ];
+	public static get requires() {
+		return [ ImageEditing, ImageUtils, ClipboardPipeline ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/image/imageediting.ts
+++ b/packages/ckeditor5-image/src/image/imageediting.ts
@@ -7,7 +7,7 @@
  * @module image/image/imageediting
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import type { ViewElement } from 'ckeditor5/src/engine';
 import ImageLoadObserver from './imageloadobserver';
 import InsertImageCommand from './insertimagecommand';
@@ -25,8 +25,8 @@ export default class ImageEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageUtils ];
+	public static get requires() {
+		return [ ImageUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/image/imageinlineediting.ts
+++ b/packages/ckeditor5-image/src/image/imageinlineediting.ts
@@ -7,7 +7,7 @@
  * @module image/image/imageinlineediting
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { ClipboardPipeline, type ClipboardInputTransformationEvent } from 'ckeditor5/src/clipboard';
 import { UpcastWriter, type ViewElement } from 'ckeditor5/src/engine';
 
@@ -39,8 +39,8 @@ export default class ImageInlineEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageEditing, ImageUtils, ClipboardPipeline ];
+	public static get requires() {
+		return [ ImageEditing, ImageUtils, ClipboardPipeline ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imageblock.ts
+++ b/packages/ckeditor5-image/src/imageblock.ts
@@ -7,7 +7,7 @@
  * @module image/imageblock
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { Widget } from 'ckeditor5/src/widget';
 
 import ImageTextAlternative from './imagetextalternative';
@@ -30,8 +30,8 @@ export default class ImageBlock extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageBlockEditing, Widget, ImageTextAlternative ];
+	public static get requires() {
+		return [ ImageBlockEditing, Widget, ImageTextAlternative ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imagecaption.ts
+++ b/packages/ckeditor5-image/src/imagecaption.ts
@@ -7,7 +7,7 @@
  * @module image/imagecaption
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import ImageCaptionEditing from './imagecaption/imagecaptionediting';
 import ImageCaptionUI from './imagecaption/imagecaptionui';
 
@@ -22,8 +22,8 @@ export default class ImageCaption extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageCaptionEditing, ImageCaptionUI ];
+	public static get requires() {
+		return [ ImageCaptionEditing, ImageCaptionUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imagecaption/imagecaptionediting.ts
+++ b/packages/ckeditor5-image/src/imagecaption/imagecaptionediting.ts
@@ -7,7 +7,7 @@
  * @module image/imagecaption/imagecaptionediting
  */
 
-import { type Editor, Plugin, type PluginDependencies, type CommandExecuteEvent } from 'ckeditor5/src/core';
+import { type Editor, Plugin, type CommandExecuteEvent } from 'ckeditor5/src/core';
 import { Element, enablePlaceholder, type DocumentChangeEvent, type DiffItemAttribute } from 'ckeditor5/src/engine';
 import { toWidgetEditable } from 'ckeditor5/src/widget';
 import type { GetCallback } from 'ckeditor5/src/utils';
@@ -27,8 +27,8 @@ export default class ImageCaptionEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageUtils, ImageCaptionUtils ];
+	public static get requires() {
+		return [ ImageUtils, ImageCaptionUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imagecaption/imagecaptionui.ts
+++ b/packages/ckeditor5-image/src/imagecaption/imagecaptionui.ts
@@ -7,7 +7,7 @@
  * @module image/imagecaption/imagecaptionui
  */
 
-import { Plugin, icons, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, icons } from 'ckeditor5/src/core';
 import { ButtonView } from 'ckeditor5/src/ui';
 import ImageCaptionUtils from './imagecaptionutils';
 import type ToggleImageCaptionCommand from './toggleimagecaptioncommand';
@@ -19,8 +19,8 @@ export default class ImageCaptionUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageCaptionUtils ];
+	public static get requires() {
+		return [ ImageCaptionUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imagecaption/imagecaptionutils.ts
+++ b/packages/ckeditor5-image/src/imagecaption/imagecaptionutils.ts
@@ -8,7 +8,7 @@
  */
 
 import type { DocumentSelection, Element, Selection, ViewElement, Match } from 'ckeditor5/src/engine';
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import ImageUtils from '../imageutils';
 
@@ -26,8 +26,8 @@ export default class ImageCaptionUtils extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageUtils ];
+	public static get requires() {
+		return [ ImageUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imageinline.ts
+++ b/packages/ckeditor5-image/src/imageinline.ts
@@ -7,7 +7,7 @@
  * @module image/imageinline
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { Widget } from 'ckeditor5/src/widget';
 
 import ImageTextAlternative from './imagetextalternative';
@@ -30,8 +30,8 @@ export default class ImageInline extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageInlineEditing, Widget, ImageTextAlternative ];
+	public static get requires() {
+		return [ ImageInlineEditing, Widget, ImageTextAlternative ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imageinsert.ts
+++ b/packages/ckeditor5-image/src/imageinsert.ts
@@ -7,7 +7,7 @@
  * @module image/imageinsert
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import ImageUpload from './imageupload';
 import ImageInsertViaUrl from './imageinsertviaurl';
 import ImageInsertUI from './imageinsert/imageinsertui';
@@ -35,7 +35,7 @@ export default class ImageInsert extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageUpload, ImageInsertViaUrl, ImageInsertUI ];
+	public static get requires() {
+		return [ ImageUpload, ImageInsertViaUrl, ImageInsertUI ] as const;
 	}
 }

--- a/packages/ckeditor5-image/src/imageinsertviaurl.ts
+++ b/packages/ckeditor5-image/src/imageinsertviaurl.ts
@@ -7,7 +7,7 @@
  * @module image/imageinsertviaurl
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import ImageInsertUI from './imageinsert/imageinsertui';
 
 /**
@@ -32,7 +32,7 @@ export default class ImageInsertViaUrl extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageInsertUI ];
+	public static get requires() {
+		return [ ImageInsertUI ] as const;
 	}
 }

--- a/packages/ckeditor5-image/src/imageresize.ts
+++ b/packages/ckeditor5-image/src/imageresize.ts
@@ -7,7 +7,7 @@
  * @module image/imageresize
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import ImageResizeButtons from './imageresize/imageresizebuttons';
 import ImageResizeEditing from './imageresize/imageresizeediting';
 import ImageResizeHandles from './imageresize/imageresizehandles';
@@ -23,8 +23,8 @@ export default class ImageResize extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageResizeEditing, ImageResizeHandles, ImageResizeButtons ];
+	public static get requires() {
+		return [ ImageResizeEditing, ImageResizeHandles, ImageResizeButtons ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imageresize/imageresizebuttons.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizebuttons.ts
@@ -7,7 +7,7 @@
  * @module image/imageresize/imageresizebuttons
  */
 
-import { Plugin, icons, type Editor, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, icons, type Editor } from 'ckeditor5/src/core';
 import {
 	ButtonView,
 	DropdownButtonView,
@@ -38,8 +38,8 @@ export default class ImageResizeButtons extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageResizeEditing ];
+	public static get requires() {
+		return [ ImageResizeEditing ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imageresize/imageresizeediting.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizeediting.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ViewElement } from 'ckeditor5/src/engine';
-import { type Editor, Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { type Editor, Plugin } from 'ckeditor5/src/core';
 import ImageUtils from '../imageutils';
 import ResizeImageCommand from './resizeimagecommand';
 
@@ -22,8 +22,8 @@ export default class ImageResizeEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageUtils ];
+	public static get requires() {
+		return [ ImageUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imageresize/imageresizehandles.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizehandles.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Element, ViewContainerElement, ViewElement } from 'ckeditor5/src/engine';
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { WidgetResize } from 'ckeditor5/src/widget';
 
 import ImageLoadObserver, { type ImageLoadedEvent } from '../image/imageloadobserver';
@@ -36,8 +36,8 @@ export default class ImageResizeHandles extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ WidgetResize ];
+	public static get requires() {
+		return [ WidgetResize ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imagestyle.ts
+++ b/packages/ckeditor5-image/src/imagestyle.ts
@@ -7,7 +7,7 @@
  * @module image/imagestyle
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import ImageStyleEditing from './imagestyle/imagestyleediting';
 import ImageStyleUI from './imagestyle/imagestyleui';
 
@@ -27,8 +27,8 @@ export default class ImageStyle extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageStyleEditing, ImageStyleUI ];
+	public static get requires() {
+		return [ ImageStyleEditing, ImageStyleUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imagestyle/imagestyleediting.ts
+++ b/packages/ckeditor5-image/src/imagestyle/imagestyleediting.ts
@@ -7,7 +7,7 @@
  * @module image/imagestyle/imagestyleediting
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import type { Element, UpcastElementEvent } from 'ckeditor5/src/engine';
 
 import ImageStyleCommand from './imagestylecommand';
@@ -31,8 +31,8 @@ export default class ImageStyleEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageUtils ];
+	public static get requires() {
+		return [ ImageUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imagestyle/imagestyleui.ts
+++ b/packages/ckeditor5-image/src/imagestyle/imagestyleui.ts
@@ -7,7 +7,7 @@
  * @module image/imagestyle/imagestyleui
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { ButtonView, createDropdown, addToolbarToDropdown, SplitButtonView } from 'ckeditor5/src/ui';
 import { isObject, identity } from 'lodash-es';
 import ImageStyleEditing from './imagestyleediting';
@@ -28,8 +28,8 @@ export default class ImageStyleUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageStyleEditing ];
+	public static get requires() {
+		return [ ImageStyleEditing ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imagetextalternative.ts
+++ b/packages/ckeditor5-image/src/imagetextalternative.ts
@@ -7,7 +7,7 @@
  * @module image/imagetextalternative
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import ImageTextAlternativeEditing from './imagetextalternative/imagetextalternativeediting';
 import ImageTextAlternativeUI from './imagetextalternative/imagetextalternativeui';
 
@@ -24,8 +24,8 @@ export default class ImageTextAlternative extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageTextAlternativeEditing, ImageTextAlternativeUI ];
+	public static get requires() {
+		return [ ImageTextAlternativeEditing, ImageTextAlternativeUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imagetextalternative/imagetextalternativeediting.ts
+++ b/packages/ckeditor5-image/src/imagetextalternative/imagetextalternativeediting.ts
@@ -7,7 +7,7 @@
  * @module image/imagetextalternative/imagetextalternativeediting
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import ImageTextAlternativeCommand from './imagetextalternativecommand';
 import ImageUtils from '../imageutils';
 
@@ -20,8 +20,8 @@ export default class ImageTextAlternativeEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageUtils ];
+	public static get requires() {
+		return [ ImageUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imagetextalternative/imagetextalternativeui.ts
+++ b/packages/ckeditor5-image/src/imagetextalternative/imagetextalternativeui.ts
@@ -7,7 +7,7 @@
  * @module image/imagetextalternative/imagetextalternativeui
  */
 
-import { Plugin, icons, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, icons } from 'ckeditor5/src/core';
 import {
 	ButtonView,
 	ContextualBalloon,
@@ -41,8 +41,8 @@ export default class ImageTextAlternativeUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ContextualBalloon ];
+	public static get requires() {
+		return [ ContextualBalloon ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imagetoolbar.ts
+++ b/packages/ckeditor5-image/src/imagetoolbar.ts
@@ -7,7 +7,7 @@
  * @module image/imagetoolbar
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { WidgetToolbarRepository } from 'ckeditor5/src/widget';
 
 import ImageUtils from './imageutils';
@@ -30,8 +30,8 @@ export default class ImageToolbar extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ WidgetToolbarRepository, ImageUtils ];
+	public static get requires() {
+		return [ WidgetToolbarRepository, ImageUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imageupload.ts
+++ b/packages/ckeditor5-image/src/imageupload.ts
@@ -7,7 +7,7 @@
  * @module image/imageupload
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import ImageUploadUI from './imageupload/imageuploadui';
 import ImageUploadProgress from './imageupload/imageuploadprogress';
 import ImageUploadEditing from './imageupload/imageuploadediting';
@@ -34,7 +34,7 @@ export default class ImageUpload extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageUploadEditing, ImageUploadUI, ImageUploadProgress ];
+	public static get requires() {
+		return [ ImageUploadEditing, ImageUploadUI, ImageUploadProgress ] as const;
 	}
 }

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
@@ -7,7 +7,7 @@
  * @module image/imageupload/imageuploadediting
  */
 
-import { Plugin, type PluginDependencies, type Editor } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 
 import { UpcastWriter, type Element, type Item, type Writer, type DataTransfer, type ViewElement } from 'ckeditor5/src/engine';
 
@@ -32,8 +32,8 @@ export default class ImageUploadEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ FileRepository, Notification, ClipboardPipeline, ImageUtils ];
+	public static get requires() {
+		return [ FileRepository, Notification, ClipboardPipeline, ImageUtils ] as const;
 	}
 
 	public static get pluginName(): 'ImageUploadEditing' {

--- a/packages/ckeditor5-image/src/pictureediting.ts
+++ b/packages/ckeditor5-image/src/pictureediting.ts
@@ -7,7 +7,7 @@
  * @module image/pictureediting
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import ImageEditing from './image/imageediting';
 import ImageUtils from './imageutils';
@@ -71,8 +71,8 @@ export default class PictureEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ImageEditing, ImageUtils ];
+	public static get requires() {
+		return [ ImageEditing, ImageUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-indent/src/indent.ts
+++ b/packages/ckeditor5-indent/src/indent.ts
@@ -7,7 +7,7 @@
  * @module indent/indent
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import IndentEditing from './indentediting';
 import IndentUI from './indentui';
@@ -43,7 +43,7 @@ export default class Indent extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ IndentEditing, IndentUI ];
+	public static get requires() {
+		return [ IndentEditing, IndentUI ] as const;
 	}
 }

--- a/packages/ckeditor5-language/src/textpartlanguage.ts
+++ b/packages/ckeditor5-language/src/textpartlanguage.ts
@@ -7,7 +7,7 @@
  * @module language/textpartlanguage
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import TextPartLanguageEditing from './textpartlanguageediting';
 import TextPartLanguageUI from './textpartlanguageui';
@@ -31,8 +31,8 @@ export default class TextPartLanguage extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TextPartLanguageEditing, TextPartLanguageUI ];
+	public static get requires() {
+		return [ TextPartLanguageEditing, TextPartLanguageUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -7,7 +7,7 @@
  * @module link/autolink
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import type { DocumentSelectionChangeEvent, Element, Model, Range } from 'ckeditor5/src/engine';
 import { Delete, TextWatcher, getLastTextLine, type TextWatcherMatchedDataEvent } from 'ckeditor5/src/typing';
 import type { EnterCommand, ShiftEnterCommand } from 'ckeditor5/src/enter';
@@ -72,8 +72,8 @@ export default class AutoLink extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ Delete ];
+	public static get requires() {
+		return [ Delete ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-link/src/link.ts
+++ b/packages/ckeditor5-link/src/link.ts
@@ -7,7 +7,7 @@
  * @module link/link
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import LinkEditing from './linkediting';
 import LinkUI from './linkui';
 import AutoLink from './autolink';
@@ -22,8 +22,8 @@ export default class Link extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ LinkEditing, LinkUI, AutoLink ];
+	public static get requires() {
+		return [ LinkEditing, LinkUI, AutoLink ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-link/src/linkediting.ts
+++ b/packages/ckeditor5-link/src/linkediting.ts
@@ -9,7 +9,6 @@
 
 import {
 	Plugin,
-	type PluginDependencies,
 	type Editor
 } from 'ckeditor5/src/core';
 import {
@@ -76,9 +75,9 @@ export default class LinkEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
+	public static get requires() {
 		// Clipboard is required for handling cut and paste events while typing over the link.
-		return [ TwoStepCaretMovement, Input, ClipboardPipeline ];
+		return [ TwoStepCaretMovement, Input, ClipboardPipeline ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-link/src/linkimage.ts
+++ b/packages/ckeditor5-link/src/linkimage.ts
@@ -7,7 +7,7 @@
  * @module link/linkimage
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import LinkImageEditing from './linkimageediting';
 import LinkImageUI from './linkimageui';
 
@@ -23,8 +23,8 @@ export default class LinkImage extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ LinkImageEditing, LinkImageUI ];
+	public static get requires() {
+		return [ LinkImageEditing, LinkImageUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-link/src/linkimageediting.ts
+++ b/packages/ckeditor5-link/src/linkimageediting.ts
@@ -9,7 +9,6 @@
 
 import {
 	Plugin,
-	type PluginDependencies,
 	type Editor
 } from 'ckeditor5/src/core';
 import {
@@ -40,8 +39,8 @@ export default class LinkImageEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ 'ImageEditing', 'ImageUtils', LinkEditing ];
+	public static get requires() {
+		return [ 'ImageEditing', 'ImageUtils', LinkEditing ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-link/src/linkimageui.ts
+++ b/packages/ckeditor5-link/src/linkimageui.ts
@@ -8,7 +8,7 @@
  */
 
 import { ButtonView } from 'ckeditor5/src/ui';
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import type {
 	DocumentSelection,
 	Selection,
@@ -35,8 +35,8 @@ export default class LinkImageUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ LinkEditing, LinkUI, 'ImageBlockEditing' ];
+	public static get requires() {
+		return [ LinkEditing, LinkUI, 'ImageBlockEditing' ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -7,7 +7,7 @@
  * @module link/linkui
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import {
 	ClickObserver,
 	type ViewAttributeElement,
@@ -60,8 +60,8 @@ export default class LinkUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ContextualBalloon ];
+	public static get requires() {
+		return [ ContextualBalloon ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-list/src/documentlist.ts
+++ b/packages/ckeditor5-list/src/documentlist.ts
@@ -7,7 +7,7 @@
  * @module list/documentlist
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import DocumentListEditing from './documentlist/documentlistediting';
 import ListUI from './list/listui';
 
@@ -21,8 +21,8 @@ export default class DocumentList extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ DocumentListEditing, ListUI ];
+	public static get requires() {
+		return [ DocumentListEditing, ListUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-list/src/documentlist/documentlistediting.ts
+++ b/packages/ckeditor5-list/src/documentlist/documentlistediting.ts
@@ -9,8 +9,7 @@
 
 import {
 	Plugin,
-	type MultiCommand,
-	type PluginDependencies
+	type MultiCommand
 } from 'ckeditor5/src/core';
 
 import type {
@@ -104,8 +103,8 @@ export default class DocumentListEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ Enter, Delete, DocumentListUtils ];
+	public static get requires() {
+		return [ Enter, Delete, DocumentListUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-list/src/documentlistproperties.ts
+++ b/packages/ckeditor5-list/src/documentlistproperties.ts
@@ -7,7 +7,7 @@
  * @module list/documentlistproperties
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import DocumentListPropertiesEditing from './documentlistproperties/documentlistpropertiesediting';
 import ListPropertiesUI from './listproperties/listpropertiesui';
 
@@ -22,8 +22,8 @@ export default class DocumentListProperties extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ DocumentListPropertiesEditing, ListPropertiesUI ];
+	public static get requires() {
+		return [ DocumentListPropertiesEditing, ListPropertiesUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-list/src/documentlistproperties/documentlistpropertiesediting.ts
+++ b/packages/ckeditor5-list/src/documentlistproperties/documentlistpropertiesediting.ts
@@ -7,7 +7,7 @@
  * @module list/documentlistproperties/documentlistpropertiesediting
  */
 
-import { Plugin, type Editor, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 
 import type {
 	Consumables,
@@ -51,8 +51,8 @@ export default class DocumentListPropertiesEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ DocumentListEditing, DocumentListPropertiesUtils ];
+	public static get requires() {
+		return [ DocumentListEditing, DocumentListPropertiesUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-list/src/list.ts
+++ b/packages/ckeditor5-list/src/list.ts
@@ -10,7 +10,7 @@
 import ListEditing from './list/listediting';
 import ListUI from './list/listui';
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 /**
  * The list feature.
@@ -22,8 +22,8 @@ export default class List extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ListEditing, ListUI ];
+	public static get requires() {
+		return [ ListEditing, ListUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-list/src/list/listediting.ts
+++ b/packages/ckeditor5-list/src/list/listediting.ts
@@ -11,7 +11,7 @@ import ListCommand from './listcommand';
 import IndentCommand from './indentcommand';
 import ListUtils from './listutils';
 
-import { Plugin, type MultiCommand, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, type MultiCommand } from 'ckeditor5/src/core';
 
 import { Enter, type ViewDocumentEnterEvent } from 'ckeditor5/src/enter';
 import { Delete, type ViewDocumentDeleteEvent } from 'ckeditor5/src/typing';
@@ -64,8 +64,8 @@ export default class ListEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ Enter, Delete, ListUtils ];
+	public static get requires() {
+		return [ Enter, Delete, ListUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-list/src/listproperties.ts
+++ b/packages/ckeditor5-list/src/listproperties.ts
@@ -7,7 +7,7 @@
  * @module list/listproperties
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import ListPropertiesEditing from './listproperties/listpropertiesediting';
 import ListPropertiesUI from './listproperties/listpropertiesui';
 
@@ -21,8 +21,8 @@ export default class ListProperties extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ListPropertiesEditing, ListPropertiesUI ];
+	public static get requires() {
+		return [ ListPropertiesEditing, ListPropertiesUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
@@ -7,7 +7,7 @@
  * @module list/listproperties/listpropertiesediting
  */
 
-import { Plugin, type Editor, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 
 import type {
 	DiffItem,
@@ -45,8 +45,8 @@ export default class ListPropertiesEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ListEditing ];
+	public static get requires() {
+		return [ ListEditing ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-list/src/liststyle.ts
+++ b/packages/ckeditor5-list/src/liststyle.ts
@@ -7,7 +7,7 @@
  * @module list/liststyle
  */
 
-import { Plugin, type Editor, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 import ListProperties from './listproperties';
 import { logWarning } from 'ckeditor5/src/utils';
 
@@ -23,8 +23,8 @@ export default class ListStyle extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ListProperties ];
+	public static get requires() {
+		return [ ListProperties ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-list/src/todolist.ts
+++ b/packages/ckeditor5-list/src/todolist.ts
@@ -9,7 +9,7 @@
 
 import TodoListEditing from './todolist/todolistediting';
 import TodoListUI from './todolist/todolistui';
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import '../theme/todolist.css';
 
 /**
@@ -22,8 +22,8 @@ export default class TodoList extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TodoListEditing, TodoListUI ];
+	public static get requires() {
+		return [ TodoListEditing, TodoListUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-list/src/todolist/todolistediting.ts
+++ b/packages/ckeditor5-list/src/todolist/todolistediting.ts
@@ -22,7 +22,7 @@ import type {
 	RenameOperation
 } from 'ckeditor5/src/engine';
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import {
 	getCode,
@@ -67,8 +67,8 @@ export default class TodoListEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ListEditing ];
+	public static get requires() {
+		return [ ListEditing ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-media-embed/src/automediaembed.ts
+++ b/packages/ckeditor5-media-embed/src/automediaembed.ts
@@ -7,7 +7,7 @@
  * @module media-embed/automediaembed
  */
 
-import { type Editor, Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { type Editor, Plugin } from 'ckeditor5/src/core';
 import { LiveRange, LivePosition } from 'ckeditor5/src/engine';
 import { Clipboard, type ClipboardPipeline } from 'ckeditor5/src/clipboard';
 import { Delete } from 'ckeditor5/src/typing';
@@ -28,8 +28,8 @@ export default class AutoMediaEmbed extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ Clipboard, Delete, Undo ];
+	public static get requires() {
+		return [ Clipboard, Delete, Undo ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-media-embed/src/mediaembed.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembed.ts
@@ -7,9 +7,8 @@
  * @module media-embed/mediaembed
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { Widget } from 'ckeditor5/src/widget';
-import type { ArrayOrItem } from 'ckeditor5/src/utils';
 
 import MediaEmbedEditing from './mediaembedediting';
 import AutoMediaEmbed from './automediaembed';
@@ -32,8 +31,8 @@ export default class MediaEmbed extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ MediaEmbedEditing, MediaEmbedUI, AutoMediaEmbed, Widget ];
+	public static get requires() {
+		return [ MediaEmbedEditing, MediaEmbedUI, AutoMediaEmbed, Widget ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-media-embed/src/mediaembedtoolbar.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedtoolbar.ts
@@ -7,7 +7,7 @@
  * @module media-embed/mediaembedtoolbar
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { WidgetToolbarRepository } from 'ckeditor5/src/widget';
 
 import { getSelectedMediaViewWidget } from './utils';
@@ -24,8 +24,8 @@ export default class MediaEmbedToolbar extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ WidgetToolbarRepository ];
+	public static get requires() {
+		return [ WidgetToolbarRepository ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-media-embed/src/mediaembedui.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedui.ts
@@ -7,7 +7,7 @@
  * @module media-embed/mediaembedui
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { createDropdown, CssTransitionDisablerMixin, type DropdownView } from 'ckeditor5/src/ui';
 
 import MediaFormView from './ui/mediaformview';
@@ -24,8 +24,8 @@ export default class MediaEmbedUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ MediaEmbedEditing ];
+	public static get requires() {
+		return [ MediaEmbedEditing ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-mention/src/mention.ts
+++ b/packages/ckeditor5-mention/src/mention.ts
@@ -7,7 +7,7 @@
  * @module mention/mention
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import type { Element } from 'ckeditor5/src/engine';
 
 import MentionEditing, { _toMentionAttribute } from './mentionediting';
@@ -49,8 +49,8 @@ export default class Mention extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ MentionEditing, MentionUI ];
+	public static get requires() {
+		return [ MentionEditing, MentionUI ] as const;
 	}
 }
 

--- a/packages/ckeditor5-mention/src/mentionui.ts
+++ b/packages/ckeditor5-mention/src/mentionui.ts
@@ -9,8 +9,7 @@
 
 import {
 	Plugin,
-	type Editor,
-	type PluginDependencies
+	type Editor
 } from 'ckeditor5/src/core';
 
 import type {
@@ -104,8 +103,8 @@ export default class MentionUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ContextualBalloon ];
+	public static get requires() {
+		return [ ContextualBalloon ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-page-break/src/pagebreak.ts
+++ b/packages/ckeditor5-page-break/src/pagebreak.ts
@@ -7,7 +7,7 @@
  * @module page-break/pagebreak
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { Widget } from 'ckeditor5/src/widget';
 
 import PageBreakEditing from './pagebreakediting';
@@ -24,8 +24,8 @@ export default class PageBreak extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ PageBreakEditing, PageBreakUI, Widget ];
+	public static get requires() {
+		return [ PageBreakEditing, PageBreakUI, Widget ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-paragraph/src/paragraphbuttonui.ts
+++ b/packages/ckeditor5-paragraph/src/paragraphbuttonui.ts
@@ -7,7 +7,7 @@
  * @module paragraph/paragraphbuttonui
  */
 
-import { Plugin, icons, type PluginDependencies } from '@ckeditor/ckeditor5-core';
+import { Plugin, icons } from '@ckeditor/ckeditor5-core';
 import { ButtonView } from '@ckeditor/ckeditor5-ui';
 
 import Paragraph from './paragraph';
@@ -36,8 +36,8 @@ export default class ParagraphButtonUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ Paragraph ];
+	public static get requires() {
+		return [ Paragraph ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-paste-from-office/src/pastefromoffice.ts
+++ b/packages/ckeditor5-paste-from-office/src/pastefromoffice.ts
@@ -7,7 +7,7 @@
  * @module paste-from-office/pastefromoffice
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import { ClipboardPipeline } from 'ckeditor5/src/clipboard';
 
@@ -41,8 +41,8 @@ export default class PasteFromOffice extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ClipboardPipeline ];
+	public static get requires() {
+		return [ ClipboardPipeline ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-remove-format/src/removeformat.ts
+++ b/packages/ckeditor5-remove-format/src/removeformat.ts
@@ -7,7 +7,7 @@
  * @module remove-format/removeformat
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import RemoveFormatUI from './removeformatui';
 import RemoveFormatEditing from './removeformatediting';
@@ -24,8 +24,8 @@ export default class RemoveFormat extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ RemoveFormatEditing, RemoveFormatUI ];
+	public static get requires() {
+		return [ RemoveFormatEditing, RemoveFormatUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmode.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmode.ts
@@ -7,7 +7,7 @@
  * @module restricted-editing/restrictededitingmode
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import RestrictedEditingModeEditing from './restrictededitingmodeediting';
 import RestrictedEditingModeUI from './restrictededitingmodeui';
@@ -33,7 +33,7 @@ export default class RestrictedEditingMode extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ RestrictedEditingModeEditing, RestrictedEditingModeUI ];
+	public static get requires() {
+		return [ RestrictedEditingModeEditing, RestrictedEditingModeUI ] as const;
 	}
 }

--- a/packages/ckeditor5-restricted-editing/src/standardeditingmode.ts
+++ b/packages/ckeditor5-restricted-editing/src/standardeditingmode.ts
@@ -7,7 +7,7 @@
  * @module restricted-editing/standardeditingmode
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import StandardEditingModeEditing from './standardeditingmodeediting';
 import StandardEditingModeUI from './standardeditingmodeui';
@@ -30,8 +30,8 @@ export default class StandardEditingMode extends Plugin {
 		return 'StandardEditingMode';
 	}
 
-	public static get requires(): PluginDependencies {
-		return [ StandardEditingModeEditing, StandardEditingModeUI ];
+	public static get requires() {
+		return [ StandardEditingModeEditing, StandardEditingModeUI ] as const;
 	}
 }
 

--- a/packages/ckeditor5-select-all/src/selectall.ts
+++ b/packages/ckeditor5-select-all/src/selectall.ts
@@ -7,7 +7,7 @@
  * @module select-all/selectall
  */
 
-import { Plugin, type PluginDependencies } from '@ckeditor/ckeditor5-core';
+import { Plugin } from '@ckeditor/ckeditor5-core';
 import SelectAllEditing from './selectallediting';
 import SelectAllUI from './selectallui';
 
@@ -23,8 +23,8 @@ export default class SelectAll extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ SelectAllEditing, SelectAllUI ];
+	public static get requires() {
+		return [ SelectAllEditing, SelectAllUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-source-editing/src/sourceediting.ts
+++ b/packages/ckeditor5-source-editing/src/sourceediting.ts
@@ -9,7 +9,7 @@
 
 /* global console */
 
-import { type Editor, Plugin, PendingActions, type PluginDependencies } from 'ckeditor5/src/core';
+import { type Editor, Plugin, PendingActions } from 'ckeditor5/src/core';
 import { ButtonView } from 'ckeditor5/src/ui';
 import { createElement, ElementReplacer } from 'ckeditor5/src/utils';
 import { formatHtml } from './utils/formathtml';
@@ -38,8 +38,8 @@ export default class SourceEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ PendingActions ];
+	public static get requires() {
+		return [ PendingActions ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-special-characters/src/specialcharacters.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharacters.ts
@@ -7,7 +7,7 @@
  * @module special-characters/specialcharacters
  */
 
-import { Plugin, type PluginDependencies, type Editor } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 import { Typing, type InsertTextCommand } from 'ckeditor5/src/typing';
 import { createDropdown, type DropdownView } from 'ckeditor5/src/ui';
 import { CKEditorError, type Locale } from 'ckeditor5/src/utils';
@@ -50,8 +50,8 @@ export default class SpecialCharacters extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ Typing ];
+	public static get requires() {
+		return [ Typing ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-special-characters/src/specialcharactersessentials.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharactersessentials.ts
@@ -7,7 +7,7 @@
  * @module special-characters/specialcharactersessentials
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import SpecialCharactersCurrency from './specialcharacterscurrency';
 import SpecialCharactersMathematical from './specialcharactersmathematical';
@@ -38,7 +38,7 @@ export default class SpecialCharactersEssentials extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
+	public static get requires() {
 		return [
 			SpecialCharactersCurrency,
 			SpecialCharactersText,

--- a/packages/ckeditor5-special-characters/src/specialcharactersessentials.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharactersessentials.ts
@@ -45,6 +45,6 @@ export default class SpecialCharactersEssentials extends Plugin {
 			SpecialCharactersMathematical,
 			SpecialCharactersArrows,
 			SpecialCharactersLatin
-		];
+		] as const;
 	}
 }

--- a/packages/ckeditor5-style/src/style.ts
+++ b/packages/ckeditor5-style/src/style.ts
@@ -7,7 +7,7 @@
  * @module style/style
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import StyleUI from './styleui';
 import StyleEditing from './styleediting';
@@ -29,7 +29,7 @@ export default class Style extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ StyleEditing, StyleUI ];
+	public static get requires() {
+		return [ StyleEditing, StyleUI ] as const;
 	}
 }

--- a/packages/ckeditor5-style/src/styleediting.ts
+++ b/packages/ckeditor5-style/src/styleediting.ts
@@ -7,7 +7,7 @@
  * @module style/styleediting
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import type { MatcherPattern } from 'ckeditor5/src/engine';
 import type { DataFilter, DataSchema } from '@ckeditor/ckeditor5-html-support';
 
@@ -33,8 +33,8 @@ export default class StyleEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ 'GeneralHtmlSupport', StyleUtils ];
+	public static get requires() {
+		return [ 'GeneralHtmlSupport', StyleUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-style/src/styleui.ts
+++ b/packages/ckeditor5-style/src/styleui.ts
@@ -7,7 +7,7 @@
  * @module style/styleui
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { createDropdown } from 'ckeditor5/src/ui';
 import type { DataSchema } from '@ckeditor/ckeditor5-html-support';
 
@@ -34,8 +34,8 @@ export default class StyleUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ StyleUtils ];
+	public static get requires() {
+		return [ StyleUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/plaintableoutput.ts
+++ b/packages/ckeditor5-table/src/plaintableoutput.ts
@@ -7,7 +7,7 @@
  * @module table/plaintableoutput
  */
 
-import { Plugin, type Editor, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 import type { DowncastWriter, Element, Node, ViewContainerElement } from 'ckeditor5/src/engine';
 
 import Table from './table';
@@ -26,8 +26,8 @@ export default class PlainTableOutput extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ Table ];
+	public static get requires() {
+		return [ Table ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/table.ts
+++ b/packages/ckeditor5-table/src/table.ts
@@ -7,7 +7,7 @@
  * @module table/table
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { Widget } from 'ckeditor5/src/widget';
 
 import TableEditing from './tableediting';
@@ -37,8 +37,8 @@ export default class Table extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TableEditing, TableUI, TableSelection, TableMouse, TableKeyboard, TableClipboard, Widget ];
+	public static get requires() {
+		return [ TableEditing, TableUI, TableSelection, TableMouse, TableKeyboard, TableClipboard, Widget ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tablecaption.ts
+++ b/packages/ckeditor5-table/src/tablecaption.ts
@@ -7,7 +7,7 @@
  * @module table/tablecaption
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import TableCaptionEditing from './tablecaption/tablecaptionediting';
 import TableCaptionUI from './tablecaption/tablecaptionui';
 
@@ -27,7 +27,7 @@ export default class TableCaption extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TableCaptionEditing, TableCaptionUI ];
+	public static get requires() {
+		return [ TableCaptionEditing, TableCaptionUI ] as const;
 	}
 }

--- a/packages/ckeditor5-table/src/tablecellproperties.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties.ts
@@ -7,7 +7,7 @@
  * @module table/tablecellproperties
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import TableCellPropertiesUI from './tablecellproperties/tablecellpropertiesui';
 import TableCellPropertiesEditing from './tablecellproperties/tablecellpropertiesediting';
@@ -33,7 +33,7 @@ export default class TableCellProperties extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TableCellPropertiesEditing, TableCellPropertiesUI ];
+	public static get requires() {
+		return [ TableCellPropertiesEditing, TableCellPropertiesUI ] as const;
 	}
 }

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
@@ -7,7 +7,7 @@
  * @module table/tablecellproperties/tablecellpropertiesediting
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { addBorderRules, addPaddingRules, addBackgroundRules, type Schema, type Conversion, type ViewElement } from 'ckeditor5/src/engine';
 
 import { downcastAttributeToStyle, upcastBorderStyles } from './../converters/tableproperties';
@@ -57,8 +57,8 @@ export default class TableCellPropertiesEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TableEditing, TableCellWidthEditing ];
+	public static get requires() {
+		return [ TableEditing, TableCellWidthEditing ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.ts
@@ -7,7 +7,7 @@
  * @module table/tablecellproperties/tablecellpropertiesui
  */
 
-import { Plugin, type Editor, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 import {
 	ButtonView,
 	clickOutsideHandler,
@@ -89,8 +89,8 @@ export default class TableCellPropertiesUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ContextualBalloon ];
+	public static get requires() {
+		return [ ContextualBalloon ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tablecellwidth/tablecellwidthediting.ts
+++ b/packages/ckeditor5-table/src/tablecellwidth/tablecellwidthediting.ts
@@ -7,7 +7,7 @@
  * @module table/tablecellwidth/tablecellwidthediting
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import TableEditing from './../tableediting';
 import TableCellWidthCommand from './commands/tablecellwidthcommand';
@@ -31,8 +31,8 @@ export default class TableCellWidthEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TableEditing ];
+	public static get requires() {
+		return [ TableEditing ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tableclipboard.ts
+++ b/packages/ckeditor5-table/src/tableclipboard.ts
@@ -13,7 +13,7 @@ import type {
 	ViewDocumentCopyEvent,
 	ViewDocumentCutEvent
 } from 'ckeditor5/src/clipboard';
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import type {
 	DocumentFragment,
@@ -60,8 +60,8 @@ export default class TableClipboard extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TableSelection, TableUtils ];
+	public static get requires() {
+		return [ TableSelection, TableUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tablecolumnresize.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize.ts
@@ -7,7 +7,7 @@
  * @module table/tablecolumnresize
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import TableColumnResizeEditing from './tablecolumnresize/tablecolumnresizeediting';
 import TableCellWidthEditing from './tablecellwidth/tablecellwidthediting';
 
@@ -22,8 +22,8 @@ export default class TableColumnResize extends Plugin {
 	/**
 	 * @inheritDoc
  	 */
-	public static get requires(): PluginDependencies {
-		return [ TableColumnResizeEditing, TableCellWidthEditing ];
+	public static get requires() {
+		return [ TableColumnResizeEditing, TableCellWidthEditing ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
@@ -17,7 +17,7 @@ import {
 	type ObservableChangeEvent
 } from 'ckeditor5/src/utils';
 
-import { Plugin, type Editor, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 
 import type {
 	Differ,
@@ -120,8 +120,8 @@ export default class TableColumnResizeEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TableEditing, TableUtils ];
+	public static get requires() {
+		return [ TableEditing, TableUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tableediting.ts
+++ b/packages/ckeditor5-table/src/tableediting.ts
@@ -7,7 +7,7 @@
  * @module table/tableediting
  */
 
-import { Plugin, type Editor, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
 import type { PositionOffset, ViewElement, SlotFilter } from 'ckeditor5/src/engine';
 
 import upcastTable, { ensureParagraphInTableCell, skipEmptyTableRow, upcastTableFigure } from './converters/upcasttable';
@@ -54,8 +54,8 @@ export default class TableEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TableUtils ];
+	public static get requires() {
+		return [ TableUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tablekeyboard.ts
+++ b/packages/ckeditor5-table/src/tablekeyboard.ts
@@ -11,7 +11,7 @@ import TableSelection from './tableselection';
 import TableWalker from './tablewalker';
 import TableUtils from './tableutils';
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import {
 	getLocalizedArrowKeyCodeDirection,
 	type EventInfo,
@@ -44,8 +44,8 @@ export default class TableKeyboard extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TableSelection, TableUtils ];
+	public static get requires() {
+		return [ TableSelection, TableUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tablemouse.ts
+++ b/packages/ckeditor5-table/src/tablemouse.ts
@@ -7,7 +7,7 @@
  * @module table/tablemouse
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import TableSelection from './tableselection';
 import MouseEventsObserver from './tablemouse/mouseeventsobserver';
@@ -29,8 +29,8 @@ export default class TableMouse extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TableSelection, TableUtils ];
+	public static get requires() {
+		return [ TableSelection, TableUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tableproperties.ts
+++ b/packages/ckeditor5-table/src/tableproperties.ts
@@ -7,7 +7,7 @@
  * @module table/tableproperties
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 
 import TablePropertiesEditing from './tableproperties/tablepropertiesediting';
 import TablePropertiesUI from './tableproperties/tablepropertiesui';
@@ -33,7 +33,7 @@ export default class TableProperties extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TablePropertiesEditing, TablePropertiesUI ];
+	public static get requires() {
+		return [ TablePropertiesEditing, TablePropertiesUI ] as const;
 	}
 }

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
@@ -7,7 +7,7 @@
  * @module table/tableproperties/tablepropertiesediting
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { addBackgroundRules, addBorderRules, type ViewElement, type Conversion, type Schema } from 'ckeditor5/src/engine';
 
 import TableEditing from '../tableediting';
@@ -57,8 +57,8 @@ export default class TablePropertiesEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TableEditing ];
+	public static get requires() {
+		return [ TableEditing ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesui.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesui.ts
@@ -7,7 +7,7 @@
  * @module table/tableproperties/tablepropertiesui
  */
 
-import { type Editor, Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { type Editor, Plugin } from 'ckeditor5/src/core';
 import {
 	ButtonView,
 	ContextualBalloon,
@@ -87,8 +87,8 @@ export default class TablePropertiesUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ContextualBalloon ];
+	public static get requires() {
+		return [ ContextualBalloon ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tableselection.ts
+++ b/packages/ckeditor5-table/src/tableselection.ts
@@ -7,7 +7,7 @@
  * @module table/tableselection
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { type EventInfo, first } from 'ckeditor5/src/utils';
 
 import type {
@@ -46,8 +46,8 @@ export default class TableSelection extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ TableUtils, TableUtils ];
+	public static get requires() {
+		return [ TableUtils, TableUtils ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tabletoolbar.ts
+++ b/packages/ckeditor5-table/src/tabletoolbar.ts
@@ -7,7 +7,7 @@
  * @module table/tabletoolbar
  */
 
-import { Plugin, type PluginDependencies } from 'ckeditor5/src/core';
+import { Plugin } from 'ckeditor5/src/core';
 import { WidgetToolbarRepository } from 'ckeditor5/src/widget';
 import { getSelectedTableWidget, getTableWidgetAncestor } from './utils/ui/widget';
 
@@ -24,8 +24,8 @@ export default class TableToolbar extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ WidgetToolbarRepository ];
+	public static get requires() {
+		return [ WidgetToolbarRepository ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-typing/src/texttransformation.ts
+++ b/packages/ckeditor5-typing/src/texttransformation.ts
@@ -9,8 +9,7 @@
 
 import {
 	Plugin,
-	type Editor,
-	type PluginDependencies
+	type Editor
 } from '@ckeditor/ckeditor5-core';
 
 import type { Position } from '@ckeditor/ckeditor5-engine';
@@ -85,8 +84,8 @@ export default class TextTransformation extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ 'Delete', 'Input' ];
+	public static get requires() {
+		return [ 'Delete', 'Input' ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-typing/src/typing.ts
+++ b/packages/ckeditor5-typing/src/typing.ts
@@ -7,7 +7,7 @@
  * @module typing/typing
  */
 
-import { Plugin, type PluginDependencies } from '@ckeditor/ckeditor5-core';
+import { Plugin } from '@ckeditor/ckeditor5-core';
 import Input from './input';
 import Delete from './delete';
 
@@ -18,8 +18,8 @@ import Delete from './delete';
  * plugins.
  */
 export default class Typing extends Plugin {
-	public static get requires(): PluginDependencies {
-		return [ Input, Delete ];
+	public static get requires() {
+		return [ Input, Delete ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-ui/src/toolbar/balloon/balloontoolbar.ts
+++ b/packages/ckeditor5-ui/src/toolbar/balloon/balloontoolbar.ts
@@ -17,8 +17,7 @@ import type { EditorUIReadyEvent, EditorUIUpdateEvent } from '../../editorui/edi
 import {
 	Plugin,
 	type Editor,
-	type EditorReadyEvent,
-	type PluginDependencies
+	type EditorReadyEvent
 } from '@ckeditor/ckeditor5-core';
 
 import {
@@ -100,8 +99,8 @@ export default class BalloonToolbar extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ContextualBalloon ];
+	public static get requires() {
+		return [ ContextualBalloon ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-undo/src/undo.ts
+++ b/packages/ckeditor5-undo/src/undo.ts
@@ -7,7 +7,7 @@
  * @module undo/undo
  */
 
-import { Plugin, type PluginDependencies } from '@ckeditor/ckeditor5-core';
+import { Plugin } from '@ckeditor/ckeditor5-core';
 import UndoEditing from './undoediting';
 import UndoUI from './undoui';
 
@@ -112,8 +112,8 @@ export default class Undo extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ UndoEditing, UndoUI ];
+	public static get requires() {
+		return [ UndoEditing, UndoUI ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-upload/src/adapters/base64uploadadapter.ts
+++ b/packages/ckeditor5-upload/src/adapters/base64uploadadapter.ts
@@ -9,7 +9,7 @@
 
 /* globals window */
 
-import { Plugin, type PluginDependencies } from '@ckeditor/ckeditor5-core';
+import { Plugin } from '@ckeditor/ckeditor5-core';
 import FileRepository, { type UploadResponse, type FileLoader, type UploadAdapter } from '../filerepository';
 
 type DomFileReader = globalThis.FileReader;
@@ -28,8 +28,8 @@ export default class Base64UploadAdapter extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ FileRepository ];
+	public static get requires() {
+		return [ FileRepository ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-upload/src/adapters/simpleuploadadapter.ts
+++ b/packages/ckeditor5-upload/src/adapters/simpleuploadadapter.ts
@@ -9,7 +9,7 @@
 
 /* globals XMLHttpRequest, FormData */
 
-import { Plugin, type PluginDependencies } from '@ckeditor/ckeditor5-core';
+import { Plugin } from '@ckeditor/ckeditor5-core';
 import FileRepository, { type UploadResponse, type FileLoader, type UploadAdapter } from '../filerepository';
 import type { SimpleUploadConfig } from '../uploadconfig';
 import { logWarning } from '@ckeditor/ckeditor5-utils';
@@ -43,8 +43,8 @@ export default class SimpleUploadAdapter extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ FileRepository ];
+	public static get requires() {
+		return [ FileRepository ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-upload/src/filerepository.ts
+++ b/packages/ckeditor5-upload/src/filerepository.ts
@@ -10,8 +10,7 @@
 import {
 	Plugin,
 	PendingActions,
-	type PendingAction,
-	type PluginDependencies
+	type PendingAction
 } from '@ckeditor/ckeditor5-core';
 
 import {
@@ -104,8 +103,8 @@ export default class FileRepository extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ PendingActions ];
+	public static get requires() {
+		return [ PendingActions ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-widget/src/widget.ts
+++ b/packages/ckeditor5-widget/src/widget.ts
@@ -7,7 +7,7 @@
  * @module widget/widget
  */
 
-import { Plugin, type PluginDependencies } from '@ckeditor/ckeditor5-core';
+import { Plugin } from '@ckeditor/ckeditor5-core';
 
 import {
 	MouseObserver,
@@ -66,8 +66,8 @@ export default class Widget extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ WidgetTypeAround, Delete ];
+	public static get requires() {
+		return [ WidgetTypeAround, Delete ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-widget/src/widgettoolbarrepository.ts
+++ b/packages/ckeditor5-widget/src/widgettoolbarrepository.ts
@@ -10,7 +10,6 @@
 import {
 	Plugin,
 	type Editor,
-	type PluginDependencies,
 	type ToolbarConfigItem
 } from '@ckeditor/ckeditor5-core';
 
@@ -71,8 +70,8 @@ export default class WidgetToolbarRepository extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ ContextualBalloon ];
+	public static get requires() {
+		return [ ContextualBalloon ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-widget/src/widgettypearound/widgettypearound.ts
+++ b/packages/ckeditor5-widget/src/widgettypearound/widgettypearound.ts
@@ -9,11 +9,7 @@
  * @module widget/widgettypearound/widgettypearound
  */
 
-import {
-	Plugin,
-	type PluginDependencies,
-	type Editor
-} from '@ckeditor/ckeditor5-core';
+import { Plugin } from '@ckeditor/ckeditor5-core';
 
 import { Template } from '@ckeditor/ckeditor5-ui';
 
@@ -110,8 +106,8 @@ export default class WidgetTypeAround extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): PluginDependencies {
-		return [ Enter, Delete ];
+	public static get requires() {
+		return [ Enter, Delete ] as const;
 	}
 
 	/**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Remove return types from 'requires()' methods.

---

Edit by @filipsobol: See comment below for rationale.