### PR TITLE
insertParagraph command creates additional empty paragraph when used at the end of block element

### DIFF
--- a/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
+++ b/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
@@ -8,7 +8,7 @@
  */
 
 import { Command, type Editor } from '@ckeditor/ckeditor5-core';
-import type { Element, Position, Text, Item } from '@ckeditor/ckeditor5-engine';
+import type { Element, Position, Item } from '@ckeditor/ckeditor5-engine';
 
 /**
  * The insert paragraph command. It inserts a new paragraph at a specific
@@ -59,17 +59,16 @@ export default class InsertParagraphCommand extends Command {
 
 		model.change( writer => {
 			const paragraph = writer.createElement( 'paragraph' );
-
-			if ( attributes ) {
-				model.schema.setAllowedAttributes( paragraph, attributes, writer );
-			}
-
 			const allowedParent = model.schema.findAllowedParent( position, paragraph );
 
 			// It could be there's no ancestor limit that would allow paragraph.
 			// In theory, "paragraph" could be disallowed even in the "$root".
 			if ( !allowedParent ) {
 				return;
+			}
+
+			if ( attributes ) {
+				model.schema.setAllowedAttributes( paragraph, attributes, writer );
 			}
 
 			if ( position.path.length < 2 ) {
@@ -79,26 +78,25 @@ export default class InsertParagraphCommand extends Command {
 				return;
 			}
 
-			if ( position.isAtStart && position.isAtEnd ) {
-				// NOTE: In case when paragraph is empty.
-				// <paragraph>[]</paragraph> ---> <paragraph></paragraph><paragraph>[]</paragraph>
+			// E.g.
+			// <paragraph>[]</paragraph> ---> <paragraph></paragraph><paragraph>[]</paragraph>
+			const isInEmptyBlock = position.isAtStart && position.isAtEnd;
+
+			// E.g.
+			// <paragraph>foo[]</paragraph> ---> <paragraph>foo</paragraph><paragraph>[]</paragraph>
+			const isAtEndOfTextBlock = position.isAtEnd && position.nodeBefore?.is( '$text' );
+
+			// E.g.
+			// <paragraph>[]foo</paragraph> ---> <paragraph>[]</paragraph><paragraph>foo</paragraph>
+			const isAtStartOfTextBlock = position.isAtStart && position.nodeAfter?.is( '$text' );
+
+			const canBeChild = model.schema.checkChild( position.parent as Element, paragraph );
+
+			if ( isInEmptyBlock || isAtEndOfTextBlock ) {
 				position = writer.createPositionAfter( position.parent as Item );
-			} else if ( position.isAtStart && ( position.nodeAfter as Text ).data ) {
-				// When position is at the start of the line we want to insert paragraph above.
-				// <paragraph>[]foo</paragraph> ---> <paragraph>[]</paragraph><paragraph>foo</paragraph>
-				position = writer.createPositionFromPath( allowedParent, position.getParentPath() );
-			} else if ( position.isAtEnd && ( position.nodeBefore as Text ).data ) {
-				// When position is at the end of the line we want to insert paragraph after.
-				// <paragraph>foo[]</paragraph> ---> <paragraph>foo</paragraph><paragraph>[]</paragraph>
-				position = writer.createPositionAfter( position.parent as Item );
-			} else if ( !model.schema.checkChild( position.parent as Element, paragraph ) ) {
-				// When position is inside the content we want to split it
-				// <paragraph>fo[]o</paragraph>
-				//            |
-				//			  ↓
-				// <paragraph>fo</paragraph>
-				// <paragraph>[]</paragraph>
-				// <paragraph>o</paragraph>
+			} else if ( isAtStartOfTextBlock ) {
+				position = writer.createPositionBefore( position.parent as Item );
+			} else if ( !canBeChild ) {
 				position = writer.split( position, allowedParent ).position;
 			}
 

--- a/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
+++ b/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
@@ -72,11 +72,11 @@ export default class InsertParagraphCommand extends Command {
 				return;
 			}
 
-			if ( position.isAtStart && position.path.length > 1 && ( position.nodeAfter! as Text ).data ) {
+			if ( position.isAtStart && position.path.length > 1 && ( position.nodeAfter as Text )?.data ) {
 				// When position is at the start of the line we want to insert paragraph before
 				// <paragraph>[]foo</paragraph> ---> <paragraph>[]</paragraph><paragraph>foo</paragraph>
 				position = writer.createPositionFromPath( allowedParent, position.getParentPath() );
-			} else if ( position.isAtEnd && position.path.length > 1 && ( position.nodeBefore! as Text ).data ) {
+			} else if ( position.isAtEnd && position.path.length > 1 && ( position.nodeBefore as Text )?.data ) {
 				// When position is at the end of the line we want to insert paragraph after
 				// <paragraph>foo[]</paragraph> ---> <paragraph>foo</paragraph><paragraph>[]</paragraph>
 				const parentPath = position.getParentPath();

--- a/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
+++ b/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
@@ -74,7 +74,6 @@ export default class InsertParagraphCommand extends Command {
 
 			if ( position.isAtStart && position.isAtEnd && position.path.length > 1 ) {
 				// NOTE: In case when paragraph is empty.
-				// When position is at the start and at the end of the line we want to insert paragraph after.
 				// <paragraph>[]</paragraph> ---> <paragraph></paragraph><paragraph>[]</paragraph>
 				position = createPositionBellow( writer, position, allowedParent );
 				console.log( position );

--- a/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
+++ b/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
@@ -8,7 +8,7 @@
  */
 
 import { Command, type Editor } from '@ckeditor/ckeditor5-core';
