### PR TITLE
Fixed empty changelog

### DIFF
--- a/scripts/docs/get-latest-changelogs.js
+++ b/scripts/docs/get-latest-changelogs.js
@@ -15,11 +15,12 @@ const VERSIONS_TO_PRINT = 3;
 
 /**
  * Returns changelogs formatted in markdown for the last three versions of the CKEditor 5 releases.
- * Additional, the following sections for each entry are modified:
+ * Additionally, the following sections for each entry are modified:
  *
  * - The "ℹ️" symbol is removed.
  * - The "Released packages" section is removed.
- * - The "Release highlights" section is removed.
+ * - If the "Release highlights" section contains a paragraph with link to a blog post,
+ *   then the entire section except for the paragraph with the link is removed.
  *
  * @returns {String}
  */
@@ -45,7 +46,16 @@ module.exports = () => {
 					const blogPostParagraphRegexp = new RegExp( `(?<=\n).*?${ blogPostLink }.*?(?=\n)` );
 					const result = section.match( blogPostParagraphRegexp );
 
-					return result ? result[ 0 ] : '';
+					// If there is no blog post link, then keep the highlights section.
+					if ( !result ) {
+						return section;
+					}
+
+					// Replace the raw text url with a functioning link.
+					return result[ 0 ].replace(
+						new RegExp( blogPostLink + '\\S+' ),
+						url => `[${ url }](${ url })`
+					);
 				} )
 				// Remove `Released packages` section.
 				.replace( getSectionRegexp( 'Released packages' ), '' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: The release highlights section will no longer be removed from the documentation changelog if it has no URL to a blog post.

Internal: Blogpost URL in the release highlights section will now be a functional link instead of raw text.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
