### PR TITLE
Fix handling of bold text in RTL lists.

### DIFF
--- a/packages/ckeditor5-paste-from-office/src/filters/list.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/list.ts
@@ -261,7 +261,7 @@ function findListMarkerNode( element: ViewElement ): ViewText | null {
 			continue;
 		}
 
-		const textNodeOrElement = childNode.getChild( 0 )!;
+		const textNodeOrElement = childNode.getChild( 0 );
 
 		if ( !textNodeOrElement ) {
 			continue;

--- a/packages/ckeditor5-paste-from-office/src/filters/list.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/list.ts
@@ -263,6 +263,10 @@ function findListMarkerNode( element: ViewElement ): ViewText | null {
 
 		const textNodeOrElement = childNode.getChild( 0 )!;
 
+		if ( !textNodeOrElement ) {
+			continue;
+		}
+
 		// If already found the marker element, use it.
 		if ( textNodeOrElement.is( '$text' ) ) {
 			return textNodeOrElement;

--- a/packages/ckeditor5-paste-from-office/tests/filters/list.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/list.js
@@ -82,6 +82,28 @@ describe( 'PasteFromOffice - filters', () => {
 				expect( stringify( view ) ).to.equal( '' );
 			} );
 
+			it( 'handles RTL lists with bold item - #13711', () => {
+				const html = '<p dir=RTL style="mso-list:l0 level1 lfo1">' +
+					'<span dir=RTL></span>' +
+					'<b><span dir=LTR>Foo<o:p></o:p></span></b>' +
+				'</p>';
+
+				const view = htmlDataProcessor.toView( html );
+
+				transformListItemLikeElementsIntoLists( view, '@list l0:level1 { mso-level-number-format: bullet; }' );
+
+				expect( view.childCount ).to.equal( 1 );
+				expect( view.getChild( 0 ).name ).to.equal( 'ul' );
+				expect( stringify( view ) ).to.equal(
+					'<ul>' +
+						'<li dir="RTL" style="mso-list:l0 level1 lfo1">' +
+							'<span dir="RTL"></span>' +
+							'<b><span dir="LTR">Foo<o:p></o:p></span></b>' +
+						'</li>' +
+					'</ul>'
+				);
+			} );
+
 			describe( 'nesting', () => {
 				const level1 = 'style="mso-list:l0 level1 lfo0"';
 				const level2 = 'style="mso-list:l0 level2 lfo0"';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (paste-from-office): Fix handling of bold text in RTL lists pasted from MS Word. Closes #13711.

