### PR TITLE
Disabled commiting on nightly release

### DIFF
--- a/scripts/release/preparepackages.js
+++ b/scripts/release/preparepackages.js
@@ -185,7 +185,8 @@ const tasks = new Listr( [
 					...ctx.updatedFiles
 				]
 			} );
-		}
+		},
+		skip: cliArguments.nightly
 	}
 ], getListrOptions( cliArguments ) );
 


### PR DESCRIPTION
Internal: Disabled commiting on nightly release. See ckeditor/ckeditor5#14728.