### PR TITLE
Wrap replace all changes into one transaction.

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/replaceallcommand.ts
+++ b/packages/ckeditor5-find-and-replace/src/replaceallcommand.ts
@@ -50,9 +50,12 @@ export default class ReplaceAllCommand extends ReplaceCommandBase {
 				) ), null as Collection<ResultType> | null )!;
 
 		if ( results.length ) {
-			[ ...results ].forEach( searchResult => {
-				// Just reuse logic from the replace command to replace a single match.
-				this._replace( newText, searchResult );
+			// Wrapped in single change will batch it into one transaction.
+			model.change( () => {
+				[ ...results ].forEach( searchResult => {
+					// Just reuse logic from the replace command to replace a single match.
+					this._replace( newText, searchResult );
+				} );
 			} );
 		}
 	}

--- a/packages/ckeditor5-find-and-replace/tests/replaceallcommand.js
+++ b/packages/ckeditor5-find-and-replace/tests/replaceallcommand.js
@@ -155,7 +155,7 @@ describe( 'ReplaceAllCommand', () => {
 			expect( getData( editor.model, { withoutSelection: true } ) ).to.equal( '<paragraph>Aaa Boo Coo Daa</paragraph>' );
 		} );
 
-		it( 'should one undo step restore all replaced text occurrences in the document at once', () => {
+		it( 'should one undo step restore every text occurrences replaced by `replace all` in the document at once.', () => {
 			setData( model, '<paragraph>Foo bar baz</paragraph><paragraph>Foo bar baz</paragraph><paragraph>Foo bar baz</paragraph>' );
 
 			editor.execute( 'replaceAll', 'new', 'bar' );
@@ -167,7 +167,7 @@ describe( 'ReplaceAllCommand', () => {
 			expect( editor.getData() ).to.equal( '<p>Foo bar baz</p><p>Foo bar baz</p><p>Foo bar baz</p>' );
 		} );
 
-		it( 'should one undo step restore all replaced text occurrences in multiple roots at once', async () => {
+		it( 'should one undo step restore every text occurrences replaced by `replace all` in multiple roots at once.', async () => {
 			class MultiRootEditor extends ModelTestEditor {
 				constructor( config ) {
 					super( config );

--- a/packages/ckeditor5-find-and-replace/tests/replaceallcommand.js
+++ b/packages/ckeditor5-find-and-replace/tests/replaceallcommand.js
@@ -66,7 +66,7 @@ describe( 'ReplaceAllCommand', () => {
 			expect( editor.getData() ).to.equal( '<p>Foo bar baz</p><p>Foo bar baz</p>' );
 		} );
 
-		it( 'should replace all passed results in the document document', () => {
+		it( 'should replace all passed results in the document', () => {
 			setData( model, '<paragraph>Foo bar [b]az</paragraph><paragraph>[Foo] bar baz</paragraph>' );
 
 			const ranges = editor.model.document.selection.getRanges();
@@ -153,6 +153,48 @@ describe( 'ReplaceAllCommand', () => {
 			editor.execute( 'undo' );
 
 			expect( getData( editor.model, { withoutSelection: true } ) ).to.equal( '<paragraph>Aaa Boo Coo Daa</paragraph>' );
+		} );
+
+		it( 'should one undo step restore all replaced text occurrences in the document at once', () => {
+			setData( model, '<paragraph>Foo bar baz</paragraph><paragraph>Foo bar baz</paragraph><paragraph>Foo bar baz</paragraph>' );
+
+			editor.execute( 'replaceAll', 'new', 'bar' );
+
+			expect( editor.getData() ).to.equal( '<p>Foo new baz</p><p>Foo new baz</p><p>Foo new baz</p>' );
+
+			editor.execute( 'undo' );
+
+			expect( editor.getData() ).to.equal( '<p>Foo bar baz</p><p>Foo bar baz</p><p>Foo bar baz</p>' );
+		} );
+
+		it( 'should one undo step restore all replaced text occurrences in multiple roots at once', async () => {
+			class MultiRootEditor extends ModelTestEditor {
+				constructor( config ) {
+					super( config );
+
+					this.model.document.createRoot( '$root', 'second' );
+				}
+			}
+
+			const multiRootEditor = await MultiRootEditor
+				.create( { plugins: [ FindAndReplaceEditing, Paragraph, UndoEditing ] } );
+
+			setData( multiRootEditor.model, '<paragraph>Foo bar baz</paragraph>' );
+			setData( multiRootEditor.model, '<paragraph>Foo bar baz</paragraph>', { rootName: 'second' } );
+
+			const { results } = multiRootEditor.execute( 'find', 'z' );
+
+			multiRootEditor.execute( 'replaceAll', 'r', results );
+
+			expect( multiRootEditor.getData() ).to.equal( '<p>Foo bar bar</p>' );
+			expect( multiRootEditor.getData( { rootName: 'second' } ) ).to.equal( '<p>Foo bar bar</p>' );
+
+			multiRootEditor.execute( 'undo' );
+
+			expect( multiRootEditor.getData() ).to.equal( '<p>Foo bar baz</p>' );
+			expect( multiRootEditor.getData( { rootName: 'second' } ) ).to.equal( '<p>Foo bar baz</p>' );
+
+			await multiRootEditor.destroy();
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (find-and-replace): Undo should restore every text occurrences replaced by `replace all` in the document at once..

Closes #13892.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
