### PR TITLE
Color picker documentation

### DIFF
--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
@@ -185,7 +185,8 @@ ClassicEditor
 				}
 			],
 			columns: 9,
-			documentColors: 18
+			documentColors: 18,
+			colorPicker: false
 		},
 		fontColor: {
 			colors: [
@@ -210,7 +211,10 @@ ClassicEditor
 				'aqua'
 			],
 			columns: 4,
-			documentColors: 12
+			documentColors: 12,
+			colorPicker: {
+				format: 'hex'
+			}
 		}
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-font/docs/features/font.md
+++ b/packages/ckeditor5-font/docs/features/font.md
@@ -9,7 +9,7 @@ The font feature lets you change font family, size, and color (including backgro
 
 ## Demo
 
-Use the toolbar dropdowns in the demo below to control the font size {@icon @ckeditor/ckeditor5-font/theme/icons/font-size.svg Font size} and font family {@icon @ckeditor/ckeditor5-font/theme/icons/font-family.svg Font family}. You can also change both the font color {@icon @ckeditor/ckeditor5-font/theme/icons/font-color.svg Font color} and the font background color {@icon @ckeditor/ckeditor5-font/theme/icons/font-background.svg Font background color}.
+Use the toolbar dropdowns in the demo below to control the font size {@icon @ckeditor/ckeditor5-font/theme/icons/font-size.svg Font size} and font family {@icon @ckeditor/ckeditor5-font/theme/icons/font-family.svg Font family}. You can also change both the font color {@icon @ckeditor/ckeditor5-font/theme/icons/font-color.svg Font color} and the font background color {@icon @ckeditor/ckeditor5-font/theme/icons/font-background.svg Font background color} with predefined palette or color picker {@icon @ckeditor/ckeditor5-ui/theme/icons/color-palette.svg Color picker}.
 
 {@snippet features/font}
 
@@ -346,6 +346,35 @@ ClassicEditor
 
 			// Background color options.
 			// ...
+		},
+		toolbar: [
+			'heading', 'bulletedList', 'numberedList', 'fontColor', 'fontBackgroundColor', 'undo', 'redo'
+		]
+	} )
+	.then( /* ... */ )
+	.catch( /* ... */ );
+```
+
+### Color picker
+
+Colors from outside the preconfigured palette can be set using the "Color picker" section, available after clicking the button with the same name at the bottom of the color dropdown.
+
+Color picker applies the colors in **HSL** format as it is the default for the whole font color feature. It can be changed using the {@link module:ui/colorpicker/utils~ColorPickerConfig `config.fontColor.colorPicker.format`} option. Available formats are defined in {@link module:ui/colorpicker/utils~ColorPickerOutputFormat} type. Note that this change will not affect the color input - it always accepts only values in `hex` format (with or without `#` sign at the beginning).
+
+To disable the color picker entirely for the given feature, set the {@link module:font/fontconfig~FontColorConfig#colorPicker `config.fontColor.colorPicker`} (or {@link module:font/fontconfig~FontColorConfig#colorPicker `config.fontBackgroundColor.colorPicker`}) option to `false`.
+
+```js
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		fontColor: {
+			colorPicker: {
+				// Use 'hex' format for output instead of 'hsl'.
+				format: 'hex'
+			}
+		},
+		fontBackgroundColor: {
+			// Don't display the color picker.
+			colorPicker: false
 		},
 		toolbar: [
 			'heading', 'bulletedList', 'numberedList', 'fontColor', 'fontBackgroundColor', 'undo', 'redo'

--- a/packages/ckeditor5-font/docs/features/font.md
+++ b/packages/ckeditor5-font/docs/features/font.md
@@ -357,9 +357,9 @@ ClassicEditor
 
 ### Color picker
 
-Colors from outside the preconfigured palette can be set using the "Color picker" section, available after clicking the button with the same name at the bottom of the color dropdown.
+Colors from outside of the preconfigured palette can be set using the "Color picker" option available at the bottom of the color selection dropdown.
 
-Color picker applies the colors in **HSL** format as it is the default for the whole font color feature. It can be changed using the {@link module:ui/colorpicker/utils~ColorPickerConfig `config.fontColor.colorPicker.format`} option. Available formats are defined in {@link module:ui/colorpicker/utils~ColorPickerOutputFormat} type. Note that this change will not affect the color input - it always accepts only values in `hex` format (with or without `#` sign at the beginning).
+Color picker applies colors in the **HSL** format as it is default for the font color feature. This can be changed using the {@link module:ui/colorpicker/utils~ColorPickerConfig#Format `config.fontColor.colorPicker.format`} option. Available color formats are defined in the {@link module:ui/colorpicker/utils~ColorPickerOutputFormat} type. Note that this change will not affect the color input &ndash; it always accepts only values given in the `hex` format (with or without the `#` sign at the beginning).
 
 To disable the color picker entirely for the given feature, set the {@link module:font/fontconfig~FontColorConfig#colorPicker `config.fontColor.colorPicker`} (or {@link module:font/fontconfig~FontColorConfig#colorPicker `config.fontBackgroundColor.colorPicker`}) option to `false`.
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal(font): Add color picker feature documentation.

---

### Additional information

I wasn't able to create a link to [http://192.168.100.6:8080/ckeditor5/37.1.0/api/module\_ui\_colorpicker\_utils-ColorPickerConfig.html#member-format](http://192.168.100.6:8080/ckeditor5/37.1.0/api/module_ui_colorpicker_utils-ColorPickerConfig.html#member-format) - ``{@link module:ui/colorpicker/utils~ColorPickerConfig#format `config.fontColor.colorPicker.format`}`` , which seems correct, remained unconverted. Is there any issue with type members link conversion? I didn't manage to find a similar example in docs unfortunately.