### PR TITLE
TextareaView should have the right height in FF

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/textarea/textarea.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/textarea/textarea.css
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/*
+ * This fixes a problem in Firefox when the initial height of the complement does not match the number of rows.
+ * This bug is especially visible when rows=1.
+ */
+.ck-textarea {
+	overflow-x: hidden
+}

--- a/packages/ckeditor5-ui/src/textarea/textareaview.ts
+++ b/packages/ckeditor5-ui/src/textarea/textareaview.ts
@@ -11,6 +11,7 @@ import { Rect, type Locale, toUnit, getBorderWidths, global } from '@ckeditor/ck
 import InputBase from '../input/inputbase';
 
 import '../../theme/components/input/input.css';
+import '../../theme/components/textarea/textarea.css';
 
 /**
  * The textarea view class.

--- a/packages/ckeditor5-ui/theme/components/textarea/textarea.css
+++ b/packages/ckeditor5-ui/theme/components/textarea/textarea.css
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/*
+ * Note: This file should contain the wireframe styles only. But since there are no such styles,
+ * it acts as a message to the builder telling that it should look for the corresponding styles
+ * **in the theme** when compiling the editor.
+ */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (theme-lark): `TextareaView` should have the right height if `#minRows` is 1 and the content is empty in FF.
