### PR TITLE
ListPropertiesEditing should not crash if there was a list in an image caption element

### DIFF
--- a/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
@@ -378,7 +378,7 @@ function upcastListItemAttributes( attributeStrategies: Array<AttributeStrategy>
 			}
 
 			const listParent = data.viewItem.parent as ViewElement;
-			const listItem = data.modelRange!.start.nodeAfter || data.modelRange!.end.nodeBefore;
+			const listItem = data.modelRange.start.nodeAfter || data.modelRange.end.nodeBefore;
 
 			for ( const strategy of attributeStrategies ) {
 				if ( strategy.appliesToListItem( listItem! ) ) {

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
@@ -372,6 +372,11 @@ function createAttributeStrategies( enabledProperties: ListPropertiesConfig ) {
 function upcastListItemAttributes( attributeStrategies: Array<AttributeStrategy> ) {
 	return ( dispatcher: UpcastDispatcher ) => {
 		dispatcher.on<UpcastElementEvent>( 'element:li', ( evt, data, conversionApi ) => {
+			// https://github.com/ckeditor/ckeditor5/issues/13858
+			if ( !data.modelRange ) {
+				return;
+			}
+
 			const listParent = data.viewItem.parent as ViewElement;
 			const listItem = data.modelRange!.start.nodeAfter || data.modelRange!.end.nodeBefore;
 

--- a/packages/ckeditor5-list/tests/listproperties/listpropertiesediting.js
+++ b/packages/ckeditor5-list/tests/listproperties/listpropertiesediting.js
@@ -5405,6 +5405,25 @@ describe( 'ListPropertiesEditing', () => {
 						'</listItem>'
 					);
 				} );
+
+				// https://github.com/ckeditor/ckeditor5/issues/13858
+				it( 'should not convert if the schema does not allow it in the given context', () => {
+					editor.model.schema.register( 'disallowedContext', {
+						inheritAllFrom: '$blockObject'
+					} );
+
+					editor.conversion.elementToElement( {
+						model: 'disallowedContext',
+						view: {
+							name: 'div',
+							classes: 'disallowed-context'
+						}
+					} );
+
+					editor.setData( '<div class="disallowed-context"><ul><li>foo</li></ul></div>' );
+
+					expect( getModelData( editor.model ) ).to.equal( '[<disallowedContext></disallowedContext>]' );
+				} );
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (list): `ListPropertiesEditing` should not crash if there was a list in an image caption element. Closes #13858.