### PR TITLE
Fix selecting color in color picker in Safari

### DIFF
--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -163,8 +163,12 @@ export default class ColorPickerView extends View {
 	 */
 	public focus(): void {
 		// In some browsers we need to move the focus to the input first.
-		// Otherwise, once the saturation slider is moved for the first time,
+		// Otherwise, the color picker doesn't behave as expected.
+		// In FF, after selecting the color via slider, it instantly moves back to the previous color.
+		// In all iOS browsers and desktop Safari, once the saturation slider is moved for the first time,
 		// editor collapses the selection and doesn't apply the color change.
+		// See: https://github.com/cksource/ckeditor5-internal/issues/3245, https://github.com/ckeditor/ckeditor5/issues/14119,
+		// https://github.com/cksource/ckeditor5-internal/issues/3268.
 		/* istanbul ignore next -- @preserve */
 		if ( env.isGecko || env.isiOS || env.isSafari ) {
 			const input: LabeledFieldView<InputTextView> = this.hexInputRow!.children.get( 1 )! as LabeledFieldView<InputTextView>;

--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -162,11 +162,11 @@ export default class ColorPickerView extends View {
 	 *
 	 */
 	public focus(): void {
-		// In Firefox and iOS we need to move the focus to the input first.
+		// In some browsers we need to move the focus to the input first.
 		// Otherwise, once the saturation slider is moved for the first time,
 		// editor collapses the selection and doesn't apply the color change.
 		/* istanbul ignore next -- @preserve */
-		if ( env.isGecko || env.isiOS ) {
+		if ( env.isGecko || env.isiOS || env.isSafari ) {
 			const input: LabeledFieldView<InputTextView> = this.hexInputRow!.children.get( 1 )! as LabeledFieldView<InputTextView>;
 
 			input.focus();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Fix selecting the color through color picker multiple times in Safari. Closes #14119.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._