### PR TITLE
Remove list items correctly with backspace.

### DIFF
--- a/packages/ckeditor5-list/tests/manual/documentlist-separator.html
+++ b/packages/ckeditor5-list/tests/manual/documentlist-separator.html
@@ -5,61 +5,95 @@
 
 <div id="editor">
 	<p style="margin-top: 0px; margin-bottom: 0px; line-height: 1">foo</p>
-	
+
 	<p style="margin-top: 0px; margin-bottom: 0px; margin-left: 24px; line-height: 1">&nbsp;</p>
 	<ol style="list-style-type: decimal">
 		<li>
-	
+
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">foobar</p>
 		</li>
 	</ol>
-	
+
 	<p style="margin-top: 0px; margin-bottom: 10.67px; margin-left: 24px; line-height: 1.05">&nbsp;</p>
 	<ol style="list-style-type: lower-latin">
 		<li>
-	
+
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">foobar</p>
 		</li>
 		<li>
-	
+
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">foobar</p>
 		</li>
 	</ol>
 	<ol start="2" style="list-style-type: decimal">
 		<li>
-	
+
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">Decimal list item again</p>
 		</li>
 		<li>
-	
+
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">Decimal list item again
 			</p>
 		</li>
 	</ol>
-	
+
 	<p style="margin-top: 0px; margin-bottom: 10.67px; margin-left: 48px; line-height: 1.05">&nbsp;</p>
 	<ol style="list-style-type: lower-latin">
 		<li>
-	
+
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">foobar</p>
 		</li>
 		<li>
-	
+
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">foobar</p>
 		</li>
 	</ol>
 	<ul style="list-style-type: disc">
 		<li>
-	
+
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">foobar</p>
 		</li>
 	</ul>
 	<ol start="3" style="list-style-type: lower-latin">
 		<li>
-	
+
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">foobar
 			</p>
 		</li>
+	</ol>
+
+	<ol style="list-style-type:decimal;">
+		<li><strong>Lorem</strong></li>
+		<li>Ipsum,</li>
+		<li>Dolor,</li>
+		<li>Remove me with backspace</li>
+	</ol>
+
+	<ol style="list-style-type:decimal;">
+		<li>Lorem</li>
+		<li>Ipsum,
+			<ul>
+				<li>Lorem</li>
+				<li>Ipsum,</li>
+				<li>Dolor,</li>
+				<li>Remove me with backspace</li>
+			</ul>
+		</li>
+		<li>Dolor,</li>
+		<li>Remove me with backspace</li>
+		<li>
+			<ol style="list-style-type:decimal;">
+				<li>Lorem</li>
+				<li>Ipsum,</li>
+				<li>Dolor,</li>
+				<li>Remove me with backspace</li>
+			</ol>
+		</li>
+	</ol>
+
+	<ol style="list-style-type:decimal;">
+		<li>Next</li>
+		<li>List</li>
 	</ol>
 </div>
 

--- a/packages/ckeditor5-list/tests/manual/documentlist-separator.html
+++ b/packages/ckeditor5-list/tests/manual/documentlist-separator.html
@@ -9,7 +9,6 @@
 	<p style="margin-top: 0px; margin-bottom: 0px; margin-left: 24px; line-height: 1">&nbsp;</p>
 	<ol style="list-style-type: decimal">
 		<li>
-
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">foobar</p>
 		</li>
 	</ol>
@@ -17,21 +16,17 @@
 	<p style="margin-top: 0px; margin-bottom: 10.67px; margin-left: 24px; line-height: 1.05">&nbsp;</p>
 	<ol style="list-style-type: lower-latin">
 		<li>
-
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">foobar</p>
 		</li>
 		<li>
-
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">foobar</p>
 		</li>
 	</ol>
 	<ol start="2" style="list-style-type: decimal">
 		<li>
-
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">Decimal list item again</p>
 		</li>
 		<li>
-
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">Decimal list item again
 			</p>
 		</li>
@@ -40,23 +35,19 @@
 	<p style="margin-top: 0px; margin-bottom: 10.67px; margin-left: 48px; line-height: 1.05">&nbsp;</p>
 	<ol style="list-style-type: lower-latin">
 		<li>
-
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">foobar</p>
 		</li>
 		<li>
-
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">foobar</p>
 		</li>
 	</ol>
 	<ul style="list-style-type: disc">
 		<li>
-
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">foobar</p>
 		</li>
 	</ul>
 	<ol start="3" style="list-style-type: lower-latin">
 		<li>
-
 			<p style="margin-top: 0px; margin-bottom: 10.67px; line-height: 1.05">foobar
 			</p>
 		</li>

--- a/packages/ckeditor5-list/theme/documentlist.css
+++ b/packages/ckeditor5-list/theme/documentlist.css
@@ -6,3 +6,15 @@
 .ck-editor__editable .ck-list-bogus-paragraph {
 	display: block;
 }
+
+.ck-content {
+	& li > p {
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (list): Document list items should now be removed correctly using backspace. Closes #11347.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
