### PR TITLE
The "powered by" logo should not be accessible using the keyboard or by a screen reader

### DIFF
--- a/packages/ckeditor5-ui/src/editorui/poweredby.ts
+++ b/packages/ckeditor5-ui/src/editorui/poweredby.ts
@@ -249,7 +249,8 @@ class PoweredByView extends View<HTMLDivElement> {
 		this.setTemplate( {
 			tag: 'div',
 			attributes: {
-				class: [ 'ck', 'ck-powered-by' ]
+				class: [ 'ck', 'ck-powered-by' ],
+				'aria-hidden': true
 			},
 			children: [
 				{

--- a/packages/ckeditor5-ui/tests/editorui/poweredby.js
+++ b/packages/ckeditor5-ui/tests/editorui/poweredby.js
@@ -305,7 +305,6 @@ describe( 'PoweredBy', () => {
 				expect( view.element.firstChild.tagName ).to.equal( 'A' );
 				expect( view.element.firstChild.href ).to.equal( 'https://ckeditor.com/' );
 				expect( view.element.firstChild.target ).to.equal( '_blank' );
-				expect( view.element.firstChild.tabIndex ).to.equal( -1 );
 			} );
 
 			it( 'should have a label inside the link', () => {
@@ -328,6 +327,14 @@ describe( 'PoweredBy', () => {
 				view.element.firstChild.dispatchEvent( evt );
 
 				sinon.assert.calledOnce( spy );
+			} );
+
+			it( 'should be excluded from the accessibility tree', () => {
+				expect( view.element.getAttribute( 'aria-hidden' ) ).to.equal( 'true' );
+			} );
+
+			it( 'should not be accessible via tab key navigation', () => {
+				expect( view.element.firstChild.tabIndex ).to.equal( -1 );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): The "powered by" logo should not be accessible using the keyboard or by a screen reader. Closes #14118.

