### PR TITLE
Docs: Prevent showing scroll in mini-inspectors in upcast/downcast guides

### DIFF
--- a/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector.html
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/mini-inspector.html
@@ -19,6 +19,10 @@
 		--ck-inspector-code-font-family: Monaco, Menlo, Consolas, "Roboto Mono", "Courier New", "Ubuntu Mono", monospace;
 	}
 
+	.ck-inspector .ck-inspector-tree {
+		overflow: hidden;
+	}
+
 	.ck-inspector.ck-mini-inspector .ck-inspector-tree .ck-inspector-tree__position.ck-inspector-tree__position_selection {
 		display: none;
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Prevent showing scroll in mini-inspectors in upcast/downcast guides. Closes #12949.

---

### Additional information

Affected guides:
https://ckeditor.com/docs/ckeditor5/latest/framework/deep-dive/conversion/downcast.html
https://ckeditor.com/docs/ckeditor5/latest/framework/deep-dive/conversion/upcast.html
