### PR TITLE
Force using the latest working version of the `get-func-name` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,5 +216,8 @@
       "external/*/packages/*",
       "."
     ]
+  },
+  "resolutions": {
+    "get-func-name": "2.0.0"
   }
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Force using the latest working version of the `get-func-name` package. See chaijs/get-func-name#41.
