### PR TITLE
Add more classes and attributes for selectors.

### DIFF
--- a/packages/ckeditor5-show-blocks/theme/showblocks.css
+++ b/packages/ckeditor5-show-blocks/theme/showblocks.css
@@ -10,22 +10,28 @@
 }
 
 @define-mixin block-name-background $text {
-	background-image: url("data:image/svg+xml;utf8,<svg width='120' height='12' xmlns='http://www.w3.org/2000/svg' ><text style='paint-order:stroke fill; clip-path: inset(-3px);' stroke='%23EAEAEA' stroke-width='13' dominant-baseline='middle' fill='black' x='3' y='7' font-size='9px' font-family='Consolas, %22Lucida Console%22, %22Lucida Sans Typewriter%22, %22DejaVu Sans Mono%22, %22Bitstream Vera Sans Mono%22, %22Liberation Mono%22, Monaco, %22Courier New%22, Courier, monospace'>$(text)</text></svg>");
-	background-repeat: no-repeat;
-	background-position: 1px 1px;
-	padding-top: 15px;
-
 	&:not(.ck-widget_selected):not(.ck-widget:hover) {
 		outline: 1px dashed var(--ck-show-blocks-border-color);
+	}
+
+	/* Some props are duplicated for both 'ltr' and 'rtl' directions for their higher specificity.
+	See https://github.com/ckeditor/ckeditor5/issues/14435 for details. */
+	@mixin ck-dir ltr {
+		background-image: url("data:image/svg+xml;utf8,<svg width='120' height='12' xmlns='http://www.w3.org/2000/svg' ><text style='paint-order:stroke fill; clip-path: inset(-3px);' stroke='%23EAEAEA' stroke-width='13' dominant-baseline='middle' fill='black' x='3' y='7' font-size='9px' font-family='Consolas, %22Lucida Console%22, %22Lucida Sans Typewriter%22, %22DejaVu Sans Mono%22, %22Bitstream Vera Sans Mono%22, %22Liberation Mono%22, Monaco, %22Courier New%22, Courier, monospace'>$(text)</text></svg>");
+		background-position: 1px 1px;
+		background-repeat: no-repeat;
+		padding-top: 15px;
 	}
 
 	@mixin ck-dir rtl {
 		background-image: url("data:image/svg+xml;utf8,<svg width='120' height='12' xmlns='http://www.w3.org/2000/svg' ><text style='paint-order:stroke fill; clip-path: inset(-3px); transform:translate(-2px, 0);' stroke='%23EAEAEA' stroke-width='13' dominant-baseline='middle' fill='black' x='100%' text-anchor='end' y='7' font-size='9px' font-family='Consolas, %22Lucida Console%22, %22Lucida Sans Typewriter%22, %22DejaVu Sans Mono%22, %22Bitstream Vera Sans Mono%22, %22Liberation Mono%22, Monaco, %22Courier New%22, Courier, monospace'>$(text)</text></svg>");
 		background-position: calc(100% - 1px) 1px;
+		background-repeat: no-repeat;
+		padding-top: 15px;
 	}
 }
 
-.ck.ck-editor__editable.ck-show-blocks {
+.ck.ck-editor__editable.ck-editor__editable_inline.ck-show-blocks :not(.ck-widget) {
 	& address {
 		@mixin block-name-background ADDRESS;
 	}

--- a/packages/ckeditor5-show-blocks/theme/showblocks.css
+++ b/packages/ckeditor5-show-blocks/theme/showblocks.css
@@ -31,7 +31,7 @@
 	}
 }
 
-.ck.ck-editor__editable.ck-editor__editable_inline.ck-show-blocks :not(.ck-widget) {
+.ck.ck-editor__editable.ck-editor__editable_inline.ck-show-blocks:not(.ck-widget) {
 	& address {
 		@mixin block-name-background ADDRESS;
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (show-blocks): Increase the specificity of the show blocks feature styling. Closes #14435.

---

### Additional information

The selector proposed in [https://github.com/ckeditor/ckeditor5/issues/14435#issuecomment-1602159551](https://github.com/ckeditor/ckeditor5/issues/14435#issuecomment-1602159551) (`.ck.ck-editor__editable.ck-editor__editable_inline.ck-show-blocks[dir=ltr] p` with specificity \[ 0 5 1 \]) turned out to be to weak for our docs as it depends on the order of stylesheets loading. Therefore I decided to add one more condition (`:not(.ck-widget)`) which we should be safe with (at least until we support the feature for widgets) and it bumps the score to \[ 0 6 1 \]. Also, I added explicit styles for both LTR and RTL editors to keep the specificity equal in both cases.