### PR TITLE
Remove italic style from TextPartLanguage feature.

### DIFF
--- a/packages/ckeditor5-language/src/textpartlanguageui.ts
+++ b/packages/ckeditor5-language/src/textpartlanguageui.ts
@@ -13,8 +13,6 @@ import { Collection } from 'ckeditor5/src/utils';
 import { stringifyLanguageAttribute } from './utils';
 import type TextPartLanguageCommand from './textpartlanguagecommand';
 
-import '../theme/language.css';
-
 /**
  * The text part language UI plugin.
  *

--- a/packages/ckeditor5-language/tests/manual/textpartlanguage-italic.html
+++ b/packages/ckeditor5-language/tests/manual/textpartlanguage-italic.html
@@ -1,0 +1,33 @@
+<style>
+	.ck-content span[lang] {
+		font-style: italic;
+	}
+</style>
+
+<div id="editor">
+	<p>
+		<strong>Language</strong> is the human ability to acquire and use complex systems of communication,
+		and a language is any specific example of such a system. The scientific study of <strong>language</strong>
+		is called linguistics.
+	</p>
+	<p>
+		<span lang="es" dir="ltr">
+			<strong>Un lenguaje</strong> (del provenzal lenguatge y este del latín lingua) es un sistema de comunicación
+			estructurado para el que existe un contexto de uso y ciertos principios combinatorios formales. Existen
+			<strong>contextos</strong> tanto naturales como artificiales.
+		</span>
+	</p>
+	<p>
+		<span lang="ar" dir="rtl">
+			اللغة نسق من الإشارات والرموز، يشكل أداة من أدوات المعرفة، وتعتبر اللغة أهم <strong>وسائل</strong> التفاهم
+			والاحتكاك بين أفراد امجتمع في <strong>جميع</strong> ميادين الحياة. وبدون اللغة يتعذر نشاط الناس المعرفي.
+		</span>
+	</p>
+	<p>
+		<span lang="fr" dir="ltr">
+			<strong>La langue</strong> est la capacité humaine à acquérir et à utiliser des systèmes complexes de communication,
+			et une langue est un exemple spécifique d'un tel système. L'étude scientifique de la langue
+			<strong>s'appelle</strong> la linguistique.
+		</span>
+	</p>
+</div>

--- a/packages/ckeditor5-language/tests/manual/textpartlanguage-italic.js
+++ b/packages/ckeditor5-language/tests/manual/textpartlanguage-italic.js
@@ -1,0 +1,26 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global document, console, window */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import TextPartLanguage from '../../src/textpartlanguage';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
+		plugins: [
+			ArticlePluginSet,
+			TextPartLanguage
+		],
+		toolbar: [ 'textPartLanguage', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote', 'undo', 'redo' ]
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-language/tests/manual/textpartlanguage-italic.md
+++ b/packages/ckeditor5-language/tests/manual/textpartlanguage-italic.md
@@ -1,6 +1,6 @@
-## Text part language feature
+## Text part language feature - previous italic behavior.
 
-1. The data should be loaded with four paragraph.
+1. The data should be loaded with four paragraph. Each paragraph style with applied language should be italic.
 2. Put selection in each paragraph and check if language dropdown label is changing properly.
 3. Play with languages:
 	* Change language of the text selection.

--- a/packages/ckeditor5-language/theme/language.css
+++ b/packages/ckeditor5-language/theme/language.css
@@ -1,8 +1,0 @@
-/*
- * Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
- * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
- */
-
-.ck-content span[lang] {
-	font-style: italic;
-}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (language): TextPartLanguage doesn't style text as italic when language is set. Closes #12672.

MINOR BREAKING CHANGE (language): Text with language set is no longer styled as italic. To re-enable previous behavior, add style `.ck-content span[lang] { font-style: italic;  }` to your css.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._