### PR TITLE
Fix (core): Add `licenseKey` property to `EditorConfig` interface

### DIFF
--- a/packages/ckeditor5-core/src/editor/editorconfig.ts
+++ b/packages/ckeditor5-core/src/editor/editorconfig.ts
@@ -488,6 +488,14 @@ export interface EditorConfig {
 	 * {@glink features/html/html-embed HTML embed} features.
 	 */
 	updateSourceElementOnDestroy?: boolean;
+
+	/**
+	 * The license key for the CKEditor 5 premium features.
+	 *
+	 * If you do not have a key yet, please [contact us](https://ckeditor.com/contact/) or
+	 * [order a trial](https://orders.ckeditor.com/trial/premium-features).
+	 */
+	licenseKey?: string;
 }
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (core): Add `licenseKey` property to `EditorConfig` interface. Closes #13906.
