### PR TITLE
Removed dependency badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ CKEditor 5 [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?styl
 [![npm version](https://badge.fury.io/js/ckeditor5.svg)](https://www.npmjs.com/package/ckeditor5)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/ckeditor5)
 ![TypeScript Support](https://badgen.net/badge/Built%20With/TypeScript/blue)
 
 [![Join newsletter](https://img.shields.io/badge/join-newsletter-00cc99.svg)](http://eepurl.com/c3zRPr)

--- a/packages/ckeditor5-adapter-ckfinder/README.md
+++ b/packages/ckeditor5-adapter-ckfinder/README.md
@@ -4,7 +4,6 @@ CKEditor 5 CKFinder adapter
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-adapter-ckfinder.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-adapter-ckfinder)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-adapter-ckfinder)
 
 This package implements a CKEditor 5 upload adapter compatible with the [CKFinder file manager and uploader](https://ckeditor.com/ckfinder/)'s server–side connector.
 

--- a/packages/ckeditor5-alignment/README.md
+++ b/packages/ckeditor5-alignment/README.md
@@ -4,7 +4,6 @@ CKEditor 5 text alignment feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-alignment.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-alignment)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-alignment)
 
 This package implements text alignment support for CKEditor 5.
 

--- a/packages/ckeditor5-autoformat/README.md
+++ b/packages/ckeditor5-autoformat/README.md
@@ -4,7 +4,6 @@ CKEditor 5 autoformat feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-autoformat.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-autoformat)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-autoformat)
 
 This package implements the autoformatting feature for CKEditor 5. It allows styling text by typing sequences like `**bold this**`.
 

--- a/packages/ckeditor5-autosave/README.md
+++ b/packages/ckeditor5-autosave/README.md
@@ -4,7 +4,6 @@ CKEditor 5 autosave feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-autosave.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-autosave)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-autosave)
 
 This package implements the autosave feature for CKEditor 5.
 

--- a/packages/ckeditor5-basic-styles/README.md
+++ b/packages/ckeditor5-basic-styles/README.md
@@ -4,7 +4,6 @@ CKEditor 5 basic styles feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-basic-styles.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-basic-styles)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-basic-styles)
 
 This package contains CKEditor 5 features allowing to apply basic text formatting such as bold, italic, underline, and code in CKEditor 5.
 

--- a/packages/ckeditor5-block-quote/README.md
+++ b/packages/ckeditor5-block-quote/README.md
@@ -4,7 +4,6 @@ CKEditor 5 block quote feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-block-quote.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-block-quote)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-block-quote)
 
 This package implements block quote support for CKEditor 5.
 

