### PR TITLE
Color picker view should handle enter key

### DIFF
--- a/packages/ckeditor5-font/src/ui/colortableview.ts
+++ b/packages/ckeditor5-font/src/ui/colortableview.ts
@@ -1015,7 +1015,6 @@ class ColorPickerPageView extends View {
 		} );
 
 		cancelButtonView.on( 'execute', () => {
-			console.log( 'cancel ---------' );
 			this.fire<ColorTableCancelEvent>( 'cancel' );
 		} );
 

--- a/packages/ckeditor5-font/src/ui/colortableview.ts
+++ b/packages/ckeditor5-font/src/ui/colortableview.ts
@@ -891,6 +891,7 @@ class ColorPickerPageView extends View {
 
 		this._addColorPickersElementsToFocusTracker();
 		this._stopPropagationOnArrowsKeys();
+		this._executeOnEnterPress();
 		this._executeUponColorChange();
 	}
 
@@ -906,6 +907,22 @@ class ColorPickerPageView extends View {
 	 */
 	public focus(): void {
 		this.colorPickerView!.focus();
+	}
+
+	/**
+	 * When color picker is focused and "enter" is pressed it executes command.
+	 */
+	private _executeOnEnterPress(): void {
+		this.keystrokes.set( 'enter', evt => {
+			if ( this.isVisible && this.focusTracker.focusedElement !== this.cancelButtonView.element ) {
+				this.fire( 'execute', {
+					value: this.selectedColor!
+				} );
+
+				evt.stopPropagation();
+				evt.preventDefault();
+			}
+		} );
 	}
 
 	/**
@@ -998,6 +1015,7 @@ class ColorPickerPageView extends View {
 		} );
 
 		cancelButtonView.on( 'execute', () => {
+			console.log( 'cancel ---------' );
 			this.fire<ColorTableCancelEvent>( 'cancel' );
 		} );
 

--- a/packages/ckeditor5-font/tests/ui/colortableview.js
+++ b/packages/ckeditor5-font/tests/ui/colortableview.js
@@ -333,6 +333,30 @@ describe( 'ColorTableView', () => {
 			sinon.assert.calledOnce( spy );
 		} );
 
+		it( 'should execute when color picker is focused and enter pressed', () => {
+			const keyEvtData = {
+				keyCode: keyCodes.enter,
+				preventDefault: sinon.spy(),
+				stopPropagation: sinon.spy()
+			};
+
+			colorTableView._appendColorPicker();
+
+			colorTableView.colorGridsPageView.colorPickerButtonView.fire( 'execute' );
+
+			// Mock the remove color button is focused.
+			colorTableView.focusTracker.isFocused = true;
+			colorTableView.focusTracker.focusedElement = colorTableView.colorPickerPageView.colorPickerView.slidersView.first.element;
+
+			const spy = sinon.spy();
+			colorTableView.on( 'execute', spy );
+
+			colorTableView.keystrokes.press( keyEvtData );
+			sinon.assert.calledOnce( keyEvtData.preventDefault );
+			sinon.assert.calledOnce( keyEvtData.stopPropagation );
+			sinon.assert.calledOnce( spy );
+		} );
+
 		it( 'should stop propagation when use arrow keys', () => {
 			const keyEvtData = {
 				keyCode: keyCodes.arrowright,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal(ui): Color picker form should accept enter key handling.
Closes [#3177](https://github.com/cksource/ckeditor5-internal/issues/3177).

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
