### PR TITLE
Adjust the balloon tip color

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/editorui/editorui.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/editorui/editorui.css
@@ -58,12 +58,12 @@
 /* https://github.com/ckeditor/ckeditor5-theme-lark/issues/111 */
 .ck.ck-balloon-panel.ck-toolbar-container[class*="arrow_n"] {
 	&::after {
-		border-bottom-color: var(--ck-color-base-foreground);
+		border-bottom-color: var(--ck-color-base-background);
 	}
 }
 
 .ck.ck-balloon-panel.ck-toolbar-container[class*="arrow_s"] {
 	&::after {
-		border-top-color: var(--ck-color-base-foreground);
+		border-top-color: var(--ck-color-base-background);
 	}
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/editorui/editorui.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/editorui/editorui.css
@@ -58,12 +58,12 @@
 /* https://github.com/ckeditor/ckeditor5-theme-lark/issues/111 */
 .ck.ck-balloon-panel.ck-toolbar-container[class*="arrow_n"] {
 	&::after {
-		border-bottom-color: var(--ck-color-base-background);
+		border-bottom-color: var(--ck-color-panel-background);
 	}
 }
 
 .ck.ck-balloon-panel.ck-toolbar-container[class*="arrow_s"] {
 	&::after {
-		border-top-color: var(--ck-color-base-background);
+		border-top-color: var(--ck-color-panel-background);
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (theme-lark): Adjusted the balloon tip color to match the rest of the panel. Closes #14652.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._