### PR TITLE
Allowed to easily set, change, save and load root attributes

### DIFF
--- a/packages/ckeditor5-core/src/editor/utils/dataapimixin.ts
+++ b/packages/ckeditor5-core/src/editor/utils/dataapimixin.ts
@@ -84,7 +84,7 @@ export interface DataApi {
 	 * editor.getData( { rootName: 'header' } ); // -> '<p>Content for header part.</p>'
 	 * ```
 	 *
-	 * By default the editor outputs HTML. This can be controlled by injecting a different data processor.
+	 * By default, the editor outputs HTML. This can be controlled by injecting a different data processor.
 	 * See the {@glink features/markdown Markdown output} guide for more details.
 	 *
 	 * A warning is logged when you try to retrieve data for a detached root, as most probably this is a mistake. A detached root should

--- a/packages/ckeditor5-editor-multi-root/src/augmentation.ts
+++ b/packages/ckeditor5-editor-multi-root/src/augmentation.ts
@@ -9,7 +9,7 @@ declare module '@ckeditor/ckeditor5-core' {
 	interface EditorConfig {
 
 		/**
-		 * Initial root attributes for the document roots.
+		 * Initial roots attributes for the document roots.
 		 *
 		 * **Note: This configuration option is supported only by the
 		 * {@link module:editor-multi-root/multirooteditor~MultiRootEditor multi-root} editor type.**
@@ -37,7 +37,7 @@ declare module '@ckeditor/ckeditor5-core' {
 		 * 	},
 		 * 	// Config:
 		 * 	{
-		 * 		rootAttributes: {
+		 * 		rootsAttributes: {
 		 * 			uid1: { order: 20, isLocked: false }, // Third, unlocked.
 		 * 			uid2: { order: 10, isLocked: true }, // Second, locked.
 		 * 			uid3: { order: 30, isLocked: true }, // Fourth, locked.
@@ -78,6 +78,6 @@ declare module '@ckeditor/ckeditor5-core' {
 		 * } );
 		 * ```
 		 */
-		rootAttributes?: Record<string, RootAttributes>;
+		rootsAttributes?: Record<string, RootAttributes>;
 	}
 }

--- a/packages/ckeditor5-editor-multi-root/src/augmentation.ts
+++ b/packages/ckeditor5-editor-multi-root/src/augmentation.ts
@@ -1,0 +1,78 @@
+import { type RootAttributes } from './multirooteditor';
+
+declare module '@ckeditor/ckeditor5-core' {
+	interface EditorConfig {
+
+		/**
+		 * Initial root attributes for the document roots.
+		 *
+		 * **Note: This configuration option is supported only by the
+		 * {@link module:editor-multi-root/multirooteditor~MultiRootEditor multi-root} editor type.**
+		 *
+		 * **Note: You must provide full set of attributes for each root. If an attribute is not set on a root, set the value to `null`.
+		 * Only provided attribute keys will be returned by
+		 * {@link module:editor-multi-root/multirooteditor~MultiRootEditor#getRootsAttributes}.**
+		 *
+		 * Roots attributes hold additional data related to the document roots, in addition to the regular document data (which usually is
+		 * HTML). In roots attributes, for each root, you can store arbitrary key-value pairs with attributes connected with that root.
+		 * Use it to store any custom data that is specific to your integration or custom features.
+		 *
+		 * Currently, roots attributes are not used only by any official plugins. This is a mechanism that is prepared for custom features
+		 * and non-standard integrations. If you do not provide any custom feature that would use root attributes, you do not need to
+		 * handle (save and load) this property.
+		 *
+		 * ```ts
+		 * MultiRootEditor.create(
+		 * 	// Roots for the editor:
+		 * 	{
+		 * 		uid1: document.querySelector( '#uid1' ),
+		 * 		uid2: document.querySelector( '#uid2' ),
+		 * 		uid3: document.querySelector( '#uid3' ),
+		 * 		uid4: document.querySelector( '#uid4' )
+		 * 	},
+		 * 	// Config:
+		 * 	{
+		 * 		rootAttributes: {
+		 * 			uid1: { order: 20, isLocked: false }, // Third, unlocked.
+		 * 			uid2: { order: 10, isLocked: true }, // Second, locked.
+		 * 			uid3: { order: 30, isLocked: true }, // Fourth, locked.
+		 * 			uid4: { order: 0, isLocked: false } // First, unlocked.
+		 * 		}
+		 * 	}
+		 * )
+		 * .then( ... )
+		 * .catch( ... );
+		 * ```
+		 *
+		 * Note, that the above code snippet is only an example. You need to implement your own features that will use these attributes.
+		 *
+		 * Roots attributes can be changed the same way as attributes set on other model nodes:
+		 *
+		 * ```ts
+		 * editor.model.change( writer => {
+		 * 	const root = editor.model.getRoot( 'uid3' );
+		 *
+		 * 	writer.setAttribute( 'order', 40, root );
+		 * } );
+		 * ```
+		 *
+		 * You can react to root attributes changes by listening to
+		 * {@link module:engine/model/document~Document#change:data document `change:data` event}:
+		 *
+		 * ```ts
+		 * editor.model.document.on( 'change:data', () => {
+		 * 	const changedRoots = editor.model.document.differ.getChangedRoots();
+		 *
+		 * 	for ( const change of changedRoots ) {
+		 * 		if ( change.attributes ) {
+		 * 			const root = editor.model.getRoot( change.name );
+		 *
+		 * 			// ...
+		 * 		}
+		 * 	}
+		 * } );
+		 * ```
+		 */
+		rootAttributes?: Record<string, RootAttributes>;
+	}
+}

