### PR TITLE
Update CKEditor 5 descriptions to reflect the fact that now CKEditor 5 is built using TS not ES6

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,34 +9,38 @@ CKEditor 5 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?styl
 [![Join newsletter](https://img.shields.io/badge/join-newsletter-00cc99.svg)](http://eepurl.com/c3zRPr)
 [![Follow twitter](https://img.shields.io/badge/follow-twitter-00cc99.svg)](https://twitter.com/ckeditor)
 
-CKEditor 5 is an ultra-modern JavaScript rich text editor with MVC architecture, custom data model and virtual DOM. It is written from scratch in ES6 and has excellent webpack support. It provides every type of WYSIWYG editing solution imaginable with extensive collaboration support. From editors similar to Google Docs and Medium, to Slack or Twitter like applications, all of which is possible within a single editing framework. As a market leader, it is constantly expanded and updated.
+CKEditor 5 is an ultra-modern JavaScript rich-text editor with MVC architecture, a custom data model, and virtual DOM. It is written from scratch in TypeScript and has excellent webpack and Vite support. It provides every type of WYSIWYG editing solution imaginable with extensive collaboration support. From editors similar to Google Docs and Medium to Slack or Twitter-like applications, all is possible within a single editing framework. As a market leader, it is constantly expanded and updated.
 
 ![A composition of screenshots presenting various features of CKEditor 5 rich text editor](https://user-images.githubusercontent.com/1099479/179190754-f4aaf2b3-21cc-49c4-a454-8de4a00cc70e.jpg)
 
 ## Table of contents
 
-* [Quick start](#quick-start)
-   * [CKEditor 5 Online builder](#ckeditor-5-online-builder)
-   * [CKEditor 5 predefined builds](#ckeditor-5-predefined-builds)
-   * [Other CKEditor 5 installation methods](#ckeditor-5-advanced-installation)
-* [Documentation and FAQ](#documentation-and-faq)
-* [Releases](#releases)
-* [CKEditor 5 features](#editing-and-collaboration-features)
-* [Contributing and project organization](#contributing-and-project-organization)
-   * [Ideas and discussions](#ideas-and-discussions)
-   * [Development](#development)
-   * [Reporting issues and feature requests](#reporting-issues-and-feature-requests)
-* [License](#license)
+- [CKEditor 5 ](#ckeditor-5-)
+	- [Table of contents](#table-of-contents)
+	- [Quick start](#quick-start)
+		- [CKEditor 5 online builder](#ckeditor-5-online-builder)
+		- [CKEditor 5 predefined builds](#ckeditor-5-predefined-builds)
+			- [Example installation](#example-installation)
+		- [CKEditor 5 advanced installation](#ckeditor-5-advanced-installation)
+			- [CKEditor 5 Framework](#ckeditor-5-framework)
+	- [Documentation and FAQ](#documentation-and-faq)
+	- [Releases](#releases)
+	- [Editing and collaboration features](#editing-and-collaboration-features)
+	- [Contributing and project organization](#contributing-and-project-organization)
+		- [Ideas and discussions](#ideas-and-discussions)
+		- [Development](#development)
+		- [Reporting issues and feature requests](#reporting-issues-and-feature-requests)
+	- [License](#license)
 
 ## Quick start
 
-### CKEditor 5 Online builder
+### CKEditor 5 online builder
 
-The easies way to start using CKEditor 5 with all the functions and features you need, is preparing a customized build with the [Online builder](https://ckeditor.com/ckeditor-5/online-builder/). All you need to do is choose the preferred predefined build as a base, add all the required plugins and download the ready package that can be then used out of the box. Refer to the [Online builder Quick start](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/quick-start.html#creating-custom-builds-with-online-builder) guide to follow this installation path.
+The easiest way to start using CKEditor 5 with all the features you need, is to prepare a customized build with the [online builder](https://ckeditor.com/ckeditor-5/online-builder/). All you need to do is choose the preferred predefined build as a base, add all the required plugins, and download the ready-to-use package. Refer to the [Online builder Quick start](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/quick-start.html#creating-custom-builds-with-online-builder) guide to follow this installation path.
 
 ### CKEditor 5 predefined builds
 
-CKEditor 5 predefined builds are a set of ready-to-use rich text editors. Every such build provides a single type of editor with a set of features and a default configuration.
+CKEditor 5 predefined builds are a set of ready-to-use rich text editors. Every build provides a single type of editor with a set of features and a default configuration.
 
 The following CKEditor 5 predefined builds are currently available:
 
@@ -53,13 +57,13 @@ Creating an editor using a CKEditor 5 build is very simple and can be described 
 1. Load the desired editor via the `<script>` tag.
 2. Call the static `create()` method to create the editor.
 
-In your HTML page add an element that CKEditor should replace:
+In your HTML page, add an element that CKEditor should replace:
 
 ```html
 <div id="editor"></div>
 ```
 
-Load the classic editor build (you can choose between [CDN](https://cdn.ckeditor.com/#ckeditor5), [npm](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/predefined-builds.html#npm) and [zip downloads](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/predefined-builds.html#zip-download)):
+Load the classic editor build (you can choose between the [CDN](https://cdn.ckeditor.com/#ckeditor5), [npm](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/predefined-builds.html#npm), and [zip downloads](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/predefined-builds.html#zip-download)):
 
 ```html
 <script src="https://cdn.ckeditor.com/ckeditor5/36.0.1/classic/ckeditor.js"></script>
@@ -79,28 +83,34 @@ Call the [`ClassicEditor.create()`](https://ckeditor.com/docs/ckeditor5/latest/a
 
 You’re ready to go!
 
-To find out how to start with other builds check the [Predefined builds](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/predefined-builds.html) guide in the CKEditor 5 documentation.
+To find out how to start with other builds, check the [Predefined builds](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/predefined-builds.html) guide in the CKEditor 5 documentation.
 
 ### CKEditor 5 advanced installation
 
-For more advanced users, or those who need to integrate CKEditor 5 with their own applications, we have prepared several other, advanced methods to do it. You can [integrate the editor from source](https://ckeditor.com/docs/ckeditor5/latest/installation/advanced/alternative-setups/integrating-from-source-webpack.html), use [DLL builds](https://ckeditor.com/docs/ckeditor5/latest/installation/advanced/alternative-setups/dll-builds.html) or utilize some of the pre-made integrations with popular [JavaScript frameworks](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/overview.html), like [Angular](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/angular.html), [React](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/react.html) or [Vue](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/vuejs-v3.html).
+For more advanced users or those who need to integrate CKEditor 5 with their applications, we have prepared several other, advanced methods to do it. You can:
+* Integrate the editor from source [using webpack](https://ckeditor.com/docs/ckeditor5/latest/installation/advanced/alternative-setups/integrating-from-source-webpack.html) or [Vite](https://ckeditor.com/docs/ckeditor5/latest/installation/advanced/alternative-setups/integrating-from-source-vite.html)
+* Use [DLL builds](https://ckeditor.com/docs/ckeditor5/latest/installation/advanced/alternative-setups/dll-builds.html)
+* Use some of the pre-made integrations with popular [JavaScript frameworks](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/overview.html):
+  * [Angular](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/angular.html)
+  * [React](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/react.html),
+  * [Vue](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/vuejs-v3.html)
 
 #### CKEditor 5 Framework
 
 CKEditor 5 builds allow you to quickly and easily initialize one of the many types of editors in your application. At the same time, CKEditor 5 is also a framework for creating custom-made rich text editing solutions.
 
-To find out how to start building your own editor from scratch go to the [CKEditor 5 Framework overview](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html) section of CKEditor 5 documentation.
+To find out how to start building your editor from scratch go to the [CKEditor 5 Framework overview](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html) section of the CKEditor 5 documentation.
 
 ## Documentation and FAQ
 
-An extensive, vast documentation dedicated to all thing CKEditor 5-related is available handy. You will find basic guides that will help you kick off your project, advanced deep-dive tutorials to tailor it your specific needs and help sections with solutions and answers to any of your possible questions. To find out more see the following [CKEditor 5 documentation](https://ckeditor.com/docs/ckeditor5/latest/index.html) sections:
+Extensive documentation dedicated to all things CKEditor 5-related is available. You will find basic guides that will help you kick off your project, advanced deep-dive tutorials to tailor the editor to your specific needs, and help sections with solutions and answers to any of your possible questions. To find out more refer to the following [CKEditor 5 documentation](https://ckeditor.com/docs/ckeditor5/latest/index.html) sections:
 
 * [Installing CKEditor 5](https://ckeditor.com/docs/ckeditor5/latest/installation/index.html)
-* [CKEditor 5 features documentation](https://ckeditor.com/docs/ckeditor5/latest/features/index.html)
+* [CKEditor 5 features](https://ckeditor.com/docs/ckeditor5/latest/features/index.html)
 * [CKEditor 5 examples](https://ckeditor.com/docs/ckeditor5/latest/examples/index.html)
 * [Updating CKEditor 5](https://ckeditor.com/docs/ckeditor5/latest/updating/index.html)
 * [Getting CKEditor 5 support](https://ckeditor.com/docs/ckeditor5/latest/support/index.html)
-* [CKEditor 5 Framework documentation](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html)
+* [CKEditor 5 Framework](https://ckeditor.com/docs/ckeditor5/latest/framework/index.html)
 * [API documentation](https://ckeditor.com/docs/ckeditor5/latest/api/index.html)
 
 For FAQ please go to the [CKEditor Ecosystem help center](https://support.ckeditor.com/hc/en-us).
@@ -112,11 +122,11 @@ Follow the [CKEditor 5 changelog](https://github.com/ckeditor/ckeditor5/blob/sta
 
 ## Editing and collaboration features
 
-The CKEditor 5 Framework offers access to plethora of various plugins, supporting [all kinds of editing features](https://ckeditor.com/docs/ckeditor5/latest/features/index.html).
+The CKEditor 5 Framework offers access to a plethora of various plugins, supporting [all kinds of editing features](https://ckeditor.com/docs/ckeditor5/latest/features/index.html).
 
-From collaborative editing support providing comments and tracking changes, through editing tools that let users control the content looks and structure such as tables, lists, font styles, to accessibility helpers and multi-language support - CKEditor 5 is easily extendable and customizable. Special duty features like Markdown input and output and source editing, or export to PDF and Word provide solutions for users with diverse and specialized needs and demands. Images and videos are easily supported and CKEditor 5 offers various upload and storage systems to manage these.
+From collaborative editing support providing comments and tracking changes, through editing tools that let users control the content looks and structure such as tables, lists, font styles, to accessibility helpers and multi-language support - CKEditor 5 is easily extensible and customizable. Special duty features like Markdown input and output and source editing, or export to PDF and Word provide solutions for users with diverse and specialized needs. Images and videos are easily supported and CKEditor 5 offers various upload and storage systems to manage these.
 
-The number of options and the easiness of customization and adding new ones makes the editing experience even better for any potential environments and professional backgrounds.
+The number of options and the ease of customization and adding new ones make the editing experience even better for any environments and professional backgrounds.
 
 Refer to the [CKEditor 5 Features](https://ckeditor.com/docs/ckeditor5/latest/features/index.html) documentation for details.
 
@@ -136,9 +146,7 @@ See the [official contributors' guide](https://ckeditor.com/docs/ckeditor5/lates
 
 ### Reporting issues and feature requests
 
-Each repository handles its issues independently. However, it is recommended to report issues in [this repository](https://github.com/ckeditor/ckeditor5/issues) unless you know to which specific repository the issue belongs.
-
-Read more on the [Getting support](https://ckeditor.com/docs/ckeditor5/latest/support/getting-support.html) guide.
+Report issues in [the `ckeditor5` repository](https://github.com/ckeditor/ckeditor5/issues). Read more on the [Getting support](https://ckeditor.com/docs/ckeditor5/latest/support/getting-support.html) guide.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ Call the [`ClassicEditor.create()`](https://ckeditor.com/docs/ckeditor5/latest/a
 
 ```html
 <script>
-    ClassicEditor
-        .create( document.querySelector( '#editor' ) )
-        .catch( error => {
-            console.error( error );
-        } );
+	ClassicEditor
+		.create( document.querySelector( '#editor' ) )
+		.catch( error => {
+			console.error( error );
+		} );
 </script>
 ```
 
@@ -92,7 +92,7 @@ For more advanced users or those who need to integrate CKEditor 5 with their app
 * Use [DLL builds](https://ckeditor.com/docs/ckeditor5/latest/installation/advanced/alternative-setups/dll-builds.html)
 * Use some of the pre-made integrations with popular [JavaScript frameworks](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/overview.html):
   * [Angular](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/angular.html)
-  * [React](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/react.html),
+  * [React](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/react.html)
   * [Vue](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/frameworks/vuejs-v3.html)
 
 #### CKEditor 5 Framework
@@ -126,7 +126,7 @@ The CKEditor 5 Framework offers access to a plethora of various plugins, support
 
 From collaborative editing support providing comments and tracking changes, through editing tools that let users control the content looks and structure such as tables, lists, font styles, to accessibility helpers and multi-language support - CKEditor 5 is easily extensible and customizable. Special duty features like Markdown input and output and source editing, or export to PDF and Word provide solutions for users with diverse and specialized needs. Images and videos are easily supported and CKEditor 5 offers various upload and storage systems to manage these.
 
-The number of options and the ease of customization and adding new ones make the editing experience even better for any environments and professional backgrounds.
+The number of options and the ease of customization and adding new ones make the editing experience even better for any environment and professional background.
 
 Refer to the [CKEditor 5 Features](https://ckeditor.com/docs/ckeditor5/latest/features/index.html) documentation for details.
 

--- a/docs/framework/index.md
+++ b/docs/framework/index.md
@@ -3,14 +3,14 @@ category: framework
 order: 10
 menu-title: Overview
 meta-title: CKEditor 5 Framework documentation
-meta-description: Learn how to install, integrate, configure and develop CKEditor 5 Framework. Browse through API documentation and online samples.
+meta-description: Learn how to install, integrate, configure, and develop CKEditor 5 Framework. Browse through API documentation and online samples.
 ---
 
 # CKEditor 5 Framework overview
 
 CKEditor 5 is a project that allows you to quickly and easily initialize one of the many types of editors it offers in your application. At the same time, it is a framework for creating custom-tailored rich-text editing solutions. The former requirement is met thanks to the {@link installation/getting-started/predefined-builds predefined CKEditor 5 builds}. The latter &mdash; thanks to CKEditor 5 Framework.
 
-CKEditor 5 Framework is a highly-flexible and universal platform providing a set of components allowing you to create any kind of rich text editing solution. It enables creating different, custom-tailored editors that suit specific needs. It also provides tools for creation and integration of user-made features and for customizing the existing ones.
+CKEditor 5 Framework is a highly-flexible and universal platform that provides a set of components allowing you to create any kind of rich text editing solution. It enables the building of different, custom-tailored editors that suit specific needs. It also provides tools for the creation and integration of user-made features and for customizing existing ones.
 
 This guide explains how the framework is built and how to start using it.
 
@@ -23,26 +23,27 @@ If the documentation is insufficient, do not be afraid to look into the source c
 The CKEditor 5 predefined builds {@link installation/getting-started/quick-start-other#customizing-a-predefined-build can be customized}, but certain types of customizations require using the framework.
 
 * **Writing your own features.** New features are implemented using the framework.
-* **Customizing existing features.** Changing the behavior or look of existing features can be done thanks to the framework capabilities.
+* **Customizing existing features.** Changing the behavior or look of existing features can be done thanks to the framework's capabilities.
 * **Creating new types of editors.** You can create new editor types using the framework.
 
 To sum up: you need to start using the framework as soon as existing builds do not meet your requirements or cannot be customized to the extent you need.
 
 ## Design
 
-The framework was designed to be a highly flexible and universal platform for creating custom rich-text editing solutions. At the same time it meets several goals that make implementing features as easy a task as possible.
+The framework was designed to be a highly flexible and universal platform for creating custom rich-text editing solutions. At the same time, it meets several goals that make implementing features as easy a task as possible.
 
 * **Plugin-based architecture.** Everything is a plugin &mdash; even such crucial features as support for typing or `<p>` elements. You can remove plugins or replace them with your own implementations to achieve fully customized results.
 * **Schema-less core.** The core makes minimal assumptions and can be controlled through the schema. This leaves all decisions to plugins and hence to you.
 * **Collaboration-ready.** Or rather, real-time collaboration is **ready for you to use**! The editor implements [Operational Transformation](https://en.wikipedia.org/wiki/Operational_transformation) for the tree-structured model as well as many other mechanisms which were required to create a seamless collaborative UX. Additionally, we provide cloud infrastructure and plugins enabling real-time collaborative editing in your application! {@link features/real-time-collaboration Check the collaboration demo}.
 * **Custom data model.** The editing engine implements a tree-structured custom data model, designed to fit multiple requirements such as enabling real-time collaboration and complex editing features (like tables or nested blocks).
 * **Virtual DOM.** The editing engine features a custom, editing-oriented virtual DOM implementation that aims to hide browser quirks from your sight. **No more `contentEditable` nightmares!**
+* **TypeScript.** The project is written in TypeScript and provides native type definitions. This helps create better, more reliable code that's easier to understand and maintain.
 * **Granular, reusable features.** Features are implemented in a granular way. This allows for reusing and recomposing them which, in turn, makes it possible to customize and extend the editor. For instance, the {@link features/images-overview image feature} consists of over 10 plugins at the moment.
 * **Extensibility.** The entire editor architecture was designed for maximum flexibility. The code is event-based and highly decoupled, allowing you to plug in or replace selected pieces. Features do not directly depend on one another and communicate in standardized ways.
 * **A beautiful UI.** Text editing is not only about typing &mdash; your users will need a UI to create links or manage images. We believe that a proper UX needs to be carefully designed and we did not skip this part. Having second thoughts about the proposed UI? No problem at all! You can always create your custom interface for CKEditor 5 thanks to its decoupled UI.
-* **Quality.** All official packages have extensive tests suites (100% code coverage is merely a step to that). All code has extensive {@link api/index API documentation}.
+* **Quality.** All official packages have extensive test suites (100% code coverage is merely a step to that). All code has extensive {@link api/index API documentation}.
 * **Minimal configuration.** To avoid bloat, features have minimal configuration. Deeper changes in their behavior can be done by recomposing them with custom features.
-* **8+ years of support.** It is not yet another framework to be gone next year or a hyped proof-of-concept to fail in a real-life scenario. We have over 15 years of experience in creating rich-text editors and invested over 4 years in designing and building your next future-proof rich-text editor of choice.
+* **8+ years of support.** It is not yet another framework to be gone next year or a hyped proof-of-concept to fail in a real-life scenario. We have over 20 years of experience in creating rich-text editors and continue working day in and day out on improving your future-proof rich-text editor of choice.
 
 ## Framework structure
 
@@ -52,7 +53,7 @@ There are a few groups of packages:
 
 * [Core libraries](https://github.com/ckeditor/ckeditor5#core-libraries) &ndash; A set of packages which are the root of the framework.
 * [Editors](https://github.com/ckeditor/ckeditor5#editors) &ndash; Packages that implement various types of editors.
-* [Features](https://github.com/ckeditor/ckeditor5#features) &ndash; Packages that implement end user features.
+* [Features](https://github.com/ckeditor/ckeditor5#features) &ndash; Packages that implement end-user features.
 * [Themes](https://github.com/ckeditor/ckeditor5#themes) &ndash; Packages that implement editor themes.
 * [Builds](https://github.com/ckeditor/ckeditor5#builds) &ndash; Packages containing {@link installation/getting-started/predefined-builds CKEditor 5 builds}.
 

--- a/docs/installation/getting-started/quick-start-other.md
+++ b/docs/installation/getting-started/quick-start-other.md
@@ -11,8 +11,6 @@ modified_at: 2022-03-15
 
 ## Introduction
 
-CKEditor 5 can provide any WYSIWYG editor type. From online editors similar to Google Docs and Medium, to Slack or Twitter like applications, the CKEditor 5 editing framework provides solutions for every user, both customized and out-of-the-box. This modern JavaScript rich text editor with MVC architecture, custom data model and virtual DOM was written from scratch in ES6 with excellent webpack support.
-
 In this guide, you will learn how to run your own CKEditor 5 instance. Below you can find two unique paths describing the installation process. Choose one (or both!) and start your CKEditor 5 journey!
 
 Available paths:
@@ -21,7 +19,7 @@ Available paths:
 
 ## Creating custom builds with online builder
 
-Although the CKEditor 5 WYSIWYG editor comes with handy {@link installation/getting-started/predefined-builds predefined builds}, sometimes these predefined bundled versions are not enough and a need for more customized  builds arises. Some of the reasons for creating custom builds are:
+Although the CKEditor 5 WYSIWYG editor comes with handy {@link installation/getting-started/predefined-builds predefined builds}, sometimes these predefined bundled versions are not enough and a need for more customized builds arises. Some of the reasons for creating custom builds are:
 
 * Adding {@link installation/plugins/plugins plugin-driven features} which are not included in the existing builds.
 * Removing unnecessary features present in a build.
@@ -31,7 +29,7 @@ Although the CKEditor 5 WYSIWYG editor comes with handy {@link installation/gett
 
 This is where the online builder comes to help you.
 
-The [online builder](https://ckeditor.com/ckeditor-5/online-builder/) is an application that lets you design and download custom CKEditor 5 builds. It allows you to create your own bundles with your desired editor type, toolbar and set of plugins in a few easy steps, through a simple and intuitive UI.
+The [online builder](https://ckeditor.com/ckeditor-5/online-builder/) is an application that lets you design and download custom CKEditor 5 builds. It allows you to create your own bundles with your desired editor type, toolbar, and set of plugins in a few easy steps, through a simple and intuitive UI.
 
 ### Choosing the editor type
 
@@ -69,7 +67,7 @@ Once you have chosen all the desired plugins, press the **Next step** button on 
 
 ### Toolbar composition
 
-Next step allows you to compose the toolbar. A simple drag-and-drop workspace allows for adding buttons (representing the plugins chosen in the previous step) to the toolbar. You may also change the order of the buttons and dropdowns and group them accordingly. Note that online builder allows you to create a multiline toolbar layout, too &mdash; just drag any button below the already placed ones to create a new toolbar line.
+The next step allows you to compose the toolbar. A simple drag-and-drop workspace allows for adding buttons (representing the plugins chosen in the previous step) to the toolbar. You may also change the order of the buttons and dropdowns and group them accordingly. Note that online builder allows you to create a multiline toolbar layout, too &mdash; just drag any button below the already placed ones to create a new toolbar line.
 
 {@img assets/img/online-builder-04-toolbar-configurator.gif 753 The toolbar drag-and-drop configurator.}
 
@@ -101,9 +99,9 @@ This is an advanced path that assumes that you are familiar with npm and your pr
 
 ### Setting up the environment
 
-Before moving to the integration, you need to prepare three files that will be filled with code presented in this guide. Create the `webpack.config.js`, `app.js` and `index.html` files.
+Before moving to the integration, you need to prepare three files that will be filled with code presented in this guide. Create the `webpack.config.js`, `app.js`, and `index.html` files.
 
-Then, install packages needed to build CKEditor 5:
+Then, install the packages needed to build CKEditor 5:
 
 ```bash
 npm install --save \
@@ -261,7 +259,7 @@ npm adds `./node_modules/.bin/` to the `PATH` automatically, so in this case you
 <info-box>
 	Use `webpack --mode production` if you want to build a minified and optimized application. Learn more about it in the [webpack documentation](https://webpack.js.org/concepts/mode/).
 
-	**Note:** Prior to version 1.2.7, `uglifyjs-webpack-plugin` (the default minifier used by webpack) had a bug which caused webpack to crash with the following error: `TypeError: Assignment to constant variable`. If you experienced this error, make sure that your `node_modules` contain an up-to-date version of this package (and that webpack uses this version).
+	**Note:** Prior to version 1.2.7, `uglifyjs-webpack-plugin` (the default minifier used by webpack) had a bug that caused webpack to crash with the following error: `TypeError: Assignment to constant variable`. If you experienced this error, make sure that your `node_modules` contain an up-to-date version of this package (and that webpack uses this version).
 
 	**Note:** CKEditor 5 builds use [`Terser`](https://github.com/terser/terser) instead of `uglifyjs-webpack-plugin` because [the latter one seems to no longer be supported](https://github.com/ckeditor/ckeditor5/issues/1353).
 </info-box>
@@ -328,12 +326,12 @@ A build is a simple [npm](https://www.npmjs.com) package (usually developed in a
 
 Some of the reasons for creating custom builds are:
 
-* Adding features which are not included in the existing builds, either from a third party or custom developed.
+* Adding features that are not included in the existing builds, either from a third party or custom developed.
 * Removing unnecessary features present in a build.
 * Changing the {@link installation/getting-started/editor-lifecycle#creating-an-editor-with-create editor creator}.
 * Changing the {@link framework/theme-customization editor theme}.
 * Changing the {@link features/ui-language localization language} of the editor.
-* Enabling bug fixes which are still not a part of any public release.
+* Enabling bug fixes that are still not a part of any public release.
 
 <info-box hint>
 	If you are looking for an easy way to create a custom build of CKEditor 5, check the [online builder](https://ckeditor.com/ckeditor-5/online-builder/), which allows you to create a custom build through a simple and intuitive UI.
@@ -371,7 +369,7 @@ git remote add upstream https://github.com/ckeditor/ckeditor5.git
 <info-box hint>
 	If you do not want to fork the official build, you can just clone it. However, you will not be able to commit and push your customizations back to GitHub.
 
-	Alternatively, instead of creating a custom build you can {@link installation/advanced/integrating-from-source-webpack integrate CKEditor 5 directly from source}. This option allows for even more flexibility and requires less overhead (you will not need to fork the official build). However, it requires that you fully control the `webpack.config.js` file (which is not that easy in some environments &mdash; for example in [`angular-cli`](https://cli.angular.io/) or [`create-react-app`](https://github.com/facebook/create-react-app)).
+	Alternatively, instead of creating a custom build, you can {@link installation/advanced/integrating-from-source-webpack integrate CKEditor 5 directly from source}. This option allows for even more flexibility and requires less overhead (you will not need to fork the official build). However, it requires that you fully control the `webpack.config.js` file (which is not that easy in some environments &mdash; for example in [`angular-cli`](https://cli.angular.io/) or [`create-react-app`](https://github.com/facebook/create-react-app)).
 </info-box>
 
 <info-box warning>
@@ -383,7 +381,7 @@ git remote add upstream https://github.com/ckeditor/ckeditor5.git
 Every build contains the following files:
 
 * `build/ckeditor.js` &ndash; The ready-to-use editor bundle, containing the editor and all plugins.
-* `src/ckeditor.js` &ndash; The source entry point of the build. Based on it the `build/ckeditor.js` file is created by [webpack](https://webpack.js.org). It defines the editor creator, the list of plugins and the default configuration of a build.
+* `src/ckeditor.js` &ndash; The source entry point of the build. Based on it the `build/ckeditor.js` file is created by [webpack](https://webpack.js.org). It defines the editor creator, the list of plugins, and the default configuration of a build.
 * `webpack-config.js` &ndash; The webpack configuration used to build the editor.
 
 ### Customizing a build
@@ -396,7 +394,7 @@ In order to customize a build you need to:
 
 #### Installing dependencies
 
-First, you need to install dependencies which are already specified in the build's `package.json`:
+First, you need to install dependencies that are already specified in the build's `package.json`:
 
 ```bash
 npm install
@@ -504,5 +502,5 @@ After your build is out, [ping us on Twitter](https://twitter.com/ckeditor)!
 
 Congratulations, you have just run your first CKEditor 5 instance! Now it is time to learn more about customization, so jump in straight to the {@link installation/getting-started/configuration Configuration guide}.
 
-P.S. If you use Angular, React or Vue.js and want to integrate CKEditor 5 in your application, refer to the {@link installation/frameworks/overview Frameworks section}.
+P.S. If you use Angular, React, or Vue.js and want to integrate CKEditor 5 in your application, refer to the {@link installation/frameworks/overview Frameworks section}.
 </info-box>

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -3,7 +3,7 @@ category: installation
 order: 10
 menu-title: Overview
 meta-title: CKEditor 5 installation documentation
-meta-description: Learn how to install, integrate, configure and develop CKEditor 5. Browse through API documentation and online samples.
+meta-description: Learn how to install, integrate, configure, and develop CKEditor 5. Browse through the API documentation and online samples.
 ---
 
 # Getting started with CKEditor 5

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -8,7 +8,7 @@ meta-description: Learn how to install, integrate, configure and develop CKEdito
 
 # Getting started with CKEditor 5
 
-CKEditor 5 provides every type of WYSIWYG editing solution imaginable. From editors similar to Google Docs and Medium, to Slack or Twitter like applications, all is possible within a single editing framework. It is an ultra-modern JavaScript rich text editor with MVC architecture, custom data model and virtual DOM, written from scratch in ES6 with excellent webpack support. Find out the most convenient way to start using it!
+CKEditor 5 provides every type of WYSIWYG editing solution imaginable. From editors similar to Google Docs and Medium to Slack or Twitter-like applications, all is possible within a single editing framework. It is an ultra-modern JavaScript rich-text editor with MVC architecture, custom data model, and virtual DOM, written from scratch in TypeScript with excellent webpack and Vite support. Find out the most convenient way to start using it!
 
 <span class="navigation-hint_mobile">
 <info-box>
@@ -22,7 +22,7 @@ CKEditor 5 provides every type of WYSIWYG editing solution imaginable. From edit
 
 ## Migrating from CKEditor 4
 
-If you are an existing CKEditor 4 user who wants to migrate to CKEditor 5, please refer to the {@link updating/migration-from-ckeditor-4 CKEditor 4 migration guide} for tips about such an installation. The "Getting started" section is an introduction to CKEditor 5 and is mostly aimed at new users who want to install and configure their WYSIWYG editor. You may want to get familiar with these guides before the migration, too.
+If you are an existing CKEditor 4 user who wants to migrate to CKEditor 5, refer to the {@link updating/migration-from-ckeditor-4 CKEditor 4 migration section} for tips about such an installation. The "Getting started" section is an introduction to CKEditor 5 and is mostly aimed at new users who want to install and configure their WYSIWYG editor. You may want to get familiar with these guides before the migration, too.
 
 ## Start using CKEditor 5 instantly with CDN
 
@@ -30,26 +30,26 @@ Start using CKEditor 5 instantly thanks to the power of our CDN. Check out the {
 
 ## Installing predefined CKEditor 5 builds
 
-Predefined CKEditor 5 builds are ready-to-use distributions aimed at specific needs that you can simply download and use out of the box. Learn more about the {@link installation/getting-started/predefined-builds available predefined builds} and choose the right one for you. This is the fastest way to kick-off your CKEditor 5 installation.
+Predefined CKEditor 5 builds are ready-to-use distributions aimed at specific needs that you can simply download and use out of the box. Learn more about the {@link installation/getting-started/predefined-builds available predefined builds} and choose the right one for you. This is the fastest way to kick off your CKEditor 5 installation.
 
 ## Customizing the CKEditor 5 installation
 
-Learn how to install a custom CKEditor 5 easily with the use of {@link installation/getting-started/quick-start-other#creating-custom-builds-with-online-builder online builder} or {@link installation/getting-started/quick-start-other#building-the-editor-from-source build the editor from scratch}, and learn to {@link installation/getting-started/configuration configure it}.
+Learn how to install a custom CKEditor 5 build easily with the use of {@link installation/getting-started/quick-start-other#creating-custom-builds-with-online-builder online builder} or {@link installation/getting-started/quick-start-other#building-the-editor-from-source build the editor from scratch}, and learn to {@link installation/getting-started/configuration configure it}.
 
 ## Integration with frameworks
 
-Get to know the supported {@link installation/frameworks/overview integrations with popular JavaScript frameworks} such as React, Angular or Vue, and learn to utilize them and to integrate CKEditor 5 with your software.
+Get to know the supported {@link installation/frameworks/overview integrations with popular JavaScript frameworks} such as React, Angular, or Vue, and learn to use them and integrate CKEditor 5 with your software.
 
 ## Advanced installation concepts
 
-Find out more about the {@link installation/plugins/plugins plugin development}, how to {@link installation/getting-started/getting-and-setting-data handle and save the data} and what the {@link installation/plugins/features-html-output-overview features' HTML output} is for each plugin. Learn about alternative setups such as {@link installation/advanced/dll-builds DLL builds} or {@link installation/advanced/integrating-from-source-webpack integrating CKEditor 5 from source}.
+Find out more about the {@link installation/plugins/plugins plugin development}, how to {@link installation/getting-started/getting-and-setting-data handle and save the data}, and what the {@link installation/plugins/features-html-output-overview features' HTML output} is for each plugin. Learn about alternative setups such as {@link installation/advanced/dll-builds DLL builds} or integrating CKEditor 5 from source {@link installation/advanced/integrating-from-source-webpack using webpack} or {@link installation/advanced/integrating-from-source-vite Vite}.
 
 **Related links**
 
  * {@link updating/updating-ckeditor-5 Updating CKEditor 5} &ndash; Find out how to keep you installation up-to-date at all times.
  * {@link features/index Features} &ndash; Learn more about the CKEditor 5 features.
  * {@link examples/index Examples} &ndash; Try live demos of available predefined builds and custom solutions.
- * {@link framework/index CKEditor 5 Framework} &ndash; Learn how to work with CKEditor 5 Framework, customize it, create your own plugins or custom editors, how to change the UI or even bring your own UI to the editor.
+ * {@link framework/index CKEditor 5 Framework} &ndash; Learn how to work with CKEditor 5 Framework, customize it, create your own plugins or custom editors, change the UI, or even bring your own UI to the editor.
 
 <script type="text/javascript">
 	const QUIZ_DEFAULT_HEADER = 'Installation method quiz';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Update CKEditor 5 descriptions to mention that CKEditor 5 is built using TypeScript. Closes cksource/ckeditor5-internal#3036.