### PR TITLE
Made the PFO testing framework open

### DIFF
--- a/packages/ckeditor5-paste-from-office/src/index.ts
+++ b/packages/ckeditor5-paste-from-office/src/index.ts
@@ -8,5 +8,7 @@
  */
 
 export { default as PasteFromOffice } from './pastefromoffice';
+export { Normalizer, type NormalizerData } from './normalizer';
+export { parseHtml } from './filters/parse';
 
 import './augmentation';

--- a/packages/ckeditor5-paste-from-office/src/pastefromoffice.ts
+++ b/packages/ckeditor5-paste-from-office/src/pastefromoffice.ts
@@ -76,7 +76,9 @@ export default class PasteFromOffice extends Plugin {
 				const activeNormalizer = normalizers.find( normalizer => normalizer.isActive( htmlString ) );
 
 				if ( activeNormalizer ) {
-					data._parsedData = parseHtml( htmlString, viewDocument.stylesProcessor );
+					if ( !data._parsedData ) {
+						data._parsedData = parseHtml( htmlString, viewDocument.stylesProcessor );
+					}
 
 					activeNormalizer.execute( data );
 

--- a/packages/ckeditor5-paste-from-office/tests/_utils/fixtures.js
+++ b/packages/ckeditor5-paste-from-office/tests/_utils/fixtures.js
@@ -18,7 +18,7 @@ import { fixtures as fontWithoutTableProperties } from '../_data/font-without-ta
 import { fixtures as googleDocsBrParagraphs } from '../_data/paste-from-google-docs/br-paragraph/index';
 
 // Generic fixtures.
-export const fixtures = {
+export const generic = {
 	'basic-styles': basicStyles,
 	image,
 	link,
@@ -33,7 +33,7 @@ export const fixtures = {
 };
 
 // Browser specific fixtures.
-export const browserFixtures = {
+export const browser = {
 	'basic-styles': basicStylesBrowser,
 	image: imageBrowser,
 	link: linkBrowser,

--- a/packages/ckeditor5-paste-from-office/tests/data/integration.js
+++ b/packages/ckeditor5-paste-from-office/tests/data/integration.js
@@ -24,6 +24,7 @@ import PageBreak from '@ckeditor/ckeditor5-page-break/src/pagebreak';
 
 import PasteFromOffice from '../../src/pastefromoffice';
 import { generateTests } from '../_utils/utils';
+import * as fixtures from '../_utils/fixtures';
 
 const browsers = [ 'chrome', 'firefox', 'safari', 'edge' ];
 
@@ -37,7 +38,8 @@ describe( 'PasteFromOffice - integration', () => {
 		},
 		skip: {
 			safari: [ 'italicStartingText', 'multipleStylesSingleLine', 'multipleStylesMultiline' ] // Skip due to spacing issue (#13).
-		}
+		},
+		fixtures
 	} );
 
 	generateTests( {
@@ -52,7 +54,8 @@ describe( 'PasteFromOffice - integration', () => {
 			firefox: [],
 			safari: [],
 			edge: [ 'adjacentGroups' ]
-		}
+		},
+		fixtures
 	} );
 
 	generateTests( {
@@ -64,7 +67,8 @@ describe( 'PasteFromOffice - integration', () => {
 		},
 		skip: {
 			safari: [ 'combined' ] // Skip due to spacing issue (#13).
-		}
+		},
+		fixtures
 	} );
 
 	generateTests( {
@@ -76,7 +80,8 @@ describe( 'PasteFromOffice - integration', () => {
 		},
 		skip: {
 			safari: [ 'heading3Styled' ] // Skip due to spacing issue (#13).
-		}
+		},
+		fixtures
 	} );
 
 	generateTests( {
@@ -85,7 +90,8 @@ describe( 'PasteFromOffice - integration', () => {
 		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Bold, Italic, Underline, PasteFromOffice ]
-		}
+		},
+		fixtures
 	} );
 
 	generateTests( {
@@ -94,7 +100,8 @@ describe( 'PasteFromOffice - integration', () => {
 		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Bold, ShiftEnter, PasteFromOffice ]
-		}
+		},
+		fixtures
 	} );
 
 	generateTests( {
@@ -103,7 +110,8 @@ describe( 'PasteFromOffice - integration', () => {
 		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, List, PasteFromOffice ]
-		}
+		},
+		fixtures
 	} );
 
 	generateTests( {
@@ -112,7 +120,8 @@ describe( 'PasteFromOffice - integration', () => {
 		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, List, Table, Bold, PasteFromOffice ]
-		}
+		},
+		fixtures
 	} );
 
 	generateTests( {
@@ -122,7 +131,8 @@ describe( 'PasteFromOffice - integration', () => {
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Table, TableProperties, TableCellProperties, Bold, PasteFromOffice,
 				FontColor, FontBackgroundColor ]
-		}
+		},
+		fixtures
 	} );
 
 	// See: https://github.com/ckeditor/ckeditor5/issues/7684.
