### PR TITLE
List markers display incorrectly when pasting from Word

### DIFF
--- a/packages/ckeditor5-paste-from-office/package.json
+++ b/packages/ckeditor5-paste-from-office/package.json
@@ -27,6 +27,7 @@
     "@ckeditor/ckeditor5-enter": "^37.1.0",
     "@ckeditor/ckeditor5-font": "^37.1.0",
     "@ckeditor/ckeditor5-heading": "^37.1.0",
+    "@ckeditor/ckeditor5-html-support": "^37.1.0",
     "@ckeditor/ckeditor5-image": "^37.1.0",
     "@ckeditor/ckeditor5-link": "^37.1.0",
     "@ckeditor/ckeditor5-list": "^37.1.0",

--- a/packages/ckeditor5-paste-from-office/src/filters/list.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/list.ts
@@ -347,6 +347,7 @@ function insertNewEmptyList(
  */
 function transformElementIntoListItem( element: ViewElement, writer: UpcastWriter ) {
 	removeBulletElement( element, writer );
+	writer.removeStyle( 'text-indent', element ); // #12361
 
 	return writer.rename( 'li', element )!;
 }

--- a/packages/ckeditor5-paste-from-office/tests/filters/list.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/list.js
@@ -104,6 +104,18 @@ describe( 'PasteFromOffice - filters', () => {
 				);
 			} );
 
+			// #12361
+			it( 'removes `text-indent` from the list item', () => {
+				const html = '<p style="mso-list:l0 level1 lfo0;text-indent:-18.0pt"><span style="mso-list:Ignore">1.</span>Item 1</p>';
+				const view = htmlDataProcessor.toView( html );
+
+				transformListItemLikeElementsIntoLists( view, '' );
+
+				expect( view.childCount ).to.equal( 1 );
+				expect( view.getChild( 0 ).name ).to.equal( 'ol' );
+				expect( stringify( view ) ).to.equal( '<ol><li style="mso-list:l0 level1 lfo0">Item 1</li></ol>' );
+			} );
+
 			describe( 'nesting', () => {
 				const level1 = 'style="mso-list:l0 level1 lfo0"';
 				const level2 = 'style="mso-list:l0 level2 lfo0"';

--- a/packages/ckeditor5-paste-from-office/tests/manual/tickets/12361/1.html
+++ b/packages/ckeditor5-paste-from-office/tests/manual/tickets/12361/1.html
@@ -1,0 +1,1 @@
+<div id="editor"></div>

--- a/packages/ckeditor5-paste-from-office/tests/manual/tickets/12361/1.js
+++ b/packages/ckeditor5-paste-from-office/tests/manual/tickets/12361/1.js
@@ -1,0 +1,86 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console:false, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import Code from '@ckeditor/ckeditor5-basic-styles/src/code';
+import CodeBlock from '@ckeditor/ckeditor5-code-block/src/codeblock';
+import EasyImage from '@ckeditor/ckeditor5-easy-image/src/easyimage';
+import FontBackgroundColor from '@ckeditor/ckeditor5-font/src/fontbackgroundcolor';
+import FontColor from '@ckeditor/ckeditor5-font/src/fontcolor';
+import FontFamily from '@ckeditor/ckeditor5-font/src/fontfamily';
+import FontSize from '@ckeditor/ckeditor5-font/src/fontsize';
+import GeneralHtmlSupport from '@ckeditor/ckeditor5-html-support/src/generalhtmlsupport';
+import ImageResize from '@ckeditor/ckeditor5-image/src/imageresize';
+import LinkImage from '@ckeditor/ckeditor5-link/src/linkimage';
+import ListProperties from '@ckeditor/ckeditor5-list/src/listproperties';
+import PageBreak from '@ckeditor/ckeditor5-page-break/src/pagebreak';
+import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
+import Subscript from '@ckeditor/ckeditor5-basic-styles/src/subscript';
+import Superscript from '@ckeditor/ckeditor5-basic-styles/src/superscript';
+import TableCellProperties from '@ckeditor/ckeditor5-table/src/tablecellproperties';
+import TableProperties from '@ckeditor/ckeditor5-table/src/tableproperties';
+import TableCaption from '@ckeditor/ckeditor5-table/src/tablecaption';
+import TableColumnResize from '@ckeditor/ckeditor5-table/src/tablecolumnresize';
+import TodoList from '@ckeditor/ckeditor5-list/src/todolist';
+import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
+import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices';
+import ImageUpload from '@ckeditor/ckeditor5-image/src/imageupload';
+
+import PasteFromOffice from '../../../../src/pastefromoffice';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [
+			ArticlePluginSet, Underline, Strikethrough, Superscript, Subscript, Code,
+			FontColor, FontBackgroundColor, FontFamily, FontSize,
+			CodeBlock, TodoList, ListProperties, TableProperties, TableCellProperties, TableCaption,
+			TableColumnResize, EasyImage, ImageResize, LinkImage,
+			PageBreak,
+			ImageUpload, CloudServices,
+			GeneralHtmlSupport,
+			PasteFromOffice
+		],
+		toolbar: [
+			'heading',
+			'|',
+			'bold', 'italic', 'strikethrough', 'underline', 'code', 'subscript', 'superscript', 'link',
+			'|',
+			'fontSize', 'fontFamily', 'fontColor', 'fontBackgroundColor',
+			'|',
+			'bulletedList', 'numberedList', 'todoList',
+			'|',
+			'blockQuote', 'uploadImage', 'insertTable', 'codeBlock',
+			'|',
+			'pageBreak',
+			'|',
+			'undo', 'redo'
+		],
+		htmlSupport: {
+			allow: [
+				{
+					name: /^.*$/,
+					styles: true,
+					attributes: true,
+					classes: true
+				}
+			]
+		},
+		image: {
+			toolbar: [
+				'imageStyle:inline',
+				'imageStyle:block',
+				'imageStyle:side'
+			]
+		}
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-paste-from-office/tests/manual/tickets/12361/1.md
+++ b/packages/ckeditor5-paste-from-office/tests/manual/tickets/12361/1.md
@@ -1,0 +1,6 @@
+## Paste from Office with GHS
+
+1. Create a list in MS Word.
+1. Copy the list and paste into the editor.
+
+List markers should appear to the left of the list items (not overlapping the list item text).


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (paste-from-office): List markers should be displayed correctly after pasting a list from Word. Closes #12361.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
