### PR TITLE
Remove HTML classes from paragraph created after pressing enter in heading

### DIFF
--- a/packages/ckeditor5-engine/src/model/writer.ts
+++ b/packages/ckeditor5-engine/src/model/writer.ts
@@ -889,7 +889,7 @@ export default class Writer {
 	 * @param element The element to rename.
 	 * @param newName New element name.
 	 */
-	public rename( element: Element, newName: string ): void {
+	public rename( element: Element | DocumentFragment, newName: string ): void {
 		this._assertWriterUsedCorrectly();
 
 		if ( !( element instanceof Element ) ) {

--- a/packages/ckeditor5-enter/src/index.ts
+++ b/packages/ckeditor5-enter/src/index.ts
@@ -10,7 +10,7 @@
 export { default as Enter } from './enter';
 export { default as ShiftEnter } from './shiftenter';
 export type { ViewDocumentEnterEvent } from './enterobserver';
-export type { default as EnterCommand } from './entercommand';
+export type { default as EnterCommand, EnterCommandAfterExecuteEvent } from './entercommand';
 export type { default as ShiftEnterCommand } from './shiftentercommand';
 
 import './augmentation';

--- a/packages/ckeditor5-heading/src/headingediting.ts
+++ b/packages/ckeditor5-heading/src/headingediting.ts
@@ -10,6 +10,7 @@
 import { Plugin, type Editor } from 'ckeditor5/src/core';
 import { Paragraph } from 'ckeditor5/src/paragraph';
 import { priorities } from 'ckeditor5/src/utils';
+import type { EnterCommandAfterExecuteEvent } from 'ckeditor5/src/enter';
 import type { HeadingOption } from './headingconfig';
 
 import HeadingCommand from './headingcommand';
@@ -94,7 +95,7 @@ export default class HeadingEditing extends Plugin {
 		const options: Array<HeadingOption> = editor.config.get( 'heading.options' )!;
 
 		if ( enterCommand ) {
-			this.listenTo( enterCommand, 'afterExecute', ( evt, data ) => {
+			this.listenTo<EnterCommandAfterExecuteEvent>( enterCommand, 'afterExecute', ( evt, data ) => {
 				const positionParent = editor.model.document.selection.getFirstPosition()!.parent;
 				const isHeading = options.some( option => positionParent.is( 'element', option.model ) );
 

--- a/packages/ckeditor5-html-support/src/converters.ts
+++ b/packages/ckeditor5-html-support/src/converters.ts
@@ -27,7 +27,7 @@ import {
 	mergeViewElementAttributes,
 	updateViewAttributes,
 	type GHSViewAttributes
-} from './conversionutils';
+} from './utils';
 import type DataFilter from './datafilter';
 import type { DataSchemaBlockElementDefinition, DataSchemaDefinition, DataSchemaInlineElementDefinition } from './dataschema';
 

--- a/packages/ckeditor5-html-support/src/datafilter.ts
+++ b/packages/ckeditor5-html-support/src/datafilter.ts
@@ -37,7 +37,7 @@ import {
 	type DataSchemaDefinition,
 	type DataSchemaInlineElementDefinition
 } from './dataschema';
-import type { GHSViewAttributes } from './conversionutils';
+import type { GHSViewAttributes } from './utils';
 
 import { isPlainObject, pull as removeItemFromArray } from 'lodash-es';
 
@@ -468,7 +468,7 @@ export default class DataFilter extends Plugin {
 
 		schema.register( modelName, definition.modelSchema );
 
-		/* istanbul ignore next: paranoid check */
+		/* istanbul ignore next: paranoid check -- @preserve */
 		if ( !viewName ) {
 			return;
 		}

--- a/packages/ckeditor5-html-support/src/generalhtmlsupport.ts
+++ b/packages/ckeditor5-html-support/src/generalhtmlsupport.ts
@@ -278,13 +278,13 @@ interface CallbackMap {
  * Updates a GHS attribute on a specified item.
  * @param callback That receives a map or set as an argument and should modify it (add or remove entries).
  */
-function modifyGhsAttribute<T extends keyof GHSViewAttributes>(
+export function modifyGhsAttribute<T extends keyof GHSViewAttributes>(
 	writer: Writer,
 	item: Item | DocumentSelection,
 	ghsAttributeName: string,
 	subject: T,
 	callback: CallbackMap[T]
-) {
+): void {
 	const oldValue = item.getAttribute( ghsAttributeName ) as Record<string, any>;
 	const newValue: Record<string, any> = {};
 

--- a/packages/ckeditor5-html-support/src/integrations/codeblock.ts
+++ b/packages/ckeditor5-html-support/src/integrations/codeblock.ts
@@ -17,7 +17,7 @@ import type {
 } from 'ckeditor5/src/engine';
 import { Plugin } from 'ckeditor5/src/core';
 
-import { updateViewAttributes, type GHSViewAttributes } from '../conversionutils';
+import { updateViewAttributes, type GHSViewAttributes } from '../utils';
 import DataFilter, { type DataFilterRegisterEvent } from '../datafilter';
 
 /**

--- a/packages/ckeditor5-html-support/src/integrations/customelement.ts
+++ b/packages/ckeditor5-html-support/src/integrations/customelement.ts
@@ -14,7 +14,7 @@ import { UpcastWriter, type ViewDocumentFragment, type ViewNode } from 'ckeditor
 
 import DataSchema from '../dataschema';
 import DataFilter, { type DataFilterRegisterEvent } from '../datafilter';
-import { type GHSViewAttributes, setViewAttributes } from '../conversionutils';
+import { type GHSViewAttributes, setViewAttributes } from '../utils';
 
 /**
  * Provides the General HTML Support for custom elements (not registered in the {@link module:html-support/dataschema~DataSchema}).

--- a/packages/ckeditor5-html-support/src/integrations/documentlist.ts
+++ b/packages/ckeditor5-html-support/src/integrations/documentlist.ts
@@ -18,7 +18,7 @@ import type {
 	DocumentListIndentCommand
 } from '@ckeditor/ckeditor5-list';
 
-import { type GHSViewAttributes, setViewAttributes } from '../conversionutils';
+import { type GHSViewAttributes, setViewAttributes } from '../utils';
 import DataFilter, { type DataFilterRegisterEvent } from '../datafilter';
 
 /**

--- a/packages/ckeditor5-html-support/src/integrations/heading.ts
+++ b/packages/ckeditor5-html-support/src/integrations/heading.ts
@@ -10,10 +10,14 @@
 import { Plugin, type Editor } from 'ckeditor5/src/core';
 import type { Item } from 'ckeditor5/src/engine';
 import type { HeadingOption } from '@ckeditor/ckeditor5-heading';
-import type { EnterCommandAfterExecuteEvent } from 'ckeditor5/src/enter';
+import {
+	Enter,
+	type EnterCommand,
+	type EnterCommandAfterExecuteEvent
+} from 'ckeditor5/src/enter';
 
 import DataSchema from '../dataschema';
-import { modifyGhsAttribute } from '../generalhtmlsupport';
+import { modifyGhsAttribute } from '../utils';
 
 /**
  * Provides the General HTML Support integration with {@link module:heading/heading~Heading Heading} feature.
@@ -23,7 +27,7 @@ export default class HeadingElementSupport extends Plugin {
 	 * @inheritDoc
 	 */
 	public static get requires() {
-		return [ DataSchema ] as const;
+		return [ DataSchema, Enter ] as const;
 	}
 
 	/**
@@ -79,7 +83,7 @@ export default class HeadingElementSupport extends Plugin {
 	 * Removes css classes from "htmlAttributes" of new paragraph created when hitting "enter" in heading.
 	 */
 	private removeClassesOnEnter( editor: Editor, options: Array<HeadingOption> ): void {
-		const enterCommand = editor.commands.get( 'enter' )!;
+		const enterCommand: EnterCommand = editor.commands.get( 'enter' )!;
 
 		this.listenTo<EnterCommandAfterExecuteEvent>( enterCommand, 'afterExecute', ( evt, data ) => {
 			const positionParent = editor.model.document.selection.getFirstPosition()!.parent;

--- a/packages/ckeditor5-html-support/src/integrations/heading.ts
+++ b/packages/ckeditor5-html-support/src/integrations/heading.ts
@@ -79,11 +79,7 @@ export default class HeadingElementSupport extends Plugin {
 	 * Removes css classes from "htmlAttributes" of new paragraph created when hitting "enter" in heading.
 	 */
 	private removeClassesOnEnter( editor: Editor, options: Array<HeadingOption> ): void {
-		const enterCommand = editor.commands.get( 'enter' );
-
-		if ( !enterCommand ) {
-			return;
-		}
+		const enterCommand = editor.commands.get( 'enter' )!;
 
 		this.listenTo<EnterCommandAfterExecuteEvent>( enterCommand, 'afterExecute', ( evt, data ) => {
 			const positionParent = editor.model.document.selection.getFirstPosition()!.parent;

--- a/packages/ckeditor5-html-support/src/integrations/heading.ts
+++ b/packages/ckeditor5-html-support/src/integrations/heading.ts
@@ -7,10 +7,13 @@
  * @module html-support/integrations/heading
  */
 
-import { Plugin } from 'ckeditor5/src/core';
+import { Plugin, type Editor } from 'ckeditor5/src/core';
+import type { Item } from 'ckeditor5/src/engine';
 import type { HeadingOption } from '@ckeditor/ckeditor5-heading';
+import type { EnterCommandAfterExecuteEvent } from 'ckeditor5/src/enter';
 
 import DataSchema from '../dataschema';
+import { modifyGhsAttribute } from '../generalhtmlsupport';
 
 /**
  * Provides the General HTML Support integration with {@link module:heading/heading~Heading Heading} feature.
@@ -40,12 +43,19 @@ export default class HeadingElementSupport extends Plugin {
 			return;
 		}
 
-		const dataSchema = editor.plugins.get( DataSchema );
 		const options: Array<HeadingOption> = editor.config.get( 'heading.options' )!;
-		const headerModels = [];
 
-		// We are registering all elements supported by HeadingEditing
-		// to enable custom attributes for those elements.
+		this.registerHeadingElements( editor, options );
+		this.removeClassesOnEnter( editor, options );
+	}
+
+	/**
+	 * Registers all elements supported by HeadingEditing to enable custom attributes for those elements.
+	 */
+	private registerHeadingElements( editor: Editor, options: Array<HeadingOption> ) {
+		const dataSchema = editor.plugins.get( DataSchema );
+
+		const headerModels = [];
 		for ( const option of options ) {
 			if ( 'model' in option && 'view' in option ) {
 				dataSchema.registerBlockElement( {
@@ -61,6 +71,32 @@ export default class HeadingElementSupport extends Plugin {
 			model: 'htmlHgroup',
 			modelSchema: {
 				allowChildren: headerModels
+			}
+		} );
+	}
+
+	/**
+	 * Removes css classes from "htmlAttributes" of new paragraph created when hitting "enter" in heading.
+	 */
+	private removeClassesOnEnter( editor: Editor, options: Array<HeadingOption> ): void {
+		const enterCommand = editor.commands.get( 'enter' );
+
+		if ( !enterCommand ) {
+			return;
+		}
+
+		this.listenTo<EnterCommandAfterExecuteEvent>( enterCommand, 'afterExecute', ( evt, data ) => {
+			const positionParent = editor.model.document.selection.getFirstPosition()!.parent;
+			const isHeading = options.some( option => positionParent.is( 'element', option.model ) );
+
+			if ( isHeading && positionParent.childCount === 0 ) {
+				modifyGhsAttribute(
+					data.writer,
+					positionParent as Item,
+					'htmlAttributes',
+					'classes',
+					classes => classes.clear()
+				);
 			}
 		} );
 	}

--- a/packages/ckeditor5-html-support/src/integrations/image.ts
+++ b/packages/ckeditor5-html-support/src/integrations/image.ts
@@ -16,7 +16,7 @@ import type {
 	ViewElement } from 'ckeditor5/src/engine';
 
 import DataFilter, { type DataFilterRegisterEvent } from '../datafilter';
-import { type GHSViewAttributes, setViewAttributes, updateViewAttributes } from '../conversionutils';
+import { type GHSViewAttributes, setViewAttributes, updateViewAttributes } from '../utils';
 import { getDescendantElement } from './integrationutils';
 
 /**

--- a/packages/ckeditor5-html-support/src/integrations/mediaembed.ts
+++ b/packages/ckeditor5-html-support/src/integrations/mediaembed.ts
@@ -11,7 +11,7 @@ import { Plugin } from 'ckeditor5/src/core';
 
 import DataFilter, { type DataFilterRegisterEvent } from '../datafilter';
 import DataSchema from '../dataschema';
-import { updateViewAttributes, type GHSViewAttributes } from '../conversionutils';
+import { updateViewAttributes, type GHSViewAttributes } from '../utils';
 import type {
 	DowncastAttributeEvent,
 	DowncastDispatcher,

--- a/packages/ckeditor5-html-support/src/integrations/table.ts
+++ b/packages/ckeditor5-html-support/src/integrations/table.ts
@@ -15,7 +15,7 @@ import type {
 	UpcastElementEvent,
 	ViewElement } from 'ckeditor5/src/engine';
 import { Plugin } from 'ckeditor5/src/core';
-import { setViewAttributes, type GHSViewAttributes } from '../conversionutils';
+import { setViewAttributes, type GHSViewAttributes } from '../utils';
 import DataFilter, { type DataFilterRegisterEvent } from '../datafilter';
 import { getDescendantElement } from './integrationutils';
 

--- a/packages/ckeditor5-html-support/src/utils.ts
+++ b/packages/ckeditor5-html-support/src/utils.ts
@@ -7,7 +7,13 @@
  * @module html-support/conversionutils
  */
 
-import type { DowncastWriter, ViewElement } from 'ckeditor5/src/engine';
+import type {
+	DocumentSelection,
+	DowncastWriter,
+	Item,
+	ViewElement,
+	Writer
+} from 'ckeditor5/src/engine';
 import { cloneDeep } from 'lodash-es';
 
 export interface GHSViewAttributes {
@@ -106,4 +112,95 @@ export function mergeViewElementAttributes( target: GHSViewAttributes, source: G
 	}
 
 	return result;
+}
+
+type ModifyGhsAttributesCallback = ( t: Map<string, unknown> ) => void;
+type ModifyGhsClassesCallback = ( t: Set<string> ) => void;
+type ModifyGhsStylesCallback = ( t: Map<string, string> ) => void;
+
+/**
+ * Updates a GHS attribute on a specified item.
+ * @param callback That receives a map as an argument and should modify it (add or remove entries).
+ */
+export function modifyGhsAttribute(
+	writer: Writer,
+	item: Item | DocumentSelection,
+	ghsAttributeName: string,
+	subject: 'attributes',
+	callback: ModifyGhsAttributesCallback
+): void;
+
+/**
+ * Updates a GHS attribute on a specified item.
+ * @param callback That receives a set as an argument and should modify it (add or remove entries).
+ */
+export function modifyGhsAttribute(
+	writer: Writer,
+	item: Item | DocumentSelection,
+	ghsAttributeName: string,
+	subject: 'classes',
+	callback: ModifyGhsClassesCallback
+): void;
+
+/**
+ * Updates a GHS attribute on a specified item.
+ * @param callback That receives a map as an argument and should modify it (add or remove entries).
+ */
+export function modifyGhsAttribute(
+	writer: Writer,
+	item: Item | DocumentSelection,
+	ghsAttributeName: string,
+	subject: 'styles',
+	callback: ModifyGhsStylesCallback
+): void;
+
+export function modifyGhsAttribute(
+	writer: Writer,
+	item: Item | DocumentSelection,
+	ghsAttributeName: string,
+	subject: 'attributes' | 'styles' | 'classes',
+	callback: ModifyGhsClassesCallback | ModifyGhsAttributesCallback | ModifyGhsStylesCallback
+): void {
+	const oldValue = item.getAttribute( ghsAttributeName ) as Record<string, any>;
+	const newValue: Record<string, any> = {};
+
+	for ( const kind of [ 'attributes', 'styles', 'classes' ] ) {
+		// Properties other than `subject` should be assigned from `oldValue`.
+		if ( kind != subject ) {
+			if ( oldValue && oldValue[ kind ] ) {
+				newValue[ kind ] = oldValue[ kind ];
+			}
+			continue;
+		}
+
+		// `callback` should be applied on property [`subject`].
+		if ( subject == 'classes' ) {
+			const values = new Set<string>( oldValue && oldValue.classes || [] );
+			( callback as ModifyGhsClassesCallback )( values );
+			if ( values.size ) {
+				newValue[ kind ] = Array.from( values );
+			}
+			continue;
+		}
+
+		const values = new Map<string, any>( Object.entries( oldValue && oldValue[ kind ] || {} ) );
+		( callback as ( ModifyGhsAttributesCallback | ModifyGhsStylesCallback ) )( values );
+		if ( values.size ) {
+			newValue[ kind ] = Object.fromEntries( values );
+		}
+	}
+
+	if ( Object.keys( newValue ).length ) {
+		if ( item.is( 'documentSelection' ) ) {
+			writer.setSelectionAttribute( ghsAttributeName, newValue );
+		} else {
+			writer.setAttribute( ghsAttributeName, newValue, item );
+		}
+	} else if ( oldValue ) {
+		if ( item.is( 'documentSelection' ) ) {
+			writer.removeSelectionAttribute( ghsAttributeName );
+		} else {
+			writer.removeAttribute( ghsAttributeName, item );
+		}
+	}
 }

--- a/packages/ckeditor5-html-support/tests/_utils/utils.js
+++ b/packages/ckeditor5-html-support/tests/_utils/utils.js
@@ -32,7 +32,7 @@ import { getData as getModelData } from '@ckeditor/ckeditor5-engine/src/dev-util
  * @returns {String} result.data The stringified data.
  * @returns {Object} result.attributes Indexed data attributes.
  */
-export function getModelDataWithAttributes( model, options ) {
+export function getModelDataWithAttributes( model, options = {} ) {
 	// Simplify GHS attributes as they are not very readable at this point due to object structure.
 	let counter = 1;
 	const data = getModelData( model, options ).replace( /(html.*?)="{.*?}"/g, ( fullMatch, attributeName ) => {

--- a/packages/ckeditor5-html-support/tests/integrations/heading.js
+++ b/packages/ckeditor5-html-support/tests/integrations/heading.js
@@ -12,7 +12,7 @@ import { getModelDataWithAttributes } from '../_utils/utils';
 /* global document */
 
 describe( 'HeadingElementSupport', () => {
-	let editor, editorElement, model, dataSchema, dataFilter, htmlSupport;
+	let editor, editorElement, model, doc, dataSchema, dataFilter, htmlSupport;
 
 	afterEach( () => {
 		editorElement.remove();
@@ -40,6 +40,7 @@ describe( 'HeadingElementSupport', () => {
 
 			editor = newEditor;
 			model = editor.model;
+			doc = model.document;
 			dataSchema = editor.plugins.get( 'DataSchema' );
 			dataFilter = editor.plugins.get( 'DataFilter' );
 			htmlSupport = editor.plugins.get( 'GeneralHtmlSupport' );
@@ -146,6 +147,53 @@ describe( 'HeadingElementSupport', () => {
 			} );
 
 			expect( editor.getData() ).to.equal( expectedHtml );
+		} );
+
+		it( 'should create a `paragraph` without html classes when pressing "enter" at the end of a heading block', () => {
+			editor.setData( '<h2 class="red-bg">foobar</h2>' );
+
+			model.change( writer => {
+				writer.setSelection( doc.getRoot().getChild( 0 ), 'end' );
+			} );
+
+			editor.execute( 'enter' );
+
+			expect( getModelDataWithAttributes( model ) ).to.deep.equal( {
+				data: '<heading2 htmlAttributes="(1)">foobar</heading2><paragraph>[]</paragraph>',
+				attributes: {
+					1: {
+						classes: [
+							'red-bg'
+						]
+					}
+				}
+			} );
+		} );
+
+		it( 'should create identical block when pressing "enter" not at the end of a heading block', () => {
+			editor.setData( '<h2 class="red-bg">foobar</h2>' );
+
+			model.change( writer => {
+				writer.setSelection( doc.getRoot().getChild( 0 ), 3 );
+			} );
+
+			editor.execute( 'enter' );
+
+			expect( getModelDataWithAttributes( model ) ).to.deep.equal( {
+				data: '<heading2 htmlAttributes="(1)">foo</heading2><heading2 htmlAttributes="(2)">[]bar</heading2>',
+				attributes: {
+					1: {
+						classes: [
+							'red-bg'
+						]
+					},
+					2: {
+						classes: [
+							'red-bg'
+						]
+					}
+				}
+			} );
 		} );
 
 		describe( 'should allow', () => {
@@ -401,6 +449,7 @@ describe( 'HeadingElementSupport', () => {
 
 			editor = newEditor;
 			model = editor.model;
+			doc = model.document;
 			dataSchema = editor.plugins.get( 'DataSchema' );
 			dataFilter = editor.plugins.get( 'DataFilter' );
 			htmlSupport = editor.plugins.get( 'GeneralHtmlSupport' );
@@ -500,6 +549,58 @@ describe( 'HeadingElementSupport', () => {
 			} );
 
 			expect( editor.getData() ).to.equal( expectedHtml );
+		} );
+
+		it( 'should create identical block when pressing "enter" at the end of a heading block', () => {
+			editor.setData( '<h2 class="red-bg">foobar</h2>' );
+
+			model.change( writer => {
+				writer.setSelection( doc.getRoot().getChild( 0 ), 3 );
+			} );
+
+			editor.execute( 'enter' );
+
+			expect( getModelDataWithAttributes( model ) ).to.deep.equal( {
+				data: '<htmlH2 htmlAttributes="(1)">foo</htmlH2><htmlH2 htmlAttributes="(2)">[]bar</htmlH2>',
+				attributes: {
+					1: {
+						classes: [
+							'red-bg'
+						]
+					},
+					2: {
+						classes: [
+							'red-bg'
+						]
+					}
+				}
+			} );
+		} );
+
+		it( 'should create identical block when pressing "enter" not at the end of a heading block', () => {
+			editor.setData( '<h2 class="red-bg">foobar</h2>' );
+
+			model.change( writer => {
+				writer.setSelection( doc.getRoot().getChild( 0 ), 3 );
+			} );
+
+			editor.execute( 'enter' );
+
+			expect( getModelDataWithAttributes( model ) ).to.deep.equal( {
+				data: '<htmlH2 htmlAttributes="(1)">foo</htmlH2><htmlH2 htmlAttributes="(2)">[]bar</htmlH2>',
+				attributes: {
+					1: {
+						classes: [
+							'red-bg'
+						]
+					},
+					2: {
+						classes: [
+							'red-bg'
+						]
+					}
+				}
+			} );
 		} );
 
 		describe( 'should allow', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (html-support): Remove HTML classes from paragraph created after pressing enter in heading. Closes #11578.
