### PR TITLE
The target ranges should not be fixed while editor is in composition mode

### DIFF
--- a/packages/ckeditor5-engine/tests/controller/editingcontroller.js
+++ b/packages/ckeditor5-engine/tests/controller/editingcontroller.js
@@ -935,6 +935,28 @@ describe( 'EditingController', () => {
 			sinon.assert.calledOnce( enterSpy );
 		} );
 
+		it( 'should not crash while trying to fix null range while composing', () => {
+			setModelData( model, '<paragraph>a</paragraph>' );
+
+			const targetRanges = [ null ];
+
+			const eventData = {
+				inputType: 'insertCompositionText',
+				data: 'ab',
+				targetRanges
+			};
+
+			viewDocument.isComposing = true;
+			fireBeforeInputEvent( eventData );
+
+			// Verify beforeinput range.
+			sinon.assert.calledOnce( beforeInputSpy );
+
+			const inputData = beforeInputSpy.args[ 0 ][ 1 ];
+			expect( inputData.inputType ).to.equal( eventData.inputType );
+			expect( inputData.targetRanges[ 0 ] ).to.be.null;
+		} );
+
 		function fireBeforeInputEvent( eventData ) {
 			viewDocument.fire( 'beforeinput', {
 				domEvent: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (engine): Composing in an empty paragraph should not throw an error. Closes #13867.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
