### PR TITLE
Fix export ColorPaletteIcon from ckeditor5-ui.

### DIFF
--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -75,6 +75,8 @@ export { default as BlockToolbar } from './toolbar/block/blocktoolbar';
 export { default as View, type UIViewRenderEvent } from './view';
 export { default as ViewCollection } from './viewcollection';
 
-export { default as ColorPaletteIcon } from '../theme/icons/color-palette.svg';
+import { default as colorPalette } from '../theme/icons/color-palette.svg';
+
+export const ColorPaletteIcon = colorPalette;
 
 import './augmentation';

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -75,8 +75,10 @@ export { default as BlockToolbar } from './toolbar/block/blocktoolbar';
 export { default as View, type UIViewRenderEvent } from './view';
 export { default as ViewCollection } from './viewcollection';
 
-import { default as colorPalette } from '../theme/icons/color-palette.svg';
+import { default as colorPaletteIcon } from '../theme/icons/color-palette.svg';
 
-export const ColorPaletteIcon = colorPalette;
+export const icons = {
+	colorPaletteIcon
+};
 
 import './augmentation';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Fixes export of `ColorPaletteIcon` from `ckeditor5-ui`. Closes #14205.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._