### PR TITLE
A note to the migration guide about a way to disable color pickers

### DIFF
--- a/docs/updating/update-to-38.md
+++ b/docs/updating/update-to-38.md
@@ -27,7 +27,7 @@ We have prepared a detailed {@link support/managing-ckeditor-logo Managing the "
 
 ## Introduction of color pickers to font color and font background color features
 
-Starting with 38.0.0 release, the user interface of the {@link features/font#configuring-the-font-color-and-font-background-color-features font color and font background color features} will display a {@link features/font#color-picker color picker}. The new feature is **enabled by default** and supplements existing color palettes to improve the editing experience and boost the creativity of content authors.
+Starting with v38.0.0, the user interface of the {@link features/font#configuring-the-font-color-and-font-background-color-features font color and font background color features} will display a {@link features/font#color-picker color picker}. The new feature is **enabled by default** and supplements existing color palettes to improve the editing experience and boost the creativity of content authors.
 
 However, we are aware of the fact that the freedom to choose any color may introduce noise and inconsistency to the content of some integrations with {@link features/font#specifying-available-colors already configured palettes}. If this is your case, you should know that you can disable color pickers in both font color and font background color features by setting the {@link module:font/fontconfig~FontColorConfig#colorPicker `colorPicker` option} in their respective configurations to `false`:
 

--- a/docs/updating/update-to-38.md
+++ b/docs/updating/update-to-38.md
@@ -24,3 +24,28 @@ Starting from version 38.0.0, all **open source installations** of CKEditor 5 wi
 If you have a **commercial license**, you can hide the logo by adding `config.licenseKey` to your configuration. If you already use pagination, productivity pack, or non-real-time collaboration features, you don't need to take any action as you should already have `config.licenseKey` in place. The logo will not be visible in your editor.
 
 We have prepared a detailed {@link support/managing-ckeditor-logo Managing the "Powered by CKEditor" logo} guide to help everyone through the transition and explain any concerns.
+
+## Introduction of color pickers to font color and font background color features
+
+Starting with 38.0.0 release, the user interface of the {@link features/font#configuring-the-font-color-and-font-background-color-features font color and font background color features} will display a {@link features/font#color-picker color picker}. The new feature is **enabled by default** and supplements existing color palettes to improve the editing experience and boost the creativity of content authors.
+
+However, we are aware of the fact that the freedom to choose any color may introduce noise and inconsistency to the content of some integrations with {@link features/font#specifying-available-colors already configured palettes}. If this is your case, you should know that you can disable color pickers in both font color and font background color features by setting the {@link module:font/fontconfig~FontColorConfig#colorPicker `colorPicker` option} in their respective configurations to `false`:
+
+```js
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		fontColor: {
+			// Disable the color picker for the font color feature.
+			colorPicker: false
+		},
+		fontBackgroundColor: {
+			// Disable the color picker for the font background color feature.
+			colorPicker: false
+		},
+		toolbar: [
+			'heading', 'bulletedList', 'numberedList', 'fontColor', 'fontBackgroundColor', 'undo', 'redo'
+		]
+	} )
+	.then( /* ... */ )
+	.catch( /* ... */ );
+```

--- a/docs/updating/update-to-38.md
+++ b/docs/updating/update-to-38.md
@@ -29,7 +29,7 @@ We have prepared a detailed {@link support/managing-ckeditor-logo Managing the "
 
 Starting with v38.0.0, the user interface of the {@link features/font#configuring-the-font-color-and-font-background-color-features font color and font background color features} will display a {@link features/font#color-picker color picker}. The new feature is **enabled by default** and supplements existing color palettes to improve the editing experience and boost the creativity of content authors.
 
-However, we are aware of the fact that the freedom to choose any color may introduce noise and inconsistency to the content of some integrations with {@link features/font#specifying-available-colors already configured palettes}. If this is your case, you should know that you can disable color pickers in both font color and font background color features by setting the {@link module:font/fontconfig~FontColorConfig#colorPicker `colorPicker` option} in their respective configurations to `false`:
+However, we are aware of the fact that the freedom to choose any color may introduce noise and inconsistency to the content of some integrations with {@link features/font#specifying-available-colors already configured palettes}. If this is your case, you can disable color pickers in both font color and font background color features by setting the {@link module:font/fontconfig~FontColorConfig#colorPicker `colorPicker` option} in their respective configurations to `false`:
 
 ```js
 ClassicEditor


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Added a note to the migration guide about a way to disable color pickers in font color and font background color features. Closes https://github.com/cksource/ckeditor5-internal/issues/3273.

---

### Additional information

This PR is built on top of https://github.com/ckeditor/ckeditor5/pull/14105.
