### PR TITLE
Color picker does not update or save on iOS

### DIFF
--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -166,7 +166,7 @@ export default class ColorPickerView extends View {
 		// Otherwise, once the saturation slider is moved for the first time,
 		// editor collapses the selection and doesn't apply the color change.
 		/* istanbul ignore next -- @preserve */
-		if ( env.isGecko ) {
+		if ( env.isGecko || env.isiOS ) {
 			const input: LabeledFieldView<InputTextView> = this.hexInputRow!.children.get( 1 )! as LabeledFieldView<InputTextView>;
 
 			input.focus();

--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -162,7 +162,7 @@ export default class ColorPickerView extends View {
 	 *
 	 */
 	public focus(): void {
-		// In Firefox we need to move the focus to the input first.
+		// In Firefox and iOS we need to move the focus to the input first.
 		// Otherwise, once the saturation slider is moved for the first time,
 		// editor collapses the selection and doesn't apply the color change.
 		/* istanbul ignore next -- @preserve */


### PR DESCRIPTION

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix: Color picker does not update or save on iOS. Closes #14109.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
