### PR TITLE
Change `htmlListAttributes` to `htmlUlAttributes` or  `htmlOlAttributes` depending on the list type

### DIFF
--- a/packages/ckeditor5-html-support/src/integrations/documentlist.ts
+++ b/packages/ckeditor5-html-support/src/integrations/documentlist.ts
@@ -18,7 +18,7 @@ import type {
 	DocumentListIndentCommand
 } from '@ckeditor/ckeditor5-list';
 
-import { type GHSViewAttributes, setViewAttributes } from '../utils';
+import { getHtmlAttributeName, setViewAttributes } from '../utils';
 import DataFilter, { type DataFilterRegisterEvent } from '../datafilter';
 
 /**
@@ -53,49 +53,52 @@ export default class DocumentListElementSupport extends Plugin {
 		const conversion = editor.conversion;
 		const dataFilter = editor.plugins.get( DataFilter );
 		const documentListEditing: DocumentListEditing = editor.plugins.get( 'DocumentListEditing' );
+		const viewElements = [ 'ul', 'ol', 'li' ];
 
 		// Register downcast strategy.
 		// Note that this must be done before document list editing registers conversion in afterInit.
 		documentListEditing.registerDowncastStrategy( {
 			scope: 'item',
 			attributeName: 'htmlLiAttributes',
-
-			setAttributeOnDowncast( writer, attributeValue: GHSViewAttributes, viewElement ) {
-				setViewAttributes( writer, attributeValue, viewElement );
-			}
+			setAttributeOnDowncast: setViewAttributes
 		} );
 
 		documentListEditing.registerDowncastStrategy( {
 			scope: 'list',
-			attributeName: 'htmlListAttributes',
+			attributeName: 'htmlUlAttributes',
+			setAttributeOnDowncast: setViewAttributes
+		} );
 
-			setAttributeOnDowncast( writer, viewAttributes: GHSViewAttributes, viewElement ) {
-				setViewAttributes( writer, viewAttributes, viewElement );
-			}
+		documentListEditing.registerDowncastStrategy( {
+			scope: 'list',
+			attributeName: 'htmlOlAttributes',
+			setAttributeOnDowncast: setViewAttributes
 		} );
 
 		dataFilter.on<DataFilterRegisterEvent>( 'register', ( evt, definition ) => {
-			if ( ![ 'ul', 'ol', 'li' ].includes( definition.view! ) ) {
+			if ( !viewElements.includes( definition.view! ) ) {
 				return;
 			}
 
 			evt.stop();
 
 			// Do not register same converters twice.
-			if ( schema.checkAttribute( '$block', 'htmlListAttributes' ) ) {
+			if ( schema.checkAttribute( '$block', 'htmlLiAttributes' ) ) {
 				return;
 			}
 
-			schema.extend( '$block', { allowAttributes: [ 'htmlListAttributes', 'htmlLiAttributes' ] } );
-			schema.extend( '$blockObject', { allowAttributes: [ 'htmlListAttributes', 'htmlLiAttributes' ] } );
-			schema.extend( '$container', { allowAttributes: [ 'htmlListAttributes', 'htmlLiAttributes' ] } );
+			const allowAttributes = viewElements.map( element => getHtmlAttributeName( element ) );
+
+			schema.extend( '$block', { allowAttributes } );
+			schema.extend( '$blockObject', { allowAttributes } );
+			schema.extend( '$container', { allowAttributes } );
 
 			conversion.for( 'upcast' ).add( dispatcher => {
 				dispatcher.on<UpcastElementEvent>(
-					'element:ul', viewToModelListAttributeConverter( 'htmlListAttributes', dataFilter ), { priority: 'low' }
+					'element:ul', viewToModelListAttributeConverter( 'htmlUlAttributes', dataFilter ), { priority: 'low' }
 				);
 				dispatcher.on<UpcastElementEvent>(
-					'element:ol', viewToModelListAttributeConverter( 'htmlListAttributes', dataFilter ), { priority: 'low' }
+					'element:ol', viewToModelListAttributeConverter( 'htmlOlAttributes', dataFilter ), { priority: 'low' }
 				);
 				dispatcher.on<UpcastElementEvent>(
 					'element:li', viewToModelListAttributeConverter( 'htmlLiAttributes', dataFilter ), { priority: 'low' }
@@ -140,10 +143,11 @@ export default class DocumentListElementSupport extends Plugin {
 				}
 
 				if ( previousNodeInList.getAttribute( 'listType' ) == node.getAttribute( 'listType' ) ) {
-					const value = previousNodeInList.getAttribute( 'htmlListAttributes' );
+					const attribute = getAttributeFromListType( previousNodeInList.getAttribute( 'listType' ) );
+					const value = previousNodeInList.getAttribute( attribute );
 
-					if ( !isEqual( node.getAttribute( 'htmlListAttributes' ), value ) ) {
-						writer.setAttribute( 'htmlListAttributes', value, node );
+					if ( !isEqual( node.getAttribute( attribute ), value ) ) {
+						writer.setAttribute( attribute, value, node );
 						evt.return = true;
 					}
 				}
@@ -155,6 +159,23 @@ export default class DocumentListElementSupport extends Plugin {
 						writer.setAttribute( 'htmlLiAttributes', value, node );
 						evt.return = true;
 					}
+				}
+			}
+		} );
+
+		// Remove `ol` attributes from `ul` elements and vice versa.
+		documentListEditing.on<DocumentListEditingPostFixerEvent>( 'postFixer', ( evt, { listNodes, writer } ) => {
+			for ( const { node } of listNodes ) {
+				const listType = node.getAttribute( 'listType' );
+
+				if ( listType === 'bulleted' && node.getAttribute( 'htmlOlAttributes' ) ) {
+					writer.removeAttribute( 'htmlOlAttributes', node );
+					evt.return = true;
+				}
+
+				if ( listType === 'numbered' && node.getAttribute( 'htmlUlAttributes' ) ) {
+					writer.removeAttribute( 'htmlUlAttributes', node );
+					evt.return = true;
 				}
 			}
 		} );
@@ -175,10 +196,12 @@ export default class DocumentListElementSupport extends Plugin {
 		this.listenTo( indentList, 'afterExecute', ( evt, changedBlocks ) => {
 			editor.model.change( writer => {
 				for ( const node of changedBlocks ) {
+					const attribute = getAttributeFromListType( node.getAttribute( 'listType' ) );
+
 					// Just reset the attribute.
 					// If there is a previous indented list that this node should be merged into,
 					// the postfixer will unify all the attributes of both sub-lists.
-					writer.setAttribute( 'htmlListAttributes', {}, node );
+					writer.setAttribute( attribute, {}, node );
 				}
 			} );
 		} );
@@ -191,8 +214,8 @@ export default class DocumentListElementSupport extends Plugin {
  *
  * @returns Returns a conversion callback.
  */