--- a/packages/ckeditor5-editor-multi-root/src/augmentation.ts
+++ b/packages/ckeditor5-editor-multi-root/src/augmentation.ts
@@ -1,3 +1,8 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
 import { type RootAttributes } from './multirooteditor';
 
 declare module '@ckeditor/ckeditor5-core' {

--- a/packages/ckeditor5-editor-multi-root/src/index.ts
+++ b/packages/ckeditor5-editor-multi-root/src/index.ts
@@ -8,3 +8,5 @@
  */
 
 export { default as MultiRootEditor } from './multirooteditor';
+
+import './augmentation';

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -283,6 +283,8 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	 *
 	 * See also {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes `rootsAttributes` configuration option}.
 	 *
+	 * Note that attributes keys of attributes added in `attributes` option are also included in {@link #getRootsAttributes} return value.
+	 *
 	 * By setting `isUndoable` flag to `true`, you can allow for detaching the root using the undo feature.
 	 *
 	 * Additionally, you can group adding multiple roots in one undo step. This can be useful if you add multiple roots that are
@@ -308,6 +310,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 		{ data = '', attributes = {}, elementName = '$root', isUndoable = false }: AddRootOptions = {}
 	): void {
 		const dataController = this.data;
+		const registeredKeys = this._registeredRootsAttributesKeys;
 
 		if ( isUndoable ) {
 			this.model.change( _addRoot );
@@ -323,6 +326,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 			}
 
 			for ( const key of Object.keys( attributes ) ) {
+				registeredKeys.add( key );
 				writer.setAttribute( key, attributes[ key ], root );
 			}
 		}

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -135,6 +135,9 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 					/**
 					 * Trying to set attributes on a non-existing root.
 					 *
+					 * Roots specified in {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes} do not match initial
+					 * editor roots.
+					 *
 					 * @error multi-root-editor-root-attributes-no-root
 					 */
 					throw new CKEditorError( 'multi-root-editor-root-attributes-no-root', null );

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -74,7 +74,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	 * Holds attributes keys that were passed in {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes `rootsAttributes`}
 	 * config property and should be returned by {@link #getRootsAttributes}.
 	 */
-	private readonly _registeredRootsAttributesKeys: Set<string> = new Set();
+	private readonly _registeredRootsAttributesKeys = new Set<string>();
 
 	/**
 	 * Creates an instance of the multi-root editor.
@@ -701,15 +701,27 @@ export type DetachRootEvent = {
 
 /**
  * Additional options available when adding a root.
- *
- * @param data Initial data for the root.
- * @param elementName Element name for the root element in the model. It can be used to set different schema rules for different roots.
- * @param isUndoable Whether creating the root can be undone (using the undo feature) or not.
  */
 export type AddRootOptions = {
+
+	/**
+	 * Initial data for the root.
+	 */
 	data?: string;
+
+	/**
+	 * Initial attributes for the root.
+	 */
 	attributes?: RootAttributes;
+
+	/**
+	 * Element name for the root element in the model. It can be used to set different schema rules for different roots.
+	 */
 	elementName?: string;
+
+	/**
+	 * Whether creating the root can be undone (using the undo feature) or not.
+	 */
 	isUndoable?: boolean;
 };
 

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -150,10 +150,10 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 			}
 		} );
 
