### PR TITLE
Add information about the Free for Open Source to the License guide

### DIFF
--- a/docs/support/license-and-legal.md
+++ b/docs/support/license-and-legal.md
@@ -14,6 +14,10 @@ Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
+## Free for Open Source
+
+If you are running an Open Source project under an OSS license incompatible with GPL, please [contact us](https://ckeditor.com/contact/). We will be happy to [support your project with a free CKEditor 5 license](https://ckeditor.com/wysiwyg-editor-open-source/).
+
 ## Sources of intellectual property included in CKEditor
 
 Where not otherwise indicated, all CKEditor 5 content is authored by CKSource engineers and consists of CKSource-owned intellectual property. In some specific instances, CKEditor will incorporate work done by developers outside of CKSource with their express permission.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Added information about the Free for Open Source to the License guide. Closes https://github.com/cksource/ckeditor5-internal/issues/3295.