### PR TITLE
CI: Added the "skipCompilingFramework" flag for testing script

### DIFF
--- a/scripts/ci/check-packages-code-coverage.js
+++ b/scripts/ci/check-packages-code-coverage.js
@@ -36,15 +36,17 @@ const travisFolder = new TravisFolder();
  * @param {Array.<String>} [options.skipPackages=[]] Parameter including names of packages that should be skipped from testing.
  * @param {Array.<String>} [options.allowNonFullCoveragePackages=[]] Parameter including names of packages that should not enforce full
  * coverage.
+ * @param {Boolean} [options.skipCompilingFramework=false] Whether to compile framework packages.
  * @returns {Number} A bash exit code. When returns `0`, everything is fine (no errors).
  */
-module.exports = function checkPackagesCodeCoverage( {
+module.exports = function executePackageTests( {
 	repositoryDirectory = CKEDITOR5_ROOT_DIRECTORY,
 	packagesDirectory = 'packages',
 	shouldRunFrameworkTests = true,
 	isPublicRepository = true,
 	skipPackages = [],
-	allowNonFullCoveragePackages = []
+	allowNonFullCoveragePackages = [],
+	skipCompilingFramework = false
 } ) {
 	childProcess.execSync( 'rm -r -f .nyc_output', { stdio: 'inherit' } );
 	childProcess.execSync( 'mkdir .nyc_output', { stdio: 'inherit' } );
@@ -66,38 +68,42 @@ module.exports = function checkPackagesCodeCoverage( {
 		[ 'ckeditor5', ...frameworkPackages ].forEach( packageName => checkPackage( packageName, allowNonFullCoveragePackages ) );
 	}
 
-	travisFolder.start( 'typescript-compilation', magenta( 'Compiling CKEditor 5 Framework TypeScript packages' ) );
+	if ( !skipCompilingFramework ) {
+		travisFolder.start( 'typescript-compilation', magenta( 'Compiling CKEditor 5 Framework TypeScript packages' ) );
 
-	for ( const fullPackageName of frameworkPackages ) {
-		console.log( yellow( `\nCompiling ${ fullPackageName }` ) );
+		for ( const fullPackageName of frameworkPackages ) {
+			console.log( yellow( `\nCompiling ${ fullPackageName }` ) );
 
-		const cwd = path.join( CKEDITOR5_ROOT_DIRECTORY, 'packages', fullPackageName );
-		const pkgJsonPath = path.join( cwd, 'package.json' );
+			const cwd = path.join( CKEDITOR5_ROOT_DIRECTORY, 'packages', fullPackageName );
+			const pkgJsonPath = path.join( cwd, 'package.json' );
 
-		const pkgJson = JSON.parse( fs.readFileSync( pkgJsonPath, 'utf-8' ) );
-		const hasBuildScript = pkgJson.scripts && pkgJson.scripts.build;
+			const pkgJson = JSON.parse( fs.readFileSync( pkgJsonPath, 'utf-8' ) );
+			const hasBuildScript = pkgJson.scripts && pkgJson.scripts.build;
 
-		if ( !hasBuildScript ) {
-			console.log( 'No build script found, skipping.' );
+			if ( !hasBuildScript ) {
+				console.log( 'No build script found, skipping.' );
 
-			continue;
+				continue;
+			}
+
+			const command = 'yarn run build --sourceMap';
+
+			console.log( '* ' + command );
+			childProcess.execSync( command, { cwd, stdio: 'inherit' } );
+
+			console.log( '* Updating the "main" field in `package.json`.' );
+
+			const pkgJsonMain = pkgJson.main;
+			pkgJson.main = pkgJsonMain.replace( /\.ts$/, '.js' );
+			pkgJson.types = pkgJsonMain.replace( /\.ts$/, '.d.ts' );
+
+			fs.writeFileSync( pkgJsonPath, JSON.stringify( pkgJson, null, 2 ) + '\n', 'utf-8' );
 		}
 
-		const command = 'yarn run build --sourceMap';
-
-		console.log( '* ' + command );
-		childProcess.execSync( command, { cwd, stdio: 'inherit' } );
-
-		console.log( '* Updating the "main" field in `package.json`.' );
-
-		const pkgJsonMain = pkgJson.main;
-		pkgJson.main = pkgJsonMain.replace( /\.ts$/, '.js' );
-		pkgJson.types = pkgJsonMain.replace( /\.ts$/, '.d.ts' );
-
-		fs.writeFileSync( pkgJsonPath, JSON.stringify( pkgJson, null, 2 ) + '\n', 'utf-8' );
+		travisFolder.end( 'typescript-compilation' );
+	} else {
+		console.log( yellow( '\nSkipping compiling CKEditor5 Framework Typescript packages\n' ) );
 	}
-
-	travisFolder.end( 'typescript-compilation' );
 
 	console.log( magenta( '\nVerifying CKEditor 5 Features\n' ) );
 

--- a/scripts/ci/check-packages-code-coverage.js
+++ b/scripts/ci/check-packages-code-coverage.js
@@ -39,7 +39,7 @@ const travisFolder = new TravisFolder();
  * @param {Boolean} [options.skipCompilingFramework=false] Whether to compile framework packages.
  * @returns {Number} A bash exit code. When returns `0`, everything is fine (no errors).
  */
-module.exports = function executePackageTests( {
+module.exports = function checkPackagesCodeCoverage( {
 	repositoryDirectory = CKEDITOR5_ROOT_DIRECTORY,
 	packagesDirectory = 'packages',
 	shouldRunFrameworkTests = true,
@@ -102,7 +102,7 @@ module.exports = function executePackageTests( {
 
 		travisFolder.end( 'typescript-compilation' );
 	} else {
-		console.log( yellow( '\nSkipping compiling CKEditor5 Framework Typescript packages\n' ) );
+		console.log( yellow( '\nSkipping compiling CKEditor 5 Framework TypeScript packages\n' ) );
 	}
 
 	console.log( magenta( '\nVerifying CKEditor 5 Features\n' ) );

--- a/scripts/ci/travis-check.js
+++ b/scripts/ci/travis-check.js
@@ -13,7 +13,7 @@ const childProcess = require( 'child_process' );
 const path = require( 'path' );
 
 const { cyan, green } = require( './ansi-colors' );
-const executePackageTests = require( './check-packages-code-coverage' );
+const checkPackagesCodeCoverage = require( './check-packages-code-coverage' );
 const execFactory = require( './exec-factory' );
 const shouldRunShortFlow = require( './should-run-short-flow' );
 const triggerCkeditor5ContinuousIntegration = require( './trigger-ckeditor5-continuous-integration' );
@@ -41,7 +41,7 @@ function testsJob() {
 	if ( shortFlow ) {
 		console.log( green( 'Only the documentation files were modified, skipping checking the code coverage.\n' ) );
 	} else {
-		const coverageExitCode = executePackageTests( {
+		const coverageExitCode = checkPackagesCodeCoverage( {
 			skipPackages: [ 'ckeditor5-minimap' ]
 		} );
 

--- a/scripts/ci/travis-check.js
+++ b/scripts/ci/travis-check.js
@@ -13,7 +13,7 @@ const childProcess = require( 'child_process' );
 const path = require( 'path' );
 
 const { cyan, green } = require( './ansi-colors' );
-const checkPackagesCodeCoverage = require( './check-packages-code-coverage' );
+const executePackageTests = require( './check-packages-code-coverage' );
 const execFactory = require( './exec-factory' );
 const shouldRunShortFlow = require( './should-run-short-flow' );
 const triggerCkeditor5ContinuousIntegration = require( './trigger-ckeditor5-continuous-integration' );
@@ -41,7 +41,7 @@ function testsJob() {
 	if ( shortFlow ) {
 		console.log( green( 'Only the documentation files were modified, skipping checking the code coverage.\n' ) );
 	} else {
-		const coverageExitCode = checkPackagesCodeCoverage( {
+		const coverageExitCode = executePackageTests( {
 			skipPackages: [ 'ckeditor5-minimap' ]
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: CI: Added the `skipCompilingFramework` flag for the testing script to avoid compiling the CKEditor 5 framework twice when executing the same command in different scenarios.

See cksource/collaboration-features#5338.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
