### PR TITLE
Editor should scroll to the selection after inserting text.

### DIFF
--- a/packages/ckeditor5-typing/src/input.ts
+++ b/packages/ckeditor5-typing/src/input.ts
@@ -101,6 +101,8 @@ export default class Input extends Plugin {
 			}
 
 			editor.execute( 'insertText', insertTextCommandData );
+
+			view.scrollToTheSelection();
 		} );
 
 		if ( env.isAndroid ) {

--- a/packages/ckeditor5-typing/tests/input.js
+++ b/packages/ckeditor5-typing/tests/input.js
@@ -192,6 +192,19 @@ describe( 'Input', () => {
 
 				sinon.assert.notCalled( spy );
 			} );
+
+			it( 'should scroll to the selection after inserting text', async () => {
+				const scrollToSelectionSpy = sinon.spy( editor.editing.view, 'scrollToTheSelection' );
+
+				viewDocument.fire( 'insertText', {
+					text: 'bar',
+					selection: viewDocument.selection,
+					preventDefault: () => {}
+				} );
+
+				sinon.assert.calledOnce( insertTextCommandSpy );
+				sinon.assert.calledOnce( scrollToSelectionSpy );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (typing): The editor should scroll to the selection after inserting the text. Closes #13411.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
