### PR TITLE
Docs: fix slotFor typo.

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
@@ -271,7 +271,7 @@ export default class DowncastHelpers extends ConversionHelpers<DowncastDispatche
 	 * } );
 	 * ```
 	 *
-	 * The `slorFor()` function can also take a callback that allows filtering which children of the model element
+	 * The `slotFor()` function can also take a callback that allows filtering which children of the model element
 	 * should be converted into this slot.
 	 *
 	 * Imagine a table feature where for this model structure:


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: fix the typo in the `slotFor` \[skip ci\]. Closes #14438.