### PR TITLE
Re-build CKEditor 5 builds after updating references in the new release process

### DIFF
--- a/scripts/release/preparepackages.js
+++ b/scripts/release/preparepackages.js
@@ -9,6 +9,7 @@
 
 'use strict';
 
+const path = require( 'path' );
 const { EventEmitter } = require( 'events' );
 const releaseTools = require( '@ckeditor/ckeditor5-dev-release-tools' );
 const { Listr } = require( 'listr2' );
@@ -20,6 +21,7 @@ const isCKEditor5Package = require( './utils/isckeditor5package' );
 const compileTypeScriptCallback = require( './utils/compiletypescriptcallback' );
 const updatePackageEntryPoint = require( './utils/updatepackageentrypoint' );
 const prepareDllBuildsCallback = require( './utils/preparedllbuildscallback' );
+const buildCKEditor5BuildsCallback = require( './utils/buildckeditor5buildscallback' );
 
 const cliArguments = parseArguments( process.argv.slice( 2 ) );
 const abortController = new AbortController();
@@ -109,9 +111,17 @@ const tasks = new Listr( [
 				},
 				{
 					title: 'Preparing "ckeditor5-build-*" builds.',
-					task: () => {
-						// TODO: Waits for #14177.
-						return Promise.resolve();
+					task: ( ctx, task ) => {
+						return releaseTools.executeInParallel( {
+							packagesDirectory: PACKAGES_DIRECTORY,
+							packagesDirectoryFilter: packageDirectory => {
+								return path.basename( packageDirectory ).startsWith( 'ckeditor5-build-' );
+							},
+							signal: abortController.signal,
+							listrTask: task,
+							taskToExecute: buildCKEditor5BuildsCallback,
+							concurrency: cliArguments.concurrency
+						} );
 					}
 				},
 				{

--- a/scripts/release/preparepackages.js
+++ b/scripts/release/preparepackages.js
@@ -121,7 +121,7 @@ const tasks = new Listr( [
 							signal: abortController.signal,
 							listrTask: task,
 							taskToExecute: buildCKEditor5BuildsCallback,
-							concurrency: cliArguments.concurrency
+							concurrency: 2
 						} );
 					}
 				},
@@ -191,6 +191,7 @@ const tasks = new Listr( [
 				files: [
 					'package.json',
 					`${ PACKAGES_DIRECTORY }/*/package.json`,
+					`${ PACKAGES_DIRECTORY }/ckeditor5-build-*/build/**`,
 					...ctx.updatedFiles
 				]
 			} );

--- a/scripts/release/utils/buildckeditor5buildscallback.js
+++ b/scripts/release/utils/buildckeditor5buildscallback.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* eslint-env node */
+
+'use strict';
+
+module.exports = async function buildCKEditor5BuildsCallback( packagePath ) {
+	const { tools } = require( '@ckeditor/ckeditor5-dev-utils' );
+
+	return tools.shExec( 'yarn run build', {
+		cwd: packagePath,
+		verbosity: 'error'
+	}, { async: true } );
+};


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other: Re-build CKEditor 5 builds after updating references in the new release process. Closes #14177.

---

### Additional information

This PR requires changes from https://github.com/ckeditor/ckeditor5-dev/pull/883.
