### PR TITLE
Added support for updating the release date references in CKEditor 5

### DIFF
--- a/scripts/release/prepare-packages.js
+++ b/scripts/release/prepare-packages.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const releaseTools = require( '@ckeditor/ckeditor5-dev-release-tools' );
+const updateVersionReferences = require( './update-version-references' );
 
 const abortController = new AbortController();
 
@@ -23,6 +24,10 @@ process.on( 'SIGINT', () => {
 	releaseTools.updateDependencies( {
 		version: '^' + latestVersion,
 		shouldUpdateVersionCallback: require( './isckeditor5package' )
+	} );
+
+	updateVersionReferences( {
+		version: latestVersion
 	} );
 
 	await releaseTools.executeInParallel( {

--- a/scripts/release/prepare-packages.js
+++ b/scripts/release/prepare-packages.js
@@ -29,7 +29,8 @@ process.on( 'SIGINT', () => {
 	} );
 
 	updateVersionReferences( {
-		version: latestVersion
+		version: latestVersion,
+		releaseDate: new Date()
 	} );
 
 	await releaseTools.executeInParallel( {

--- a/scripts/release/update-version-references.js
+++ b/scripts/release/update-version-references.js
@@ -74,6 +74,7 @@ module.exports = function updateVersionReferences( options = {} ) {
 	}
 };
 
+// TODO: Not sure if the date format is OK.
 function getCurrentDate() {
 	const now = new Date();
 	const day = String( now.getDate() ).padStart( 2, '0' );

--- a/scripts/release/update-version-references.js
+++ b/scripts/release/update-version-references.js
@@ -10,27 +10,19 @@
 'use strict';
 
 const fs = require( 'fs' );
-const path = require( 'path' );
 const chalk = require( 'chalk' );
-const { getLastFromChangelog } = require( '@ckeditor/ckeditor5-dev-release-tools' );
+const upath = require( 'upath' );
 
-const ROOT_DIRECTORY = path.join( __dirname, '..', '..' );
+const ROOT_DIRECTORY = upath.join( __dirname, '..', '..' );
 
 /**
  * Updates CKEditor 5 version and release date references in several places.
  *
- * @param {Object} [options]
- * @param {String} [options.version] The version of CKEditor 5 to set.
- * @param {String} [options.releaseDate] Release date to set.
+ * @param {Object} options
+ * @param {String} options.version The version of CKEditor 5 to set.
+ * @param {Date} options.releaseDate The release date to set.
  */
-module.exports = function updateVersionReferences( options = {} ) {
-	const {
-		version = getLastFromChangelog(),
-		releaseDate = getCurrentDate()
-	} = options;
-
-	const currentDate = new Date();
-
+module.exports = function updateVersionReferences( { version, releaseDate } ) {
 	const filesToUpdate = [
 		{
 			label: 'CDN',
@@ -40,22 +32,22 @@ module.exports = function updateVersionReferences( options = {} ) {
 		},
 		{
 			label: 'version',
-			file: path.join( 'packages', 'ckeditor5-utils', 'src', 'version.ts' ),
+			file: upath.join( 'packages', 'ckeditor5-utils', 'src', 'version.ts' ),
 			pattern: /(?<=const version = ')\d+\.\d+\.\d+(?=';)/,
 			value: version
 		},
 		{
 			label: 'release date',
-			file: path.join( 'packages', 'ckeditor5-utils', 'src', 'version.ts' ),
+			file: upath.join( 'packages', 'ckeditor5-utils', 'src', 'version.ts' ),
 			pattern: /(?<=const releaseDate = new Date\( )\d+, \d+, \d+(?= \);)/,
-			value: `${ currentDate.getFullYear() }, ${ currentDate.getMonth() }, ${ currentDate.getDate() }`
+			value: `${ releaseDate.getFullYear() }, ${ releaseDate.getMonth() }, ${ releaseDate.getDate() }`
 		}
 	];
 
 	console.log( chalk.blue( `Updating CKEditor 5 version (${ version }) and release date (${ releaseDate }) references.\n` ) );
 
 	for ( const { file, pattern, value, label } of filesToUpdate ) {
-		const absolutePath = path.join( ROOT_DIRECTORY, file ).split( path.sep ).join( path.posix.sep );
+		const absolutePath = upath.join( ROOT_DIRECTORY, file );
 
 		if ( !fs.existsSync( absolutePath ) ) {
 			console.log( chalk.red( `* File does not exist: "${ chalk.underline( absolutePath ) }" (${ label })` ) );
@@ -77,13 +69,3 @@ module.exports = function updateVersionReferences( options = {} ) {
 		console.log( chalk.cyan( `* Updated file: "${ chalk.underline( absolutePath ) }" (${ label })` ) );
 	}
 };
-
-// TODO: Not sure if the date format is OK.
-function getCurrentDate() {
-	const now = new Date();
-	const day = String( now.getDate() ).padStart( 2, '0' );
-	const month = String( now.getMonth() + 1 ).padStart( 2, '0' );
-	const year = now.getFullYear();
-
-	return year + '-' + month + '-' + day;
-}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Added support for updating the release date references in CKEditor 5. Closes #13972.

---

### Additional information

Notes:
- Removed the ability to make a commit. In the new release process a commit will be done at the end.
- Now, this script exports a function to make it possible to use it in the new release process.
