### PR TITLE
Remove underscore from _updateEditorData method name and make it public.

### DIFF
--- a/packages/ckeditor5-source-editing/src/sourceediting.ts
+++ b/packages/ckeditor5-source-editing/src/sourceediting.ts
@@ -9,7 +9,7 @@
 
 /* global console */
 
-import { type ContextPluginDependencies, type Editor, Plugin, PendingActions } from 'ckeditor5/src/core';
+import { type Editor, Plugin, PendingActions } from 'ckeditor5/src/core';
 import { ButtonView } from 'ckeditor5/src/ui';
 import { createElement, ElementReplacer } from 'ckeditor5/src/utils';
 import { formatHtml } from './utils/formathtml';
@@ -38,7 +38,7 @@ export default class SourceEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public static get requires(): ContextPluginDependencies {
+	public static get requires() {
 		return [ PendingActions ] as const;
 	}
 

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -514,6 +514,22 @@ describe( 'SourceEditing', () => {
 		} );
 	} );
 
+	describe( 'updateEditorData', () => {
+		it( 'should update editor model when called', () => {
+			button.fire( 'execute' );
+
+			const domRoot = editor.editing.view.getDomRoot();
+			const textarea = domRoot.nextSibling.children[ 0 ];
+
+			textarea.value = 'bar';
+			textarea.dispatchEvent( new Event( 'input' ) );
+
+			expect( getData( editor.model, { withoutSelection: true } ) ).to.equal( '<paragraph>Foo</paragraph>' );
+			plugin.updateEditorData();
+			expect( getData( editor.model, { withoutSelection: true } ) ).to.equal( '<paragraph>bar</paragraph>' );
+		} );
+	} );
+
 	describe( 'integration with undo', () => {
 		it( 'should preserve the undo/redo stacks when no changes has been in the source editing mode', () => {
 			editor.model.change( writer => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (source-editing): Remove the underscore from `_updateEditorData` method name and make it public. Closes #11008.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
