### PR TITLE
Clearing DOM selection on editable blur on iOS.

### DIFF
--- a/packages/ckeditor5-engine/src/view/domconverter.ts
+++ b/packages/ckeditor5-engine/src/view/domconverter.ts
@@ -1061,6 +1061,28 @@ export default class DomConverter {
 	}
 
 	/**
+	 * Remove DOM selection from blurred editable, so it won't interfere with clicking on dropdowns (especially on iOS).
+	 *
+	 * @internal
+	 */
+	public _clearDomSelection(): void {
+		const domEditable = this.mapViewToDom( this.document.selection.editableElement! );
+
+		if ( !domEditable ) {
+			return;
+		}
+
+		// Check if DOM selection is inside editor editable element.
+		const domSelection = domEditable.ownerDocument.defaultView!.getSelection()!;
+		const newViewSelection = this.domSelectionToView( domSelection );
+		const selectionInEditable = newViewSelection && newViewSelection.rangeCount > 0;
+
+		if ( selectionInEditable ) {
+			domSelection.removeAllRanges();
+		}
+	}
+
+	/**
 	 * Returns `true` when `node.nodeType` equals `Node.ELEMENT_NODE`.
 	 *
 	 * @param node Node to check.

--- a/packages/ckeditor5-engine/src/view/view.ts
+++ b/packages/ckeditor5-engine/src/view/view.ts
@@ -30,7 +30,7 @@ import KeyObserver from './observer/keyobserver';
 import FakeSelectionObserver from './observer/fakeselectionobserver';
 import MutationObserver from './observer/mutationobserver';
 import SelectionObserver from './observer/selectionobserver';
-import FocusObserver from './observer/focusobserver';
+import FocusObserver, { type ViewDocumentBlurEvent } from './observer/focusobserver';
 import CompositionObserver from './observer/compositionobserver';
 import InputObserver from './observer/inputobserver';
 import ArrowKeysObserver from './observer/arrowkeysobserver';
@@ -38,6 +38,7 @@ import TabObserver from './observer/tabobserver';
 
 import {
 	CKEditorError,
+	env,
 	ObservableMixin,
 	scrollViewportToShowTarget,
 	type ObservableChangeEvent
@@ -215,6 +216,19 @@ export default class View extends ObservableMixin() {
 		this.listenTo<ObservableChangeEvent>( this.document, 'change:isFocused', () => {
 			this._hasChangedSinceTheLastRendering = true;
 		} );
+
+		// Remove ranges from DOM selection if editor is blurred.
+		// See https://github.com/ckeditor/ckeditor5/issues/5753.
+		if ( env.isiOS ) {
+			this.listenTo<ViewDocumentBlurEvent>( this.document, 'blur', ( evt, data ) => {
+				const relatedViewElement = this.domConverter.mapDomToView( data.domEvent.relatedTarget as HTMLElement );
+
+				// Do not modify DOM selection if focus is moved to other editable of the same editor.
+				if ( !relatedViewElement ) {
+					this.domConverter._clearDomSelection();
+				}
+			} );
+		}
 	}
 
 	/**

--- a/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
@@ -15,6 +15,9 @@ import { BR_FILLER, INLINE_FILLER, INLINE_FILLER_LENGTH, NBSP_FILLER, MARKED_NBS
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 import { StylesProcessor } from '../../../src/view/stylesmap';
+import ViewPosition from '../../../src/view/position';
+import ViewRange from '../../../src/view/range';
+import { ViewText } from '@ckeditor/ckeditor5-engine';
 
 describe( 'DomConverter', () => {
 	let converter, viewDocument;
@@ -1038,6 +1041,92 @@ describe( 'DomConverter', () => {
 			expect( domElement.outerHTML ).to.equal(
 				'<p>foo<span data-ck-unsafe-element="style" style="foo-style" data-foo="bar">bar</span></p>'
 			);
+		} );
+	} );
+
+	describe( '_clearDomSelection()', () => {
+		let viewEditable, domEditable, domEditableParent, domP, domTextNode, viewP, viewText;
+
+		beforeEach( () => {
+			// View structure.
+			viewEditable = new ViewEditable( viewDocument, 'div' );
+			viewP = new ViewContainerElement( viewDocument, 'p' );
+			viewText = new ViewText( viewDocument, 'foobar' );
+
+			viewEditable._insertChild( 0, viewP );
+			viewP._insertChild( 0, viewText );
+
+			// DOM structure.
+			domEditableParent = document.createElement( 'div' );
+			domEditable = document.createElement( 'div' );
+			domP = document.createElement( 'p' );
+			domTextNode = document.createTextNode( 'foobar' );
+
+			domEditable.setAttribute( 'contenteditable', 'true' );
+
+			domP.appendChild( domTextNode );
+			domEditable.appendChild( domP );
+			domEditableParent.appendChild( domEditable );
+			document.body.appendChild( domEditableParent );
+
+			// Binding.
+			converter.bindElements( domEditable, viewEditable );
+			converter.bindElements( domP, viewP );
+		} );
+
+		afterEach( () => {
+			converter.unbindDomElement( domEditable );
+			document.body.removeChild( domEditableParent );
+		} );
+
+		it( 'should remove all selection ranges if selection is in editor editable element', () => {
+			const domSelection = document.getSelection();
+			const viewSelection = viewDocument.selection;
+
+			domSelection.setBaseAndExtent( domTextNode, 3, domTextNode, 5 );
+			viewSelection._setTo( new ViewRange(
+				new ViewPosition( viewP.getChild( 0 ), 3 ),
+				new ViewPosition( viewP.getChild( 0 ), 5 )
+			) );
+
+			converter._clearDomSelection();
+
+			expect( domSelection.rangeCount ).to.equal( 0 );
+		} );
+
+		it( 'should do nothing if DOM selection is not in editor editable element', () => {
+			const domSelection = document.getSelection();
+			const viewSelection = viewDocument.selection;
+
+			domSelection.setBaseAndExtent( domEditableParent, 0, domEditableParent, 0 );
+			viewSelection._setTo( new ViewRange(
+				new ViewPosition( viewP.getChild( 0 ), 3 ),
+				new ViewPosition( viewP.getChild( 0 ), 5 )
+			) );
+
+			converter._clearDomSelection();
+
+			expect( domSelection.rangeCount ).to.equal( 1 );
+			expect( domSelection.anchorNode ).to.equal( domEditableParent );
+			expect( domSelection.anchorOffset ).to.equal( 0 );
+			expect( domSelection.focusNode ).to.equal( domEditableParent );
+			expect( domSelection.focusOffset ).to.equal( 0 );
+		} );
+
+		it( 'should do nothing if view selection is not in editor editable element', () => {
+			const domSelection = document.getSelection();
+			const viewSelection = viewDocument.selection;
+
+			domSelection.setBaseAndExtent( domTextNode, 3, domTextNode, 5 );
+			viewSelection._setTo( null );
+
+			converter._clearDomSelection();
+
+			expect( domSelection.rangeCount ).to.equal( 1 );
+			expect( domSelection.anchorNode ).to.equal( domTextNode );
+			expect( domSelection.anchorOffset ).to.equal( 3 );
+			expect( domSelection.focusNode ).to.equal( domTextNode );
+			expect( domSelection.focusOffset ).to.equal( 5 );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (engine): The DOM selection should not obscure the clickability of dropdown items on iOS. Closes #5753.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
