### PR TITLE
docs (engine): Small typo

### DIFF
--- a/packages/ckeditor5-engine/src/model/markercollection.ts
+++ b/packages/ckeditor5-engine/src/model/markercollection.ts
@@ -279,7 +279,7 @@ export interface MarkerData {
 }
 
 /**
- * `Marker` is a continuous parts of model (like a range), is named and represent some kind of information about marked
+ * `Marker` is a continuous part of model (like a range), is named and represent some kind of information about marked
  * part of model document. In contrary to {@link module:engine/model/node~Node nodes}, which are building blocks of
  * model document tree, markers are not stored directly in document tree but in
  * {@link module:engine/model/model~Model#markers model markers' collection}. Still, they are document data, by giving


### PR DESCRIPTION
Type: Doc fix. Closes #000.

---

### Additional information

Did not include a issue due to it being a typo

Related area of docs:

https://github.com/ckeditor/ckeditor5/blob/6325b271765d14ffc3921cd0a012edd2dc423848/packages/ckeditor5-engine/src/model/markercollection.ts#L282