### PR TITLE
Created aliases when building docs

### DIFF
--- a/scripts/docs/snippetadapter.js
+++ b/scripts/docs/snippetadapter.js
@@ -21,6 +21,41 @@ const DEFAULT_LANGUAGE = 'en';
 const MULTI_LANGUAGE = 'multi-language';
 const SNIPPETS_BUILD_CHUNK_SIZE = 50;
 
+const CKEDITOR5_ROOT_DIRECTORY = path.join( __dirname, '..', '..' );
+
+const CLOUD_SERVICES_CONFIG_PATH = path.join(
+	CKEDITOR5_ROOT_DIRECTORY, 'packages', 'ckeditor5-cloud-services', 'tests', '_utils', 'cloud-services-config'
+);
+
+const CKBOX_CONFIG_PATH = path.join(
+	CKEDITOR5_ROOT_DIRECTORY, 'packages', 'ckeditor5-ckbox', 'tests', '_utils', 'ckbox-config'
+);
+
+const ARTICLE_PLUGIN_PATH = path.join(
+	CKEDITOR5_ROOT_DIRECTORY, 'packages', 'ckeditor5-core', 'tests', '_utils', 'articlepluginset.js'
+);
+
+// CKEditor 5 snippets require files and modules from directories that are not published on npm.
+// While webpack does not complain when building docs locally, it reports errors related to importing non-existing files
+// when building the nightly/production docs.
+// Hence, we create a map that translates imports from the non-published directories to sources in the `packages/*` directory.
+const RESOLVE_ALIAS_MAP = {
+	// Import icons that are not a part of the package, but used only in the documentation.
+	'@ckeditor/ckeditor5-image/docs/assets': path.join( CKEDITOR5_ROOT_DIRECTORY, 'packages', 'ckeditor5-image', 'docs', 'assets' ),
+
+	// The `ArticlePluginSet` that loads a simple article plugins.
+	'@ckeditor/ckeditor5-core/tests/_utils/articlepluginset': ARTICLE_PLUGIN_PATH,
+	'@ckeditor/ckeditor5-core/tests/_utils/articlepluginset.js': ARTICLE_PLUGIN_PATH,
+
+	// Configuration for the Cloud Services used.
+	'@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config': CLOUD_SERVICES_CONFIG_PATH,
+	'@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config.js': CLOUD_SERVICES_CONFIG_PATH,
+
+	// Configuration for the CKBox service.
+	'@ckeditor/ckeditor5-ckbox/tests/_utils/ckbox-config.js': CKBOX_CONFIG_PATH,
+	'@ckeditor/ckeditor5-ckbox/tests/_utils/ckbox-config': CKBOX_CONFIG_PATH
+};
+
 /**
  * @param {Set.<Snippet>} snippets Snippet collection extracted from documentation files.
  * @param {Object} options
@@ -429,6 +464,7 @@ function getWebpackConfig( snippets, config ) {
 				...getPackageDependenciesPaths(),
 				...getModuleResolvePaths()
 			],
+			alias: RESOLVE_ALIAS_MAP,
 			extensions: [ '.ts', '.js', '.json' ]
 		},
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Created a map for snippet adapter that redirects imports of non-existing files from `node_modules/` to the `packages/` directory. Closes #13835.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
