### PR TITLE
fix: load only specified typings for TypeScript

### DIFF
--- a/packages/ckeditor5-engine/src/view/observer/mutationobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/mutationobserver.ts
@@ -55,7 +55,7 @@ export default class MutationObserver extends Observer {
 	/**
 	 * Native mutation observer.
 	 */
-	private _mutationObserver: InstanceType<typeof global.MutationObserver>;
+	private _mutationObserver: InstanceType<typeof window.MutationObserver>;
 
 	/**
 	 * @inheritDoc

--- a/packages/ckeditor5-utils/src/dom/getelementsintersectionrect.ts
+++ b/packages/ckeditor5-utils/src/dom/getelementsintersectionrect.ts
@@ -24,7 +24,7 @@ export default function getElementsIntersectionRect(
 	const elementRects = elements.map( element => {
 		// The document (window) is yet another "element", but cropped by the top offset.
 		if ( element instanceof Document ) {
-			const windowRect = new Rect( global.window );
+			const windowRect = new Rect( window );
 
 			windowRect.top += viewportTopOffset;
 			windowRect.height -= viewportTopOffset;

--- a/packages/ckeditor5-utils/src/dom/getelementsintersectionrect.ts
+++ b/packages/ckeditor5-utils/src/dom/getelementsintersectionrect.ts
@@ -7,6 +7,7 @@
  * @module utils/dom/getelementsintersectionrect
  */
 
+import global from './global';
 import Rect from './rect';
 
 /**
@@ -24,7 +25,7 @@ export default function getElementsIntersectionRect(
 	const elementRects = elements.map( element => {
 		// The document (window) is yet another "element", but cropped by the top offset.
 		if ( element instanceof Document ) {
-			const windowRect = new Rect( window );
+			const windowRect = new Rect( global.window );
 
 			windowRect.top += viewportTopOffset;
 			windowRect.height -= viewportTopOffset;

--- a/packages/ckeditor5-utils/src/version.ts
+++ b/packages/ckeditor5-utils/src/version.ts
@@ -7,7 +7,7 @@
  * @module utils/version
  */
 
-/* globals window, global */
+/* globals global */
 
 import CKEditorError from './ckeditorerror';
 
@@ -19,6 +19,8 @@ export default version;
 export const releaseDate = new Date( 2023, 7, 10 );
 
 /* istanbul ignore next -- @preserve */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
 const windowOrGlobal = typeof window === 'object' ? window : global;
 
 declare global {

--- a/packages/ckeditor5-utils/src/version.ts
+++ b/packages/ckeditor5-utils/src/version.ts
@@ -7,8 +7,6 @@
  * @module utils/version
  */
 
-/* globals window, global */
-
 import CKEditorError from './ckeditorerror';
 
 const version = '39.0.1';
@@ -18,18 +16,13 @@ export default version;
 // The second argument is not a month. It is `monthIndex` and starts from `0`.
 export const releaseDate = new Date( 2023, 7, 10 );
 
-/* istanbul ignore next -- @preserve */
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-const windowOrGlobal = typeof window === 'object' ? window : global;
-
 declare global {
 	// eslint-disable-next-line no-var
 	var CKEDITOR_VERSION: string;
 }
 
 /* istanbul ignore next -- @preserve */
-if ( windowOrGlobal.CKEDITOR_VERSION ) {
+if ( globalThis.CKEDITOR_VERSION ) {
 	/**
 	 * This error is thrown when due to a mistake in how CKEditor 5 was installed or initialized, some
 	 * of its modules were duplicated (evaluated and executed twice). Module duplication leads to inevitable runtime
@@ -169,5 +162,5 @@ if ( windowOrGlobal.CKEDITOR_VERSION ) {
 		null
 	);
 } else {
-	windowOrGlobal.CKEDITOR_VERSION = version;
+	globalThis.CKEDITOR_VERSION = version;
 }

--- a/packages/ckeditor5-utils/src/version.ts
+++ b/packages/ckeditor5-utils/src/version.ts
@@ -7,7 +7,7 @@
  * @module utils/version
  */
 
-/* globals global */
+/* globals window, global */
 
 import CKEditorError from './ckeditorerror';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
     ],
     "lib": [
       "ES2019", // Must match the "target"
+      "ES2020.String",
       "DOM",
       "DOM.Iterable"
     ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,22 @@
  */
 {
   "compilerOptions": {
+    /**
+     * TypeScript automagically loads typings from all "@types/*" packages if the "compilerOptions.types" array is not defined in
+     * this file. However, if some dependencies have "@types/*" packages as their dependencies, they'll also be loaded as well.
+     * As a result, TypeScript loaded "@types/node" which we don't want to use, because it allows using Node.js specific APIs that
+     * are not available in the browsers. 
+     *
+     * To avoid such issues, we need to define this array with the typings we want to use and that are direct dependencies of our
+     * packages. Typings not listed in this array will not be loaded.
+     */
+    "types": [
+      "@types/color-convert",
+      "@types/lodash-es",
+      "@types/marked"
+    ],
     "lib": [
+      "ES2019", // Must match the "target"
       "DOM",
       "DOM.Iterable"
     ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,16 +9,11 @@
      * TypeScript automagically loads typings from all "@types/*" packages if the "compilerOptions.types" array is not defined in
      * this file. However, if some dependencies have "@types/*" packages as their dependencies, they'll also be loaded as well.
      * As a result, TypeScript loaded "@types/node" which we don't want to use, because it allows using Node.js specific APIs that
-     * are not available in the browsers. 
+     * are not available in the browsers.
      *
-     * To avoid such issues, we need to define this array with the typings we want to use and that are direct dependencies of our
-     * packages. Typings not listed in this array will not be loaded.
+     * To avoid such issues, we defined this empty "types" to disable automatic inclusion of the "@types/*" packages.
      */
-    "types": [
-      "@types/color-convert",
-      "@types/lodash-es",
-      "@types/marked"
-    ],
+    "types": [],
     "lib": [
       "ES2019", // Must match the "target"
       "ES2020.String",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix: Don't rely on `global` object available only in Node. Fixes https://github.com/ckeditor/vite-plugin-ckeditor5/issues/17 and #14801.

Internal: Load only specified typings for TypeScript. Closes #14173.