--- a/packages/ckeditor5-build-balloon-block/README.md
+++ b/packages/ckeditor5-build-balloon-block/README.md
@@ -4,7 +4,6 @@ CKEditor 5 balloon block editor build
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-build-balloon-block.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-balloon-block)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-build-balloon-block)
 
 The build of CKEditor 5 featuring the balloon and block toolbars. Read more about the [balloon block editor build](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/predefined-builds.html#balloon-block-editor) and see the [demo](https://ckeditor.com/docs/ckeditor5/latest/examples/builds/balloon-block-editor.html).
 

--- a/packages/ckeditor5-build-balloon/README.md
+++ b/packages/ckeditor5-build-balloon/README.md
@@ -4,7 +4,6 @@ CKEditor 5 balloon editor build
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-build-balloon.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-balloon)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-build-balloon)
 
 The balloon editor build for CKEditor 5. Read more about the [balloon editor build](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/predefined-builds.html#balloon-editor) and see the [demo](https://ckeditor.com/docs/ckeditor5/latest/examples/builds/balloon-editor.html).
 

--- a/packages/ckeditor5-build-classic/README.md
+++ b/packages/ckeditor5-build-classic/README.md
@@ -4,7 +4,6 @@ CKEditor 5 classic editor build
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-build-classic.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-classic)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-build-classic)
 
 The classic editor build for CKEditor 5. Read more about the [classic editor build](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/predefined-builds.html#classic-editor) and see the [demo](https://ckeditor.com/docs/ckeditor5/latest/examples/builds/classic-editor.html).
 

--- a/packages/ckeditor5-build-decoupled-document/README.md
+++ b/packages/ckeditor5-build-decoupled-document/README.md
@@ -4,7 +4,6 @@ CKEditor 5 document editor build
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-build-decoupled-document.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-decoupled-document)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-build-decoupled-document)
 
 The document editor build for CKEditor 5, featuring the decoupled UI editor implementation. Read more about the [document editor build](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/predefined-builds.html#document-editor) and see the [demo](https://ckeditor.com/docs/ckeditor5/latest/examples/builds/document-editor.html).
 

--- a/packages/ckeditor5-build-inline/README.md
+++ b/packages/ckeditor5-build-inline/README.md
@@ -4,7 +4,6 @@ CKEditor 5 inline editor build
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-build-inline.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-inline)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-build-inline)
 
 The inline editor build for CKEditor 5. Read more about the [inline editor build](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/predefined-builds.html#inline-editor) and see the [demo](https://ckeditor.com/docs/ckeditor5/latest/examples/builds/inline-editor.html).
 

--- a/packages/ckeditor5-build-multi-root/README.md
+++ b/packages/ckeditor5-build-multi-root/README.md
@@ -4,7 +4,6 @@ CKEditor 5 multi-root editor build
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-build-multi-root.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-build-multi-root)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-build-multi-root)
 
 The multi-root editor build for CKEditor 5. Read more about the [multi-root editor build](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/predefined-builds.html#multi-root-editor) and see the [demo](https://ckeditor.com/docs/ckeditor5/latest/examples/builds/multi-root-editor.html).
 

--- a/packages/ckeditor5-ckbox/README.md
+++ b/packages/ckeditor5-ckbox/README.md
@@ -4,7 +4,6 @@ CKEditor 5 CKBox integration
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-ckbox.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-ckbox)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-ckbox)
 
 This package implements the [CKBox feature](https://ckeditor.com/docs/ckeditor5/latest/features/file-management/ckbox.html). It allows you to easily insert images as well as links to files into the editor content. It is a bridge between CKEditor 5 WYSIWYG editor and [CKBox](https://ckeditor.com/ckbox/) file manager and uploader.
 

--- a/packages/ckeditor5-ckfinder/README.md
+++ b/packages/ckeditor5-ckfinder/README.md
@@ -4,7 +4,6 @@ CKEditor 5's CKFinder integration
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-ckfinder.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-ckfinder)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-ckfinder)
 
 This package implements the [CKFinder feature](https://ckeditor.com/docs/ckeditor5/latest/features/ckfinder.html). This feature allows you to easily insert images as well as links to files into the editor content. It is a bridge between CKEditor 5 WYSIWYG editor and [CKFinder file manager and uploader](https://ckeditor.com/ckfinder).
 

--- a/packages/ckeditor5-clipboard/README.md
+++ b/packages/ckeditor5-clipboard/README.md
@@ -4,7 +4,6 @@ CKEditor 5 clipboard feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-clipboard.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-clipboard)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-clipboard)
 
 This package implements the clipboard (copy, cut, paste) support for CKEditor 5.
 

--- a/packages/ckeditor5-cloud-services/README.md
+++ b/packages/ckeditor5-cloud-services/README.md
@@ -4,7 +4,6 @@ CKEditor 5's Cloud Services integration
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-cloud-services.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-cloud-services)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-cloud-services)
 
 CKEditor 5's [Cloud Services](https://ckeditor.com/ckeditor-cloud-services/) integration layer, which handles `config.cloudServices` and tokens.
 

--- a/packages/ckeditor5-code-block/README.md
+++ b/packages/ckeditor5-code-block/README.md
@@ -4,7 +4,6 @@ CKEditor 5 code block feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-code-block.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-code-block)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-code-block)
 
 This package implements the code block feature for CKEditor 5.
 

