### PR TITLE
Export image plugins as classes.

### DIFF
--- a/packages/ckeditor5-image/src/index.ts
+++ b/packages/ckeditor5-image/src/index.ts
@@ -31,14 +31,14 @@ export { default as ImageUploadEditing, type ImageUploadCompleteEvent } from './
 export { default as ImageUploadProgress } from './imageupload/imageuploadprogress';
 export { default as ImageUploadUI } from './imageupload/imageuploadui';
 export { default as PictureEditing } from './pictureediting';
+export { default as ImageBlock } from './imageblock';
+export { default as ImageInline } from './imageinline';
+export { default as ImageInsertViaUrl } from './imageinsertviaurl';
+export { default as ImageUtils } from './imageutils';
+export { default as ImageBlockEditing } from './image/imageblockediting';
+export { default as ImageCaptionUI } from './imagecaption/imagecaptionui';
 
 export type { ImageConfig } from './imageconfig';
-export type { default as ImageBlock } from './imageblock';
-export type { default as ImageInline } from './imageinline';
-export type { default as ImageInsertViaUrl } from './imageinsertviaurl';
-export type { default as ImageUtils } from './imageutils';
-export type { default as ImageBlockEditing } from './image/imageblockediting';
-export type { default as ImageCaptionUI } from './imagecaption/imagecaptionui';
 export type { default as ImageTypeCommand } from './image/imagetypecommand';
 export type { default as InsertImageCommand } from './image/insertimagecommand';
 export type { default as ReplaceImageSourceCommand } from './image/replaceimagesourcecommand';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (image): Change `export type` to `export` for `ckeditor5-image` plugins. Closes #13868.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