-function viewToModelListAttributeConverter( attributeName: string, dataFilter: DataFilter ) {
-	const callback: GetCallback<UpcastElementEvent> = ( evt, data, conversionApi ) => {
+function viewToModelListAttributeConverter( attributeName: string, dataFilter: DataFilter ): GetCallback<UpcastElementEvent> {
+	return ( evt, data, conversionApi ) => {
 		const viewElement = data.viewItem;
 
 		if ( !data.modelRange ) {
@@ -216,6 +239,13 @@ function viewToModelListAttributeConverter( attributeName: string, dataFilter: D
 			conversionApi.writer.setAttribute( attributeName, viewAttributes || {}, item );
 		}
 	};
+}
 
-	return callback;
+/**
+ * Returns HTML attribute name based on provided list type.
+ */
+function getAttributeFromListType( listType: 'bulleted' | 'numbered' ) {
+	return listType === 'bulleted' ?
+		'htmlUlAttributes' :
+		'htmlOlAttributes';
 }

--- a/packages/ckeditor5-html-support/src/schemadefinitions.ts
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.ts
@@ -524,13 +524,13 @@ export default {
 			coupledAttribute: 'listItemId'
 		},
 		{
-			model: 'htmlListAttributes',
+			model: 'htmlOlAttributes',
 			view: 'ol',
 			appliesToBlock: true,
 			coupledAttribute: 'listItemId'
 		},
 		{
-			model: 'htmlListAttributes',
+			model: 'htmlUlAttributes',
 			view: 'ul',
 			appliesToBlock: true,
 			coupledAttribute: 'listItemId'

--- a/packages/ckeditor5-html-support/tests/generalhtmlsupport.js
+++ b/packages/ckeditor5-html-support/tests/generalhtmlsupport.js
@@ -58,8 +58,8 @@ describe( 'GeneralHtmlSupport', () => {
 		} );
 
 		it( 'should return model attribute name for list elements with multiple view representations', () => {
-			expect( generalHtmlSupport.getGhsAttributeNameForElement( 'ul' ) ).to.equal( 'htmlListAttributes' );
-			expect( generalHtmlSupport.getGhsAttributeNameForElement( 'ol' ) ).to.equal( 'htmlListAttributes' );
+			expect( generalHtmlSupport.getGhsAttributeNameForElement( 'ul' ) ).to.equal( 'htmlUlAttributes' );
+			expect( generalHtmlSupport.getGhsAttributeNameForElement( 'ol' ) ).to.equal( 'htmlOlAttributes' );
 			expect( generalHtmlSupport.getGhsAttributeNameForElement( 'li' ) ).to.equal( 'htmlLiAttributes' );
 		} );
 

--- a/packages/ckeditor5-html-support/tests/integrations/documentlist.js
+++ b/packages/ckeditor5-html-support/tests/integrations/documentlist.js
@@ -80,6 +80,30 @@ describe( 'DocumentListElementSupport', () => {
 		expect( editor.getData() ).to.equal( '<p data-foo="bar-p">1.</p>' );
 	} );
 
+	it( 'removes list attributes when list type changed', () => {
+		dataFilter.allowElement( /^.*$/ );
+		dataFilter.allowAttributes( { name: /^.*$/, attributes: true } );
+		dataFilter.allowAttributes( { name: /^.*$/, classes: true } );
+
+		editor.setData(
+			'<ol data-foo="bar-list">' +
+				'<li data-foo="bar-item">' +
+					'<p data-foo="bar-p">1.</p>' +
+				'</li>' +
+			'</ol>'
+		);
+
+		editor.commands.get( 'bulletedList' ).execute();
+
+		expect( editor.getData() ).to.equal(
+			'<ul>' +
+				'<li data-foo="bar-item">' +
+					'<p data-foo="bar-p">1.</p>' +
+				'</li>' +
+			'</ul>'
+		);
+	} );
+
 	describe( 'downcast', () => {
 		beforeEach( () => {
 			dataFilter.allowElement( /^.*$/ );
@@ -187,8 +211,12 @@ describe( 'DocumentListElementSupport', () => {
 		} );
 
 		function makeList( listType, listIndent, listAttributes, elements ) {
-			const htmlListAttributes = listAttributes ?
-				`htmlListAttributes="${ JSON.stringify( listAttributes ).replaceAll( '"', '&quot;' ) }" ` :
+			const attribute = listType === 'bulleted' ?
+				'htmlUlAttributes' :
+				'htmlOlAttributes';
+
+			const htmlElementAttributes = listAttributes ?
+				`${ attribute }="${ JSON.stringify( listAttributes ).replaceAll( '"', '&quot;' ) }" ` :
 				'';
 
 			return elements.map( ( element, index ) => {
@@ -205,7 +233,7 @@ describe( 'DocumentListElementSupport', () => {
 				return (
 					'<paragraph ' +
 						htmlLiAttributes +
-						htmlListAttributes +
+						htmlElementAttributes +
 						`listIndent="${ listIndent }" ` +
 						`listItemId="${ index }" ` +
 						`listType="${ listType }">` +
@@ -226,10 +254,10 @@ describe( 'DocumentListElementSupport', () => {
 
 			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
 				data:
-					'<paragraph htmlLiAttributes="(1)" htmlListAttributes="(2)" listIndent="0" listItemId="a00" listType="bulleted">' +
+					'<paragraph htmlLiAttributes="(1)" htmlUlAttributes="(2)" listIndent="0" listItemId="a00" listType="bulleted">' +
 						'Foo' +
 					'</paragraph>' +
-					'<paragraph htmlLiAttributes="(3)" htmlListAttributes="(4)" listIndent="0" listItemId="a01" listType="bulleted">' +
+					'<paragraph htmlLiAttributes="(3)" htmlUlAttributes="(4)" listIndent="0" listItemId="a01" listType="bulleted">' +
 						'Bar' +
 					'</paragraph>',
 				attributes: {
@@ -258,10 +286,10 @@ describe( 'DocumentListElementSupport', () => {
 
 			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
 				data:
-					'<paragraph htmlLiAttributes="(1)" htmlListAttributes="(2)" listIndent="0" listItemId="a00" listType="numbered">' +
+					'<paragraph htmlLiAttributes="(1)" htmlOlAttributes="(2)" listIndent="0" listItemId="a00" listType="numbered">' +
 						'Foo' +
 					'</paragraph>' +
-					'<paragraph htmlLiAttributes="(3)" htmlListAttributes="(4)" listIndent="0" listItemId="a01" listType="numbered">' +
+					'<paragraph htmlLiAttributes="(3)" htmlOlAttributes="(4)" listIndent="0" listItemId="a01" listType="numbered">' +
 						'Bar' +
 					'</paragraph>',
 				attributes: {
@@ -290,10 +318,10 @@ describe( 'DocumentListElementSupport', () => {
 
 			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
 				data:
-					'<paragraph htmlLiAttributes="(1)" htmlListAttributes="(2)" listIndent="0" listItemId="a00" listType="numbered">' +
+					'<paragraph htmlLiAttributes="(1)" htmlOlAttributes="(2)" listIndent="0" listItemId="a00" listType="numbered">' +
 						'Foo' +
 					'</paragraph>' +
-					'<paragraph htmlLiAttributes="(3)" htmlListAttributes="(4)" listIndent="0" listItemId="a01" listType="numbered">' +
+					'<paragraph htmlLiAttributes="(3)" htmlOlAttributes="(4)" listIndent="0" listItemId="a01" listType="numbered">' +
 						'Bar' +
 					'</paragraph>',
 				attributes: {
@@ -331,13 +359,13 @@ describe( 'DocumentListElementSupport', () => {
 
 			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
 				data:
-					'<paragraph htmlLiAttributes="(1)" htmlListAttributes="(2)" listIndent="0" listItemId="a01" listType="bulleted">' +
+					'<paragraph htmlLiAttributes="(1)" htmlUlAttributes="(2)" listIndent="0" listItemId="a01" listType="bulleted">' +
 						'Foo' +
 					'</paragraph>' +
-					'<paragraph htmlLiAttributes="(3)" htmlListAttributes="(4)" listIndent="1" listItemId="a00" listType="numbered">' +
+					'<paragraph htmlLiAttributes="(3)" htmlOlAttributes="(4)" listIndent="1" listItemId="a00" listType="numbered">' +
 						'Bar' +
 					'</paragraph>' +
-					'<paragraph htmlLiAttributes="(5)" htmlListAttributes="(6)" listIndent="0" listItemId="a01" listType="bulleted">' +
+					'<paragraph htmlLiAttributes="(5)" htmlUlAttributes="(6)" listIndent="0" listItemId="a01" listType="bulleted">' +
 						'Baz' +
 					'</paragraph>',
 				attributes: {
@@ -386,7 +414,7 @@ describe( 'DocumentListElementSupport', () => {
 
 			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
 				data:
-					'<paragraph htmlLiAttributes="(1)" htmlListAttributes="(2)" listIndent="0" listItemId="a00" listType="bulleted">' +
+					'<paragraph htmlLiAttributes="(1)" htmlUlAttributes="(2)" listIndent="0" listItemId="a00" listType="bulleted">' +
 						'Foo' +
 					'</paragraph>' +
 					'<div htmlDivAttributes="(3)">Bar</div>',
@@ -416,10 +444,10 @@ describe( 'DocumentListElementSupport', () => {
 
 			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
 				data:
-					'<paragraph htmlLiAttributes="(1)" htmlListAttributes="(2)" listIndent="0" listItemId="a00" listType="bulleted">' +
+					'<paragraph htmlLiAttributes="(1)" htmlUlAttributes="(2)" listIndent="0" listItemId="a00" listType="bulleted">' +
 						'Foo' +
 					'</paragraph>' +
-					'<paragraph htmlLiAttributes="(3)" htmlListAttributes="(4)" listIndent="0" listItemId="a01" listType="bulleted">' +
+					'<paragraph htmlLiAttributes="(3)" htmlUlAttributes="(4)" listIndent="0" listItemId="a01" listType="bulleted">' +
 						'Bar' +
 					'</paragraph>',
 				attributes: {
@@ -443,10 +471,10 @@ describe( 'DocumentListElementSupport', () => {
 
 			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
 				data:
-					'<paragraph htmlLiAttributes="(1)" htmlListAttributes="(2)" listIndent="0" listItemId="a00" listType="numbered">' +
+					'<paragraph htmlLiAttributes="(1)" htmlOlAttributes="(2)" listIndent="0" listItemId="a00" listType="numbered">' +
 						'Foo' +
 					'</paragraph>' +
-					'<paragraph htmlLiAttributes="(3)" htmlListAttributes="(4)" listIndent="0" listItemId="a01" listType="numbered">' +
+					'<paragraph htmlLiAttributes="(3)" htmlOlAttributes="(4)" listIndent="0" listItemId="a01" listType="numbered">' +
 						'Bar' +
 					'</paragraph>',
 				attributes: {
@@ -470,10 +498,10 @@ describe( 'DocumentListElementSupport', () => {
 
 			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
 				data:
-					'<paragraph htmlLiAttributes="(1)" htmlListAttributes="(2)" listIndent="0" listItemId="a00" listType="numbered">' +
+					'<paragraph htmlLiAttributes="(1)" htmlOlAttributes="(2)" listIndent="0" listItemId="a00" listType="numbered">' +
 						'Foo' +
 					'</paragraph>' +
-						'<paragraph htmlLiAttributes="(3)" htmlListAttributes="(4)" listIndent="0" listItemId="a01" listType="numbered">' +
+						'<paragraph htmlLiAttributes="(3)" htmlOlAttributes="(4)" listIndent="0" listItemId="a01" listType="numbered">' +
 						'Bar' +
 					'</paragraph>',
 				attributes: {
@@ -487,7 +515,7 @@ describe( 'DocumentListElementSupport', () => {
 	} );
 
 	describe( 'post-fixer', () => {
-		describe( 'htmlListAttributes', () => {
+		describe( 'html*Attributes', () => {
 			beforeEach( () => {
 				dataFilter.allowElement( /^.*$/ );
 				dataFilter.allowAttributes( { name: /^.*$/, attributes: true } );
@@ -497,7 +525,7 @@ describe( 'DocumentListElementSupport', () => {
 				editor.setData( '' );
 			} );
 
-			it( 'should ensure that all items in a single list have the same `htmlListAttributes`', () => {
+			it( 'should ensure that all items in a single list have the same `html*Attributes`', () => {
 				setModelData( model,
 					paragraph( '1.', '01', 0, 'numbered', { 'data-foo': 'A' } ) +
 					paragraph( '2.', '02', 0, 'numbered', { 'data-foo': 'A' } ) +
@@ -527,7 +555,7 @@ describe( 'DocumentListElementSupport', () => {
 				) );
 			} );
 
-			it( 'should ensure that all list items have the same `htmlListAttributes` after removing a block between them', () => {
+			it( 'should ensure that all list items have the same `html*Attributes` after removing a block between them', () => {
 				setModelData( model,
 					paragraph( '1.', '01', 0, 'bulleted', { 'data-foo': 'A' } ) +
 					paragraph( '2.', '02', 0, 'bulleted', { 'data-foo': 'A' } ) +
@@ -548,7 +576,7 @@ describe( 'DocumentListElementSupport', () => {
 				) );
 			} );
 
-			it( 'should restore `htmlListAttributes` attribute after it\'s changed in one of the following items', () => {
+			it( 'should restore `html*Attributes` attribute after it\'s changed in one of the following items', () => {
 				setModelData( model,
 					paragraph( '1.', '01', 0, 'bulleted', { 'data-foo': 'A' } ) +
 					paragraph( '2.', '02', 0, 'bulleted', { 'data-foo': 'A' } ) +
@@ -557,7 +585,7 @@ describe( 'DocumentListElementSupport', () => {
 
 				model.change( writer => {
 					writer.setAttribute(
-						'htmlListAttributes',
+						'htmlUlAttributes',
 						{ attributes: { 'data-foo': 'B' } },
 						model.document.getRoot().getChild( 2 )
 					);
@@ -570,7 +598,7 @@ describe( 'DocumentListElementSupport', () => {
 				) );
 			} );
 
-			it( 'should change `htmlListAttributes` attribute for all the following items after the first one is changed', () => {
+			it( 'should change `html*Attributes` attribute for all the following items after the first one is changed', () => {
 				setModelData( model,
 					paragraph( '1.', '01', 0, 'bulleted', { 'data-foo': 'A' } ) +
 					paragraph( '2.', '02', 0, 'bulleted', { 'data-foo': 'A' } ) +
@@ -579,7 +607,7 @@ describe( 'DocumentListElementSupport', () => {
 
 				model.change( writer => {
 					writer.setAttribute(
-						'htmlListAttributes',
+						'htmlUlAttributes',
 						{ attributes: { 'data-foo': 'B' } },
 						model.document.getRoot().getChild( 0 )
 					);
@@ -689,7 +717,7 @@ describe( 'DocumentListElementSupport', () => {
 			editor.setData( '' );
 		} );
 
-		it( 'should reset `htmlListAttributes` attribute after indenting a single item', () => {
+		it( 'should reset `html*Attributes` attribute after indenting a single item', () => {
 			setModelData( model,
 				paragraph( '1.', '01', 0, 'numbered', { 'data-foo': 'foo' } ) +
 				paragraph( '1a.', '02', 1, 'bulleted', { 'data-foo': 'bar' } ) +
@@ -709,7 +737,7 @@ describe( 'DocumentListElementSupport', () => {
 			) );
 		} );
 
-		it( 'should reset `htmlListAttributes` attribute after indenting a few items', () => {
+		it( 'should reset `html*Attributes` attribute after indenting a few items', () => {
 			setModelData( model,
 				paragraph( '1.', '01', 0, 'bulleted', { 'data-foo': 'foo' } ) +
 				paragraph( '[2.', '02', 0, 'bulleted', { 'data-foo': 'foo' } ) +
@@ -725,7 +753,7 @@ describe( 'DocumentListElementSupport', () => {
 			) );
 		} );
 
-		it( 'should copy `htmlListAttributes` attribute after indenting a single item into previously nested list', () => {
+		it( 'should copy `html*Attributes` attribute after indenting a single item into previously nested list', () => {
 			setModelData( model,
 				paragraph( '1.', '01', 0, 'bulleted', { 'data-foo': 'foo' } ) +
 				paragraph( '1a.', '02', 1, 'bulleted', { 'data-foo': 'bar' } ) +
@@ -745,7 +773,7 @@ describe( 'DocumentListElementSupport', () => {
 			) );
 		} );
 
-		it( 'should copy `htmlListAttributes` attribute after indenting a few items into previously nested list', () => {
+		it( 'should copy `html*Attributes` attribute after indenting a few items into previously nested list', () => {
 			setModelData( model,
 				paragraph( '1.', '01', 0, 'bulleted', { 'data-foo': 'foo' } ) +
 				paragraph( '1a.', '02', 1, 'bulleted', { 'data-foo': 'bar' } ) +
@@ -769,10 +797,13 @@ describe( 'DocumentListElementSupport', () => {
 	} );
 
 	function paragraph( text, id, indent, type, listAttributes ) {
+		const attributeName = type === 'bulleted' ?
+			'htmlUlAttributes' :
+			'htmlOlAttributes';
 		const attrs = JSON.stringify( { attributes: listAttributes } ).replaceAll( '"', '&quot;' );
 
 		return (
-			`<paragraph htmlListAttributes="${ attrs }" listIndent="${ indent }" listItemId="${ id }" listType="${ type }">` +
+			`<paragraph ${ attributeName }="${ attrs }" listIndent="${ indent }" listItemId="${ id }" listType="${ type }">` +
 				text +
 			'</paragraph>'
 		);

--- a/packages/ckeditor5-style/tests/integrations/documentlist.js
+++ b/packages/ckeditor5-style/tests/integrations/documentlist.js
@@ -130,9 +130,9 @@ describe( 'DocumentListStyleSupport', () => {
 			expect( command.enabledStyles ).to.have.members( [ 'P style' ] );
 		} );
 
-		it( 'UL style should be disabled if htmlListAttributes is disabled', () => {
+		it( 'OL style should be disabled if htmlOlAttributes is disabled', () => {
 			model.schema.addAttributeCheck( ( context, attributeName ) => {
-				if ( attributeName == 'htmlListAttributes' ) {
+				if ( attributeName == 'htmlOlAttributes' ) {
 					return false;
 				}
 			} );
@@ -143,9 +143,9 @@ describe( 'DocumentListStyleSupport', () => {
 			expect( command.enabledStyles ).to.have.members( [ 'LI style', 'P style' ] );
 		} );
 
-		it( 'OL style should be disabled if htmlListAttributes is disabled', () => {
+		it( 'UL style should be disabled if htmlUlAttributes is disabled', () => {
 			model.schema.addAttributeCheck( ( context, attributeName ) => {
-				if ( attributeName == 'htmlListAttributes' ) {
+				if ( attributeName == 'htmlUlAttributes' ) {
 					return false;
 				}
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (html-support): Changing list type removes styles from the old type. Closes #14216.
