### PR TITLE
Additional configuration for context elements in dropdown

### DIFF
--- a/docs/_snippets/examples/bottom-toolbar-editor.js
+++ b/docs/_snippets/examples/bottom-toolbar-editor.js
@@ -12,7 +12,7 @@ import { List } from '@ckeditor/ckeditor5-list';
 import { Alignment } from '@ckeditor/ckeditor5-alignment';
 import { Autoformat } from '@ckeditor/ckeditor5-autoformat';
 import { BlockQuote } from '@ckeditor/ckeditor5-block-quote';
-import { DropdownView, DropdownButtonView, DropdownPanelView, ToolbarView, clickOutsideHandler } from '@ckeditor/ckeditor5-ui';
+import { DropdownView, ToolbarView, createDropdown } from '@ckeditor/ckeditor5-ui';
 import { EasyImage } from '@ckeditor/ckeditor5-easy-image';
 import { Essentials } from '@ckeditor/ckeditor5-essentials';
 import { Heading } from '@ckeditor/ckeditor5-heading';
@@ -46,9 +46,7 @@ class FormattingOptions extends Plugin {
 
 		editor.ui.componentFactory.add( 'formattingOptions', locale => {
 			const t = locale.t;
-			const buttonView = new DropdownButtonView( locale );
-			const panelView = new DropdownPanelView( locale );
-			const dropdownView = new DropdownView( locale, buttonView, panelView );
+			const dropdownView = createDropdown( locale );
 			const toolbarView = this.toolbarView = dropdownView.toolbarView = new ToolbarView( locale );
 
 			// Accessibility: Give the toolbar a human-readable ARIA label.
@@ -88,26 +86,15 @@ class FormattingOptions extends Plugin {
 			// * the dropdown or it contents,
 			// * any editing root,
 			// * any floating UI in the "body" collection
-			// It should close, for instance, when another (main) toolbar button was pressed, though.
-			dropdownView.on( 'render', () => {
-				clickOutsideHandler( {
-					emitter: dropdownView,
-					activator: () => dropdownView.isOpen,
-					callback: () => { dropdownView.isOpen = false; },
-					contextElements: [
-						dropdownView.element,
-						...[ ...editor.ui.getEditableElementsNames() ].map( name => editor.ui.getEditableElement( name ) ),
-						document.querySelector( '.ck-body-wrapper' )
-					]
-				} );
-			} );
+			const focusableElements = [
+				...[ ...editor.ui.getEditableElementsNames() ].map( name => editor.ui.getEditableElement( name ) ),
+				document.querySelector( '.ck-body-wrapper' )
+			];
 
-			// The main button of the dropdown should be bound to the state of the dropdown.
-			buttonView.bind( 'isOn' ).to( dropdownView, 'isOpen' );
-			buttonView.bind( 'isEnabled' ).to( dropdownView );
+			focusableElements.forEach( el => dropdownView.focusTracker.add( el ) );
 
 			// Using the font color icon to visually represent the formatting.
-			buttonView.set( {
+			dropdownView.buttonView.set( {
 				tooltip: t( 'Formatting options' ),
 				icon: fontColorIcon
 			} );

--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -106,11 +106,13 @@ import '../../theme/components/dropdown/listdropdown.css';
  * @param locale The locale instance.
  * @param ButtonClass The dropdown button view class. Needs to implement the
  * {@link module:ui/dropdown/button/dropdownbutton~DropdownButton} interface.
+ * @param contextElements The view collection of elements that should be supported by `clickOutsideHandler`.
  * @returns The dropdown view instance.
  */
 export function createDropdown(
 	locale: Locale | undefined,
-	ButtonClass: new ( locale?: Locale ) => DropdownButton & FocusableView = DropdownButtonView
+	ButtonClass: new ( locale?: Locale ) => DropdownButton & FocusableView = DropdownButtonView,
+	contextElements?: Collection<HTMLElement>
 ): DropdownView {
 	const buttonView = new ButtonClass( locale );
 
@@ -125,7 +127,7 @@ export function createDropdown(
 		buttonView.bind( 'isOn' ).to( dropdownView, 'isOpen' );
 	}
 
-	addDefaultBehavior( dropdownView );
+	addDefaultBehavior( dropdownView, contextElements );
 
 	return dropdownView;
 }
@@ -433,8 +435,8 @@ export function focusChildOnDropdownOpen(
 /**
  * Add a set of default behaviors to dropdown view.
  */
-function addDefaultBehavior( dropdownView: DropdownView ) {
-	closeDropdownOnClickOutside( dropdownView );
+function addDefaultBehavior( dropdownView: DropdownView, contextElements?: Collection<HTMLElement> ) {
+	closeDropdownOnClickOutside( dropdownView, contextElements );
 	closeDropdownOnExecute( dropdownView );
 	closeDropdownOnBlur( dropdownView );
 	focusDropdownContentsOnArrows( dropdownView );
@@ -445,7 +447,7 @@ function addDefaultBehavior( dropdownView: DropdownView ) {
 /**
  * Adds a behavior to a dropdownView that closes opened dropdown when user clicks outside the dropdown.
  */
-function closeDropdownOnClickOutside( dropdownView: DropdownView ) {
+function closeDropdownOnClickOutside( dropdownView: DropdownView, contextElements?: Collection<HTMLElement> ) {
 	dropdownView.on<UIViewRenderEvent>( 'render', () => {
 		clickOutsideHandler( {
 			emitter: dropdownView,
@@ -453,7 +455,9 @@ function closeDropdownOnClickOutside( dropdownView: DropdownView ) {
 			callback: () => {
 				dropdownView.isOpen = false;
 			},
-			contextElements: [ dropdownView.element! ]
+			contextElements: () => {
+				return [ dropdownView.element!, ...Array.from( contextElements || [] ) ];
+			}
 		} );
 	} );
 }

--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -106,13 +106,11 @@ import '../../theme/components/dropdown/listdropdown.css';
  * @param locale The locale instance.
  * @param ButtonClass The dropdown button view class. Needs to implement the
  * {@link module:ui/dropdown/button/dropdownbutton~DropdownButton} interface.
- * @param contextElements The view collection of elements that should be supported by `clickOutsideHandler`.
  * @returns The dropdown view instance.
  */
 export function createDropdown(
 	locale: Locale | undefined,
-	ButtonClass: new ( locale?: Locale ) => DropdownButton & FocusableView = DropdownButtonView,
-	contextElements?: Collection<HTMLElement>
+	ButtonClass: new ( locale?: Locale ) => DropdownButton & FocusableView = DropdownButtonView
 ): DropdownView {
 	const buttonView = new ButtonClass( locale );
 
@@ -127,7 +125,7 @@ export function createDropdown(
 		buttonView.bind( 'isOn' ).to( dropdownView, 'isOpen' );
 	}
 
-	addDefaultBehavior( dropdownView, contextElements );
+	addDefaultBehavior( dropdownView );
 
 	return dropdownView;
 }
@@ -435,8 +433,8 @@ export function focusChildOnDropdownOpen(
 /**
  * Add a set of default behaviors to dropdown view.
  */
-function addDefaultBehavior( dropdownView: DropdownView, contextElements?: Collection<HTMLElement> ) {
-	closeDropdownOnClickOutside( dropdownView, contextElements );
+function addDefaultBehavior( dropdownView: DropdownView ) {
+	closeDropdownOnClickOutside( dropdownView );
 	closeDropdownOnExecute( dropdownView );
 	closeDropdownOnBlur( dropdownView );
 	focusDropdownContentsOnArrows( dropdownView );
@@ -447,7 +445,7 @@ function addDefaultBehavior( dropdownView: DropdownView, contextElements?: Colle
 /**
  * Adds a behavior to a dropdownView that closes opened dropdown when user clicks outside the dropdown.
  */
-function closeDropdownOnClickOutside( dropdownView: DropdownView, contextElements?: Collection<HTMLElement> ) {
+function closeDropdownOnClickOutside( dropdownView: DropdownView ) {
 	dropdownView.on<UIViewRenderEvent>( 'render', () => {
 		clickOutsideHandler( {
 			emitter: dropdownView,
@@ -456,7 +454,7 @@ function closeDropdownOnClickOutside( dropdownView: DropdownView, contextElement
 				dropdownView.isOpen = false;
 			},
 			contextElements: () => {
-				return [ dropdownView.element!, ...Array.from( contextElements || [] ) ];
+				return [ dropdownView.element!, ...Array.from( dropdownView.focusTracker._elements as Set<HTMLElement> ) ];
 			}
 		} );
 	} );

--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -453,9 +453,10 @@ function closeDropdownOnClickOutside( dropdownView: DropdownView ) {
 			callback: () => {
 				dropdownView.isOpen = false;
 			},
-			contextElements: () => {
-				return [ dropdownView.element!, ...Array.from( dropdownView.focusTracker._elements as Set<HTMLElement> ) ];
-			}
+			contextElements: () => [
+				dropdownView.element!,
+				...( dropdownView.focusTracker._elements as Set<HTMLElement> )
+			]
 		} );
 	} );
 }

--- a/packages/ckeditor5-ui/tests/dropdown/utils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/utils.js
@@ -172,6 +172,8 @@ describe( 'utils', () => {
 
 					// Dropdown is still open.
 					expect( dropdownView.isOpen ).to.be.true;
+
+					element.remove();
 				} );
 			} );
 

--- a/packages/ckeditor5-ui/tests/dropdown/utils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/utils.js
@@ -29,7 +29,6 @@ import ListItemView from '../../src/list/listitemview';
 import ListSeparatorView from '../../src/list/listseparatorview';
 import ListView from '../../src/list/listview';
 import ViewCollection from '../../src/viewcollection';
-import { DropdownButtonView } from '@ckeditor/ckeditor5-ui';
 
 describe( 'utils', () => {
 	let locale, dropdownView;
@@ -155,25 +154,32 @@ describe( 'utils', () => {
 				} );
 
 				it( 'listens to view#isOpen and reacts to DOM events (context elements)', () => {
-					const contextElements = new Collection();
-
-					const element = document.createElement( 'div' );
-					document.body.appendChild( element );
-
-					contextElements.add( element );
-
-					const dropdownView = createDropdown( locale, DropdownButtonView, contextElements );
 					// Open the dropdown.
 					dropdownView.isOpen = true;
 
-					element.dispatchEvent( new Event( 'mousedown', {
+					// Event from view.element should be discarded.
+					dropdownView.element.dispatchEvent( new Event( 'mousedown', {
 						bubbles: true
 					} ) );
 
 					// Dropdown is still open.
 					expect( dropdownView.isOpen ).to.be.true;
 
-					element.remove();
+					const documentElement = document.createElement( 'div' );
+					document.body.appendChild( documentElement );
+
+					// Add the new document element to dropdown focus tracker.
+					dropdownView.focusTracker.add( documentElement );
+
+					// Fire event from document element.
+					documentElement.dispatchEvent( new Event( 'mousedown', {
+						bubbles: true
+					} ) );
+
+					// Dropdown is still open.
+					expect( dropdownView.isOpen ).to.be.true;
+
+					documentElement.remove();
 				} );
 			} );
 

--- a/packages/ckeditor5-ui/tests/dropdown/utils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/utils.js
@@ -29,6 +29,7 @@ import ListItemView from '../../src/list/listitemview';
 import ListSeparatorView from '../../src/list/listseparatorview';
 import ListView from '../../src/list/listview';
 import ViewCollection from '../../src/viewcollection';
+import { DropdownButtonView } from '@ckeditor/ckeditor5-ui';
 
 describe( 'utils', () => {
 	let locale, dropdownView;
@@ -144,7 +145,28 @@ describe( 'utils', () => {
 					const child = document.createElement( 'div' );
 					dropdownView.element.appendChild( child );
 
+					// Fire event from context element.
 					child.dispatchEvent( new Event( 'mousedown', {
+						bubbles: true
+					} ) );
+
+					// Dropdown is still open.
+					expect( dropdownView.isOpen ).to.be.true;
+				} );
+
+				it( 'listens to view#isOpen and reacts to DOM events (context elements)', () => {
+					const contextElements = new Collection();
+
+					const element = document.createElement( 'div' );
+					document.body.appendChild( element );
+
+					contextElements.add( element );
+
+					const dropdownView = createDropdown( locale, DropdownButtonView, contextElements );
+					// Open the dropdown.
+					dropdownView.isOpen = true;
+
+					element.dispatchEvent( new Event( 'mousedown', {
 						bubbles: true
 					} ) );
 

--- a/packages/ckeditor5-ui/tests/dropdown/utils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/utils.js
@@ -144,7 +144,6 @@ describe( 'utils', () => {
 					const child = document.createElement( 'div' );
 					dropdownView.element.appendChild( child );
 
-					// Fire event from context element.
 					child.dispatchEvent( new Event( 'mousedown', {
 						bubbles: true
 					} ) );
@@ -153,7 +152,7 @@ describe( 'utils', () => {
 					expect( dropdownView.isOpen ).to.be.true;
 				} );
 
-				it( 'listens to view#isOpen and reacts to DOM events (context elements)', () => {
+				it( 'listens to view#isOpen and reacts to DOM events (focus tracker elements)', () => {
 					// Open the dropdown.
 					dropdownView.isOpen = true;
 
@@ -171,7 +170,7 @@ describe( 'utils', () => {
 					// Add the new document element to dropdown focus tracker.
 					dropdownView.focusTracker.add( documentElement );
 
-					// Fire event from document element.
+					// Fire event from outside of the dropdown.
 					documentElement.dispatchEvent( new Event( 'mousedown', {
 						bubbles: true
 					} ) );

--- a/packages/ckeditor5-utils/src/focustracker.ts
+++ b/packages/ckeditor5-utils/src/focustracker.ts
@@ -48,8 +48,10 @@ export default class FocusTracker extends DomEmitterMixin( ObservableMixin() ) {
 
 	/**
 	 * List of registered elements.
+	 *
+	 * @internal
 	 */
-	private _elements: Set<Element> = new Set();
+	public _elements: Set<Element> = new Set();
 
 	/**
 	 * Event loop timeout.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (ui): Dropdowns will stay open after clicking on an HTML element added to the dropdown's focus tracker.