### PR TITLE
Lowered the timeframe to 2 years and fixed the list of labels to exclude

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,14 +15,14 @@ jobs:
           repo-token: ${{ secrets.GH_BOT_TOKEN }}
           stale-issue-label: status:stale
           close-issue-label: resolution:expired
-          stale-issue-message: "There has been no activity on this issue for the past five years. We've marked it as stale and will close it in 30 days. We understand it may be relevant, so if you're interested in the solution, leave a comment or reaction under this issue."
-          stale-pr-message: "There has been no activity on this PR for the past five years. We've marked it as stale and will close it in 30 days. We understand it may be relevant, so if you're interested in the contribution, leave a comment or reaction under this PR."
-          close-issue-message: "We've closed your issue due to inactivity over the last five years. We understand that the issue may still be relevant. If so, feel free to open a new one (and link this issue to it)."
-          close-pr-message: "We've closed your PR due to inactivity over the last five years. While time has passed, the core of your contribution might still be relevant. If you're able, consider reopening a similar PR."
-          days-before-stale: 1825
+          stale-issue-message: "There has been no activity on this issue for the past two years. We've marked it as stale and will close it in 30 days. We understand it may be relevant, so if you're interested in the solution, leave a comment or reaction under this issue."
+          stale-pr-message: "There has been no activity on this PR for the past two years. We've marked it as stale and will close it in 30 days. We understand it may be relevant, so if you're interested in the contribution, leave a comment or reaction under this PR."
+          close-issue-message: "We've closed your issue due to inactivity over the last two years. We understand that the issue may still be relevant. If so, feel free to open a new one (and link this issue to it)."
+          close-pr-message: "We've closed your PR due to inactivity over the last two years. While time has passed, the core of your contribution might still be relevant. If you're able, consider reopening a similar PR."
+          days-before-stale: 730
           days-before-close: 30
-          exempt-issue-labels: support,domain:accessibility
-          exempt-pr-labels: support,domain:accessibility
+          exempt-issue-labels: support:1,support:2,support:3,domain:accessibility
+          exempt-pr-labels: support:1,support:2,support:3,domain:accessibility
           ignore-reactions: false
           operations-per-run: 60
           ascending: true


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Lowered the timeframe to 2 years and fixed the list of labels to exclude.

---

### Additional information

From what I can see the exempt-issue-labels option requires an exact match. I may be wrong (I didn't dig super deep), but it doesn't hurt us to have those labels listed explicitly.