### PR TITLE
Add a stylesheet for color-picker shadow component with look of focue…

### DIFF
--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -138,6 +138,16 @@ export default class ColorPickerView extends View {
 
 		if ( this.element ) {
 			this.element.insertBefore( this.picker, this.hexInputRow.element );
+
+			// Create custom stylesheet with a look of focused pointer in color picker and append it into the color picker shadowDom
+			const styleSheetForFocusedColorPicker = document.createElement( 'style' );
+
+			styleSheetForFocusedColorPicker.textContent = '[role="slider"]:focus [part$="pointer"] {' +
+					'border: 1px solid #fff;' +
+					'outline: 1px solid var(--ck-color-focus-border);' +
+					'box-shadow: 0 0 0 2px #fff;' +
+				'}';
+			this.picker.shadowRoot!.appendChild( styleSheetForFocusedColorPicker );
 		}
 
 		this.picker.addEventListener( 'color-changed', event => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Unify style of focused pointer in color picker feature. 
Closes https://github.com/cksource/ckeditor5-internal/issues/3050.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
