### PR TITLE
Introduce lazy loading for multi-root editor

### DIFF
--- a/packages/ckeditor5-core/src/command.ts
+++ b/packages/ckeditor5-core/src/command.ts
@@ -121,9 +121,15 @@ export default class Command extends ObservableMixin() {
 				return;
 			}
 
+			const selection = editor.model.document.selection;
+			const selectionInGraveyard = selection.getFirstPosition()!.root.rootName == '$graveyard';
+			const canEditAtSelection = !selectionInGraveyard && editor.model.canEditAt( selection );
+
+			// Disable if editor is read only, or when selection is in a place which cannot be edited.
+			//
 			// Checking `editor.isReadOnly` is needed for all commands that have `_isEnabledBasedOnSelection == false`.
 			// E.g. undo does not base on selection, but affects data and should be disabled when the editor is in read-only mode.
-			if ( editor.isReadOnly || this._isEnabledBasedOnSelection && !editor.model.canEditAt( editor.model.document.selection ) ) {
+			if ( editor.isReadOnly || this._isEnabledBasedOnSelection && !canEditAtSelection ) {
 				evt.return = false;
 				evt.stop();
 			}

--- a/packages/ckeditor5-core/tests/command.js
+++ b/packages/ckeditor5-core/tests/command.js
@@ -70,7 +70,7 @@ describe( 'Command', () => {
 			expect( spy.calledOnce ).to.be.true;
 		} );
 
-		it( 'is falsy when the editor is in read-only mode and command affects data', () => {
+		it( 'is false when the editor is in read-only mode and command affects data', () => {
 			command.affectsData = true;
 			command.isEnabled = true;
 
@@ -110,7 +110,7 @@ describe( 'Command', () => {
 			expect( command.isEnabled ).to.true;
 		} );
 
-		it( 'should disable commands when selection is in non-editable place and _isEnabledBasedOnSelection is true', () => {
+		it( 'should disable command when selection is in non-editable place and `isEnabled` bases on selection', () => {
 			command.isEnabled = true;
 			command.affectsData = true;
 			command._isEnabledBasedOnSelection = true;
@@ -121,13 +121,37 @@ describe( 'Command', () => {
 			expect( command.isEnabled ).to.be.false;
 		} );
 
-		it( 'should not disable commands when selection is in non-editable place, but _isEnabledBasedOnSelection is false', () => {
+		it( 'should not disable command when selection is in non-editable place and `isEnabled` bases on selection', () => {
 			command.isEnabled = true;
 			command.affectsData = true;
 			command._isEnabledBasedOnSelection = false;
 
 			editor.model.document.isReadOnly = true;
 			command.refresh();
+
+			expect( command.isEnabled ).to.be.true;
+		} );
+
+		it( 'should disable command if the selection is in graveyard and and `isEnabled` bases on selection', () => {
+			command.isEnabled = true;
+			command.affectsData = true;
+			command._isEnabledBasedOnSelection = true;
+
+			editor.model.change( writer => {
+				writer.detachRoot( 'main' );
+			} );
+
+			expect( command.isEnabled ).to.be.false;
+		} );
+
+		it( 'should not disable command if the selection is in graveyard and and `isEnabled` bases on selection', () => {
+			command.isEnabled = true;
+			command.affectsData = true;
+			command._isEnabledBasedOnSelection = false;
+
+			editor.model.change( writer => {
+				writer.detachRoot( 'main' );
+			} );
 
 			expect( command.isEnabled ).to.be.true;
 		} );

--- a/packages/ckeditor5-core/tests/editor/editor.js
+++ b/packages/ckeditor5-core/tests/editor/editor.js
@@ -713,6 +713,7 @@ describe( 'Editor', () => {
 			class SomeCommand extends Command {
 				constructor( editor ) {
 					super( editor );
+					this._isEnabledBasedOnSelection = false;
 					this.isEnabled = true;
 				}
 				execute() {

--- a/packages/ckeditor5-editor-multi-root/src/augmentation.ts
+++ b/packages/ckeditor5-editor-multi-root/src/augmentation.ts
@@ -79,5 +79,16 @@ declare module '@ckeditor/ckeditor5-core' {
 		 * ```
 		 */
 		rootsAttributes?: Record<string, RootAttributes>;
+
+		/**
+		 * List of names of all the roots that exist in the document but are not initially loaded by the editor.
+		 *
+		 * These roots can be loaded at any time after the editor has been initialized, using
+		 * {@link module:editor-multi-root/multirooteditor~MultiRootEditor#loadRoot `MultiRootEditor#lazyRoot()`}.
+		 *
+		 * This is useful for handling big documents that contain hundreds of roots, or contain very large roots, which may have
+		 * impact editor performance if loaded all together.
+		 */
+		lazyRoots?: Array<string>;
 	}
 }

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -561,7 +561,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	public loadRoot(
 		rootName: string,
 		{ data = '', attributes = {} as Record<string, unknown> }: LoadRootOptions = {}
-	) {
+	): void {
 		// `root` will be defined as it is guaranteed by a check in a higher priority callback.
 		const root = this.model.document.getRoot( rootName )!;
 

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -20,6 +20,7 @@ import {
 	CKEditorError,
 	getDataFromElement,
 	setDataInElement,
+	logWarning,
 	type CollectionAddEvent
 } from 'ckeditor5/src/utils';
 
@@ -103,7 +104,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 		const rootNames = Object.keys( sourceElementsOrData );
 		const sourceIsData = rootNames.length === 0 || typeof sourceElementsOrData[ rootNames[ 0 ] ] === 'string';
 
-		if ( sourceIsData && config.initialData !== undefined ) {
+		if ( sourceIsData && config.initialData !== undefined && Object.keys( config.initialData ).length > 0 ) {
 			// Documented in core/editor/editorconfig.jsdoc.
 			// eslint-disable-next-line ckeditor5-rules/ckeditor-error-message
 			throw new CKEditorError( 'editor-create-initial-data', null );
@@ -161,11 +162,19 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 			this.model.document.createRoot( '$root', rootName );
 		}
 
+		if ( this.config.get( 'lazyRoots' ) ) {
+			for ( const rootName of this.config.get( 'lazyRoots' )! ) {
+				const root = this.model.document.createRoot( '$root', rootName );
+
+				root._isLoaded = false;
+			}
+		}
+
 		if ( this.config.get( 'rootsAttributes' ) ) {
 			const rootsAttributes = this.config.get( 'rootsAttributes' )!;
 
 			for ( const [ rootName, attributes ] of Object.entries( rootsAttributes ) ) {
-				if ( !rootNames.includes( rootName ) ) {
+				if ( !this.model.document.getRoot( rootName ) ) {
 					/**
 					 * Trying to set attributes on a non-existing root.
 					 *
@@ -240,9 +249,9 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 			let selectionInReadOnlyRoot = false;
 
 			for ( const range of selection.getRanges() ) {
-				const rootName = range.root.rootName!;
+				const root = range.root as RootElement;
 
-				if ( this._readOnlyRootLocks.has( rootName ) ) {
+				if ( this._readOnlyRootLocks.has( root.rootName ) ) {
 					selectionInReadOnlyRoot = true;
 
 					break;
@@ -256,6 +265,31 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 				evt.stop();
 			}
 		}, { priority: 'high' } );
+
+		this.decorate( 'loadRoot' );
+		this.on( 'loadRoot', ( evt, [ rootName ] ) => {
+			const root = this.model.document.getRoot( rootName )!;
+
+			if ( !root ) {
+				/**
+				 * The root to load does not exist.
+				 *
+				 * @error multi-root-editor-load-root-no-root
+				 */
+				throw new CKEditorError( 'multi-root-editor-load-root-no-root', this, { rootName } );
+			}
+
+			if ( root._isLoaded ) {
+				/**
+				 * The root to load was already loaded before. The `loadRoot()` call has no effect.
+				 *
+				 * @error multi-root-editor-load-root-already-loaded
+				 */
+				logWarning( 'multi-root-editor-load-root-already-loaded' );
+
+				evt.stop();
+			}
+		}, { priority: 'highest' } );
 	}
 
 	/**
@@ -501,6 +535,54 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	}
 
 	/**
+	 * Loads a root that has been previously declared in {@link module:core/editor/editorconfig~EditorConfig#lazyRoots `lazyRoots`}
+	 * configuration option.
+	 *
+	 * Only roots specified in the editor config can be loaded. A root cannot be loaded multiple times. A root cannot be unloaded and
+	 * loading a root cannot be reverted using the undo feature.
+	 *
+	 * When a root becomes loaded, it will be treated by the editor as though it was just added. This, among other, means that all
+	 * related events and mechanisms will be fired, including {@link ~MultiRootEditor#event:addRoot `addRoot` event},
+	 * {@link module:engine/model/document~Document#event:change `model.Document` `change` event}, model post-fixers and conversion.
+	 *
+	 * Until the root becomes loaded, all above mechanisms are suppressed.
+	 *
+	 * This method is {@link module:utils/observablemixin~Observable#decorate decorated}.
+	 *
+	 * When this method is used in real-time collaboration environment, its effects become asynchronous as the editor will first synchronize
+	 * with the remote editing session, before the root is added to the editor.
+	 *
+	 * If the root has been already loaded by any other client, the additional data passed in `loadRoot()` parameters will be ignored.
+	 *
+	 * @param rootName Name of the root to load.
+	 * @param options Additional options for the loaded root.
+	 * @fires loadRoot
+	 */
+	public loadRoot(
+		rootName: string,
+		{ data = '', attributes = {} as Record<string, unknown> }: LoadRootOptions = {}
+	) {
+		// `root` will be defined as it is guaranteed by a check in a higher priority callback.
+		const root = this.model.document.getRoot( rootName )!;
+
+		this.model.enqueueChange( { isUndoable: false }, writer => {
+			if ( data ) {
+				writer.insert( this.data.parse( data, root ), root, 0 );
+			}
+
+			for ( const key of Object.keys( attributes ) ) {
+				this._registeredRootsAttributesKeys.add( key );
+
+				writer.setAttribute( key, attributes[ key ], root );
+			}
+
+			root._isLoaded = true;
+
+			this.model.document.differ._loadRoot( root );
+		} );
+	}
+
+	/**
 	 * Returns the document data for all attached roots.
 	 *
 	 * @param options Additional configuration for the retrieved data.
@@ -521,26 +603,40 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	}
 
 	/**
-	 * Returns currently set roots attributes for attributes specified in
-	 * {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes `rootsAttributes`} configuration option.
+	 * Returns attributes for all attached roots.
+	 *
+	 * Note: only attributes specified in {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes `rootsAttributes`}
+	 * configuration option will be returned.
 	 *
 	 * @returns Object with roots attributes. Keys are roots names, while values are attributes set on given root.
 	 */
 	public getRootsAttributes(): Record<string, RootAttributes> {
 		const rootsAttributes: Record<string, RootAttributes> = {};
-		const keys = Array.from( this._registeredRootsAttributesKeys );
 
 		for ( const rootName of this.model.document.getRootNames() ) {
-			rootsAttributes[ rootName ] = {};
-
-			const root = this.model.document.getRoot( rootName )!;
-
-			for ( const key of keys ) {
-				rootsAttributes[ rootName ][ key ] = root.hasAttribute( key ) ? root.getAttribute( key ) : null;
-			}
+			rootsAttributes[ rootName ] = this.getRootAttributes( rootName );
 		}
 
 		return rootsAttributes;
+	}
+
+	/**
+	 * Returns attributes for the specified root.
+	 *
+	 * Note: only attributes specified in {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes `rootsAttributes`}
+	 * configuration option will be returned.
+	 *
+	 * @param rootName
+	 */
+	public getRootAttributes( rootName: string ): RootAttributes {
+		const rootAttributes: RootAttributes = {};
+		const root = this.model.document.getRoot( rootName )!;
+
+		for ( const key of this._registeredRootsAttributesKeys ) {
+			rootAttributes[ key ] = root.hasAttribute( key ) ? root.getAttribute( key ) : null;
+		}
+
+		return rootAttributes;
 	}
 
 	/**
@@ -925,6 +1021,11 @@ export type AddRootOptions = {
 	 */
 	isUndoable?: boolean;
 };
+
+/**
+ * Additional options available when loading a root.
+ */
+export type LoadRootOptions = Omit<AddRootOptions, 'elementName' | 'isUndoable'>;
 
 /**
  * Attributes set on a model root element.

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -21,7 +21,8 @@ import {
 	getDataFromElement,
 	setDataInElement,
 	logWarning,
-	type CollectionAddEvent, DecoratedMethodEvent
+	type CollectionAddEvent,
+	type DecoratedMethodEvent
 } from 'ckeditor5/src/utils';
 
 import { ContextWatchdog, EditorWatchdog } from 'ckeditor5/src/watchdog';

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -21,7 +21,7 @@ import {
 	getDataFromElement,
 	setDataInElement,
 	logWarning,
-	type CollectionAddEvent
+	type CollectionAddEvent, DecoratedMethodEvent
 } from 'ckeditor5/src/utils';
 
 import { ContextWatchdog, EditorWatchdog } from 'ckeditor5/src/watchdog';
@@ -267,7 +267,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 		}, { priority: 'high' } );
 
 		this.decorate( 'loadRoot' );
-		this.on( 'loadRoot', ( evt, [ rootName ] ) => {
+		this.on<LoadRootEvent>( 'loadRoot', ( evt, [ rootName ] ) => {
 			const root = this.model.document.getRoot( rootName )!;
 
 			if ( !root ) {
@@ -995,6 +995,17 @@ export type DetachRootEvent = {
 	name: 'detachRoot';
 	args: [ root: RootElement ];
 };
+
+/**
+ * Event fired when {@link ~MultiRootEditor#loadRoot} method is called.
+ *
+ * The {@link ~MultiRootEditor#loadRoot default action of that method} is implemented as a
+ * listener to this event, so it can be fully customized by the features.
+ *
+ * @eventName ~MultiRootEditor#loadRoot
+ * @param args The arguments passed to the original method.
+ */
+export type LoadRootEvent = DecoratedMethodEvent<MultiRootEditor, 'loadRoot'>;
 
 /**
  * Additional options available when adding a root.

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -578,7 +578,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 
 			root._isLoaded = true;
 
-			this.model.document.differ._loadRoot( root );
+			this.model.document.differ._bufferRootLoad( root );
 		} );
 	}
 

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
@@ -558,6 +558,115 @@ describe( 'MultiRootEditor', () => {
 		} );
 	} );
 
+	describe( 'loading roots', () => {
+		describe( 'config.lazyRoots', () => {
+			it( 'should create specified, non-loaded roots', async () => {
+				editor = await MultiRootEditor.create( { main: '<p>Main.</p>' }, {
+					plugins: [ Paragraph, Undo ],
+					lazyRoots: [ 'foo', 'bar' ]
+				} );
+
+				const rootFoo = editor.model.document.getRoot( 'foo' );
+				const rootBar = editor.model.document.getRoot( 'bar' );
+
+				expect( rootFoo ).not.to.be.null;
+				expect( rootFoo.rootName ).to.equal( 'foo' );
+				expect( rootFoo.isAttached() ).to.be.true;
+				expect( rootFoo._isLoaded ).to.be.false;
+
+				expect( rootBar ).not.to.be.null;
+				expect( rootBar.rootName ).to.equal( 'bar' );
+				expect( rootBar.isAttached() ).to.be.true;
+				expect( rootBar._isLoaded ).to.be.false;
+
+				expect( editor.model.document.getRootNames() ).to.deep.equal( [ 'main' ] );
+
+				return editor.destroy();
+			} );
+
+			it( 'should work correctly when there are no initial loaded roots', async () => {
+				editor = await MultiRootEditor.create( {}, {
+					plugins: [ Paragraph, Undo ],
+					lazyRoots: [ 'foo', 'bar' ]
+				} );
+
+				expect( editor.model.document.getRootNames() ).to.deep.equal( [] );
+
+				return editor.destroy();
+			} );
+		} );
+
+		describe( 'loadRoot()', () => {
+			let root;
+
+			beforeEach( async () => {
+				editor = await MultiRootEditor.create( {}, {
+					plugins: [ Paragraph, Undo ],
+					lazyRoots: [ 'foo', 'bar' ]
+				} );
+
+				root = editor.model.document.getRoot( 'foo' );
+			} );
+
+			afterEach( async () => {
+				await editor.destroy();
+			} );
+
+			it( 'should throw if given root does not exist', async () => {
+				expect( () => {
+					editor.loadRoot( 'xyz' );
+				} ).to.throw( CKEditorError, 'multi-root-editor-load-root-no-root' );
+			} );
+
+			it( 'should set not-loaded root as loaded and set initial data and attributes', () => {
+				editor.loadRoot( 'foo', { data: '<p>Foo</p>', attributes: { order: 100 } } );
+
+				expect( root._isLoaded ).to.be.true;
+				expect( editor.getData( { rootName: 'foo' } ) ).to.equal( '<p>Foo</p>' );
+				expect( editor.getRootAttributes( 'foo' ) ).to.deep.equal( { order: 100 } );
+			} );
+
+			it( 'should load an empty root', () => {
+				editor.loadRoot( 'foo' );
+
+				expect( root._isLoaded ).to.be.true;
+				expect( editor.getData( { rootName: 'foo' } ) ).to.equal( '' );
+				expect( editor.getRootAttributes( 'foo' ) ).to.deep.equal( {} );
+			} );
+
+			it( 'should log a warning and not do anything when a root is loaded for the second time', () => {
+				editor.loadRoot( 'foo', { data: '<p>Foo</p>', attributes: { order: 100 } } );
+
+				const spy = sinon.spy();
+
+				editor.on( 'loadRoot', spy );
+				editor.loadRoot( 'foo', { data: '<p>Bar</p>', attributes: { order: 200 } } );
+
+				expect( console.warn.calledWith( sinon.match( /^multi-root-editor-load-root-already-loaded/ ) ) ).to.be.true;
+
+				expect( root._isLoaded ).to.be.true;
+				expect( editor.getData( { rootName: 'foo' } ) ).to.equal( '<p>Foo</p>' );
+				expect( editor.getRootAttributes( 'foo' ) ).to.deep.equal( { order: 100 } );
+
+				expect( spy.notCalled ).to.be.true;
+			} );
+
+			it( 'should buffer the root in the differ', () => {
+				const spy = sinon.spy( editor.model.document.differ, '_loadRoot' );
+
+				editor.loadRoot( 'foo', { data: '<p>Foo</p>', attributes: { order: 100 } } );
+
+				expect( spy.calledWithExactly( root ) ).to.be.true;
+			} );
+
+			it( 'should not be undoable', () => {
+				editor.loadRoot( 'foo', { data: '<p>Foo</p>', attributes: { order: 100 } } );
+
+				expect( editor.commands.get( 'undo' ).isEnabled ).to.be.false;
+			} );
+		} );
+	} );
+
 	describe( 'model.canEditAt()', () => {
 		beforeEach( async () => {
 			editor = await MultiRootEditor.create( { main: '<p>Main.</p>' }, { plugins: [ Paragraph, Undo ] } );
@@ -720,7 +829,10 @@ describe( 'MultiRootEditor', () => {
 
 	describe( 'getFullData()', () => {
 		beforeEach( async () => {
-			editor = await MultiRootEditor.create( { main: '<p>Main.</p>' }, { plugins: [ Paragraph, Undo ] } );
+			editor = await MultiRootEditor.create( { main: '<p>Main.</p>', old: '<p>Old.</p>' }, {
+				plugins: [ Paragraph, Undo ],
+				lazyRoots: [ 'abc', 'xyz' ]
+			} );
 		} );
 
 		afterEach( () => {
@@ -731,12 +843,15 @@ describe( 'MultiRootEditor', () => {
 			editor.addRoot( 'new', { data: '<p>New.</p>' } );
 			editor.detachRoot( 'main' );
 			editor.addRoot( 'foo', { data: '<p>Foo.</p>' } );
+			editor.loadRoot( 'abc', { data: '<p>Abc.</p>' } );
 
 			const fullData = editor.getFullData();
 
 			expect( fullData ).to.deep.equal( {
+				old: '<p>Old.</p>',
 				foo: '<p>Foo.</p>',
-				new: '<p>New.</p>'
+				new: '<p>New.</p>',
+				abc: '<p>Abc.</p>'
 			} );
 		} );
 
@@ -958,8 +1073,8 @@ describe( 'MultiRootEditor', () => {
 		} );
 	} );
 
-	describe( '#getRootsAttributes()', () => {
-		it( 'should return current values of roots attributes', async () => {
+	describe( '#getRootAttributes()', () => {
+		it( 'should return current values of attributes of the given root', async () => {
 			editor = await MultiRootEditor.create( { foo: '', bar: '' }, {
 				rootsAttributes: {
 					foo: { order: 10, isLocked: true },
@@ -972,15 +1087,14 @@ describe( 'MultiRootEditor', () => {
 				writer.setAttribute( 'isLocked', true, editor.model.document.getRoot( 'bar' ) );
 			} );
 
-			expect( editor.getRootsAttributes() ).to.deep.equal( {
-				bar: {
-					isLocked: true,
-					order: 20
-				},
-				foo: {
-					isLocked: true,
-					order: 30
-				}
+			expect( editor.getRootAttributes( 'foo' ) ).to.deep.equal( {
+				isLocked: true,
+				order: 30
+			} );
+
+			expect( editor.getRootAttributes( 'bar' ) ).to.deep.equal( {
+				isLocked: true,
+				order: 20
 			} );
 
 			await editor.destroy();
@@ -999,15 +1113,14 @@ describe( 'MultiRootEditor', () => {
 				writer.setAttribute( 'keyB', 'bar', editor.model.document.getRoot( 'bar' ) );
 			} );
 
-			expect( editor.getRootsAttributes() ).to.deep.equal( {
-				bar: {
-					isLocked: false,
-					order: 20
-				},
-				foo: {
-					isLocked: true,
-					order: 10
-				}
+			expect( editor.getRootAttributes( 'foo' ) ).to.deep.equal( {
+				isLocked: true,
+				order: 10
+			} );
+
+			expect( editor.getRootAttributes( 'bar' ) ).to.deep.equal( {
+				isLocked: false,
+				order: 20
 			} );
 
 			await editor.destroy();
@@ -1025,40 +1138,14 @@ describe( 'MultiRootEditor', () => {
 				writer.setAttribute( 'isLocked', true, editor.model.document.getRoot( 'foo' ) );
 			} );
 
-			expect( editor.getRootsAttributes() ).to.deep.equal( {
-				bar: {
-					isLocked: false,
-					order: null
-				},
-				foo: {
-					isLocked: true,
-					order: 10
-				}
+			expect( editor.getRootAttributes( 'foo' ) ).to.deep.equal( {
+				isLocked: true,
+				order: 10
 			} );
 
-			await editor.destroy();
-		} );
-
-		it( 'should return attributes for all and only currently attached roots', async () => {
-			editor = await MultiRootEditor.create( { foo: '', bar: '' }, {
-				rootsAttributes: {
-					foo: { order: 10, isLocked: true },
-					bar: { order: 20, isLocked: false }
-				}
-			} );
-
-			editor.detachRoot( 'bar' );
-			editor.addRoot( 'abc', { attributes: { order: 30 } } );
-
-			expect( editor.getRootsAttributes() ).to.deep.equal( {
-				abc: {
-					isLocked: null,
-					order: 30
-				},
-				foo: {
-					isLocked: true,
-					order: 10
-				}
+			expect( editor.getRootAttributes( 'bar' ) ).to.deep.equal( {
+				isLocked: false,
+				order: null
 			} );
 
 			await editor.destroy();
@@ -1075,14 +1162,78 @@ describe( 'MultiRootEditor', () => {
 				writer.setAttribute( 'order', 30, editor.model.document.getRoot( 'foo' ) );
 			} );
 
+			expect( editor.getRootAttributes( 'foo' ) ).to.deep.equal( {
+				isLocked: null,
+				order: 30
+			} );
+
+			expect( editor.getRootAttributes( 'bar' ) ).to.deep.equal( {
+				isLocked: true,
+				order: null
+			} );
+
+			await editor.destroy();
+		} );
+	} );
+
+	describe( '#getRootsAttributes()', () => {
+		it( 'should return current values of roots attributes', async () => {
+			editor = await MultiRootEditor.create( { foo: '', bar: '' }, {
+				rootsAttributes: {
+					foo: { order: 10, isLocked: true },
+					bar: { order: 20, isLocked: false }
+				}
+			} );
+
+			editor.model.change( writer => {
+				writer.setAttribute( 'order', 30, editor.model.document.getRoot( 'foo' ) );
+				writer.setAttribute( 'isLocked', true, editor.model.document.getRoot( 'bar' ) );
+			} );
+
+			sinon.spy( editor, 'getRootAttributes' );
+
 			expect( editor.getRootsAttributes() ).to.deep.equal( {
 				bar: {
 					isLocked: true,
-					order: null
+					order: 20
 				},
 				foo: {
+					isLocked: true,
+					order: 30
+				}
+			} );
+
+			expect( editor.getRootAttributes.calledWith( 'foo' ) ).to.be.true;
+			expect( editor.getRootAttributes.calledWith( 'bar' ) ).to.be.true;
+
+			await editor.destroy();
+		} );
+
+		it( 'should return attributes for all and only currently attached roots', async () => {
+			editor = await MultiRootEditor.create( { foo: '', bar: '' }, {
+				rootsAttributes: {
+					foo: { order: 10, isLocked: true },
+					bar: { order: 20, isLocked: false }
+				},
+				lazyRoots: [ 'xxx', 'yyy' ]
+			} );
+
+			editor.detachRoot( 'bar' );
+			editor.addRoot( 'abc', { attributes: { order: 30 } } );
+			editor.loadRoot( 'xxx', { data: '', attributes: { order: 40, isLocked: false } } );
+
+			expect( editor.getRootsAttributes() ).to.deep.equal( {
+				abc: {
 					isLocked: null,
 					order: 30
+				},
+				foo: {
+					isLocked: true,
+					order: 10
+				},
+				xxx: {
+					isLocked: false,
+					order: 40
 				}
 			} );
 

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
@@ -652,7 +652,7 @@ describe( 'MultiRootEditor', () => {
 			} );
 
 			it( 'should buffer the root in the differ', () => {
-				const spy = sinon.spy( editor.model.document.differ, '_loadRoot' );
+				const spy = sinon.spy( editor.model.document.differ, '_bufferRootLoad' );
 
 				editor.loadRoot( 'foo', { data: '<p>Foo</p>', attributes: { order: 100 } } );
 

--- a/packages/ckeditor5-engine/src/controller/editingcontroller.ts
+++ b/packages/ckeditor5-engine/src/controller/editingcontroller.ts
@@ -20,10 +20,11 @@ import Mapper from '../conversion/mapper';
 import DowncastDispatcher, {
 	type DowncastInsertEvent,
 	type DowncastRemoveEvent,
-	type DowncastSelectionEvent
+	type DowncastSelectionEvent,
+	type DowncastCleanSelectionEvent
 } from '../conversion/downcastdispatcher';
 import {
-	clearAttributes,
+	cleanSelection,
 	convertCollapsedSelection,
 	convertRangeSelection,
 	insertAttributesAndChildren,
@@ -136,7 +137,7 @@ export default class EditingController extends ObservableMixin() {
 		this.downcastDispatcher.on<DowncastRemoveEvent>( 'remove', remove(), { priority: 'low' } );
 
 		// Attach default model selection converters.
-		this.downcastDispatcher.on<DowncastSelectionEvent>( 'selection', clearAttributes(), { priority: 'high' } );
+		this.downcastDispatcher.on<DowncastCleanSelectionEvent>( 'cleanSelection', cleanSelection() );
 		this.downcastDispatcher.on<DowncastSelectionEvent>( 'selection', convertRangeSelection(), { priority: 'low' } );
 		this.downcastDispatcher.on<DowncastSelectionEvent>( 'selection', convertCollapsedSelection(), { priority: 'low' } );
 

--- a/packages/ckeditor5-engine/src/conversion/downcastdispatcher.ts
+++ b/packages/ckeditor5-engine/src/conversion/downcastdispatcher.ts
@@ -17,6 +17,7 @@ import type { default as MarkerCollection, Marker } from '../model/markercollect
 import type { TreeWalkerValue } from '../model/treewalker';
 import type DocumentSelection from '../model/documentselection';
 import type DowncastWriter from '../view/downcastwriter';
+import type RootElement from '../model/rootelement';
 import type Element from '../model/element';
 import type Item from '../model/item';
 import type Mapper from './mapper';
@@ -252,9 +253,15 @@ export default class DowncastDispatcher extends EmitterMixin() {
 		markers: MarkerCollection,
 		writer: DowncastWriter
 	): void {
-		const markersAtSelection = Array.from( markers.getMarkersAtPosition( selection.getFirstPosition()! ) );
-
 		const conversionApi = this._createConversionApi( writer );
+		const modelRoot = selection.getFirstPosition()!.root as RootElement;
+
+		// Don't convert selection if it is in a model root that does not have a view root (for now this is only the graveyard root).
+		if ( !conversionApi.mapper.toViewElement( modelRoot ) ) {
+			return;
+		}
+
+		const markersAtSelection = Array.from( markers.getMarkersAtPosition( selection.getFirstPosition()! ) );
 
 		this._addConsumablesForSelection( conversionApi.consumable, selection, markersAtSelection );
 

--- a/packages/ckeditor5-engine/src/conversion/downcastdispatcher.ts
+++ b/packages/ckeditor5-engine/src/conversion/downcastdispatcher.ts
@@ -258,7 +258,12 @@ export default class DowncastDispatcher extends EmitterMixin() {
 
 		this._addConsumablesForSelection( conversionApi.consumable, selection, markersAtSelection );
 
-		this.fire<DowncastSelectionEvent>( 'selection', { selection }, conversionApi );
+		const isConversionCorrect = this.fire<DowncastSelectionEvent>( 'selection', { selection }, conversionApi );
+
+		// Check `false` exactly, as `undefined` may be returned as well.
+		if ( isConversionCorrect === false ) {
+			return;
+		}
 
 		if ( !selection.isCollapsed ) {
 			return;
@@ -783,12 +788,15 @@ export type DowncastAttributeEvent<TItem = Item | Selection | DocumentSelection>
 /**
  * Fired for {@link module:engine/model/selection~Selection selection} changes.
  *
+ * The event callback (converter) should return `false` if the selection conversion could not be performed and further selection-related
+ * conversion (selection markers and attributes) should be cancelled.
+ *
  * @eventName ~DowncastDispatcher#selection
  * @param {module:engine/model/selection~Selection} selection Selection that is converted.
  * @param {module:engine/conversion/downcastdispatcher~DowncastConversionApi} conversionApi Conversion interface
  * to be used by callback, passed in `DowncastDispatcher` constructor.
  */
-export type DowncastSelectionEvent = DowncastEvent<'selection'>;
+export type DowncastSelectionEvent = DowncastEvent<'selection'> & { return: boolean };
 
 /**
  * Fired when a new marker is added to the model. Also fired when a collapsed model selection that is inside a marker is converted.

--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
@@ -56,6 +56,7 @@ import {
 } from '@ckeditor/ckeditor5-utils';
 
 import { cloneDeep } from 'lodash-es';
+import RootElement from "../model/rootelement";
 
 /**
  * Downcast conversion helper functions.
@@ -991,6 +992,17 @@ export function convertRangeSelection() {
 			return;
 		}
 
+		const modelRoot = selection.getFirstPosition()!.root as RootElement;
+
+		// Don't convert selection if it is in a model root that does not have a view root (for now this is only the graveyard root).
+		// Note that the view selection should be cleared at this moment.
+		if ( !conversionApi.mapper.toViewElement( modelRoot ) ) {
+			// Prevent further selection conversion (markers and attributes).
+			conversionApi.consumable.consumeAll( selection );
+
+			return;
+		}
+
 		const viewRanges: Array<ViewRange> = [];
 
 		for ( const range of selection.getRanges() ) {
@@ -1040,6 +1052,17 @@ export function convertCollapsedSelection() {
 		}
 
 		if ( !conversionApi.consumable.consume( selection, 'selection' ) ) {
+			return;
+		}
+
+		const modelRoot = selection.getFirstPosition()!.root as RootElement;
+
+		// Don't convert selection if it is in a model root that does not have a view root (for now this is only the graveyard root).
+		// Note that the view selection should be cleared at this moment.
+		if ( !conversionApi.mapper.toViewElement( modelRoot ) ) {
+			// Prevent further selection conversion (markers and attributes).
+			conversionApi.consumable.consumeAll( selection );
+
 			return;
 		}
 
@@ -1098,6 +1121,7 @@ export function clearAttributes() {
 				}
 			}
 		}
+
 		viewWriter.setSelection( null );
 	};
 }

--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
@@ -56,7 +56,7 @@ import {
 } from '@ckeditor/ckeditor5-utils';
 
 import { cloneDeep } from 'lodash-es';
-import RootElement from "../model/rootelement";
+import type RootElement from '../model/rootelement';
 
 /**
  * Downcast conversion helper functions.

--- a/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
+++ b/packages/ckeditor5-engine/src/conversion/downcasthelpers.ts
@@ -974,6 +974,9 @@ export function createViewElementFromHighlightDescriptor( writer: DowncastWriter
  * modelDispatcher.on( 'selection', convertRangeSelection() );
  * ```
  *
+ * Note: the converter will return `false` if the selection is in a model root that does not have a corresponding view root and thus
+ * the conversion cannot be performed.
+ *
  * @returns Selection converter.
  */
 export function convertRangeSelection() {
@@ -998,7 +1001,8 @@ export function convertRangeSelection() {
 		// Note that the view selection should be cleared at this moment.
 		if ( !conversionApi.mapper.toViewElement( modelRoot ) ) {
 			// Prevent further selection conversion (markers and attributes).
-			conversionApi.consumable.consumeAll( selection );
+			evt.return = false;
+			evt.stop();
 
 			return;
 		}
@@ -1037,6 +1041,9 @@ export function convertRangeSelection() {
  * See also {@link module:engine/conversion/downcasthelpers~clearAttributes} which does a clean-up
  * by merging attributes.
  *
+ * Note: the converter will return `false` if the selection is in a model root that does not have a corresponding view root and thus
+ * the conversion cannot be performed.
+ *
  * @returns Selection converter.
  */
 export function convertCollapsedSelection() {
@@ -1061,7 +1068,8 @@ export function convertCollapsedSelection() {
 		// Note that the view selection should be cleared at this moment.
 		if ( !conversionApi.mapper.toViewElement( modelRoot ) ) {
 			// Prevent further selection conversion (markers and attributes).
-			conversionApi.consumable.consumeAll( selection );
+			evt.return = false;
+			evt.stop();
 
 			return;
 		}

--- a/packages/ckeditor5-engine/src/conversion/modelconsumable.ts
+++ b/packages/ckeditor5-engine/src/conversion/modelconsumable.ts
@@ -180,6 +180,30 @@ export default class ModelConsumable {
 	}
 
 	/**
+	 * Removes all consumable values from a given model item.
+	 *
+	 * It is equal to calling {@link module:engine/conversion/modelconsumable~ModelConsumable#consume `consume()`} for all consumable types
+	 * for a given model item.
+	 *
+	 * This is useful to prevent any further conversion for a given model item.
+	 *
+	 * @param item Model item, range or selection from which all consumables will be consumed.
+	 */
+	public consumeAll( item: Item | Selection | DocumentSelection | Range ) {
+		if ( item instanceof TextProxy ) {
+			item = this._getSymbolForTextProxy( item ) as any;
+		}
+
+		const consumable = this._consumable.get( item );
+
+		if ( consumable ) {
+			for ( const type of consumable.keys() ) {
+				consumable.set( type, false );
+			}
+		}
+	}
+
+	/**
 	 * Tests whether there is a consumable value of a given type connected with a given model item.
 	 *
 	 * ```ts

--- a/packages/ckeditor5-engine/src/conversion/modelconsumable.ts
+++ b/packages/ckeditor5-engine/src/conversion/modelconsumable.ts
@@ -189,7 +189,7 @@ export default class ModelConsumable {
 	 *
 	 * @param item Model item, range or selection from which all consumables will be consumed.
 	 */
-	public consumeAll( item: Item | Selection | DocumentSelection | Range ) {
+	public consumeAll( item: Item | Selection | DocumentSelection | Range ): void {
 		if ( item instanceof TextProxy ) {
 			item = this._getSymbolForTextProxy( item ) as any;
 		}

--- a/packages/ckeditor5-engine/src/conversion/modelconsumable.ts
+++ b/packages/ckeditor5-engine/src/conversion/modelconsumable.ts
@@ -180,30 +180,6 @@ export default class ModelConsumable {
 	}
 
 	/**
-	 * Removes all consumable values from a given model item.
-	 *
-	 * It is equal to calling {@link module:engine/conversion/modelconsumable~ModelConsumable#consume `consume()`} for all consumable types
-	 * for a given model item.
-	 *
-	 * This is useful to prevent any further conversion for a given model item.
-	 *
-	 * @param item Model item, range or selection from which all consumables will be consumed.
-	 */
-	public consumeAll( item: Item | Selection | DocumentSelection | Range ): void {
-		if ( item instanceof TextProxy ) {
-			item = this._getSymbolForTextProxy( item ) as any;
-		}
-
-		const consumable = this._consumable.get( item );
-
-		if ( consumable ) {
-			for ( const type of consumable.keys() ) {
-				consumable.set( type, false );
-			}
-		}
-	}
-
-	/**
 	 * Tests whether there is a consumable value of a given type connected with a given model item.
 	 *
 	 * ```ts

--- a/packages/ckeditor5-engine/src/model/differ.ts
+++ b/packages/ckeditor5-engine/src/model/differ.ts
@@ -258,6 +258,11 @@ export default class Differ {
 					return;
 				}
 
+				// Don't buffer if the root state does not change.
+				if ( root.isAttached() == operation.isAdd ) {
+					return;
+				}
+
 				this._bufferRootStateChange( operation.rootName, operation.isAdd );
 
 				break;
@@ -648,7 +653,7 @@ export default class Differ {
 		const diffItem = this._changedRoots.get( rootName )!;
 
 		if ( diffItem.state !== undefined ) {
-			// Root `state` can only toggle between of the values ('attached' or 'detached') and no value. It cannot be any other way,
+			// Root `state` can only toggle between one of the values and no value. It cannot be any other way,
 			// because if the root was originally attached it can only become detached. Then, if it is re-attached in the same batch of
 			// changes, it gets back to "no change" (which means no value). Same if the root was originally detached.
 			delete diffItem.state;

--- a/packages/ckeditor5-engine/src/model/differ.ts
+++ b/packages/ckeditor5-engine/src/model/differ.ts
@@ -742,7 +742,7 @@ export default class Differ {
 	 *
 	 * @internal
 	 */
-	public _loadRoot( root: RootElement ) {
+	public _loadRoot( root: RootElement ): void {
 		if ( !root.isAttached() ) {
 			return;
 		}

--- a/packages/ckeditor5-engine/src/model/differ.ts
+++ b/packages/ckeditor5-engine/src/model/differ.ts
@@ -747,7 +747,7 @@ export default class Differ {
 	 *
 	 * @internal
 	 */
-	public _loadRoot( root: RootElement ): void {
+	public _bufferRootLoad( root: RootElement ): void {
 		if ( !root.isAttached() ) {
 			return;
 		}

--- a/packages/ckeditor5-engine/src/model/document.ts
+++ b/packages/ckeditor5-engine/src/model/document.ts
@@ -276,12 +276,22 @@ export default class Document extends EmitterMixin() {
 	 * on the document data know which roots are still a part of the document and should be processed.
 	 *
 	 * @param includeDetached Specified whether detached roots should be returned as well.
-	 * @returns Roots names.
 	 */
 	public getRootNames( includeDetached = false ): Array<string> {
+		return this.getRoots( includeDetached ).map( root => root.rootName );
+	}
+
+	/**
+	 * Returns an array with all roots added to the document (except the {@link #graveyard graveyard root}).
+	 *
+	 * Detached roots **are not** returned by this method by default. This is to make sure that all features or algorithms that operate
+	 * on the document data know which roots are still a part of the document and should be processed.
+	 *
+	 * @param includeDetached Specified whether detached roots should be returned as well.
+	 */
+	public getRoots( includeDetached = false ): Array<RootElement> {
 		return Array.from( this.roots )
-			.filter( root => root.rootName != graveyardName && ( includeDetached || root.isAttached() ) )
-			.map( root => root.rootName );
+			.filter( root => root != this.graveyard && ( includeDetached || root.isAttached() ) && root._isLoaded );
 	}
 
 	/**
@@ -391,13 +401,9 @@ export default class Document extends EmitterMixin() {
 	 * @returns The default root for this document.
 	 */
 	protected _getDefaultRoot(): RootElement {
-		for ( const root of this.roots ) {
-			if ( root !== this.graveyard ) {
-				return root;
-			}
-		}
+		const roots = this.getRoots();
 
-		return this.graveyard;
+		return roots.length ? roots[ 0 ] : this.graveyard;
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/model/documentselection.ts
+++ b/packages/ckeditor5-engine/src/model/documentselection.ts
@@ -1127,6 +1127,10 @@ class LiveSelection extends Selection {
 		const position = this.getFirstPosition()!;
 		const schema = this._model.schema;
 
+		if ( position.root.rootName == '$graveyard' ) {
+			return null;
+		}
+
 		let attrs = null;
 
 		if ( !this.isCollapsed ) {

--- a/packages/ckeditor5-engine/src/model/model.ts
+++ b/packages/ckeditor5-engine/src/model/model.ts
@@ -1097,7 +1097,6 @@ export default class Model extends ObservableMixin() {
 	/**
 	 * Common part of {@link module:engine/model/model~Model#change} and {@link module:engine/model/model~Model#enqueueChange}
 	 * which calls callbacks and returns array of values returned by these callbacks.
-	 *
 	 */
 	private _runPendingChanges() {
 		const ret = [];

--- a/packages/ckeditor5-engine/src/model/operation/rootoperation.ts
+++ b/packages/ckeditor5-engine/src/model/operation/rootoperation.ts
@@ -102,36 +102,6 @@ export default class RootOperation extends Operation {
 	/**
 	 * @inheritDoc
 	 */
-	public override _validate(): void {
-		// Keep in mind that at this point the root will always exist as it was created in the `constructor()`, even for detach operation.
-		const root = this._document.getRoot( this.rootName )!;
-
-		if ( root.isAttached() && this.isAdd ) {
-			/**
-			 * Trying to attach a root that is already attached.
-			 *
-			 * @error root-operation-root-attached
-			 */
-			throw new CKEditorError(
-				'root-operation-root-attached',
-				this
-			);
-		} else if ( !root.isAttached() && !this.isAdd ) {
-			/**
-			 * Trying to detach a root that is already detached.
-			 *
-			 * @error root-operation-root-detached
-			 */
-			throw new CKEditorError(
-				'root-operation-root-detached',
-				this
-			);
-		}
-	}
-
-	/**
-	 * @inheritDoc
-	 */
 	public override _execute(): void {
 		this._document.getRoot( this.rootName )!._isAttached = this.isAdd;
 	}

--- a/packages/ckeditor5-engine/src/model/operation/transform.ts
+++ b/packages/ckeditor5-engine/src/model/operation/transform.ts
@@ -1977,8 +1977,8 @@ setTransformation( RootAttributeOperation, RootAttributeOperation, ( a, b, conte
 
 // -----------------------
 
-setTransformation( RootOperation, RootOperation, ( a, b, context ) => {
-	if ( a.rootName === b.rootName && a.isAdd === b.isAdd && !context.bWasUndone ) {
+setTransformation( RootOperation, RootOperation, ( a, b ) => {
+	if ( a.rootName === b.rootName && a.isAdd === b.isAdd ) {
 		return [ new NoOperation( 0 ) ];
 	}
 

--- a/packages/ckeditor5-engine/src/model/rootelement.ts
+++ b/packages/ckeditor5-engine/src/model/rootelement.ts
@@ -31,6 +31,13 @@ export default class RootElement extends Element {
 	public _isAttached = true;
 
 	/**
+	 * Informs if the root element is loaded (default).
+	 *
+	 * @internal
+	 */
+	public _isLoaded = true;
+
+	/**
 	 * Creates root element.
 	 *
 	 * @param document Document that is an owner of this root.

--- a/packages/ckeditor5-engine/src/model/schema.ts
+++ b/packages/ckeditor5-engine/src/model/schema.ts
@@ -760,6 +760,12 @@ export default class Schema extends ObservableMixin() {
 	 * @returns Nearest selection range or `null` if one cannot be found.
 	 */
 	public getNearestSelectionRange( position: Position, direction: 'both' | 'forward' | 'backward' = 'both' ): Range | null {
+		if ( position.root.rootName == '$graveyard' ) {
+			// No valid selection range in the graveyard.
+			// This is important when getting the document selection default range.
+			return null;
+		}
+
 		// Return collapsed range if provided position is valid.
 		if ( this.checkChild( position, '$text' ) ) {
 			return new Range( position );

--- a/packages/ckeditor5-engine/src/model/utils/autoparagraphing.ts
+++ b/packages/ckeditor5-engine/src/model/utils/autoparagraphing.ts
@@ -22,9 +22,7 @@ import type Writer from '../writer';
 export function autoParagraphEmptyRoots( writer: Writer ): boolean {
 	const { schema, document } = writer.model;
 
-	for ( const rootName of document.getRootNames() ) {
-		const root = document.getRoot( rootName )!;
-
+	for ( const root of document.getRoots() ) {
 		if ( root.isEmpty && !schema.checkChild( root, '$text' ) ) {
 			// If paragraph element is allowed in the root, create paragraph element.
 			if ( schema.checkChild( root, 'paragraph' ) ) {

--- a/packages/ckeditor5-engine/tests/conversion/downcastdispatcher.js
+++ b/packages/ckeditor5-engine/tests/conversion/downcastdispatcher.js
@@ -1145,16 +1145,8 @@ describe( 'DowncastDispatcher', () => {
 			viewFigure._setCustomProperty( 'addHighlight', () => {} );
 			viewFigure._setCustomProperty( 'removeHighlight', () => {} );
 
-			// Create mapper mock.
-			dispatcher._conversionApi.mapper = {
-				toViewElement( modelElement ) {
-					if ( modelElement == image ) {
-						return viewFigure;
-					} else if ( modelElement == caption ) {
-						return viewCaption;
-					}
-				}
-			};
+			mapper.bindElements( image, viewFigure );
+			mapper.bindElements( caption, viewCaption );
 
 			model.change( writer => {
 				const range = writer.createRange( writer.createPositionAt( root, 0 ), writer.createPositionAt( root, 1 ) );

--- a/packages/ckeditor5-engine/tests/conversion/downcastdispatcher.js
+++ b/packages/ckeditor5-engine/tests/conversion/downcastdispatcher.js
@@ -960,20 +960,6 @@ describe( 'DowncastDispatcher', () => {
 			expect( dispatcher._conversionApi.consumable ).to.be.undefined;
 		} );
 
-		it( 'should not convert if selection is in a model root that does not have a corresponding view root', () => {
-			const newRoot = doc.createRoot( '$root', 'foo' );
-
-			model.change( writer => {
-				writer.setSelection( writer.createPositionAt( newRoot, 0 ) );
-			} );
-
-			sinon.spy( dispatcher, 'fire' );
-
-			dispatcher.convertSelection( doc.selection, model.markers, [] );
-
-			expect( dispatcher.fire.notCalled ).to.be.true;
-		} );
-
 		it( 'should prepare correct list of consumable values', () => {
 			model.change( writer => {
 				writer.setAttribute( 'bold', true, writer.createRangeIn( root ) );

--- a/packages/ckeditor5-engine/tests/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/downcasthelpers.js
@@ -5111,6 +5111,22 @@ describe( 'downcast selection converters', () => {
 
 				expect( viewSelection.focus.offset ).to.equal( 1 );
 			} );
+
+			it( 'should not convert if selection is in a model root that does not have a corresponding view root', () => {
+				model.change( writer => {
+					const newRoot = writer.addRoot( 'new' );
+
+					writer.insertText( 'foo', newRoot, 0 );
+					writer.setSelection( writer.createRangeIn( newRoot ) );
+				} );
+
+				// Convert model to view.
+				view.change( writer => {
+					dispatcher.convertSelection( docSelection, model.markers, writer );
+				} );
+
+				expect( viewSelection.rangeCount ).to.equal( 0 );
+			} );
 		} );
 
 		describe( 'collapsed selection', () => {
@@ -5339,6 +5355,26 @@ describe( 'downcast selection converters', () => {
 					'f<$text bold="true">ooba</$text>r',
 					'foobar' // No selection in view and no attribute.
 				);
+			} );
+
+			it( 'should not convert if selection is in a model root that does not have a corresponding view root', () => {
+				model.change( writer => {
+					const newRoot = writer.addRoot( 'new' );
+
+					writer.insertText( 'foo', { bold: true }, newRoot, 0 );
+					writer.addMarker( 'marker', { range: writer.createRangeIn( newRoot ), usingOperation: false } );
+					writer.setSelection( newRoot, 1 );
+				} );
+
+				sinon.spy( dispatcher, 'fire' );
+
+				// Convert model to view.
+				view.change( writer => {
+					dispatcher.convertSelection( docSelection, model.markers, writer );
+				} );
+
+				expect( viewSelection.rangeCount ).to.equal( 0 );
+				expect( dispatcher.fire.calledWith( 'attribute:bold:$text' ) ).to.be.false;
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-engine/tests/conversion/downcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/downcasthelpers.js
@@ -22,7 +22,7 @@ import ViewDocument from '../../src/view/document';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 
 import DowncastHelpers, {
-	clearAttributes,
+	cleanSelection,
 	convertCollapsedSelection,
 	convertRangeSelection,
 	createViewElementFromHighlightDescriptor,
@@ -5004,7 +5004,7 @@ describe( 'downcast selection converters', () => {
 		downcastHelpers.markerToHighlight( { model: 'marker', view: { classes: 'marker' }, converterPriority: 1 } );
 
 		// Default selection converters.
-		dispatcher.on( 'selection', clearAttributes(), { priority: 'high' } );
+		dispatcher.on( 'cleanSelection', cleanSelection() );
 		dispatcher.on( 'selection', convertRangeSelection(), { priority: 'low' } );
 		dispatcher.on( 'selection', convertCollapsedSelection(), { priority: 'low' } );
 	} );
@@ -5110,22 +5110,6 @@ describe( 'downcast selection converters', () => {
 				);
 
 				expect( viewSelection.focus.offset ).to.equal( 1 );
-			} );
-
-			it( 'should not convert if selection is in a model root that does not have a corresponding view root', () => {
-				model.change( writer => {
-					const newRoot = writer.addRoot( 'new' );
-
-					writer.insertText( 'foo', newRoot, 0 );
-					writer.setSelection( writer.createRangeIn( newRoot ) );
-				} );
-
-				// Convert model to view.
-				view.change( writer => {
-					dispatcher.convertSelection( docSelection, model.markers, writer );
-				} );
-
-				expect( viewSelection.rangeCount ).to.equal( 0 );
 			} );
 		} );
 
@@ -5356,26 +5340,6 @@ describe( 'downcast selection converters', () => {
 					'foobar' // No selection in view and no attribute.
 				);
 			} );
-
-			it( 'should not convert if selection is in a model root that does not have a corresponding view root', () => {
-				model.change( writer => {
-					const newRoot = writer.addRoot( 'new' );
-
-					writer.insertText( 'foo', { bold: true }, newRoot, 0 );
-					writer.addMarker( 'marker', { range: writer.createRangeIn( newRoot ), usingOperation: false } );
-					writer.setSelection( newRoot, 1 );
-				} );
-
-				sinon.spy( dispatcher, 'fire' );
-
-				// Convert model to view.
-				view.change( writer => {
-					dispatcher.convertSelection( docSelection, model.markers, writer );
-				} );
-
-				expect( viewSelection.rangeCount ).to.equal( 0 );
-				expect( dispatcher.fire.calledWith( 'attribute:bold:$text' ) ).to.be.false;
-			} );
 		} );
 	} );
 
@@ -5416,7 +5380,7 @@ describe( 'downcast selection converters', () => {
 			} );
 		} );
 
-		describe( 'clearAttributes', () => {
+		describe( 'cleanSelection', () => {
 			it( 'should remove all ranges before adding new range', () => {
 				testSelection(
 					[ 3, 3 ],

--- a/packages/ckeditor5-engine/tests/conversion/modelconsumable.js
+++ b/packages/ckeditor5-engine/tests/conversion/modelconsumable.js
@@ -155,6 +155,44 @@ describe( 'ModelConsumable', () => {
 		} );
 	} );
 
+	describe( 'consumeAll()', () => {
+		it( 'should remove all consumable values for given element', () => {
+			modelConsumable.add( modelElement, 'typeA' );
+			modelConsumable.add( modelElement, 'typeB' );
+			modelConsumable.add( modelElement, 'typeC' );
+
+			modelConsumable.consumeAll( modelElement );
+
+			expect( modelConsumable.test( modelElement, 'typeA' ) ).to.be.false;
+			expect( modelConsumable.test( modelElement, 'typeB' ) ).to.be.false;
+			expect( modelConsumable.test( modelElement, 'typeC' ) ).to.be.false;
+
+			// Consumable type that didn't exist should still return `null`:
+			expect( modelConsumable.test( modelElement, 'typeD' ) ).to.be.null;
+		} );
+
+		it( 'should correctly consume text proxy instances', () => {
+			const proxy1To4 = new ModelTextProxy( modelElement.getChild( 0 ), 1, 3 );
+			const proxy1To5 = new ModelTextProxy( modelElement.getChild( 0 ), 1, 4 );
+			const proxyOther1To4 = new ModelTextProxy( new ModelText( 'abcdef' ), 1, 3 );
+
+			modelConsumable.add( proxy1To4, 'typeA' );
+			modelConsumable.add( proxy1To4, 'typeB' );
+			modelConsumable.add( proxy1To4, 'typeC' );
+
+			modelConsumable.add( proxy1To5, 'type' );
+			modelConsumable.add( proxyOther1To4, 'type' );
+
+			modelConsumable.consumeAll( proxy1To4 );
+
+			expect( modelConsumable.test( proxy1To4, 'typeA' ) ).to.be.false;
+			expect( modelConsumable.test( proxy1To4, 'typeB' ) ).to.be.false;
+			expect( modelConsumable.test( proxy1To4, 'typeC' ) ).to.be.false;
+			expect( modelConsumable.test( proxy1To5, 'type' ) ).to.be.true;
+			expect( modelConsumable.test( proxyOther1To4, 'type' ) ).to.be.true;
+		} );
+	} );
+
 	describe( 'revert()', () => {
 		it( 'should re-add consumable value if it was already consumed and return true', () => {
 			modelConsumable.add( modelElement, 'type' );

--- a/packages/ckeditor5-engine/tests/conversion/modelconsumable.js
+++ b/packages/ckeditor5-engine/tests/conversion/modelconsumable.js
@@ -155,44 +155,6 @@ describe( 'ModelConsumable', () => {
 		} );
 	} );
 
-	describe( 'consumeAll()', () => {
-		it( 'should remove all consumable values for given element', () => {
-			modelConsumable.add( modelElement, 'typeA' );
-			modelConsumable.add( modelElement, 'typeB' );
-			modelConsumable.add( modelElement, 'typeC' );
-
-			modelConsumable.consumeAll( modelElement );
-
-			expect( modelConsumable.test( modelElement, 'typeA' ) ).to.be.false;
-			expect( modelConsumable.test( modelElement, 'typeB' ) ).to.be.false;
-			expect( modelConsumable.test( modelElement, 'typeC' ) ).to.be.false;
-
-			// Consumable type that didn't exist should still return `null`:
-			expect( modelConsumable.test( modelElement, 'typeD' ) ).to.be.null;
-		} );
-
-		it( 'should correctly consume text proxy instances', () => {
-			const proxy1To4 = new ModelTextProxy( modelElement.getChild( 0 ), 1, 3 );
-			const proxy1To5 = new ModelTextProxy( modelElement.getChild( 0 ), 1, 4 );
-			const proxyOther1To4 = new ModelTextProxy( new ModelText( 'abcdef' ), 1, 3 );
-
-			modelConsumable.add( proxy1To4, 'typeA' );
-			modelConsumable.add( proxy1To4, 'typeB' );
-			modelConsumable.add( proxy1To4, 'typeC' );
-
-			modelConsumable.add( proxy1To5, 'type' );
-			modelConsumable.add( proxyOther1To4, 'type' );
-
-			modelConsumable.consumeAll( proxy1To4 );
-
-			expect( modelConsumable.test( proxy1To4, 'typeA' ) ).to.be.false;
-			expect( modelConsumable.test( proxy1To4, 'typeB' ) ).to.be.false;
-			expect( modelConsumable.test( proxy1To4, 'typeC' ) ).to.be.false;
-			expect( modelConsumable.test( proxy1To5, 'type' ) ).to.be.true;
-			expect( modelConsumable.test( proxyOther1To4, 'type' ) ).to.be.true;
-		} );
-	} );
-
 	describe( 'revert()', () => {
 		it( 'should re-add consumable value if it was already consumed and return true', () => {
 			modelConsumable.add( modelElement, 'type' );

--- a/packages/ckeditor5-engine/tests/model/differ.js
+++ b/packages/ckeditor5-engine/tests/model/differ.js
@@ -741,7 +741,7 @@ describe( 'Differ', () => {
 
 				expectChanges( [
 					// Only buffer "remove" from the loaded root.
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ) },
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ) }
 				] );
 			} );
 		} );
@@ -1494,8 +1494,6 @@ describe( 'Differ', () => {
 			model.change( () => {
 				attribute( range, attributeKey, attributeOldValue, attributeNewValue );
 
-				const diffRange = new Range( Position._createAt( root, 0 ), Position._createAt( root.getChild( 0 ), 0 ) );
-
 				expectChanges( [] );
 			} );
 		} );
@@ -1977,7 +1975,7 @@ describe( 'Differ', () => {
 					name: 'name',
 					data: {
 						oldRange: null,
-						newRange: newRange
+						newRange
 					}
 				}
 			] );

--- a/packages/ckeditor5-engine/tests/model/differ.js
+++ b/packages/ckeditor5-engine/tests/model/differ.js
@@ -37,7 +37,6 @@ describe( 'Differ', () => {
 	} );
 
 	describe( 'insert', () => {
-		// Simple.
 		it( 'an element', () => {
 			const position = new Position( root, [ 1 ] );
 
@@ -265,6 +264,18 @@ describe( 'Differ', () => {
 					},
 					{ type: 'insert', name: '$text', length: 2, position }
 				] );
+			} );
+		} );
+
+		it( 'inside non-loaded root - not buffered', () => {
+			root._isLoaded = false;
+
+			const position = new Position( root, [ 0 ] );
+
+			model.change( () => {
+				insert( new Element( 'imageBlock' ), position );
+
+				expectChanges( [] );
 			} );
 		} );
 	} );
@@ -600,6 +611,18 @@ describe( 'Differ', () => {
 				] );
 			} );
 		} );
+
+		it( 'from non-loaded root - not buffered', () => {
+			root._isLoaded = false;
+
+			const position = new Position( root, [ 0 ] );
+
+			model.change( () => {
+				remove( position, 1 );
+
+				expectChanges( [] );
+			} );
+		} );
 	} );
 
 	// The only main difference between remove operation and move operation is target position.
@@ -692,6 +715,54 @@ describe( 'Differ', () => {
 				expectChanges( [] );
 			} );
 		} );
+
+		it( 'inside non-loaded root - not buffered', () => {
+			root._isLoaded = false;
+
+			const sourcePosition = new Position( root, [ 0 ] );
+			const targetPosition = new Position( root, [ 2 ] );
+
+			model.change( () => {
+				move( sourcePosition, 1, targetPosition );
+
+				expectChanges( [] );
+			} );
+		} );
+
+		it( 'into non-loaded root - partially not buffered', () => {
+			const newRoot = model.document.createRoot( '$root', 'new' );
+			newRoot._isLoaded = false;
+
+			const sourcePosition = new Position( root, [ 0 ] );
+			const targetPosition = new Position( newRoot, [ 0 ] );
+
+			model.change( () => {
+				move( sourcePosition, 1, targetPosition );
+
+				expectChanges( [
+					// Only buffer "remove" from the loaded root.
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ) },
+				] );
+			} );
+		} );
+
+		it( 'from non-loaded root - partially not buffered', () => {
+			const newRoot = model.document.createRoot( '$root', 'new' );
+
+			root._isLoaded = false;
+
+			const sourcePosition = new Position( root, [ 0 ] );
+			const targetPosition = new Position( newRoot, [ 0 ] );
+
+			model.change( () => {
+				move( sourcePosition, 1, targetPosition );
+
+				expectChanges( [
+					// Only buffer "insert" to the loaded root.
+					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( newRoot, [ 0 ] ) }
+				] );
+			} );
+		} );
 	} );
 
 	describe( 'rename', () => {
@@ -751,6 +822,16 @@ describe( 'Differ', () => {
 
 				expect( markersToRefresh ).to.deep.equal( markersToRemove );
 				expect( markersToRefresh ).to.deep.equal( markersToAdd );
+			} );
+		} );
+
+		it( 'inside a non-loaded root - not buffered', () => {
+			root._isLoaded = false;
+
+			model.change( () => {
+				rename( root.getChild( 1 ), 'listItem' );
+
+				expectChanges( [] );
 			} );
 		} );
 	} );
@@ -1404,6 +1485,20 @@ describe( 'Differ', () => {
 				] );
 			} );
 		} );
+
+		it( 'inside a non-loaded root - not buffered', () => {
+			root._isLoaded = false;
+
+			const range = new Range( Position._createAt( root, 0 ), Position._createAt( root, 1 ) );
+
+			model.change( () => {
+				attribute( range, attributeKey, attributeOldValue, attributeNewValue );
+
+				const diffRange = new Range( Position._createAt( root, 0 ), Position._createAt( root.getChild( 0 ), 0 ) );
+
+				expectChanges( [] );
+			} );
+		} );
 	} );
 
 	describe( 'split', () => {
@@ -1471,6 +1566,18 @@ describe( 'Differ', () => {
 				], true );
 			} );
 		} );
+
+		it( 'inside a non-loaded root - not buffered', () => {
+			root._isLoaded = false;
+
+			const position = new Position( root, [ 0, 2 ] );
+
+			model.change( () => {
+				split( position );
+
+				expectChanges( [] );
+			} );
+		} );
 	} );
 
 	describe( 'merge', () => {
@@ -1535,6 +1642,16 @@ describe( 'Differ', () => {
 					{ type: 'insert', name: '$text', length: 3, position: new Position( root, [ 0, 3 ] ) },
 					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ) }
 				], true );
+			} );
+		} );
+
+		it( 'inside a non-loaded root - not buffered', () => {
+			root._isLoaded = false;
+
+			model.change( () => {
+				merge( new Position( root, [ 1, 0 ] ), new Position( root, [ 0, 3 ] ) );
+
+				expectChanges( [] );
 			} );
 		} );
 	} );
@@ -1791,6 +1908,76 @@ describe( 'Differ', () => {
 					data: {
 						oldRange: range,
 						newRange: range
+					}
+				}
+			] );
+		} );
+
+		it( 'add marker inside a non-loaded root - not buffered', () => {
+			root._isLoaded = false;
+
+			differ.bufferMarkerChange( 'name', { range: null, affectsData: true }, { range, affectsData: true } );
+
+			expect( differ.getMarkersToRemove() ).to.deep.equal( [] );
+			expect( differ.getMarkersToAdd() ).to.deep.equal( [] );
+			expect( differ.getChangedMarkers() ).to.deep.equal( [] );
+		} );
+
+		it( 'remove marker inside a non-loaded root - not buffered', () => {
+			root._isLoaded = false;
+
+			differ.bufferMarkerChange( 'name', { range, affectsData: true }, { range: null, affectsData: true } );
+
+			expect( differ.getMarkersToRemove() ).to.deep.equal( [] );
+			expect( differ.getMarkersToAdd() ).to.deep.equal( [] );
+			expect( differ.getChangedMarkers() ).to.deep.equal( [] );
+		} );
+
+		it( 'move marker from a loaded to a non-loaded root - partially not buffered', () => {
+			const newRoot = model.document.createRoot( '$root', 'new' );
+			newRoot._isLoaded = false;
+
+			const newRange = new Range( Position._createAt( newRoot, 0 ), Position._createAt( newRoot, 0 ) );
+
+			differ.bufferMarkerChange( 'name', { range, affectsData: true }, { range: newRange, affectsData: true } );
+
+			expect( differ.getMarkersToRemove() ).to.deep.equal( [
+				{ name: 'name', range }
+			] );
+
+			expect( differ.getMarkersToAdd() ).to.deep.equal( [] );
+
+			expect( differ.getChangedMarkers() ).to.deep.equal( [
+				{
+					name: 'name',
+					data: {
+						oldRange: range,
+						newRange: null
+					}
+				}
+			] );
+		} );
+
+		it( 'move marker from a non-loaded to a loaded root - partially not buffered', () => {
+			const newRoot = model.document.createRoot( '$root', 'new' );
+			const newRange = new Range( Position._createAt( newRoot, 0 ), Position._createAt( newRoot, 0 ) );
+
+			root._isLoaded = false;
+
+			differ.bufferMarkerChange( 'name', { range, affectsData: true }, { range: newRange, affectsData: true } );
+
+			expect( differ.getMarkersToRemove() ).to.deep.equal( [] );
+
+			expect( differ.getMarkersToAdd() ).to.deep.equal( [
+				{ name: 'name', range: newRange }
+			] );
+
+			expect( differ.getChangedMarkers() ).to.deep.equal( [
+				{
+					name: 'name',
+					data: {
+						oldRange: null,
+						newRange: newRange
 					}
 				}
 			] );
@@ -2188,6 +2375,45 @@ describe( 'Differ', () => {
 				} );
 			} );
 		} );
+
+		it( 'detach non-loaded root - not buffered', () => {
+			root._isLoaded = false;
+
+			model.change( writer => {
+				writer.detachRoot( 'main' );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expectChanges( [] );
+
+				expect( rootChanges.length ).to.equal( 0 );
+			} );
+		} );
+
+		it( 'change attributes on non-loaded root - not buffered', () => {
+			root._isLoaded = false;
+
+			model.change( writer => {
+				writer.setAttribute( 'foo', 'foo', root );
+				writer.setAttribute( 'bar', 'bar', root );
+				writer.setAttribute( 'baz', 'baz', root )
+
+				writer.removeAttribute( 'baz', root );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 0 );
+			} );
+
+			model.change( writer => {
+				writer.setAttribute( 'foo', 'xyz', root );
+				writer.removeAttribute( 'bar', root );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 0 );
+			} );
+		} );
 	} );
 
 	describe( 'other cases', () => {
@@ -2298,6 +2524,177 @@ describe( 'Differ', () => {
 					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ) },
 					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ) },
 					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ) }
+				] );
+			} );
+		} );
+	} );
+
+	describe( '_loadRoot()', () => {
+		let newRoot, rangeA, rangeB;
+
+		beforeEach( () => {
+			model.change( writer => {
+				newRoot = model.document.createRoot( '$root', 'new' );
+				newRoot._isLoaded = false;
+
+				writer.insertElement( 'heading2', newRoot, 0 );
+				writer.insertElement( 'paragraph', newRoot, 1 );
+
+				rangeA = writer.createRangeIn( newRoot.getChild( 0 ) );
+				rangeB = writer.createRangeIn( newRoot );
+				writer.addMarker( 'markerA', { range: rangeA, usingOperation: true } );
+				writer.addMarker( 'markerB', { range: rangeB, usingOperation: true } );
+
+				writer.setAttribute( 'foo', 'foo', newRoot );
+				writer.setAttribute( 'bar', 'bar', newRoot );
+
+				// Marker in a different root.
+				writer.addMarker( 'marker', { range: writer.createRangeIn( root ), usingOperation: true } );
+			} );
+		} );
+
+		it( 'should buffer root state attached', () => {
+			model.change( () => {
+				newRoot._isLoaded = true;
+				differ._loadRoot( newRoot );
+
+				const changes = differ.getChangedRoots();
+
+				expect( changes.length ).to.equal( 1 );
+				expect( changes[ 0 ] ).to.deep.equal( { name: 'new', state: 'attached' } );
+			} );
+		} );
+
+		it( 'should buffer all root content as inserted', () => {
+			model.change( () => {
+				newRoot._isLoaded = true;
+				differ._loadRoot( newRoot );
+
+				expectChanges( [
+					{ type: 'insert', name: 'heading2', length: 1, position: new Position( newRoot, [ 0 ] ) },
+					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( newRoot, [ 1 ] ) }
+				] );
+			} );
+		} );
+
+		it( 'should buffer all markers inside the root as inserted', () => {
+			model.change( () => {
+				newRoot._isLoaded = true;
+				differ._loadRoot( newRoot );
+
+				expect( differ.getMarkersToRemove() ).to.deep.equal( [] );
+
+				expect( differ.getMarkersToAdd() ).to.deep.equal( [
+					{ name: 'markerA', range: rangeA },
+					{ name: 'markerB', range: rangeB }
+				] );
+
+				expect( differ.getChangedMarkers() ).to.deep.equal( [
+					{
+						name: 'markerA',
+						data: {
+							oldRange: null,
+							newRange: rangeA
+						}
+					},
+					{
+						name: 'markerB',
+						data: {
+							oldRange: null,
+							newRange: rangeB
+						}
+					}
+				] );
+			} );
+		} );
+
+		it( 'should not buffer any changes if the root is detached', () => {
+			model.change( writer => {
+				writer.detachRoot( newRoot );
+			} );
+
+			model.change( () => {
+				newRoot._isLoaded = true;
+				differ._loadRoot( newRoot );
+
+				expectChanges( [] );
+				expect( differ.getChangedMarkers() ).to.deep.equal( [] );
+				expect( differ.getChangedRoots().length ).to.equal( 0 );
+				expect( differ.hasDataChanges() ).to.be.false;
+			} );
+		} );
+
+		it( 'should not buffer any root-related changes if the root is detached after it is loaded', () => {
+			model.change( writer => {
+				newRoot._isLoaded = true;
+				differ._loadRoot( newRoot );
+				writer.detachRoot( newRoot );
+
+				expectChanges( [] );
+				expect( differ.getChangedMarkers() ).to.deep.equal( [] );
+				expect( differ.getChangedRoots().length ).to.equal( 0 );
+
+				// It has changes in graveyard!
+				expect( differ.hasDataChanges() ).to.be.true;
+			} );
+		} );
+
+		it( 'should work well with changes that happens after the root was loaded', () => {
+			model.change( writer => {
+				newRoot._isLoaded = true;
+				differ._loadRoot( newRoot );
+
+				// Remove `paragraph` and add an `imageBlock` before `heading2`.
+				writer.remove( newRoot.getChild( 1 ) );
+				writer.insertElement( 'imageBlock', newRoot, 0 );
+
+				// Do some attribute changes. This should result in NO buffered attribute changes.
+				// We don't return buffered attribute changes if the root was attached!
+				writer.removeAttribute( 'foo', newRoot );
+				writer.setAttribute( 'bar', 'xyz', newRoot );
+				writer.setAttribute( 'baz', 'baz', newRoot );
+
+				// Do some marker changes.
+				// `markerA` was in the `heading2` which was moved, so let's refresh it.
+				const newRangeA = writer.createRangeIn( newRoot.getChild( 1 ) );
+				// `markerB` will be removed.
+				writer.removeMarker( 'markerB' );
+				// `markerC` will be added on the new `imageBlock` and should be [ 0 ] - [ 1 ].
+				const rangeC = writer.createRangeOn( newRoot.getChild( 0 ) );
+				writer.addMarker( 'markerC', { range: rangeC, usingOperation: true } );
+
+				expectChanges( [
+					{ type: 'insert', name: 'imageBlock', length: 1, position: new Position( newRoot, [ 0 ] ) },
+					{ type: 'insert', name: 'heading2', length: 1, position: new Position( newRoot, [ 1 ] ) }
+				] );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 1 );
+				expect( rootChanges[ 0 ] ).to.deep.equal( { name: 'new', state: 'attached' } );
+
+				expect( differ.getMarkersToRemove() ).to.deep.equal( [] );
+
+				expect( differ.getMarkersToAdd() ).to.deep.equal( [
+					{ name: 'markerA', range: newRangeA },
+					{ name: 'markerC', range: rangeC }
+				] );
+
+				expect( differ.getChangedMarkers() ).to.deep.equal( [
+					{
+						name: 'markerA',
+						data: {
+							oldRange: null,
+							newRange: newRangeA
+						}
+					},
+					{
+						name: 'markerC',
+						data: {
+							oldRange: null,
+							newRange: rangeC
+						}
+					}
 				] );
 			} );
 		} );
