### PR TITLE
Docs: Fix the misleading link in the Angular guide.

### DIFF
--- a/docs/installation/integrations/angular.md
+++ b/docs/installation/integrations/angular.md
@@ -19,7 +19,7 @@ CKEditor 5 consists of the {@link installation/getting-started/predefined-builds
 Currently, the CKEditor 5 component for Angular supports integrating CKEditor 5 only via builds. Integrating {@link installation/advanced/integrating-from-source-webpack CKEditor 5 built from source} is not possible yet due to the lack of ability to [adjust webpack configuration in `angular-cli`](https://github.com/angular/angular-cli/issues/10618).
 
 <info-box>
-	While there is no support to integrate CKEditor 5 from source yet, you can still {@link installation/getting-started/quick-start-other#building-the-editor-from-source create a custom build of CKEditor 5} and include it in your Angular application.
+	While there is no support to integrate CKEditor 5 from source yet, you can still {@link installation/getting-started/quick-start-other#customizing-a-build create a custom build of CKEditor 5} and include it in your Angular application.
 </info-box>
 
 <info-box hint>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Fix the misleading link in the Angular guide. Closes https://github.com/ckeditor/ckeditor5/issues/14100.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
