### PR TITLE
The "powered by" label should be configurable.

### DIFF
--- a/packages/ckeditor5-core/src/editor/editorconfig.ts
+++ b/packages/ckeditor5-core/src/editor/editorconfig.ts
@@ -493,7 +493,7 @@ export interface EditorConfig {
 	 *
 	 * 	* **`label`** (default: `'Powered by'`) &ndash; Allows changing the label displayed next to the project's logo.
 	 *
-	 * 		**Note**: Set the value to `null` to hide the label.
+	 * 		**Note**: Set the value to `null` to display the logo without a text.
 	 *
 	 * 	* **`verticalOffset`** (default: `5`) &ndash; The vertical distance the logo can be moved away from its default position.
 	 *
@@ -622,7 +622,7 @@ export interface UiConfig {
 		side: 'left' | 'right';
 
 		/**
-		 * Allows changing the label displayed next to the project's logo.
+		 * Allows changing the label displayed next to the CKEditor logo.
 		 *
 		 * **Note:** Set the value to `null` to hide the label.
 		 *

--- a/packages/ckeditor5-core/src/editor/editorconfig.ts
+++ b/packages/ckeditor5-core/src/editor/editorconfig.ts
@@ -491,6 +491,10 @@ export interface EditorConfig {
 	 * 		**Note**: If {@link module:core/editor/editorconfig~EditorConfig#language `config.language`} is set to an RTL (right-to-left)
 	 * 		language, the side switches to `'left'` by default.
 	 *
+	 * 	* **`label`** (default: `'Powered by'`) &ndash; Allows changing the label displayed next to the project's logo.
+	 *
+	 * 		**Note**: Set the value to `null` to hide the label.
+	 *
 	 * 	* **`verticalOffset`** (default: `5`) &ndash; The vertical distance the logo can be moved away from its default position.
 	 *
 	 * 		**Note**: If `position` is `'border'`, the offset is measured from the (vertical) center of the logo.
@@ -616,6 +620,15 @@ export interface UiConfig {
 		 * @default 'right'
 		 */
 		side: 'left' | 'right';
+
+		/**
+		 * Allows changing the label displayed next to the project's logo.
+		 *
+		 * **Note:** Set the value to `null` to hide the label.
+		 *
+		 * @default 'Powered by'
+		 */
+		label: string | null;
 
 		/**
 		 * The vertical distance the logo can be moved away from its default position.

--- a/packages/ckeditor5-ui/src/editorui/poweredby.ts
+++ b/packages/ckeditor5-ui/src/editorui/poweredby.ts
@@ -28,6 +28,7 @@ const ICON_WIDTH = 53;
 const ICON_HEIGHT = 10;
 const NARROW_ROOT_HEIGHT_THRESHOLD = 50;
 const NARROW_ROOT_WIDTH_THRESHOLD = 350;
+const DEFAULT_LABEL = 'Powered by';
 const OFF_THE_SCREEN_POSITION = {
 	top: -99999,
 	left: -99999,
@@ -148,7 +149,8 @@ export default class PoweredBy extends DomEmitterMixin() {
 	private _createBalloonView() {
 		const editor = this.editor;
 		const balloon = this._balloonView = new BalloonPanelView();
-		const view = new PoweredByView( editor.locale );
+		const poweredByConfig = getNormalizedConfig( editor );
+		const view = new PoweredByView( editor.locale, poweredByConfig.label );
 
 		balloon.content.add( view );
 		balloon.set( {
@@ -225,8 +227,9 @@ class PoweredByView extends View<HTMLDivElement> {
 	 * Created an instance of the "powered by" view.
 	 *
 	 * @param locale The localization services instance.
+	 * @param label The label text.
 	 */
-	constructor( locale: Locale ) {
+	constructor( locale: Locale, label: string | null ) {
 		super( locale );
 
 		const iconView = new IconView();
@@ -262,13 +265,15 @@ class PoweredByView extends View<HTMLDivElement> {
 						tabindex: '-1'
 					},
 					children: [
-						{
-							tag: 'span',
-							attributes: {
-								class: [ 'ck', 'ck-powered-by__label' ]
-							},
-							children: [ 'Powered by' ]
-						},
+						...label ? [
+							{
+								tag: 'span',
+								attributes: {
+									class: [ 'ck', 'ck-powered-by__label' ]
+								},
+								children: [ label ]
+							}
+						] : [],
 						iconView
 					],
 					on: {
@@ -370,6 +375,7 @@ function getNormalizedConfig( editor: Editor ): PoweredByConfig {
 
 	return {
 		position,
+		label: DEFAULT_LABEL,
 		verticalOffset: position === 'inside' ? 5 : 0,
 		horizontalOffset: 5,
 

--- a/packages/ckeditor5-ui/tests/editorui/poweredby.js
+++ b/packages/ckeditor5-ui/tests/editorui/poweredby.js
@@ -338,6 +338,43 @@ describe( 'PoweredBy', () => {
 			it( 'should not be accessible via tab key navigation', () => {
 				expect( view.element.firstChild.tabIndex ).to.equal( -1 );
 			} );
+
+			it( 'should have a configurable label (custom text)', async () => {
+				const editor = await createEditor( element, {
+					ui: {
+						poweredBy: {
+							label: 'foo'
+						}
+					}
+				} );
+
+				focusEditor( editor );
+
+				const view = editor.ui.poweredBy._balloonView.content.first;
+
+				expect( view.element.firstChild.firstChild.textContent ).to.equal( 'foo' );
+
+				await editor.destroy();
+			} );
+
+			it( 'should have an option to hide the label', async () => {
+				const editor = await createEditor( element, {
+					ui: {
+						poweredBy: {
+							label: null
+						}
+					}
+				} );
+
+				focusEditor( editor );
+
+				const view = editor.ui.poweredBy._balloonView.content.first;
+
+				expect( view.element.firstChild.childElementCount ).to.equal( 1 );
+				expect( view.element.firstChild.firstChild.tagName ).to.equal( 'svg' );
+
+				await editor.destroy();
+			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-ui/tests/manual/poweredby/poweredby.html
+++ b/packages/ckeditor5-ui/tests/manual/poweredby/poweredby.html
@@ -170,3 +170,18 @@
 			ridiculous it is to be afraid of something before it happens. The moment you face your fear and see there is nothing
 			to be afraid of, is the moment you discover bliss.</p>
 </div>
+
+<h2>Custom label</h2>
+<h3>Custom text</h3>
+<div id="custom-label">
+	<p>Going to a new place can be quite terrifying. While change and uncertainty make us scared, traveling teaches us how
+			ridiculous it is to be afraid of something before it happens. The moment you face your fear and see there is nothing
+			to be afraid of, is the moment you discover bliss.</p>
+</div>
+
+<h3>No text</h3>
+<div id="custom-label-empty">
+	<p>Going to a new place can be quite terrifying. While change and uncertainty make us scared, traveling teaches us how
+			ridiculous it is to be afraid of something before it happens. The moment you face your fear and see there is nothing
+			to be afraid of, is the moment you discover bliss.</p>
+</div>

--- a/packages/ckeditor5-ui/tests/manual/poweredby/poweredby.js
+++ b/packages/ckeditor5-ui/tests/manual/poweredby/poweredby.js
@@ -90,3 +90,9 @@ createEditor( '#custom-side-inside', {
 createEditor( '#custom-side-on-border', {
 	side: 'left'
 } );
+createEditor( '#custom-label', {
+	label: 'Hello'
+} );
+createEditor( '#custom-label-empty', {
+	label: null
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): The "powered by" label should be configurable. Closes https://github.com/cksource/ckeditor5-internal/issues/3286.