### PR TITLE
Add image width and height on image paste

### DIFF
--- a/packages/ckeditor5-image/tests/image/imageblockediting.js
+++ b/packages/ckeditor5-image/tests/image/imageblockediting.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* global document, Event */
+/* global document, Event, setTimeout */
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
@@ -709,6 +709,44 @@ describe( 'ImageBlockEditing', () => {
 			expect( getModelData( model ) ).to.equal(
 				'[<imageBlock alt="abc" src="/assets/sample.png"></imageBlock>]'
 			);
+		} );
+
+		it( 'should add image width and height on image paste', done => {
+			const dataTransfer = new DataTransfer( {
+				types: [ 'text/html' ],
+				getData: () => '<figure class="image"><img src="/assets/sample.png" /></figure>'
+			} );
+
+			setModelData( model, '<paragraph>[]</paragraph>' );
+
+			viewDocument.fire( 'clipboardInput', { dataTransfer, method: 'paste' } );
+
+			setTimeout( () => {
+				expect( getModelData( model ) ).to.equal(
+					'[<imageBlock height="96" src="/assets/sample.png" width="96"></imageBlock>]'
+				);
+
+				done();
+			}, 100 );
+		} );
+
+		it( 'should not add image width and height on image method other than paste', done => {
+			const dataTransfer = new DataTransfer( {
+				types: [ 'text/html' ],
+				getData: () => '<figure class="image"><img src="/assets/sample.png" /></figure>'
+			} );
+
+			setModelData( model, '<paragraph>[]</paragraph>' );
+
+			viewDocument.fire( 'clipboardInput', { dataTransfer, method: 'foo' } );
+
+			setTimeout( () => {
+				expect( getModelData( model ) ).to.equal(
+					'[<imageBlock src="/assets/sample.png"></imageBlock>]'
+				);
+
+				done();
+			}, 100 );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-image/tests/image/imageinlineediting.js
+++ b/packages/ckeditor5-image/tests/image/imageinlineediting.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* global document, Event */
+/* global document, Event, setTimeout */
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
@@ -837,6 +837,44 @@ describe( 'ImageInlineEditing', () => {
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>f<imageInline resizedWidth="25%" src="/assets/sample.png"></imageInline>[]oo</paragraph>'
 			);
+		} );
+
+		it( 'should add image width and height on image paste', done => {
+			const dataTransfer = new DataTransfer( {
+				types: [ 'text/html' ],
+				getData: () => '<img src="/assets/sample.png" />'
+			} );
+
+			setModelData( model, '<paragraph>f[]oo</paragraph>' );
+
+			viewDocument.fire( 'clipboardInput', { dataTransfer, method: 'paste' } );
+
+			setTimeout( () => {
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>f<imageInline height="96" src="/assets/sample.png" width="96"></imageInline>[]oo</paragraph>'
+				);
+
+				done();
+			}, 100 );
+		} );
+
+		it( 'should not add image width and height on image method other than paste', done => {
+			const dataTransfer = new DataTransfer( {
+				types: [ 'text/html' ],
+				getData: () => '<img src="/assets/sample.png" />'
+			} );
+
+			setModelData( model, '<paragraph>f[]oo</paragraph>' );
+
+			viewDocument.fire( 'clipboardInput', { dataTransfer, method: 'foo' } );
+
+			setTimeout( () => {
+				expect( getModelData( model ) ).to.equal(
+					'<paragraph>f<imageInline src="/assets/sample.png"></imageInline>[]oo</paragraph>'
+				);
+
+				done();
+			}, 100 );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (image): Image `width` and `height` attributes should be added when pasting a copied image. Closes #15088.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
