### PR TITLE
Make possible get function through get() method in config

### DIFF
--- a/packages/ckeditor5-utils/src/config.ts
+++ b/packages/ckeditor5-utils/src/config.ts
@@ -250,6 +250,11 @@ export default class Config<Cfg> {
 			source = source[ part ];
 		}
 
+		// Return actual value if it's a function.
+		if ( source && typeof source[ name ] === 'function' ) {
+			return source[ name ];
+		}
+
 		// Always returns undefined for non existing configuration.
 		return source ? cloneConfig( source[ name ] ) : undefined;
 	}

--- a/packages/ckeditor5-utils/tests/config.js
+++ b/packages/ckeditor5-utils/tests/config.js
@@ -29,7 +29,8 @@ describe( 'Config', () => {
 					{ bar: 'a' },
 					{ bar: 'z' }
 				]
-			}
+			},
+			callback: () => null
 		} );
 	} );
 
@@ -363,6 +364,11 @@ describe( 'Config', () => {
 			expect( config.get( 'resize.icon.path' ) ).to.equal( 'xyz' );
 		} );
 
+		it( 'should return a function', () => {
+			expect( typeof config.get( 'callback' ) ).to.equal( 'function' );
+			expect( config.get( 'callback' )() ).to.equal( null );
+		} );
+
 		it( 'should retrieve an object of the configuration', () => {
 			const resize = config.get( 'resize' );
 
@@ -482,7 +488,9 @@ describe( 'Config', () => {
 
 	describe( 'names()', () => {
 		it( 'should return an iterator of top level names of the configuration', () => {
-			expect( Array.from( config.names() ) ).to.be.deep.equal( [ 'creator', 'language', 'resize', 'toolbar', 'options' ] );
+			expect( Array.from( config.names() ) ).to.be.deep.equal(
+				[ 'creator', 'language', 'resize', 'toolbar', 'options', 'callback' ]
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (utils): Config's `get()` method should be able return a function. 
Closes #14804.
Closes #12835.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
