### PR TITLE
Deactivate "Show blocks" toolbar button when source mode is on.

### DIFF
--- a/packages/ckeditor5-show-blocks/src/showblocksui.ts
+++ b/packages/ckeditor5-show-blocks/src/showblocksui.ts
@@ -44,7 +44,9 @@ export default class ShowBlocksUI extends Plugin {
 				tooltip: true
 			} );
 
-			view.bind( 'isOn', 'isEnabled' ).to( command, 'value', 'isEnabled' );
+			view.bind( 'isOn' ).to( command, 'value', command, 'isEnabled',
+				( value, isEnabled ) => value && isEnabled );
+			view.bind( 'isEnabled' ).to( command );
 
 			// Execute the command.
 			this.listenTo( view, 'execute', () => {

--- a/packages/ckeditor5-show-blocks/tests/showblocksui.js
+++ b/packages/ckeditor5-show-blocks/tests/showblocksui.js
@@ -5,6 +5,7 @@
 
 import { global } from '@ckeditor/ckeditor5-utils';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
 import { ButtonView } from '@ckeditor/ckeditor5-ui';
 
 import ShowBlocksEditing from '../src/showblocksediting';
@@ -19,7 +20,7 @@ describe( 'ShowBlocksUI', () => {
 
 		return ClassicTestEditor
 			.create( element, {
-				plugins: [ ShowBlocksEditing, ShowBlocksUI ]
+				plugins: [ ShowBlocksEditing, ShowBlocksUI, SourceEditing ]
 			} )
 			.then( newEditor => {
 				editor = newEditor;
@@ -68,6 +69,18 @@ describe( 'ShowBlocksUI', () => {
 			expect( button.isOn ).to.be.false;
 
 			editor.commands.get( 'showBlocks' ).value = true;
+
+			expect( button.isOn ).to.be.true;
+		} );
+
+		it( 'should have #isOn bound to the mode of SourceEditing plugin', async () => {
+			editor.commands.get( 'showBlocks' ).value = true;
+
+			editor.plugins.get( 'SourceEditing' ).isSourceEditingMode = true;
+
+			expect( button.isOn ).to.be.false;
+
+			editor.plugins.get( 'SourceEditing' ).isSourceEditingMode = false;
 
 			expect( button.isOn ).to.be.true;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (sjhow-blocks): Should deactivate "Show blocks" toolbar button when "Source Editing" is on.

Closes #14400 .

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
