### PR TITLE
Opening color picker on firefox throws an error

### DIFF
--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -174,7 +174,7 @@ export default class ColorPickerView extends View {
 	 */
 	private _createSlidersView(): void {
 		const colorPickersChildren = [ ...this.picker.shadowRoot!.children ] as Array<HTMLElement>;
-		const sliders = colorPickersChildren.filter( item => item.tagName === 'DIV' );
+		const sliders = colorPickersChildren.filter( item => item.getAttribute( 'role' ) === 'slider' );
 
 		const slidersView = sliders.map( slider => {
 			const view = new SliderView( slider );

--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -174,7 +174,7 @@ export default class ColorPickerView extends View {
 	 */
 	private _createSlidersView(): void {
 		const colorPickersChildren = [ ...this.picker.shadowRoot!.children ] as Array<HTMLElement>;
-		const sliders = colorPickersChildren.filter( item => item.role === 'slider' );
+		const sliders = colorPickersChildren.filter( item => item.tagName === 'DIV' );
 
 		const slidersView = sliders.map( slider => {
 			const view = new SliderView( slider );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix: Opening color picker on firefox throws an error. Closes [#3243](https://github.com/cksource/ckeditor5-internal/issues/3243).

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
