### PR TITLE
Randomly failing Table of Contents editing test (before each)

### DIFF
--- a/packages/ckeditor5-table/tests/manual/plaintableoutput.js
+++ b/packages/ckeditor5-table/tests/manual/plaintableoutput.js
@@ -88,3 +88,4 @@ ClassicEditor
 	.catch( err => {
 		console.error( err.stack );
 	} );
+// check CI


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (table): Randomly failing Table of Contents editing test (before each. Closes [#3349](https://github.com/cksource/ckeditor5-internal/issues/3349).

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
