### PR TITLE
Fix (table): fix scrolling bug when headings are in the table

### DIFF
--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -2862,15 +2862,14 @@ describe( 'TableColumnResizeEditing', () => {
 				);
 
 				const table = document.getElementsByTagName( 'tbody' )[ 0 ];
+				const shift = table.getBoundingClientRect().y - table.parentElement.getBoundingClientRect().y;
 
 				editor.editing.view.scrollToTheSelection( {
 					alignToTop: true,
 					forceScroll: true
 				} );
 
-				expect( Math.floor( table.getBoundingClientRect().y ) ).to.be.equal(
-					Math.floor( table.parentElement.getBoundingClientRect().y )
-				);
+				expect( table.getBoundingClientRect().y - table.parentElement.getBoundingClientRect().y ).to.be.equal( shift );
 			} );
 		} );
 

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -17,6 +17,7 @@ import PlainTableOutput from '../../src/plaintableoutput';
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+
 import LinkEditing from '@ckeditor/ckeditor5-link/src/linkediting';
 import HighlightEditing from '@ckeditor/ckeditor5-highlight/src/highlightediting';
 import GeneralHtmlSupport from '@ckeditor/ckeditor5-html-support/src/generalhtmlsupport';
@@ -2806,6 +2807,69 @@ describe( 'TableColumnResizeEditing', () => {
 							'</tr>' +
 						'</tbody>' +
 					'</table>'
+				);
+			} );
+
+			it( 'should not overflow table after scrolling', () => {
+				setModelData( editor.model,
+					'<table tableWidth="100%">' +
+						'<tableRow>' +
+							'<tableCell>' +
+								'<table tableWidth="90%">' +
+									'<tableRow>' +
+										'<tableCell>' +
+											'<paragraph></paragraph>' +
+										'</tableCell>' +
+										'<tableCell>' +
+											'<paragraph></paragraph>' +
+										'</tableCell>' +
+									'</tableRow>' +
+									'<tableRow>' +
+										'<tableCell>' +
+											'<paragraph></paragraph>' +
+										'</tableCell>' +
+										'<tableCell>' +
+											'<paragraph></paragraph>' +
+										'</tableCell>' +
+									'</tableRow>' +
+									'<tableRow>' +
+										'<tableCell>' +
+											'<paragraph></paragraph>' +
+										'</tableCell>' +
+										'<tableCell>' +
+											'<paragraph></paragraph>' +
+										'</tableCell>' +
+									'</tableRow>' +
+									'<tableRow>' +
+										'<tableCell>' +
+											'<paragraph>[]foo</paragraph>' +
+										'</tableCell>' +
+										'<tableCell>' +
+											'<paragraph>bar</paragraph>' +
+										'</tableCell>' +
+									'</tableRow>' +
+									'<tableColumnGroup>' +
+										'<tableColumn columnWidth="50%"></tableColumn>' +
+										'<tableColumn columnWidth="50%"></tableColumn>' +
+									'</tableColumnGroup>' +
+								'</table>' +
+							'</tableCell>' +
+						'</tableRow>' +
+						'<tableColumnGroup>' +
+							'<tableColumn columnWidth="100%"></tableColumn>' +
+						'</tableColumnGroup>' +
+					'</table>' + '<paragraph></paragraph>'.repeat( 50 )
+				);
+
+				const table = document.getElementsByTagName( 'tbody' )[ 0 ];
+
+				editor.editing.view.scrollToTheSelection( {
+					alignToTop: true,
+					forceScroll: true
+				} );
+
+				expect( Math.floor( table.getBoundingClientRect().y ) ).to.be.equal(
+					Math.floor( table.parentElement.getBoundingClientRect().y )
 				);
 			} );
 		} );

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -17,7 +17,6 @@ import PlainTableOutput from '../../src/plaintableoutput';
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
-
 import LinkEditing from '@ckeditor/ckeditor5-link/src/linkediting';
 import HighlightEditing from '@ckeditor/ckeditor5-highlight/src/highlightediting';
 import GeneralHtmlSupport from '@ckeditor/ckeditor5-html-support/src/generalhtmlsupport';

--- a/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
+++ b/packages/ckeditor5-table/tests/tablecolumnresize/tablecolumnresizeediting.js
@@ -2809,7 +2809,7 @@ describe( 'TableColumnResizeEditing', () => {
 				);
 			} );
 
-			it( 'should not overflow table after scrolling', () => {
+			it( 'should not scroll `tbody` inside `table` after scrolling to the selection in a cell.', () => {
 				setModelData( editor.model,
 					'<table tableWidth="100%">' +
 						'<tableRow>' +

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -34,8 +34,8 @@
 	   it is extended to an extremely high height. Even for screens with a very high pixel density, the resizer will fulfill its role as
 	   it should, i.e. for a screen of 476 ppi the total height of the resizer will take over 350 sheets of A4 format, which is totally
 	   unrealistic height for a single table. */
-	top: -999999px;
-	bottom: -999999px;
+	top: 0;
+	bottom: 0;
 	right: var(--ck-table-column-resizer-position-offset);
 	width: var(--ck-table-column-resizer-width);
 	cursor: col-resize;
@@ -57,6 +57,8 @@
 .ck.ck-editor__editable .table .ck-table-column-resizer__active {
 	background-color: var(--ck-color-selector-column-resizer-hover);
 	opacity: 0.25;
+	top: -999999px;
+	bottom: -999999px;
 }
 
 .ck.ck-editor__editable[dir=rtl] .table .ck-table-column-resizer {

--- a/packages/ckeditor5-table/theme/tablecolumnresize.css
+++ b/packages/ckeditor5-table/theme/tablecolumnresize.css
@@ -30,10 +30,6 @@
 
 .ck.ck-editor__editable .table .ck-table-column-resizer {
 	position: absolute;
-	/* The resizer element resides in each cell so to occupy the entire height of the table, which is unknown from a CSS point of view,
-	   it is extended to an extremely high height. Even for screens with a very high pixel density, the resizer will fulfill its role as
-	   it should, i.e. for a screen of 476 ppi the total height of the resizer will take over 350 sheets of A4 format, which is totally
-	   unrealistic height for a single table. */
 	top: 0;
 	bottom: 0;
 	right: var(--ck-table-column-resizer-position-offset);
@@ -57,6 +53,10 @@
 .ck.ck-editor__editable .table .ck-table-column-resizer__active {
 	background-color: var(--ck-color-selector-column-resizer-hover);
 	opacity: 0.25;
+	/* The resizer element resides in each cell so to occupy the entire height of the table, which is unknown from a CSS point of view,
+	   it is extended to an extremely high height. Even for screens with a very high pixel density, the resizer will fulfill its role as
+	   it should, i.e. for a screen of 476 ppi the total height of the resizer will take over 350 sheets of A4 format, which is totally
+	   unrealistic height for a single table. */
 	top: -999999px;
 	bottom: -999999px;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (table): fix scrolling bug when headings are in the table. Closes [#3489](https://github.com/cksource/ckeditor5-internal/issues/3489).

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
