### PR TITLE
Prevent throwing the warning by sticky panel

### DIFF
--- a/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.ts
@@ -114,11 +114,6 @@ export default class StickyPanelView extends View {
 	declare public _isStickyToTheBottomOfLimiter: boolean;
 
 	/**
-	 * The DOM bounding client rect of the {@link module:ui/view~View#element} of the panel.
-	 */
-	private _panelRect?: Rect;
-
-	/**
 	 * The `top` CSS position of the panel when it is sticky to the top of the viewport or scrollable
 	 * ancestors of the {@link #limiterElement}.
 	 *
@@ -181,7 +176,7 @@ export default class StickyPanelView extends View {
 				style: {
 					display: bind.to( 'isSticky', isSticky => isSticky ? 'block' : 'none' ),
 					height: bind.to( 'isSticky', isSticky => {
-						return isSticky ? toPx( this._panelRect!.height ) : null;
+						return isSticky ? toPx( this._contentPanelRect.height ) : null;
 					} )
 				}
 			}
@@ -269,7 +264,6 @@ export default class StickyPanelView extends View {
 			return;
 		}
 
-		this._panelRect = new Rect( this._contentPanel );
 		const visibleAncestorsRect = _getVisibleAncestorsRect( scrollableAncestors, this.viewportTopOffset );
 		const limiterRect = new Rect( this.limiterElement );
 
@@ -303,7 +297,7 @@ export default class StickyPanelView extends View {
 				const visibleAncestorsTop = visibleAncestorsRect.top;
 
 				// Check if there's a change the panel can be sticky to the bottom of the limiter.
-				if ( visibleAncestorsTop + this._panelRect.height + this.limiterBottomOffset > visibleLimiterRect.bottom ) {
+				if ( visibleAncestorsTop + this._contentPanelRect.height + this.limiterBottomOffset > visibleLimiterRect.bottom ) {
 					const stickyBottomOffset = Math.max( limiterRect.bottom - visibleAncestorsRect.bottom, 0 ) + this.limiterBottomOffset;
 					// @if CK_DEBUG_STICKYPANEL // const stickyBottomOffsetRect = new Rect( {
 					// @if CK_DEBUG_STICKYPANEL // 	top: limiterRect.bottom - stickyBottomOffset, left: 0, right: 2000,
@@ -316,13 +310,13 @@ export default class StickyPanelView extends View {
 
 					// Check if sticking the panel to the bottom of the limiter does not cause it to suddenly
 					// move upwards if there's not enough space for it.
-					if ( limiterRect.bottom - stickyBottomOffset > limiterRect.top + this._panelRect.height ) {
+					if ( limiterRect.bottom - stickyBottomOffset > limiterRect.top + this._contentPanelRect.height ) {
 						this._stickToBottomOfLimiter( stickyBottomOffset );
 					} else {
 						this._unstick();
 					}
 				} else {
-					if ( this._panelRect.height + this.limiterBottomOffset < limiterRect.height ) {
+					if ( this._contentPanelRect.height + this.limiterBottomOffset < limiterRect.height ) {
 						this._stickToTopOfAncestors( visibleAncestorsTop );
 					} else {
 						this._unstick();
@@ -381,6 +375,15 @@ export default class StickyPanelView extends View {
 		this._stickyTopOffset = null;
 		this._stickyBottomOffset = null;
 		this._marginLeft = null;
+	}
+
+	/**
+	 * Returns the bounding rect of the {@link #_contentPanel}.
+	 *
+	 * @private
+	 */
+	private get _contentPanelRect(): Rect {
+		return new Rect( this._contentPanel );
 	}
 }
 

--- a/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.ts
@@ -181,7 +181,7 @@ export default class StickyPanelView extends View {
 				style: {
 					display: bind.to( 'isSticky', isSticky => isSticky ? 'block' : 'none' ),
 					height: bind.to( 'isSticky', isSticky => {
-						return isSticky && this._panelRect ? toPx( this._panelRect.height ) : null;
+						return isSticky ? toPx( this._panelRect!.height ) : null;
 					} )
 				}
 			}

