### PR TITLE
The color picker view should not throw if focusing the component in FF/Safari/iOS but the color input is not available

### DIFF
--- a/packages/ckeditor5-font/tests/integration.js
+++ b/packages/ckeditor5-font/tests/integration.js
@@ -261,7 +261,7 @@ describe( 'Integration test Font', () => {
 
 			expect( getData( editor.model ) ).to.equal( '<paragraph>[<$text fontColor="lab( 18% -17 7 )">foo</$text>]</paragraph>' );
 
-			editor.destroy();
+			await editor.destroy();
 		} );
 
 		it( 'should properly discard changes', () => {

--- a/packages/ckeditor5-font/tests/integration.js
+++ b/packages/ckeditor5-font/tests/integration.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* global document */
+/* global document, CustomEvent */
 
 import Font from '../src/font';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
@@ -228,8 +228,20 @@ describe( 'Integration test Font', () => {
 			expect( getData( model ) ).to.equal( '<paragraph>[<$text fontColor="hsl( 150, 50%, 13% )">foo</$text>]</paragraph>' );
 		} );
 
-		it( 'should set colors in model in configured format', () => {
-			setModelData( model,
+		it( 'should set colors in model in configured format', async () => {
+			const editor = await ClassicTestEditor.create( element, {
+				plugins: [ Font, ArticlePluginSet ],
+				fontColor: {
+					colorPicker: {
+						format: 'lab'
+					}
+				},
+				image: {
+					toolbar: [ 'imageStyle:block', 'imageStyle:side' ]
+				}
+			} );
+
+			setModelData( editor.model,
 				'<paragraph>' +
 					'<$text>[foo]</$text>' +
 				'</paragraph>'
@@ -238,10 +250,18 @@ describe( 'Integration test Font', () => {
 			const dropdown = editor.ui.componentFactory.create( 'fontColor' );
 
 			dropdown.isOpen = true;
-			dropdown.colorTableView.colorPickerPageView.colorPickerView._format = 'lab';
-			dropdown.colorTableView.colorPickerPageView.colorPickerView.color = '#113322';
 
-			expect( getData( model ) ).to.equal( '<paragraph>[<$text fontColor="lab( 18% -17 7 )">foo</$text>]</paragraph>' );
+			const event = new CustomEvent( 'color-changed', {
+				detail: {
+					value: '#113322'
+				}
+			} );
+
+			dropdown.colorTableView.colorPickerPageView.colorPickerView.picker.dispatchEvent( event );
+
+			expect( getData( editor.model ) ).to.equal( '<paragraph>[<$text fontColor="lab( 18% -17 7 )">foo</$text>]</paragraph>' );
+
+			editor.destroy();
 		} );
 
 		it( 'should properly discard changes', () => {

--- a/packages/ckeditor5-font/tests/integration.js
+++ b/packages/ckeditor5-font/tests/integration.js
@@ -223,7 +223,14 @@ describe( 'Integration test Font', () => {
 			const dropdown = editor.ui.componentFactory.create( 'fontColor' );
 
 			dropdown.isOpen = true;
-			dropdown.colorTableView.colorPickerPageView.colorPickerView.color = '#113322';
+
+			const event = new CustomEvent( 'color-changed', {
+				detail: {
+					value: '#113322'
+				}
+			} );
+
+			dropdown.colorTableView.colorPickerPageView.colorPickerView.picker.dispatchEvent( event );
 
 			expect( getData( model ) ).to.equal( '<paragraph>[<$text fontColor="hsl( 150, 50%, 13% )">foo</$text>]</paragraph>' );
 		} );

--- a/packages/ckeditor5-table/tests/utils/ui/table-properties.js
+++ b/packages/ckeditor5-table/tests/utils/ui/table-properties.js
@@ -519,7 +519,8 @@ describe( 'table utils', () => {
 				const panelView = labeledField.fieldView.dropdownView.panelView;
 				const colorPicker = panelView.children.get( 0 ).colorPickerPageView.colorPickerView;
 
-				expect( colorPicker._format ).to.equal( 'hex' );
+				colorPicker.color = 'hsl(180, 75%, 60%)';
+				expect( colorPicker.color ).to.equal( '#4CE6E6' );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -71,9 +71,11 @@ export default class ColorPickerView extends View {
 	private _debounceColorPickerEvent: DebouncedFunc<( arg: string ) => void>;
 
 	/**
-	 * The output format (the one in which colors are applied in the model) of color picker.
+	 * A reference to the configuration of the color picker specified in the constructor.
+	 *
+	 * @private
 	 */
-	private _format: ColorPickerOutputFormat;
+	private _config: ColorPickerViewConfig;
 
 	/**
 	 * Creates a view of color picker.
@@ -81,15 +83,13 @@ export default class ColorPickerView extends View {
 	 * @param locale
 	 * @param config
 	 */
-	constructor( locale: Locale | undefined, config: ColorPickerViewConfig ) {
+	constructor( locale: Locale | undefined, config: ColorPickerViewConfig = {} ) {
 		super( locale );
 
 		this.set( {
 			color: '',
 			_hexColor: ''
 		} );
-
-		this._format = config.format || 'hsl';
 
 		this.hexInputRow = this._createInputRow();
 		const children = this.createCollection();
@@ -107,6 +107,8 @@ export default class ColorPickerView extends View {
 			children
 		} );
 
+		this._config = config;
+
 		this._debounceColorPickerEvent = debounce( ( color: string ) => {
 			// At first, set the color internally in the component. It's converted to the configured output format.
 			this.set( 'color', color );
@@ -120,7 +122,7 @@ export default class ColorPickerView extends View {
 		// The `color` property holds the color in the configured output format.
 		// Ensure it before actually setting the value.
 		this.on( 'set:color', ( evt, propertyName, newValue ) => {
-			evt.return = convertColor( newValue, this._format );
+			evt.return = convertColor( newValue, this._config.format || 'hsl' );
 		} );
 
 		// The `_hexColor` property is bound to the `color` one, but requires conversion.
@@ -193,7 +195,7 @@ export default class ColorPickerView extends View {
 		// See: https://github.com/cksource/ckeditor5-internal/issues/3245, https://github.com/ckeditor/ckeditor5/issues/14119,
 		// https://github.com/cksource/ckeditor5-internal/issues/3268.
 		/* istanbul ignore next -- @preserve */
-		if ( env.isGecko || env.isiOS || env.isSafari ) {
+		if ( !this._config.hideInput && ( env.isGecko || env.isiOS || env.isSafari ) ) {
 			const input: LabeledFieldView<InputTextView> = this.hexInputRow!.children.get( 1 )! as LabeledFieldView<InputTextView>;
 
 			input.focus();

--- a/packages/ckeditor5-ui/tests/colorpicker/colorpickerview.js
+++ b/packages/ckeditor5-ui/tests/colorpicker/colorpickerview.js
@@ -7,6 +7,7 @@
 
 import ColorPickerView from './../../src/colorpicker/colorpickerview';
 import 'vanilla-colorful/hex-color-picker.js';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import { Locale } from '@ckeditor/ckeditor5-utils';
@@ -38,9 +39,15 @@ describe( 'ColorPickerView', () => {
 			expect( [ ...input.classList ] ).to.include( 'color-picker-hex-input' );
 		} );
 
-		it( 'assigns a proper default format value', () => {
-			const pickerView = new ColorPickerView( locale, {} );
-			expect( pickerView._format ).to.equal( 'hsl' );
+		it( 'uses a default color format (HSL)', () => {
+			const view = new ColorPickerView( locale );
+			view.render();
+
+			view.color = 'red';
+
+			expect( view.color ).to.equal( 'hsl( 0, 100%, 50% )' );
+
+			view.destroy();
 		} );
 	} );
 
@@ -332,6 +339,34 @@ describe( 'ColorPickerView', () => {
 
 			sinon.assert.calledOnce( spy );
 		} );
+
+		it( 'should not throw on Firefox/Safari/iOS if the input was hidden via config', () => {
+			const view = new ColorPickerView( locale, { hideInput: true } );
+
+			view.render();
+			document.body.appendChild( view.element );
+
+			testUtils.sinon.stub( env, 'isGecko' ).value( true );
+			testUtils.sinon.stub( env, 'isiOS' ).value( false );
+			testUtils.sinon.stub( env, 'isSafari' ).value( false );
+
+			expect( () => view.focus() ).to.not.throw();
+
+			testUtils.sinon.stub( env, 'isGecko' ).value( false );
+			testUtils.sinon.stub( env, 'isiOS' ).value( true );
+			testUtils.sinon.stub( env, 'isSafari' ).value( false );
+
+			expect( () => view.focus() ).to.not.throw();
+
+			testUtils.sinon.stub( env, 'isGecko' ).value( false );
+			testUtils.sinon.stub( env, 'isiOS' ).value( false );
+			testUtils.sinon.stub( env, 'isSafari' ).value( true );
+
+			expect( () => view.focus() ).to.not.throw();
+
+			view.destroy();
+			view.element.remove();
+		} );
 	} );
 
 	describe( 'color property', () => {
@@ -351,46 +386,38 @@ describe( 'ColorPickerView', () => {
 
 		describe( 'output format integration', () => {
 			it( 'respects rgb output format', () => {
-				view._format = 'rgb';
-				view.color = '#001000';
-
-				expect( view.color ).to.equal( 'rgb( 0, 16, 0 )' );
+				testOutputFormat( 'rgb', '#001000', 'rgb( 0, 16, 0 )' );
 			} );
 
 			it( 'respects hex output format', () => {
-				view._format = 'hex';
-				view.color = '#0000f1';
-
-				expect( view.color ).to.equal( '#0000f1' );
+				testOutputFormat( 'hex', '#0000f1', '#0000f1' );
 			} );
 
 			it( 'respects hsl output format', () => {
-				view._format = 'hsl';
-				view.color = '#3D9BFF';
-
-				expect( view.color ).to.equal( 'hsl( 211, 100%, 62% )' );
+				testOutputFormat( 'hsl', '#3D9BFF', 'hsl( 211, 100%, 62% )' );
 			} );
 
 			it( 'respects hwb output format', () => {
-				view._format = 'hwb';
-				view.color = '#5cb291';
-
-				expect( view.color ).to.equal( 'hwb( 157, 36, 30 )' );
+				testOutputFormat( 'hwb', '#5cb291', 'hwb( 157, 36, 30 )' );
 			} );
 
 			it( 'respects lab output format', () => {
-				view._format = 'lab';
-				view.color = '#bfe972';
-
-				expect( view.color ).to.equal( 'lab( 87% -32 53 )' );
+				testOutputFormat( 'lab', '#bfe972', 'lab( 87% -32 53 )' );
 			} );
 
 			it( 'respects lch output format', () => {
-				view._format = 'lch';
-				view.color = '#be0909';
-
-				expect( view.color ).to.equal( 'lch( 40% 81 39 )' );
+				testOutputFormat( 'lch', '#be0909', 'lch( 40% 81 39 )' );
 			} );
+
+			function testOutputFormat( format, inputColor, outputColor ) {
+				const view = new ColorPickerView( locale, { format } );
+				view.render();
+
+				view.color = inputColor;
+				expect( view.color ).to.equal( outputColor );
+
+				view.destroy();
+			}
 		} );
 
 		it( 'normalizes format for subsequent changes to the same color but in different format', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): The color picker view should not throw if focusing the component in FF/Safari/iOS but the color input is not available. Closes https://github.com/ckeditor/ckeditor5/issues/14462. Closes https://github.com/ckeditor/ckeditor5/issues/14468.