--- a/packages/ckeditor5-core/README.md
+++ b/packages/ckeditor5-core/README.md
@@ -4,7 +4,6 @@ CKEditor 5 core editor architecture
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-core.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-core)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-core)
 
 This package implements CKEditor 5's core editor architecture &mdash; a set of classes and interfaces which glue everything together.
 

--- a/packages/ckeditor5-easy-image/README.md
+++ b/packages/ckeditor5-easy-image/README.md
@@ -4,7 +4,6 @@ CKEditor 5 Easy Image feature with Cloud Services
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-easy-image.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-easy-image)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-easy-image)
 
 This package implements the [Easy Image](https://ckeditor.com/docs/ckeditor5/latest/features/easy-image.html) feature for CKEditor 5.
 

--- a/packages/ckeditor5-editor-balloon/README.md
+++ b/packages/ckeditor5-editor-balloon/README.md
@@ -4,7 +4,6 @@ CKEditor 5 balloon editor implementation
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-editor-balloon.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-editor-balloon)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-editor-balloon)
 
 The balloon editor implementation (Medium-like editor) for CKEditor 5.
 

--- a/packages/ckeditor5-editor-classic/README.md
+++ b/packages/ckeditor5-editor-classic/README.md
@@ -4,7 +4,6 @@ CKEditor 5 classic editor implementation
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-editor-classic.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-editor-classic)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-editor-classic)
 
 The classic editor implementation for CKEditor 5.
 

--- a/packages/ckeditor5-editor-decoupled/README.md
+++ b/packages/ckeditor5-editor-decoupled/README.md
@@ -4,7 +4,6 @@ CKEditor 5 decoupled editor implementation
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-editor-decoupled.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-editor-decoupled)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-editor-decoupled)
 
 The decoupled editor implementation for CKEditor 5.
 

--- a/packages/ckeditor5-editor-inline/README.md
+++ b/packages/ckeditor5-editor-inline/README.md
@@ -4,7 +4,6 @@ CKEditor 5 inline editor implementation
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-editor-inline.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-editor-inline)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-editor-inline)
 
 The inline editor implementation for CKEditor 5.
 

--- a/packages/ckeditor5-editor-multi-root/README.md
+++ b/packages/ckeditor5-editor-multi-root/README.md
@@ -4,7 +4,6 @@ CKEditor 5 multi-root editor implementation
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-editor-multi-root.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-editor-multi-root)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-editor-multi-root)
 
 The multi-root editor implementation for CKEditor 5. Read more about the [multi-root editor build](https://ckeditor.com/docs/ckeditor5/latest/installation/getting-started/predefined-builds.html#multi-root-editor) and see the [demo](https://ckeditor.com/docs/ckeditor5/latest/examples/builds/multi-root-editor.html).
 

--- a/packages/ckeditor5-engine/README.md
+++ b/packages/ckeditor5-engine/README.md
@@ -4,7 +4,6 @@ CKEditor 5 editing engine
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-engine.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-engine)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-engine)
 
 The CKEditor 5 editing engine implements a flexible MVC-based architecture for creating rich text editing features.
 

--- a/packages/ckeditor5-enter/README.md
+++ b/packages/ckeditor5-enter/README.md
@@ -4,7 +4,6 @@ CKEditor 5 enter feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-enter.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-enter)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-enter)
 
 This package implements the <kbd>Enter</kbd> and <kbd>Shift</kbd>+<kbd>Enter</kbd> (soft break) support for CKEditor 5.
 

--- a/packages/ckeditor5-essentials/README.md
+++ b/packages/ckeditor5-essentials/README.md
@@ -4,7 +4,6 @@ CKEditor 5 essentials plugin
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-essentials.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-essentials)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-essentials)
 
 Essential editing features for CKEditor 5 wrapped in one plugin.
 

--- a/packages/ckeditor5-find-and-replace/README.md
+++ b/packages/ckeditor5-find-and-replace/README.md
@@ -4,7 +4,6 @@ CKEditor 5 find and replace feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-find-and-replace.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-find-and-replace)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-find-and-replace)
 
 This package implements the find and replace feature for CKEditor 5.
 

