### PR TITLE
Set up block toolbar resize mechanism on given editable after the toolbar button is attached to it, instead of when editor is initialized

### DIFF
--- a/packages/ckeditor5-ui/package.json
+++ b/packages/ckeditor5-ui/package.json
@@ -23,6 +23,7 @@
     "@ckeditor/ckeditor5-block-quote": "^38.0.1",
     "@ckeditor/ckeditor5-editor-balloon": "^38.0.1",
     "@ckeditor/ckeditor5-editor-classic": "^38.0.1",
+    "@ckeditor/ckeditor5-editor-multi-root": "^38.0.1",
     "@ckeditor/ckeditor5-engine": "^38.0.1",
     "@ckeditor/ckeditor5-enter": "^38.0.1",
     "@ckeditor/ckeditor5-essentials": "^38.0.1",

--- a/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
+++ b/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
@@ -381,6 +381,7 @@ export default class BlockToolbar extends Plugin {
 		this.panelView.show();
 
 		const editableElement = this._getSelectedEditableElement();
+
 		this.toolbarView.maxWidth = this._getToolbarMaxWidth( editableElement );
 
 		this.panelView.pin( {

--- a/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
+++ b/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
@@ -188,25 +188,11 @@ export default class BlockToolbar extends Plugin {
 	 * **Note:** This needs to be done after all plugins are ready.
 	 */
 	public afterInit(): void {
-		const factory = this.editor.ui.componentFactory;
-		const config = this._blockToolbarConfig;
-
-		this.toolbarView.fillFromConfig( config, factory );
+		this.toolbarView.fillFromConfig( this._blockToolbarConfig, this.editor.ui.componentFactory );
 
 		// Hide panel before executing each button in the panel.
 		for ( const item of this.toolbarView.items ) {
 			item.on<ButtonExecuteEvent>( 'execute', () => this._hidePanel( true ), { priority: 'high' } );
-		}
-
-		if ( !config.shouldNotGroupWhenFull ) {
-			this.listenTo( this.editor, 'ready', () => {
-				const editableElement = this.editor.ui.view.editable.element!;
-
-				// Set #toolbarView's max-width just after the initialization and update it on the editable resize.
-				this._resizeObserver = new ResizeObserver( editableElement, () => {
-					this.toolbarView.maxWidth = this._getToolbarMaxWidth();
-				} );
-			} );
 		}
 	}
 
@@ -335,6 +321,9 @@ export default class BlockToolbar extends Plugin {
 		// Show block button.
 		this.buttonView.isVisible = true;
 
+		// Make sure that the block toolbar panel is resized properly.
+		this._setupToolbarResize();
+
 		// Attach block button to target DOM element.
 		this._attachButtonToElement( domTarget as any );
 
@@ -390,16 +379,27 @@ export default class BlockToolbar extends Plugin {
 		//
 		// https://github.com/ckeditor/ckeditor5/issues/6449, https://github.com/ckeditor/ckeditor5/issues/6575
 		this.panelView.show();
-		this.toolbarView.maxWidth = this._getToolbarMaxWidth();
+
+		const editableElement = this._getSelectedEditableElement();
+		this.toolbarView.maxWidth = this._getToolbarMaxWidth( editableElement );
 
 		this.panelView.pin( {
 			target: this.buttonView.element!,
-			limiter: this.editor.ui.getEditableElement()
+			limiter: editableElement
 		} );
 
 		if ( !wasVisible ) {
 			( this.toolbarView.items.get( 0 ) as any ).focus();
 		}
+	}
+
+	/**
+	 * Returns currently selected editable, based on the model selection.
+	 */
+	private _getSelectedEditableElement(): HTMLElement {
+		const selectedModelRootName = this.editor.model.document.selection.getFirstRange()!.root.rootName!;
+
+		return this.editor.ui.getEditableElement( selectedModelRootName )!;
 	}
 
 	/**
@@ -423,10 +423,9 @@ export default class BlockToolbar extends Plugin {
 	private _attachButtonToElement( targetElement: HTMLElement ) {
 		const contentStyles = window.getComputedStyle( targetElement );
 
-		const selectedModelRootName = this.editor.model.document.selection.getFirstRange()!.root.rootName!;
-		const editableRect = new Rect( this.editor.ui.getEditableElement( selectedModelRootName )! );
+		const editableRect = new Rect( this._getSelectedEditableElement() );
 		const contentPaddingTop = parseInt( contentStyles.paddingTop, 10 );
-		// When line height is not an integer then thread it as "normal".
+		// When line height is not an integer then treat it as "normal".
 		// MDN says that 'normal' == ~1.2 on desktop browsers.
 		const contentLineHeight = parseInt( contentStyles.lineHeight, 10 ) || parseInt( contentStyles.fontSize, 10 ) * 1.2;
 
@@ -456,13 +455,34 @@ export default class BlockToolbar extends Plugin {
 	}
 
 	/**
-	 * Gets the {@link #toolbarView} max-width, based on
-	 * editable width plus distance between farthest edge of the {@link #buttonView} and the editable.
+	 * Creates a resize observer that observes selected editable and resizes the toolbar panel accordingly.
+	 */
+	private _setupToolbarResize() {
+		const editableElement = this._getSelectedEditableElement();
+
+		// Do this only if the automatic grouping is turned on.
+		if ( !this._blockToolbarConfig.shouldNotGroupWhenFull ) {
+			// If resize observer is attached to a different editable than currently selected editable, re-attach it.
+			if ( this._resizeObserver && this._resizeObserver.element !== editableElement ) {
+				this._resizeObserver.destroy();
+				this._resizeObserver = null;
+			}
+
+			if ( !this._resizeObserver ) {
+				this._resizeObserver = new ResizeObserver( editableElement, () => {
+					this.toolbarView.maxWidth = this._getToolbarMaxWidth( editableElement );
+				} );
+			}
+		}
+	}
+
+	/**
+	 * Gets the {@link #toolbarView} max-width, based on given `editableElement` width plus the distance between the farthest
+	 * edge of the {@link #buttonView} and the editable.
 	 *
 	 * @returns A maximum width that toolbar can have, in pixels.
 	 */
-	private _getToolbarMaxWidth() {
-		const editableElement = this.editor.ui.view.editable.element!;
+	private _getToolbarMaxWidth( editableElement: HTMLElement ) {
 		const editableRect = new Rect( editableElement );
 		const buttonRect = new Rect( this.buttonView.element! );
 		const isRTL = this.editor.locale.uiLanguageDirection === 'rtl';

--- a/packages/ckeditor5-ui/tests/toolbar/block/blocktoolbar.js
+++ b/packages/ckeditor5-ui/tests/toolbar/block/blocktoolbar.js
@@ -6,6 +6,7 @@
 /* global document, window, Event */
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import MultiRootEditor from '@ckeditor/ckeditor5-editor-multi-root/src/multirooteditor';
 
 import EditorUI from '../../../src/editorui/editorui';
 import BlockToolbar from '../../../src/toolbar/block/blocktoolbar';
@@ -760,6 +761,96 @@ describe( 'BlockToolbar', () => {
 			blockToolbar.destroy();
 
 			sinon.assert.calledOnce( destroySpy );
+		} );
+	} );
+
+	describe( 'multi-root integration', () => {
+		it( 'should not throw if there are not roots in the editor', () => {
+			return MultiRootEditor.create( {}, {
+				plugins: [ BlockToolbar, Heading, HeadingButtonsUI, Paragraph, ParagraphButtonUI, BlockQuote, Image, ImageCaption ],
+				blockToolbar: [ 'paragraph', 'heading1', 'heading2', 'blockQuote' ]
+			} ).then( newEditor => {
+				return newEditor.destroy();
+			} );
+		} );
+
+		it( 'should set a proper toolbar max-width based on selected editable', async () => {
+			const elFoo = document.createElement( 'div' );
+			elFoo.innerHTML = '<p>Foo</p>';
+			document.body.appendChild( elFoo );
+
+			const elBar = document.createElement( 'div' );
+			elBar.innerHTML = '<p>Bar</p>';
+			document.body.appendChild( elBar );
+
+			const multiRootEditor = await MultiRootEditor.create( { foo: elFoo, bar: elBar }, {
+				plugins: [ BlockToolbar, Heading, HeadingButtonsUI, Paragraph, ParagraphButtonUI, BlockQuote, Image, ImageCaption ],
+				blockToolbar: [ 'paragraph', 'heading1', 'heading2', 'blockQuote' ]
+			} );
+
+			blockToolbar = multiRootEditor.plugins.get( BlockToolbar );
+			multiRootEditor.ui.focusTracker.isFocused = true;
+
+			const viewFoo = multiRootEditor.ui.getEditableElement( 'foo' );
+			const viewBar = multiRootEditor.ui.getEditableElement( 'bar' );
+
+			testUtils.sinon.stub( viewFoo, 'getBoundingClientRect' ).returns( {
+				left: 100,
+				width: 200
+			} );
+
+			testUtils.sinon.stub( viewBar, 'getBoundingClientRect' ).returns( {
+				left: 100,
+				width: 300
+			} );
+
+			testUtils.sinon.stub( blockToolbar.buttonView.element, 'getBoundingClientRect' ).returns( {
+				left: 60,
+				width: 40
+			} );
+
+			// Starting, default value.
+			expect( blockToolbar.toolbarView.maxWidth ).to.equal( 'auto' );
+
+			multiRootEditor.model.change( writer => {
+				writer.setSelection( multiRootEditor.model.document.getRoot( 'foo' ).getChild( 0 ), 0 );
+			} );
+
+			// Fire the callback after the selection was moved to `foo` root.
+			resizeCallback( [ {
+				target: viewFoo
+			} ] );
+
+			// Expected value given the size of `foo` editable.
+			expect( blockToolbar.toolbarView.maxWidth ).to.equal( '240px' );
+
+			// Resize `bar` editable.
+			// It is not observed at the moment as the selection is in `foo` root.
+			// This callback should not affect the toolbar size.
+			resizeCallback( [ {
+				target: viewBar
+			} ] );
+
+			// Expected value same as previously.
+			expect( blockToolbar.toolbarView.maxWidth ).to.equal( '240px' );
+
+			// Move selection to `bar` root.
+			multiRootEditor.model.change( writer => {
+				writer.setSelection( multiRootEditor.model.document.getRoot( 'bar' ).getChild( 0 ), 0 );
+			} );
+
+			// Resize `bar` editable.
+			resizeCallback( [ {
+				target: viewBar
+			} ] );
+
+			// Expected value given the size of `bar` editable.
+			expect( blockToolbar.toolbarView.maxWidth ).to.equal( '340px' );
+
+			elFoo.remove();
+			elBar.remove();
+
+			return multiRootEditor.destroy();
 		} );
 	} );
 } );

--- a/packages/ckeditor5-utils/src/dom/resizeobserver.ts
+++ b/packages/ckeditor5-utils/src/dom/resizeobserver.ts
@@ -73,7 +73,7 @@ export default class ResizeObserver {
 	/**
 	 * The element observed by this observer.
 	 */
-	get element(): Element {
+	public get element(): Element {
 		return this._element;
 	}
 

--- a/packages/ckeditor5-utils/src/dom/resizeobserver.ts
+++ b/packages/ckeditor5-utils/src/dom/resizeobserver.ts
@@ -71,6 +71,13 @@ export default class ResizeObserver {
 	}
 
 	/**
+	 * The element observed by this observer.
+	 */
+	get element(): Element {
+		return this._element;
+	}
+
+	/**
 	 * Destroys the observer which disables the `callback` passed to the {@link #constructor}.
 	 */
 	public destroy(): void {

--- a/packages/ckeditor5-utils/tests/dom/resizeobserver.js
+++ b/packages/ckeditor5-utils/tests/dom/resizeobserver.js
@@ -173,6 +173,14 @@ describe( 'ResizeObserver()', () => {
 		} );
 	} );
 
+	describe( 'element', () => {
+		it( 'should return observed element', () => {
+			const observer = new ResizeObserver( elementA, () => {} );
+
+			expect( observer.element ).to.equal( elementA );
+		} );
+	} );
+
 	describe( 'destroy()', () => {
 		it( 'should make the observer stop responding to resize of an element', () => {
 			const callbackA = sinon.spy();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Set up block toolbar resize mechanism on given editable after the toolbar button is attached to it, instead of when editor is initialized. Closes #14445.