### PR TITLE
Fix documentation

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
@@ -819,7 +819,7 @@ export default class DowncastHelpers extends ConversionHelpers<DowncastDispatche
 	 * ```ts
 	 * // Using a custom function which is the same as the default conversion:
 	 * editor.conversion.for( 'dataDowncast' ).markerToData( {
-	 * 	model: 'comment'
+	 * 	model: 'comment',
 	 * 	view: markerName => ( {
 	 * 		group: 'comment',
 	 * 		name: markerName.substr( 8 ) // Removes 'comment:' part.
@@ -828,7 +828,7 @@ export default class DowncastHelpers extends ConversionHelpers<DowncastDispatche
 	 *
 	 * // Using the converter priority:
 	 * editor.conversion.for( 'dataDowncast' ).markerToData( {
-	 * 	model: 'comment'
+	 * 	model: 'comment',
 	 * 	view: markerName => ( {
 	 * 		group: 'comment',
 	 * 		name: markerName.substr( 8 ) // Removes 'comment:' part.


### PR DESCRIPTION
markerToData missing comma in json object

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Type: Message. Closes #000.

---

### Additional information

Documentation did contain invalid json. I fixed it