--- a/packages/ckeditor5-font/README.md
+++ b/packages/ckeditor5-font/README.md
@@ -4,7 +4,6 @@ CKEditor 5 font feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-font.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-font)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-font)
 
 This package implements support for the following CKEditor 5 features:
 

--- a/packages/ckeditor5-heading/README.md
+++ b/packages/ckeditor5-heading/README.md
@@ -4,7 +4,6 @@ CKEditor 5 headings feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-heading.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-heading)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-heading)
 
 This package implements the headings feature for CKEditor 5.
 

--- a/packages/ckeditor5-highlight/README.md
+++ b/packages/ckeditor5-highlight/README.md
@@ -4,7 +4,6 @@ CKEditor 5 highlight feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-highlight.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-highlight)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-highlight)
 
 This package implements text highlight support for CKEditor 5.
 

--- a/packages/ckeditor5-horizontal-line/README.md
+++ b/packages/ckeditor5-horizontal-line/README.md
@@ -4,7 +4,6 @@ CKEditor 5 horizontal line feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-horizontal-line.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-horizontal-line)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-horizontal-line)
 
 This package implements the horizontal line feature for CKEditor 5.
 

--- a/packages/ckeditor5-html-embed/README.md
+++ b/packages/ckeditor5-html-embed/README.md
@@ -4,7 +4,6 @@ CKEditor 5 HTML embed feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-html-embed.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-html-embed)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-html-embed)
 
 This package implements the HTML embed feature for CKEditor 5. It allows embedding an arbitrary HTML snippet in the rich-text editor.
 

--- a/packages/ckeditor5-html-support/README.md
+++ b/packages/ckeditor5-html-support/README.md
@@ -4,7 +4,6 @@ CKEditor 5 HTML Support feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-html-support.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-html-support)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-html-support)
 
 This package implements the General HTML Support feature for CKEditor 5. It allows enabling unsupported HTML features in the rich-text editor at low cost.
 

--- a/packages/ckeditor5-image/README.md
+++ b/packages/ckeditor5-image/README.md
@@ -4,7 +4,6 @@ CKEditor 5 image feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-image.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-image)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-image)
 
 This package implements the image feature for CKEditor 5. The feature is introduced in a granular form implemented by a couple of plugins.
 

--- a/packages/ckeditor5-indent/README.md
+++ b/packages/ckeditor5-indent/README.md
@@ -4,7 +4,6 @@ CKEditor 5 block indentation feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-indent.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-indent)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-indent)
 
 This package implements block indentation support for CKEditor 5.
 

--- a/packages/ckeditor5-language/README.md
+++ b/packages/ckeditor5-language/README.md
@@ -4,7 +4,6 @@ CKEditor 5 text part language feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-language.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-language)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-language)
 
 This package implements text part language support for CKEditor 5 that allows you to define the language for each passage of content written in multiple languages. It helps satisfy the [WCAG Success Criterion 3.1.2 Language of Parts](https://www.w3.org/TR/UNDERSTANDING-WCAG20/meaning-other-lang-id.html).
 

--- a/packages/ckeditor5-link/README.md
+++ b/packages/ckeditor5-link/README.md
@@ -4,7 +4,6 @@ CKEditor 5 link feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-link.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-link)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-link)
 
 This package implements the link feature for CKEditor 5. It allows for inserting hyperlinks into the edited content and offers the UI to create and edit them.
 

--- a/packages/ckeditor5-list/README.md
+++ b/packages/ckeditor5-list/README.md
@@ -4,7 +4,6 @@ CKEditor 5 list feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-list.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-list)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-list)
 
 This package implements bulleted, numbered and to-do list feature for CKEditor 5.
 

--- a/packages/ckeditor5-markdown-gfm/README.md
+++ b/packages/ckeditor5-markdown-gfm/README.md
@@ -4,7 +4,6 @@ GitHub Flavored Markdown support for CKEditor 5
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-markdown-gfm.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-markdown-gfm)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-markdown-gfm)
 
 This package implements the GitHub Flavored Markdown data processor for CKEditor 5.
 

