### PR TITLE
PoweredBy is shown outside parent with overflow while scrolling horizontally.

### DIFF
--- a/packages/ckeditor5-ui/src/editorui/poweredby.ts
+++ b/packages/ckeditor5-ui/src/editorui/poweredby.ts
@@ -352,14 +352,21 @@ function getLowerCornerPosition(
 
 			if ( firstScrollableEditableElementAncestor ) {
 				const firstScrollableEditableElementAncestorRect = new Rect( firstScrollableEditableElementAncestor );
+				const notVisibleVertically = visibleEditableElementRect.bottom + balloonRect.height / 2 >
+				firstScrollableEditableElementAncestorRect.bottom;
+				const notVisibleHorizontally = visibleEditableElementRect.right >= firstScrollableEditableElementAncestorRect.right;
 
-				// The watermark cannot be positioned in this corner because the corner is "not visible enough".
-				if ( visibleEditableElementRect.bottom + balloonRect.height / 2 > firstScrollableEditableElementAncestorRect.bottom ) {
+				// The watermark cannot be positioned in this corner because the corner is "not visible enough" vertically.
+				if ( notVisibleVertically ) {
+					return OFF_THE_SCREEN_POSITION;
+				}
+
+				// The watermark cannot be positioned in this corner because the corner is "not visible enough" horizontally.
+				if ( notVisibleHorizontally ) {
 					return OFF_THE_SCREEN_POSITION;
 				}
 			}
 		}
-
 		return {
 			top: balloonTop,
 			left: balloonLeft,

--- a/packages/ckeditor5-ui/tests/editorui/poweredby.js
+++ b/packages/ckeditor5-ui/tests/editorui/poweredby.js
@@ -479,14 +479,34 @@ describe( 'PoweredBy', () => {
 			balloonRect = new Rect( { top: 0, left: 0, width: 20, right: 20, bottom: 10, height: 10 } );
 		} );
 
-		it( 'should not show the balloon if the root is not visible', async () => {
+		it( 'should not show the balloon if the root is not visible vertically', async () => {
 			const domRoot = editor.editing.view.getDomRoot();
 			const parentWithOverflow = document.createElement( 'div' );
 			parentWithOverflow.style.overflow = 'scroll';
-			parentWithOverflow.style.height = '0px';
-			parentWithOverflow.style.width = '0px';
-			domRoot.style.marginTop = '1000px';
-			domRoot.style.marginLeft = '1000px';
+			// Is not enough height to be visible vertically.
+			parentWithOverflow.style.height = '99px';
+			// Enough width to be visible horizontally.
+			parentWithOverflow.style.width = '393px';
+
+			document.body.appendChild( parentWithOverflow );
+			parentWithOverflow.appendChild( domRoot );
+
+			focusEditor( editor );
+
+			expect( editor.ui.poweredBy._balloonView.isVisible ).to.be.true;
+			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'invalid' );
+
+			parentWithOverflow.remove();
+		} );
+
+		it( 'should not show the balloon if the root is not visible horizontally', async () => {
+			const domRoot = editor.editing.view.getDomRoot();
+			const parentWithOverflow = document.createElement( 'div' );
+			parentWithOverflow.style.overflow = 'scroll';
+			// Enough height to be visible vertically.
+			parentWithOverflow.style.height = '100px';
+			// Is not enough width to be visible horizontally.
+			parentWithOverflow.style.width = '392px';
 
 			document.body.appendChild( parentWithOverflow );
 			parentWithOverflow.appendChild( domRoot );
@@ -899,8 +919,8 @@ describe( 'PoweredBy', () => {
 			domRoot.getBoundingClientRect.returns( {
 				top: 0,
 				left: 0,
-				right: 1000,
-				width: 1000,
+				right: 999,
+				width: 999,
 				bottom: 49,
 				height: 49
 			} );
@@ -920,8 +940,8 @@ describe( 'PoweredBy', () => {
 			domRoot.getBoundingClientRect.returns( {
 				top: 0,
 				left: 0,
-				right: 1000,
-				width: 1000,
+				right: 999,
+				width: 999,
 				bottom: 50,
 				height: 50
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): hide PWC ballon when it is outside the editor horizontally. Closes #14524 .

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
