### PR TITLE
Google Analytics v4

### DIFF
--- a/docs/umberto.json
+++ b/docs/umberto.json
@@ -336,8 +336,7 @@
 			"ckeditor5.github.io"
 		],
 		"config": {
-			"trackingId": "UA-271067-19",
-			"cookieDomain": "ckeditor5.github.io"
+			"trackingId": "G-H2PK3PSE3F"
 		}
 	},
 	"og": {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Enabled Google Analytics v4 in the nightly documentation. 

---

- Closes cksource/ckeditor5-internal#3579.
- Requires: https://github.com/cksource/umberto/pull/1169.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
