### PR TITLE
enablePlaceholder() API should remain backward compatible for some time

### DIFF
--- a/packages/ckeditor5-engine/src/view/placeholder.ts
+++ b/packages/ckeditor5-engine/src/view/placeholder.ts
@@ -20,6 +20,8 @@ import type { ObservableChangeEvent } from '@ckeditor/ckeditor5-utils';
 // Each document stores information about its placeholder elements and check functions.
 const documentPlaceholders = new WeakMap<Document, Map<Element, PlaceholderConfig>>();
 
+let hasDisplayedWarning = false;
+
 /**
  * A helper that enables a placeholder on the provided view element (also updates its visibility).
  * The placeholder is a CSS pseudo–element (with a text content) attached to the element.
@@ -37,10 +39,11 @@ const documentPlaceholders = new WeakMap<Document, Map<Element, PlaceholderConfi
  * editable root elements.
  * @param options.keepOnFocus If set `true`, the placeholder stay visible when the host element is focused.
  */
-export function enablePlaceholder( { view, element, isDirectHost = true, keepOnFocus = false }: {
+export function enablePlaceholder( { view, element, text, isDirectHost = true, keepOnFocus = false }: {
 	view: View;
 	element: PlaceholderableElement | EditableElement;
 	isDirectHost?: boolean;
+	text?: string;
 	keepOnFocus?: boolean;
 } ): void {
 	const doc = view.document;
@@ -67,6 +70,12 @@ export function enablePlaceholder( { view, element, isDirectHost = true, keepOnF
 
 	if ( element.placeholder ) {
 		setPlaceholder( element.placeholder );
+	} else if ( text ) {
+		setPlaceholder( text );
+	}
+
+	if ( text ) {
+		showDeprecationWarning();
 	}
 
 	function setPlaceholder( text: string ) {
@@ -297,6 +306,19 @@ function getChildPlaceholderHostSubstitute( parent: Element ): Element | null {
 	}
 
 	return null;
+}
+
+/**
+ * Displays a deprecation warning message in the console, but only once per page load.
+ */
+function showDeprecationWarning() {
+	if ( !hasDisplayedWarning ) {
+		console.warn( 'Deprecation Warning: The "text" argument in the "enableProperty" function will be deprecated ' +
+		'in the next version. Please update your code. Refer to the documentation for alternative usage: ' +
+		'https://ckeditor.com/docs/ckeditor5/latest/updating/guides/update-to-39.html#view-element-placeholder' );
+	}
+
+	hasDisplayedWarning = true;
 }
 
 /**

--- a/packages/ckeditor5-engine/tests/view/placeholder.js
+++ b/packages/ckeditor5-engine/tests/view/placeholder.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+/* globals console */
+
 import {
 	enablePlaceholder,
 	disablePlaceholder,
@@ -618,8 +620,7 @@ describe( 'placeholder', () => {
 
 			enablePlaceholder( {
 				view,
-				element: viewRoot,
-				text: 'foo bar baz'
+				element: viewRoot
 			} );
 			viewRoot.placeholder = 'new placeholder';
 
@@ -632,12 +633,62 @@ describe( 'placeholder', () => {
 			enablePlaceholder( {
 				view,
 				element: viewRoot,
-				text: 'foo bar baz',
 				isDirectHost: false
 			} );
 			viewRoot.placeholder = 'new placeholder';
 
 			expect( viewRoot.getChild( 0 ).getAttribute( 'data-placeholder' ) ).to.equal( 'new placeholder' );
+		} );
+
+		it( 'should through warning once if "text" is used as argument', () => {
+			const spy = sinon.spy( console, 'warn' );
+			const warning = 'Deprecation Warning: The "text" argument in the "enableProperty" function will be deprecated ' +
+			'in the next version. Please update your code. Refer to the documentation for alternative usage: ' +
+			'https://ckeditor.com/docs/ckeditor5/latest/updating/guides/update-to-39.html#view-element-placeholder';
+
+			setData( view, '<div></div><div>{another div}</div>' );
+
+			enablePlaceholder( {
+				view,
+				element: viewRoot,
+				isDirectHost: false,
+				text: 'foo bar'
+			} );
+
+			enablePlaceholder( {
+				view,
+				element: viewRoot,
+				isDirectHost: false,
+				text: 'foo bar baz'
+			} );
+
+			sinon.assert.calledOnce( spy.withArgs( warning ) );
+		} );
+
+		it( 'should set placeholder using "text" argument', () => {
+			setData( view, '<div></div><div>{another div}</div>' );
+
+			enablePlaceholder( {
+				view,
+				element: viewRoot,
+				text: 'placeholder'
+			} );
+
+			expect( viewRoot.getAttribute( 'data-placeholder' ) ).to.equal( 'placeholder' );
+		} );
+
+		it( 'should use element\'s placeholder as more prior value', () => {
+			setData( view, '<div></div><div>{another div}</div>' );
+
+			enablePlaceholder( {
+				view,
+				element: viewRoot,
+				text: 'foo'
+			} );
+
+			viewRoot.placeholder = 'bar';
+
+			expect( viewRoot.getAttribute( 'data-placeholder' ) ).to.equal( 'bar' );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (engine): enablePlaceholder() API remain backward compatible for some time. Closes #14743.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
