### PR TITLE
Fix for shifting Rect with deep level of scrollable positioned ancestors.

### DIFF
--- a/packages/ckeditor5-utils/src/dom/rect.ts
+++ b/packages/ckeditor5-utils/src/dom/rect.ts
@@ -235,7 +235,7 @@ export default class Rect {
 	}
 
 	/**
-	 * Returns a new rect, a part of the original rect, which is actually visible to the user,
+	 * Returns a new rect, a part of the original rect, which is actually visible to the user and is relative to the,`body`,
 	 * e.g. an original rect cropped by parent element rects which have `overflow` set in CSS
 	 * other than `"visible"`.
 	 *

--- a/packages/ckeditor5-utils/src/dom/rect.ts
+++ b/packages/ckeditor5-utils/src/dom/rect.ts
@@ -371,7 +371,7 @@ export default class Rect {
 	}
 
 	/**
-	 * Calculates absolute `Rect` coordinates.
+	 * Recalculates screen coordinates to coordinates relative to the positioned ancestor offset.
 	 */
 	public toAbsoluteRect(): Rect {
 		const { scrollX, scrollY } = global.window;

--- a/packages/ckeditor5-utils/src/dom/rect.ts
+++ b/packages/ckeditor5-utils/src/dom/rect.ts
@@ -576,7 +576,7 @@ function getElementOverflow( element: HTMLElement | Range ): string {
  * (and scrollable) ancestors.
  */
 function shiftRectToCompensatePositionedAncestor( rect: Rect, positionedElementAncestor: HTMLElement ): void {
-	const ancestorPosition = new Rect( positionedElementAncestor ).toAbsoluteRect();
+	const ancestorPosition = new Rect( positionedElementAncestor );
 	const ancestorBorderWidths = getBorderWidths( positionedElementAncestor );
 
 	let moveX = 0;

--- a/packages/ckeditor5-utils/tests/dom/position.js
+++ b/packages/ckeditor5-utils/tests/dom/position.js
@@ -261,8 +261,8 @@ describe( 'getOptimalPosition()', () => {
 				parent.appendChild( element );
 
 				assertPosition( { element, target, positions: [ attachLeftBottom ] }, {
-					top: -900,
-					left: -920,
+					top: 100,
+					left: 80,
 					name: 'left-bottom'
 				} );
 			} );
@@ -307,8 +307,8 @@ describe( 'getOptimalPosition()', () => {
 				parent.scrollTop = 100;
 
 				assertPosition( { element, target, positions: [ attachLeftBottom ] }, {
-					top: 200,
-					left: 280,
+					top: 1200,
+					left: 1280,
 					name: 'left-bottom'
 				} );
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix(utils): Should correct calculate coordinates to element in refer to target element in any situations. Closes #14992 .

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
