### PR TITLE
Ck/11748 preserve classes used by other styles

### DIFF
--- a/packages/ckeditor5-style/src/stylecommand.ts
+++ b/packages/ckeditor5-style/src/stylecommand.ts
@@ -15,6 +15,8 @@ import { isObject } from 'lodash-es';
 
 import type { BlockStyleDefinition, InlineStyleDefinition, NormalizedStyleDefinitions } from './styleutils';
 
+type Definition = BlockStyleDefinition | InlineStyleDefinition;
+
 /**
  * Style command.
  *
@@ -174,11 +176,13 @@ export default class StyleCommand extends Command {
 		const selection = model.document.selection;
 		const htmlSupport: GeneralHtmlSupport = this.editor.plugins.get( 'GeneralHtmlSupport' );
 
-		const definition: BlockStyleDefinition | InlineStyleDefinition = [
+		const allDefinitions: Array<Definition> = [
 			...this._styleDefinitions.inline,
 			...this._styleDefinitions.block
-		].find( ( { name } ) => name == styleName )!;
+		];
 
+		const activeDefinitions = allDefinitions.filter( ( { name } ) => this.value.includes( name ) );
+		const definition: Definition = allDefinitions.find( ( { name } ) => name == styleName )!;
 		const shouldAddStyle = forceValue === undefined ? !this.value.includes( definition.name ) : forceValue;
 
 		model.change( () => {
@@ -194,7 +198,11 @@ export default class StyleCommand extends Command {
 				if ( shouldAddStyle ) {
 					htmlSupport.addModelHtmlClass( definition.element, definition.classes, selectable );
 				} else {
-					htmlSupport.removeModelHtmlClass( definition.element, definition.classes, selectable );
+					htmlSupport.removeModelHtmlClass(
+						definition.element,
+						getDefinitionExclusiveClasses( activeDefinitions, definition ),
+						selectable
+					);
 				}
 			}
 		} );
@@ -267,9 +275,27 @@ function getAffectedBlocks(
 }
 
 /**
+ * Returns classes that are defined only in the supplied definition and not in any other active definition. It's used
+ * to ensure that classes used by other definitions are preserved when a style is removed. See #11748.
+ *
+ * @param activeDefinitions All currently active definitions affecting selected element(s).
+ * @param definition Definition whose classes will be compared with all other active definition classes.
+ * @returns Array of classes exclusive to the supplied definition.
+ */
+function getDefinitionExclusiveClasses( activeDefinitions: Array<Definition>, definition: Definition ): Array<string> {
+	return activeDefinitions.reduce( ( classes: Array<string>, currentDefinition: Definition ) => {
+		if ( currentDefinition.name === definition.name ) {
+			return classes;
+		}
+
+		return classes.filter( className => !currentDefinition.classes.includes( className ) );
+	}, definition.classes );
+}
+
+/**
  * Checks if provided style definition is of type block.
  */
-function isBlockStyleDefinition( definition: BlockStyleDefinition | InlineStyleDefinition ): definition is BlockStyleDefinition {
+function isBlockStyleDefinition( definition: Definition ): definition is BlockStyleDefinition {
 	return 'isBlock' in definition;
 }
 

--- a/packages/ckeditor5-style/tests/manual/styledropdown.html
+++ b/packages/ckeditor5-style/tests/manual/styledropdown.html
@@ -109,6 +109,33 @@
 			color: hsl(0, 0%, 40%);
 		}
 
+		.ck.ck-content pre.fancy-code {
+			border: 0;
+			margin-left: 2em;
+			margin-right: 2em;
+			border-radius: 10px;
+		}
+
+		.ck.ck-content pre.fancy-code::before {
+			content: "";
+			display: block;
+			height: 13px;
+			background: url(data:image/svg+xml;base64,PHN2ZyBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA1NCAxMyI+CiAgPGNpcmNsZSBjeD0iNi41IiBjeT0iNi41IiByPSI2LjUiIGZpbGw9IiNGMzZCNUMiLz4KICA8Y2lyY2xlIGN4PSIyNi41IiBjeT0iNi41IiByPSI2LjUiIGZpbGw9IiNGOUJFNEQiLz4KICA8Y2lyY2xlIGN4PSI0Ny41IiBjeT0iNi41IiByPSI2LjUiIGZpbGw9IiM1NkM0NTMiLz4KPC9zdmc+Cg==);
+			margin-bottom: 8px;
+			background-repeat: no-repeat;
+		}
+
+		.ck.ck-content pre.fancy-code-dark {
+			background: #272822;
+			color: #fff;
+			box-shadow: 5px 5px 0 #0000001f;
+		}
+
+		.ck.ck-content pre.fancy-code-bright {
+			background: #dddfe0;
+			color: #000;
+			box-shadow: 5px 5px 0 #b3b3b3;
+		}
 	</style>
 </head>
 

--- a/packages/ckeditor5-style/tests/manual/styledropdown.js
+++ b/packages/ckeditor5-style/tests/manual/styledropdown.js
@@ -310,6 +310,16 @@ ClassicEditor
 					name: 'code.Qux',
 					element: 'code',
 					classes: [ 'Qux' ]
+				},
+				{
+					name: 'Code (dark)',
+					element: 'pre',
+					classes: [ 'fancy-code', 'fancy-code-dark' ]
+				},
+				{
+					name: 'Code (bright)',
+					element: 'pre',
+					classes: [ 'fancy-code', 'fancy-code-bright' ]
 				}
 			]
 		}

--- a/packages/ckeditor5-style/tests/stylecommand.js
+++ b/packages/ckeditor5-style/tests/stylecommand.js
@@ -78,6 +78,16 @@ describe( 'StyleCommand', () => {
 			name: 'Vibrant code block',
 			element: 'pre',
 			classes: [ 'vibrant-code' ]
+		},
+		{
+			name: 'Code (dark)',
+			element: 'pre',
+			classes: [ 'fancy-code', 'fancy-code-dark' ]
+		},
+		{
+			name: 'Code (bright)',
+			element: 'pre',
+			classes: [ 'fancy-code', 'fancy-code-bright' ]
 		}
 	];
 
@@ -478,6 +488,26 @@ describe( 'StyleCommand', () => {
 
 			expect( getData( model ) ).to.equal( '<paragraph>fo[ob]ar</paragraph>' );
 			sinon.assert.calledWithMatch( stub, 'style-command-executed-with-incorrect-style-name' );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/11748
+		it( 'should keep classes of removed style if other active styles also use them', () => {
+			setData( model, '<codeBlock language="typescript">[]</codeBlock>' );
+
+			// Add light and dark themes
+			command.execute( { styleName: 'Code (bright)' } );
+			command.execute( { styleName: 'Code (dark)' } );
+
+			// Remove light theme
+			command.execute( { styleName: 'Code (bright)' } );
+
+			expect( getData( model, { withoutSelection: true } ) ).to.equal(
+				'<codeBlock ' +
+					'htmlAttributes="{"classes":["fancy-code","fancy-code-dark"]}" ' +
+					'language="typescript"' +
+				'>' +
+				'</codeBlock>'
+			);
 		} );
 
 		describe( 'inline styles', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (style): Preserve classes of removed style if other active styles also use them. Closes #11748.
