### PR TITLE
Added metadata for to-do document lists

### DIFF
--- a/packages/ckeditor5-list/ckeditor5-metadata.json
+++ b/packages/ckeditor5-list/ckeditor5-metadata.json
@@ -97,6 +97,7 @@
 			"name": "Document list",
 			"className": "DocumentList",
 			"description": "Implements bulleted and numbered list features. Supports block content inside list elements. Incompatible with the List plugin.",
+			"docs": "features/lists/document-lists.html",
 			"path": "src/documentlist.js",
 			"uiComponents": [
 				{
@@ -123,9 +124,52 @@
 			]
 		},
 		{
+			"name": "To-do document list",
+			"className": "TodoDocumentList",
+			"description": "Allows for creating a list of interactive checkboxes with labels. It supports all features of document lists so you can nest a to-do list together with bulleted and numbered lists in any combination.",
+			"docs": "features/lists/document-lists.html#to-do-lists",
+			"path": "src/tododocumentlist.js",
+			"requires": [
+				"DocumentList"
+			],
+			"uiComponents": [
+				{
+					"type": "Button",
+					"name": "todoList",
+					"iconPath": "theme/icons/todolist.svg"
+				}
+			],
+			"htmlOutput": [
+				{
+					"elements": "ul",
+					"classes": "todo-list"
+				},
+				{
+					"elements": "li"
+				},
+				{
+					"elements": "label",
+					"classes": [ "todo-list__label", "todo-list__label_without-description" ]
+				},
+				{
+					"elements": "span",
+					"classes": "todo-list__label__description"
+				},
+				{
+					"elements": "input",
+					"attributes": [
+						"checked",
+						"disabled",
+						"type"
+					]
+				}
+			]
+		},
+		{
 			"name": "Document list properties",
 			"className": "DocumentListProperties",
 			"description": "Enables styling the list item markers for both ordered and unordered lists created by the document list plugin. You can choose various types of numerals and letters or visual markers to use with these lists. Also enables setting start index (initial marker value) and list reversal (from ascending to descending) for numbered lists.",
+			"docs": "features/lists/document-lists.html#document-list-properties",
 			"path": "src/documentlistproperties.js",
 			"requires": [
 				"DocumentList"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (list): Added metadata for to-do document lists. Closes #15107.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
