### PR TITLE
Exclude some eslint rules from both JS and TS tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
 	},
 	overrides: [
 		{
-			files: [ '**/tests/**/*.js' ],
+			files: [ '**/tests/**/*.@(js|ts)' ],
 			rules: {
 				'no-unused-expressions': 'off',
 				'ckeditor5-rules/ckeditor-imports': 'off',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Excluded some ESLint rules from both JavaScript and TypeScript tests. See #14451.
