### PR TITLE
Fixed script that checks whether a package is a CKEditor 5 dependency

### DIFF
--- a/scripts/release/utils/isckeditor5packagefactory.js
+++ b/scripts/release/utils/isckeditor5packagefactory.js
@@ -17,17 +17,14 @@ const { glob } = require( 'glob' );
  * @returns {Promise.<Function>}
  */
 module.exports = async function isCKEditor5PackageFactory() {
-	const allCKEditor5NamePatterns = [
-		/^@ckeditor\/ckeditor5-(.*)/,
-		/^ckeditor5(-collaboration)?$/
-	];
-
 	const pathToCKEditor5 = upath.resolve( __dirname, '../../..' );
 
-	const globPattern = require( `${ pathToCKEditor5 }/package.json` ).workspaces.packages
-		.map( pattern => `${ pattern }/package.json` );
-
-	const allPathsToPackageJson = await glob( globPattern, {
+	const allPathsToPackageJson = await glob( [
+		'package.json',
+		'packages/*/package.json',
+		'external/ckeditor5-internal/packages/*/package.json',
+		'external/collaboration-features/packages/*/package.json'
+	], {
 		cwd: pathToCKEditor5,
 		nodir: true,
 		absolute: true
@@ -39,10 +36,5 @@ module.exports = async function isCKEditor5PackageFactory() {
 
 	const allPackageNames = allPackageJson.map( packageJson => packageJson.name );
 
-	return packageName => {
-		const doesPackageMatchNaming = allCKEditor5NamePatterns.some( pattern => pattern.test( packageName ) );
-		const doesPackageExist = allPackageNames.includes( packageName );
-
-		return ( doesPackageMatchNaming && doesPackageExist );
-	};
+	return packageName => allPackageNames.includes( packageName );
 };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Fixed release tools script that checks whether a package is a CKEditor 5 dependency by limiting the search scope to predefined paths only. Closes #14513.

---

### Additional information

The CS Client path is not needed because it is not considered as a CKEditor 5 dependency anyway.