### PR TITLE
Drag-and-drop preview is blackened when using the block balloon.

### DIFF
--- a/packages/ckeditor5-clipboard/src/dragdrop.ts
+++ b/packages/ckeditor5-clipboard/src/dragdrop.ts
@@ -659,6 +659,14 @@ export default class DragDrop extends Plugin {
 		preview.style.width = computedStyle.width;
 		preview.style.paddingLeft = `${ domRect.left - clientX + domEditablePaddingLeft }px`;
 
+		/**
+		 * Set white background in drag and drop preview if iOS.
+		 * Check: https://github.com/ckeditor/ckeditor5/issues/15085
+		 */
+		if ( env.isiOS ) {
+			preview.style.backgroundColor = 'white';
+		}
+
 		preview.innerHTML = dataTransfer.getData( 'text/html' );
 
 		dataTransfer.setDragImage( preview, 0, 0 );

--- a/packages/ckeditor5-clipboard/src/dragdrop.ts
+++ b/packages/ckeditor5-clipboard/src/dragdrop.ts
@@ -664,7 +664,7 @@ export default class DragDrop extends Plugin {
 		 * Check: https://github.com/ckeditor/ckeditor5/issues/15085
 		 */
 		if ( env.isiOS ) {
-			preview.style.backgroundColor = 'white';
+			preview.style.backgroundColor = computedStyle.getPropertyValue( '--ck-color-base-background' );
 		}
 
 		preview.innerHTML = dataTransfer.getData( 'text/html' );

--- a/packages/ckeditor5-clipboard/src/dragdrop.ts
+++ b/packages/ckeditor5-clipboard/src/dragdrop.ts
@@ -664,7 +664,7 @@ export default class DragDrop extends Plugin {
 		 * Check: https://github.com/ckeditor/ckeditor5/issues/15085
 		 */
 		if ( env.isiOS ) {
-			preview.style.backgroundColor = computedStyle.getPropertyValue( '--ck-color-base-background' );
+			preview.style.backgroundColor = 'white';
 		}
 
 		preview.innerHTML = dataTransfer.getData( 'text/html' );

--- a/packages/ckeditor5-clipboard/tests/dragdropblocktoolbar.js
+++ b/packages/ckeditor5-clipboard/tests/dragdropblocktoolbar.js
@@ -341,7 +341,7 @@ describe( 'Drag and Drop Block Toolbar', () => {
 
 			sinon.assert.calledWith( spy, sinon.match( {
 				style: {
-					backgroundColor: 'rgb(255, 255, 255)'
+					backgroundColor: 'white'
 				},
 				className: 'ck ck-content',
 				firstChild: sinon.match( {

--- a/packages/ckeditor5-clipboard/tests/dragdropblocktoolbar.js
+++ b/packages/ckeditor5-clipboard/tests/dragdropblocktoolbar.js
@@ -341,7 +341,39 @@ describe( 'Drag and Drop Block Toolbar', () => {
 
 			sinon.assert.calledWith( spy, sinon.match( {
 				style: {
-					backgroundColor: 'white'
+					backgroundColor: 'rgb(255, 255, 255)'
+				},
+				className: 'ck ck-content',
+				firstChild: sinon.match( {
+					tagName: 'P',
+					innerHTML: 'foobar'
+				} )
+			} ), 0, 0 );
+
+			env.isiOS = originalEnviOs;
+		} );
+
+		it( 'should show preview without white background if not iOS', () => {
+			const originalEnviOs = env.isiOS;
+
+			env.isiOS = false;
+
+			setModelData( model, '<paragraph>[foo]bar</paragraph>' );
+
+			const dataTransfer = new DataTransfer();
+			const spy = sinon.spy( dataTransfer, 'setDragImage' );
+
+			const dragStartEvent = new DragEvent( 'dragstart', {
+				dataTransfer
+			} );
+
+			blockToolbarButton.dispatchEvent( dragStartEvent );
+
+			sinon.assert.calledOnce( spy );
+
+			sinon.assert.calledWith( spy, sinon.match( {
+				style: {
+					backgroundColor: ''
 				},
 				className: 'ck ck-content',
 				firstChild: sinon.match( {

--- a/packages/ckeditor5-clipboard/tests/dragdropblocktoolbar.js
+++ b/packages/ckeditor5-clipboard/tests/dragdropblocktoolbar.js
@@ -322,7 +322,7 @@ describe( 'Drag and Drop Block Toolbar', () => {
 		} );
 
 		it( 'should show preview with white background on iOS', () => {
-			const originalEnvGecko = env.isiOS;
+			const originalEnviOs = env.isiOS;
 
 			env.isiOS = true;
 
@@ -350,7 +350,7 @@ describe( 'Drag and Drop Block Toolbar', () => {
 				} )
 			} ), 0, 0 );
 
-			env.isiOS = originalEnvGecko;
+			env.isiOS = originalEnviOs;
 		} );
 	} );
 

--- a/packages/ckeditor5-clipboard/tests/dragdropblocktoolbar.js
+++ b/packages/ckeditor5-clipboard/tests/dragdropblocktoolbar.js
@@ -320,6 +320,38 @@ describe( 'Drag and Drop Block Toolbar', () => {
 
 			expect( dragDropBlockToolbar._isBlockDragging ).to.be.false;
 		} );
+
+		it( 'should show preview with white background on iOS', () => {
+			const originalEnvGecko = env.isiOS;
+
+			env.isiOS = true;
+
+			setModelData( model, '<paragraph>[foo]bar</paragraph>' );
+
+			const dataTransfer = new DataTransfer();
+			const spy = sinon.spy( dataTransfer, 'setDragImage' );
+
+			const dragStartEvent = new DragEvent( 'dragstart', {
+				dataTransfer
+			} );
+
+			blockToolbarButton.dispatchEvent( dragStartEvent );
+
+			sinon.assert.calledOnce( spy );
+
+			sinon.assert.calledWith( spy, sinon.match( {
+				style: {
+					backgroundColor: 'white'
+				},
+				className: 'ck ck-content',
+				firstChild: sinon.match( {
+					tagName: 'P',
+					innerHTML: 'foobar'
+				} )
+			} ), 0, 0 );
+
+			env.isiOS = originalEnvGecko;
+		} );
 	} );
 
 	function expectDraggingMarker( targetPositionOrRange ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (clipboard): Drag and drop preview should not have black background on iOS. Closes #15085.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