-		if ( this.config.get( 'rootAttributes' ) ) {
-			const rootAttributes = this.config.get( 'rootAttributes' )!;
+		if ( this.config.get( 'rootsAttributes' ) ) {
+			const rootsAttributes = this.config.get( 'rootsAttributes' )!;
 
-			for ( const attributes of Object.values( rootAttributes ) ) {
+			for ( const attributes of Object.values( rootsAttributes ) ) {
 				for ( const key of Object.keys( attributes ) ) {
 					this._registeredRootAttributes.add( key );
 				}
@@ -161,7 +161,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 
 			this.data.on( 'init', () => {
 				this.model.enqueueChange( { isUndoable: false }, writer => {
-					for ( const [ name, attributes ] of Object.entries( rootAttributes ) ) {
+					for ( const [ name, attributes ] of Object.entries( rootsAttributes ) ) {
 						const root = this.model.document.getRoot( name );
 
 						if ( !root ) {
@@ -281,7 +281,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	 * editor.addRoot( 'myRoot', { attributes: { isCollapsed: true, index: 4 } } );
 	 * ```
 	 *
-	 * See also {@link module:core/editor/editorconfig~EditorConfig#rootAttributes `rootAttributes` configuration option}.
+	 * See also {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes `rootsAttributes` configuration option}.
 	 *
 	 * By setting `isUndoable` flag to `true`, you can allow for detaching the root using the undo feature.
 	 *
@@ -449,7 +449,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	/**
 	 * Returns root attributes.
 	 *
-	 * See also {@link module:core/editor/editorconfig~EditorConfig#rootAttributes `rootAttributes` configuration option}.
+	 * See also {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes `rootsAttributes` configuration option}.
 	 *
 	 * @returns Root attributes.
 	 */

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
@@ -669,7 +669,7 @@ describe( 'MultiRootEditor', () => {
 		it( 'should throw when trying to set an attribute on non-existing root', done => {
 			MultiRootEditor.create( { foo: '', bar: '' }, {
 				rootAttributes: {
-					abc: { order: 10, isLocked: null },
+					abc: { order: 10, isLocked: null }
 				}
 			} ).then(
 				() => {

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
@@ -789,6 +789,31 @@ describe( 'MultiRootEditor', () => {
 
 			await editor.destroy();
 		} );
+
+		it( 'should return attributes added while adding roots', async () => {
+			// Empty multi-root, no roots, no roots attributes.
+			editor = await MultiRootEditor.create( {} );
+
+			editor.addRoot( 'foo', { attributes: { order: 10, isLocked: null } } );
+			editor.addRoot( 'bar', { attributes: { order: null, isLocked: true } } );
+
+			editor.model.change( writer => {
+				writer.setAttribute( 'order', 30, editor.model.document.getRoot( 'foo' ) );
+			} );
+
+			expect( editor.getRootsAttributes() ).to.deep.equal( {
+				bar: {
+					isLocked: true,
+					order: null
+				},
+				foo: {
+					isLocked: null,
+					order: 30
+				}
+			} );
+
+			await editor.destroy();
+		} );
 	} );
 
 	describe( 'destroy', () => {

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
@@ -645,10 +645,10 @@ describe( 'MultiRootEditor', () => {
 		} );
 	} );
 
-	describe( 'EditorConfig#rootAttributes', () => {
+	describe( 'EditorConfig#rootsAttributes', () => {
 		it( 'should load attributes from editor configuration', async () => {
 			editor = await MultiRootEditor.create( { foo: '', bar: '' }, {
-				rootAttributes: {
+				rootsAttributes: {
 					foo: { order: 10, isLocked: null },
 					bar: { order: null, isLocked: false }
 				}
@@ -668,7 +668,7 @@ describe( 'MultiRootEditor', () => {
 
 		it( 'should throw when trying to set an attribute on non-existing root', done => {
 			MultiRootEditor.create( { foo: '', bar: '' }, {
-				rootAttributes: {
+				rootsAttributes: {
 					abc: { order: 10, isLocked: null }
 				}
 			} ).then(
@@ -687,7 +687,7 @@ describe( 'MultiRootEditor', () => {
 	describe( '#getRootsAttributes()', () => {
 		it( 'should return current values of roots attributes', async () => {
 			editor = await MultiRootEditor.create( { foo: '', bar: '' }, {
-				rootAttributes: {
+				rootsAttributes: {
 					foo: { order: 10, isLocked: true },
 					bar: { order: 20, isLocked: false }
 				}
@@ -714,7 +714,7 @@ describe( 'MultiRootEditor', () => {
 
 		it( 'should not return roots attributes that were not specified in config', async () => {
 			editor = await MultiRootEditor.create( { foo: '', bar: '' }, {
-				rootAttributes: {
+				rootsAttributes: {
 					foo: { order: 10, isLocked: true },
 					bar: { order: 20, isLocked: false }
 				}
@@ -741,7 +741,7 @@ describe( 'MultiRootEditor', () => {
 
 		it( 'should properly handle null values', async () => {
 			editor = await MultiRootEditor.create( { foo: '', bar: '' }, {
-				rootAttributes: {
+				rootsAttributes: {
 					foo: { order: 10, isLocked: null },
 					bar: { order: null, isLocked: false }
 				}
@@ -767,7 +767,7 @@ describe( 'MultiRootEditor', () => {
 
 		it( 'should return attributes for all and only currently attached roots', async () => {
 			editor = await MultiRootEditor.create( { foo: '', bar: '' }, {
-				rootAttributes: {
+				rootsAttributes: {
 					foo: { order: 10, isLocked: true },
 					bar: { order: 20, isLocked: false }
 				}

--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -69,6 +69,7 @@ export { default as MarkerOperation } from './model/operation/markeroperation';
 export { default as OperationFactory } from './model/operation/operationfactory';
 export { default as AttributeOperation } from './model/operation/attributeoperation';
 export { default as RenameOperation } from './model/operation/renameoperation';
+export { default as RootAttributeOperation } from './model/operation/rootattributeoperation';
 export { transformSets } from './model/operation/transform';
 
 // Model.

--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -70,6 +70,7 @@ export { default as OperationFactory } from './model/operation/operationfactory'
 export { default as AttributeOperation } from './model/operation/attributeoperation';
 export { default as RenameOperation } from './model/operation/renameoperation';
 export { default as RootAttributeOperation } from './model/operation/rootattributeoperation';
+export { default as RootOperation } from './model/operation/rootoperation';
 export { transformSets } from './model/operation/transform';
 
 // Model.

--- a/packages/ckeditor5-engine/src/model/differ.ts
+++ b/packages/ckeditor5-engine/src/model/differ.ts
@@ -577,7 +577,7 @@ export default class Differ {
 	 * @returns Diff between the old and the new roots state.
 	 */
 	public getChangedRoots(): Array<DiffItemRoot> {
-		return Array.from( this._changedRoots.values() ).map( ( diffItem ) => {
+		return Array.from( this._changedRoots.values() ).map( diffItem => {
 			const entry = { ...diffItem };
 
 			if ( entry.state !== undefined ) {
@@ -646,7 +646,7 @@ export default class Differ {
 	 */
 	private _bufferRootAttributeChange( rootName: string, key: string, oldValue: unknown, newValue: unknown ): void {
 		const diffItem: DiffItemRoot = this._changedRoots.get( rootName ) || { name: rootName };
-		const attrs: Record<string, { oldValue: unknown, newValue: unknown }> = diffItem.attributes || {};
+		const attrs: Record<string, { oldValue: unknown; newValue: unknown }> = diffItem.attributes || {};
 
 		if ( attrs[ key ] ) {
 			// If this attribute or metadata was already changed earlier and is changed again, check to what value it is changed.
@@ -1438,7 +1438,7 @@ export interface DiffItemRoot {
 	 * Note, that if the root state changed (`state` is set), then `attributes` property will not be set. All attributes should be
 	 * handled together with the root being attached or detached.
 	 */
-	attributes?: Record<string, { oldValue: unknown, newValue: unknown }>;
+	attributes?: Record<string, { oldValue: unknown; newValue: unknown }>;
 }
 
 interface DiffItemInternal {

--- a/packages/ckeditor5-engine/src/model/node.ts
+++ b/packages/ckeditor5-engine/src/model/node.ts
@@ -87,7 +87,7 @@ export default abstract class Node extends TypeCheckable {
 	}
 
 	/**
-	 * Index of this node in it's parent or `null` if the node has no parent.
+	 * Index of this node in its parent or `null` if the node has no parent.
 	 *
 	 * Accessing this property throws an error if this node's parent element does not contain it.
 	 * This means that model tree got broken.
@@ -107,8 +107,8 @@ export default abstract class Node extends TypeCheckable {
 	}
 
 	/**
-	 * Offset at which this node starts in it's parent. It is equal to the sum of {@link #offsetSize offsetSize}
-	 * of all it's previous siblings. Equals to `null` if node has no parent.
+	 * Offset at which this node starts in its parent. It is equal to the sum of {@link #offsetSize offsetSize}
+	 * of all its previous siblings. Equals to `null` if node has no parent.
 	 *
 	 * Accessing this property throws an error if this node's parent element does not contain it.
 	 * This means that model tree got broken.

--- a/packages/ckeditor5-engine/src/model/operation/rootattributeoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/rootattributeoperation.ts
@@ -27,17 +27,13 @@ import { CKEditorError } from '@ckeditor/ckeditor5-utils';
 export default class RootAttributeOperation extends Operation {
 	/**
 	 * Root element to change.
-	 *
-	 * @readonly
 	 */
-	public root: RootElement;
+	public readonly root: RootElement;
 
 	/**
 	 * Key of an attribute to change or remove.
-	 *
-	 * @readonly
 	 */
-	public key: string;
+	public readonly key: string;
 
 	/**
 	 * Old value of the attribute with given key or `null` if adding a new attribute.

--- a/packages/ckeditor5-engine/src/model/operation/rootattributeoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/rootattributeoperation.ts
@@ -36,14 +36,14 @@ export default class RootAttributeOperation extends Operation {
 	public readonly key: string;
 
 	/**
-	 * Old value of the attribute with given key or `null` if adding a new attribute.
+	 * Old value of the attribute with given key or `null`, if attribute was not set before.
 	 *
 	 * @readonly
 	 */
 	public oldValue: unknown;
 
 	/**
-	 * New value to set for the attribute. If `null`, then the operation just removes the attribute.
+	 * New value of the attribute with given key or `null`, if operation should remove attribute.
 	 *
 	 * @readonly
 	 */
@@ -55,8 +55,8 @@ export default class RootAttributeOperation extends Operation {
 	 * @see module:engine/model/operation/attributeoperation~AttributeOperation
 	 * @param root Root element to change.
 	 * @param key Key of an attribute to change or remove.
-	 * @param oldValue Old value of the attribute with given key or `null` if adding a new attribute.
-	 * @param newValue New value to set for the attribute. If `null`, then the operation just removes the attribute.
+	 * @param oldValue Old value of the attribute with given key or `null`, if attribute was not set before.
+	 * @param newValue New value of the attribute with given key or `null`, if operation should remove attribute.
 	 * @param baseVersion Document {@link module:engine/model/document~Document#version} on which operation
 	 * can be applied or `null` if the operation operates on detached (non-document) tree.
 	 */
@@ -71,8 +71,8 @@ export default class RootAttributeOperation extends Operation {
 
 		this.root = root;
 		this.key = key;
-		this.oldValue = oldValue;
-		this.newValue = newValue;
+		this.oldValue = oldValue === undefined ? null : oldValue;
+		this.newValue = newValue === undefined ? null : newValue;
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/model/writer.ts
+++ b/packages/ckeditor5-engine/src/model/writer.ts
@@ -1392,6 +1392,11 @@ export default class Writer {
 			}
 		}
 
+		// Remove all attributes from the root.
+		for ( const key of root.getAttributeKeys() ) {
+			this.removeAttribute( key, root );
+		}
+
 		// Remove all contents of the root.
 		this.remove( this.createRangeIn( root ) );
 

--- a/packages/ckeditor5-engine/src/model/writer.ts
+++ b/packages/ckeditor5-engine/src/model/writer.ts
@@ -630,7 +630,7 @@ export default class Writer {
 	 * writer.move( sourceRange, image, 'after' );
 	 * ```
 	 *
-	 * These parameters works the same way as {@link #createPositionAt `writer.createPositionAt()`}.
+	 * These parameters work the same way as {@link #createPositionAt `writer.createPositionAt()`}.
 	 *
 	 * Note that items can be moved only within the same tree. It means that you can move items within the same root
 	 * (element or document fragment) or between {@link module:engine/model/document~Document#roots documents roots},

--- a/packages/ckeditor5-engine/tests/model/differ.js
+++ b/packages/ckeditor5-engine/tests/model/differ.js
@@ -1804,8 +1804,8 @@ describe( 'Differ', () => {
 
 				const rootChanges = differ.getChangedRoots();
 
-				expect( rootChanges.get( 'new' ) ).to.be.true;
-				expect( rootChanges.size ).to.equal( 1 );
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( { name: 'new', state: 'attached' } );
 				expect( differ.hasDataChanges() ).to.be.true;
 				expect( differ.isEmpty ).to.be.false;
 			} );
@@ -1817,8 +1817,8 @@ describe( 'Differ', () => {
 
 				const rootChanges = differ.getChangedRoots();
 
-				expect( rootChanges.get( 'main' ) ).to.be.false;
-				expect( rootChanges.size ).to.equal( 1 );
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( { name: 'main', state: 'detached' } );
 				expect( differ.hasDataChanges() ).to.be.true;
 				expect( differ.isEmpty ).to.be.false;
 			} );
@@ -1830,7 +1830,7 @@ describe( 'Differ', () => {
 				writer.detachRoot( 'new' );
 
 				let rootChanges = differ.getChangedRoots();
-				expect( rootChanges.size ).to.equal( 0 );
+				expect( rootChanges.length ).to.equal( 0 );
 				expect( differ.hasDataChanges() ).to.be.false;
 				expect( differ.isEmpty ).to.be.true;
 
@@ -1838,8 +1838,8 @@ describe( 'Differ', () => {
 
 				rootChanges = differ.getChangedRoots();
 
-				expect( rootChanges.get( 'new' ) ).to.be.true;
-				expect( rootChanges.size ).to.equal( 1 );
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( { name: 'new', state: 'attached' } );
 				expect( differ.hasDataChanges() ).to.be.true;
 				expect( differ.isEmpty ).to.be.false;
 			} );
@@ -1850,7 +1850,7 @@ describe( 'Differ', () => {
 				writer.addRoot( 'new' );
 			} );
 
-			expect( differ.getChangedRoots().size ).to.equal( 0 );
+			expect( differ.getChangedRoots().length ).to.equal( 0 );
 			expect( differ.hasDataChanges() ).to.be.false;
 			expect( differ.isEmpty ).to.be.true;
 		} );
@@ -1867,7 +1867,7 @@ describe( 'Differ', () => {
 				writer.addRoot( 'main2' );
 
 				let rootChanges = differ.getChangedRoots();
-				expect( rootChanges.size ).to.equal( 0 );
+				expect( rootChanges.length ).to.equal( 0 );
 				expect( differ.hasDataChanges() ).to.be.false;
 				expect( differ.isEmpty ).to.be.true;
 
@@ -1875,14 +1875,14 @@ describe( 'Differ', () => {
 
 				rootChanges = differ.getChangedRoots();
 
-				expect( rootChanges.get( 'main2' ) ).to.be.false;
-				expect( rootChanges.size ).to.equal( 1 );
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( { name: 'main2', state: 'detached' } );
 				expect( differ.hasDataChanges() ).to.be.true;
 				expect( differ.isEmpty ).to.be.false;
 			} );
 		} );
 
-		it( 'multiple roots added and removed', () => {
+		it( 'multiple roots added and detached', () => {
 			// Add extra root to have more things to remove.
 			model.change( writer => {
 				writer.addRoot( 'main2' );
@@ -1896,10 +1896,282 @@ describe( 'Differ', () => {
 
 				const rootChanges = differ.getChangedRoots();
 
-				expect( rootChanges.size ).to.equal( 4 );
-				expect( rootChanges.get( 'main' ) ).to.be.false;
+				expect( rootChanges.length ).to.equal( 4 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( { name: 'new', state: 'attached' } );
+				expect( rootChanges[ 1 ] ).to.deep.equal( { name: 'main', state: 'detached' } );
+				expect( rootChanges[ 2 ] ).to.deep.equal( { name: 'main2', state: 'detached' } );
+				expect( rootChanges[ 3 ] ).to.deep.equal( { name: 'new2', state: 'attached' } );
 				expect( differ.hasDataChanges() ).to.be.true;
 				expect( differ.isEmpty ).to.be.false;
+			} );
+		} );
+
+		it( 'add attribute', () => {
+			const root = model.document.getRoot();
+
+			model.change( writer => {
+				writer.setAttribute( 'key', 'foo', root );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( { name: 'main', attributes: { key: { oldValue: null, newValue: 'foo' } } } );
+				expect( differ.hasDataChanges() ).to.be.true;
+				expect( differ.isEmpty ).to.be.false;
+			} );
+		} );
+
+		it( 'remove attribute', () => {
+			const root = model.document.getRoot();
+
+			model.change( writer => {
+				writer.setAttribute( 'key', 'foo', root );
+			} );
+
+			model.change( writer => {
+				writer.removeAttribute( 'key', root );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( { name: 'main', attributes: { key: { oldValue: 'foo', newValue: null } } } );
+				expect( differ.hasDataChanges() ).to.be.true;
+				expect( differ.isEmpty ).to.be.false;
+			} );
+		} );
+
+		it( 'change attribute', () => {
+			const root = model.document.getRoot();
+
+			model.change( writer => {
+				writer.setAttribute( 'key', 'foo', root );
+			} );
+
+			model.change( writer => {
+				writer.setAttribute( 'key', 'bar', root );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( { name: 'main', attributes: { key: { oldValue: 'foo', newValue: 'bar' } } } );
+				expect( differ.hasDataChanges() ).to.be.true;
+				expect( differ.isEmpty ).to.be.false;
+			} );
+		} );
+
+		it( 'add then remove attribute', () => {
+			const root = model.document.getRoot();
+
+			model.change( writer => {
+				writer.setAttribute( 'key', 'foo', root );
+				writer.removeAttribute( 'key', root );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 0 );
+				expect( differ.hasDataChanges() ).to.be.false;
+				expect( differ.isEmpty ).to.be.true;
+			} );
+		} );
+
+		it( 'add then change attribute', () => {
+			const root = model.document.getRoot();
+
+			model.change( writer => {
+				writer.setAttribute( 'key', 'foo', root );
+				writer.setAttribute( 'key', 'bar', root );
+				writer.setAttribute( 'key', 'baz', root );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( { name: 'main', attributes: { key: { oldValue: null, newValue: 'baz' } } } );
+				expect( differ.hasDataChanges() ).to.be.true;
+				expect( differ.isEmpty ).to.be.false;
+			} );
+		} );
+
+		it( 'change then change back attribute', () => {
+			const root = model.document.getRoot();
+
+			model.change( writer => {
+				writer.setAttribute( 'key', 'foo', root );
+			} );
+
+			model.change( writer => {
+				writer.setAttribute( 'key', 'bar', root );
+				writer.setAttribute( 'key', 'foo', root );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 0 );
+				expect( differ.hasDataChanges() ).to.be.false;
+				expect( differ.isEmpty ).to.be.true;
+			} );
+		} );
+
+		it( 'change multiple attributes', () => {
+			const root = model.document.getRoot();
+
+			model.change( writer => {
+				writer.setAttribute( 'key', 'foo', root );
+			} );
+
+			model.change( writer => {
+				writer.setAttribute( 'key', 'bar', root );
+				writer.setAttribute( 'abc', 'xyz', root );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( {
+					name: 'main',
+					attributes: {
+						abc: { oldValue: null, newValue: 'xyz' },
+						key: { oldValue: 'foo', newValue: 'bar' }
+					}
+				} );
+			} );
+		} );
+
+		it( 'change attributes on added root', () => {
+			model.change( writer => {
+				const root = writer.addRoot( 'root' );
+
+				writer.setAttribute( 'key', 'foo', root );
+				writer.setAttribute( 'abc', 'xyz', root );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( {
+					name: 'root',
+					state: 'attached'
+				} );
+			} );
+		} );
+
+		it( 'change attributes on detached root', () => {
+			const root = model.document.getRoot();
+
+			model.change( writer => {
+				writer.setAttribute( 'key', 'foo', root );
+			} );
+
+			model.change( writer => {
+				writer.detachRoot( root );
+
+				writer.removeAttribute( 'key', root );
+				writer.setAttribute( 'abc', 'xyz', root );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( {
+					name: 'main',
+					state: 'detached'
+				} );
+			} );
+		} );
+
+		it( 'change attribute then attach root', () => {
+			const root = model.document.getRoot();
+
+			model.change( writer => {
+				writer.detachRoot( root );
+			} );
+
+			model.change( writer => {
+				writer.setAttribute( 'foo', 'bar', root );
+				writer.addRoot( 'main' );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( {
+					name: 'main',
+					state: 'attached'
+				} );
+			} );
+		} );
+
+		it( 'change attribute then detach root', () => {
+			const root = model.document.getRoot();
+
+			model.change( writer => {
+				writer.setAttribute( 'foo', 'bar', root );
+				writer.detachRoot( root );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( {
+					name: 'main',
+					state: 'detached'
+				} );
+			} );
+		} );
+
+		it( 'change attributes on detached and then re-attached root', () => {
+			const root = model.document.getRoot();
+
+			model.change( writer => {
+				writer.setAttribute( 'key', 'foo', root );
+			} );
+
+			model.change( writer => {
+				writer.detachRoot( root );
+
+				writer.removeAttribute( 'key', root );
+				writer.setAttribute( 'abc', 'xyz', root );
+
+				writer.addRoot( 'main' );
+
+				writer.setAttribute( 'abc', 'abc', root );
+				writer.setAttribute( 'xxx', 'yyy', root );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( {
+					name: 'main',
+					attributes: {
+						abc: { oldValue: null, newValue: 'abc' },
+						key: { oldValue: 'foo', newValue: null },
+						xxx: { oldValue: null, newValue: 'yyy' }
+					}
+				} );
+			} );
+		} );
+
+		it( 'change attributes on multiple roots', () => {
+			const root = model.document.getRoot();
+			let root2;
+
+			model.change( writer => {
+				writer.setAttribute( 'key', 'foo', root );
+				root2 = writer.addRoot( 'root' );
+			} );
+
+			model.change( writer => {
+				writer.removeAttribute( 'key', root );
+				writer.setAttribute( 'abc', 'xyz', root2 );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 2 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( {
+					name: 'main',
+					attributes: {
+						key: { oldValue: 'foo', newValue: null }
+					}
+				} );
+				expect( rootChanges[ 1 ] ).to.deep.equal( {
+					name: 'root',
+					attributes: {
+						abc: { oldValue: null, newValue: 'xyz' }
+					}
+				} );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-engine/tests/model/operation/rootattributeoperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/rootattributeoperation.js
@@ -105,6 +105,19 @@ describe( 'RootAttributeOperation', () => {
 		expect( root.hasAttribute( 'x' ) ).to.be.false;
 	} );
 
+	it( 'should set oldValue and newValue to null if undefined was passed', () => {
+		const op = new RootAttributeOperation(
+			root,
+			'x',
+			undefined,
+			undefined,
+			doc.version
+		);
+
+		expect( op.oldValue ).to.be.null;
+		expect( op.newValue ).to.be.null;
+	} );
+
 	it( 'should create a RootAttributeOperation as a reverse', () => {
 		const operation = new RootAttributeOperation( root, 'x', 'old', 'new', doc.version );
 		const reverse = operation.getReversed();

--- a/packages/ckeditor5-engine/tests/model/writer.js
+++ b/packages/ckeditor5-engine/tests/model/writer.js
@@ -2654,13 +2654,15 @@ describe( 'Writer', () => {
 	} );
 
 	describe( 'detachRoot()', () => {
-		it( 'should detach the root from the model and remove all children and markers from it', () => {
+		it( 'should detach the root from the model and remove all children, attributes and markers from it', () => {
 			let root, p;
 
 			model.change( writer => {
 				root = writer.addRoot( 'new' );
 				p = writer.createElement( 'paragraph' );
 				writer.insert( p, root, 0 );
+				writer.setAttribute( 'foo', true, root );
+				writer.setAttribute( 'bar', false, root );
 				writer.addMarker( 'newMarker', { usingOperation: true, affectsData: true, range: writer.createRangeIn( root ) } );
 			} );
 
@@ -2670,6 +2672,7 @@ describe( 'Writer', () => {
 
 			expect( root.isAttached() ).to.be.false;
 			expect( root.isEmpty );
+			expect( Array.from( root.getAttributes() ).length ).to.equal( 0 );
 			expect( p.parent.rootName ).to.equal( '$graveyard' );
 			expect( model.markers.get( 'newMarker' ) ).to.be.null;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (engine): `RootAttributeOperation` is now correctly handled by `Differ`. Root attribute changes will be returned in `Differ#getChangedRoots()`.

Internal (editor-multi-root): Introduced API to easily save and load root attributes. Introduced `EditorConfig#rootsAttributes` and `MultiRootEditor#getRootsAttributes()`. Closes #13395.

Internal (editor-multi-root): Introduced `MultiRootEditor#getFullData()`. The method returns document data for all roots in multi-root editor.

Internal (editor-multi-root): `MultiRootEditor#addRoot()` has a new option `attributes`.

Internal (engine): `model.Writer#detachRoot()` will now remove attributes from the detached root.

---

### Additional information

Most things as internal because the changes will be in the changelog as "introduced multi-root editor type".

See https://github.com/ckeditor/ckeditor5/issues/13395#issuecomment-1484150081 for summary of proposed solution.