### PR TITLE
Added script that checks if a package is CKEditor 5 dependency

### DIFF
--- a/scripts/release/isckeditor5package.js
+++ b/scripts/release/isckeditor5package.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* eslint-env node */
+
+'use strict';
+
+// Patterns that define all possible CKEditor 5 dependencies.
+const PATTERNS_TO_MATCH = [
+	/^@ckeditor\/ckeditor5-(.*)/,
+	/^ckeditor5(-collaboration)?$/
+];
+
+// Packages that match the CKEditor 5 patterns, but should not be updated, because they aren't a dependency of the project.
+const PATTERNS_TO_SKIP = [
+	/^@ckeditor\/ckeditor5-dev$/,
+	/^@ckeditor\/ckeditor5-dev-.*/,
+	'@ckeditor/ckeditor5-angular',
+	'@ckeditor/ckeditor5-react',
+	'@ckeditor/ckeditor5-vue',
+	'@ckeditor/ckeditor5-vue2',
+	'@ckeditor/ckeditor5-inspector'
+];
+
+/**
+ * Checks whether provided package name is the CKEditor 5 dependency.
+ *
+ * @param {String} packageName Package name to check.
+ * @returns {Boolean}
+ */
+module.exports = function isCKEditor5Package( packageName ) {
+	const match = PATTERNS_TO_MATCH.some( pattern => packageName.match( pattern ) );
+	const shouldSkip = PATTERNS_TO_SKIP.some( pattern => packageName.match( pattern ) );
+
+	return ( match && !shouldSkip );
+};


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Added script that checks if a package is CKEditor 5 dependency. See ckeditor/ckeditor5#13953.

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5-dev/pull/871.