@@ -132,7 +142,8 @@ describe( 'PasteFromOffice - integration', () => {
 		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Table, Bold, PasteFromOffice, FontColor, FontBackgroundColor ]
-		}
+		},
+		fixtures
 	} );
 
 	generateTests( {
@@ -141,7 +152,8 @@ describe( 'PasteFromOffice - integration', () => {
 		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Bold, PasteFromOffice, PageBreak ]
-		}
+		},
+		fixtures
 	} );
 
 	generateTests( {
@@ -150,6 +162,7 @@ describe( 'PasteFromOffice - integration', () => {
 		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Bold, ShiftEnter, PasteFromOffice ]
-		}
+		},
+		fixtures
 	} );
 } );

--- a/packages/ckeditor5-paste-from-office/tests/data/integration.js
+++ b/packages/ckeditor5-paste-from-office/tests/data/integration.js
@@ -29,23 +29,18 @@ import * as fixtures from '../_utils/fixtures';
 const browsers = [ 'chrome', 'firefox', 'safari', 'edge' ];
 
 describe( 'PasteFromOffice - integration', () => {
-	generateTests( {
+	generateIntegrationTests( {
 		input: 'basic-styles',
-		type: 'integration',
-		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Heading, Bold, Italic, Underline, Strikethrough, PasteFromOffice ]
 		},
 		skip: {
 			safari: [ 'italicStartingText', 'multipleStylesSingleLine', 'multipleStylesMultiline' ] // Skip due to spacing issue (#13).
-		},
-		fixtures
+		}
 	} );
 
-	generateTests( {
+	generateIntegrationTests( {
 		input: 'image',
-		type: 'integration',
-		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Image, Table, PasteFromOffice ]
 		},
@@ -54,115 +49,94 @@ describe( 'PasteFromOffice - integration', () => {
 			firefox: [],
 			safari: [],
 			edge: [ 'adjacentGroups' ]
-		},
-		fixtures
+		}
 	} );
 
-	generateTests( {
+	generateIntegrationTests( {
 		input: 'link',
-		type: 'integration',
-		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Heading, Bold, Link, ShiftEnter, PasteFromOffice ]
 		},
 		skip: {
 			safari: [ 'combined' ] // Skip due to spacing issue (#13).
-		},
-		fixtures
+		}
 	} );
 
-	generateTests( {
+	generateIntegrationTests( {
 		input: 'list',
-		type: 'integration',
-		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Heading, Bold, Italic, Underline, Link, List, ListProperties, PasteFromOffice ]
 		},
 		skip: {
 			safari: [ 'heading3Styled' ] // Skip due to spacing issue (#13).
-		},
-		fixtures
+		}
 	} );
 
-	generateTests( {
+	generateIntegrationTests( {
 		input: 'spacing',
-		type: 'integration',
-		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Bold, Italic, Underline, PasteFromOffice ]
-		},
-		fixtures
+		}
 	} );
 
-	generateTests( {
+	generateIntegrationTests( {
 		input: 'google-docs-bold-wrapper',
-		type: 'integration',
-		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Bold, ShiftEnter, PasteFromOffice ]
-		},
-		fixtures
+		}
 	} );
 
-	generateTests( {
+	generateIntegrationTests( {
 		input: 'google-docs-list',
-		type: 'integration',
-		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, List, PasteFromOffice ]
-		},
-		fixtures
+		}
 	} );
 
-	generateTests( {
+	generateIntegrationTests( {
 		input: 'generic-list-in-table',
-		type: 'integration',
-		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, List, Table, Bold, PasteFromOffice ]
-		},
-		fixtures
+		}
 	} );
 