@@ -2555,7 +2952,7 @@ describe( 'Differ', () => {
 	function expectChanges( expected, includeChangesInGraveyard = false ) {
 		const changes = differ.getChanges( { includeChangesInGraveyard } );
 
-		expect( changes.length ).to.equal( expected.length );
+		expect( changes.length, 'changes length' ).to.equal( expected.length );
 
 		for ( let i = 0; i < expected.length; i++ ) {
 			for ( const key in expected[ i ] ) {

--- a/packages/ckeditor5-engine/tests/model/differ.js
+++ b/packages/ckeditor5-engine/tests/model/differ.js
@@ -15,6 +15,7 @@ import RenameOperation from '../../src/model/operation/renameoperation';
 import AttributeOperation from '../../src/model/operation/attributeoperation';
 import SplitOperation from '../../src/model/operation/splitoperation';
 import MergeOperation from '../../src/model/operation/mergeoperation';
+import RootOperation from '../../src/model/operation/rootoperation';
 
 describe( 'Differ', () => {
 	let doc, differ, root, model;
@@ -1996,6 +1997,22 @@ describe( 'Differ', () => {
 			} );
 		} );
 
+		it( 'add root operation when root is attached should be ignored by differ', () => {
+			// This may happen during RTC when joining an editing session when a root was added during that editing session.
+			model.change( writer => {
+				const operation = new RootOperation( 'main', '$root', true, model.document, model.document.version );
+
+				writer.batch.addOperation( operation );
+				model.applyOperation( operation );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 0 );
+				expect( differ.hasDataChanges() ).to.be.false;
+				expect( differ.isEmpty ).to.be.true;
+			} );
+		} );
+
 		it( 'detach root', () => {
 			model.change( writer => {
 				writer.detachRoot( 'main' );
@@ -2006,6 +2023,22 @@ describe( 'Differ', () => {
 				expect( rootChanges[ 0 ] ).to.deep.equal( { name: 'main', state: 'detached' } );
 				expect( differ.hasDataChanges() ).to.be.true;
 				expect( differ.isEmpty ).to.be.false;
+			} );
+		} );
+
+		it( 'detach root operation when root is not attached should be ignored by differ', () => {
+			// This may happen during RTC when joining an editing session when a root was detached during that editing session.
+			model.change( writer => {
+				const operation = new RootOperation( 'new', '$root', false, model.document, model.document.version );
+
+				writer.batch.addOperation( operation );
+				model.applyOperation( operation );
+
+				const rootChanges = differ.getChangedRoots();
+
+				expect( rootChanges.length ).to.equal( 0 );
+				expect( differ.hasDataChanges() ).to.be.false;
+				expect( differ.isEmpty ).to.be.true;
 			} );
 		} );
 

--- a/packages/ckeditor5-engine/tests/model/differ.js
+++ b/packages/ckeditor5-engine/tests/model/differ.js
@@ -2427,7 +2427,7 @@ describe( 'Differ', () => {
 			model.change( writer => {
 				writer.setAttribute( 'foo', 'foo', root );
 				writer.setAttribute( 'bar', 'bar', root );
-				writer.setAttribute( 'baz', 'baz', root )
+				writer.setAttribute( 'baz', 'baz', root );
 
 				writer.removeAttribute( 'baz', root );
 

--- a/packages/ckeditor5-engine/tests/model/differ.js
+++ b/packages/ckeditor5-engine/tests/model/differ.js
@@ -2560,7 +2560,7 @@ describe( 'Differ', () => {
 		} );
 	} );
 
-	describe( '_loadRoot()', () => {
+	describe( '_bufferRootLoad()', () => {
 		let newRoot, rangeA, rangeB;
 
 		beforeEach( () => {
@@ -2587,7 +2587,7 @@ describe( 'Differ', () => {
 		it( 'should buffer root state attached', () => {
 			model.change( () => {
 				newRoot._isLoaded = true;
-				differ._loadRoot( newRoot );
+				differ._bufferRootLoad( newRoot );
 
 				const changes = differ.getChangedRoots();
 
@@ -2599,7 +2599,7 @@ describe( 'Differ', () => {
 		it( 'should buffer all root content as inserted', () => {
 			model.change( () => {
 				newRoot._isLoaded = true;
-				differ._loadRoot( newRoot );
+				differ._bufferRootLoad( newRoot );
 
 				expectChanges( [
 					{ type: 'insert', name: 'heading2', length: 1, position: new Position( newRoot, [ 0 ] ) },
@@ -2611,7 +2611,7 @@ describe( 'Differ', () => {
 		it( 'should buffer all markers inside the root as inserted', () => {
 			model.change( () => {
 				newRoot._isLoaded = true;
-				differ._loadRoot( newRoot );
+				differ._bufferRootLoad( newRoot );
 
 				expect( differ.getMarkersToRemove() ).to.deep.equal( [] );
 
@@ -2646,7 +2646,7 @@ describe( 'Differ', () => {
 
 			model.change( () => {
 				newRoot._isLoaded = true;
-				differ._loadRoot( newRoot );
+				differ._bufferRootLoad( newRoot );
 
 				expectChanges( [] );
 				expect( differ.getChangedMarkers() ).to.deep.equal( [] );
@@ -2658,7 +2658,7 @@ describe( 'Differ', () => {
 		it( 'should not buffer any root-related changes if the root is detached after it is loaded', () => {
 			model.change( writer => {
 				newRoot._isLoaded = true;
-				differ._loadRoot( newRoot );
+				differ._bufferRootLoad( newRoot );
 				writer.detachRoot( newRoot );
 
 				expectChanges( [] );
@@ -2673,7 +2673,7 @@ describe( 'Differ', () => {
 		it( 'should work well with changes that happens after the root was loaded', () => {
 			model.change( writer => {
 				newRoot._isLoaded = true;
-				differ._loadRoot( newRoot );
+				differ._bufferRootLoad( newRoot );
 
 				// Remove `paragraph` and add an `imageBlock` before `heading2`.
 				writer.remove( newRoot.getChild( 1 ) );

--- a/packages/ckeditor5-engine/tests/model/document.js
+++ b/packages/ckeditor5-engine/tests/model/document.js
@@ -121,15 +121,15 @@ describe( 'Document', () => {
 	} );
 
 	describe( 'getRootNames()', () => {
-		it( 'should return empty iterator if no roots exist', () => {
+		it( 'should return empty array if no roots exist', () => {
 			expect( count( doc.getRootNames() ) ).to.equal( 0 );
 		} );
 
-		it( 'should return an iterator of all roots without the graveyard', () => {
+		it( 'should return array with all roots without the graveyard', () => {
 			doc.createRoot( '$root', 'a' );
 			doc.createRoot( '$root', 'b' );
 
-			expect( Array.from( doc.getRootNames() ) ).to.deep.equal( [ 'a', 'b' ] );
+			expect( doc.getRootNames() ).to.deep.equal( [ 'a', 'b' ] );
 		} );
 
 		it( 'should return only attached roots', () => {
@@ -138,7 +138,7 @@ describe( 'Document', () => {
 
 			rootB._isAttached = false;
 
-			expect( Array.from( doc.getRootNames() ) ).to.deep.equal( [ 'a' ] );
+			expect( doc.getRootNames() ).to.deep.equal( [ 'a' ] );
 		} );
 
 		it( 'should return detached roots when `includeDetached` flag is set to `true`', () => {
@@ -147,7 +147,58 @@ describe( 'Document', () => {
 
 			rootB._isAttached = false;
 
-			expect( Array.from( doc.getRootNames( true ) ) ).to.deep.equal( [ 'a', 'b' ] );
+			expect( doc.getRootNames( true ) ).to.deep.equal( [ 'a', 'b' ] );
+		} );
+
+		it( 'should not return non-loaded roots', () => {
+			doc.createRoot( '$root', 'a' );
+			const rootB = doc.createRoot( '$root', 'b' );
+
+			rootB._isLoaded = false;
+
+			expect( doc.getRootNames() ).to.deep.equal( [ 'a' ] );
+			expect( doc.getRootNames( true ) ).to.deep.equal( [ 'a' ] );
+		} );
+	} );
+
+	describe( 'getRoots()', () => {
+		it( 'should return empty iterator if no roots exist', () => {
+			expect( count( doc.getRoots() ) ).to.equal( 0 );
+		} );
+
+		it( 'should return an iterator of all roots without the graveyard', () => {
+			const rootA = doc.createRoot( '$root', 'a' );
+			const rootB = doc.createRoot( '$root', 'b' );
+
+			expect( doc.getRoots() ).to.deep.equal( [ rootA, rootB ] );
+		} );
+
+		it( 'should return only attached roots', () => {
+			const rootA = doc.createRoot( '$root', 'a' );
+			const rootB = doc.createRoot( '$root', 'b' );
+
+			rootB._isAttached = false;
+
+			expect( doc.getRoots() ).to.deep.equal( [ rootA ] );
+		} );
+
+		it( 'should return detached roots when `includeDetached` flag is set to `true`', () => {
+			const rootA = doc.createRoot( '$root', 'a' );
+			const rootB = doc.createRoot( '$root', 'b' );
+
+			rootB._isAttached = false;
+
+			expect( doc.getRoots( true ) ).to.deep.equal( [ rootA, rootB ] );
+		} );
+
+		it( 'should not return non-loaded roots', () => {
+			const rootA = doc.createRoot( '$root', 'a' );
+			const rootB = doc.createRoot( '$root', 'b' );
+
+			rootA._isLoaded = false;
+
+			expect( doc.getRoots() ).to.deep.equal( [ rootB ] );
+			expect( doc.getRoots( true ) ).to.deep.equal( [ rootB ] );
 		} );
 	} );
 

--- a/packages/ckeditor5-engine/tests/model/documentselection.js
+++ b/packages/ckeditor5-engine/tests/model/documentselection.js
@@ -1254,6 +1254,19 @@ describe( 'DocumentSelection', () => {
 			} );
 		} );
 
+		it( 'are not inherited from nodes in graveyard', () => {
+			model.change( writer => {
+				writer.insertText( 'foo', { bold: true }, model.document.graveyard, 0 );
+
+				// The only way to place selection in the graveyard is to remove all roots.
+				// This way the default range will be placed in the graveyard.
+				writer.detachRoot( 'main' );
+			} );
+
+			expect( selection.anchor.root ).to.equal( model.document.graveyard );
+			expect( selection.hasAttribute( 'bold' ) ).to.equal( false );
+		} );
+
 		describe( 'parent element\'s attributes', () => {
 			it( 'are set using a normal batch', () => {
 				let batch;

--- a/packages/ckeditor5-engine/tests/model/operation/rootoperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/rootoperation.js
@@ -96,29 +96,6 @@ describe( 'RootOperation', () => {
 		expect( clone.isAdd ).to.equal( true );
 	} );
 
-	describe( '_validate()', () => {
-		it( 'should throw an error when trying to add an existing and attached root', () => {
-			doc.createRoot( '$root', 'new' );
-
-			expectToThrowCKEditorError( () => {
-				const op = new RootOperation( 'new', '$root', true, doc, doc.version );
-
-				op._validate();
-			}, /root-operation-root-attached/ );
-		} );
-
-		it( 'should throw an error when trying to detach a detached root', () => {
-			const root = doc.createRoot( '$root', 'new' );
-			root._isAttached = false;
-
-			expectToThrowCKEditorError( () => {
-				const op = new RootOperation( 'new', '$root', false, doc, doc.version );
-
-				op._validate();
-			}, /root-operation-root-detached/ );
-		} );
-	} );
-
 	describe( 'toJSON', () => {
 		it( 'should create proper serialized object', () => {
 			const op = new RootOperation( 'new', '$root', true, doc, doc.version );

--- a/packages/ckeditor5-engine/tests/model/operation/rootoperation.js
+++ b/packages/ckeditor5-engine/tests/model/operation/rootoperation.js
@@ -5,7 +5,6 @@
 
 import Model from '../../../src/model/model';
 import RootOperation from '../../../src/model/operation/rootoperation';
-import { expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 
 describe( 'RootOperation', () => {
 	let model, doc;

--- a/packages/ckeditor5-engine/tests/model/operation/transform/root.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/root.js
@@ -80,6 +80,80 @@ describe( 'transform', () => {
 				expect( john.document.getRoot( 'new' ).isAttached() ).to.be.false;
 				expect( kate.document.getRoot( 'new' ).isAttached() ).to.be.false;
 			} );
+
+			it( 'with the same name, then undo one', () => {
+				john.addRoot( 'new' );
+				kate.addRoot( 'new' );
+
+				syncClients();
+
+				john.detachRoot( 'new' );
+
+				kate.detachRoot( 'new' );
+				kate.undo();
+
+				syncClients();
+
+				expect( john.document.getRoot( 'new' ).isAttached() ).to.be.true;
+				expect( kate.document.getRoot( 'new' ).isAttached() ).to.be.true;
+			} );
+
+			it( 'with the same name, then undo both', () => {
+				john.addRoot( 'new' );
+				kate.addRoot( 'new' );
+
+				syncClients();
+
+				john.detachRoot( 'new' );
+				john.undo();
+
+				kate.detachRoot( 'new' );
+				kate.undo();
+
+				syncClients();
+
+				expect( john.document.getRoot( 'new' ).isAttached() ).to.be.true;
+				expect( kate.document.getRoot( 'new' ).isAttached() ).to.be.true;
+			} );
+
+			it( 'with the same name, then undo both, then redo one', () => {
+				john.addRoot( 'new' );
+				kate.addRoot( 'new' );
+
+				syncClients();
+
+				john.detachRoot( 'new' );
+				john.undo();
+				john.redo();
+
+				kate.detachRoot( 'new' );
+				kate.undo();
+
+				syncClients();
+
+				expect( john.document.getRoot( 'new' ).isAttached() ).to.be.false;
+				expect( kate.document.getRoot( 'new' ).isAttached() ).to.be.false;
+			} );
+
+			it( 'with the same name, then undo both, then redo both', () => {
+				john.addRoot( 'new' );
+				kate.addRoot( 'new' );
+
+				syncClients();
+
+				john.detachRoot( 'new' );
+				john.undo();
+				john.redo();
+
+				kate.detachRoot( 'new' );
+				kate.undo();
+				john.redo();
+
+				syncClients();
+
+				expect( john.document.getRoot( 'new' ).isAttached() ).to.be.false;
+				expect( kate.document.getRoot( 'new' ).isAttached() ).to.be.false;
+			} );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-engine/tests/model/schema.js
+++ b/packages/ckeditor5-engine/tests/model/schema.js
@@ -1653,6 +1653,18 @@ describe( 'Schema', () => {
 			'<paragraph></paragraph><paragraph>[]</paragraph>'
 		);
 
+		it( 'should return null for a position in graveyard even if there is a paragraph there', () => {
+			let range;
+
+			model.enqueueChange( { isUndoable: false }, writer => {
+				writer.insertElement( 'paragraph', model.document.graveyard, 0 );
+			} );
+
+			range = schema.getNearestSelectionRange( model.createPositionFromPath( model.document.graveyard, [ 0 ] ) );
+
+			expect( range ).to.be.null;
+		} );
+
 		describe( 'in case of objects which do not allow text inside', () => {
 			test(
 				'should select nearest object (o[]o) - both',

--- a/packages/ckeditor5-engine/tests/model/schema.js
+++ b/packages/ckeditor5-engine/tests/model/schema.js
@@ -1654,13 +1654,11 @@ describe( 'Schema', () => {
 		);
 
 		it( 'should return null for a position in graveyard even if there is a paragraph there', () => {
-			let range;
-
 			model.enqueueChange( { isUndoable: false }, writer => {
 				writer.insertElement( 'paragraph', model.document.graveyard, 0 );
 			} );
 
-			range = schema.getNearestSelectionRange( model.createPositionFromPath( model.document.graveyard, [ 0 ] ) );
+			const range = schema.getNearestSelectionRange( model.createPositionFromPath( model.document.graveyard, [ 0 ] ) );
 
 			expect( range ).to.be.null;
 		} );

--- a/packages/ckeditor5-heading/src/title.ts
+++ b/packages/ckeditor5-heading/src/title.ts
@@ -247,9 +247,7 @@ export default class Title extends Plugin {
 		let changed = false;
 		const model = this.editor.model;
 
-		for ( const rootName of this.editor.model.document.getRootNames() ) {
-			const modelRoot = model.document.getRoot( rootName )!;
-
+		for ( const modelRoot of this.editor.model.document.getRoots() ) {
 			const titleElements = Array.from( modelRoot.getChildren() as IterableIterator<Element> ).filter( isTitle );
 			const firstTitleElement = titleElements[ 0 ];
 			const firstRootChild = modelRoot.getChild( 0 ) as Element;

--- a/packages/ckeditor5-html-support/src/htmlcomment.ts
+++ b/packages/ckeditor5-html-support/src/htmlcomment.ts
@@ -229,10 +229,11 @@ export default class HtmlComment extends Plugin {
 		}
 
 		let content = '';
-		for ( const rootName of this.editor.model.document.getRootNames() ) {
-			const root = editor.model.document.getRoot( rootName )!;
+
+		for ( const root of this.editor.model.document.getRoots() ) {
 			if ( root.hasAttribute( commentID ) ) {
 				content = root.getAttribute( commentID ) as string;
+
 				break;
 			}
 		}

--- a/packages/ckeditor5-html-support/src/htmlcomment.ts
+++ b/packages/ckeditor5-html-support/src/htmlcomment.ts
@@ -218,7 +218,6 @@ export default class HtmlComment extends Plugin {
 	 * Gets the HTML comment data for the comment with a given ID.
 	 *
 	 * Returns `null` if the comment does not exist.
-	 *
 	 */
 	public getHtmlCommentData( commentID: string ): HtmlCommentData | null {
 		const editor = this.editor;
@@ -247,7 +246,7 @@ export default class HtmlComment extends Plugin {
 	/**
 	 * Gets all HTML comments in the given range.
 	 *
-	 * By default it includes comments at the range boundaries.
+	 * By default, it includes comments at the range boundaries.
 	 *
 	 * @param range
 	 * @param options.skipBoundaries When set to `true` the range boundaries will be skipped.

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmode/converters.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmode/converters.ts
@@ -64,7 +64,7 @@ export function setupExceptionHighlighting( editor: Editor ): void {
 		dispatcher.on( 'insert', removeHighlight, { priority: 'highest' } );
 		dispatcher.on( 'remove', removeHighlight, { priority: 'highest' } );
 		dispatcher.on( 'attribute', removeHighlight, { priority: 'highest' } );
-		dispatcher.on( 'selection', removeHighlight, { priority: 'highest' } );
+		dispatcher.on( 'cleanSelection', removeHighlight );
 
 		function removeHighlight() {
 			view.change( writer => {

--- a/packages/ckeditor5-ui/src/colorselector/colorgridsfragmentview.ts
+++ b/packages/ckeditor5-ui/src/colorselector/colorgridsfragmentview.ts
@@ -215,8 +215,7 @@ export default class ColorGridsFragmentView extends View {
 
 		this.documentColors.clear();
 
-		for ( const rootName of document.getRootNames() ) {
-			const root = document.getRoot( rootName )!;
+		for ( const root of document.getRoots() ) {
 			const range = model.createRangeIn( root );
 
 			for ( const node of range.getItems() ) {

--- a/packages/ckeditor5-undo/src/undocommand.ts
+++ b/packages/ckeditor5-undo/src/undocommand.ts
@@ -41,9 +41,12 @@ export default class UndoCommand extends BaseCommand {
 
 			const operations = this.editor.model.document.history.getOperations( item.batch.baseVersion! );
 			this._restoreSelection( item.selection.ranges, item.selection.isBackward, operations );
-
-			this.fire<UndoCommandRevertEvent>( 'revert', item.batch, undoingBatch );
 		} );
+
+		// Firing `revert` event after the change block to make sure that it includes all changes from post-fixers
+		// and make sure that the selection is "stabilized" (the selection range is saved after undo is executed and then
+		// restored on redo, so it is important that the selection range is saved after post-fixers are done).
+		this.fire<UndoCommandRevertEvent>( 'revert', item.batch, undoingBatch );
 
 		this.refresh();
 	}

--- a/packages/ckeditor5-watchdog/package.json
+++ b/packages/ckeditor5-watchdog/package.json
@@ -15,10 +15,12 @@
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-core": "38.1.1",
+    "@ckeditor/ckeditor5-comments": "38.1.1",
     "@ckeditor/ckeditor5-editor-classic": "38.1.1",
     "@ckeditor/ckeditor5-editor-multi-root": "38.1.1",
     "@ckeditor/ckeditor5-paragraph": "38.1.1",
     "@ckeditor/ckeditor5-utils": "38.1.1",
+    "@ckeditor/ckeditor5-track-changes": "38.1.1",
     "ckeditor5": "38.1.1",
     "typescript": "^4.8.4"
   },

--- a/packages/ckeditor5-watchdog/src/augmentation.ts
+++ b/packages/ckeditor5-watchdog/src/augmentation.ts
@@ -4,22 +4,10 @@
  */
 
 // eslint-disable-next-line ckeditor5-rules/no-cross-package-imports
-import type { RootAttributes } from '@ckeditor/ckeditor5-editor-multi-root';
-
 import type { EditorData } from './editorwatchdog';
 
 declare module '@ckeditor/ckeditor5-core' {
 	interface EditorConfig {
-
-		/**
-		 * Initial roots attributes for the document roots.
-		 */
-		rootsAttributes?: Record<string, RootAttributes>;
-
-		/**
-		 * List of names of all the roots that exist in the document but are not initially loaded by the editor.
-		 */
-		lazyRoots?: Array<string>;
 
 		/**
 		 * The temporary property that is used for passing data to the plugin which restores the editor state.

--- a/packages/ckeditor5-watchdog/src/augmentation.ts
+++ b/packages/ckeditor5-watchdog/src/augmentation.ts
@@ -26,6 +26,6 @@ declare module '@ckeditor/ckeditor5-core' {
 		 *
 		 * @internal
 		 */
-		_watchdogInitialData?: EditorData | null;
+		_watchdogInitialData?: EditorData;
 	}
 }

--- a/packages/ckeditor5-watchdog/src/augmentation.ts
+++ b/packages/ckeditor5-watchdog/src/augmentation.ts
@@ -3,10 +3,23 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+// eslint-disable-next-line ckeditor5-rules/no-cross-package-imports
+import type { RootAttributes } from '@ckeditor/ckeditor5-editor-multi-root';
+
 import type { EditorData } from './editorwatchdog';
 
 declare module '@ckeditor/ckeditor5-core' {
 	interface EditorConfig {
+
+		/**
+		 * Initial roots attributes for the document roots.
+		 */
+		rootsAttributes?: Record<string, RootAttributes>;
+
+		/**
+		 * List of names of all the roots that exist in the document but are not initially loaded by the editor.
+		 */
+		lazyRoots?: Array<string>;
 
 		/**
 		 * The temporary property that is used for passing data to the plugin which restores the editor state.

--- a/packages/ckeditor5-watchdog/src/editorwatchdog.ts
+++ b/packages/ckeditor5-watchdog/src/editorwatchdog.ts
@@ -15,6 +15,9 @@ import type { CKEditorError } from 'ckeditor5/src/utils';
 // eslint-disable-next-line ckeditor5-rules/no-cross-package-imports
 import type { Editor, EditorConfig, Context, EditorReadyEvent } from 'ckeditor5/src/core';
 
+// eslint-disable-next-line ckeditor5-rules/no-cross-package-imports
+import type { RootAttributes } from '@ckeditor/ckeditor5-editor-multi-root';
+
 import areConnectedThroughProperties from './utils/areconnectedthroughproperties';
 import Watchdog, { type WatchdogConfig } from './watchdog';
 
@@ -186,9 +189,9 @@ export default class EditorWatchdog<TEditor extends Editor = Editor> extends Wat
 				// Keeps lazy roots. They may be different when compared to initial config if some of the roots were loaded.
 				const lazyRoots: Array<string> = [];
 				// Roots attributes from the old config. Will be referred when setting new attributes.
-				const oldRootsAttributes: Record<string, unknown> = this._config!.rootsAttributes || {};
+				const oldRootsAttributes: Record<string, RootAttributes> = this._config!.rootsAttributes || {};
 				// New attributes to be set. Is filled only for roots that still exist in the document.
-				const rootsAttributes: Record<string, unknown> = {};
+				const rootsAttributes: Record<string, RootAttributes> = {};
 
 				// Traverse through the roots saved when the editor crashed and set up the discussed values.
 				for ( const [ rootName, rootData ] of Object.entries( this._data!.roots ) ) {

--- a/packages/ckeditor5-watchdog/src/editorwatchdog.ts
+++ b/packages/ckeditor5-watchdog/src/editorwatchdog.ts
@@ -26,12 +26,6 @@ import { throttle, cloneDeepWith, isElement, type DebouncedFunc } from 'lodash-e
 // eslint-disable-next-line ckeditor5-rules/no-cross-package-imports
 import type { Node, Text, Element, Writer } from 'ckeditor5/src/engine';
 
-// eslint-disable-next-line ckeditor5-rules/no-cross-package-imports
-import type { CommentsRepository, CommentThreadDataJSON } from '@ckeditor/ckeditor5-comments';
-
-// eslint-disable-next-line ckeditor5-rules/no-cross-package-imports
-import type { TrackChanges, TrackChangesEditing, SuggestionJSON } from '@ckeditor/ckeditor5-track-changes';
-
 /**
  * A watchdog for CKEditor 5 editors.
  *
@@ -367,8 +361,9 @@ export default class EditorWatchdog<TEditor extends Editor = Editor> extends Wat
 		const roots = editor.model.document.roots.filter( root => root.isAttached() && root.rootName != '$graveyard' );
 
 		const { plugins } = editor;
-		const commentsRepository = plugins.has( 'CommentsRepository' ) && plugins.get( 'CommentsRepository' ) as CommentsRepository;
-		const trackChanges = plugins.has( 'TrackChanges' ) && plugins.get( 'TrackChanges' ) as TrackChanges;
+		// `as any` to avoid linking from external private repo.
+		const commentsRepository = plugins.has( 'CommentsRepository' ) && plugins.get( 'CommentsRepository' ) as any;
+		const trackChanges = plugins.has( 'TrackChanges' ) && plugins.get( 'TrackChanges' ) as any;
 
 		const data: EditorData = {
 			roots: {},
@@ -556,12 +551,13 @@ class EditorWatchdogInitPlugin {
 	 * Restores the editor collaboration data - comment threads and suggestions.
 	 */
 	private _restoreCollaborationData() {
-		const parsedCommentThreads: Array<CommentThreadDataJSON> = JSON.parse( this._data.commentThreads );
-		const parsedSuggestions: Array<SuggestionJSON> = JSON.parse( this._data.suggestions );
+		// `as any` to avoid linking from external private repo.
+		const parsedCommentThreads: Array<any> = JSON.parse( this._data.commentThreads );
+		const parsedSuggestions: Array<any> = JSON.parse( this._data.suggestions );
 
 		parsedCommentThreads.forEach( commentThreadData => {
 			const channelId = this.editor.config.get( 'collaboration.channelId' )!;
-			const commentsRepository = this.editor!.plugins.get( 'CommentsRepository' ) as CommentsRepository;
+			const commentsRepository = this.editor!.plugins.get( 'CommentsRepository' ) as any;
 
 			if ( commentsRepository.hasCommentThread( commentThreadData.threadId ) ) {
 				const commentThread = commentsRepository.getCommentThread( commentThreadData.threadId )!;
@@ -573,7 +569,7 @@ class EditorWatchdogInitPlugin {
 		} );
 
 		parsedSuggestions.forEach( suggestionData => {
-			const trackChangesEditing = this.editor!.plugins.get( 'TrackChangesEditing' ) as TrackChangesEditing;
+			const trackChangesEditing = this.editor!.plugins.get( 'TrackChangesEditing' ) as any;
 
 			if ( trackChangesEditing.hasSuggestion( suggestionData.id ) ) {
 				const suggestion = trackChangesEditing.getSuggestion( suggestionData.id );

--- a/packages/ckeditor5-watchdog/tests/editorwatchdog.js
+++ b/packages/ckeditor5-watchdog/tests/editorwatchdog.js
@@ -10,6 +10,35 @@ import MultiRootEditor from '@ckeditor/ckeditor5-editor-multi-root/src/multiroot
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import { Comments } from '@ckeditor/ckeditor5-comments';
+import { TrackChanges } from '@ckeditor/ckeditor5-track-changes';
+import Suggestion from '@ckeditor/ckeditor5-track-changes/src/suggestion';
+
+class UsersInit {
+	static get requires() {
+		return [ 'Users' ];
+	}
+
+	constructor( editor ) {
+		this.editor = editor;
+	}
+
+	init() {
+		const users = this.editor.plugins.get( 'Users' );
+
+		users.addUser( {
+			id: 'u1',
+			name: 'John Smith'
+		} );
+
+		users.addUser( {
+			id: 'u2',
+			name: 'Kate Jones'
+		} );
+
+		users.defineMe( 'u1' );
+	}
+}
 
 // The error handling testing with mocha & chai is quite broken and hard to test.
 // sinon.stub( window, 'onerror' ).value( undefined ); and similar do not work.
@@ -219,6 +248,261 @@ describe( 'EditorWatchdog', () => {
 				.then( () => {
 					expect( watchdog.editor ).to.be.null;
 				} );
+		} );
+	} );
+
+	describe( 'collaboration data', () => {
+		let watchdog;
+
+		beforeEach( async () => {
+			watchdog = new EditorWatchdog();
+
+			watchdog.setCreator( ( data, config ) => ClassicTestEditor.create( data, config ) );
+		} );
+
+		afterEach( async () => {
+			await watchdog.destroy();
+		} );
+
+		it( 'should support comment threads', async () => {
+			await watchdog.create( '<p>Foo bar</p>', {
+				plugins: [ Paragraph, UsersInit, Comments, TrackChanges ],
+				licenseKey: 'uI0zfya2yTle649FSKlQCRsBSez+W4Vh5reIiKp0uDVYRCuPjaPYlf8=',
+				comments: {
+					editorConfig: {}
+				}
+			} );
+
+			const originalErrorHandler = window.onerror;
+			const windowErrorSpy = sinon.spy();
+			window.onerror = windowErrorSpy;
+
+			const commentsRepository = watchdog.editor.plugins.get( 'CommentsRepository' );
+
+			commentsRepository.addCommentThread( { threadId: 't1', target: () => null } );
+
+			watchdog.editor.setData(
+				'<p>' +
+				'Fo' +
+				'<comment id="t1" type="start"></comment>' +
+				'o b' +
+				'<comment id="t1" type="end"></comment>' +
+				'ar' +
+				'</p>'
+			);
+
+			expect( watchdog.editor.getData() ).to.equal(
+				'<p>Fo<comment-start name="t1"></comment-start>o b<comment-end name="t1"></comment-end>ar</p>'
+			);
+
+			await new Promise( res => {
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.editor ) );
+
+				watchdog.on( 'restart', () => {
+					window.onerror = originalErrorHandler;
+					res();
+				} );
+			} );
+
+			expect( watchdog.editor.getData() ).to.equal(
+				'<p>Fo<comment-start name="t1"></comment-start>o b<comment-end name="t1"></comment-end>ar</p>'
+			);
+			expect( watchdog.editor.plugins.get( 'CommentsRepository' ).getCommentThread( 't1' ) ).to.be.not.null;
+		} );
+
+		it( 'should support suggestions', async () => {
+			await watchdog.create( '<p>Foo bar</p>', {
+				plugins: [ Paragraph, UsersInit, Comments, TrackChanges ],
+				licenseKey: 'uI0zfya2yTle649FSKlQCRsBSez+W4Vh5reIiKp0uDVYRCuPjaPYlf8=',
+				comments: {
+					editorConfig: {}
+				}
+			} );
+
+			const originalErrorHandler = window.onerror;
+			const windowErrorSpy = sinon.spy();
+			window.onerror = windowErrorSpy;
+
+			sinon.stub( Suggestion, 'getMultiRangeId' ).callsFake( () => 'test' );
+
+			const trackChangesEditing = watchdog.editor.plugins.get( 'TrackChangesEditing' );
+
+			watchdog.editor.model.change( writer => {
+				const suggestion = trackChangesEditing.addSuggestionData( {
+					id: '1',
+					type: 'insertion:subType',
+					authorId: 'u1',
+					data: null,
+					createdAt: new Date(),
+					attributes: {}
+				} );
+
+				const root = watchdog.editor.model.document.getRoot();
+
+				const startPos = writer.createPositionFromPath( root, [ 0, 0 ] );
+				const endPos = writer.createPositionFromPath( root, [ 0, 3 ] );
+				const range = writer.createRange( startPos, endPos );
+
+				suggestion.addRange( range );
+			} );
+
+			expect( watchdog.editor.getData() ).to.equal(
+				'<p>' +
+				'<suggestion-start name="insertion:subType:1:u1:test"></suggestion-start' +
+				'>Foo<' +
+				'suggestion-end name="insertion:subType:1:u1:test"></suggestion-end> ' +
+				'bar</p>'
+			);
+
+			await new Promise( res => {
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.editor ) );
+
+				watchdog.on( 'restart', () => {
+					window.onerror = originalErrorHandler;
+					res();
+				} );
+			} );
+
+			expect( watchdog.editor.getData() ).to.equal(
+				'<p>' +
+				'<suggestion-start name="insertion:subType:1:u1:test"></suggestion-start' +
+				'>Foo<' +
+				'suggestion-end name="insertion:subType:1:u1:test"></suggestion-end> ' +
+				'bar</p>'
+			);
+		} );
+
+		it( 'should support comment data created by another plugins', async () => {
+			// Plugin that creates comment thread on init.
+			class InitPlugin {
+				constructor( editor ) {
+					this.editor = editor;
+				}
+
+				init() {
+					const commentsRepository = this.editor.plugins.get( 'CommentsRepository' );
+
+					commentsRepository.addCommentThread( { threadId: 't1', target: () => null } );
+				}
+			}
+
+			await watchdog.create( '<p>Foo bar</p>', {
+				plugins: [ Paragraph, UsersInit, Comments, TrackChanges, InitPlugin ],
+				licenseKey: 'uI0zfya2yTle649FSKlQCRsBSez+W4Vh5reIiKp0uDVYRCuPjaPYlf8=',
+				comments: {
+					editorConfig: {}
+				}
+			} );
+
+			const originalErrorHandler = window.onerror;
+			const windowErrorSpy = sinon.spy();
+			window.onerror = windowErrorSpy;
+
+			watchdog.editor.setData(
+				'<p>' +
+				'Fo' +
+				'<comment id="t1" type="start"></comment>' +
+				'o b' +
+				'<comment id="t1" type="end"></comment>' +
+				'ar' +
+				'</p>'
+			);
+
+			// Set comment thread attributes to test if it will be restored after restart.
+			const commentThread = watchdog.editor.plugins.get( 'CommentsRepository' ).getCommentThread( 't1' );
+			commentThread.setAttribute( 'test', 'value' );
+
+			watchdog._save();
+
+			await new Promise( res => {
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.editor ) );
+
+				watchdog.on( 'restart', () => {
+					window.onerror = originalErrorHandler;
+					res();
+				} );
+			} );
+
+			// Should keep the comment thread up to date even if the InitPlugin creates the new instance.
+			expect( watchdog.editor.plugins.get( 'CommentsRepository' ).getCommentThread( 't1' ).attributes ).to.deep.equal( {
+				test: 'value'
+			} );
+		} );
+
+		it( 'should support suggestion data created by another plugins', async () => {
+			sinon.stub( Suggestion, 'getMultiRangeId' ).callsFake( () => 'test' );
+
+			// Plugin that creates suggestion on init.
+			class InitPlugin {
+				constructor( editor ) {
+					this.editor = editor;
+				}
+
+				init() {
+					const trackChangesEditing = this.editor.plugins.get( 'TrackChangesEditing' );
+
+					trackChangesEditing.addSuggestionData( {
+						id: '1',
+						type: 'insertion:subType',
+						authorId: 'u1',
+						data: null,
+						createdAt: new Date(),
+						attributes: {}
+					} );
+				}
+			}
+
+			await watchdog.create( '<p>Foo bar</p>', {
+				plugins: [ Paragraph, UsersInit, Comments, TrackChanges, InitPlugin ],
+				licenseKey: 'uI0zfya2yTle649FSKlQCRsBSez+W4Vh5reIiKp0uDVYRCuPjaPYlf8=',
+				comments: {
+					editorConfig: {}
+				}
+			} );
+
+			const originalErrorHandler = window.onerror;
+			const windowErrorSpy = sinon.spy();
+			window.onerror = windowErrorSpy;
+
+			// Set comment thread attributes to test if it will be restored after restart.
+			const suggestion = watchdog.editor.plugins.get( 'TrackChangesEditing' ).getSuggestion( '1' );
+
+			watchdog.editor.model.change( writer => {
+				const root = watchdog.editor.model.document.getRoot();
+
+				const startPos = writer.createPositionFromPath( root, [ 0, 0 ] );
+				const endPos = writer.createPositionFromPath( root, [ 0, 3 ] );
+				const range = writer.createRange( startPos, endPos );
+
+				suggestion.addRange( range );
+			} );
+
+			// Set suggestion attributes to test if it will be restored after restart.
+			suggestion.setAttribute( 'test', 'value' );
+
+			watchdog._save();
+
+			await new Promise( res => {
+				setTimeout( () => throwCKEditorError( 'foo', watchdog.editor ) );
+
+				watchdog.on( 'restart', () => {
+					window.onerror = originalErrorHandler;
+					res();
+				} );
+			} );
+
+			expect( watchdog.editor.getData() ).to.equal(
+				'<p>' +
+				'<suggestion-start name="insertion:subType:1:u1:test"></suggestion-start' +
+				'>Foo<' +
+				'suggestion-end name="insertion:subType:1:u1:test"></suggestion-end> ' +
+				'bar</p>'
+			);
+
+			// Should keep the suggestion attributes up to date even if the InitPlugin creates the new instance.
+			expect( watchdog.editor.plugins.get( 'TrackChangesEditing' ).getSuggestion( '1' ).attributes ).to.deep.equal( {
+				test: 'value'
+			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-watchdog/tests/editorwatchdog.js
+++ b/packages/ckeditor5-watchdog/tests/editorwatchdog.js
@@ -1409,6 +1409,8 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		describe( 'init using data', () => {
+			let clock;
+
 			beforeEach( async () => {
 				await watchdog.create( {
 					header: '<p>Foo</p>',
@@ -1448,8 +1450,13 @@ describe( 'EditorWatchdog', () => {
 			} );
 
 			it( 'should properly handle added and removed roots', async () => {
+				clock = sinon.useFakeTimers();
+
 				watchdog.editor.detachRoot( 'content' );
 				watchdog.editor.addRoot( 'new', { data: '<p>New</p>', attributes: { order: 3 } } );
+
+				clock.tick( 6000 );
+				clock.restore();
 
 				setTimeout( () => throwCKEditorError( 'foo', watchdog.editor ) );
 
@@ -1469,8 +1476,13 @@ describe( 'EditorWatchdog', () => {
 			} );
 
 			it( 'should properly handle lazy roots', async () => {
+				clock = sinon.useFakeTimers();
+
 				watchdog.editor.detachRoot( 'lazyOne' );
 				watchdog.editor.loadRoot( 'lazyTwo', { data: '<p>Two</p>', attributes: { order: 5 } } );
+
+				clock.tick( 6000 );
+				clock.restore();
 
 				setTimeout( () => throwCKEditorError( 'foo', watchdog.editor ) );
 
@@ -1493,6 +1505,8 @@ describe( 'EditorWatchdog', () => {
 		} );
 
 		describe( 'init using elements', () => {
+			let clock;
+
 			beforeEach( async () => {
 				class MultiRootEditorIntegration {
 					constructor( editor ) {
@@ -1561,8 +1575,13 @@ describe( 'EditorWatchdog', () => {
 			} );
 
 			it( 'should properly handle added and removed roots', async () => {
+				clock = sinon.useFakeTimers();
+
 				watchdog.editor.detachRoot( 'content' );
 				watchdog.editor.addRoot( 'new', { data: '<p>New</p>', attributes: { order: 3 } } );
+
+				clock.tick( 6000 );
+				clock.restore();
 
 				setTimeout( () => throwCKEditorError( 'foo', watchdog.editor ) );
 
@@ -1582,8 +1601,13 @@ describe( 'EditorWatchdog', () => {
 			} );
 
 			it( 'should properly handle lazy roots', async () => {
+				clock = sinon.useFakeTimers();
+
 				watchdog.editor.detachRoot( 'lazyOne' );
 				watchdog.editor.loadRoot( 'lazyTwo', { data: '<p>Two</p>', attributes: { order: 5 } } );
+
+				clock.tick( 6000 );
+				clock.restore();
 
 				setTimeout( () => throwCKEditorError( 'foo', watchdog.editor ) );
 

--- a/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-data.html
+++ b/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-data.html
@@ -1,0 +1,25 @@
+<button id="random-error">Simulate a random `Error`</button>
+
+<div class="state">Editor state: <span id='editor-state'></span></div>
+
+<div id="toolbar"></div>
+
+<div contenteditable="true">
+	<div contenteditable="false" id="editors">
+	</div>
+</div>
+
+<button id="add-root">Add root</button>
+<button id="remove-root">Remove root</button>
+<button id="load-root">Load root</button>
+
+<style>
+	.state {
+		margin: 20px 0;
+	}
+
+	.editor {
+		border: #ccced1 1px solid;
+		margin-top: 10px;
+	}
+</style>

--- a/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-data.js
+++ b/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-data.js
@@ -1,0 +1,174 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals document, console, window */
+
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import { MultiRootEditor } from '@ckeditor/ckeditor5-editor-multi-root';
+
+import EditorWatchdog from '../../src/editorwatchdog';
+
+class TypingError {
+	constructor ( editor ) {
+		this.editor = editor;
+	}
+
+	init() {
+		const inputCommand = this.editor.commands.get( 'input' );
+
+		inputCommand.on( 'execute', ( evt, data ) => {
+			const commandArgs = data[ 0 ];
+
+			if ( commandArgs.text === '1' ) {
+				// Simulate error.
+				this.editor.foo.bar = 'bom';
+			}
+		} );
+	}
+}
+
+class MultiRootEditorIntegration {
+	constructor ( editor ) {
+		this.editor = editor;
+	}
+
+	init() {
+		this.editor.on( 'addRoot', ( evt, root ) => {
+			this.addRoot( root );
+		} );
+
+		this.editor.on( 'detachRoot', ( evt, root ) => {
+			this.detachRoot( root );
+		} );
+	}
+
+	addRoot( root ) {
+		const domElement = this.editor.createEditable( root );
+
+		this.attachEditable( domElement );
+	}
+
+	attachEditable( domElement ) {
+		const container = document.createElement( 'div' );
+		container.className = 'editor';
+		container.appendChild( domElement );
+
+		document.getElementById( 'editors' ).appendChild( container );
+	}
+
+	detachRoot( root ) {
+		const domElement = this.editor.detachEditable( root );
+
+		domElement.parentElement.remove();
+	}
+}
+
+const lazyRoots = [ 'lazyFoo', 'lazyBar' ];
+
+const editorConfig = {
+	image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
+	plugins: [
+		ArticlePluginSet, TypingError, MultiRootEditorIntegration
+	],
+	toolbar: [ 'heading', '|', 'bold', 'italic', 'link', 'bulletedList', 'numberedList', 'blockQuote',
+		'insertTable', 'mediaEmbed', 'undo', 'redo' ],
+	table: {
+		contentToolbar: [
+			'tableColumn',
+			'tableRow',
+			'mergeTableCells'
+		]
+	},
+	lazyRoots
+};
+
+const watchdog = createWatchdog( document.getElementById( 'editor-state' ) );
+
+Object.assign( window, { watchdog } );
+
+document.getElementById( 'random-error' ).addEventListener( 'click', () => {
+	throw new Error( 'foo' );
+} );
+
+let i = 0;
+
+document.getElementById( 'add-root' ).addEventListener( 'click', () => {
+	window.editor.addRoot( 'root' + ( ++i ), { data: '<p>' + i + '</p>' } );
+} );
+
+document.getElementById( 'remove-root' ).addEventListener( 'click', () => {
+	const rootNames = window.editor.model.document.getRootNames();
+
+	window.editor.detachRoot( rootNames[ rootNames.length - 1 ] );
+} );
+
+document.getElementById( 'load-root' ).addEventListener( 'click', () => {
+	const rootName = lazyRoots.shift();
+
+	window.editor.loadRoot( rootName, { data: '<p>' + rootName + '</p>' } );
+
+	if ( lazyRoots.length == 0 ) {
+		document.getElementById( 'load-root' ).remove();
+	}
+} );
+
+function createWatchdog( stateElement ) {
+	const watchdog = new EditorWatchdog( MultiRootEditor );
+
+	watchdog.setCreator( ( elementsOrData, config ) => {
+		return MultiRootEditor.create( elementsOrData, config ).then( editor => {
+			window.editor = editor;
+
+			document.querySelector( '#toolbar' ).appendChild( editor.ui.view.toolbar.element );
+
+			const multiRootEditorIntegration = editor.plugins.get( MultiRootEditorIntegration );
+
+			for ( const name of editor.ui.getEditableElementsNames() ) {
+				const editable = editor.ui.getEditableElement( name );
+
+				multiRootEditorIntegration.attachEditable( editable );
+			}
+
+			return editor;
+		} );
+	} );
+
+	watchdog.setDestructor( editor => {
+		document.querySelector( '#toolbar' ).innerHTML = '';
+		document.querySelector( '#editors' ).innerHTML = '';
+
+		return editor.destroy();
+	} );
+
+	watchdog.create(
+		{
+			header: `<h2>Gone traveling</h2><h3>Monthly travel news and inspiration</h3>`,
+			content: `<h3>Destination of the Month</h3><h4>Valletta</h4><p>The capital city of <a href="https://en.wikipedia.org/wiki/Malta" target="_blank" rel="external">Malta</a> is the top destination this summer. It’s home to cutting-edge contemporary architecture, baroque masterpieces, delicious local cuisine, and at least 8 months of sun. It’s also a top destination for filmmakers, so you can take a tour through locations familiar to you from Game of Thrones, Gladiator, Troy, and many more.</p>`
+		},
+		editorConfig
+	);
+
+	watchdog.on( 'error', () => {
+		console.log( 'Editor crashed!' );
+	} );
+
+	watchdog.on( 'restart', () => {
+		console.log( 'Editor restarted.' );
+	} );
+
+	watchdog.on( 'stateChange', () => {
+		console.log( `Watchdog state changed to '${ watchdog.state }'` );
+
+		stateElement.innerText = watchdog.state;
+
+		if ( watchdog.state === 'crashedPermanently' ) {
+			watchdog.editor.enableReadOnlyMode( 'manual-test' );
+		}
+	} );
+
+	stateElement.innerText = watchdog.state;
+
+	return watchdog;
+}

--- a/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-data.js
+++ b/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-data.js
@@ -11,7 +11,7 @@ import { MultiRootEditor } from '@ckeditor/ckeditor5-editor-multi-root';
 import EditorWatchdog from '../../src/editorwatchdog';
 
 class TypingError {
-	constructor ( editor ) {
+	constructor( editor ) {
 		this.editor = editor;
 	}
 
@@ -30,7 +30,7 @@ class TypingError {
 }
 
 class MultiRootEditorIntegration {
-	constructor ( editor ) {
+	constructor( editor ) {
 		this.editor = editor;
 	}
 
@@ -144,8 +144,15 @@ function createWatchdog( stateElement ) {
 
 	watchdog.create(
 		{
-			header: `<h2>Gone traveling</h2><h3>Monthly travel news and inspiration</h3>`,
-			content: `<h3>Destination of the Month</h3><h4>Valletta</h4><p>The capital city of <a href="https://en.wikipedia.org/wiki/Malta" target="_blank" rel="external">Malta</a> is the top destination this summer. It’s home to cutting-edge contemporary architecture, baroque masterpieces, delicious local cuisine, and at least 8 months of sun. It’s also a top destination for filmmakers, so you can take a tour through locations familiar to you from Game of Thrones, Gladiator, Troy, and many more.</p>`
+			header: '<h2>Gone traveling</h2><h3>Monthly travel news and inspiration</h3>',
+			content: '<h3>Destination of the Month</h3>' +
+				'<h4>Valletta</h4>' +
+				'<p>' +
+					'The capital city of <a href="https://en.wikipedia.org/wiki/Malta" target="_blank" rel="external">Malta</a> ' +
+					'is the top destination this summer. It’s home to cutting-edge contemporary architecture, baroque masterpieces, ' +
+					'delicious local cuisine, and at least 8 months of sun. It’s also a top destination for filmmakers, so you can take ' +
+					'a tour through locations familiar to you from Game of Thrones, Gladiator, Troy, and many more.' +
+				'</p>'
 		},
 		editorConfig
 	);

--- a/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-data.md
+++ b/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-data.md
@@ -1,0 +1,17 @@
+This is a watchdog + multi-root manual test where initial roots are given as strings and editables are created after the editor is initialized.
+
+**Important:** Be sure to run manual test with the `--debug false` flag. Otherwise errors won't be rethrown by the `CKEditorError.rethrowUnexpectedError()` method.
+
+1. Whenever you type `1` in the editor, the multi-root editor should crash and watchdog should react to it.
+
+1. Click `Simulate a random error`. Editor should not be restarted.
+
+1. Refresh page and quickly type `1` in the editor 4 times. After the last error the editor should be crashed permanently and it should not restart.
+
+1. Refresh page and slowly (slower than 1 per 5 seconds) type `1` in the editor 4 times. After the last error the editor should be restarted and it should still work.
+
+1. Try adding and removing roots to the editor and see if the editor is properly restarted after it crashes. Roots state should be the same as before the crash.
+
+1. Try loading roots (two roots can be loaded) and see if the editor is properly restarted after it crashes. Loaded roots should be visible after the editor restart.
+
+1. Finally, try loading, adding and removing roots together and see if the editor is properly restarted after it crashes.

--- a/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-elements.html
+++ b/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-elements.html
@@ -5,7 +5,7 @@
 <div id="toolbar"></div>
 
 <div contenteditable="true">
-	<div contenteditable="false">
+	<div contenteditable="false" id="editors">
 		<div class="editor">
 			<div id="header">
 				<h2>Gone traveling</h2>
@@ -24,6 +24,10 @@
 		</div>
 	</div>
 </div>
+
+<button id="add-root">Add root</button>
+<button id="remove-root">Remove root</button>
+<button id="load-root">Load root</button>
 
 <style>
 	.state {

--- a/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-elements.js
+++ b/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-elements.js
@@ -11,7 +11,7 @@ import { MultiRootEditor } from '@ckeditor/ckeditor5-editor-multi-root';
 import EditorWatchdog from '../../src/editorwatchdog';
 
 class TypingError {
-	constructor ( editor ) {
+	constructor( editor ) {
 		this.editor = editor;
 	}
 
@@ -30,7 +30,7 @@ class TypingError {
 }
 
 class MultiRootEditorIntegration {
-	constructor ( editor ) {
+	constructor( editor ) {
 		this.editor = editor;
 	}
 

--- a/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-elements.md
+++ b/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-elements.md
@@ -1,0 +1,17 @@
+This is a watchdog + multi-root manual test where initial roots are given as elements which are used as editables when the editor is initialized.
+
+**Important:** Be sure to run manual test with the `--debug false` flag. Otherwise errors won't be rethrown by the `CKEditorError.rethrowUnexpectedError()` method.
+
+1. Whenever you type `1` in the editor, the multi-root editor should crash and watchdog should react to it.
+
+1. Click `Simulate a random error`. Editor should not be restarted.
+
+1. Refresh page and quickly type `1` in the editor 4 times. After the last error the editor should be crashed permanently and it should not restart.
+
+1. Refresh page and slowly (slower than 1 per 5 seconds) type `1` in the editor 4 times. After the last error the editor should be restarted and it should still work.
+
+1. Try adding and removing roots to the editor and see if the editor is properly restarted after it crashes. Roots state should be the same as before the crash.
+
+1. Try loading roots (two roots can be loaded) and see if the editor is properly restarted after it crashes. Loaded roots should be visible after the editor restart.
+
+1. Finally, try loading, adding and removing roots together and see if the editor is properly restarted after it crashes.

--- a/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root.md
+++ b/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root.md
@@ -1,9 +1,0 @@
-**Important:** Be sure to run manual test with the `--debug false` flag. Otherwise errors won't be rethrown by the `CKEditorError.rethrowUnexpectedError()` method.
-
-1. Type `1` in the editor. Only the editor should crash and be restarted. The error should be logged in the console.
-
-1. Click `Simulate a random error`. Editor should not be restarted.
-
-1. Refresh page and quickly type `1` in the editor 4 times. After the last error the editor should be crashed and it should not restart.
-
-1. Refresh page and slowly (slower than 1 per 5 seconds) type `1` in the editor 4 times. After the last error the editor should be restarted and it should still work.

--- a/packages/ckeditor5-word-count/src/wordcount.ts
+++ b/packages/ckeditor5-word-count/src/wordcount.ts
@@ -254,13 +254,13 @@ export default class WordCount extends Plugin {
 	private _getText(): string {
 		let txt = '';
 
-		for ( const rootName of this.editor.model.document.getRootNames() ) {
+		for ( const root of this.editor.model.document.getRoots() ) {
 			if ( txt !== '' ) {
 				// Add a delimiter, so words from each root are treated independently.
 				txt += '\n';
 			}
 
-			txt += modelElementToPlainText( this.editor.model.document.getRoot( rootName )! );
+			txt += modelElementToPlainText( root );
 		}
 
 		return txt;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (multi-root-editor): Introduced `MultiRootEditor#loadRoot()` and `EditorConfig.lazyRoots` which can be used to implement root "lazy loading".

Feature (multi-root-editor): Introduced `MultiRootEditor#getRootAttributes()`.

Feature (engine): Introduced `model.Document#getRoots()`.

Fix: Fixed editor crash happening in real-time collaboration when two clients removed and re-attached a root at the same moment.

Fix (undo): Fixed incorrect selection reversion which lead to editor crash in very peculiar scenarios involving adding and removing roots and using undo and redo.

Fix (watchdog): Watchdog now correctly supports multi-root editor after roots were added or detached.

Fix (watchdog): Comments and suggestions data was not correctly restored by Watchdog in non-real-time editing "load and save" integrations.

Other (engine): Introduced \`cleanSelection\` event in \`DowncastDispatcher\` for downcast conversion. The event is fired before \`selection\` events and should be used to do any clean-ups before the model document selection is downcasted.

Other (engine): Prevented document selection conversion if the selection is inside a model root that does not have a corresponding view root. In such case, `selection` downcast event will not be fired.

Other (engine): `Schema#getNearestSelectionRange()` will now return `null` for any position inside the graveyard root.

Other (engine): `model.DocumentSelection` will not inherit attributes from nodes inside a graveyard.

Other (core): Commands will now be disabled when the editor has no roots (applies only to commands which state is based on document selection placement).

Other (undo): `UndoCommand#event:revert` will now be fired after all changes triggered by undo are applied (including changes in post-fixer).