### PR TITLE
Internal: Removed 'explicit-module-boundary-types' rule from eslintrc.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,18 +27,6 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '**/*.ts' ],
-			rules: {
-				'@typescript-eslint/explicit-module-boundary-types': [
-					'error',
-					{
-						'allowedNames': [ 'requires' ],
-						'allowArgumentsExplicitlyTypedAsAny': true
-					}
-				]
-			}
-		},
-		{
 			files: [ '**/tests/**/*.js' ],
 			rules: {
 				'no-unused-expressions': 'off',

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "coveralls": "^3.1.0",
     "css-loader": "^5.2.7",
     "eslint": "^7.19.0",
-    "eslint-config-ckeditor5": "^4.1.1",
+    "eslint-config-ckeditor5": "^4.2.1",
     "glob": "^7.1.6",
     "http-server": "^14.1.1",
     "husky": "^8.0.2",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Removed 'explicit-module-boundary-types' rule from .eslintrc.js.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._