### PR TITLE
Replacing type from 'submit' to 'button'

### DIFF
--- a/packages/ckeditor5-font/src/ui/colortableview.ts
+++ b/packages/ckeditor5-font/src/ui/colortableview.ts
@@ -1002,7 +1002,7 @@ class ColorPickerPageView extends View {
 			class: 'ck-button-save',
 			withText: false,
 			label: t( 'Accept' ),
-			type: 'submit'
+			type: 'button'
 		} );
 
 		cancelButtonView.set( {

--- a/packages/ckeditor5-font/tests/ui/colortableview.js
+++ b/packages/ckeditor5-font/tests/ui/colortableview.js
@@ -519,6 +519,10 @@ describe( 'ColorTableView', () => {
 				expect( saveButton.element.classList.contains( 'ck-button-save' ) ).to.be.true;
 			} );
 
+			it( 'should have a proper type', () => {
+				expect( saveButton.type ).to.be.equal( 'button' );
+			} );
+
 			it( 'should have proper settings', () => {
 				expect( saveButton.withText ).to.be.false;
 				expect( saveButton.icon ).to.equal( icons.check );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (font): The accept button in the color picker will no longer submit forms . Closes #14361.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._