### PR TITLE
Link on image should not be lost with LinkImage and full GHS.

### DIFF
--- a/packages/ckeditor5-html-support/tests/integrations/image.js
+++ b/packages/ckeditor5-html-support/tests/integrations/image.js
@@ -882,20 +882,37 @@ describe( 'ImageElementSupport', () => {
 			);
 
 			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
-				data: '<imageBlock htmlLinkAttributes="(1)" src="/assets/sample.png"></imageBlock>',
-				attributes: {
-					1: {
-						attributes: {
-							href: 'www.example.com'
-						}
-					}
-				}
+				data: '<imageBlock linkHref="www.example.com" src="/assets/sample.png"></imageBlock>',
+				attributes: {}
 			} );
 
 			const marker = model.markers.get( 'commented:foo:id' );
 
 			expect( marker.getStart().path ).to.deep.equal( [ 0 ] );
 			expect( marker.getEnd().path ).to.deep.equal( [ 1 ] );
+		} );
+
+		it( 'should upcast `href` attribute if LinkImage plugin is available', () => {
+			dataFilter.loadAllowedConfig( [ {
+				name: /.*/,
+				attributes: true
+			} ] );
+
+			const expectedHtml =
+				'<figure class="image">' +
+					'<a href="www.example.com">' +
+						'<img src="/assets/sample.png">' +
+					'</a>' +
+				'</figure>';
+
+			editor.setData( expectedHtml );
+
+			expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+				data: '<imageBlock linkHref="www.example.com" src="/assets/sample.png"></imageBlock>',
+				attributes: {}
+			} );
+
+			expect( editor.getData() ).to.equal( expectedHtml );
 		} );
 
 		// it( 'should allow modifying styles, classes and attributes', () => {

--- a/packages/ckeditor5-html-support/tests/integrations/image.js
+++ b/packages/ckeditor5-html-support/tests/integrations/image.js
@@ -347,6 +347,58 @@ describe( 'ImageElementSupport', () => {
 			expect( marker.getEnd().path ).to.deep.equal( [ 1 ] );
 		} );
 
+		describe( 'BlockImage without LinkImage', () => {
+			let editor, model, editorElement, dataFilter;
+
+			beforeEach( () => {
+				editorElement = document.createElement( 'div' );
+				document.body.appendChild( editorElement );
+
+				return ClassicTestEditor
+					.create( editorElement, {
+						plugins: [ Image, ImageCaption, Paragraph, GeneralHtmlSupport ]
+					} )
+					.then( newEditor => {
+						editor = newEditor;
+						model = editor.model;
+
+						dataFilter = editor.plugins.get( 'DataFilter' );
+					} );
+			} );
+
+			afterEach( () => {
+				editorElement.remove();
+
+				return editor.destroy();
+			} );
+
+			it( 'should not upcast `href` attribute if LinkImage plugin is not available', () => {
+				dataFilter.loadAllowedConfig( [ {
+					name: /.*/,
+					attributes: true
+				} ] );
+
+				editor.setData(
+					'<figure class="image">' +
+						'<a href="www.example.com">' +
+							'<img src="/assets/sample.png">' +
+						'</a>' +
+					'</figure>'
+				);
+
+				expect( getModelDataWithAttributes( model, { withoutSelection: true } ) ).to.deep.equal( {
+					data: '<imageBlock src="/assets/sample.png"></imageBlock>',
+					attributes: {}
+				} );
+
+				expect( editor.getData() ).to.equal(
+					'<figure class="image">' +
+						'<img src="/assets/sample.png">' +
+					'</figure>'
+				);
+			} );
+		} );
+
 		// it( 'should allow modifying styles, classes and attributes', () => {
 		// 	// This should also work when we set `attributes: true` but currently there are some
 		// 	// problems related to GHS picking up non-GHS attributes (like src) due to some attributes not


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (html-support): Link on image should not be lost when loading content with LinkImage and full GHS enabled. Closes #12831.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
