### PR TITLE
Fix for balloon positioning where it would stick outside of an editable

### DIFF
--- a/packages/ckeditor5-ui/src/dropdown/dropdownview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/dropdownview.ts
@@ -269,12 +269,16 @@ export default class DropdownView extends View<HTMLDivElement> {
 			// If "auto", find the best position of the panel to fit into the viewport.
 			// Otherwise, simply assign the static position.
 			if ( this.panelPosition === 'auto' ) {
-				this.panelView.position = DropdownView._getOptimalPosition( {
+				const optimalPanelPosition = DropdownView._getOptimalPosition( {
 					element: this.panelView.element!,
 					target: this.buttonView.element!,
 					fitInViewport: true,
 					positions: this._panelPositions
-				} ).name as PanelPosition;
+				} );
+
+				this.panelView.position = (
+					optimalPanelPosition ? optimalPanelPosition.name : this._panelPositions[ 0 ].name
+				) as PanelPosition;
 			} else {
 				this.panelView.position = this.panelPosition;
 			}

--- a/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
@@ -17,17 +17,34 @@ import {
 	toUnit,
 	type Locale,
 	type ObservableChangeEvent,
+	type Position,
 	type PositionOptions,
 	type PositioningFunction,
 	type Rect
 } from '@ckeditor/ckeditor5-utils';
 
 import { isElement } from 'lodash-es';
-
 import '../../../theme/components/panel/balloonpanel.css';
 
 const toPx = toUnit( 'px' );
 const defaultLimiterElement = global.document.body;
+
+// A static balloon panel positioning function that moves the balloon far off the viewport.
+// It is used as a fallback when there is no way to position the balloon using provided
+// positioning functions (see: `getOptimalPosition()`), for instance, when the target the
+// balloon should be attached to gets obscured by scrollable containers or the viewport.
+//
+// It prevents the balloon from being attached to the void and possible degradation of the UX.
+// At the same time, it keeps the balloon physically visible in the DOM so the focus remains
+// uninterrupted.
+const POSITION_OFF_SCREEN: Position = {
+	top: -99999,
+	left: -99999,
+	name: 'arrowless',
+	config: {
+		withArrow: false
+	}
+};
 
 /**
  * The balloon panel view class.
@@ -251,7 +268,7 @@ export default class BalloonPanelView extends View {
 			fitInViewport: true
 		}, options ) as PositionOptions;
 
-		const optimalPosition = BalloonPanelView._getOptimalPosition( positionOptions );
+		const optimalPosition = BalloonPanelView._getOptimalPosition( positionOptions ) || POSITION_OFF_SCREEN;
 
 		// Usually browsers make some problems with super accurate values like 104.345px
 		// so it is better to use int values.

--- a/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
+++ b/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
@@ -18,7 +18,6 @@ import {
 import {
 	Rect,
 	ResizeObserver,
-	getOptimalPosition,
 	toUnit,
 	type ObservableChangeEvent
 } from '@ckeditor/ckeditor5-utils';
@@ -430,29 +429,21 @@ export default class BlockToolbar extends Plugin {
 		// MDN says that 'normal' == ~1.2 on desktop browsers.
 		const contentLineHeight = parseInt( contentStyles.lineHeight, 10 ) || parseInt( contentStyles.fontSize, 10 ) * 1.2;
 
-		const position = getOptimalPosition( {
-			element: this.buttonView.element!,
-			target: targetElement,
-			positions: [
-				( contentRect, buttonRect ) => {
-					let left;
+		const buttonRect = new Rect( this.buttonView.element! );
+		const contentRect = new Rect( targetElement );
 
-					if ( this.editor.locale.uiLanguageDirection === 'ltr' ) {
-						left = editableRect.left - buttonRect.width;
-					} else {
-						left = editableRect.right;
-					}
+		let positionLeft;
 
-					return {
-						top: contentRect.top + contentPaddingTop + ( contentLineHeight - buttonRect.height ) / 2,
-						left
-					};
-				}
-			]
-		} );
+		if ( this.editor.locale.uiLanguageDirection === 'ltr' ) {
+			positionLeft = editableRect.left - buttonRect.width;
+		} else {
+			positionLeft = editableRect.right;
+		}
 
-		this.buttonView.top = position.top;
-		this.buttonView.left = position.left;
+		const positionTop = contentRect.top + contentPaddingTop + ( contentLineHeight - buttonRect.height ) / 2;
+
+		this.buttonView.top = positionTop;
+		this.buttonView.left = positionLeft;
 	}
 
 	/**

--- a/packages/ckeditor5-ui/tests/dropdown/dropdownview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/dropdownview.js
@@ -184,6 +184,34 @@ describe( 'DropdownView', () => {
 							fitInViewport: true
 						} ) );
 					} );
+
+					it( 'fallback when _getOptimalPosition() will return null', () => {
+						const locale = {
+							t() {}
+						};
+
+						const buttonView = new ButtonView( locale );
+						const panelView = new DropdownPanelView( locale );
+
+						const view = new DropdownView( locale, buttonView, panelView );
+						view.render();
+
+						const parentWithOverflow = global.document.createElement( 'div' );
+						parentWithOverflow.style.width = '100px';
+						parentWithOverflow.style.height = '1px';
+						parentWithOverflow.style.overflow = 'scroll';
+
+						parentWithOverflow.appendChild( view.element );
+
+						global.document.body.appendChild( parentWithOverflow );
+
+						view.isOpen = true;
+
+						expect( view.panelView.position ).is.equal( 'southEast' ); // first position from position list.
+
+						view.element.remove();
+						parentWithOverflow.remove();
+					} );
 				} );
 			} );
 

--- a/packages/ckeditor5-ui/tests/editorui/poweredby.js
+++ b/packages/ckeditor5-ui/tests/editorui/poweredby.js
@@ -13,7 +13,7 @@ import View from '../../src/view';
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
-import { Rect } from '@ckeditor/ckeditor5-utils';
+import { Rect, global } from '@ckeditor/ckeditor5-utils';
 import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
 import Heading from '@ckeditor/ckeditor5-heading/src/heading';
 import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
@@ -45,6 +45,9 @@ describe( 'PoweredBy', () => {
 			width: 1000,
 			height: 1000
 		} );
+
+		sinon.stub( global.window, 'innerWidth' ).value( 1000 );
+		sinon.stub( global.window, 'innerHeight' ).value( 1000 );
 	} );
 
 	afterEach( async () => {
@@ -493,7 +496,7 @@ describe( 'PoweredBy', () => {
 			focusEditor( editor );
 
 			expect( editor.ui.poweredBy._balloonView.isVisible ).to.be.true;
-			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'invalid' );
+			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'arrowless' );
 
 			parentWithOverflow.remove();
 		} );
@@ -512,7 +515,7 @@ describe( 'PoweredBy', () => {
 			focusEditor( editor );
 
 			expect( editor.ui.poweredBy._balloonView.isVisible ).to.be.true;
-			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'invalid' );
+			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'arrowless' );
 
 			parentWithOverflow.remove();
 		} );
@@ -870,7 +873,7 @@ describe( 'PoweredBy', () => {
 			const pinSpy = testUtils.sinon.spy( editor.ui.poweredBy._balloonView, 'pin' );
 
 			expect( editor.ui.poweredBy._balloonView.isVisible ).to.be.true;
-			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'invalid' );
+			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'arrowless' );
 
 			domRoot.getBoundingClientRect.returns( {
 				top: 0,
@@ -933,7 +936,7 @@ describe( 'PoweredBy', () => {
 			const pinSpy = testUtils.sinon.spy( editor.ui.poweredBy._balloonView, 'pin' );
 
 			expect( editor.ui.poweredBy._balloonView.isVisible ).to.be.true;
-			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'invalid' );
+			expect( editor.ui.poweredBy._balloonView.position ).to.equal( 'arrowless' );
 
 			domRoot.getBoundingClientRect.returns( {
 				top: 0,

--- a/packages/ckeditor5-ui/tests/manual/tickets/5328/1.html
+++ b/packages/ckeditor5-ui/tests/manual/tickets/5328/1.html
@@ -1,0 +1,662 @@
+<div class="container-outer">
+	<div class="container-inner">
+		<div>
+			<div id="editor-stick">
+				<p>Balloon sticks to the <strong>TARGET</strong> element.</p>
+				<figure class="table">
+					<table>
+						<tbody>
+							<tr>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+							</tr>
+							<tr>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+							</tr>
+							<tr>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+							</tr>
+							<tr>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+							</tr>
+							<tr>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+							</tr>
+							<tr>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+							</tr>
+							<tr>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+							</tr>
+							<tr>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+							</tr>
+							<tr>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+							</tr>
+							<tr>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+								<td>
+									&nbsp;
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</figure>
+				<p>
+					<a href="https://ckeditor.com">Test link</a>
+				</p>
+			</div>
+		</div>
+	</div>
+</div>
+
+<div class="container-outer container-outer--large">
+	<div class="container-inner">
+		<div>
+			<div id="editor-with-scroll">
+				<p>
+					Lorem ipsum Lorem ipsum <a href="https://ckeditor.com">Lorem</a> ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem
+					ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem ipsum
+					Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum&nbsp;
+				</p>
+				<p>
+					Lorem ipsum Lorem ipsum <a href="https://ckeditor.com">Lorem</a> ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem
+					ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem ipsum
+					Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum&nbsp;
+				</p>
+				<p>
+					Lorem ipsum Lorem ipsum <a href="https://ckeditor.com">Lorem</a> ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem
+					ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem ipsum
+					Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum&nbsp;
+				</p>
+				<p>Balloon sticks to the <strong>TARGET</strong> element.</p>
+				<p>
+					Lorem ipsum Lorem ipsum <a href="https://ckeditor.com">Lorem</a> ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem
+					ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem ipsum
+					Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum&nbsp;
+				</p>
+				<p>
+					Lorem ipsum Lorem ipsum <a href="https://ckeditor.com">Lorem</a> ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem
+					ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem ipsum
+					Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum&nbsp;
+				</p>
+				<figure class="table">
+					<table>
+						<tbody>
+							<tr>
+								<td>
+									1
+								</td>
+								<td>
+									2
+								</td>
+							</tr>
+							<tr>
+								<td>
+									3
+								</td>
+								<td>
+									4
+								</td>
+							</tr>
+							<tr>
+								<td>
+									5
+								</td>
+								<td>
+									6
+								</td>
+							</tr>
+							<tr>
+								<td>
+									7
+								</td>
+								<td>
+									8
+								</td>
+							</tr>
+							<tr>
+								<td>
+									1
+								</td>
+								<td>
+									2
+								</td>
+							</tr>
+							<tr>
+								<td>
+									3
+								</td>
+								<td>
+									4
+								</td>
+							</tr>
+							<tr>
+								<td>
+									5
+								</td>
+								<td>
+									6
+								</td>
+							</tr>
+							<tr>
+								<td>
+									7
+								</td>
+								<td>
+									8
+								</td>
+							</tr>
+							<tr>
+								<td>
+									1
+								</td>
+								<td>
+									2
+								</td>
+							</tr>
+							<tr>
+								<td>
+									3
+								</td>
+								<td>
+									4
+								</td>
+							</tr>
+							<tr>
+								<td>
+									5
+								</td>
+								<td>
+									6
+								</td>
+							</tr>
+							<tr>
+								<td>
+									7
+								</td>
+								<td>
+									8
+								</td>
+							</tr>
+							<tr>
+								<td>
+									1
+								</td>
+								<td>
+									2
+								</td>
+							</tr>
+							<tr>
+								<td>
+									3
+								</td>
+								<td>
+									4
+								</td>
+							</tr>
+							<tr>
+								<td>
+									5
+								</td>
+								<td>
+									6
+								</td>
+							</tr>
+							<tr>
+								<td>
+									7
+								</td>
+								<td>
+									8
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</figure>
+
+				<figure class="image"><img src="https://ckeditor.com/docs/ckeditor5/latest/assets/img/umbrellas.jpg"
+						alt="Three monks ascending the stairs of an ancient temple."
+						srcset="https://ckeditor.com/docs/ckeditor5/latest/assets/img/umbrellas.jpg, https://ckeditor.com/docs/ckeditor5/latest/assets/img/umbrellas_2x.jpg 2x"
+						sizes="100vw">
+					<figcaption>Three monks ascending the stairs of an ancient temple.</figcaption>
+				</figure>
+				<p>
+					Lorem ipsum Lorem ipsum <a href="https://ckeditor.com">Lorem</a> ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem
+					ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem ipsum
+					Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+					Lorem ipsum Lorem
+					ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem ipsum
+					Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+					Lorem ipsum Lorem
+					ipsum Lorem ipsum <a href="https://ckeditor.com">Lorem</a> ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+					Lorem ipsum
+					Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+					Lorem ipsum Lorem
+					ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem ipsum
+					Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+					Lorem ipsum Lorem
+					ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem ipsum
+					Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+					Lorem ipsum Lorem
+					ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem ipsum
+					Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+					Lorem ipsum Lorem
+					ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem ipsum
+					Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+					Lorem ipsum Lorem
+					ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+					ipsum Lorem ipsum
+					Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+					Lorem ipsum Lorem
+					ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+				</p>
+			</div>
+		</div>
+	</div>
+</div>
+
+<hr>
+
+<div id="editor-out-of-the-box">
+	<p>
+		Lorem ipsum Lorem ipsum <a href="https://ckeditor.com">Lorem</a> ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem
+		ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem ipsum
+		Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum&nbsp;
+	</p>
+	<p>
+		Lorem ipsum Lorem ipsum <a href="https://ckeditor.com">Lorem</a> ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem
+		ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem ipsum
+		Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum&nbsp;
+	</p>
+	<p>
+		Lorem ipsum Lorem ipsum <a href="https://ckeditor.com">Lorem</a> ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem
+		ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem ipsum
+		Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum&nbsp;
+	</p>
+	<p>Balloon sticks to the <strong>TARGET</strong> element.</p>
+	<p>
+		Lorem ipsum Lorem ipsum <a href="https://ckeditor.com">Lorem</a> ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem
+		ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem ipsum
+		Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum&nbsp;
+	</p>
+	<p>
+		Lorem ipsum Lorem ipsum <a href="https://ckeditor.com">Lorem</a> ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem
+		ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem ipsum
+		Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum&nbsp;
+	</p>
+	<figure class="table">
+		<table>
+			<tbody>
+				<tr>
+					<td>
+						1
+					</td>
+					<td>
+						2
+					</td>
+				</tr>
+				<tr>
+					<td>
+						3
+					</td>
+					<td>
+						4
+					</td>
+				</tr>
+				<tr>
+					<td>
+						5
+					</td>
+					<td>
+						6
+					</td>
+				</tr>
+				<tr>
+					<td>
+						7
+					</td>
+					<td>
+						8
+					</td>
+				</tr>
+				<tr>
+					<td>
+						1
+					</td>
+					<td>
+						2
+					</td>
+				</tr>
+				<tr>
+					<td>
+						3
+					</td>
+					<td>
+						4
+					</td>
+				</tr>
+				<tr>
+					<td>
+						5
+					</td>
+					<td>
+						6
+					</td>
+				</tr>
+				<tr>
+					<td>
+						7
+					</td>
+					<td>
+						8
+					</td>
+				</tr>
+				<tr>
+					<td>
+						1
+					</td>
+					<td>
+						2
+					</td>
+				</tr>
+				<tr>
+					<td>
+						3
+					</td>
+					<td>
+						4
+					</td>
+				</tr>
+				<tr>
+					<td>
+						5
+					</td>
+					<td>
+						6
+					</td>
+				</tr>
+				<tr>
+					<td>
+						7
+					</td>
+					<td>
+						8
+					</td>
+				</tr>
+				<tr>
+					<td>
+						1
+					</td>
+					<td>
+						2
+					</td>
+				</tr>
+				<tr>
+					<td>
+						3
+					</td>
+					<td>
+						4
+					</td>
+				</tr>
+				<tr>
+					<td>
+						5
+					</td>
+					<td>
+						6
+					</td>
+				</tr>
+				<tr>
+					<td>
+						7
+					</td>
+					<td>
+						8
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</figure>
+
+	<figure class="image"><img src="https://ckeditor.com/docs/ckeditor5/latest/assets/img/umbrellas.jpg"
+			alt="Three monks ascending the stairs of an ancient temple."
+			srcset="https://ckeditor.com/docs/ckeditor5/latest/assets/img/umbrellas.jpg, https://ckeditor.com/docs/ckeditor5/latest/assets/img/umbrellas_2x.jpg 2x"
+			sizes="100vw">
+		<figcaption>Three monks ascending the stairs of an ancient temple.</figcaption>
+	</figure>
+	<p>
+		Lorem ipsum Lorem ipsum <a href="https://ckeditor.com">Lorem</a> ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem
+		ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem ipsum
+		Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+		Lorem ipsum Lorem
+		ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem ipsum
+		Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+		Lorem ipsum Lorem
+		ipsum Lorem ipsum <a href="https://ckeditor.com">Lorem</a> ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+		Lorem ipsum
+		Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+		Lorem ipsum Lorem
+		ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem ipsum
+		Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+		Lorem ipsum Lorem
+		ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem ipsum
+		Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+		Lorem ipsum Lorem
+		ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem ipsum
+		Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+		Lorem ipsum Lorem
+		ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem ipsum
+		Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+		Lorem ipsum Lorem
+		ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem
+		ipsum Lorem ipsum
+		Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+		Lorem ipsum Lorem
+		ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum Lorem ipsum
+	</p>
+</div>
+
+<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+<br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+
+<style>
+	body {
+		height: 100%;
+	}
+
+	.ck-balloon-panel {
+		padding: 2em;
+	}
+
+	.ck-editor__editable {
+		max-height: 300px;
+	}
+
+	.container-outer {
+		height: 300px;
+		width: 400px;
+		margin: 5rem auto;
+		overflow: scroll;
+	}
+
+	.container-outer--large {
+		width: 100%;
+		height: auto;
+		margin: 5rem auto 1000px auto;
+	}
+
+	.container-inner {
+		padding: 500px 30px 30px 500px;
+		display: flex;
+		width: 1000px;
+		height: 2000px;
+		background: #e1e1e1;
+	}
+
+	.container-outer--large .container-inner {
+		width: 100%;
+		height: auto;
+		justify-content: center;
+		padding: 120px 40px;
+	}
+
+	.container-inner > div {
+		margin: 0 20px;
+	}
+
+	.container-outer .container-inner .ck.ck-content:not(.ck-comment__input *) {
+		height: 50px;
+		width: 400px;
+	}
+
+	.container-outer--large .container-inner .ck.ck-content:not(.ck-comment__input *) {
+		height: 300px;
+		width: 400px;
+		overflow-y: auto;
+	}
+</style>

--- a/packages/ckeditor5-ui/tests/manual/tickets/5328/1.js
+++ b/packages/ckeditor5-ui/tests/manual/tickets/5328/1.js
@@ -1,0 +1,107 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals window, document, console:false */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import { TableCaption, TableCellProperties, TableColumnResize, TableProperties, TableToolbar } from '@ckeditor/ckeditor5-table';
+import BalloonPanelView from '../../../../src/panel/balloon/balloonpanelview';
+
+// Set initial scroll for the outer container element.
+document.querySelector( '.container-outer:not( .container-outer--large )' ).scrollTop = 420;
+document.querySelector( '.container-outer:not( .container-outer--large )' ).scrollLeft = 460;
+
+ClassicEditor
+	.create( document.querySelector( '#editor-stick' ), {
+		image: {
+			toolbar: [ 'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|', 'imageTextAlternative' ]
+		},
+		plugins: [ ArticlePluginSet, TableToolbar, TableCaption, TableCellProperties, TableColumnResize, TableProperties ],
+		toolbar: [ 'undo', 'redo', '|', 'bold', 'italic', 'link', '|', 'insertTable' ],
+		table: {
+			contentToolbar: [
+				'tableColumn', 'tableRow', 'mergeTableCells', 'tableProperties', 'tableCellProperties', 'toggleTableCaption'
+			]
+		},
+		ui: {
+			poweredBy: {
+				position: 'inside'
+			}
+		}
+	} )
+	.then( editor => {
+		const panel = new BalloonPanelView();
+
+		editor.ui.view.body.add( panel );
+		panel.element.innerHTML = 'Balloon content.';
+
+		editor.ui.view.element.querySelector( '.ck-editor__editable' ).scrollTop = 360;
+
+		panel.pin( {
+			target: editor.ui.view.element.querySelector( '.ck-editor__editable p strong' ),
+			limiter: editor.ui.getEditableElement()
+		} );
+
+		window.stickEditor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );
+
+// Editor with scroll
+ClassicEditor
+	.create( document.querySelector( '#editor-with-scroll' ), {
+		image: {
+			toolbar: [ 'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|', 'imageTextAlternative' ]
+		},
+		plugins: [ ArticlePluginSet, TableToolbar, TableCaption, TableCellProperties, TableColumnResize, TableProperties ],
+		toolbar: [ 'undo', 'redo', '|', 'bold', 'italic', 'link', '|', 'insertTable' ],
+		table: {
+			contentToolbar: [
+				'tableColumn', 'tableRow', 'mergeTableCells', 'tableProperties', 'tableCellProperties', 'toggleTableCaption'
+			]
+		}
+	} )
+	.then( editor => {
+		const panel = new BalloonPanelView();
+
+		editor.ui.view.body.add( panel );
+		panel.element.innerHTML = 'Balloon content.';
+
+		editor.ui.view.element.querySelector( '.ck-editor__editable' ).scrollTop = 360;
+
+		panel.pin( {
+			target: editor.ui.view.element.querySelector( '.ck-editor__editable p strong' ),
+			limiter: editor.ui.getEditableElement()
+		} );
+
+		window.scrollEditor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );
+
+// Editor "out of the box"
+ClassicEditor
+	.create( document.querySelector( '#editor-out-of-the-box' ), {
+		image: {
+			toolbar: [ 'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|', 'imageTextAlternative' ]
+		},
+		plugins: [ ArticlePluginSet, TableToolbar, TableCaption, TableCellProperties, TableColumnResize, TableProperties ],
+		toolbar: [ 'undo', 'redo', '|', 'bold', 'italic', 'link', '|', 'insertTable' ],
+		table: {
+			contentToolbar: [
+				'tableColumn', 'tableRow', 'mergeTableCells', 'tableProperties', 'tableCellProperties', 'toggleTableCaption'
+			]
+		}
+	} )
+	.then( editor => {
+		window.outOfTheBoxEditor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );
+

--- a/packages/ckeditor5-ui/tests/manual/tickets/5328/1.md
+++ b/packages/ckeditor5-ui/tests/manual/tickets/5328/1.md
@@ -1,0 +1,3 @@
+## BalloonPanelView
+
+Scroll editable elements and the container (horizontally as well). The balloon should disappear when elements it should be attached to move off the visible area (fixed balloon, tables, images, links).

--- a/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
+++ b/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
@@ -452,7 +452,7 @@ describe( 'BalloonPanelView', () => {
 			it( 'should put balloon on the `south east` position when `north east` is limited', () => {
 				mockBoundingBox( limiter, {
 					left: 0,
-					top: -400,
+					top: -350,
 					width: 500,
 					height: 500
 				} );
@@ -467,6 +467,286 @@ describe( 'BalloonPanelView', () => {
 				view.attachTo( { target, limiter } );
 
 				expect( view.position ).to.equal( 'arrow_nw' );
+			} );
+		} );
+
+		describe( 'limited by parent with overflow', () => {
+			let parentWithOverflow, limiter, target;
+			const OFF_THE_SCREEN_POSITION = -99999;
+
+			beforeEach( () => {
+				parentWithOverflow = document.createElement( 'div' );
+				parentWithOverflow.style.overflow = 'scroll';
+				parentWithOverflow.style.width = '100px';
+				parentWithOverflow.style.height = '100px';
+
+				limiter = document.createElement( 'div' );
+				target = document.createElement( 'div' );
+
+				// Mock parent dimensions.
+				mockBoundingBox( parentWithOverflow, {
+					left: 0,
+					top: 0,
+					width: 100,
+					height: 100
+				} );
+
+				target.style.width = '50px';
+				target.style.height = '50px';
+
+				parentWithOverflow.appendChild( limiter );
+				parentWithOverflow.appendChild( target );
+				document.body.appendChild( parentWithOverflow );
+			} );
+
+			afterEach( () => {
+				limiter.remove();
+				target.remove();
+				parentWithOverflow.remove();
+			} );
+
+			it( 'should not show the balloon if the target is not visible (vertical top)', () => {
+				mockBoundingBox( target, {
+					top: -51,
+					left: 0,
+					width: 50,
+					height: 50
+				} );
+
+				view.attachTo( { target, limiter } );
+
+				expect( view.top ).to.equal( OFF_THE_SCREEN_POSITION );
+				expect( view.left ).to.equal( OFF_THE_SCREEN_POSITION );
+			} );
+
+			it( 'should not show the balloon if the target is not visible (vertical bottom)', () => {
+				mockBoundingBox( target, {
+					top: 101,
+					left: 0,
+					width: 50,
+					height: 50
+				} );
+
+				view.attachTo( { target, limiter } );
+
+				expect( view.top ).to.equal( OFF_THE_SCREEN_POSITION );
+				expect( view.left ).to.equal( OFF_THE_SCREEN_POSITION );
+			} );
+
+			it( 'should not show the balloon if the target is not visible (horizontal left)', () => {
+				mockBoundingBox( target, {
+					top: 0,
+					left: -100,
+					width: 50,
+					height: 50
+				} );
+
+				view.attachTo( { target, limiter } );
+
+				expect( view.top ).to.equal( OFF_THE_SCREEN_POSITION );
+				expect( view.left ).to.equal( OFF_THE_SCREEN_POSITION );
+			} );
+
+			it( 'should not show the balloon if the target is not visible (horizontal right)', () => {
+				mockBoundingBox( target, {
+					top: 0,
+					left: 101,
+					width: 50,
+					height: 50
+				} );
+
+				view.attachTo( { target, limiter } );
+
+				expect( view.top ).to.equal( OFF_THE_SCREEN_POSITION );
+				expect( view.left ).to.equal( OFF_THE_SCREEN_POSITION );
+			} );
+
+			it( 'should get proper HTML element when callback is passed as a target', () => {
+				const callback = sinon.stub().returns( document.createElement( 'a' ) );
+
+				view.attachTo( { target: callback, limiter } );
+
+				sinon.assert.called( callback );
+			} );
+
+			it( 'should show the balloon when limiter is not defined', () => {
+				mockBoundingBox( target, {
+					top: 50,
+					left: 50,
+					width: 50,
+					height: 50
+				} );
+
+				view.attachTo( { target } );
+
+				expect( view.left ).to.equal( 25 );
+			} );
+		} );
+
+		describe( 'limited by editor with overflow', () => {
+			let limiter, target;
+			const OFF_THE_SCREEN_POSITION = -99999;
+
+			beforeEach( () => {
+				limiter = document.createElement( 'div' );
+				limiter.style.overflow = 'scroll';
+				limiter.style.width = '100px';
+				limiter.style.height = '100px';
+
+				// Mock parent dimensions.
+				mockBoundingBox( limiter, {
+					left: 0,
+					top: 0,
+					width: 100,
+					height: 100
+				} );
+
+				target = document.createElement( 'div' );
+				target.style.width = '200px';
+				target.style.height = '200px';
+
+				limiter.appendChild( target );
+				document.body.appendChild( limiter );
+			} );
+
+			afterEach( () => {
+				limiter.remove();
+				target.remove();
+			} );
+
+			it( 'should not show the balloon if the target is not visible (vertical top)', () => {
+				mockBoundingBox( target, {
+					top: -51,
+					left: 0,
+					width: 50,
+					height: 50
+				} );
+
+				view.attachTo( { target, limiter } );
+
+				expect( view.top ).to.equal( OFF_THE_SCREEN_POSITION );
+				expect( view.left ).to.equal( OFF_THE_SCREEN_POSITION );
+			} );
+
+			it( 'should not show the balloon if the target is not visible (vertical bottom)', () => {
+				mockBoundingBox( target, {
+					top: 159,
+					left: 0,
+					width: 50,
+					height: 50
+				} );
+
+				view.attachTo( { target, limiter } );
+
+				expect( view.top ).to.equal( OFF_THE_SCREEN_POSITION );
+				expect( view.left ).to.equal( OFF_THE_SCREEN_POSITION );
+			} );
+
+			it( 'should not show the balloon if the target is not visible (horizontal left)', () => {
+				mockBoundingBox( target, {
+					top: 0,
+					left: -100,
+					width: 50,
+					height: 50
+				} );
+
+				view.attachTo( { target, limiter } );
+
+				expect( view.top ).to.equal( OFF_THE_SCREEN_POSITION );
+				expect( view.left ).to.equal( OFF_THE_SCREEN_POSITION );
+			} );
+
+			it( 'should not show the balloon if the target is not visible (horizontal right)', () => {
+				mockBoundingBox( target, {
+					top: 0,
+					left: 101,
+					width: 50,
+					height: 50
+				} );
+
+				view.attachTo( { target, limiter } );
+
+				expect( view.top ).to.equal( OFF_THE_SCREEN_POSITION );
+				expect( view.left ).to.equal( OFF_THE_SCREEN_POSITION );
+			} );
+
+			it( 'should show the balloon when limiter is not defined', () => {
+				mockBoundingBox( target, {
+					top: 50,
+					left: 50,
+					width: 50,
+					height: 50
+				} );
+
+				view.attachTo( { target } );
+
+				expect( view.left ).to.equal( 25 );
+			} );
+		} );
+
+		describe( 'limited by editor with overflow and a parent with overflow', () => {
+			let limiter, target, parentWithOverflow, limiterParent;
+			const OFF_THE_SCREEN_POSITION = -99999;
+
+			beforeEach( () => {
+				limiter = document.createElement( 'div' );
+				limiter.style.overflow = 'scroll';
+
+				parentWithOverflow = document.createElement( 'div' );
+				parentWithOverflow.style.overflow = 'scroll';
+
+				limiterParent = document.createElement( 'div' );
+
+				target = document.createElement( 'div' );
+
+				// Mock parent dimensions.
+				mockBoundingBox( parentWithOverflow, {
+					left: 0,
+					top: 0,
+					width: 200,
+					height: 200
+				} );
+
+				// Mock limiter parent dimensions.
+				mockBoundingBox( limiterParent, {
+					left: 0,
+					top: 0,
+					width: 400,
+					height: 400
+				} );
+
+				// Mock limiter dimensions.
+				mockBoundingBox( limiter, {
+					left: 0,
+					top: 0,
+					width: 100,
+					height: 100
+				} );
+
+				limiter.appendChild( target );
+				limiterParent.appendChild( limiter );
+				parentWithOverflow.appendChild( limiterParent );
+				document.body.appendChild( parentWithOverflow );
+			} );
+
+			afterEach( () => {
+				limiter.remove();
+				target.remove();
+				parentWithOverflow.remove();
+			} );
+
+			it( 'should not show the balloon if the target is not visible ( target higher than scrollable ancestor )', () => {
+				mockBoundingBox( target, {
+					top: -250,
+					left: 0,
+					width: 200,
+					height: 200
+				} );
+
+				view.attachTo( { target, limiter } );
+
+				expect( view.top ).to.equal( OFF_THE_SCREEN_POSITION );
+				expect( view.left ).to.equal( OFF_THE_SCREEN_POSITION );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-utils/tests/dom/position.js
+++ b/packages/ckeditor5-utils/tests/dom/position.js
@@ -134,8 +134,13 @@ describe( 'getOptimalPosition()', () => {
 	} );
 
 	afterEach( () => {
-		element.remove();
-		target.remove();
+		if ( element ) {
+			element.remove();
+		}
+
+		if ( target ) {
+			target.remove();
+		}
 
 		if ( limiter ) {
 			limiter.remove();
@@ -179,6 +184,24 @@ describe( 'getOptimalPosition()', () => {
 		}, {
 			top: 100,
 			left: 80,
+			name: 'left-bottom'
+		} );
+	} );
+
+	it( 'should work when the target is a Range', () => {
+		setElementTargetPlayground();
+
+		const range = document.createRange();
+
+		range.selectNode( document.body );
+
+		assertPosition( {
+			element,
+			target: range,
+			positions: [ attachLeftBottom ]
+		}, {
+			top: 8,
+			left: -12,
 			name: 'left-bottom'
 		} );
 	} );
@@ -320,7 +343,7 @@ describe( 'getOptimalPosition()', () => {
 		it( 'should allow position function to return null to be ignored', () => {
 			assertPosition( {
 				element, target,
-				positions: [ attachRightBottom, attachNone ]
+				positions: [ attachRightBottom ]
 			}, {
 				top: 100,
 				left: 110,
@@ -343,8 +366,8 @@ describe( 'getOptimalPosition()', () => {
 				positions: [ attachLeftBottom, attachRightBottom ]
 			}, {
 				top: 100,
-				left: -20,
-				name: 'left-bottom'
+				left: 10,
+				name: 'right-bottom'
 			} );
 		} );
 
@@ -355,8 +378,8 @@ describe( 'getOptimalPosition()', () => {
 				positions: [ attachLeftBottom, attachRightBottom ]
 			}, {
 				top: 100,
-				left: -20,
-				name: 'left-bottom'
+				left: 10,
+				name: 'right-bottom'
 			} );
 		} );
 
@@ -366,8 +389,8 @@ describe( 'getOptimalPosition()', () => {
 				positions: [ attachLeftBottom, attachRightBottom ]
 			}, {
 				top: 100,
-				left: -20,
-				name: 'left-bottom'
+				left: 10,
+				name: 'right-bottom'
 			} );
 		} );
 
@@ -377,8 +400,8 @@ describe( 'getOptimalPosition()', () => {
 				positions: [ attachRightBottom, attachLeftBottom ]
 			}, {
 				top: 100,
-				left: -20,
-				name: 'left-bottom'
+				left: 10,
+				name: 'right-bottom'
 			} );
 		} );
 
@@ -422,21 +445,17 @@ describe( 'getOptimalPosition()', () => {
 				positions: [ attachRightBottom, attachLeftBottom ]
 			}, {
 				top: 100,
-				left: -5,
-				name: 'left-bottom'
+				left: 10,
+				name: 'right-bottom'
 			} );
 
 			element.remove();
 		} );
 
 		it( 'should allow position function to return null to be ignored', () => {
-			assertPosition( {
+			assertNullPosition( {
 				element, target, limiter,
 				positions: [ attachLeftBottom, attachNone ]
-			}, {
-				top: 100,
-				left: -20,
-				name: 'left-bottom'
 			} );
 		} );
 	} );
@@ -533,7 +552,7 @@ describe( 'getOptimalPosition()', () => {
 		} );
 
 		it( 'should return the very first coordinates if no fitting position with a positive intersection has been found', () => {
-			assertPosition( {
+			assertNullPosition( {
 				element, target, limiter,
 				positions: [
 					() => ( {
@@ -543,14 +562,10 @@ describe( 'getOptimalPosition()', () => {
 					} )
 				],
 				fitInViewport: true
-			}, {
-				left: -10000,
-				top: -10000,
-				name: 'no-intersect-position'
 			} );
 		} );
 
-		it( 'should return the very first coordinates if limiter does not fit into the viewport', () => {
+		it( 'should return the last coordinates if limiter does not fit into the viewport', () => {
 			const limiter = getElement( {
 				top: -100,
 				right: -80,
@@ -706,6 +721,234 @@ describe( 'getOptimalPosition()', () => {
 			element.remove();
 		} );
 	} );
+
+	describe( 'with scrollable ancestors', () => {
+		let parentWithOverflow, limiter, target, element, parentAncestorWithOverflow;
+
+		beforeEach( () => {
+			limiter = getElement( {
+				top: -100,
+				right: 100,
+				bottom: 100,
+				left: -100,
+				width: 200,
+				height: 200
+			} );
+
+			target = getElement( {
+				top: 0,
+				right: 50,
+				bottom: 50,
+				left: 0,
+				width: 50,
+				height: 50
+			} );
+
+			element = getElement( {
+				top: 0,
+				right: 200,
+				bottom: 200,
+				left: 0,
+				width: 200,
+				height: 200
+			} );
+
+			parentWithOverflow = getElement( {
+				top: 0,
+				left: 0,
+				right: 100,
+				bottom: 100,
+				width: 100,
+				height: 100
+			} );
+			parentWithOverflow.style.overflow = 'scroll';
+		} );
+
+		afterEach( () => {
+			if ( element ) {
+				element.remove();
+			}
+
+			if ( target ) {
+				target.remove();
+			}
+
+			if ( limiter ) {
+				limiter.remove();
+			}
+
+			if ( parentWithOverflow ) {
+				parentWithOverflow.remove();
+			}
+
+			if ( parentAncestorWithOverflow ) {
+				parentAncestorWithOverflow.remove();
+			}
+		} );
+
+		it( 'should return null when target is not visible', () => {
+			const target = getElement( {
+				top: -200,
+				right: -100,
+				bottom: -100,
+				left: -200,
+				width: 100,
+				height: 100
+			} );
+			limiter.appendChild( target );
+			parentWithOverflow.appendChild( limiter );
+			parentWithOverflow.appendChild( element );
+			document.body.appendChild( parentWithOverflow );
+
+			assertNullPosition( {
+				element, target, limiter,
+				positions: allPositions,
+				fitInViewport: true
+			} );
+
+			parentWithOverflow.remove();
+		} );
+
+		it( 'should return position when element is fully contained by the limiter', () => {
+			const limiter = getElement( {
+				top: 0,
+				right: 1000,
+				bottom: 1000,
+				left: 0,
+				width: 1000,
+				height: 1000
+			} );
+			const target = getElement( {
+				top: 0,
+				right: 100,
+				bottom: 100,
+				left: 0,
+				width: 100,
+				height: 100
+			} );
+
+			const parentWithOverflow = getElement( {
+				top: 0,
+				left: 0,
+				right: 1000,
+				bottom: 1000,
+				width: 1000,
+				height: 1000
+			} );
+
+			limiter.appendChild( target );
+			parentWithOverflow.appendChild( limiter );
+			parentWithOverflow.appendChild( element );
+			document.body.appendChild( parentWithOverflow );
+
+			assertPositionName( {
+				element, target, limiter,
+				positions: allPositions,
+				fitInViewport: true
+			}, 'right-bottom' );
+
+			parentWithOverflow.remove();
+		} );
+
+		it( 'should return position when element is fully contained by the limiter and cropped by top offset', () => {
+			const limiter = getElement( {
+				top: 0,
+				right: 1000,
+				bottom: 1000,
+				left: 0,
+				width: 1000,
+				height: 1000
+			} );
+			const target = getElement( {
+				top: 0,
+				right: 100,
+				bottom: 100,
+				left: 0,
+				width: 100,
+				height: 100
+			} );
+
+			const parentWithOverflow = getElement( {
+				top: 0,
+				left: 0,
+				right: 1000,
+				bottom: 1000,
+				width: 1000,
+				height: 1000
+			} );
+
+			limiter.appendChild( target );
+			parentWithOverflow.appendChild( limiter );
+			parentWithOverflow.appendChild( element );
+			document.body.appendChild( parentWithOverflow );
+
+			assertPositionName( {
+				element, target, limiter,
+				positions: allPositions,
+				fitInViewport: true,
+				viewportOffsetConfig: {
+					top: 100,
+					left: 0,
+					right: 0,
+					bottom: 0
+				}
+			}, 'bottom-right' );
+
+			parentWithOverflow.remove();
+		} );
+
+		it( 'should return proper calculated position when first ancestor\'s Rect has undefined values', () => {
+			limiter.appendChild( target );
+			parentWithOverflow.appendChild( limiter );
+			parentWithOverflow.appendChild( element );
+			document.body.appendChild( parentWithOverflow );
+
+			assertPositionName( {
+				element, target, limiter,
+				positions: allPositions,
+				fitInViewport: true
+			}, 'right-bottom' );
+
+			parentWithOverflow.remove();
+		} );
+
+		it( 'should return proper calculated position when `target` is a Range', () => {
+			const limiter = getElement( {
+				top: 0,
+				right: 100,
+				bottom: 100,
+				left: 0,
+				width: 100,
+				height: 100
+			} );
+
+			const target = document.createRange();
+			target.selectNode( document.body );
+
+			const element = getElement( {
+				top: 0,
+				right: 100,
+				bottom: 100,
+				left: 0,
+				width: 100,
+				height: 100
+			} );
+
+			parentWithOverflow.appendChild( limiter );
+			parentWithOverflow.appendChild( element );
+			document.body.appendChild( parentWithOverflow );
+
+			assertPositionName( {
+				element, target, limiter,
+				positions: allPositions,
+				fitInViewport: true
+			}, 'bottom-right' );
+
+			limiter.remove();
+			element.remove();
+			parentWithOverflow.remove();
+		} );
+	} );
 } );
 
 function assertPosition( options, expected ) {
@@ -719,6 +962,12 @@ function assertPositionName( options, expected ) {
 	const position = getOptimalPosition( options );
 
 	expect( position.name ).to.equal( expected );
+}
+
+function assertNullPosition( options ) {
+	const position = getOptimalPosition( options );
+
+	expect( position ).to.be.null;
 }
 
 // Returns a synthetic element.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui,utils): A balloon panel should hide when its target (anchor) becomes invisible due to scrolling or cropping. Closes [#5328](https://github.com/ckeditor/ckeditor5/issues/5328).

MINOR BREAKING CHANGE (utils): The `getOptimalPosition()` helper will now return `null` (previously first available position) if the positioning criteria cannot be met, for instance, if the `target` is off the visible viewport.

---

### Additional information

This PR is based on #14630.