### PR TITLE
Move exports and import to a common Document conversion category

### DIFF
--- a/docs/umberto.json
+++ b/docs/umberto.json
@@ -101,12 +101,15 @@
 		"features/image.html": "features/images/images-overview.html",
 		"features/image-upload.html": "features/images/image-upload/image-upload.html",
 		"features/easy-image.html": "features/images/image-upload/easy-image.html",
+		"features/export-pdf.html": "features/converters/export-pdf.html",
+		"features/export-word.html": "features/converters/export-word.html",
 		"features/image-upload/image-upload.html": "features/images/image-upload/image-upload.html",
 		"features/image-upload/easy-image.html": "features/images/image-upload/easy-image.html",
 		"features/image-upload/ckfinder.html": "features/file-management/ckfinder.html",
 		"features/image-upload/base64-upload-adapter.html": "features/images/image-upload/base64-upload-adapter.html",
 		"features/image-upload/simple-upload-adapter.html": "features/images/image-upload/simple-upload-adapter.html",
 		"features/images/image-upload/images-inserting.html": "features/images/images-inserting.html",
+		"features/import-word/import-word.html": "features/converters/import-word/import-word.html",
 		"features/lists.html": "features/lists/lists.html",
 		"features/todo-lists.html": "features/lists/todo-lists.html",
 		"features/general-html-support.html": "features/html/general-html-support.html",
@@ -415,6 +418,21 @@
 					]
 				},
 				{
+					"name": "Document conversion",
+					"id": "features-converters",
+					"slug": "converters",
+					"categories": [
+						{
+							"name": "Import from Word",
+							"id": "import-word",
+							"slug": "import-word",
+							"badges": [
+								"premium"
+							]
+						}
+					]
+				},
+				{
 					"name": "HTML advanced support",
 					"id": "features-html",
 					"slug": "html"
@@ -435,14 +453,6 @@
 							"slug": "image-upload",
 							"order": 80
 						}
-					]
-				},
-				{
-					"name": "Import from Word",
-					"id": "import-word",
-					"slug": "import-word",
-					"badges": [
-						"premium"
 					]
 				},
 				{

--- a/docs/umberto.json
+++ b/docs/umberto.json
@@ -433,14 +433,14 @@
 					]
 				},
 				{
-					"name": "HTML advanced support",
-					"id": "features-html",
-					"slug": "html"
-				},
-				{
 					"name": "File management",
 					"id": "features-file-management",
 					"slug": "file-management"
+				},
+				{
+					"name": "HTML advanced support",
+					"id": "features-html",
+					"slug": "html"
 				},
 				{
 					"name": "Images",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Moved exports and import to a common Document conversion category. Closes cksource/ckeditor5-internal#3104.

---

### Additional information

Another PR is needed to complete this task: https://github.com/cksource/ckeditor5-internal/pull/3176