### PR TITLE
TypeScript should suggest `editingDowncast` and `dataDowncast` in `conversion.for`

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/conversion.ts
+++ b/packages/ckeditor5-engine/src/conversion/conversion.ts
@@ -145,9 +145,9 @@ export default class Conversion {
 		this._createConversionHelpers( { name: alias, dispatchers: [ dispatcher ], isDowncast } );
 	}
 
-	public for( groupName: 'downcast' | `${ string }Downcast` ): DowncastHelpers;
-	public for( groupName: 'upcast' | `${ string }Upcast` ): UpcastHelpers;
-	public for( groupName: string ): DowncastHelpers | UpcastHelpers;
+	public for( groupName: 'downcast' | 'dataDowncast' | 'editingDowncast' ): DowncastHelpers;
+	public for( groupName: 'upcast' ): UpcastHelpers;
+	public for<T extends string>( groupName: T ): ConversionType<T>;
 
 	/**
 	 * Provides a chainable API to assign converters to a conversion dispatchers group.
@@ -712,3 +712,9 @@ function* _getUpcastDefinition( model: unknown, view: unknown, upcastAlso?: unkn
 		}
 	}
 }
+
+type ConversionType<T extends string> = T extends `${ string }Downcast`
+	? DowncastHelpers
+	: T extends `${ string }Upcast`
+		? UpcastHelpers
+		: DowncastHelpers | UpcastHelpers;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (engine): TypeScript should suggest `editingDowncast` and `dataDowncast` in `conversion.for`. Closes #13750.

---

### Additional information

Because of the [bug described here](https://github.com/microsoft/TypeScript/issues/54177), I couldn't just add `'dataDowncast' | 'editingDowncast'` to the string union. Instead, we now have three overload signatures:
* One for all predefined downcast group names,
* One for `upcast`,
* A "fallback" signature that accepts any group name, but tries to determine whether it's downcast or upcast based on whether the group name ends with "Downcast" or "Upcast".