### PR TITLE
Fix output color format in color picker

### DIFF
--- a/packages/ckeditor5-font/tests/integration.js
+++ b/packages/ckeditor5-font/tests/integration.js
@@ -211,4 +211,37 @@ describe( 'Integration test Font', () => {
 				} );
 		} );
 	} );
+
+	describe( 'color picker feature', () => {
+		it( 'should set colors in model in hsl format by default', () => {
+			setModelData( model,
+				'<paragraph>' +
+					'<$text>[foo]</$text>' +
+				'</paragraph>'
+			);
+
+			const dropdown = editor.ui.componentFactory.create( 'fontColor' );
+
+			dropdown.isOpen = true;
+			dropdown.colorTableView.colorPickerPageView.colorPickerView.color = '#113322';
+
+			expect( getData( model ) ).to.equal( '<paragraph>[<$text fontColor="hsl( 150, 50%, 13% )">foo</$text>]</paragraph>' );
+		} );
+
+		it( 'should set colors in model in configured format', () => {
+			setModelData( model,
+				'<paragraph>' +
+					'<$text>[foo]</$text>' +
+				'</paragraph>'
+			);
+
+			const dropdown = editor.ui.componentFactory.create( 'fontColor' );
+
+			dropdown.isOpen = true;
+			dropdown.colorTableView.colorPickerPageView.colorPickerView._format = 'lab';
+			dropdown.colorTableView.colorPickerPageView.colorPickerView.color = '#113322';
+
+			expect( getData( model ) ).to.equal( '<paragraph>[<$text fontColor="lab( 18% -17 7 )">foo</$text>]</paragraph>' );
+		} );
+	} );
 } );

--- a/packages/ckeditor5-font/tests/ui/colorui.js
+++ b/packages/ckeditor5-font/tests/ui/colorui.js
@@ -180,10 +180,9 @@ describe( 'ColorUI', () => {
 		describe( 'color picker', () => {
 			it( 'should execute command if the color gets changed when dropdown is open', () => {
 				const spy = sinon.spy( editor, 'execute' );
-
 				dropdown.colorTableView.colorPickerPageView.colorPickerView.color = '#a37474';
 
-				sinon.assert.calledWithExactly( spy, 'testColorCommand', sinon.match( { value: '#a37474' } ) );
+				sinon.assert.calledWithExactly( spy, 'testColorCommand', sinon.match( { value: 'hsl( 0, 20%, 55% )' } ) );
 			} );
 
 			it( 'should not execute command if the color gets changed when dropdown is closed', () => {

--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -104,16 +104,9 @@ export default class ColorPickerView extends View {
 		} );
 
 		// Sets color in the picker if color was updated.
-		this.on( 'set:color', ( evt, propertyName, newValue, oldValue ) => {
-			const convertedColor = convertColor( newValue, this._format );
-
-			if ( convertedColor != oldValue ) {
-				evt.return = convertedColor;
-
-				return;
-			}
-
-			evt.return = oldValue;
+		this.on( 'set:color', ( evt, propertyName, newValue ) => {
+			// The color needs always to be kept in the output format.
+			evt.return = convertColor( newValue, this._format );
 		} );
 
 		this.on( 'change:color', () => {

--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -104,13 +104,19 @@ export default class ColorPickerView extends View {
 		} );
 
 		// Sets color in the picker if color was updated.
-		this.on( 'change:color', () => {
-			const convertedColor = convertColor( this.color, this._format );
+		this.on( 'set:color', ( evt, propertyName, newValue, oldValue ) => {
+			const convertedColor = convertColor( newValue, this._format );
 
-			if ( convertedColor != this.color ) {
-				this.color = convertedColor;
+			if ( convertedColor != oldValue ) {
+				evt.return = convertedColor;
+
+				return;
 			}
 
+			evt.return = oldValue;
+		} );
+
+		this.on( 'change:color', () => {
 			this._hexColor = convertColorToCommonHexFormat( this.color );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal(font): Fix output format in color picker.

---

### Additional information

The flow causing the bug was as follows:

1.  Color is picked from color picker. It's in `hex` format. Property `color` in color picker is set.
2.  On `color` property change, it's converted to desired output format (HSL by default). This fires another nested `.on( 'change:color' )` call. The first one is on hold - the `_hexColor` property is not updated yet.
3.  The second color change is propagated to `colorTableView` and higher. Formatting in HSL format is set in the model.
4.  Afterwards, the first `color` property change is resumed. It re-triggers the changes in `colorTableView`, but this time with the older value - in `hex` format. It overwrites the previously set model property. In color picker everything seems to be fine - `color` property is in HSL format.

To fix this, I put the logic `color` prop logic to `.on( 'set:color' )` listener instead (with minor adjustments). Now we no longer have the duplicated color change events.