-import type { Element, Position, Item } from '@ckeditor/ckeditor5-engine';
+import type { Element, Position } from '@ckeditor/ckeditor5-engine';
 
 /**
  * The insert paragraph command. It inserts a new paragraph at a specific

--- a/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
+++ b/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
@@ -76,7 +76,6 @@ export default class InsertParagraphCommand extends Command {
 				// NOTE: In case when paragraph is empty.
 				// <paragraph>[]</paragraph> ---> <paragraph></paragraph><paragraph>[]</paragraph>
 				position = createPositionBellow( writer, position, allowedParent );
-				console.log( position );
 			} else if ( position.isAtStart && position.path.length > 1 && ( position.nodeAfter as Text ).data ) {
 				// When position is at the start of the line we want to insert paragraph above.
 				// <paragraph>[]foo</paragraph> ---> <paragraph>[]</paragraph><paragraph>foo</paragraph>

--- a/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
+++ b/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
@@ -78,24 +78,26 @@ export default class InsertParagraphCommand extends Command {
 				return;
 			}
 
+			const positionParent = position.parent as Element;
+
 			// E.g.
 			// <paragraph>[]</paragraph> ---> <paragraph></paragraph><paragraph>[]</paragraph>
-			const isInEmptyBlock = position.isAtStart && position.isAtEnd;
+			const isInEmptyBlock = positionParent.isEmpty;
 
 			// E.g.
 			// <paragraph>foo[]</paragraph> ---> <paragraph>foo</paragraph><paragraph>[]</paragraph>
-			const isAtEndOfTextBlock = position.isAtEnd && position.nodeBefore?.is( '$text' );
+			const isAtEndOfTextBlock = position.isAtEnd && !positionParent.isEmpty;
 
 			// E.g.
 			// <paragraph>[]foo</paragraph> ---> <paragraph>[]</paragraph><paragraph>foo</paragraph>
-			const isAtStartOfTextBlock = position.isAtStart && position.nodeAfter?.is( '$text' );
+			const isAtStartOfTextBlock = position.isAtStart && !positionParent.isEmpty;
 
-			const canBeChild = model.schema.checkChild( position.parent as Element, paragraph );
+			const canBeChild = model.schema.checkChild( positionParent, paragraph );
 
 			if ( isInEmptyBlock || isAtEndOfTextBlock ) {
-				position = writer.createPositionAfter( position.parent as Item );
+				position = writer.createPositionAfter( positionParent );
 			} else if ( isAtStartOfTextBlock ) {
-				position = writer.createPositionBefore( position.parent as Item );
+				position = writer.createPositionBefore( positionParent );
 			} else if ( !canBeChild ) {
 				position = writer.split( position, allowedParent ).position;
 			}

--- a/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
+++ b/packages/ckeditor5-paragraph/src/insertparagraphcommand.ts
@@ -8,7 +8,7 @@
  */
 
 import { Command, type Editor } from '@ckeditor/ckeditor5-core';
