### PR TITLE
Use fake timers for PBC unit tests

### DIFF
--- a/packages/ckeditor5-ui/tests/editorui/poweredby.js
+++ b/packages/ckeditor5-ui/tests/editorui/poweredby.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* global document, Event, window, HTMLElement */
+/* global document, Event, HTMLElement */
 
 import { Editor } from '@ckeditor/ckeditor5-core';
 import EditorUI from '../../src/editorui/editorui';
@@ -16,11 +16,12 @@ import { Rect } from '@ckeditor/ckeditor5-utils';
 import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
 
 describe( 'PoweredBy', () => {
-	let editor, element;
+	let editor, element, clock;
 
 	testUtils.createSinonSandbox();
 
 	beforeEach( async () => {
+		clock = sinon.useFakeTimers();
 		element = document.createElement( 'div' );
 		document.body.appendChild( element );
 		editor = await createEditor( element );
@@ -98,7 +99,7 @@ describe( 'PoweredBy', () => {
 				focusEditor( editor );
 				blurEditor( editor );
 
-				await wait( 10 );
+				clock.tick( 10 );
 				const pinSpy = testUtils.sinon.spy( editor.ui.poweredBy._balloonView, 'pin' );
 
 				focusEditor( editor, focusableEditorUIElement );
@@ -117,7 +118,7 @@ describe( 'PoweredBy', () => {
 				blurEditor( editor );
 
 				// FocusTracker's blur handler is asynchronous.
-				await wait( 200 );
+				clock.tick( 200 );
 
 				expect( editor.ui.poweredBy._balloonView.isVisible ).to.be.false;
 			} );
@@ -173,7 +174,7 @@ describe( 'PoweredBy', () => {
 
 				editor.ui.fire( 'update' );
 
-				await wait( 75 );
+				clock.tick( 75 );
 
 				expect( editor.ui.poweredBy._balloonView.isVisible ).to.be.true;
 				expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'position_border-side_right' );
@@ -220,7 +221,7 @@ describe( 'PoweredBy', () => {
 
 				sinon.assert.notCalled( pinSpy );
 
-				await wait( 75 );
+				clock.tick( 75 );
 
 				sinon.assert.calledOnce( pinSpy );
 				sinon.assert.calledWith( pinSpy.firstCall, sinon.match.has( 'target', editor.editing.view.getDomRoot() ) );
@@ -243,7 +244,7 @@ describe( 'PoweredBy', () => {
 
 				sinon.assert.calledOnce( pinSpy );
 
-				await wait( 75 );
+				clock.tick( 75 );
 
 				sinon.assert.calledTwice( pinSpy );
 				sinon.assert.calledWith( pinSpy, sinon.match.has( 'target', editor.editing.view.getDomRoot() ) );
@@ -430,7 +431,7 @@ describe( 'PoweredBy', () => {
 			editor.ui.fire( 'update' );
 
 			// Throttled #update listener.
-			await wait( 75 );
+			clock.tick( 75 );
 
 			sinon.assert.calledOnce( pinSpy );
 
@@ -458,7 +459,7 @@ describe( 'PoweredBy', () => {
 			editor.ui.fire( 'update' );
 
 			// Throttled #update listener.
-			await wait( 75 );
+			clock.tick( 75 );
 
 			sinon.assert.calledOnce( pinSpy );
 
@@ -492,7 +493,7 @@ describe( 'PoweredBy', () => {
 			editor.ui.fire( 'update' );
 
 			// Throttled #update listener.
-			await wait( 75 );
+			clock.tick( 75 );
 
 			sinon.assert.calledOnce( pinSpy );
 
@@ -528,7 +529,7 @@ describe( 'PoweredBy', () => {
 			editor.ui.fire( 'update' );
 
 			// Throttled #update listener.
-			await wait( 75 );
+			clock.tick( 75 );
 
 			sinon.assert.calledOnce( pinSpy );
 
@@ -564,7 +565,7 @@ describe( 'PoweredBy', () => {
 			editor.ui.fire( 'update' );
 
 			// Throttled #update listener.
-			await wait( 75 );
+			clock.tick( 75 );
 
 			sinon.assert.calledOnce( pinSpy );
 
@@ -600,7 +601,7 @@ describe( 'PoweredBy', () => {
 			editor.ui.fire( 'update' );
 
 			// Throttled #update listener.
-			await wait( 75 );
+			clock.tick( 75 );
 
 			sinon.assert.calledOnce( pinSpy );
 
@@ -640,7 +641,7 @@ describe( 'PoweredBy', () => {
 			editor.ui.fire( 'update' );
 
 			// Throttled #update listener.
-			await wait( 75 );
+			clock.tick( 75 );
 
 			sinon.assert.calledOnce( pinSpy );
 
@@ -684,7 +685,7 @@ describe( 'PoweredBy', () => {
 			editor.ui.fire( 'update' );
 
 			// Throttled #update listener.
-			await wait( 75 );
+			clock.tick( 75 );
 
 			sinon.assert.calledOnce( pinSpy );
 
@@ -721,7 +722,7 @@ describe( 'PoweredBy', () => {
 			editor.ui.fire( 'update' );
 
 			// Throttled #update listener.
-			await wait( 75 );
+			clock.tick( 75 );
 
 			sinon.assert.calledOnce( pinSpy );
 
@@ -766,7 +767,7 @@ describe( 'PoweredBy', () => {
 			editor.ui.fire( 'update' );
 
 			// Throttled #update listener.
-			await wait( 75 );
+			clock.tick( 75 );
 
 			const pinSpy = testUtils.sinon.spy( editor.ui.poweredBy._balloonView, 'pin' );
 
@@ -785,7 +786,7 @@ describe( 'PoweredBy', () => {
 			editor.ui.fire( 'update' );
 
 			// Throttled #update listener.
-			await wait( 75 );
+			clock.tick( 75 );
 
 			expect( editor.ui.poweredBy._balloonView.isVisible ).to.be.true;
 			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'position_border-side_right' );
@@ -829,7 +830,7 @@ describe( 'PoweredBy', () => {
 			editor.ui.fire( 'update' );
 
 			// Throttled #update listener.
-			await wait( 75 );
+			clock.tick( 75 );
 
 			const pinSpy = testUtils.sinon.spy( editor.ui.poweredBy._balloonView, 'pin' );
 
@@ -848,7 +849,7 @@ describe( 'PoweredBy', () => {
 			editor.ui.fire( 'update' );
 
 			// Throttled #update listener.
-			await wait( 75 );
+			clock.tick( 75 );
 
 			expect( editor.ui.poweredBy._balloonView.isVisible ).to.be.true;
 			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'position_border-side_right' );
@@ -870,12 +871,6 @@ describe( 'PoweredBy', () => {
 
 	async function createEditor( element, config = { plugins: [ SourceEditing ] } ) {
 		return ClassicTestEditor.create( element, config );
-	}
-
-	function wait( time ) {
-		return new Promise( res => {
-			window.setTimeout( res, time );
-		} );
 	}
 
 	function focusEditor( editor, focusableUIElement ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Tests (ui): Use faked timers instead of real timeouts to execute faster.

---

### Additional information

⚠ Diff will look terrible for few days, until `release` branch gets merged to the `master`. That's because I based this branch on PR #14152 ⚠

The timeouts currently sums to `1230` which is in line with actual testing results (first run without this change, and second with fake timers):

```
START:
  PoweredBy
    constructor()
      balloon creation
        √ should not throw if there is no view in EditorUI
        √ should create the balloon on demand
      balloon management on editor focus change
        √ should show the balloon when the editor gets focused
        √ should show the balloon if the focus is not in the editing root but in other editor UI
        √ should hide the balloon on blur
        √ should show the balloon when the source editing is engaged
      balloon management on EditorUI#update
        √ should not trigger if the editor is not focused
        √ should (re-)show the balloon but throttled
        √ should (re-)show the balloon if the focus is not in the editing root but in other editor UI
      balloon view
        √ should be an instance of BalloonPanelView
        √ should host a powered by view
        √ should have no arrow
        √ should have a specific CSS class
        √ should be added to editor's body view collection
        √ should be registered in the focus tracker to avoid focus loss on click
      powered by view
        √ should have specific CSS classes
        √ should have a link that opens in a new tab
        √ should have a label inside the link
        √ should have an icon next to the label
        √ should be impossible to drag and drop into editor's content
        √ should be excluded from the accessibility tree
        √ should not be accessible via tab key navigation
    destroy()
      √ should destroy the emitter listeners
      if there was a balloon
        √ should unpin the balloon
        √ should destroy the balloon
        √ should cancel any throttled show to avoid post-destroy timed errors
      if there was no balloon
        √ should not throw
    balloon positioning depending on environment and configuration
      √ should not show the balloon if the root is not visible
      √ should position the to the left side if the UI language is RTL and no side was configured
      √ should position the balloon in the lower right corner by default
      √ should position the balloon in the lower left corner if configured
      √ should position the balloon over the bottom root border if configured
      √ should position the balloon in the corner of the root if configured
      √ should hide the balloon if the root is invisible (cropped by ancestors)
      √ should hide the balloon if displayed over the bottom root border but partially cropped by an ancestor
      √ should hide the balloon if displayed in the corner of the root but partially cropped by an ancestor
      √ should allow configuring balloon position offsets
      √ should not display the balloon if the root is narrower than 350px
      √ should not display the balloon if the root is shorter than 50px

Finished in 2.545 secs / 1.645 secs @ 16:03:38 GMT+0200 (Central European Summer Time)

SUMMARY:
√ 39 tests completed
asset entry-point.1240656817.js 8.58 MiB [emitted] (name: entry-point.1240656817)
webpack 5.82.1 compiled successfully in 798 ms

=============================================================================================================================================================================================================================================

START:
  PoweredBy
    constructor()
      balloon creation
        √ should not throw if there is no view in EditorUI
        √ should create the balloon on demand
      balloon management on editor focus change
        √ should show the balloon when the editor gets focused
        √ should show the balloon if the focus is not in the editing root but in other editor UI
        √ should hide the balloon on blur
        √ should show the balloon when the source editing is engaged
      balloon management on EditorUI#update
        √ should not trigger if the editor is not focused
        √ should (re-)show the balloon but throttled
        √ should (re-)show the balloon if the focus is not in the editing root but in other editor UI
      balloon view
        √ should be an instance of BalloonPanelView
        √ should host a powered by view
        √ should have no arrow
        √ should have a specific CSS class
        √ should be added to editor's body view collection
        √ should be registered in the focus tracker to avoid focus loss on click
      powered by view
        √ should have specific CSS classes
        √ should have a link that opens in a new tab
        √ should have a label inside the link
        √ should have an icon next to the label
        √ should be impossible to drag and drop into editor's content
        √ should be excluded from the accessibility tree
        √ should not be accessible via tab key navigation
    destroy()
      √ should destroy the emitter listeners
      if there was a balloon
        √ should unpin the balloon
        √ should destroy the balloon
        √ should cancel any throttled show to avoid post-destroy timed errors
      if there was no balloon
        √ should not throw
    balloon positioning depending on environment and configuration
      √ should not show the balloon if the root is not visible
      √ should position the to the left side if the UI language is RTL and no side was configured
      √ should position the balloon in the lower right corner by default
      √ should position the balloon in the lower left corner if configured
      √ should position the balloon over the bottom root border if configured
      √ should position the balloon in the corner of the root if configured
      √ should hide the balloon if the root is invisible (cropped by ancestors)
      √ should hide the balloon if displayed over the bottom root border but partially cropped by an ancestor
      √ should hide the balloon if displayed in the corner of the root but partially cropped by an ancestor
      √ should allow configuring balloon position offsets
      √ should not display the balloon if the root is narrower than 350px
      √ should not display the balloon if the root is shorter than 50px

Finished in 1.098 secs / 0.183 secs @ 16:06:49 GMT+0200 (Central European Summer Time)

SUMMARY:
√ 39 tests completed
assets by status 8.58 MiB [cached] 1 asset
webpack 5.82.1 compiled successfully in 513 ms
```

There are a few real timeouts calls in the unit tests that could be repalced with sinon fake timers to save a little over 1s in entire test suite.