### PR TITLE
Fixed focus handling on buttons in iOS

### DIFF
--- a/packages/ckeditor5-ui/src/button/buttonview.ts
+++ b/packages/ckeditor5-ui/src/button/buttonview.ts
@@ -279,6 +279,10 @@ export default class ButtonView extends View<HTMLButtonElement> implements Butto
 			template.on.mousedown = bind.to( () => {
 				this._focusDelayed!();
 			} );
+
+			template.on.mouseup = bind.to( () => {
+				this._focusDelayed!.cancel();
+			} );
 		}
 
 		this.setTemplate( template );

--- a/packages/ckeditor5-ui/tests/button/buttonview.js
+++ b/packages/ckeditor5-ui/tests/button/buttonview.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals Event */
+/* globals Event, document */
 
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import ButtonView from '../../src/button/buttonview';
@@ -344,6 +344,17 @@ describe( 'ButtonView', () => {
 					clock.tick( 0 );
 
 					expect( spy.callCount ).to.equal( 1 );
+				} );
+
+				it( 'does not steal focus from other element if the focus already moved', () => {
+					const spy = sinon.spy( view.element, 'focus' );
+					view.element.dispatchEvent( new Event( 'mousedown', { cancelable: true } ) );
+					view.element.dispatchEvent( new Event( 'mouseup', { cancelable: true } ) );
+
+					document.body.focus();
+					clock.tick( 0 );
+
+					expect( spy.callCount ).to.equal( 0 );
 				} );
 
 				it( 'the event is not prevented', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Buttons in `iOS` should not steal focus after click. Closes #14112.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
