### PR TITLE
13985 -  Resolve Link plugin manual decorators quirks

### DIFF
--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -678,7 +678,7 @@ describe( 'LinkCommand', () => {
 		} );
 
 		describe( 'collapsed selection', () => {
-			it( 'should insert additional attributes to link when it is created', () => {
+			it( 'should insert and merge additional attributes to link when it is created', () => {
 				setData( model, 'foo[]bar' );
 
 				command.execute( 'url', { linkIsFoo: true, linkIsBar: true, linkIsSth: true } );
@@ -693,7 +693,8 @@ describe( 'LinkCommand', () => {
 				command.execute( 'url', { linkIsFoo: true, linkIsBar: true, linkIsSth: true } );
 
 				expect( getData( model ) ).to
-					.equal( 'f<$text linkHref="url" linkIsBar="true" linkIsFoo="true" linkIsSth="true">ooba</$text>[]r' );
+					.equal( 'f<$text linkClass="Foo sth" linkHref="url" linkTarget="_blank">' +
+					'ooba</$text><$text linkClass="Foo sth" linkTarget="_blank">[]</$text>r' );
 			} );
 
 			it( 'should remove additional attributes to link if those are falsy', () => {
@@ -710,7 +711,8 @@ describe( 'LinkCommand', () => {
 				command.execute( 'url2', { linkIsFoo: true, linkIsBar: true, linkIsSth: true } );
 
 				expect( getData( model ) ).to
-					.equal( '<$text linkHref="url2" linkIsBar="true" linkIsFoo="true" linkIsSth="true">url2</$text>[]' );
+					.equal( '<$text linkClass="Foo sth" linkHref="url2" linkTarget="_blank">' +
+					'url2</$text><$text linkClass="Foo sth" linkTarget="_blank">[]</$text>' );
 			} );
 
 			it( 'should not add new attributes if there are falsy when href is equal to content', () => {
@@ -724,13 +726,13 @@ describe( 'LinkCommand', () => {
 		} );
 
 		describe( 'range selection', () => {
-			it( 'should insert additional attributes to link when it is created', () => {
+			it( 'should insert and merge additional attributes to link when it is created', () => {
 				setData( model, 'f[ooba]r' );
 
 				command.execute( 'url', { linkIsFoo: true, linkIsBar: true, linkIsSth: true } );
 
 				expect( getData( model ) ).to
-					.equal( 'f[<$text linkHref="url" linkIsBar="true" linkIsFoo="true" linkIsSth="true">ooba</$text>]r' );
+					.equal( 'f[<$text linkClass="Foo sth" linkHref="url" linkTarget="_blank">ooba</$text>]r' );
 			} );
 
 			it( 'should add additional attributes to link when link is modified', () => {
@@ -739,7 +741,7 @@ describe( 'LinkCommand', () => {
 				command.execute( 'url', { linkIsFoo: true, linkIsBar: true, linkIsSth: true } );
 
 				expect( getData( model ) ).to
-					.equal( 'f[<$text linkHref="url" linkIsBar="true" linkIsFoo="true" linkIsSth="true">ooba</$text>]r' );
+					.equal( 'f[<$text linkClass="Foo sth" linkHref="url" linkTarget="_blank">ooba</$text>]r' );
 			} );
 
 			it( 'should remove additional attributes to link if those are falsy', () => {
@@ -756,7 +758,7 @@ describe( 'LinkCommand', () => {
 				command.execute( 'url', { linkIsFoo: true, linkIsBar: true, linkIsSth: true } );
 
 				expect( getData( model ) ).to
-					.equal( '[<linkableBlock linkHref="url" linkIsBar="true" linkIsFoo="true" linkIsSth="true"></linkableBlock>]' );
+					.equal( '[<linkableBlock linkClass="Foo sth" linkHref="url" linkTarget="_blank"></linkableBlock>]' );
 			} );
 
 			it( 'should insert additional attributes to a linkable inline element when it is created', () => {
@@ -766,7 +768,7 @@ describe( 'LinkCommand', () => {
 
 				expect( getData( model ) ).to.equal(
 					'<paragraph>' +
-						'foo[<linkableInline linkHref="url" linkIsBar="true" linkIsFoo="true" linkIsSth="true"></linkableInline>]bar' +
+						'foo[<linkableInline linkClass="Foo sth" linkHref="url" linkTarget="_blank"></linkableInline>]bar' +
 					'</paragraph>'
 				);
 			} );
@@ -777,7 +779,7 @@ describe( 'LinkCommand', () => {
 				command.execute( 'url2', { linkIsFoo: true, linkIsBar: true, linkIsSth: true } );
 
 				expect( getData( model ) ).to
-					.equal( '[<$text linkHref="url2" linkIsBar="true" linkIsFoo="true" linkIsSth="true">url2</$text>]' );
+					.equal( '[<$text linkClass="Foo sth" linkHref="url2" linkTarget="_blank">url2</$text>]' );
 			} );
 
 			it( 'should not update content if href is equal to content but there is a non-link following in the selection', () => {
@@ -787,7 +789,7 @@ describe( 'LinkCommand', () => {
 
 				expect( getData( model ) ).to
 					.equal(
-						'<paragraph>[<$text linkHref="url2" linkIsBar="true" linkIsFoo="true" linkIsSth="true">urlfoo</$text>]</paragraph>'
+						'<paragraph>[<$text linkClass="Foo sth" linkHref="url2" linkTarget="_blank">urlfoo</$text>]</paragraph>'
 					);
 			} );
 
@@ -798,7 +800,7 @@ describe( 'LinkCommand', () => {
 
 				expect( getData( model ) ).to
 					.equal(
-						'<paragraph>[<$text linkHref="url2" linkIsBar="true" linkIsFoo="true" linkIsSth="true">foourl</$text>]</paragraph>'
+						'<paragraph>[<$text linkClass="Foo sth" linkHref="url2" linkTarget="_blank">foourl</$text>]</paragraph>'
 					);
 			} );
 
@@ -841,25 +843,25 @@ describe( 'LinkCommand', () => {
 				setData( model, 'foo<$text linkHref="url" linkIsBar="true" linkIsFoo="true" linkIsSth="true">u[]rl</$text>bar' );
 
 				expect( decoratorStates( command.manualDecorators ) ).to.deep.equal( {
-					linkIsFoo: true,
-					linkIsBar: true,
-					linkIsSth: true
+					linkIsFoo: undefined,
+					linkIsBar: undefined,
+					linkIsSth: undefined
 				} );
 
 				command.manualDecorators.first.value = false;
 
 				expect( decoratorStates( command.manualDecorators ) ).to.deep.equal( {
 					linkIsFoo: false,
-					linkIsBar: true,
-					linkIsSth: true
+					linkIsBar: undefined,
+					linkIsSth: undefined
 				} );
 
 				command.restoreManualDecoratorStates();
 
 				expect( decoratorStates( command.manualDecorators ) ).to.deep.equal( {
-					linkIsFoo: true,
-					linkIsBar: true,
-					linkIsSth: true
+					linkIsFoo: undefined,
+					linkIsBar: undefined,
+					linkIsSth: undefined
 				} );
 			} );
 
@@ -867,32 +869,32 @@ describe( 'LinkCommand', () => {
 				setData( model, 'foo<$text linkHref="url" linkIsBar="true" linkIsFoo="true" linkIsSth="false">u[]rl</$text>bar' );
 
 				expect( decoratorStates( command.manualDecorators ) ).to.deep.equal( {
-					linkIsFoo: true,
-					linkIsBar: true,
-					linkIsSth: false
+					linkIsFoo: undefined,
+					linkIsBar: undefined,
+					linkIsSth: undefined
 				} );
 
 				command.manualDecorators.last.value = true;
 
 				expect( decoratorStates( command.manualDecorators ) ).to.deep.equal( {
-					linkIsFoo: true,
-					linkIsBar: true,
+					linkIsFoo: undefined,
+					linkIsBar: undefined,
 					linkIsSth: true
 				} );
 
 				command.restoreManualDecoratorStates();
 
 				expect( decoratorStates( command.manualDecorators ) ).to.deep.equal( {
-					linkIsFoo: true,
-					linkIsBar: true,
-					linkIsSth: false
+					linkIsFoo: undefined,
+					linkIsBar: undefined,
+					linkIsSth: undefined
 				} );
 			} );
 		} );
 
 		describe( '_getDecoratorStateFromModel', () => {
 			it( 'obtain current values from the model', () => {
-				setData( model, 'foo[<$text linkHref="url" linkIsBar="true">url</$text>]bar' );
+				setData( model, 'foo[<$text linkHref="url" linkTarget="_blank">url</$text>]bar' );
 
 				expect( command._getDecoratorStateFromModel( 'linkIsFoo' ) ).to.be.undefined;
 				expect( command._getDecoratorStateFromModel( 'linkIsBar' ) ).to.be.true;

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -649,6 +649,12 @@ describe( 'LinkCommand', () => {
 						},
 						defaultValue: true
 					} ) );
+					command.manualDecorators.add( new ManualDecorator( {
+						id: 'linkIsNoattr',
+						label: 'NoAttr',
+						classes: [ 'noattr' ],
+						defaultValue: true
+					} ) );
 
 					model.schema.extend( '$text', {
 						allowIn: '$root',
@@ -703,6 +709,15 @@ describe( 'LinkCommand', () => {
 				command.execute( 'url', { linkIsFoo: false, linkIsBar: false } );
 
 				expect( getData( model ) ).to.equal( 'foo<$text linkHref="url">url</$text>[]bar' );
+			} );
+
+			it( 'should handle attribute conflicts', () => {
+				setData( model, 'foo<$text linkHref="url" linkIsBar="true" linkIsFoo="true">u[]rl</$text>bar' );
+
+				command.execute( 'url', { linkIsFoo: false, linkIsBar: false, linkIsSth: true, linkIsNoattr: false } );
+
+				expect( getData( model ) ).to
+					.equal( 'foo<$text linkClass="sth" linkHref="url">url</$text><$text linkClass="sth">[]</$text>bar' );
 			} );
 
 			it( 'should update content if href is equal to content', () => {
@@ -845,6 +860,7 @@ describe( 'LinkCommand', () => {
 				expect( decoratorStates( command.manualDecorators ) ).to.deep.equal( {
 					linkIsFoo: undefined,
 					linkIsBar: undefined,
+					linkIsNoattr: undefined,
 					linkIsSth: undefined
 				} );
 
@@ -853,6 +869,7 @@ describe( 'LinkCommand', () => {
 				expect( decoratorStates( command.manualDecorators ) ).to.deep.equal( {
 					linkIsFoo: false,
 					linkIsBar: undefined,
+					linkIsNoattr: undefined,
 					linkIsSth: undefined
 				} );
 
@@ -861,6 +878,7 @@ describe( 'LinkCommand', () => {
 				expect( decoratorStates( command.manualDecorators ) ).to.deep.equal( {
 					linkIsFoo: undefined,
 					linkIsBar: undefined,
+					linkIsNoattr: undefined,
 					linkIsSth: undefined
 				} );
 			} );
@@ -871,6 +889,7 @@ describe( 'LinkCommand', () => {
 				expect( decoratorStates( command.manualDecorators ) ).to.deep.equal( {
 					linkIsFoo: undefined,
 					linkIsBar: undefined,
+					linkIsNoattr: undefined,
 					linkIsSth: undefined
 				} );
 
@@ -879,7 +898,8 @@ describe( 'LinkCommand', () => {
 				expect( decoratorStates( command.manualDecorators ) ).to.deep.equal( {
 					linkIsFoo: undefined,
 					linkIsBar: undefined,
-					linkIsSth: true
+					linkIsNoattr: true,
+					linkIsSth: undefined
 				} );
 
 				command.restoreManualDecoratorStates();
@@ -887,6 +907,7 @@ describe( 'LinkCommand', () => {
 				expect( decoratorStates( command.manualDecorators ) ).to.deep.equal( {
 					linkIsFoo: undefined,
 					linkIsBar: undefined,
+					linkIsNoattr: undefined,
 					linkIsSth: undefined
 				} );
 			} );

--- a/packages/ckeditor5-link/tests/linkediting.js
+++ b/packages/ckeditor5-link/tests/linkediting.js
@@ -891,7 +891,7 @@ describe( 'LinkEditing', () => {
 
 				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
 					'<paragraph>' +
-						'<$text linkHref="url" linkIsDownloadable="true" linkIsExternal="true">Foo</$text>' +
+						'<$text linkHref="url" linkIsDownloadable="true" linkRel="noopener noreferrer" linkTarget="_blank">Foo</$text>' +
 						'<$text linkHref="example.com" linkIsFile="true">Bar</$text>' +
 						'<$text linkHref="example.com" linkIsDownloadable="true">Baz</$text>' +
 					'</paragraph>'
@@ -930,7 +930,7 @@ describe( 'LinkEditing', () => {
 
 				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
 					'<paragraph>' +
-						'<$text linkHref="url">Foo</$text>' +
+						'<$text linkHref="url" linkTarget="_blank">Foo</$text>' +
 						'<$text linkHref="example.com">Bar</$text>' +
 					'</paragraph>'
 				);

--- a/packages/ckeditor5-link/tests/linkimageediting.js
+++ b/packages/ckeditor5-link/tests/linkimageediting.js
@@ -940,7 +940,10 @@ describe( 'LinkImageEditing', () => {
 						'src="sample.jpg">' +
 					'</imageBlock>' +
 					'<paragraph>' +
-						'<$text linkHref="https://cksource.com" linkIsDownloadable="true" linkIsExternal="true">' +
+						'<$text linkHref="https://cksource.com" ' +
+						'linkIsDownloadable="true" ' +
+						'linkRel="noopener noreferrer" ' +
+						'linkTarget="_blank">' +
 							'https://cksource.com' +
 						'</$text>' +
 					'</paragraph>'
@@ -963,15 +966,18 @@ describe( 'LinkImageEditing', () => {
 
 				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
 					'<imageBlock alt="bar" ' +
-						'linkHref="https://cksource.com" ' +
-						'linkIsDownloadable="true" ' +
-						'linkIsExternal="true" ' +
-						'linkIsGallery="true" ' +
-						'linkIsHighlighted="true" ' +
-						'src="sample.jpg">' +
+					'linkHref="https://cksource.com" ' +
+					'linkIsDownloadable="true" ' +
+					'linkIsExternal="true" ' +
+					'linkIsGallery="true" ' +
+					'linkIsHighlighted="true" ' +
+					'src="sample.jpg">' +
 					'</imageBlock>' +
 					'<paragraph>' +
-						'<$text linkHref="https://cksource.com" linkIsDownloadable="true" linkIsExternal="true">' +
+						'<$text linkHref="https://cksource.com" ' +
+							'linkIsDownloadable="true" ' +
+							'linkRel="noopener noreferrer" ' +
+							'linkTarget="_blank">' +
 							'https://cksource.com' +
 						'</$text>' +
 					'</paragraph>'
@@ -1094,15 +1100,18 @@ describe( 'LinkImageEditing', () => {
 				} );
 
 				expect( editor.getData() ).to.equal(
-					'<figure class="image">' +
-						'<a class="gallery highlighted" style="text-decoration:underline;" href="https://cksource.com" ' +
-						'download="download" target="_blank" rel="noopener noreferrer">' +
-							'<img alt="bar" src="sample.jpg">' +
-						'</a>' +
-					'</figure>' +
+					'<a target="_blank" ' +
+					'rel="noopener noreferrer">' +
+						'<figure class="image">' +
+							'<a href="https://cksource.com">' +
+								'<img alt="bar" src="sample.jpg">' +
+							'</a>' +
+						'</figure>' +
+					'</a>' +
 					'<p>' +
-						'<a class="gallery highlighted" style="text-decoration:underline;" href="https://cksource.com" ' +
-						'download="download" target="_blank" rel="noopener noreferrer">' +
+						'<a href="https://cksource.com" ' +
+						'target="_blank" ' +
+						'rel="noopener noreferrer">' +
 							'https://cksource.com' +
 						'</a>' +
 					'</p>'
@@ -1134,9 +1143,7 @@ describe( 'LinkImageEditing', () => {
 				} ).to.not.throw();
 
 				expect( editor.getData() ).to.equal(
-					'<figure class="image">' +
-						'<img alt="bar" src="sample.jpg">' +
-					'</figure>'
+					'<a target="_blank" rel="noopener noreferrer"><figure class="image"><img alt="bar" src="sample.jpg"></figure></a>'
 				);
 			} );
 

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -1734,12 +1734,12 @@ describe( 'LinkUI', () => {
 
 					setModelData( model, 'f[<$text linkHref="url" linkIsFoo="true">ooba</$text>]r' );
 					expect( formView.urlInputView.fieldView.element.value ).to.equal( 'url' );
-					expect( formView.getDecoratorSwitchesState() ).to.deep.equal( { linkIsFoo: true } );
+					expect( formView.getDecoratorSwitchesState() ).to.deep.equal( { linkIsFoo: false } );
 
 					formView.fire( 'submit' );
 
 					expect( executeSpy.calledOnce ).to.be.true;
-					expect( executeSpy.calledWithExactly( 'link', 'url', { linkIsFoo: true } ) ).to.be.true;
+					expect( executeSpy.calledWithExactly( 'link', 'url', { linkIsFoo: true } ) ).to.be.false;
 				} );
 
 				it( 'should reset switch state when form view is closed', () => {
@@ -1749,16 +1749,16 @@ describe( 'LinkUI', () => {
 					const firstDecoratorModel = manualDecorators.first;
 					const firstDecoratorSwitch = formView._manualDecoratorSwitches.first;
 
-					expect( firstDecoratorModel.value, 'Initial value should be read from the model (true)' ).to.be.true;
-					expect( firstDecoratorSwitch.isOn, 'Initial value should be read from the model (true)' ).to.be.true;
+					expect( firstDecoratorModel.value, 'Initial value should be read from the model (true)' ).to.be.undefined;
+					expect( firstDecoratorSwitch.isOn, 'Initial value should be read from the model (true)' ).to.be.false;
 
 					firstDecoratorSwitch.fire( 'execute' );
-					expect( firstDecoratorModel.value, 'Pressing button toggles value' ).to.be.false;
-					expect( firstDecoratorSwitch.isOn, 'Pressing button toggles value' ).to.be.false;
+					expect( firstDecoratorModel.value, 'Pressing button toggles value' ).to.be.true;
+					expect( firstDecoratorSwitch.isOn, 'Pressing button toggles value' ).to.be.true;
 
 					linkUIFeature._closeFormView();
-					expect( firstDecoratorModel.value, 'Close form view without submit resets value to initial state' ).to.be.true;
-					expect( firstDecoratorSwitch.isOn, 'Close form view without submit resets value to initial state' ).to.be.true;
+					expect( firstDecoratorModel.value, 'Close form view without submit resets value to initial state' ).to.be.undefined;
+					expect( firstDecoratorSwitch.isOn, 'Close form view without submit resets value to initial state' ).to.be.false;
 				} );
 			} );
 		} );


### PR DESCRIPTION
Fix (link): Resolve Link plugin manual decorators quirks. Attempt to solve #13985.

See issue description

MAJOR BREAKING CHANGE (link): link attributes in decorators for standard html a tag attributes are now treated as strings rather than boolean