### PR TITLE
Focus observer should be flushed even if the new selection is equal to the document selection.

### DIFF
--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -253,6 +253,9 @@ export default class SelectionObserver extends Observer {
 
 		this.view.hasDomSelection = true;
 
+		// Mark the latest focus change as complete (we got new selection after the focus so the selection is in the focused element).
+		this.focusObserver.flush();
+
 		if ( this.selection.isEqual( newViewSelection ) && this.domConverter.isDomSelectionCorrect( domSelection ) ) {
 			return;
 		}
@@ -269,9 +272,6 @@ export default class SelectionObserver extends Observer {
 
 			return;
 		}
-
-		// Mark the latest focus change as complete (we got new selection after the focus so the selection is in the focused element).
-		this.focusObserver.flush();
 
 		if ( this.selection.isSimilar( newViewSelection ) ) {
 			// If selection was equal and we are at this point of algorithm, it means that it was incorrect.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (engine): Fixed reverse typing issue on editor gaining focus. Closes #14569.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