--- a/packages/ckeditor5-media-embed/README.md
+++ b/packages/ckeditor5-media-embed/README.md
@@ -4,7 +4,6 @@ CKEditor 5 media embed feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-media-embed.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-media-embed)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-media-embed)
 
 This package implements the media embed feature for CKEditor 5. You can use it to insert embeddable media such as YouTube or Vimeo videos and tweets into your rich text content.
 

--- a/packages/ckeditor5-mention/README.md
+++ b/packages/ckeditor5-mention/README.md
@@ -4,7 +4,6 @@ CKEditor 5 mention feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-mention.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-mention)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-mention)
 
 This package implements mention support for CKEditor 5 and brings smart autocompletion based on user input.
 

--- a/packages/ckeditor5-minimap/README.md
+++ b/packages/ckeditor5-minimap/README.md
@@ -4,7 +4,6 @@ CKEditor 5 Minimap Feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-minimap.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-minimap)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-minimap)
 
 This package implements the content minimap feature for CKEditor 5.
 

--- a/packages/ckeditor5-page-break/README.md
+++ b/packages/ckeditor5-page-break/README.md
@@ -4,7 +4,6 @@ CKEditor 5 page break feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-page-break.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-page-break)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-page-break)
 
 This package implements the page break feature for CKEditor 5.
 

--- a/packages/ckeditor5-paragraph/README.md
+++ b/packages/ckeditor5-paragraph/README.md
@@ -4,7 +4,6 @@ CKEditor 5 paragraph feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-paragraph.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-paragraph)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-paragraph)
 
 This package implements paragraph support for CKEditor 5.
 

--- a/packages/ckeditor5-paste-from-office/README.md
+++ b/packages/ckeditor5-paste-from-office/README.md
@@ -4,7 +4,6 @@ CKEditor 5 paste from Office feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-paste-from-office.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-paste-from-office)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-paste-from-office)
 
 This package implements the [paste from Office](https://docs.ckeditor.com/ckeditor5/latest/features/paste-from-office.html) feature for CKEditor 5.
 

--- a/packages/ckeditor5-remove-format/README.md
+++ b/packages/ckeditor5-remove-format/README.md
@@ -4,7 +4,6 @@ CKEditor 5 remove format feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-remove-format.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-remove-format)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-remove-format)
 
 This package implements remove format support for CKEditor 5.
 

--- a/packages/ckeditor5-restricted-editing/README.md
+++ b/packages/ckeditor5-restricted-editing/README.md
@@ -4,7 +4,6 @@ CKEditor 5 restricted editing feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-restricted-editing.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-restricted-editing)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-restricted-editing)
 
 This package implements the restricted editing feature for CKEditor 5.
 

--- a/packages/ckeditor5-select-all/README.md
+++ b/packages/ckeditor5-select-all/README.md
@@ -4,7 +4,6 @@ CKEditor 5 select all feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-select-all.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-select-all)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-select-all)
 
 This package implements the select all feature for CKEditor 5.
 

--- a/packages/ckeditor5-show-blocks/README.md
+++ b/packages/ckeditor5-show-blocks/README.md
@@ -4,7 +4,6 @@ CKEditor 5 show blocks feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-show-blocks.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-show-blocks)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-show-blocks)
 
 This package contains the show blocks feature for CKEditor 5. It allows to visualize all block-level elements by surrounding them with an outline and displaying their element name at the top-left.
 

--- a/packages/ckeditor5-source-editing/README.md
+++ b/packages/ckeditor5-source-editing/README.md
@@ -4,7 +4,6 @@ CKEditor 5 source editing feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-source-editing.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-source-editing)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-source-editing)
 
 This package implements the source editing support for CKEditor 5 that allows you to view and edit the source of the document.
 

--- a/packages/ckeditor5-special-characters/README.md
+++ b/packages/ckeditor5-special-characters/README.md
@@ -4,7 +4,6 @@ CKEditor 5 special characters feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-special-characters.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-special-characters)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-special-characters)
 
 This package implements the special characters feature for CKEditor 5.
 

