### PR TITLE
Manual scrolling of SearchResultsView should not blur the whole search component.

### DIFF
--- a/packages/ckeditor5-ui/src/search/searchresultsview.ts
+++ b/packages/ckeditor5-ui/src/search/searchresultsview.ts
@@ -10,11 +10,12 @@
 import View from '../view';
 import type ViewCollection from '../viewcollection';
 import type { Locale } from '@ckeditor/ckeditor5-utils';
+import type { FocusableView } from '../focuscycler';
 
 /**
  * A sub-component of {@link module:ui/search/text/searchtextview~SearchTextView}. It hosts the filtered and the information views.
  */
-export default class SearchResultsView extends View {
+export default class SearchResultsView extends View implements FocusableView {
 	/**
 	 * The collection of the child views inside of the list item {@link #element}.
 	 *
@@ -36,9 +37,21 @@ export default class SearchResultsView extends View {
 				class: [
 					'ck',
 					'ck-search__results'
-				]
+				],
+				tabindex: -1
 			},
 			children: this.children
 		} );
+	}
+
+	/**
+	 * Focuses the first child view.
+	 */
+	public focus(): void {
+		const firstFocusableChild = this.children.find( ( child: any ) => typeof child.focus === 'function' );
+
+		if ( firstFocusableChild ) {
+			( firstFocusableChild as FocusableView ).focus();
+		}
 	}
 }

--- a/packages/ckeditor5-ui/src/search/text/searchtextview.ts
+++ b/packages/ckeditor5-ui/src/search/text/searchtextview.ts
@@ -143,7 +143,7 @@ export default class SearchTextView<
 		this.keystrokes = new KeystrokeHandler();
 		this.resultsView = new SearchResultsView( locale );
 		this.children = this.createCollection();
-		this.focusableChildren = this.createCollection( [ this.queryView, this.filteredView ] );
+		this.focusableChildren = this.createCollection( [ this.queryView, this.resultsView ] );
 
 		this.set( 'isEnabled', true );
 		this.set( 'resultsCount', 0 );

--- a/packages/ckeditor5-ui/tests/search/searchresultsview.js
+++ b/packages/ckeditor5-ui/tests/search/searchresultsview.js
@@ -7,7 +7,7 @@ import { Locale } from '@ckeditor/ckeditor5-utils';
 import SearchResultsView from '../../src/search/searchresultsview';
 
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
-import { ButtonView, ViewCollection } from '../../src';
+import { ButtonView, View, ViewCollection } from '../../src';
 
 describe( 'SearchResultsView', () => {
 	let locale, view;
@@ -29,6 +29,7 @@ describe( 'SearchResultsView', () => {
 		it( 'creates and element from template with CSS classes', () => {
 			expect( view.element.classList.contains( 'ck' ) ).to.be.true;
 			expect( view.element.classList.contains( 'ck-search__results' ) ).to.be.true;
+			expect( view.element.getAttribute( 'tabIndex' ) ).to.equal( '-1' );
 		} );
 
 		it( 'has a collection of #children', () => {
@@ -37,6 +38,25 @@ describe( 'SearchResultsView', () => {
 			view.children.add( new ButtonView() );
 
 			expect( view.element.firstChild ).to.equal( view.children.first.element );
+		} );
+	} );
+
+	describe( 'focus()', () => {
+		it( 'does nothing for empty panel', () => {
+			expect( () => view.focus() ).to.not.throw();
+		} );
+
+		it( 'focuses first focusable view in #children', () => {
+			const firstChild = new View();
+			const firstFocusableChild = new View();
+
+			firstFocusableChild.focus = sinon.spy();
+
+			view.children.addMany( [ firstChild, firstFocusableChild ] );
+
+			view.focus();
+
+			sinon.assert.calledOnce( firstFocusableChild.focus );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-ui/tests/search/text/searchtextview.js
+++ b/packages/ckeditor5-ui/tests/search/text/searchtextview.js
@@ -395,9 +395,9 @@ describe( 'SearchTextView', () => {
 
 	describe( 'render()', () => {
 		describe( 'focus tracking and cycling', () => {
-			it( 'should add #queryView and #filteredView to the #focusableChildren collection', () => {
+			it( 'should add #queryView and #resultsView to the #focusableChildren collection', () => {
 				expect( view.focusableChildren.map( view => view ) ).to.have.ordered.members( [
-					view.queryView, view.filteredView
+					view.queryView, view.resultsView
 				] );
 			} );
 
@@ -413,7 +413,7 @@ describe( 'SearchTextView', () => {
 					view.focusTracker.isFocused = true;
 					view.focusTracker.focusedElement = view.queryView.element;
 
-					const spy = sinon.spy( filteredView, 'focus' );
+					const spy = sinon.spy( view.resultsView, 'focus' );
 
 					view.keystrokes.press( keyEvtData );
 					sinon.assert.calledOnce( keyEvtData.preventDefault );
@@ -433,7 +433,7 @@ describe( 'SearchTextView', () => {
 					view.focusTracker.isFocused = true;
 					view.focusTracker.focusedElement = filteredView.element;
 
-					const spy = sinon.spy( view.queryView, 'focus' );
+					const spy = sinon.spy( view.resultsView, 'focus' );
 
 					view.keystrokes.press( keyEvtData );
 					sinon.assert.calledOnce( keyEvtData.preventDefault );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Manual scrolling of `SearchResultsView` should not blur the whole search component. 

Made the `SearchResultsView` focusable. `SearchTextView` should focus the `#resultsView` instead of `#filteredView` upon focus(). 