### PR TITLE
Discovery: Export to PDF: text goes beyond its cell when columns are resized by resize handler

### DIFF
--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -52,10 +52,6 @@ when content is available outside the editor. See https://github.com/ckeditor/ck
 	text-align: left;
 }
 
-.ck.ck-content .table td {
-	overflow-wrap: break-word;
-}
-
 .ck-editor__editable .ck-table-bogus-paragraph {
 	/*
 	 * Use display:inline-block to force Chrome/Safari to limit text mutations to this element.

--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -52,6 +52,10 @@ when content is available outside the editor. See https://github.com/ckeditor/ck
 	text-align: left;
 }
 
+.ck.ck-content .table td {
+	overflow-wrap: break-word;
+}
+
 .ck-editor__editable .ck-table-bogus-paragraph {
 	/*
 	 * Use display:inline-block to force Chrome/Safari to limit text mutations to this element.

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -22,8 +22,10 @@
 
 .ck-content .table td,
 .ck-content .table th {
-	position: relative;
+	/* To prevent text overflowing beyond its cell when columns are resized by resize handler
+	(https://github.com/ckeditor/ckeditor5/pull/14379). */
 	overflow-wrap: break-word;
+	position: relative;
 }
 
 .ck.ck-editor__editable .table .ck-table-column-resizer {

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -23,6 +23,7 @@
 .ck-content .table td,
 .ck-content .table th {
 	position: relative;
+	overflow-wrap: break-word;
 }
 
 .ck.ck-editor__editable .table .ck-table-column-resizer {

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -23,7 +23,7 @@
 .ck-content .table td,
 .ck-content .table th {
 	/* To prevent text overflowing beyond its cell when columns are resized by resize handler
-	(https://github.com/ckeditor/ckeditor5/pull/14379). */
+	(https://github.com/ckeditor/ckeditor5/pull/14379#issuecomment-1589460978). */
 	overflow-wrap: break-word;
 	position: relative;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (table): Text will no longer go beyond its cell when columns are resized by resize handler in Firefox. Closes [#14386](https://github.com/ckeditor/ckeditor5/issues/14386).
Fix (export-pdf): Text will no longer go beyond its cell when columns are resized by resize handler in exported PDFs. Closes [#3355](https://github.com/cksource/ckeditor5-internal/issues/3355).

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
