### PR TITLE
Prevent closing dropdown view on scrollbar click.

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/dropdown.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/dropdown.css
@@ -83,7 +83,7 @@
 		&.ck-off:active,
 		&.ck-on:active {
 			box-shadow: none;
-			
+
 			&:focus {
 				@mixin ck-box-shadow var(--ck-focus-outer-shadow);
 			}
@@ -118,5 +118,9 @@
 
 	&.ck-dropdown__panel_nw {
 		border-bottom-right-radius: 0;
+	}
+
+	&:focus {
+		outline: none;
 	}
 }

--- a/packages/ckeditor5-ui/src/dropdown/dropdownpanelview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/dropdownpanelview.ts
@@ -69,7 +69,8 @@ export default class DropdownPanelView extends View implements DropdownPanelFocu
 					'ck-dropdown__panel',
 					bind.to( 'position', value => `ck-dropdown__panel_${ value }` ),
 					bind.if( 'isVisible', 'ck-dropdown__panel-visible' )
-				]
+				],
+				tabindex: '-1'
 			},
 
 			children: this.children,

--- a/packages/ckeditor5-ui/tests/dropdown/dropdownpanelview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/dropdownpanelview.js
@@ -38,6 +38,7 @@ describe( 'DropdownPanelView', () => {
 			expect( view.element.classList.contains( 'ck' ) ).to.be.true;
 			expect( view.element.classList.contains( 'ck-reset' ) ).to.be.true;
 			expect( view.element.classList.contains( 'ck-dropdown__panel' ) ).to.be.true;
+			expect( view.element.getAttribute( 'tabindex' ) ).to.equal( '-1' );
 		} );
 
 		describe( 'template bindings', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Dropdown view should not be closed when interacting with a scrollbar. Closes #14364.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
