### PR TITLE
Implemented `FocusCycler#forwardCycle` and `#backwardCycle` events

### DIFF
--- a/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.ts
@@ -22,7 +22,9 @@ import {
 	ViewCollection,
 	type FocusableView,
 	type NormalizedColorOption,
-	type ColorPickerConfig
+	type ColorPickerConfig,
+	type FocusCyclerBackwardCycleEvent,
+	type FocusCyclerForwardCycleEvent
 } from 'ckeditor5/src/ui';
 import {
 	KeystrokeHandler,
@@ -390,13 +392,24 @@ export default class TableCellPropertiesView extends View {
 			view: this
 		} );
 
+		// Maintain continuous focus cycling over views that have focusable children and focus cyclers themselves.
+		[ this.borderColorInput, this.backgroundInput ].forEach( view => {
+			view.fieldView.focusCycler.on<FocusCyclerForwardCycleEvent>( 'forwardCycle', evt => {
+				this._focusCycler.focusNext();
+				evt.stop();
+			} );
+
+			view.fieldView.focusCycler.on<FocusCyclerBackwardCycleEvent>( 'backwardCycle', evt => {
+				this._focusCycler.focusPrevious();
+				evt.stop();
+			} );
+		} );
+
 		[
 			this.borderStyleDropdown,
 			this.borderColorInput,
-			this.borderColorInput.fieldView.dropdownView.buttonView,
 			this.borderWidthInput,
 			this.backgroundInput,
-			this.backgroundInput.fieldView.dropdownView.buttonView,
 			this.widthInput,
 			this.heightInput,
 			this.paddingInput,

--- a/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.ts
+++ b/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.ts
@@ -23,7 +23,9 @@ import {
 	type DropdownView,
 	type InputTextView,
 	type NormalizedColorOption,
-	type ColorPickerConfig
+	type ColorPickerConfig,
+	type FocusCyclerForwardCycleEvent,
+	type FocusCyclerBackwardCycleEvent
 } from 'ckeditor5/src/ui';
 import { FocusTracker, KeystrokeHandler, type ObservableChangeEvent, type Locale } from 'ckeditor5/src/utils';
 import { icons } from 'ckeditor5/src/core';
@@ -358,13 +360,24 @@ export default class TablePropertiesView extends View {
 			view: this
 		} );
 
