### PR TITLE
Fix triple click issue in paragraph with widget

### DIFF
--- a/packages/ckeditor5-widget/src/widget.ts
+++ b/packages/ckeditor5-widget/src/widget.ts
@@ -207,20 +207,17 @@ export default class Widget extends Plugin {
 			// But at least triple click inside nested editable causes broken selection in Safari.
 			// For such event, we select the entire nested editable element.
 			// See: https://github.com/ckeditor/ckeditor5/issues/1463.
+
 			if ( ( env.isSafari || env.isGecko ) && domEventData.domEvent.detail >= 3 ) {
-				const mapper = editor.editing.mapper;
-				const viewElement = element.is( 'attributeElement' ) ?
-					element.findAncestor( element => !element.is( 'attributeElement' ) )! : element;
-				const modelElement = mapper.toModelElement( viewElement )!;
-
-				domEventData.preventDefault();
-
-				this.editor.model.change( writer => {
-					writer.setSelection( modelElement, 'in' );
-				} );
+				setSelectionInAncestorElement();
 			}
 
 			return;
+		}
+
+		// If triple click should select entire paragraph.
+		if ( domEventData.domEvent.detail >= 3 ) {
+			setSelectionInAncestorElement();
 		}
 
 		// If target is not a widget element - check if one of the ancestors is.
@@ -247,6 +244,21 @@ export default class Widget extends Plugin {
 		const modelElement = editor.editing.mapper.toModelElement( element );
 
 		this._setSelectionOverElement( modelElement! );
+
+		function setSelectionInAncestorElement() {
+			if ( element ) {
+				const mapper = editor.editing.mapper;
+				const viewElement = element.is( 'attributeElement' ) ?
+					element.findAncestor( element => !element.is( 'attributeElement' ) )! : element;
+				const modelElement = mapper.toModelElement( viewElement )!;
+
+				domEventData.preventDefault();
+
+				editor.model.change( writer => {
+					writer.setSelection( modelElement, 'in' );
+				} );
+			}
+		}
 	}
 
 	/**

--- a/packages/ckeditor5-widget/tests/widget-integration.js
+++ b/packages/ckeditor5-widget/tests/widget-integration.js
@@ -249,6 +249,27 @@ describe( 'Widget - integration', () => {
 		expect( getModelData( model ) ).to.equal( '<widget><nested>foo</nested><nested>[bar]</nested></widget>' );
 	} );
 
+	it( 'should select entire paragraph when triple click', () => {
+		setModelData( model, '<paragraph>[]foo bar</paragraph>' );
+
+		const viewRoot = viewDocument.getRoot();
+		const paragraph = viewRoot.getChild( 0 );
+		const preventDefault = sinon.spy();
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( paragraph ),
+			preventDefault,
+			detail: 3
+		} );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		sinon.assert.called( preventDefault );
+
+		expect( getViewData( view ) ).to.equal( '<p>{foo bar}</p>' );
+
+		expect( getModelData( model ) ).to.equal( '<paragraph>[foo bar]</paragraph>' );
+	} );
+
 	it( 'should select the entire nested editable if quadra clicked', () => {
 		setModelData( model, '[]<widget><nested>foo bar</nested></widget>' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix ( widget ): Not able to select whole paragraph with triple click when there is a table right after it. Closes #11130.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
