### PR TITLE
Don't display the "powered by" logo if the editor is short or narrow

### DIFF
--- a/packages/ckeditor5-ui/src/editorui/poweredby.ts
+++ b/packages/ckeditor5-ui/src/editorui/poweredby.ts
@@ -26,6 +26,7 @@ import type { UiConfig } from '@ckeditor/ckeditor5-core/src/editor/editorconfig'
 
 const ICON_WIDTH = 53;
 const ICON_HEIGHT = 10;
+const NARROW_ROOT_HEIGHT_THRESHOLD = 50;
 const NARROW_ROOT_WIDTH_THRESHOLD = 250;
 const OFF_THE_SCREEN_POSITION = {
 	top: -9999999,
@@ -291,7 +292,9 @@ function getLowerCornerPosition(
 			return OFF_THE_SCREEN_POSITION;
 		}
 
-		const isRootNarrow = rootRect.width < NARROW_ROOT_WIDTH_THRESHOLD;
+		if ( rootRect.width < NARROW_ROOT_WIDTH_THRESHOLD || rootRect.height < NARROW_ROOT_HEIGHT_THRESHOLD ) {
+			return OFF_THE_SCREEN_POSITION;
+		}
 
 		let balloonTop;
 
@@ -330,7 +333,7 @@ function getLowerCornerPosition(
 		return {
 			top: balloonTop,
 			left: balloonLeft,
-			name: `root-width_${ isRootNarrow ? 'narrow' : 'default' }-position_${ config.position }-side_${ config.side }`,
+			name: `position_${ config.position }-side_${ config.side }`,
 			config: {
 				withArrow: false
 			}

--- a/packages/ckeditor5-ui/tests/editorui/poweredby.js
+++ b/packages/ckeditor5-ui/tests/editorui/poweredby.js
@@ -566,7 +566,7 @@ describe( 'PoweredBy', () => {
 				height: 100
 			} );
 
-			editor.editing.view.focus();
+			focusEditor( editor );
 
 			editor.ui.fire( 'update' );
 
@@ -629,7 +629,7 @@ describe( 'PoweredBy', () => {
 				height: 49
 			} );
 
-			editor.editing.view.focus();
+			focusEditor( editor );
 
 			editor.ui.fire( 'update' );
 

--- a/packages/ckeditor5-ui/tests/editorui/poweredby.js
+++ b/packages/ckeditor5-ui/tests/editorui/poweredby.js
@@ -23,6 +23,24 @@ describe( 'PoweredBy', () => {
 		element = document.createElement( 'div' );
 		document.body.appendChild( element );
 		editor = await createEditor( element );
+
+		testUtils.sinon.stub( editor.editing.view.getDomRoot(), 'getBoundingClientRect' ).returns( {
+			top: 0,
+			left: 0,
+			right: 400,
+			width: 400,
+			bottom: 100,
+			height: 100
+		} );
+
+		testUtils.sinon.stub( document.body, 'getBoundingClientRect' ).returns( {
+			top: 0,
+			right: 1000,
+			bottom: 1000,
+			left: 0,
+			width: 1000,
+			height: 1000
+		} );
 	} );
 
 	afterEach( async () => {
@@ -295,20 +313,12 @@ describe( 'PoweredBy', () => {
 	} );
 
 	describe( 'balloon positioning depending on environment and configuration', () => {
+		const originalGetVisible = Rect.prototype.getVisible;
 		let rootRect, balloonRect;
 
 		beforeEach( () => {
-			rootRect = new Rect( { top: 0, left: 0, width: 100, right: 100, bottom: 100, height: 100 } );
+			rootRect = new Rect( { top: 0, left: 0, width: 300, right: 300, bottom: 100, height: 100 } );
 			balloonRect = new Rect( { top: 0, left: 0, width: 20, right: 20, bottom: 10, height: 10 } );
-
-			sinon.stub( document.body, 'getBoundingClientRect' ).returns( {
-				top: 0,
-				right: 1000,
-				bottom: 1000,
-				left: 0,
-				width: 1000,
-				height: 1000
-			} );
 		} );
 
 		it( 'should not show the balloon if the root is not visible', async () => {
@@ -354,7 +364,7 @@ describe( 'PoweredBy', () => {
 			expect( positioningFunction( rootRect, balloonRect ) ).to.deep.equal( {
 				top: 85,
 				left: 5,
-				name: 'root-width_narrow-position_inside-side_left',
+				name: 'position_inside-side_left',
 				config: {
 					withArrow: false
 				}
@@ -363,7 +373,7 @@ describe( 'PoweredBy', () => {
 			await editor.destroy();
 		} );
 
-		it( 'should positiong the balloon in the lower right corner by default', async () => {
+		it( 'should position the balloon in the lower right corner by default', async () => {
 			editor.editing.view.focus();
 
 			const pinSpy = testUtils.sinon.spy( editor.ui.poweredBy._balloonView, 'pin' );
@@ -381,15 +391,15 @@ describe( 'PoweredBy', () => {
 			expect( pinArgs.target ).to.equal( editor.editing.view.getDomRoot() );
 			expect( positioningFunction( rootRect, balloonRect ) ).to.deep.equal( {
 				top: 85,
-				left: 75,
-				name: 'root-width_narrow-position_inside-side_right',
+				left: 275,
+				name: 'position_inside-side_right',
 				config: {
 					withArrow: false
 				}
 			} );
 		} );
 
-		it( 'should positiong the balloon in the lower left corner if configured', async () => {
+		it( 'should position the balloon in the lower left corner if configured', async () => {
 			const editor = await createEditor( element, {
 				ui: {
 					poweredBy: {
@@ -416,7 +426,7 @@ describe( 'PoweredBy', () => {
 			expect( positioningFunction( rootRect, balloonRect ) ).to.deep.equal( {
 				top: 85,
 				left: 5,
-				name: 'root-width_narrow-position_inside-side_left',
+				name: 'position_inside-side_left',
 				config: {
 					withArrow: false
 				}
@@ -425,7 +435,7 @@ describe( 'PoweredBy', () => {
 			await editor.destroy();
 		} );
 
-		it( 'should positiong the balloon over the bottom root border if configured', async () => {
+		it( 'should position the balloon over the bottom root border if configured', async () => {
 			const editor = await createEditor( element, {
 				ui: {
 					poweredBy: {
@@ -451,8 +461,8 @@ describe( 'PoweredBy', () => {
 			expect( pinArgs.target ).to.equal( editor.editing.view.getDomRoot() );
 			expect( positioningFunction( rootRect, balloonRect ) ).to.deep.equal( {
 				top: 95,
-				left: 75,
-				name: 'root-width_narrow-position_border-side_right',
+				left: 275,
+				name: 'position_border-side_right',
 				config: {
 					withArrow: false
 				}
@@ -537,14 +547,140 @@ describe( 'PoweredBy', () => {
 			expect( pinArgs.target ).to.equal( editor.editing.view.getDomRoot() );
 			expect( positioningFunction( rootRect, balloonRect ) ).to.deep.equal( {
 				top: 80,
-				left: 70,
-				name: 'root-width_narrow-position_inside-side_right',
+				left: 270,
+				name: 'position_inside-side_right',
 				config: {
 					withArrow: false
 				}
 			} );
 
 			await editor.destroy();
+		} );
+
+		it( 'should not display the balloon if the root is narrower than 250px', async () => {
+			const domRoot = editor.editing.view.getDomRoot();
+
+			testUtils.sinon.stub( Rect.prototype, 'getVisible' ).callsFake( function() {
+				if ( this._source === domRoot ) {
+					return new Rect( domRoot );
+				} else {
+					return originalGetVisible.call( this );
+				}
+			} );
+
+			domRoot.getBoundingClientRect.returns( {
+				top: 0,
+				left: 0,
+				right: 249,
+				width: 249,
+				bottom: 100,
+				height: 100
+			} );
+
+			editor.editing.view.focus();
+
+			editor.ui.fire( 'update' );
+
+			// Throttled #update listener.
+			await wait( 75 );
+
+			const pinSpy = testUtils.sinon.spy( editor.ui.poweredBy._balloonView, 'pin' );
+
+			expect( editor.ui.poweredBy._balloonView.isVisible ).to.be.true;
+			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'invalid' );
+
+			domRoot.getBoundingClientRect.returns( {
+				top: 0,
+				left: 0,
+				right: 250,
+				width: 250,
+				bottom: 100,
+				height: 100
+			} );
+
+			editor.ui.fire( 'update' );
+
+			// Throttled #update listener.
+			await wait( 75 );
+
+			expect( editor.ui.poweredBy._balloonView.isVisible ).to.be.true;
+			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'position_inside-side_right' );
+
+			const pinArgs = pinSpy.firstCall.args[ 0 ];
+			const positioningFunction = pinArgs.positions[ 0 ];
+
+			expect( pinArgs.target ).to.equal( editor.editing.view.getDomRoot() );
+			expect( positioningFunction( rootRect, balloonRect ) ).to.deep.equal( {
+				top: 85,
+				left: 275,
+				name: 'position_inside-side_right',
+				config: {
+					withArrow: false
+				}
+			} );
+		} );
+
+		it( 'should not display the balloon if the root is shorter than 50px', async () => {
+			const domRoot = editor.editing.view.getDomRoot();
+
+			testUtils.sinon.stub( Rect.prototype, 'getVisible' ).callsFake( function() {
+				if ( this._source === domRoot ) {
+					return new Rect( domRoot );
+				} else {
+					return originalGetVisible.call( this );
+				}
+			} );
+
+			domRoot.getBoundingClientRect.returns( {
+				top: 0,
+				left: 0,
+				right: 300,
+				width: 300,
+				bottom: 49,
+				height: 49
+			} );
+
+			editor.editing.view.focus();
+
+			editor.ui.fire( 'update' );
+
+			// Throttled #update listener.
+			await wait( 75 );
+
+			const pinSpy = testUtils.sinon.spy( editor.ui.poweredBy._balloonView, 'pin' );
+
+			expect( editor.ui.poweredBy._balloonView.isVisible ).to.be.true;
+			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'invalid' );
+
+			domRoot.getBoundingClientRect.returns( {
+				top: 0,
+				left: 0,
+				right: 300,
+				width: 300,
+				bottom: 50,
+				height: 50
+			} );
+
+			editor.ui.fire( 'update' );
+
+			// Throttled #update listener.
+			await wait( 75 );
+
+			expect( editor.ui.poweredBy._balloonView.isVisible ).to.be.true;
+			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'position_inside-side_right' );
+
+			const pinArgs = pinSpy.firstCall.args[ 0 ];
+			const positioningFunction = pinArgs.positions[ 0 ];
+
+			expect( pinArgs.target ).to.equal( editor.editing.view.getDomRoot() );
+			expect( positioningFunction( rootRect, balloonRect ) ).to.deep.equal( {
+				top: 85,
+				left: 275,
+				name: 'position_inside-side_right',
+				config: {
+					withArrow: false
+				}
+			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-ui/tests/manual/poweredby/poweredby.html
+++ b/packages/ckeditor5-ui/tests/manual/poweredby/poweredby.html
@@ -95,6 +95,7 @@
 <h2>Padding-less editor</h2>
 <div id="padding-less">
 	<p>Like all the great things on earth traveling teaches us by example. Here are some of the most precious lessons I’ve</p>
+	<p>Like all the great things on earth traveling teaches us by example. Here are some of the most precious lessons I’ve</p>
 </div>
 
 <h2>Parent with overflow</h2>
@@ -132,25 +133,35 @@
 
 <h2>Configurable position: on border</h2>
 <div id="position-border">
-	<p>Like all the great things on earth traveling teaches us by example. Here are some of the most precious lessons I’ve</p>
+	<p>Going to a new place can be quite terrifying. While change and uncertainty make us scared, traveling teaches us how
+			ridiculous it is to be afraid of something before it happens. The moment you face your fear and see there is nothing
+			to be afraid of, is the moment you discover bliss.</p>
 </div>
 
 <h2>Configurable offset (default position)</h2>
 <div id="custom-offset-default">
-	<p>Like all the great things on earth traveling teaches us by example. Here are some of the most precious lessons I’ve</p>
+	<p>Going to a new place can be quite terrifying. While change and uncertainty make us scared, traveling teaches us how
+			ridiculous it is to be afraid of something before it happens. The moment you face your fear and see there is nothing
+			to be afraid of, is the moment you discover bliss.</p>
 </div>
 
 <h2>Configurable offset (default position)</h2>
 <div id="custom-offset-on-border">
-	<p>Like all the great things on earth traveling teaches us by example. Here are some of the most precious lessons I’ve</p>
+	<p>Going to a new place can be quite terrifying. While change and uncertainty make us scared, traveling teaches us how
+			ridiculous it is to be afraid of something before it happens. The moment you face your fear and see there is nothing
+			to be afraid of, is the moment you discover bliss.</p>
 </div>
 
 <h2>Custom side (default position)</h2>
 <div id="custom-side-default">
-	<p>Like all the great things on earth traveling teaches us by example. Here are some of the most precious lessons I’ve</p>
+	<p>Going to a new place can be quite terrifying. While change and uncertainty make us scared, traveling teaches us how
+			ridiculous it is to be afraid of something before it happens. The moment you face your fear and see there is nothing
+			to be afraid of, is the moment you discover bliss.</p>
 </div>
 
 <h2>Custom side (on border position)</h2>
 <div id="custom-side-on-border">
-	<p>Like all the great things on earth traveling teaches us by example. Here are some of the most precious lessons I’ve</p>
+	<p>Going to a new place can be quite terrifying. While change and uncertainty make us scared, traveling teaches us how
+			ridiculous it is to be afraid of something before it happens. The moment you face your fear and see there is nothing
+			to be afraid of, is the moment you discover bliss.</p>
 </div>

--- a/packages/ckeditor5-ui/theme/globals/_poweredby.css
+++ b/packages/ckeditor5-ui/theme/globals/_poweredby.css
@@ -60,61 +60,8 @@
 		}
 	}
 
-	&[class*="root-width_narrow"] {
-		/* Label sliding out on :hover when the editor is narrow */
-		& .ck.ck-powered-by .ck-powered-by__label {
-			visibility: hidden;
-			position: absolute;
-			display: block;
-			left: 6px;
-			top: 0px;
-			bottom: 0px;
-			transform: translateX(0%);
-			max-width: 0px;
-			transition: transform .1s ease-in-out, max-width .1s ease-in-out;
-			overflow: hidden;
-			background: var(--ck-powered-by-background);
-			border-radius: var(--ck-powered-by-border-radius) 0 0 var(--ck-powered-by-border-radius);
-			padding: var(--ck-powered-by-padding-top) 6px var(--ck-powered-by-padding-top) var(--ck-powered-by-padding-left);
-			z-index: 0;
-		}
-
-		&:hover .ck.ck-powered-by .ck-powered-by__label {
-			visibility: visible;
-			max-width: 60px;
-			transform: translateX(-100%);
-		}
-	}
-
 	&[class*="position_border"] {
 		border: var(--ck-focus-ring);
-
-		&[class*="narrow"] {
-			& .ck.ck-powered-by .ck-powered-by__label {
-				top: -1px;
-				bottom: -1px;
-				border-width: 1px 0 1px 1px;
-				border-style: solid;
-				border-color: var(--ck-powered-by-border-color);
-			}
-		}
-	}
-
-	&[class*="side_left"][class*="root-width_narrow"] {
-		& .ck.ck-powered-by .ck-powered-by__label {
-			position: static;
-			border: none;
-			padding: 0;
-			margin: 0;
-		}
-
-		&:hover .ck.ck-powered-by .ck-powered-by__label {
-			visibility: visible;
-			max-width: auto;
-			transform: translateX(0%);
-			padding: 0 0 0 2px;
-			margin-right: 4px;
-		}
 	}
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Don't display the "powered by" logo if the editor is short or narrow. Closes https://github.com/cksource/ckeditor5-internal/issues/3217.

---

Requires https://github.com/ckeditor/ckeditor5/pull/14074.

* I got rid of the compact look with "powered by" showing up on `:hover`.
* I restricted min width to 250px and min height to 50px for the logo to show up.