-import type { Element, Position } from '@ckeditor/ckeditor5-engine';
+import type { Element, Position, Text } from '@ckeditor/ckeditor5-engine';
 
 /**
  * The insert paragraph command. It inserts a new paragraph at a specific
@@ -59,7 +59,6 @@ export default class InsertParagraphCommand extends Command {
 
 		model.change( writer => {
 			const paragraph = writer.createElement( 'paragraph' );
-			const parent = position.parent;
 
 			if ( attributes ) {
 				model.schema.setAllowedAttributes( paragraph, attributes, writer );
@@ -73,15 +72,16 @@ export default class InsertParagraphCommand extends Command {
 				return;
 			}
 
-			if ( position.offset === 0 && position.path.length > 1 ) {
+			if ( position.isAtStart && position.path.length > 1 && ( position.nodeAfter! as Text ).data ) {
 				// When position is at the start of the line we want to insert paragraph before
 				// <paragraph>[]foo</paragraph> ---> <paragraph>[]</paragraph><paragraph>foo</paragraph>
 				position = writer.createPositionFromPath( allowedParent, position.getParentPath() );
-			} else if ( parent.maxOffset === position.offset && position.path.length > 1 ) {
+			} else if ( position.isAtEnd && position.path.length > 1 && ( position.nodeBefore! as Text ).data ) {
 				// When position is at the end of the line we want to insert paragraph after
 				// <paragraph>foo[]</paragraph> ---> <paragraph>foo</paragraph><paragraph>[]</paragraph>
-				const length = position.getParentPath().length;
-				const path = [ ...position.getParentPath().slice( 0, length - 1 ), position.getParentPath()[ length - 1 ] + 1 ];
+				const parentPath = position.getParentPath();
+				const length = parentPath.length;
+				const path = [ ...parentPath.slice( 0, length - 1 ), parentPath[ length - 1 ] + 1 ];
 				position = writer.createPositionFromPath( allowedParent, path );
 			} else if ( !model.schema.checkChild( position.parent as Element, paragraph ) ) {
 				// When position is inside the content we want to split it

--- a/packages/ckeditor5-paragraph/tests/insertparagraphcommand.js
+++ b/packages/ckeditor5-paragraph/tests/insertparagraphcommand.js
@@ -4,7 +4,7 @@
  */
 
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
-import InsertParagraphCommand, { createPositionBellow } from '../src/insertparagraphcommand';
+import InsertParagraphCommand from '../src/insertparagraphcommand';
 
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
@@ -96,7 +96,7 @@ describe( 'InsertParagraphCommand', () => {
 			);
 		} );
 