--- a/packages/ckeditor5-style/README.md
+++ b/packages/ckeditor5-style/README.md
@@ -4,7 +4,6 @@ CKEditor 5 style feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-style.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-style)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-style)
 
 This package implements the style feature for CKEditor 5.
 

--- a/packages/ckeditor5-table/README.md
+++ b/packages/ckeditor5-table/README.md
@@ -4,7 +4,6 @@ CKEditor 5 table feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-table.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-table)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-table)
 
 This package implements table support for CKEditor 5.
 

--- a/packages/ckeditor5-theme-lark/README.md
+++ b/packages/ckeditor5-theme-lark/README.md
@@ -4,7 +4,6 @@ CKEditor 5 lark theme
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-theme-lark.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-theme-lark)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-theme-lark)
 
 This package implements lark theme &mdash; the default CKEditor 5 theme.
 

--- a/packages/ckeditor5-typing/README.md
+++ b/packages/ckeditor5-typing/README.md
@@ -4,7 +4,6 @@ CKEditor 5 typing feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-typing.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-typing)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-typing)
 
 This package implements support for typing (inputting and deleting text) in CKEditor 5. It also includes the automatic text transformations (autocorrect) feature that lets you automatically turn predefined snippets into their improved forms.
 

--- a/packages/ckeditor5-ui/README.md
+++ b/packages/ckeditor5-ui/README.md
@@ -4,7 +4,6 @@ CKEditor 5 UI framework
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-ui.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-ui)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-ui)
 
 This package implements a simple UI framework and CKEditor 5's standard UI library.
 

--- a/packages/ckeditor5-undo/README.md
+++ b/packages/ckeditor5-undo/README.md
@@ -4,7 +4,6 @@ CKEditor 5 undo feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-undo.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-undo)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-undo)
 
 This package implements undo support for CKEditor 5.
 

--- a/packages/ckeditor5-upload/README.md
+++ b/packages/ckeditor5-upload/README.md
@@ -4,7 +4,6 @@ CKEditor 5 file upload feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-upload.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-upload)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-upload)
 
 This package implements various file upload utilities for CKEditor 5.
 

--- a/packages/ckeditor5-utils/README.md
+++ b/packages/ckeditor5-utils/README.md
@@ -4,7 +4,6 @@ CKEditor 5 utilities
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-utils.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-utils)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-utils)
 
 Various utilities used by CKEditor 5 and its features. This is a sort of  CKEditor 5's standard library.
 

--- a/packages/ckeditor5-watchdog/README.md
+++ b/packages/ckeditor5-watchdog/README.md
@@ -4,7 +4,6 @@ CKEditor 5 watchdog feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-watchdog.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-watchdog)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-watchdog)
 
 This package implements the watchdog feature for CKEditor 5. It keeps a CKEditor 5 rich-text editor instance running.
 

--- a/packages/ckeditor5-widget/README.md
+++ b/packages/ckeditor5-widget/README.md
@@ -4,7 +4,6 @@ CKEditor 5 widget API
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-widget.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-widget)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-widget)
 
 This package implements the widget API for CKEditor 5.
 

--- a/packages/ckeditor5-word-count/README.md
+++ b/packages/ckeditor5-word-count/README.md
@@ -4,7 +4,6 @@ CKEditor 5 word and character count feature
 [![npm version](https://badge.fury.io/js/%40ckeditor%2Fckeditor5-word-count.svg)](https://www.npmjs.com/package/@ckeditor/ckeditor5-word-count)
 [![Coverage Status](https://coveralls.io/repos/github/ckeditor/ckeditor5/badge.svg?branch=master)](https://coveralls.io/github/ckeditor/ckeditor5?branch=master)
 [![Build Status](https://travis-ci.com/ckeditor/ckeditor5.svg?branch=master)](https://app.travis-ci.com/github/ckeditor/ckeditor5)
-![Dependency Status](https://img.shields.io/librariesio/release/npm/@ckeditor/ckeditor5-word-count)
 
 This package implements word count and character count support for CKEditor 5.
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Removed dependency badges from all CKEditor 5 packages.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
