### PR TITLE
Multi-root editor will now throw if `EditorConfig#initialData` is mismatched with initial roots set in `MultiRootEditor#create()`

### DIFF
--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
@@ -233,6 +233,48 @@ describe( 'MultiRootEditor', () => {
 				.catch( done );
 		} );
 
+		it( 'throws error when initial roots are different than initial data - missing root in initial roots', done => {
+			MultiRootEditor.create( {
+				foo: document.createElement( 'div' )
+			}, {
+				initialData: {
+					foo: '<p>Foo</p>',
+					bar: '<p>Bar</p>'
+				}
+			} )
+				.then(
+					() => {
+						expect.fail( 'Multi-root editor should throw an error when initital roots and initial data are mismatched.' );
+					},
+					err => {
+						assertCKEditorError( err, 'multi-root-editor-root-initial-data-mismatch', null );
+					}
+				)
+				.then( done )
+				.catch( done );
+		} );
+
+		it( 'throws error when initial roots are different than initial data - missing root in initial data', done => {
+			MultiRootEditor.create( {
+				foo: document.createElement( 'div' ),
+				bar: document.createElement( 'div' )
+			}, {
+				initialData: {
+					foo: '<p>Foo</p>'
+				}
+			} )
+				.then(
+					() => {
+						expect.fail( 'Multi-root editor should throw an error when initital roots and initial data are mismatched.' );
+					},
+					err => {
+						assertCKEditorError( err, 'multi-root-editor-root-initial-data-mismatch', null );
+					}
+				)
+				.then( done )
+				.catch( done );
+		} );
+
 		function test( getElementOrData ) {
 			it( 'creates an instance which inherits from the MultiRootEditor', () => {
 				return MultiRootEditor

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
@@ -254,6 +254,42 @@ describe( 'MultiRootEditor', () => {
 				.catch( done );
 		} );
 
+		it( 'throws error when initial roots are different than initial data - detached root', done => {
+			// Artificial fake plugin that simulates a root being removed as the editor is initialized.
+			class RemoveRoot {
+				constructor( editor ) {
+					this.editor = editor;
+				}
+
+				init() {
+					const rootFoo = this.editor.model.document.getRoot( 'foo' );
+
+					rootFoo._isAttached = false;
+				}
+			}
+
+			MultiRootEditor.create( {
+				foo: document.createElement( 'div' )
+			}, {
+				initialData: {
+					foo: '<p>Foo</p>'
+				},
+				extraPlugins: [
+					RemoveRoot
+				]
+			} )
+				.then(
+					() => {
+						expect.fail( 'Multi-root editor should throw an error when initital roots and initial data are mismatched.' );
+					},
+					err => {
+						assertCKEditorError( err, 'multi-root-editor-root-initial-data-mismatch', null );
+					}
+				)
+				.then( done )
+				.catch( done );
+		} );
+
 		it( 'throws error when initial roots are different than initial data - missing root in initial data', done => {
 			MultiRootEditor.create( {
 				foo: document.createElement( 'div' ),


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (editor-multi-root): Multi-root editor will now throw if `EditorConfig#initialData` is mismatched with initial roots set in `MultiRootEditor#create()`.