### PR TITLE
Moved a translation context from `ckeditor5-template` to `ckeditor5-core`

### DIFF
--- a/packages/ckeditor5-core/lang/contexts.json
+++ b/packages/ckeditor5-core/lang/contexts.json
@@ -1,5 +1,6 @@
 {
 	"Cancel": "Label for the Cancel button.",
+	"Clear": "Label for the Clear button.",
 	"Remove color": "The label used by a button next to the color palette in the color picker that removes the color (resets it to an empty value, example usages in font color or table properties).",
 	"Restore default": "The label used by a button next to the color palette in the color picker that restores the default value if the default table properties are specified.",
 	"Save": "Label for the Save button.",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (core, template): Moved a translation context from `ckeditor5-template` to `ckeditor5-core` to make it shareable.

---

### Additional information

Needed by https://github.com/cksource/ckeditor5-commercial/pull/5524.