--- a/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.ts
@@ -181,7 +181,7 @@ export default class StickyPanelView extends View {
 				style: {
 					display: bind.to( 'isSticky', isSticky => isSticky ? 'block' : 'none' ),
 					height: bind.to( 'isSticky', isSticky => {
-						return isSticky ? toPx( this._panelRect!.height ) : null;
+						return isSticky && this._panelRect ? toPx( this._panelRect.height ) : null;
 					} )
 				}
 			}
@@ -256,7 +256,6 @@ export default class StickyPanelView extends View {
 	 */
 	public checkIfShouldBeSticky( scrollTarget?: HTMLElement | Document ): void {
 		// @if CK_DEBUG_STICKYPANEL // RectDrawer.clear();
-		this._panelRect = new Rect( this._contentPanel );
 
 		if ( !this.limiterElement || !this.isActive ) {
 			this._unstick();
@@ -270,6 +269,7 @@ export default class StickyPanelView extends View {
 			return;
 		}
 
+		this._panelRect = new Rect( this._contentPanel );
 		const visibleAncestorsRect = _getVisibleAncestorsRect( scrollableAncestors, this.viewportTopOffset );
 		const limiterRect = new Rect( this.limiterElement );
 

--- a/packages/ckeditor5-ui/tests/panel/sticky/stickypanelview.js
+++ b/packages/ckeditor5-ui/tests/panel/sticky/stickypanelview.js
@@ -82,7 +82,6 @@ describe( 'StickyPanelView', () => {
 	describe( 'element view bindings', () => {
 		beforeEach( () => {
 			view.limiterElement = limiterElement;
-			view._panelRect = new Rect( { top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 } );
 		} );
 
 		it( 'update the class on view#isSticky change', () => {
@@ -141,7 +140,6 @@ describe( 'StickyPanelView', () => {
 	describe( '_contentPanelPlaceholder view bindings', () => {
 		beforeEach( () => {
 			view.limiterElement = limiterElement;
-			view._panelRect = new Rect( { top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 } );
 		} );
 
 		it( 'update the style.display on view#isSticky change', () => {
@@ -153,7 +151,9 @@ describe( 'StickyPanelView', () => {
 		} );
 
 		it( 'update the style.height on view#isSticky change', () => {
-			view._panelRect = { height: 50 };
+			sinon.stub( view, '_contentPanelRect' ).get( () => new Rect( {
+				top: 0, right: 50, left: 0, bottom: 50, height: 50, width: 50
+			} ) );
 
 			view.isSticky = false;
 			expect( placeholderElement.style.height ).to.equal( '' );

--- a/packages/ckeditor5-ui/tests/panel/sticky/stickypanelview.js
+++ b/packages/ckeditor5-ui/tests/panel/sticky/stickypanelview.js
@@ -5,7 +5,7 @@
 
 /* globals document, Event */
 
-import global from '@ckeditor/ckeditor5-utils/src/dom/global';
+import { Rect, global } from '@ckeditor/ckeditor5-utils';
 import StickyPanelView from '../../../src/panel/sticky/stickypanelview';
 import View from '../../../src/view';
 import LabelView from '../../../src/label/labelview';
@@ -82,6 +82,7 @@ describe( 'StickyPanelView', () => {
 	describe( 'element view bindings', () => {
 		beforeEach( () => {
 			view.limiterElement = limiterElement;
+			view._panelRect = new Rect( { top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 } );
 		} );
 
 		it( 'update the class on view#isSticky change', () => {
@@ -140,6 +141,7 @@ describe( 'StickyPanelView', () => {
 	describe( '_contentPanelPlaceholder view bindings', () => {
 		beforeEach( () => {
 			view.limiterElement = limiterElement;
+			view._panelRect = new Rect( { top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0 } );
 		} );
 
 		it( 'update the style.display on view#isSticky change', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix(ui): Sticky panel will no longer log a warning to the console on initialisation. Closes #14582.

---

### Additional information

This change [https://github.com/ckeditor/ckeditor5/blob/0634ea16bb1429688ee1aa27c62f17ab9837ca36/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.ts#L184](https://github.com/ckeditor/ckeditor5/blob/0634ea16bb1429688ee1aa27c62f17ab9837ca36/packages/ckeditor5-ui/src/panel/sticky/stickypanelview.ts#L184) was necessary to keep the tests passing.