### PR TITLE
Docs: fix wrong function name.

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
@@ -271,7 +271,7 @@ export default class DowncastHelpers extends ConversionHelpers<DowncastDispatche
 	 * } );
 	 * ```
 	 *
-	 * The `slotFor()` function can also take a callback that allows filtering which children of the model element
+	 * The `createSlot()` function can also take a callback that allows filtering which children of the model element
 	 * should be converted into this slot.
 	 *
 	 * Imagine a table feature where for this model structure:


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: replace the wrong function name in the comment. Closes #14438.