-		it( 'should insert paragraph when position is at the start of line asd', () => {
+		it( 'should insert paragraph bellow when paragraph is empty', () => {
 			setData( model, '<paragraph>[]</paragraph>' );
 
 			command.execute( {
@@ -107,20 +107,6 @@ describe( 'InsertParagraphCommand', () => {
 				'<paragraph></paragraph>' +
 				'<paragraph>[]</paragraph>'
 			);
-		} );
-
-		it( 'Should create position bellow', () => {
-			model.change( writer => {
-				let position = model.createPositionFromPath( root, [ 0, 2 ] );
-				let expectedPosition = model.createPositionFromPath( root, [ 1 ] );
-				expect( createPositionBellow( writer, position, root ), '[ 0, 2 ] --> [ 1 ]' )
-					.to.eql( expectedPosition );
-
-				position = model.createPositionFromPath( root, [ 1, 2, 3 ] );
-				expectedPosition = model.createPositionFromPath( root, [ 1, 3 ] );
-				expect( createPositionBellow( writer, position, root ), '[ 1, 2, 3 ] --> [ 1, 3 ]' )
-					.to.eql( expectedPosition );
-			} );
 		} );
 
 		it( 'should do nothing if the paragraph is not allowed at the provided position', () => {

--- a/packages/ckeditor5-paragraph/tests/insertparagraphcommand.js
+++ b/packages/ckeditor5-paragraph/tests/insertparagraphcommand.js
@@ -70,6 +70,32 @@ describe( 'InsertParagraphCommand', () => {
 			);
 		} );
 
+		it( 'should insert paragraph when position is at the end of line', () => {
+			setData( model, '<paragraph>foo[]</paragraph>' );
+
+			command.execute( {
+				position: model.document.selection.getFirstPosition()
+			} );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph>foo</paragraph>' +
+				'<paragraph>[]</paragraph>'
+			);
+		} );
+
+		it( 'should insert paragraph when position is at the start of line', () => {
+			setData( model, '<paragraph>[]foo</paragraph>' );
+
+			command.execute( {
+				position: model.document.selection.getLastPosition()
+			} );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph>[]</paragraph>' +
+				'<paragraph>foo</paragraph>'
+			);
+		} );
+
 		it( 'should do nothing if the paragraph is not allowed at the provided position', () => {
 			// Create a situation where "paragraph" is disallowed even in the "root".
 			schema.addChildCheck( ( context, childDefinition ) => {

--- a/packages/ckeditor5-paragraph/tests/insertparagraphcommand.js
+++ b/packages/ckeditor5-paragraph/tests/insertparagraphcommand.js
@@ -4,7 +4,7 @@
  */
 
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor';
-import InsertParagraphCommand from '../src/insertparagraphcommand';
+import InsertParagraphCommand, { createPositionBellow } from '../src/insertparagraphcommand';
 
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 
@@ -94,6 +94,33 @@ describe( 'InsertParagraphCommand', () => {
 				'<paragraph>[]</paragraph>' +
 				'<paragraph>foo</paragraph>'
 			);
+		} );
+
+		it( 'should insert paragraph when position is at the start of line asd', () => {
+			setData( model, '<paragraph>[]</paragraph>' );
+
+			command.execute( {
+				position: model.document.selection.getLastPosition()
+			} );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph></paragraph>' +
+				'<paragraph>[]</paragraph>'
+			);
+		} );
+
+		it( 'Should create position bellow', () => {
+			model.change( writer => {
+				let position = model.createPositionFromPath( root, [ 0, 2 ] );
+				let expectedPosition = model.createPositionFromPath( root, [ 1 ] );
+				expect( createPositionBellow( writer, position, root ), '[ 0, 2 ] --> [ 1 ]' )
+					.to.eql( expectedPosition );
+
+				position = model.createPositionFromPath( root, [ 1, 2, 3 ] );
+				expectedPosition = model.createPositionFromPath( root, [ 1, 3 ] );
+				expect( createPositionBellow( writer, position, root ), '[ 1, 2, 3 ] --> [ 1, 3 ]' )
+					.to.eql( expectedPosition );
+			} );
 		} );
 
 		it( 'should do nothing if the paragraph is not allowed at the provided position', () => {

--- a/packages/ckeditor5-paragraph/tests/insertparagraphcommand.js
+++ b/packages/ckeditor5-paragraph/tests/insertparagraphcommand.js
@@ -83,6 +83,20 @@ describe( 'InsertParagraphCommand', () => {
 			);
 		} );
 
+		it( 'should insert paragraph when position is at the end of line with an inline widget', () => {
+			schema.register( 'inlineWidget', { inheritAllFrom: '$inlineObject' } );
+			setData( model, '<paragraph><inlineWidget></inlineWidget>[]</paragraph>' );
+
+			command.execute( {
+				position: model.document.selection.getFirstPosition()
+			} );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph><inlineWidget></inlineWidget></paragraph>' +
+				'<paragraph>[]</paragraph>'
+			);
+		} );
+
 		it( 'should insert paragraph when position is at the start of line', () => {
 			setData( model, '<paragraph>[]foo</paragraph>' );
 
@@ -93,6 +107,20 @@ describe( 'InsertParagraphCommand', () => {
 			expect( getData( model ) ).to.equal(
 				'<paragraph>[]</paragraph>' +
 				'<paragraph>foo</paragraph>'
+			);
+		} );
+
+		it( 'should insert paragraph when position is at the start of line with an inline widget', () => {
+			schema.register( 'inlineWidget', { inheritAllFrom: '$inlineObject' } );
+			setData( model, '<paragraph>[]<inlineWidget></inlineWidget></paragraph>' );
+
+			command.execute( {
+				position: model.document.selection.getLastPosition()
+			} );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph>[]</paragraph>' +
+				'<paragraph><inlineWidget></inlineWidget></paragraph>'
 			);
 		} );
 

--- a/packages/ckeditor5-widget/tests/widgettypearound/widgettypearound.js
+++ b/packages/ckeditor5-widget/tests/widgettypearound/widgettypearound.js
@@ -1053,7 +1053,7 @@ describe( 'WidgetTypeAround', () => {
 					expect( modelSelection.getAttribute( TYPE_AROUND_SELECTION_ATTRIBUTE ) ).to.be.undefined;
 				} );
 
-				it( 'should split ancestors to find a place that allows a widget', () => {
+				it( 'should split ancestors to find a place that allows a widget (no content after widget)', () => {
 					model.schema.register( 'allowP', {
 						inheritAllFrom: '$block'
 					} );
@@ -1083,7 +1083,41 @@ describe( 'WidgetTypeAround', () => {
 						'<allowP>' +
 							'<disallowP><blockWidget></blockWidget></disallowP>' +
 							'<paragraph>[]</paragraph>' +
-							'<disallowP></disallowP>' +
+						'</allowP>'
+					);
+				} );
+
+				it( 'should split ancestors to find a place that allows a widget (with content after widget)', () => {
+					model.schema.register( 'allowP', {
+						inheritAllFrom: '$block'
+					} );
+					model.schema.register( 'disallowP', {
+						inheritAllFrom: '$block',
+						allowIn: [ 'allowP' ]
+					} );
+					model.schema.extend( 'blockWidget', {
+						allowIn: [ 'allowP', 'disallowP' ]
+					} );
+					model.schema.extend( 'paragraph', {
+						allowIn: [ 'allowP' ]
+					} );
+
+					editor.conversion.for( 'downcast' ).elementToElement( { model: 'allowP', view: 'allowP' } );
+					editor.conversion.for( 'downcast' ).elementToElement( { model: 'disallowP', view: 'disallowP' } );
+
+					setModelData( model,
+						'<allowP>' +
+							'<disallowP>[<blockWidget></blockWidget>]<blockWidget></blockWidget></disallowP>' +
+						'</allowP>'
+					);
+
+					fireEnter();
+
+					expect( getModelData( model ) ).to.equal(
+						'<allowP>' +
+							'<disallowP><blockWidget></blockWidget></disallowP>' +
+							'<paragraph>[]</paragraph>' +
+							'<disallowP><blockWidget></blockWidget></disallowP>' +
 						'</allowP>'
 					);
 				} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (paragraph): "insertParagraph" command doesn't insert two paragraphs when position is at the edge of the line. Closes [#13866](https://github.com/ckeditor/ckeditor5/issues/13866).

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
