### PR TITLE
Styles for `<thead>` and `<tbody>` should be enabled only for tables that have one

### DIFF
--- a/packages/ckeditor5-html-support/src/integrations/table.ts
+++ b/packages/ckeditor5-html-support/src/integrations/table.ts
@@ -13,8 +13,14 @@ import type {
 	Element,
 	UpcastDispatcher,
 	UpcastElementEvent,
-	ViewElement } from 'ckeditor5/src/engine';
+	ViewElement,
+	ModelPostFixer,
+	Model
+} from 'ckeditor5/src/engine';
+
 import { Plugin } from 'ckeditor5/src/core';
+import type { TableUtils } from '@ckeditor/ckeditor5-table';
+
 import { updateViewAttributes, type GHSViewAttributes } from '../utils';
 import DataFilter, { type DataFilterRegisterEvent } from '../datafilter';
 import { getDescendantElement } from './integrationutils';
@@ -50,6 +56,7 @@ export default class TableElementSupport extends Plugin {
 		const schema = editor.model.schema;
 		const conversion = editor.conversion;
 		const dataFilter = editor.plugins.get( DataFilter );
+		const tableUtils: TableUtils = editor.plugins.get( 'TableUtils' );
 
 		dataFilter.on<DataFilterRegisterEvent>( 'register:figure', ( ) => {
 			conversion.for( 'upcast' ).add( viewToModelFigureAttributeConverter( dataFilter ) );
@@ -72,9 +79,42 @@ export default class TableElementSupport extends Plugin {
 			conversion.for( 'upcast' ).add( viewToModelTableAttributeConverter( dataFilter ) );
 			conversion.for( 'downcast' ).add( modelToViewTableAttributeConverter() );
 
+			editor.model.document.registerPostFixer( createHeadingRowsPostFixer( editor.model, tableUtils ) );
+
 			evt.stop();
 		} );
 	}
+}
+
+/**
+ * Creates a model post-fixer for thead and tbody GHS related attributes.
+ */
+function createHeadingRowsPostFixer( model: Model, tableUtils: TableUtils ): ModelPostFixer {
+	return writer => {
+		const changes = model.document.differ.getChanges();
+		let wasFixed = false;
+
+		for ( const change of changes ) {
+			if ( change.type != 'attribute' || change.attributeKey != 'headingRows' ) {
+				continue;
+			}
+
+			const table = change.range.start.nodeAfter as Element;
+			const hasTHeadAttributes = table.getAttribute( 'htmlTheadAttributes' );
+			const hasTBodyAttributes = table.getAttribute( 'htmlTbodyAttributes' );
+
+			if ( hasTHeadAttributes && !change.attributeNewValue ) {
+				writer.removeAttribute( 'htmlTheadAttributes', table );
+				wasFixed = true;
+			}
+			else if ( hasTBodyAttributes && change.attributeNewValue == tableUtils.getRows( table ) ) {
+				writer.removeAttribute( 'htmlTbodyAttributes', table );
+				wasFixed = true;
+			}
+		}
+
+		return wasFixed;
+	};
 }
 
 /**
@@ -154,12 +194,18 @@ function modelToViewTableAttributeConverter() {
 
 		function addAttributeConversionDispatcherHandler( elementName: string, attributeName: string ) {
 			dispatcher.on<DowncastAttributeEvent>( `attribute:${ attributeName }:table`, ( evt, data, conversionApi ) => {
-				if ( !conversionApi.consumable.consume( data.item, evt.name ) ) {
+				if ( !conversionApi.consumable.test( data.item, evt.name ) ) {
 					return;
 				}
 
 				const containerElement = conversionApi.mapper.toViewElement( data.item as Element );
 				const viewElement = getDescendantElement( conversionApi.writer, containerElement!, elementName );
+
+				if ( !viewElement ) {
+					return;
+				}
+
+				conversionApi.consumable.consume( data.item, evt.name );
 
 				updateViewAttributes(
 					conversionApi.writer,

--- a/packages/ckeditor5-html-support/tests/integrations/table.js
+++ b/packages/ckeditor5-html-support/tests/integrations/table.js
@@ -1569,6 +1569,132 @@ describe( 'TableElementSupport', () => {
 		expect( marker.getEnd().path ).to.deep.equal( [ 1 ] );
 	} );
 
+	it( 'should remove htmlTheadAttributes if table does not have thead', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /.*/,
+			attributes: true
+		} ] );
+
+		editor.setData(
+			'<figure class="table">' +
+				'<table>' +
+					'<thead data-foo="head">' +
+						'<tr>' +
+							'<th>1</th>' +
+						'</tr>' +
+					'</thead>' +
+					'<tbody data-bar="body">' +
+						'<tr>' +
+							'<td>2</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+				'<table headingRows="1" htmlTbodyAttributes="(1)" htmlTheadAttributes="(2)">' +
+					'<tableRow><tableCell><paragraph>1</paragraph></tableCell></tableRow>' +
+					'<tableRow><tableCell><paragraph>2</paragraph></tableCell></tableRow>' +
+				'</table>',
+			attributes: {
+				1: {
+					attributes: {
+						'data-bar': 'body'
+					}
+				},
+				2: {
+					attributes: {
+						'data-foo': 'head'
+					}
+				}
+			}
+		} );
+
+		model.change( writer => {
+			writer.removeAttribute( 'headingRows', model.document.getRoot().getChild( 0 ) );
+		} );
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+				'<table htmlTbodyAttributes="(1)">' +
+					'<tableRow><tableCell><paragraph>1</paragraph></tableCell></tableRow>' +
+					'<tableRow><tableCell><paragraph>2</paragraph></tableCell></tableRow>' +
+				'</table>',
+			attributes: {
+				1: {
+					attributes: {
+						'data-bar': 'body'
+					}
+				}
+			}
+		} );
+	} );
+
+	it( 'should remove htmlTbodyAttributes if table does not have tbody', () => {
+		dataFilter.loadAllowedConfig( [ {
+			name: /.*/,
+			attributes: true
+		} ] );
+
+		editor.setData(
+			'<figure class="table">' +
+				'<table>' +
+					'<thead data-foo="head">' +
+						'<tr>' +
+							'<th>1</th>' +
+						'</tr>' +
+					'</thead>' +
+					'<tbody data-bar="body">' +
+						'<tr>' +
+							'<td>2</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</figure>'
+		);
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+				'<table headingRows="1" htmlTbodyAttributes="(1)" htmlTheadAttributes="(2)">' +
+					'<tableRow><tableCell><paragraph>1</paragraph></tableCell></tableRow>' +
+					'<tableRow><tableCell><paragraph>2</paragraph></tableCell></tableRow>' +
+				'</table>',
+			attributes: {
+				1: {
+					attributes: {
+						'data-bar': 'body'
+					}
+				},
+				2: {
+					attributes: {
+						'data-foo': 'head'
+					}
+				}
+			}
+		} );
+
+		model.change( writer => {
+			writer.setAttribute( 'headingRows', 2, model.document.getRoot().getChild( 0 ) );
+		} );
+
+		expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+			data:
+				'<table headingRows="2" htmlTheadAttributes="(1)">' +
+					'<tableRow><tableCell><paragraph>1</paragraph></tableCell></tableRow>' +
+					'<tableRow><tableCell><paragraph>2</paragraph></tableCell></tableRow>' +
+				'</table>',
+			attributes: {
+				1: {
+					attributes: {
+						'data-foo': 'head'
+					}
+				}
+			}
+		} );
+	} );
+
 	describe( 'TableCaption', () => {
 		// Sanity tests verifying if table caption is correctly handled by default converters.
 

--- a/packages/ckeditor5-style/src/integrations/table.ts
+++ b/packages/ckeditor5-style/src/integrations/table.ts
@@ -82,6 +82,7 @@ export default class TableStyleSupport extends Plugin {
 
 	/**
 	 * Checks if this plugin's custom logic should be applied for defintion-block pair.
+	 *
 	 * @param definition Style definition that is being considered.
 	 * @param block Block element to check if should be styled.
 	 * @returns True if the defintion-block pair meet the plugin criteria, false otherwise.
@@ -100,6 +101,7 @@ export default class TableStyleSupport extends Plugin {
 
 	/**
 	 * Checks if the style definition should be applied to selected block.
+	 *
 	 * @param definition Style definition that is being considered.
 	 * @param block Block element to check if should be styled.
 	 * @returns True if the block should be style with the style description, false otherwise.
@@ -132,11 +134,13 @@ export default class TableStyleSupport extends Plugin {
 			}
 		}
 
+		/* istanbul ignore next -- @preserve */
 		return false;
 	}
 
 	/**
 	 * Gets all blocks that the style should be applied to.
+	 *
 	 * @param definition Style definition that is being considered.
 	 * @param block A block element from selection.
 	 * @returns An array with the block that was passed as an argument if meets the criteria, null otherwise.

--- a/packages/ckeditor5-style/src/integrations/table.ts
+++ b/packages/ckeditor5-style/src/integrations/table.ts
@@ -87,7 +87,15 @@ export default class TableStyleSupport extends Plugin {
 	 * @returns True if the defintion-block pair meet the plugin criteria, false otherwise.
 	 */
 	private _isApplicable( definition: BlockStyleDefinition, block: Element ): boolean {
-		return [ 'td', 'th' ].includes( definition.element ) && block.name == 'tableCell';
+		if ( [ 'td', 'th' ].includes( definition.element ) ) {
+			return block.name == 'tableCell';
+		}
+
+		if ( [ 'thead', 'tbody' ].includes( definition.element ) ) {
+			return block.name == 'table';
+		}
+
+		return false;
 	}
 
 	/**
@@ -97,20 +105,34 @@ export default class TableStyleSupport extends Plugin {
 	 * @returns True if the block should be style with the style description, false otherwise.
 	 */
 	private _isStyleEnabledForBlock( definition: BlockStyleDefinition, block: Element ): boolean {
-		const location = this._tableUtils.getCellLocation( block )!;
+		if ( [ 'td', 'th' ].includes( definition.element ) ) {
+			const location = this._tableUtils.getCellLocation( block )!;
 
-		const tableRow = block.parent!;
-		const table = tableRow.parent as Element;
+			const tableRow = block.parent!;
+			const table = tableRow.parent as Element;
 
-		const headingRows = table.getAttribute( 'headingRows' ) as number || 0;
-		const headingColumns = table.getAttribute( 'headingColumns' ) as number || 0;
-		const isHeadingCell = location.row < headingRows || location.column < headingColumns;
+			const headingRows = table.getAttribute( 'headingRows' ) as number || 0;
+			const headingColumns = table.getAttribute( 'headingColumns' ) as number || 0;
+			const isHeadingCell = location.row < headingRows || location.column < headingColumns;
 
-		if ( definition.element == 'th' ) {
-			return isHeadingCell;
-		} else {
-			return !isHeadingCell;
+			if ( definition.element == 'th' ) {
+				return isHeadingCell;
+			} else {
+				return !isHeadingCell;
+			}
 		}
+
+		if ( [ 'thead', 'tbody' ].includes( definition.element ) ) {
+			const headingRows = block.getAttribute( 'headingRows' ) as number || 0;
+
+			if ( definition.element == 'thead' ) {
+				return headingRows > 0;
+			} else {
+				return headingRows < this._tableUtils.getRows( block );
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/packages/ckeditor5-style/src/styleutils.ts
+++ b/packages/ckeditor5-style/src/styleutils.ts
@@ -24,6 +24,8 @@ const NON_PREVIEWABLE_ELEMENT_NAMES = [
 ];
 
 export default class StyleUtils extends Plugin {
+	private _htmlSupport!: GeneralHtmlSupport;
+
 	/**
 	 * @inheritDoc
 	 */
@@ -47,6 +49,13 @@ export default class StyleUtils extends Plugin {
 
 		this.decorate( 'getStylePreview' );
 		this.decorate( 'configureGHSDataFilter' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public init(): void {
+		this._htmlSupport = this.editor.plugins.get( 'GeneralHtmlSupport' );
 	}
 
 	/**
@@ -127,8 +136,7 @@ export default class StyleUtils extends Plugin {
 	 */
 	public isStyleEnabledForBlock( definition: BlockStyleDefinition, block: Element ): boolean {
 		const model = this.editor.model;
-		const htmlSupport: GeneralHtmlSupport = this.editor.plugins.get( 'GeneralHtmlSupport' );
-		const attributeName = htmlSupport.getGhsAttributeNameForElement( definition.element );
+		const attributeName = this._htmlSupport.getGhsAttributeNameForElement( definition.element );
 
 		if ( !model.schema.checkAttribute( block, attributeName ) ) {
 			return false;
@@ -143,8 +151,7 @@ export default class StyleUtils extends Plugin {
 	 * @internal
 	 */
 	public isStyleActiveForBlock( definition: BlockStyleDefinition, block: Element ): boolean {
-		const htmlSupport: GeneralHtmlSupport = this.editor.plugins.get( 'GeneralHtmlSupport' );
-		const attributeName = htmlSupport.getGhsAttributeNameForElement( definition.element );
+		const attributeName = this._htmlSupport.getGhsAttributeNameForElement( definition.element );
 		const ghsAttributeValue = block.getAttribute( attributeName );
 
 		return this.hasAllClasses( ghsAttributeValue, definition.classes );

--- a/packages/ckeditor5-style/tests/integrations/table.js
+++ b/packages/ckeditor5-style/tests/integrations/table.js
@@ -30,6 +30,16 @@ describe( 'TableStyleSupport', () => {
 		element: 'table',
 		classes: [ 'test-table-style' ]
 	};
+	const theadStyle = {
+		name: 'Test thead style',
+		element: 'thead',
+		classes: [ 'test-thead-style' ]
+	};
+	const tbodyStyle = {
+		name: 'Test tbody style',
+		element: 'tbody',
+		classes: [ 'test-tbody-style' ]
+	};
 	const trStyle = {
 		name: 'Test tr style',
 		element: 'tr',
@@ -59,6 +69,8 @@ describe( 'TableStyleSupport', () => {
 	beforeEach( async () => {
 		await createEditor( [
 			tableStyle,
+			theadStyle,
+			tbodyStyle,
 			trStyle,
 			thStyle,
 			tdStyle,
@@ -117,6 +129,181 @@ describe( 'TableStyleSupport', () => {
 				'<tableRow>' +
 					'<tableCell>' +
 						'<paragraph>foo</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>'
+		);
+	} );
+
+	it( 'should add class to thead element', () => {
+		setData( model,
+			'<table headingRows="1">' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>[foo]</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>bar</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>'
+		);
+
+		expect( command.enabledStyles ).to.have.members( [
+			tableStyle.name,
+			tbodyStyle.name,
+			theadStyle.name,
+			trStyle.name,
+			thStyle.name
+		] );
+
+		command.execute( { styleName: 'Test thead style' } );
+
+		expect( getData( model, { withoutSelection: true } ) ).to.equal(
+			'<table headingRows="1" htmlTheadAttributes="{"classes":["test-thead-style"]}">' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>foo</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>bar</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>'
+		);
+
+		command.execute( { styleName: 'Test thead style' } );
+
+		expect( getData( model, { withoutSelection: true } ) ).to.equal(
+			'<table headingRows="1">' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>foo</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>bar</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>'
+		);
+	} );
+
+	it( 'should add class to tbody element (table without heading rows)', () => {
+		setData( model,
+			'<table>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>[foo]</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>bar</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>'
+		);
+
+		expect( command.enabledStyles ).to.have.members( [
+			tableStyle.name,
+			tbodyStyle.name,
+			trStyle.name,
+			tdStyle.name
+		] );
+
+		command.execute( { styleName: 'Test tbody style' } );
+
+		expect( getData( model, { withoutSelection: true } ) ).to.equal(
+			'<table htmlTbodyAttributes="{"classes":["test-tbody-style"]}">' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>foo</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>bar</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>'
+		);
+
+		command.execute( { styleName: 'Test tbody style' } );
+
+		expect( getData( model, { withoutSelection: true } ) ).to.equal(
+			'<table>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>foo</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>bar</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>'
+		);
+	} );
+
+	it( 'should add class to thead element (table only with heading rows)', () => {
+		setData( model,
+			'<table headingRows="2">' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>[foo]</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>bar</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>'
+		);
+
+		expect( command.enabledStyles ).to.have.members( [
+			tableStyle.name,
+			theadStyle.name,
+			trStyle.name,
+			thStyle.name
+		] );
+
+		command.execute( { styleName: 'Test thead style' } );
+
+		expect( getData( model, { withoutSelection: true } ) ).to.equal(
+			'<table headingRows="2" htmlTheadAttributes="{"classes":["test-thead-style"]}">' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>foo</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>bar</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+			'</table>'
+		);
+
+		command.execute( { styleName: 'Test thead style' } );
+
+		expect( getData( model, { withoutSelection: true } ) ).to.equal(
+			'<table headingRows="2">' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>foo</paragraph>' +
+					'</tableCell>' +
+				'</tableRow>' +
+				'<tableRow>' +
+					'<tableCell>' +
+						'<paragraph>bar</paragraph>' +
 					'</tableCell>' +
 				'</tableRow>' +
 			'</table>'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (style): Styles for `<thead>` and `<tbody>` should be enabled only for tables that have one. Closes #14113.

Internal (html-support): Attributes for `<thead>` and `<tbody>` should be removed when not relevant for a table. See #14113.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
