### PR TITLE
Ci/3236 retain color picker input value

### DIFF
--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -159,9 +159,20 @@ export default class ColorPickerView extends View {
 
 	/**
 	 * Focuses the first pointer in color picker.
-	 *
 	 */
 	public focus(): void {
+		const input: LabeledFieldView<InputTextView> = this.hexInputRow!.children.get( 1 )! as LabeledFieldView<InputTextView>;
+
+		// Set the value in the input to match the selected color (set in _hexColor prop).
+		// As the input is not cleared automatically at any time,
+		// it can desynchronise with the hex color value in the component
+		// (e.g. if incorrect color string was set - like 'a').
+		// We need a hard refresh (always triggering the 'change' event)
+		// because in some scenarios input value can be equal to the hex color,
+		// but vary from DOM element value.
+		// See https://github.com/cksource/ckeditor5-internal/issues/3236 for reference.
+		this._hardRefreshInputValue( input );
+
 		// In some browsers we need to move the focus to the input first.
 		// Otherwise, the color picker doesn't behave as expected.
 		// In FF, after selecting the color via slider, it instantly moves back to the previous color.
@@ -171,8 +182,6 @@ export default class ColorPickerView extends View {
 		// https://github.com/cksource/ckeditor5-internal/issues/3268.
 		/* istanbul ignore next -- @preserve */
 		if ( env.isGecko || env.isiOS || env.isSafari ) {
-			const input: LabeledFieldView<InputTextView> = this.hexInputRow!.children.get( 1 )! as LabeledFieldView<InputTextView>;
-
 			input.focus();
 		}
 
@@ -263,6 +272,16 @@ export default class ColorPickerView extends View {
 		} );
 
 		return labeledInput;
+	}
+
+	/**
+	 * Refreshes the input value. Triggers the 'change' event even if the value didn't actually change.
+	 *
+	 * @private
+	 */
+	private _hardRefreshInputValue( input: LabeledFieldView<InputTextView> ) {
+		input.fieldView.value = '';
+		input.fieldView.value = this._hexColor.slice( 1 );
 	}
 }
 

--- a/packages/ckeditor5-ui/tests/colorpicker/colorpickerview.js
+++ b/packages/ckeditor5-ui/tests/colorpicker/colorpickerview.js
@@ -287,6 +287,36 @@ describe( 'ColorPickerView', () => {
 
 			sinon.assert.calledOnce( spy );
 		} );
+
+		describe( 'should update the input field value', () => {
+			it( 'if input value was removed', () => {
+				view._hexColor = '#123123';
+
+				const input = view.hexInputRow.children.get( 1 );
+
+				input.fieldView.value = '321321';
+				input.fieldView.element.value = '';
+
+				view.focus();
+
+				expect( input.fieldView.element.value ).to.equal( '123123' );
+				expect( input.fieldView.value ).to.equal( '123123' );
+			} );
+
+			it( 'if input value was modified to incorrect color string', () => {
+				view._hexColor = '#123123';
+
+				const input = view.hexInputRow.children.get( 1 );
+
+				input.fieldView.value = '321321';
+				input.fieldView.element.value = '32';
+
+				view.focus();
+
+				expect( input.fieldView.element.value ).to.equal( '123123' );
+				expect( input.fieldView.value ).to.equal( '123123' );
+			} );
+		} );
 	} );
 
 	describe( 'color property', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Color picker will always fetch the current selection color upon opening. Closes cksource/ckeditor5-internal#3236.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._