### PR TITLE
Ctrl+A doesn't work in color picker input

### DIFF
--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -134,6 +134,12 @@ export default class ColorPickerView extends View {
 			const color = customEvent.detail.value;
 			this._debounceColorPickerEvent( color );
 		} );
+
+		// Intercept the `selectstart` event, which is blocked by default because of the default behavior
+		// of the DropdownView#panelView. This blocking prevents the native select all on Ctrl+A.
+		this.listenTo( this.input.element!, 'selectstart', ( evt, domEvt ) => {
+			domEvt.stopPropagation();
+		}, { priority: 'high' } );
 	}
 
 	private _createSlidersView(): void {

--- a/packages/ckeditor5-ui/tests/colorpicker/colorpickerview.js
+++ b/packages/ckeditor5-ui/tests/colorpicker/colorpickerview.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals CustomEvent, document */
+/* globals CustomEvent, Event, document */
 
 import ColorPickerView from './../../src/colorpicker/colorpickerview';
 import 'vanilla-colorful/hex-color-picker.js';
@@ -95,6 +95,19 @@ describe( 'ColorPickerView', () => {
 			clock.tick( 200 );
 
 			expect( view.color ).to.equal( '#ff0000' );
+		} );
+
+		it( 'intercepts the "selectstart" in the #input with the high priority to unlock select all', () => {
+			const spy = sinon.spy();
+			const event = new Event( 'selectstart', {
+				bubbles: true,
+				cancelable: true
+			} );
+
+			event.stopPropagation = spy;
+
+			view.input.element.dispatchEvent( event );
+			sinon.assert.calledOnce( spy );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): It should now be possible to select text in the color picker with Ctrl+A.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
