### PR TITLE
CKE5 properly reflects table alignments from Microsoft Word 

### DIFF
--- a/packages/ckeditor5-paste-from-office/src/filters/table.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/table.ts
@@ -29,7 +29,7 @@ export function tableAlignmentFilter( documentFragment: ViewDocumentFragment, wr
 		const align = item.getAttribute( 'align' );
 		const child = item.getChild( 0 );
 
-		// Element should have alignemt attribute and should have child and should be div.
+		// Element should have alignment attribute and should have child and should be div.
 		if ( !align || !child || item.name !== 'div' ) {
 			continue;
 		}

--- a/packages/ckeditor5-paste-from-office/src/filters/table.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/table.ts
@@ -15,6 +15,10 @@ import type { UpcastWriter, ViewDocumentFragment } from 'ckeditor5/src/engine';
  */
 export function tableAlignmentFilter( documentFragment: ViewDocumentFragment, writer: UpcastWriter ): void {
 	for ( const item of documentFragment.getChildren() ) {
+		if ( !item.is( 'element' ) ) {
+			continue;
+		}
+
 		// If table is not wrapped in div[align] it should be alligned left.
 		// More details:(https://github.com/ckeditor/ckeditor5/issues/8752#issuecomment-1623507171).
 		if ( item.is( 'element', 'table' ) ) {
@@ -22,25 +26,18 @@ export function tableAlignmentFilter( documentFragment: ViewDocumentFragment, wr
 			continue;
 		}
 
-		const align = item.is( 'element' ) && item.getAttribute( 'align' );
-		const child = item.is( 'element' ) && item.getChild( 0 );
+		const align = item.getAttribute( 'align' );
+		const child = item.getChild( 0 );
 
 		// Element should have alignment attribute and should have child and should be div.
 		if ( !align || !child || item.name !== 'div' ) {
 			continue;
 		}
 
-		// If table is wrapped in div[right|left] table should be alligned right or left.
+		// If table is wrapped in div[align] table should be alligned with defined alignment value.
 		// More details:(https://github.com/ckeditor/ckeditor5/issues/8752#issuecomment-1629065676)
-		if ( align !== 'center' && child.is( 'element', 'table' ) ) {
-			writer.setAttribute( 'align', align, child );
-			continue;
-		}
-
-		// If table is wrapped in div[center] table should be centered.
-		// More details:(https://github.com/ckeditor/ckeditor5/issues/8752#issuecomment-1629065676)
-		if ( align === 'center' && child.is( 'element', 'table' ) ) {
-			writer.setAttribute( 'align', 'none', child );
+		if ( child.is( 'element', 'table' ) ) {
+			writer.setAttribute( 'align', align === 'center' ? 'none' : align, child );
 		}
 	}
 }

--- a/packages/ckeditor5-paste-from-office/src/filters/table.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/table.ts
@@ -6,14 +6,16 @@
 /**
  * @module paste-from-office/filters/parse
  */
-import type { UpcastWriter, ViewDocumentFragment } from 'ckeditor5/src/engine';
+import { UpcastWriter, type ViewDocumentFragment } from 'ckeditor5/src/engine';
 
 /**
  * Set alignment for table pasted from MS Word.
  *
  * @param documentFragment The view structure to be transformed.
  */
-export function tableAlignmentFilter( documentFragment: ViewDocumentFragment, writer: UpcastWriter ): void {
+export function setTableAlignment( documentFragment: ViewDocumentFragment ): void {
+	const upcastWriter = new UpcastWriter( documentFragment.document );
+
 	for ( const item of documentFragment.getChildren() ) {
 		if ( !item.is( 'element' ) ) {
 			continue;
@@ -22,7 +24,7 @@ export function tableAlignmentFilter( documentFragment: ViewDocumentFragment, wr
 		// If table is not wrapped in div[align] it should be alligned left.
 		// More details:(https://github.com/ckeditor/ckeditor5/issues/8752#issuecomment-1623507171).
 		if ( item.is( 'element', 'table' ) ) {
-			writer.setAttribute( 'align', 'left', item );
+			upcastWriter.setAttribute( 'align', 'left', item );
 			continue;
 		}
 
@@ -37,7 +39,7 @@ export function tableAlignmentFilter( documentFragment: ViewDocumentFragment, wr
 		// If table is wrapped in div[align] table should be alligned with defined alignment value.
 		// More details:(https://github.com/ckeditor/ckeditor5/issues/8752#issuecomment-1629065676)
 		if ( child.is( 'element', 'table' ) ) {
-			writer.setAttribute( 'align', align === 'center' ? 'none' : align, child );
+			upcastWriter.setAttribute( 'align', align === 'center' ? 'none' : align, child );
 		}
 	}
 }

--- a/packages/ckeditor5-paste-from-office/src/filters/table.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/table.ts
@@ -1,0 +1,50 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module paste-from-office/filters/parse
+ */
+import type { UpcastWriter, ViewDocumentFragment } from 'ckeditor5/src/engine';
+
+/**
+ * Set alignment for table pasted from MS Word.
+ *
+ * @param documentFragment The view structure to be transformed.
+ */
+export function tableAlignmentFilter( documentFragment: ViewDocumentFragment, writer: UpcastWriter ): void {
+	for ( const item of documentFragment.getChildren() ) {
+		if ( !item.is( 'element' ) ) {
+			continue;
+		}
+
+		// If table is not wrapped in div[align] it should be alligned left.
+		// More details:(https://github.com/ckeditor/ckeditor5/issues/8752#issuecomment-1623507171).
+		if ( item.is( 'element', 'table' ) ) {
+			writer.setAttribute( 'align', 'left', item );
+			continue;
+		}
+
+		const align = item.getAttribute( 'align' );
+		const child = item.getChild( 0 );
+
+		// Element should have alignemt attribute and should have child and should be div.
+		if ( !align || !child || item.name !== 'div' ) {
+			continue;
+		}
+
+		// If table is wrapped in div[right|left] table should be alligned right or left.
+		// More details:(https://github.com/ckeditor/ckeditor5/issues/8752#issuecomment-1629065676)
+		if ( align !== 'center' && child.is( 'element', 'table' ) ) {
+			writer.setAttribute( 'align', align, child );
+			continue;
+		}
+
+		// If table is wrapped in div[center] table should be centered.
+		// More details:(https://github.com/ckeditor/ckeditor5/issues/8752#issuecomment-1629065676)
+		if ( align === 'center' && child.is( 'element', 'table' ) ) {
+			writer.setAttribute( 'align', 'none', child );
+		}
+	}
+}

--- a/packages/ckeditor5-paste-from-office/src/filters/table.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/table.ts
@@ -21,8 +21,10 @@ export function setTableAlignment( documentFragment: ViewDocumentFragment ): voi
 			continue;
 		}
 
-		// If table is not wrapped in div[align] it should be alligned left.
-		// More details:(https://github.com/ckeditor/ckeditor5/issues/8752#issuecomment-1623507171).
+		// If table is not wrapped into div[align], it should be aligned left.
+		// More details: https://github.com/ckeditor/ckeditor5/issues/8752#issuecomment-1623507171.
+		// RTL tables have the `align` attribute set explicitly -
+		// see https://github.com/ckeditor/ckeditor5/issues/8752#issuecomment-1628876074.
 		if ( item.is( 'element', 'table' ) ) {
 			upcastWriter.setAttribute( 'align', 'left', item );
 			continue;
@@ -31,13 +33,13 @@ export function setTableAlignment( documentFragment: ViewDocumentFragment ): voi
 		const align = item.getAttribute( 'align' );
 		const child = item.getChild( 0 );
 
-		// Element should have alignment attribute and should have child and should be div.
-		if ( !align || !child || item.name !== 'div' ) {
+		// We're looking for the `<div>` elements with `align` attribute and a child.
+		if ( item.name !== 'div' || !align || !child ) {
 			continue;
 		}
 
-		// If table is wrapped in div[align] table should be alligned with defined alignment value.
-		// More details:(https://github.com/ckeditor/ckeditor5/issues/8752#issuecomment-1629065676)
+		// If table is wrapped in div[align], the defined alignment value should be preserved.
+		// More details: https://github.com/ckeditor/ckeditor5/issues/8752#issuecomment-1629065676.
 		if ( child.is( 'element', 'table' ) ) {
 			upcastWriter.setAttribute( 'align', align === 'center' ? 'none' : align, child );
 		}

--- a/packages/ckeditor5-paste-from-office/src/filters/table.ts
+++ b/packages/ckeditor5-paste-from-office/src/filters/table.ts
@@ -15,10 +15,6 @@ import type { UpcastWriter, ViewDocumentFragment } from 'ckeditor5/src/engine';
  */
 export function tableAlignmentFilter( documentFragment: ViewDocumentFragment, writer: UpcastWriter ): void {
 	for ( const item of documentFragment.getChildren() ) {
-		if ( !item.is( 'element' ) ) {
-			continue;
-		}
-
 		// If table is not wrapped in div[align] it should be alligned left.
 		// More details:(https://github.com/ckeditor/ckeditor5/issues/8752#issuecomment-1623507171).
 		if ( item.is( 'element', 'table' ) ) {
@@ -26,8 +22,8 @@ export function tableAlignmentFilter( documentFragment: ViewDocumentFragment, wr
 			continue;
 		}
 
-		const align = item.getAttribute( 'align' );
-		const child = item.getChild( 0 );
+		const align = item.is( 'element' ) && item.getAttribute( 'align' );
+		const child = item.is( 'element' ) && item.getChild( 0 );
 
 		// Element should have alignment attribute and should have child and should be div.
 		if ( !align || !child || item.name !== 'div' ) {

--- a/packages/ckeditor5-paste-from-office/src/normalizers/mswordnormalizer.ts
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/mswordnormalizer.ts
@@ -9,8 +9,8 @@
 
 import { transformListItemLikeElementsIntoLists } from '../filters/list';
 import { replaceImagesSourceWithBase64 } from '../filters/image';
-import { tableAlignmentFilter } from '../filters/table';
-import { UpcastWriter, type ViewDocument } from 'ckeditor5/src/engine';
+import { setTableAlignment } from '../filters/table';
+import type { ViewDocument } from 'ckeditor5/src/engine';
 import type { Normalizer, NormalizerData } from '../normalizer';
 
 const msWordMatch1 = /<meta\s*name="?generator"?\s*content="?microsoft\s*word\s*\d+"?\/?>/i;
@@ -42,12 +42,11 @@ export default class MSWordNormalizer implements Normalizer {
 	 * @inheritDoc
 	 */
 	public execute( data: NormalizerData ): void {
-		const writer = new UpcastWriter( this.document );
 		const { body: documentFragment, stylesString } = data._parsedData;
 
 		transformListItemLikeElementsIntoLists( documentFragment, stylesString );
 		replaceImagesSourceWithBase64( documentFragment, data.dataTransfer.getData( 'text/rtf' ) );
-		tableAlignmentFilter( documentFragment, writer );
+		setTableAlignment( documentFragment );
 		data.content = documentFragment;
 	}
 }

--- a/packages/ckeditor5-paste-from-office/src/normalizers/mswordnormalizer.ts
+++ b/packages/ckeditor5-paste-from-office/src/normalizers/mswordnormalizer.ts
@@ -9,9 +9,9 @@
 
 import { transformListItemLikeElementsIntoLists } from '../filters/list';
 import { replaceImagesSourceWithBase64 } from '../filters/image';
+import { tableAlignmentFilter } from '../filters/table';
+import { UpcastWriter, type ViewDocument } from 'ckeditor5/src/engine';
 import type { Normalizer, NormalizerData } from '../normalizer';
-
-import type { ViewDocument } from 'ckeditor5/src/engine';
 
 const msWordMatch1 = /<meta\s*name="?generator"?\s*content="?microsoft\s*word\s*\d+"?\/?>/i;
 const msWordMatch2 = /xmlns:o="urn:schemas-microsoft-com/i;
@@ -42,11 +42,12 @@ export default class MSWordNormalizer implements Normalizer {
 	 * @inheritDoc
 	 */
 	public execute( data: NormalizerData ): void {
+		const writer = new UpcastWriter( this.document );
 		const { body: documentFragment, stylesString } = data._parsedData;
 
 		transformListItemLikeElementsIntoLists( documentFragment, stylesString );
 		replaceImagesSourceWithBase64( documentFragment, data.dataTransfer.getData( 'text/rtf' ) );
-
+		tableAlignmentFilter( documentFragment, writer );
 		data.content = documentFragment;
 	}
 }

--- a/packages/ckeditor5-paste-from-office/tests/_data/table/tablecellproperties/model.html
+++ b/packages/ckeditor5-paste-from-office/tests/_data/table/tablecellproperties/model.html
@@ -1,4 +1,4 @@
-<table tableBorderColor="{}" tableBorderWidth="{}">
+<table tableAlignment="left" tableBorderColor="{}" tableBorderWidth="{}">
 	<tableRow>
 		<tableCell tableCellBackgroundColor="#CCCCCC" tableCellBorderColor="windowtext" tableCellBorderStyle="solid" tableCellBorderWidth="1.0pt" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
 			<paragraph><$text bold="true">Project Phase</$text></paragraph>

--- a/packages/ckeditor5-paste-from-office/tests/filters/table.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/table.js
@@ -1,0 +1,190 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
+import { tableAlignmentFilter } from '../../src/filters/table';
+import UpcastWriter from '@ckeditor/ckeditor5-engine/src/view/upcastwriter';
+import Document from '@ckeditor/ckeditor5-engine/src/view/document';
+import { StylesProcessor } from '@ckeditor/ckeditor5-engine/src/view/stylesmap';
+
+describe( 'PasteFromOffice - filters', () => {
+	const htmlDataProcessor = new HtmlDataProcessor( new Document( new StylesProcessor() ) );
+
+	describe( 'tableAlignmentFilter', () => {
+		let writer, viewDocument;
+
+		before( () => {
+			viewDocument = new Document();
+			writer = new UpcastWriter( viewDocument );
+		} );
+
+		it( 'should align table to left', () => {
+			const inputData =
+				'<table>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>123</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>';
+
+			const documentFragment = htmlDataProcessor.toView( inputData );
+
+			tableAlignmentFilter( documentFragment, writer );
+
+			expect( htmlDataProcessor.toData( documentFragment ) ).to.equal(
+				'<table align="left"><tbody><tr><td>123</td></tr></tbody></table>'
+			);
+		} );
+
+		it( 'should align table to left when table allocated in div', () => {
+			const inputData =
+			'<div align="left">' +
+				'<table>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>123</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</div>';
+
+			const documentFragment = htmlDataProcessor.toView( inputData );
+
+			tableAlignmentFilter( documentFragment, writer );
+
+			expect( htmlDataProcessor.toData( documentFragment ) ).to.equal(
+				'<div align="left">' +
+					'<table align="left">' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>123</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+				'</div>'
+			);
+		} );
+
+		it( 'should align table to center', () => {
+			const inputData =
+				'<div align="center">' +
+					'<table>' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>123</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+				'</div>';
+
+			const documentFragment = htmlDataProcessor.toView( inputData );
+
+			tableAlignmentFilter( documentFragment, writer );
+
+			expect( htmlDataProcessor.toData( documentFragment ) ).to.equal(
+				'<div align="center">' +
+					'<table align="none">' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>123</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+				'</div>'
+			);
+		} );
+
+		it( 'should align table to right', () => {
+			const inputData =
+				'<div align="right">' +
+					'<table align="right">' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>123</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+				'</div>';
+
+			const documentFragment = htmlDataProcessor.toView( inputData );
+
+			tableAlignmentFilter( documentFragment, writer );
+
+			expect( htmlDataProcessor.toData( documentFragment ) ).to.equal(
+				'<div align="right">' +
+					'<table align="right">' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>123</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+				'</div>'
+			);
+		} );
+
+		it( 'should properly align tables', () => {
+			const inputData =
+			'<table>' +
+				'<tbody>' +
+					'<tr>' +
+						'<td>123</td>' +
+					'</tr>' +
+				'</tbody>' +
+			'</table>' +
+			'<div align="center">' +
+				'<table>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>123</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</div>' +
+			'<div align="right">' +
+				'<table>' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>123</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+			'</div>';
+
+			const documentFragment = htmlDataProcessor.toView( inputData );
+
+			tableAlignmentFilter( documentFragment, writer );
+
+			expect( htmlDataProcessor.toData( documentFragment ) ).to.equal(
+				'<table align="left">' +
+					'<tbody>' +
+						'<tr>' +
+							'<td>123</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>' +
+				'<div align="center">' +
+					'<table align="none">' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>123</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+				'</div>' +
+				'<div align="right">' +
+					'<table align="right">' +
+						'<tbody>' +
+							'<tr>' +
+								'<td>123</td>' +
+							'</tr>' +
+						'</tbody>' +
+					'</table>' +
+				'</div>'
+			);
+		} );
+	} );
+} );

--- a/packages/ckeditor5-paste-from-office/tests/filters/table.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/table.js
@@ -39,6 +39,18 @@ describe( 'PasteFromOffice - filters', () => {
 			);
 		} );
 
+		it( 'should return only text', () => {
+			const inputData = 'text';
+
+			const documentFragment = htmlDataProcessor.toView( inputData );
+
+			tableAlignmentFilter( documentFragment, writer );
+
+			expect( htmlDataProcessor.toData( documentFragment ) ).to.equal(
+				'text'
+			);
+		} );
+
 		it( 'should align table to left when table allocated in div', () => {
 			const inputData =
 			'<div align="left">' +

--- a/packages/ckeditor5-paste-from-office/tests/filters/table.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/table.js
@@ -4,7 +4,7 @@
  */
 
 import HtmlDataProcessor from '@ckeditor/ckeditor5-engine/src/dataprocessor/htmldataprocessor';
-import { tableAlignmentFilter } from '../../src/filters/table';
+import { setTableAlignment } from '../../src/filters/table';
 import UpcastWriter from '@ckeditor/ckeditor5-engine/src/view/upcastwriter';
 import Document from '@ckeditor/ckeditor5-engine/src/view/document';
 import { StylesProcessor } from '@ckeditor/ckeditor5-engine/src/view/stylesmap';
@@ -32,7 +32,7 @@ describe( 'PasteFromOffice - filters', () => {
 
 			const documentFragment = htmlDataProcessor.toView( inputData );
 
-			tableAlignmentFilter( documentFragment, writer );
+			setTableAlignment( documentFragment, writer );
 
 			expect( htmlDataProcessor.toData( documentFragment ) ).to.equal(
 				'<table align="left"><tbody><tr><td>123</td></tr></tbody></table>'
@@ -44,7 +44,7 @@ describe( 'PasteFromOffice - filters', () => {
 
 			const documentFragment = htmlDataProcessor.toView( inputData );
 
-			tableAlignmentFilter( documentFragment, writer );
+			setTableAlignment( documentFragment, writer );
 
 			expect( htmlDataProcessor.toData( documentFragment ) ).to.equal(
 				'text'
@@ -65,7 +65,7 @@ describe( 'PasteFromOffice - filters', () => {
 
 			const documentFragment = htmlDataProcessor.toView( inputData );
 
-			tableAlignmentFilter( documentFragment, writer );
+			setTableAlignment( documentFragment, writer );
 
 			expect( htmlDataProcessor.toData( documentFragment ) ).to.equal(
 				'<div align="left">' +
@@ -94,7 +94,7 @@ describe( 'PasteFromOffice - filters', () => {
 
 			const documentFragment = htmlDataProcessor.toView( inputData );
 
-			tableAlignmentFilter( documentFragment, writer );
+			setTableAlignment( documentFragment, writer );
 
 			expect( htmlDataProcessor.toData( documentFragment ) ).to.equal(
 				'<div align="center">' +
@@ -112,7 +112,7 @@ describe( 'PasteFromOffice - filters', () => {
 		it( 'should align table to right', () => {
 			const inputData =
 				'<div align="right">' +
-					'<table align="right">' +
+					'<table>' +
 						'<tbody>' +
 							'<tr>' +
 								'<td>123</td>' +
@@ -123,7 +123,7 @@ describe( 'PasteFromOffice - filters', () => {
 
 			const documentFragment = htmlDataProcessor.toView( inputData );
 
-			tableAlignmentFilter( documentFragment, writer );
+			setTableAlignment( documentFragment, writer );
 
 			expect( htmlDataProcessor.toData( documentFragment ) ).to.equal(
 				'<div align="right">' +
@@ -168,7 +168,7 @@ describe( 'PasteFromOffice - filters', () => {
 
 			const documentFragment = htmlDataProcessor.toView( inputData );
 
-			tableAlignmentFilter( documentFragment, writer );
+			setTableAlignment( documentFragment, writer );
 
 			expect( htmlDataProcessor.toData( documentFragment ) ).to.equal(
 				'<table align="left">' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (paste from word): CKE5 properly reflects table alignments from Microsoft Word . Closes #8752.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
