### PR TITLE
CircleCI: Improved detecting a community PR

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -58,6 +58,22 @@ commands:
           name: Checkout code (single branch)
           command: git clone --single-branch --depth 10 --branch "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL" .
 
+  # In the PRs that comes from forked repositories, we do not share secret variables.
+  # Hence, some of the scripts will not be executed. See: https://github.com/ckeditor/ckeditor5/issues/7745.
+  # This command breaks given job if environment variables are not available.
+  community_verification_command:
+    description: "Check if a build was trigger by a community member"
+    steps:
+      - run:
+          name: 👤 Verify if the build was triggered by community - Check if the build should continue
+          command: |
+            #!/bin/bash
+            
+            if [[ -z ${COVERALLS_REPO_TOKEN} ]];
+            then
+              circleci-agent step halt
+            fi
+
 jobs:
   cke5_manual:
     machine: true
@@ -106,14 +122,10 @@ jobs:
   cke5_coverage:
     machine: true
     steps:
+      - community_verification_command
       - checkout_command
       - bootstrap_repository_command
       - prepare_environment_command
-      - run:
-          # In the PRs that comes from forked repositories, we do not share secret variables.
-          # Hence, some of the scripts will not be executed. See: https://github.com/ckeditor/ckeditor5/issues/7745.
-          name: 👤 Verify if the build was triggered by community - Check if the build should continue
-          command: node scripts/ci/is-community-pr.js --exit && circleci-agent step halt || echo "" > /dev/null
       - attach_workspace:
           at: .out
       - run:
@@ -132,13 +144,9 @@ jobs:
   cke5_trigger_uber_ci:
     machine: true
     steps:
+      - community_verification_command
       - checkout_command
       - bootstrap_repository_command
-      - run:
-          # In the PRs that comes from forked repositories, we do not share secret variables.
-          # Hence, some of the scripts will not be executed. See: https://github.com/ckeditor/ckeditor5/issues/7745.
-          name: 👤 Verify if the build was triggered by community - Check if the build should continue
-          command: node scripts/ci/is-community-pr.js --exit && circleci-agent step halt || echo "" > /dev/null
       - run:
           name: Trigger the Uber CI
           command: node scripts/ci/trigger-ckeditor5-continuous-integration.js -r ckeditor/ckeditor5 -c $CIRCLE_SHA1
@@ -161,13 +169,9 @@ jobs:
         type: string
         default: "false"
     steps:
+      - community_verification_command
       - checkout_command
       - bootstrap_repository_command
-      - run:
-          # In the PRs that comes from forked repositories, we do not share secret variables.
-          # Hence, some of the scripts will not be executed. See: https://github.com/ckeditor/ckeditor5/issues/7745.
-          name: 👤 Verify if the build was triggered by community - Check if the build should continue
-          command: node scripts/ci/is-community-pr.js --exit && circleci-agent step halt || echo "" > /dev/null
       - run:
           environment:
             CKE5_SLACK_NOTIFY_HIDE_AUTHOR: << parameters.hideAuthor >>

--- a/scripts/ci/is-community-pr.js
+++ b/scripts/ci/is-community-pr.js
@@ -9,8 +9,6 @@
 
 'use strict';
 
-const minimist = require( 'minimist' );
-
 const {
 	// The number of the associated GitHub or Bitbucket pull request. Only available on forked PRs.
 	CIRCLE_PR_NUMBER
@@ -19,27 +17,9 @@ const {
 module.exports = main();
 
 function main() {
-	const { exit } = getOptions( process.argv.slice( 2 ) );
-
 	if ( CIRCLE_PR_NUMBER ) {
-		return exit ? process.exit( 0 ) : true;
+		return true;
 	}
 
-	return exit ? process.exit( 1 ) : false;
-}
-
-/**
- * @param {Array.<String>} argv
- * @returns {Object} options
- * @returns {Boolean} options.exit
- */
-function getOptions( argv ) {
-	return minimist( argv, {
-		boolean: [
-			'exit'
-		],
-		default: {
-			exit: false
-		}
-	} );
+	return false;
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: CircleCI: Improved detecting a community PR.

---

### Additional information

- Extracted the common logic to a command. Thanks @przemyslaw-zan, for the tip (cke5-inspector).
- Simplified the `is-community-pr.js` script by removing the `process.exit()` parts.
- Thanks to simplifying the PR community detection logic, it can be executed before bootstrapping the project to speed up a job.
- ~First commit contains enabled the coverage build for the `ci/improve-community-pr-detection` to see what happens if I create a PR from a forked repository.~ Creating a PR to a feature branch does not trigger CI anymore.