+		// Maintain continuous focus cycling over views that have focusable children and focus cyclers themselves.
+		[ this.borderColorInput, this.backgroundInput ].forEach( view => {
+			view.fieldView.focusCycler.on<FocusCyclerForwardCycleEvent>( 'forwardCycle', evt => {
+				this._focusCycler.focusNext();
+				evt.stop();
+			} );
+
+			view.fieldView.focusCycler.on<FocusCyclerBackwardCycleEvent>( 'backwardCycle', evt => {
+				this._focusCycler.focusPrevious();
+				evt.stop();
+			} );
+		} );
+
 		[
 			this.borderStyleDropdown,
 			this.borderColorInput,
-			this.borderColorInput!.fieldView.dropdownView.buttonView,
 			this.borderWidthInput,
 			this.backgroundInput,
-			this.backgroundInput!.fieldView.dropdownView.buttonView,
 			this.widthInput,
 			this.heightInput,
 			this.alignmentToolbar,

--- a/packages/ckeditor5-table/src/ui/colorinputview.ts
+++ b/packages/ckeditor5-table/src/ui/colorinputview.ts
@@ -18,7 +18,8 @@ import {
 	type DropdownView,
 	type ColorPickerConfig,
 	type ColorSelectorExecuteEvent,
-	type ColorSelectorColorPickerCancelEvent
+	type ColorSelectorColorPickerCancelEvent,
+	type FocusableView
 } from 'ckeditor5/src/ui';
 
 import { FocusTracker, KeystrokeHandler, type Locale } from 'ckeditor5/src/utils';
@@ -38,7 +39,7 @@ export type ColorInputViewOptions = {
  *
  * @internal
  */
-export default class ColorInputView extends View {
+export default class ColorInputView extends View implements FocusableView {
 	/**
 	 * The value of the input.
 	 *
@@ -88,6 +89,11 @@ export default class ColorInputView extends View {
 	public readonly focusTracker: FocusTracker;
 
 	/**
+	 * Helps cycling over focusable children in the input view.
+	 */
+	public readonly focusCycler: FocusCycler;
+
+	/**
 	 * A collection of views that can be focused in the view.
 	 */
 	protected readonly _focusables: ViewCollection;
@@ -115,11 +121,6 @@ export default class ColorInputView extends View {
 	protected _stillTyping: boolean;
 
 	/**
-	 * Helps cycling over focusable items in the view.
-	 */
-	protected readonly _focusCycler: FocusCycler;
-
-	/**
 	 * Creates an instance of the color input view.
 	 *
 	 * @param locale The locale instance.
@@ -145,7 +146,7 @@ export default class ColorInputView extends View {
 		this.keystrokes = new KeystrokeHandler();
 		this._stillTyping = false;
 
-		this._focusCycler = new FocusCycler( {
+		this.focusCycler = new FocusCycler( {
 			focusables: this._focusables,
 			focusTracker: this.focusTracker,
 			keystrokeHandler: this.keystrokes,
@@ -181,15 +182,23 @@ export default class ColorInputView extends View {
 	public override render(): void {
 		super.render();
 
-		// Start listening for the keystrokes coming from the dropdown panel view.
-		this.keystrokes.listenTo( this.dropdownView.panelView.element! );
+		[ this.inputView, this.dropdownView.buttonView ].forEach( view => {
+			this.focusTracker.add( view.element! );
+			this._focusables.add( view );
+		} );
+
+		this.keystrokes.listenTo( this.element! );
 	}
 
 	/**
-	 * Focuses the input.
+	 * Focuses the view.
 	 */
-	public focus(): void {
-		this.inputView.focus();
+	public focus( direction: 1 | -1 ): void {
+		if ( direction === -1 ) {
+			this.focusCycler.focusLast();
+		} else {
+			this.focusCycler.focusFirst();
+		}
 	}
 
 	/**
@@ -249,10 +258,6 @@ export default class ColorInputView extends View {
 		dropdown.panelPosition = locale.uiLanguageDirection === 'rtl' ? 'se' : 'sw';
 		dropdown.panelView.children.add( colorSelector );
 		dropdown.bind( 'isEnabled' ).to( this, 'isReadOnly', value => !value );
-
-		this._focusables.add( colorSelector );
-
-		this.focusTracker.add( colorSelector.element! );
 
 		dropdown.on( 'change:isOpen', ( evt, name, isVisible ) => {
 			if ( isVisible ) {

--- a/packages/ckeditor5-table/tests/tablecellproperties/ui/tablecellpropertiesview.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/ui/tablecellpropertiesview.js
@@ -695,10 +695,8 @@ describe( 'table cell properties', () => {
 				expect( view._focusables.map( f => f ) ).to.have.members( [
 					view.borderStyleDropdown,
 					view.borderColorInput,
-					view.borderColorInput.fieldView.dropdownView.buttonView,
 					view.borderWidthInput,
 					view.backgroundInput,
-					view.backgroundInput.fieldView.dropdownView.buttonView,
 					view.widthInput,
 					view.heightInput,
 					view.paddingInput,
@@ -771,6 +769,49 @@ describe( 'table cell properties', () => {
 					const spy = sinon.spy( view.cancelButtonView, 'focus' );
 
 					view.keystrokes.press( keyEvtData );
+					sinon.assert.calledOnce( keyEvtData.preventDefault );
+					sinon.assert.calledOnce( keyEvtData.stopPropagation );
+					sinon.assert.calledOnce( spy );
+				} );
+
+				it( 'providing seamless forward navigation over child views with their own focusable children and focus cyclers', () => {
+					const keyEvtData = {
+						keyCode: keyCodes.tab,
+						preventDefault: sinon.spy(),
+						stopPropagation: sinon.spy()
+					};
+
+					// Mock the border color dropdown button button is focused.
+					view.focusTracker.isFocused = view.borderColorInput.fieldView.focusTracker.isFocused = true;
+					view.focusTracker.focusedElement = view.borderColorInput.element;
+					view.borderColorInput.fieldView.focusTracker.focusedElement =
+						view.borderColorInput.fieldView.dropdownView.buttonView.element;
+
+					const spy = sinon.spy( view.borderWidthInput, 'focus' );
+
+					view.borderColorInput.fieldView.keystrokes.press( keyEvtData );
+					sinon.assert.calledOnce( keyEvtData.preventDefault );
+					sinon.assert.calledOnce( keyEvtData.stopPropagation );
+					sinon.assert.calledOnce( spy );
+				} );
+
+				it( 'providing seamless backward navigation over child views with their own focusable children and focus cyclers', () => {
+					const keyEvtData = {
+						keyCode: keyCodes.tab,
+						shiftKey: true,
+						preventDefault: sinon.spy(),
+						stopPropagation: sinon.spy()
+					};
+
+					// Mock the border color dropdown input is focused.
+					view.focusTracker.isFocused = view.borderColorInput.fieldView.focusTracker.isFocused = true;
+					view.focusTracker.focusedElement = view.borderColorInput.element;
+					view.borderColorInput.fieldView.focusTracker.focusedElement =
+						view.borderColorInput.fieldView.inputView.element;
+
+					const spy = sinon.spy( view.borderStyleDropdown, 'focus' );
+
+					view.borderColorInput.fieldView.keystrokes.press( keyEvtData );
 					sinon.assert.calledOnce( keyEvtData.preventDefault );
 					sinon.assert.calledOnce( keyEvtData.stopPropagation );
 					sinon.assert.calledOnce( spy );

--- a/packages/ckeditor5-table/tests/tableproperties/ui/tablepropertiesview.js
+++ b/packages/ckeditor5-table/tests/tableproperties/ui/tablepropertiesview.js
@@ -630,10 +630,8 @@ describe( 'table properties', () => {
 				expect( view._focusables.map( f => f ) ).to.have.members( [
 					view.borderStyleDropdown,
 					view.borderColorInput,
-					view.borderColorInput.fieldView.dropdownView.buttonView,
 					view.borderWidthInput,
 					view.backgroundInput,
-					view.backgroundInput.fieldView.dropdownView.buttonView,
 					view.widthInput,
 					view.heightInput,
 					view.alignmentToolbar,
@@ -704,6 +702,49 @@ describe( 'table properties', () => {
 					const spy = sinon.spy( view.cancelButtonView, 'focus' );
 
 					view.keystrokes.press( keyEvtData );
+					sinon.assert.calledOnce( keyEvtData.preventDefault );
+					sinon.assert.calledOnce( keyEvtData.stopPropagation );
+					sinon.assert.calledOnce( spy );
+				} );
+
+				it( 'providing seamless forward navigation over child views with their own focusable children and focus cyclers', () => {
+					const keyEvtData = {
+						keyCode: keyCodes.tab,
+						preventDefault: sinon.spy(),
+						stopPropagation: sinon.spy()
+					};
+
+					// Mock the border color dropdown button button is focused.
+					view.focusTracker.isFocused = view.borderColorInput.fieldView.focusTracker.isFocused = true;
+					view.focusTracker.focusedElement = view.borderColorInput.element;
+					view.borderColorInput.fieldView.focusTracker.focusedElement =
+						view.borderColorInput.fieldView.dropdownView.buttonView.element;
+
+					const spy = sinon.spy( view.borderWidthInput, 'focus' );
+
+					view.borderColorInput.fieldView.keystrokes.press( keyEvtData );
+					sinon.assert.calledOnce( keyEvtData.preventDefault );
+					sinon.assert.calledOnce( keyEvtData.stopPropagation );
+					sinon.assert.calledOnce( spy );
+				} );
+
+				it( 'providing seamless backward navigation over child views with their own focusable children and focus cyclers', () => {
+					const keyEvtData = {
+						keyCode: keyCodes.tab,
+						shiftKey: true,
+						preventDefault: sinon.spy(),
+						stopPropagation: sinon.spy()
+					};
+
+					// Mock the border color dropdown input is focused.
+					view.focusTracker.isFocused = view.borderColorInput.fieldView.focusTracker.isFocused = true;
+					view.focusTracker.focusedElement = view.borderColorInput.element;
+					view.borderColorInput.fieldView.focusTracker.focusedElement =
+						view.borderColorInput.fieldView.inputView.element;
+
+					const spy = sinon.spy( view.borderStyleDropdown, 'focus' );
+
+					view.borderColorInput.fieldView.keystrokes.press( keyEvtData );
 					sinon.assert.calledOnce( keyEvtData.preventDefault );
 					sinon.assert.calledOnce( keyEvtData.stopPropagation );
 					sinon.assert.calledOnce( spy );

--- a/packages/ckeditor5-table/tests/ui/colorinputview.js
+++ b/packages/ckeditor5-table/tests/ui/colorinputview.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* global Event */
+/* global document, Event */
 
 import ColorInputView from '../../src/ui/colorinputview';
 import InputTextView from '@ckeditor/ckeditor5-ui/src/inputtext/inputtextview';
@@ -48,10 +48,12 @@ describe( 'ColorInputView', () => {
 		inputView = view.inputView;
 		removeColorButton = colorSelectorView.colorGridsFragmentView.removeColorButtonView;
 		colorGridView = colorSelectorView.colorGridsFragmentView.staticColorsGrid;
+		document.body.appendChild( view.element );
 	} );
 
 	afterEach( () => {
 		view.destroy();
+		view.element.remove();
 	} );
 
 	describe( 'constructor()', () => {
@@ -106,8 +108,8 @@ describe( 'ColorInputView', () => {
 			expect( view.keystrokes ).to.be.instanceOf( KeystrokeHandler );
 		} );
 
-		it( 'should have #_focusCycler', () => {
-			expect( view._focusCycler ).to.be.instanceOf( FocusCycler );
+		it( 'should have #focusCycler', () => {
+			expect( view.focusCycler ).to.be.instanceOf( FocusCycler );
 		} );
 
 		describe( 'dropdown', () => {
@@ -230,6 +232,12 @@ describe( 'ColorInputView', () => {
 			} );
 
 			describe( 'position', () => {
+				let view;
+
+				afterEach( () => {
+					view.destroy();
+				} );
+
 				it( 'should be SouthWest in LTR', () => {
 					locale.uiLanguageDirection = 'ltr';
 					view = new ColorInputView( locale, {
@@ -251,17 +259,6 @@ describe( 'ColorInputView', () => {
 
 					expect( view.dropdownView.panelPosition ).to.equal( 'se' );
 				} );
-			} );
-
-			it( 'should register panelView children in #_focusables', () => {
-				expect( view._focusables.map( f => f ) ).to.have.members( [
-					view.dropdownView.panelView.children.first
-				] );
-			} );
-
-			it( 'should register panelView children elements in #focusTracker', () => {
-				expect( view.focusTracker._elements ).to.include( view.dropdownView.panelView.children.first.element );
-				expect( view.focusTracker._elements ).to.include( view.dropdownView.panelView.children.last.element );
 			} );
 		} );
 
@@ -590,10 +587,10 @@ describe( 'ColorInputView', () => {
 
 					// Mock the remove color button view is focused.
 					view.focusTracker.isFocused = true;
-					view.focusTracker.focusedElement = view._focusables.first.element;
+					view.focusTracker.focusedElement = view.inputView.element;
 
 					// Spy the next view which in this case is the color grid view.
-					const spy = sinon.spy( view._focusables.last, 'focus' );
+					const spy = sinon.spy( view.dropdownView.buttonView, 'focus' );
 
 					view.keystrokes.press( keyEvtData );
 					sinon.assert.calledOnce( keyEvtData.preventDefault );
@@ -613,10 +610,10 @@ describe( 'ColorInputView', () => {
 
 					// Mock the remove color button view is focused.
 					view.focusTracker.isFocused = true;
-					view.focusTracker.focusedElement = view._focusables.first.element;
+					view.focusTracker.focusedElement = view.inputView.element;
 
 					// Spy the previous view which in this case is the color grid view.
-					const spy = sinon.spy( view._focusables.last, 'focus' );
+					const spy = sinon.spy( view.dropdownView.buttonView, 'focus' );
 
 					view.keystrokes.press( keyEvtData );
 					sinon.assert.calledOnce( keyEvtData.preventDefault );
@@ -679,6 +676,14 @@ describe( 'ColorInputView', () => {
 
 			sinon.assert.calledOnce( spy );
 		} );
+
+		it( 'should focus the dropdown button if the backwards direction was specified', () => {
+			const spy = sinon.spy( view.dropdownView.buttonView, 'focus' );
+
+			view.focus( -1 );
+
+			sinon.assert.calledOnce( spy );
+		} );
 	} );
 
 	describe( 'render()', () => {
@@ -692,7 +697,7 @@ describe( 'ColorInputView', () => {
 
 			view.render();
 			sinon.assert.calledOnce( spy );
-			sinon.assert.calledWithExactly( spy, view.dropdownView.panelView.element );
+			sinon.assert.calledWithExactly( spy, view.element );
 
 			view.destroy();
 		} );

--- a/packages/ckeditor5-ui/src/focuscycler.ts
+++ b/packages/ckeditor5-ui/src/focuscycler.ts
@@ -274,11 +274,9 @@ export default class FocusCycler extends EmitterMixin() {
 	 * @returns
 	 */
 	private _focus( view: FocusableView | null, direction: 1 | -1 ) {
-		if ( !view ) {
-			return;
+		if ( view ) {
+			view.focus( direction );
 		}
-
-		view.focus( direction );
 	}
 
 	/**

--- a/packages/ckeditor5-ui/src/focuscycler.ts
+++ b/packages/ckeditor5-ui/src/focuscycler.ts
@@ -317,13 +317,17 @@ export default class FocusCycler extends EmitterMixin() {
 	}
 }
 
-export type FocusableView = SimpleFocusableView	| ViewWithFocusableChildren;
-
-export type SimpleFocusableView = View & {
+/**
+ * A view that can be focused.
+ */
+export type FocusableView = View & {
 	focus(): void;
 };
 
-export type ViewWithFocusableChildren = SimpleFocusableView & {
+/**
+ * A view that can be focused and contains some children that also can be focused.
+ */
+export type ViewWithFocusableChildren = FocusableView & {
 	focusFirst(): void;
 	focusLast(): void;
 };
@@ -362,7 +366,7 @@ export type FocusCyclerBackwardCycleEvent = {
  *
  * @param view A view to be checked.
  */
-function isPlainFocusableView( view: View ): view is SimpleFocusableView {
+function isPlainFocusableView( view: View ): view is FocusableView {
 	return !!( 'focus' in view && isVisible( view.element ) );
 }
 

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -52,7 +52,6 @@ export { default as FormHeaderView } from './formheader/formheaderview';
 export {
 	default as FocusCycler,
 	type FocusableView,
-	type SimpleFocusableView,
 	type ViewWithFocusableChildren,
 	type FocusCyclerForwardCycleEvent,
 	type FocusCyclerBackwardCycleEvent

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -49,7 +49,14 @@ export { default as BoxedEditorUIView } from './editorui/boxed/boxededitoruiview
 export { default as InlineEditableUIView } from './editableui/inline/inlineeditableuiview';
 
 export { default as FormHeaderView } from './formheader/formheaderview';
-export { default as FocusCycler, type FocusableView } from './focuscycler';
+export {
+	default as FocusCycler,
+	type FocusableView,
+	type SimpleFocusableView,
+	type ViewWithFocusableChildren,
+	type FocusCyclerForwardCycleEvent,
+	type FocusCyclerBackwardCycleEvent
+} from './focuscycler';
 
 export { default as IconView } from './icon/iconview';
 export { default as InputView } from './input/inputview';

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -52,7 +52,6 @@ export { default as FormHeaderView } from './formheader/formheaderview';
 export {
 	default as FocusCycler,
 	type FocusableView,
-	type ViewWithFocusableChildren,
 	type FocusCyclerForwardCycleEvent,
 	type FocusCyclerBackwardCycleEvent
 } from './focuscycler';

--- a/packages/ckeditor5-ui/src/labeledfield/labeledfieldview.ts
+++ b/packages/ckeditor5-ui/src/labeledfield/labeledfieldview.ts
@@ -291,7 +291,7 @@ export default class LabeledFieldView<TFieldView extends FocusableView = Focusab
 	/**
 	 * Focuses the {@link #fieldView}.
 	 */
-	public focus( direction: 1 | -1 ): void {
+	public focus( direction?: 1 | -1 ): void {
 		this.fieldView.focus( direction );
 	}
 }

--- a/packages/ckeditor5-ui/src/labeledfield/labeledfieldview.ts
+++ b/packages/ckeditor5-ui/src/labeledfield/labeledfieldview.ts
@@ -291,8 +291,8 @@ export default class LabeledFieldView<TFieldView extends FocusableView = Focusab
 	/**
 	 * Focuses the {@link #fieldView}.
 	 */
-	public focus(): void {
-		this.fieldView.focus();
+	public focus( direction: 1 | -1 ): void {
+		this.fieldView.focus( direction );
 	}
 }
 

--- a/packages/ckeditor5-ui/src/list/listview.ts
+++ b/packages/ckeditor5-ui/src/list/listview.ts
@@ -186,6 +186,13 @@ export default class ListView extends View<HTMLUListElement> implements Dropdown
 	}
 
 	/**
+	 * Focuses the first focusable in {@link #items}.
+	 */
+	public focusFirst(): void {
+		this._focusCycler.focusFirst();
+	}
+
+	/**
 	 * Focuses the last focusable in {@link #items}.
 	 */
 	public focusLast(): void {

--- a/packages/ckeditor5-ui/src/search/filteredview.ts
+++ b/packages/ckeditor5-ui/src/search/filteredview.ts
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import type { ViewWithFocusableChildren } from '../focuscycler';
+import type { FocusableView } from '../focuscycler';
 
 /**
  * @module ui/search/filteredview
@@ -12,7 +12,7 @@ import type { ViewWithFocusableChildren } from '../focuscycler';
 /**
  * A view that can be filtered by a {@link module:ui/search/text/searchtextview~SearchTextView}.
  */
-export default interface FilteredView extends ViewWithFocusableChildren {
+export default interface FilteredView extends FocusableView {
 
 	/**
 	 * Filters the view by the given regular expression.

--- a/packages/ckeditor5-ui/src/search/filteredview.ts
+++ b/packages/ckeditor5-ui/src/search/filteredview.ts
@@ -3,8 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import type { FocusableView } from '../focuscycler';
-import type View from '../view';
+import type { ViewWithFocusableChildren } from '../focuscycler';
 
 /**
  * @module ui/search/filteredview
@@ -13,7 +12,7 @@ import type View from '../view';
 /**
  * A view that can be filtered by a {@link module:ui/search/text/searchtextview~SearchTextView}.
  */
-export default interface FilteredView extends View, FocusableView {
+export default interface FilteredView extends ViewWithFocusableChildren {
 
 	/**
 	 * Filters the view by the given regular expression.

--- a/packages/ckeditor5-ui/src/search/searchinfoview.ts
+++ b/packages/ckeditor5-ui/src/search/searchinfoview.ts
@@ -7,7 +7,7 @@
  * @module ui/search/searchinfoview
 */
 
-import type { SimpleFocusableView } from '../focuscycler';
+import type { FocusableView } from '../focuscycler';
 import View from '../view';
 
 /**
@@ -15,7 +15,7 @@ import View from '../view';
  *
  * @internal
  */
-export default class SearchInfoView extends View implements SimpleFocusableView {
+export default class SearchInfoView extends View implements FocusableView {
 	/**
 	 * Controls whether the view is visible.
 	 *

--- a/packages/ckeditor5-ui/src/search/searchinfoview.ts
+++ b/packages/ckeditor5-ui/src/search/searchinfoview.ts
@@ -7,6 +7,7 @@
  * @module ui/search/searchinfoview
 */
 
+import type { SimpleFocusableView } from '../focuscycler';
 import View from '../view';
 
 /**
@@ -14,7 +15,7 @@ import View from '../view';
  *
  * @internal
  */
-export default class SearchInfoView extends View {
+export default class SearchInfoView extends View implements SimpleFocusableView {
 	/**
 	 * Controls whether the view is visible.
 	 *
@@ -60,7 +61,8 @@ export default class SearchInfoView extends View {
 					'ck',
 					'ck-search__info',
 					bind.if( 'isVisible', 'ck-hidden', value => !value )
-				]
+				],
+				tabindex: -1
 			},
 			children: [
 				{
@@ -81,5 +83,12 @@ export default class SearchInfoView extends View {
 				}
 			]
 		} );
+	}
+
+	/**
+	 * Focuses the view
+	 */
+	public focus(): void {
+		this.element!.focus();
 	}
 }

--- a/packages/ckeditor5-ui/src/search/searchresultsview.ts
+++ b/packages/ckeditor5-ui/src/search/searchresultsview.ts
@@ -10,12 +10,12 @@
 import View from '../view';
 import type ViewCollection from '../viewcollection';
 import { FocusTracker, type Locale } from '@ckeditor/ckeditor5-utils';
-import { default as FocusCycler, type ViewWithFocusableChildren } from '../focuscycler';
+import { default as FocusCycler, type FocusableView } from '../focuscycler';
 
 /**
  * A sub-component of {@link module:ui/search/text/searchtextview~SearchTextView}. It hosts the filtered and the information views.
  */
-export default class SearchResultsView extends View implements ViewWithFocusableChildren {
+export default class SearchResultsView extends View implements FocusableView {
 	/**
 	 * Tracks information about the DOM focus in the view.
 	 *

--- a/packages/ckeditor5-ui/src/search/text/searchtextview.ts
+++ b/packages/ckeditor5-ui/src/search/text/searchtextview.ts
@@ -122,7 +122,7 @@ export default class SearchTextView<
 	 *
 	 * @readonly
 	 */
-	protected _focusCycler: FocusCycler;
+	public focusCycler: FocusCycler;
 
 	/**
 	 * The cached configuration object.
@@ -169,7 +169,7 @@ export default class SearchTextView<
 
 		this.resultsView.children.addMany( [ this.infoView, this.filteredView ] );
 
-		this._focusCycler = new FocusCycler( {
+		this.focusCycler = new FocusCycler( {
 			focusables: this.focusableChildren,
 			focusTracker: this.focusTracker,
 			keystrokeHandler: this.keystrokes,

--- a/packages/ckeditor5-ui/src/search/text/searchtextview.ts
+++ b/packages/ckeditor5-ui/src/search/text/searchtextview.ts
@@ -122,7 +122,7 @@ export default class SearchTextView<
 	 *
 	 * @readonly
 	 */
-	private _focusCycler: FocusCycler;
+	protected _focusCycler: FocusCycler;
 
 	/**
 	 * The cached configuration object.

--- a/packages/ckeditor5-ui/tests/focuscycler.js
+++ b/packages/ckeditor5-ui/tests/focuscycler.js
@@ -404,6 +404,25 @@ describe( 'FocusCycler', () => {
 				cycler.focusNext();
 			} ).to.not.throw();
 		} );
+
+		it( 'fires an event while making full cycle back to the beginning', () => {
+			focusables = new ViewCollection( [ focusable(), focusable(), focusable() ] );
+			cycler = new FocusCycler( { focusables, focusTracker } );
+			focusTracker.focusedElement = focusables.get( 2 ).element;
+
+			const forwardCycleSpy = sinon.spy();
+			const backwardCycleSpy = sinon.spy();
+
+			cycler.on( 'forwardCycle', forwardCycleSpy );
+			cycler.on( 'backwardCycle', backwardCycleSpy );
+
+			cycler.focusNext();
+			focusTracker.focusedElement = focusables.get( 0 ).element;
+			cycler.focusNext();
+
+			sinon.assert.calledOnce( forwardCycleSpy );
+			sinon.assert.notCalled( backwardCycleSpy );
+		} );
 	} );
 
 	describe( 'focusPrevious()', () => {
@@ -430,6 +449,25 @@ describe( 'FocusCycler', () => {
 			expect( () => {
 				cycler.focusPrevious();
 			} ).to.not.throw();
+		} );
+
+		it( 'fires an event while making full cycle back to the end', () => {
+			focusables = new ViewCollection( [ focusable(), focusable(), focusable() ] );
+			cycler = new FocusCycler( { focusables, focusTracker } );
+			focusTracker.focusedElement = focusables.get( 0 ).element;
+
+			const forwardCycleSpy = sinon.spy();
+			const backwardCycleSpy = sinon.spy();
+
+			cycler.on( 'forwardCycle', forwardCycleSpy );
+			cycler.on( 'backwardCycle', backwardCycleSpy );
+
+			cycler.focusPrevious();
+			focusTracker.focusedElement = focusables.get( 2 ).element;
+			cycler.focusPrevious();
+
+			sinon.assert.notCalled( forwardCycleSpy );
+			sinon.assert.calledOnce( backwardCycleSpy );
 		} );
 	} );
 

--- a/packages/ckeditor5-ui/tests/labeledfield/labeledfieldview.js
+++ b/packages/ckeditor5-ui/tests/labeledfield/labeledfieldview.js
@@ -211,5 +211,13 @@ describe( 'LabeledFieldView', () => {
 
 			sinon.assert.calledOnce( spy );
 		} );
+
+		it( 'should pass down the focus direction parameter', () => {
+			const spy = sinon.spy( fieldView, 'focus' );
+
+			labeledField.focus( -1 );
+
+			sinon.assert.calledOnceWithExactly( spy, -1 );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-ui/tests/list/listview.js
+++ b/packages/ckeditor5-ui/tests/list/listview.js
@@ -425,6 +425,24 @@ describe( 'ListView', () => {
 		} );
 	} );
 
+	describe( 'focusFirst()', () => {
+		it( 'focuses the first focusable item in DOM', () => {
+			// No children to focus.
+			view.focusFirst();
+
+			// The second child is focusable.
+			view.items.add( nonFocusable() );
+			view.items.add( focusable() );
+			view.items.add( focusable() );
+			view.items.add( nonFocusable() );
+
+			const spy = sinon.spy( view.items.get( 1 ), 'focus' );
+			view.focusFirst();
+
+			sinon.assert.calledOnce( spy );
+		} );
+	} );
+
 	describe( 'focusLast()', () => {
 		it( 'focuses the last focusable item in DOM', () => {
 			// No children to focus.
@@ -433,9 +451,10 @@ describe( 'ListView', () => {
 			// The second child is focusable.
 			view.items.add( nonFocusable() );
 			view.items.add( focusable() );
+			view.items.add( focusable() );
 			view.items.add( nonFocusable() );
 
-			const spy = sinon.spy( view.items.get( 1 ), 'focus' );
+			const spy = sinon.spy( view.items.get( 2 ), 'focus' );
 			view.focusLast();
 
 			sinon.assert.calledOnce( spy );

--- a/packages/ckeditor5-ui/tests/search/searchinfoview.js
+++ b/packages/ckeditor5-ui/tests/search/searchinfoview.js
@@ -51,4 +51,14 @@ describe( 'SearchInfoView', () => {
 			expect( view.element.innerHTML ).to.equal( '<span></span><span>bar</span>' );
 		} );
 	} );
+
+	describe( 'focus()', () => {
+		it( 'should focus #element', () => {
+			const spy = sinon.spy( view.element, 'focus' );
+
+			view.focus();
+
+			sinon.assert.calledOnce( spy );
+		} );
+	} );
 } );

--- a/packages/ckeditor5-ui/tests/search/searchresultsview.js
+++ b/packages/ckeditor5-ui/tests/search/searchresultsview.js
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+/* global document */
+
 import { Locale } from '@ckeditor/ckeditor5-utils';
 import SearchResultsView from '../../src/search/searchresultsview';
 
@@ -18,11 +20,15 @@ describe( 'SearchResultsView', () => {
 		locale = new Locale();
 
 		view = new SearchResultsView( locale );
+		view.children.addMany( [ createNonFocusableView(), createFocusableView(), createFocusableView() ] );
 		view.render();
+
+		document.body.appendChild( view.element );
 	} );
 
 	afterEach( () => {
 		view.destroy();
+		view.element.remove();
 	} );
 
 	describe( 'constructor()', () => {
@@ -47,16 +53,45 @@ describe( 'SearchResultsView', () => {
 		} );
 
 		it( 'focuses first focusable view in #children', () => {
-			const firstChild = new View();
-			const firstFocusableChild = new View();
-
-			firstFocusableChild.focus = sinon.spy();
-
-			view.children.addMany( [ firstChild, firstFocusableChild ] );
-
 			view.focus();
 
-			sinon.assert.calledOnce( firstFocusableChild.focus );
+			sinon.assert.calledOnce( view.children.get( 1 ).focus );
 		} );
 	} );
+
+	describe( 'focusFirst()', () => {
+		it( 'focuses first focusable view in #children', () => {
+			view.focusFirst();
+
+			sinon.assert.calledOnce( view.children.get( 1 ).focus );
+		} );
+	} );
+
+	describe( 'focusLast()', () => {
+		it( 'focuses first focusable view in #children', () => {
+			view.focusLast();
+
+			sinon.assert.calledOnce( view.children.get( 2 ).focus );
+		} );
+	} );
+
+	function createFocusableView( name ) {
+		const view = createNonFocusableView();
+
+		view.name = name;
+		view.focus = () => view.element.focus();
+		sinon.spy( view, 'focus' );
+
+		return view;
+	}
+
+	function createNonFocusableView() {
+		const view = new View();
+
+		view.element = document.createElement( 'div' );
+		view.element.textContent = 'foo';
+		document.body.appendChild( view.element );
+
+		return view;
+	}
 } );

--- a/packages/ckeditor5-ui/tests/search/text/searchtextview.js
+++ b/packages/ckeditor5-ui/tests/search/text/searchtextview.js
@@ -85,8 +85,8 @@ describe( 'SearchTextView', () => {
 			expect( view.keystrokes ).to.be.instanceOf( KeystrokeHandler );
 		} );
 
-		it( 'creates and instance of FocusCycle', () => {
-			expect( view._focusCycler ).to.be.instanceOf( FocusCycler );
+		it( 'creates and instance of FocusCycler', () => {
+			expect( view.focusCycler ).to.be.instanceOf( FocusCycler );
 		} );
 
 		it( 'assigns an instance of a view to #filteredView', () => {
@@ -413,7 +413,7 @@ describe( 'SearchTextView', () => {
 					view.focusTracker.isFocused = true;
 					view.focusTracker.focusedElement = view.queryView.element;
 
-					const spy = sinon.spy( view.resultsView, 'focusFirst' );
+					const spy = sinon.spy( view.resultsView, 'focus' );
 
 					view.keystrokes.press( keyEvtData );
 					sinon.assert.calledOnce( keyEvtData.preventDefault );
@@ -433,7 +433,7 @@ describe( 'SearchTextView', () => {
 					view.focusTracker.isFocused = true;
 					view.focusTracker.focusedElement = filteredView.element;
 
-					const spy = sinon.spy( view.resultsView, 'focusLast' );
+					const spy = sinon.spy( view.resultsView, 'focus' );
 
 					view.keystrokes.press( keyEvtData );
 					sinon.assert.calledOnce( keyEvtData.preventDefault );

--- a/packages/ckeditor5-ui/tests/search/text/searchtextview.js
+++ b/packages/ckeditor5-ui/tests/search/text/searchtextview.js
@@ -413,7 +413,7 @@ describe( 'SearchTextView', () => {
 					view.focusTracker.isFocused = true;
 					view.focusTracker.focusedElement = view.queryView.element;
 
-					const spy = sinon.spy( view.resultsView, 'focus' );
+					const spy = sinon.spy( view.resultsView, 'focusFirst' );
 
 					view.keystrokes.press( keyEvtData );
 					sinon.assert.calledOnce( keyEvtData.preventDefault );
@@ -433,7 +433,7 @@ describe( 'SearchTextView', () => {
 					view.focusTracker.isFocused = true;
 					view.focusTracker.focusedElement = filteredView.element;
 
-					const spy = sinon.spy( view.resultsView, 'focus' );
+					const spy = sinon.spy( view.resultsView, 'focusLast' );
 
 					view.keystrokes.press( keyEvtData );
 					sinon.assert.calledOnce( keyEvtData.preventDefault );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (ui): Implemented `FocusCycler#forwardCycle` and `#backwardCycle` events.
Internal (ui): Made `SearchResultsView` a focus-friendly container. Made `SearchInfoView` focusable.