-	generateTests( {
+	generateIntegrationTests( {
 		input: 'table',
-		type: 'integration',
-		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Table, TableProperties, TableCellProperties, Bold, PasteFromOffice,
 				FontColor, FontBackgroundColor ]
-		},
-		fixtures
+		}
 	} );
 
 	// See: https://github.com/ckeditor/ckeditor5/issues/7684.
-	generateTests( {
+	generateIntegrationTests( {
 		input: 'font-without-table-properties',
-		type: 'integration',
-		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Table, Bold, PasteFromOffice, FontColor, FontBackgroundColor ]
-		},
-		fixtures
+		}
 	} );
 
-	generateTests( {
+	generateIntegrationTests( {
 		input: 'page-break',
-		type: 'integration',
-		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Bold, PasteFromOffice, PageBreak ]
-		},
-		fixtures
+		}
 	} );
 
-	generateTests( {
+	generateIntegrationTests( {
 		input: 'google-docs-br-paragraphs',
-		type: 'integration',
-		browsers,
 		editorConfig: {
 			plugins: [ Clipboard, Paragraph, Bold, ShiftEnter, PasteFromOffice ]
-		},
-		fixtures
+		}
 	} );
+
+	function generateIntegrationTests( config ) {
+		const commonIntegrationConfig = {
+			type: 'integration',
+			fixtures,
+			browsers
+		};
+
+		return generateTests( Object.assign( {}, config, commonIntegrationConfig ) );
+	}
 } );

--- a/packages/ckeditor5-paste-from-office/tests/data/normalization.js
+++ b/packages/ckeditor5-paste-from-office/tests/data/normalization.js
@@ -8,6 +8,7 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import PasteFromOffice from '../../src/pastefromoffice';
 
 import { generateTests } from '../_utils/utils';
+import * as fixtures from '../_utils/fixtures';
 
 const browsers = [ 'chrome', 'firefox', 'safari', 'edge' ];
 
@@ -20,55 +21,63 @@ describe( 'PasteFromOffice - normalization', () => {
 		input: 'basic-styles',
 		type: 'normalization',
 		browsers,
-		editorConfig
+		editorConfig,
+		fixtures
 	} );
 
 	generateTests( {
 		input: 'image',
 		type: 'normalization',
 		browsers,
-		editorConfig
+		editorConfig,
+		fixtures
 	} );
 
 	generateTests( {
 		input: 'link',
 		type: 'normalization',
 		browsers,
-		editorConfig
+		editorConfig,
+		fixtures
 	} );
 
 	generateTests( {
 		input: 'list',
 		type: 'normalization',
 		browsers,
-		editorConfig
+		editorConfig,
+		fixtures
 	} );
 
 	generateTests( {
 		input: 'spacing',
 		type: 'normalization',
 		browsers,
-		editorConfig
+		editorConfig,
+		fixtures
 	} );
 
 	generateTests( {
 		input: 'google-docs-bold-wrapper',
 		type: 'normalization',
 		browsers,
-		editorConfig
+		editorConfig,
+		fixtures
 	} );
 
 	generateTests( {
 		input: 'generic-list-in-table',
 		type: 'normalization',
 		browsers,
-		editorConfig
+		editorConfig,
+		fixtures
 	} );
 
 	generateTests( {
 		input: 'google-docs-br-paragraphs',
 		type: 'normalization',
 		browsers,
-		editorConfig
+		editorConfig,
+		fixtures
 	} );
 } );

