### PR TITLE
Update CKE4 plugin and configuration compatibility tables after Productivity Pack is released

### DIFF
--- a/docs/_snippets/updating/plugins-mapping/plugins-mapping.html
+++ b/docs/_snippets/updating/plugins-mapping/plugins-mapping.html
@@ -176,7 +176,7 @@
                 <p style="margin-left:0px;"><a href="https://ckeditor.com/cke4/addon/copyformatting">copyformatting</a></p>
              </td>
              <td>
-                 <p style="margin-left:0px;"><a href="https://ckeditor.com/contact/">Coming soon</a></p>
+                 <p style="margin-left:0px;"><a href="https://ckeditor.com/docs/ckeditor5/latest/features/format-painter.html">Format painter</a></p>
              </td>
           </tr>
           <tr>
@@ -794,7 +794,7 @@
                 <p style="margin-left:0px;"><a href="https://ckeditor.com/cke4/addon/templates">templates</a></p>
              </td>
              <td>
-                 <p style="margin-left:0px;"><a href="https://ckeditor.com/contact/">Coming soon</a></p>
+                 <p style="margin-left:0px;"><a href="https://ckeditor.com/docs/ckeditor5/latest/features/template.html">Template</a></p>
              </td>
           </tr>
           <tr>

--- a/docs/updating/ckeditor4-configuration-compatibility.md
+++ b/docs/updating/ckeditor4-configuration-compatibility.md
@@ -153,7 +153,7 @@ Note: In CKEditor 5, the number of options was reduced on purpose. Configuring C
 		</tr>
 		<tr>
 			<td><a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-copyFormatting_allowRules">copyFormatting_allowRules</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-copyFormatting_allowedContexts">copyFormatting_allowedContexts</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-copyFormatting_disallowRules">copyFormatting_disallowRules</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-copyFormatting_keystrokeCopy">copyFormatting_keystrokeCopy</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-copyFormatting_keystrokePaste">copyFormatting_keystrokePaste</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-copyFormatting_outerCursor">copyFormatting_outerCursor</a></td>
-			<td><a href="https://ckeditor.com/contact/" target="_blank">Coming soon</a>!</td>
+			<td>Refer to the {@link features/format-painter Format painter} guide to learn how the copy formatting functionality works in CKEditor 5.</td>
 		</tr>
 		<tr>
 			<td><a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-coreStyles_bold">coreStyles_bold</a></td>
@@ -369,7 +369,7 @@ Note: In CKEditor 5, the number of options was reduced on purpose. Configuring C
 		</tr>
 		<tr>
 			<td><a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-fullPage">fullPage</a></td>
-			<td>N/A</td>
+			<td>Available through the {@link module:html-support/fullpage~FullPage} API.</td>
 		</tr>
 		<tr>
 			<td><a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-grayt_autoStartup">grayt_autoStartup</a></td>
@@ -482,7 +482,7 @@ Note: In CKEditor 5, the number of options was reduced on purpose. Configuring C
 			<td>N/A</td>
 		</tr>
 		<tr>
-			<td><a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-cfg-observableParent">observableParent</a></td>
+			<td><a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-observableParent">observableParent</a></td>
 			<td>N/A</td>
 		</tr>
 		<tr>
@@ -618,7 +618,7 @@ Note: In CKEditor 5, the number of options was reduced on purpose. Configuring C
 		</tr>
 		<tr>
 			<td><a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-templates">templates</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-templates_files">templates_files</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-templates_replaceContent">templates_replaceContent</a></td>
-			<td><a href="https://ckeditor.com/contact/" target="_blank">Coming soon</a>!</td>
+			<td>Refer to the {@link features/template Content templates} guide to learn about support for templates in CKEditor 5.</td>
 		</tr>
 		<tr>
 			<td><a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-title">title</a></td>
@@ -679,10 +679,6 @@ Note: In CKEditor 5, the number of options was reduced on purpose. Configuring C
 } );</code></pre>
 				<p>See also <a href="https://stackoverflow.com/questions/46559354/how-to-set-the-height-of-ckeditor-5-classic-editor" target="_blank" rel="noopener">How to set the height of CKEditor 5 (Classic editor)</a>.</p>
 			</td>
-		</tr>
-		<tr>
-			<td><a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-scayt_cmd">wsc_cmd</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-scayt_customDictionaryIds">wsc_customDictionaryIds</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-scayt_customLoaderScript">wsc_customLoaderScript</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-scayt_customerId">wsc_customerId</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-scayt_height">wsc_height</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-scayt_lang">wsc_lang</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-scayt_left">wsc_left</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-scayt_top">wsc_top</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-scayt_userDictionaryName">wsc_userDictionaryName</a> <br> <a href="/docs/ckeditor4/latest/api/CKEDITOR_config.html#cfg-scayt_width">wsc_width</a></td>
-			<td>The spell and grammar checking functionality for CKEditor 5 is provided by a partner solution, {@link features/spelling-and-grammar-checking WProofreader}.</td>
 		</tr>
 	</tbody>
 </table>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Updated CKE4 plugin and configuration compatibility tables with templates and format painter. Closes cksource/ckeditor5-internal#3138.

---

### Additional information

_Also:_

*   _Removed WSC from the configuration compatibility table as it's no longer available in CKE4 so the links are invalid._
*   _Added `FullPage` API as an equivalent to CKE4's `fullPage` configuration option._