### PR TITLE
Do not indent block elements in Document Lists.

### DIFF
--- a/packages/ckeditor5-indent/package.json
+++ b/packages/ckeditor5-indent/package.json
@@ -20,6 +20,7 @@
     "@ckeditor/ckeditor5-editor-classic": "39.0.0",
     "@ckeditor/ckeditor5-engine": "39.0.0",
     "@ckeditor/ckeditor5-heading": "39.0.0",
+    "@ckeditor/ckeditor5-list": "39.0.0",
     "@ckeditor/ckeditor5-paragraph": "39.0.0",
     "@ckeditor/ckeditor5-theme-lark": "39.0.0",
     "@ckeditor/ckeditor5-ui": "39.0.0",

--- a/packages/ckeditor5-indent/src/indentblock.ts
+++ b/packages/ckeditor5-indent/src/indentblock.ts
@@ -125,7 +125,12 @@ export default class IndentBlock extends Plugin {
 			},
 			model: {
 				key: 'blockIndent',
-				value: ( viewElement: ViewElement ) => viewElement.getStyle( marginProperty )
+				value: ( viewElement: ViewElement ) => {
+					// Do not indent block elements in Document Lists. See https://github.com/ckeditor/ckeditor5/issues/12466.
+					if ( !viewElement.is( 'element', 'li' ) ) {
+						return viewElement.getStyle( marginProperty );
+					}
+				}
 			}
 		} );
 

--- a/packages/ckeditor5-indent/tests/indentblock.js
+++ b/packages/ckeditor5-indent/tests/indentblock.js
@@ -8,6 +8,7 @@ import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import HeadingEditing from '@ckeditor/ckeditor5-heading/src/headingediting';
+import DocumentListEditing from '@ckeditor/ckeditor5-list/src/documentlist/documentlistediting';
 
 import IndentEditing from '../src/indentediting';
 import IndentBlock from '../src/indentblock';
@@ -157,6 +158,30 @@ describe( 'IndentBlock', () => {
 					expect( editor.getData() ).to.equal( '<p style="margin-left:42em;">foo</p>' );
 					expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
 						.to.equal( '<p style="margin-left:42em">foo</p>' );
+				} );
+
+				describe( 'integration with List', () => {
+					beforeEach( () => {
+						return VirtualTestEditor
+							.create( Object.assign( {
+								plugins: [ Paragraph, DocumentListEditing, IndentEditing, IndentBlock ]
+							} ) )
+							.then( newEditor => {
+								editor = newEditor;
+								model = editor.model;
+								doc = model.document;
+							} );
+					} );
+
+					// Block elements in Document Lists should not be indented. See https://github.com/ckeditor/ckeditor5/issues/12466.
+					it( 'should not convert margin-left to indent attribute for a list item', () => {
+						editor.setData( '<ul><li style="margin-left:72.0pt">foo</li></ul>' );
+
+						const paragraph = doc.getRoot().getChild( 0 );
+
+						expect( paragraph.hasAttribute( 'blockIndent' ) ).to.be.false;
+						expect( editor.getData() ).to.equal( '<ul><li>foo</li></ul>' );
+					} );
 				} );
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (indent): Nested lists pasted from Word should be displayed properly in Document Lists. Closes #12466.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
