### PR TITLE
Mentions should reexport MentionFeed and ItemRenderer

### DIFF
--- a/packages/ckeditor5-mention/src/index.ts
+++ b/packages/ckeditor5-mention/src/index.ts
@@ -11,7 +11,7 @@ export { default as Mention } from './mention';
 export { default as MentionEditing } from './mentionediting';
 export { default as MentionUI } from './mentionui';
 
-export type { MentionConfig } from './mentionconfig';
+export type { MentionConfig, MentionFeed, ItemRenderer } from './mentionconfig';
 export type { default as MentionCommand } from './mentioncommand';
 
 import './augmentation';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (mention): Mentions should reexport MentionFeed and ItemRenderer.

Closes #13705.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
