### PR TITLE
Display "Powered by" logo in editor with scrollable parent on Firefox.

### DIFF
--- a/packages/ckeditor5-ui/src/editorui/poweredby.ts
+++ b/packages/ckeditor5-ui/src/editorui/poweredby.ts
@@ -28,8 +28,8 @@ const ICON_WIDTH = 53;
 const ICON_HEIGHT = 10;
 const NARROW_ROOT_WIDTH_THRESHOLD = 250;
 const OFF_THE_SCREEN_POSITION = {
-	top: -9999999,
-	left: -9999999,
+	top: -99999,
+	left: -99999,
 	name: 'invalid',
 	config: {
 		withArrow: false

--- a/packages/ckeditor5-ui/tests/editorui/poweredby.js
+++ b/packages/ckeditor5-ui/tests/editorui/poweredby.js
@@ -486,8 +486,8 @@ describe( 'PoweredBy', () => {
 
 			expect( pinArgs.target ).to.equal( domRoot );
 			expect( positioningFunction( rootRect, balloonRect ) ).to.deep.equal( {
-				top: -9999999,
-				left: -9999999,
+				top: -99999,
+				left: -99999,
 				name: 'invalid',
 				config: {
 					withArrow: false


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Display "Powered by" logo in editor with scrollable parent on Firefox.

Closes cksource/ckeditor5-internal#3256.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._