### PR TITLE
Release date in CKEditor 5

### DIFF
--- a/packages/ckeditor5-utils/src/index.ts
+++ b/packages/ckeditor5-utils/src/index.ts
@@ -89,4 +89,4 @@ export { default as spliceArray } from './splicearray';
 export { default as uid } from './uid';
 export * from './unicode';
 
-export { default as version } from './version';
+export { default as version, releaseDate } from './version';

--- a/packages/ckeditor5-utils/src/version.ts
+++ b/packages/ckeditor5-utils/src/version.ts
@@ -15,6 +15,7 @@ const version = '37.1.0';
 
 export default version;
 
+// The second argument is not a month. It is `monthIndex` and starts from `0`.
 export const releaseDate = new Date( 2023, 3, 19 );
 
 /* istanbul ignore next -- @preserve */

--- a/packages/ckeditor5-utils/src/version.ts
+++ b/packages/ckeditor5-utils/src/version.ts
@@ -15,6 +15,8 @@ const version = '37.1.0';
 
 export default version;
 
+export const releaseDate = new Date( 2023, 3, 19 );
+
 /* istanbul ignore next -- @preserve */
 const windowOrGlobal = typeof window === 'object' ? window : global;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (utils): Added the `releaseDate` property containing the latest CKEditor 5 release date.