### PR TITLE
Fixed z-index of floating images next to a document list.

### DIFF
--- a/packages/ckeditor5-image/theme/image.css
+++ b/packages/ckeditor5-image/theme/image.css
@@ -87,25 +87,42 @@
 		text-overflow: ellipsis;
 	}
 
-
 	/*
-	 * Make sure the selected inline image always stays on top of its siblings.
-	 * See https://github.com/ckeditor/ckeditor5/issues/9108.
+	 * See https://github.com/ckeditor/ckeditor5/issues/15115.
 	 */
-	& .image.ck-widget_selected {
-		z-index: 1;
-	}
-
-	& .image-inline.ck-widget_selected {
+	& .image {
 		z-index: 1;
 
 		/*
-		 * Make sure the native browser selection style is not displayed.
-		 * Inline image widgets have their own styles for the selected state and
-		 * leaving this up to the browser is asking for a visual collision.
+		 * Make sure the selected image always stays on top of its siblings.
+		 * See https://github.com/ckeditor/ckeditor5/issues/9108.
 		 */
-		& ::selection {
-			display: none;
+		&.ck-widget_selected {
+			z-index: 2;
+		}
+	}
+
+	/*
+	 * See https://github.com/ckeditor/ckeditor5/issues/15115.
+	 */
+	& .image-inline {
+		z-index: 1;
+
+		/*
+		 * Make sure the selected inline image always stays on top of its siblings.
+		 * See https://github.com/ckeditor/ckeditor5/issues/9108.
+		 */
+		&.ck-widget_selected {
+			z-index: 2;
+
+			/*
+			 * Make sure the native browser selection style is not displayed.
+			 * Inline image widgets have their own styles for the selected state and
+			 * leaving this up to the browser is asking for a visual collision.
+			 */
+			& ::selection {
+				display: none;
+			}
 		}
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (image): A floating image should be clickable when next to a to-do document list. Closes #15115.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
