### PR TITLE
Pressing Shift+Enter in Safari should fire soft enter event

### DIFF
--- a/packages/ckeditor5-enter/package.json
+++ b/packages/ckeditor5-enter/package.json
@@ -13,7 +13,8 @@
   "main": "src/index.ts",
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^36.0.1",
-    "@ckeditor/ckeditor5-engine": "^36.0.1"
+    "@ckeditor/ckeditor5-engine": "^36.0.1",
+    "@ckeditor/ckeditor5-utils": "^36.0.1"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "^36.0.1",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (enter): Pressing <kbd>Shift</kbd>+<kbd>Enter</kbd> in Safari should insert `<br>` instead of splitting block. Closes #13321.

---

### Additional information