--- a/packages/ckeditor5-paste-from-office/tests/data/normalization.js
+++ b/packages/ckeditor5-paste-from-office/tests/data/normalization.js
@@ -17,67 +17,46 @@ const editorConfig = {
 };
 
 describe( 'PasteFromOffice - normalization', () => {
-	generateTests( {
-		input: 'basic-styles',
-		type: 'normalization',
-		browsers,
-		editorConfig,
-		fixtures
+	generateNormalizationTests( {
+		input: 'basic-styles'
 	} );
 
-	generateTests( {
-		input: 'image',
-		type: 'normalization',
-		browsers,
-		editorConfig,
-		fixtures
+	generateNormalizationTests( {
+		input: 'image'
 	} );
 
-	generateTests( {
-		input: 'link',
-		type: 'normalization',
-		browsers,
-		editorConfig,
-		fixtures
+	generateNormalizationTests( {
+		input: 'link'
 	} );
 
-	generateTests( {
-		input: 'list',
-		type: 'normalization',
-		browsers,
-		editorConfig,
-		fixtures
+	generateNormalizationTests( {
+		input: 'list'
 	} );
 
-	generateTests( {
-		input: 'spacing',
-		type: 'normalization',
-		browsers,
-		editorConfig,
-		fixtures
+	generateNormalizationTests( {
+		input: 'spacing'
 	} );
 
-	generateTests( {
-		input: 'google-docs-bold-wrapper',
-		type: 'normalization',
-		browsers,
-		editorConfig,
-		fixtures
+	generateNormalizationTests( {
+		input: 'google-docs-bold-wrapper'
 	} );
 
-	generateTests( {
-		input: 'generic-list-in-table',
-		type: 'normalization',
-		browsers,
-		editorConfig,
-		fixtures
+	generateNormalizationTests( {
+		input: 'generic-list-in-table'
 	} );
 
-	generateTests( {
-		input: 'google-docs-br-paragraphs',
-		type: 'normalization',
-		browsers,
-		editorConfig,
-		fixtures
+	generateNormalizationTests( {
+		input: 'google-docs-br-paragraphs'
 	} );
+
+	function generateNormalizationTests( config ) {
+		const commonIntegrationConfig = {
+			type: 'normalization',
+			fixtures,
+			editorConfig,
+			browsers
+		};
+
+		return generateTests( Object.assign( {}, config, commonIntegrationConfig ) );
+	}
 } );

--- a/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
+++ b/packages/ckeditor5-paste-from-office/tests/pastefromoffice.js
@@ -16,8 +16,10 @@ import ViewDocumentFragment from '@ckeditor/ckeditor5-engine/src/view/documentfr
 import CodeBlockUI from '@ckeditor/ckeditor5-code-block/src/codeblockui';
 import CodeBlockEditing from '@ckeditor/ckeditor5-code-block/src/codeblockediting';
 import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import { priorities } from '@ckeditor/ckeditor5-utils';
+import { DomConverter } from '@ckeditor/ckeditor5-engine';
 
-/* global document */
+/* global document, DOMParser */
 
 describe( 'PasteFromOffice', () => {
 	const htmlDataProcessor = new HtmlDataProcessor( new ViewDocument( new StylesProcessor() ) );
@@ -52,6 +54,37 @@ describe( 'PasteFromOffice', () => {
 
 	it( 'should load Clipboard plugin', () => {
 		expect( editor.plugins.get( ClipboardPipeline ) ).to.be.instanceOf( ClipboardPipeline );
+	} );
+
+	it( 'should work on already parsed data if another plugin hooked into #inputTransformation with a higher priority', () => {
+		const clipboardPipeline = editor.plugins.get( 'ClipboardPipeline' );
+		const viewDocument = editor.editing.view.document;
+
+		// Simulate a plugin that hooks into the pipeline earlier and parses the data.
+		clipboardPipeline.on( 'inputTransformation', ( evt, data ) => {
+			const domParser = new DOMParser();
+			const htmlDocument = domParser.parseFromString( '<p>Existing data</p>', 'text/html' );
+			const domConverter = new DomConverter( viewDocument, { renderingMode: 'data' } );
+			const fragment = htmlDocument.createDocumentFragment();
+
+			data._parsedData = {
+				body: domConverter.domToView( fragment, { skipComments: true } ),
+				bodyString: '<body>Already parsed data</body>',
+				styles: [],
+				stylesString: ''
+			};
+		}, { priority: priorities.get( 'high' ) + 1 } );
+
+		const eventData = {
+			content: htmlDataProcessor.toView( '<meta name=Generator content="Microsoft Word 15">' ),
+			dataTransfer: createDataTransfer( { 'text/html': '<meta name=Generator content="Microsoft Word 15">' } )
+		};
+
+		// Trigger some event that would normally trigger the paste from office plugin.
+		clipboard.fire( 'inputTransformation', eventData );
+
+		// Verify if the PFO plugin works on an already parsed data.
+		expect( eventData._parsedData.bodyString ).to.equal( '<body>Already parsed data</body>' );
 	} );
 
 	describe( 'isTransformedWithPasteFromOffice - flag', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (paste-from-office): Made the PFO testing framework open. Also, the feature should be able to work on already parsed `inputTransformation` data. Closes https://github.com/ckeditor/ckeditor5/issues/14377.

---

### Additional information

Required by https://github.com/cksource/ckeditor5-internal/pull/3366.
