### PR TITLE
Logo visibility.

### DIFF
--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -295,3 +295,8 @@ https://github.com/ckeditor/ckeditor5/issues/1545 */
 	width: 100%;
 	overflow: auto;
 }
+
+/* https://github.com/cksource/ckeditor5-internal/issues/3223 */
+.ck-body-wrapper .ck.ck-powered-by-balloon.ck-balloon-panel.ck-balloon-panel_visible {
+	display: none
+}

--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -298,5 +298,5 @@ https://github.com/ckeditor/ckeditor5/issues/1545 */
 
 /* https://github.com/cksource/ckeditor5-internal/issues/3223 */
 .ck-body-wrapper .ck.ck-powered-by-balloon.ck-balloon-panel.ck-balloon-panel_visible {
-	display: none
+	display: none;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Should hide the logo.

---

### Additional information

Source: https://github.com/cksource/ckeditor5-internal/issues/3223#issuecomment-1549360961
