### PR TITLE
CKE4:CKE5 comparison table in the migration guide

### DIFF
--- a/docs/updating/migration-from-ckeditor-4.md
+++ b/docs/updating/migration-from-ckeditor-4.md
@@ -19,7 +19,7 @@ What differentiates CKEditor 5 from its predecessor the most is its core archite
 Here are the key differences between the two editor versions:
 
 <figure class="table" style="width:100%;">
-    <table class="ck-table-resized">
+    <table>
         <tbody>
             <tr>
                 <td>

--- a/docs/updating/migration-from-ckeditor-4.md
+++ b/docs/updating/migration-from-ckeditor-4.md
@@ -14,15 +14,126 @@ When compared to its predecessor, CKEditor 5 should be considered **a totally ne
 There is no automatic solution for migrating. This section summarizes the most important aspects you need to consider before you proceed with moving to CKEditor 5.
 ## Differences between CKEditor 4 and CKEditor 5
 
+What differentiates CKEditor 5 from its predecessor the most is its core architecture. CKEditor 5 is a highly flexible and extensible editing framework with a powerful API. You can use it to create any WYSIWYG editor implementation, from a lightweight chat to a complex Google Docs-like solution. CKEditor 5 is also collaboration-ready and offers features such as real-time collaboration, comments, or track changes.
+
 Here are the key differences between the two editor versions:
 
-* CKEditor 5 is written in TypeScript/ES6.
-* CKEditor 5 has a custom data model and virtual DOM implementation. CKEditor 4 used to operate directly on HTML and DOM.
-* CKEditor 5 has an MVC architecture and the data is transformed between the model and the view in a process called conversion.
-* CKEditor 5 is collaboration-ready and offers features such as real-time collaboration, comments, or track changes.
-* CKEditor 5 is a highly flexible and extensible editing framework with a powerful API. You can use it to create any WYSIWYG editor implementation, from a lightweight chat to a complex Google Docs-like solution.
-* CKEditor 5 has a modern, lightweight UI. It does not use dialogs. Features are used through UI elements such as toolbar dropdowns or contextual feature toolbars.
-* CKEditor 5 is licensed under a GPL 2+ Open Source license while CKEditor 4 was available under GPL, MPL, and LGPL.
+<figure class="table" style="width:100%;">
+    <table class="ck-table-resized">
+        <tbody>
+            <tr>
+                <td>
+                    &nbsp;
+                </td>
+                <td>
+                    <strong>CKEditor 4</strong>
+                </td>
+                <td>
+                    <strong>CKEditor 5</strong>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <strong>Programming language</strong>
+                </td>
+                <td>
+                    JavaScript
+                </td>
+                <td>
+                    TypeScript
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <strong>Data model</strong>
+                </td>
+                <td>
+                    HTML/DOM
+                </td>
+                <td>
+                    Custom data model and virtual DOM implementation
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <strong>Architecture</strong>
+                </td>
+                <td>
+                    Plugin-based
+                </td>
+                <td>
+                    Plugin-based, MVC
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <strong>Collaboration-ready</strong>
+                </td>
+                <td>
+                    ❌
+                </td>
+                <td>
+                    ✅
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <strong>File management and image upload</strong>
+                </td>
+                <td>
+                    CKFinder, Easy Image
+                </td>
+                <td>
+                    CKBox, CKFinder, Easy Image
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <strong>UI</strong>
+                </td>
+                <td>
+                    Toolbar, dialogs, features manipulated through right-click context menu
+                </td>
+                <td>
+                    Toolbar, dropdowns, balloons, features manipulated through on-click feature toolbars
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <strong>UI customization</strong>
+                </td>
+                <td>
+                    Skins, UI color change
+                </td>
+                <td>
+                    Themes, customization with CSS variables
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <strong>Ready-to-use packages</strong>
+                </td>
+                <td>
+                    Basic, Standard, Full presets
+                </td>
+                <td>
+                    Classic, Document, Inline, Balloon, Balloon Block editor builds
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <strong>License</strong>
+                </td>
+                <td>
+                    GPL, MPL, LGPL, commercial license
+                </td>
+                <td>
+                    GPL 2+ or commercial license
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</figure>
 
 ## Feature comparison of CKEditor 4 and CKEditor 5
 

--- a/docs/updating/migration-from-ckeditor-4.md
+++ b/docs/updating/migration-from-ckeditor-4.md
@@ -65,6 +65,17 @@ Here are the key differences between the two editor versions:
                     Plugin-based, MVC
                 </td>
             </tr>
+			<tr>
+                <td>
+                    <strong>Editor types</strong>
+                </td>
+                <td>
+                    Classic, inline
+                </td>
+                <td>
+                    Classic, inline, decoupled (document), balloon, balloon block, multi-root
+                </td>
+            </tr>
             <tr>
                 <td>
                     <strong>Collaboration-ready</strong>
@@ -107,17 +118,6 @@ Here are the key differences between the two editor versions:
                 </td>
                 <td>
                     Themes, customization with CSS variables
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <strong>Ready-to-use packages</strong>
-                </td>
-                <td>
-                    Basic, Standard, Full presets
-                </td>
-                <td>
-                    Classic, Document, Inline, Balloon, Balloon Block editor builds
                 </td>
             </tr>
             <tr>
@@ -180,6 +180,8 @@ Check the {@link installation/plugins/plugins#creating-plugins Creating plugins}
 In CKEditor 5, the previous concept of "skins" was reviewed and is now called "themes".
 
 If you have custom skins for CKEditor 4, they need to be recreated for CKEditor 5. Fortunately, custom theming in CKEditor 5 is much more powerful and simpler than before.
+
+What's new: CKEditor 5 can also be used as a {@link framework/external-ui headless editor integrated with an external UI}, for example, built in React. Many projects use the powerful editing engine of CKEditor 5 coupled with their own UI for seamless integration with their application.
 
 For more information, check how to {@link framework/theme-customization customize the themes} in the CKEditor 5 Framework documentation.
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Added a CKE4:CKE5 comparison table to the migration guide. Closes cksource/ckeditor5-internal#2968.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._