### PR TITLE
Styles dropdown should apply to DIV elements.

### DIFF
--- a/packages/ckeditor5-html-support/src/index.ts
+++ b/packages/ckeditor5-html-support/src/index.ts
@@ -9,7 +9,7 @@
 
 export { default as GeneralHtmlSupport } from './generalhtmlsupport';
 export { default as DataFilter } from './datafilter';
-export { default as DataSchema } from './dataschema';
+export { default as DataSchema, type DataSchemaBlockElementDefinition } from './dataschema';
 export { default as HtmlComment } from './htmlcomment';
 export { default as FullPage } from './fullpage';
 export { default as HtmlPageDataProcessor } from './htmlpagedataprocessor';

--- a/packages/ckeditor5-style/src/styleutils.ts
+++ b/packages/ckeditor5-style/src/styleutils.ts
@@ -12,7 +12,7 @@ import type { Element, MatcherPattern, DocumentSelection, Selectable } from 'cke
 import type { DecoratedMethodEvent } from 'ckeditor5/src/utils';
 import type { TemplateDefinition } from 'ckeditor5/src/ui';
 
-import type { DataFilter, DataSchema, GeneralHtmlSupport } from '@ckeditor/ckeditor5-html-support';
+import type { DataFilter, DataSchema, GeneralHtmlSupport, DataSchemaBlockElementDefinition } from '@ckeditor/ckeditor5-html-support';
 
 import type { StyleDefinition } from './styleconfig';
 import { isObject } from 'lodash-es';
@@ -99,7 +99,13 @@ export default class StyleUtils extends Plugin {
 					if ( typeof appliesToBlock == 'string' ) {
 						modelElements.push( appliesToBlock );
 					} else if ( ghsDefinition.isBlock ) {
+						const ghsBlockDefinition: DataSchemaBlockElementDefinition = ghsDefinition;
+
 						modelElements.push( ghsDefinition.model );
+
+						if ( ghsBlockDefinition.paragraphLikeModel ) {
+							modelElements.push( ghsBlockDefinition.paragraphLikeModel );
+						}
 					}
 				} else {
 					ghsAttributes.push( ghsDefinition.model );

--- a/packages/ckeditor5-style/tests/manual/styledropdown.html
+++ b/packages/ckeditor5-style/tests/manual/styledropdown.html
@@ -101,6 +101,20 @@
 			border: 1px solid hsl(120, 89%, 27%);
 		}
 
+		.ck.ck-content div.callout {
+			background: yellow;
+			border: 1px solid orange;
+			padding: 1em;
+			margin-top: 1em;
+			margin-bottom: 1em;
+		}
+		.ck.ck-content div.callout p:first-child {
+			margin-top: 0;
+		}
+		.ck.ck-content div.callout p:last-child {
+			margin-bottom: 0;
+		}
+
 		/* ---------------- Inline --------------- */
 
 		.ck.ck-content .marker {
@@ -291,6 +305,15 @@
 			<p>Florence is also regarded as one of the top 15 fashion capitals of the world.</p>
 		</li>
 	</ol>
+
+	<div class="callout">
+		Div block styled (div as a paragraph).
+	</div>
+	<div class="callout">
+		<p>
+			Div container styled.
+		</p>
+	</div>
 
 </div>
 

--- a/packages/ckeditor5-style/tests/manual/styledropdown.js
+++ b/packages/ckeditor5-style/tests/manual/styledropdown.js
@@ -236,6 +236,11 @@ ClassicEditor
 		style: {
 			definitions: [
 				{
+					name: 'Callout',
+					element: 'div',
+					classes: [ 'callout' ]
+				},
+				{
 					name: 'Link',
 					element: 'a',
 					classes: [ 'styled-link' ]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (style): Styles dropdown should allow styling `<div>` elements. Closes #13341.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
