### PR TITLE
Inserting a link by pasting directly into the editor

### DIFF
--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -8,12 +8,11 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core';
-import type { ClipboardInputTransformationData, ClipboardPipeline } from 'ckeditor5/src/clipboard';
+import type { ClipboardInputTransformationData } from 'ckeditor5/src/clipboard';
 import type { DocumentSelectionChangeEvent, Element, Model, Range } from 'ckeditor5/src/engine';
 import { Delete, TextWatcher, getLastTextLine, type TextWatcherMatchedDataEvent } from 'ckeditor5/src/typing';
 import type { EnterCommand, ShiftEnterCommand } from 'ckeditor5/src/enter';
 import { priorities } from 'ckeditor5/src/utils';
-import type LinkCommand from './linkcommand';
 
 import { addLinkProtocolIfApplicable, linkHasProtocol } from './utils';
 import LinkEditing from './linkediting';
@@ -117,11 +116,12 @@ export default class AutoLink extends Plugin {
 	private _enablePasteLinking(): void {
 		const editor = this.editor;
 		const modelDocument = editor.model.document;
-		const clipboardPipeline: ClipboardPipeline = editor.plugins.get( 'ClipboardPipeline' );
-		const linkCommand: LinkCommand = editor.commands.get( 'link' )!;
+		const clipboardPipeline = editor.plugins.get( 'ClipboardPipeline' );
+		const linkCommand = editor.commands.get( 'link' )!;
 
 		clipboardPipeline.on( 'inputTransformation', ( evt, data: ClipboardInputTransformationData ) => {
-			if ( linkCommand.isEnabled && !modelDocument.selection.isCollapsed ) {
+			const selection = modelDocument.selection;
+			if ( linkCommand.isEnabled && !selection.isCollapsed ) {
 				const textString = data.dataTransfer.getData( 'text/plain' );
 				const matches = textString.match( URL_REG_EXP );
 

--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -121,11 +121,12 @@ export default class AutoLink extends Plugin {
 		const linkCommand: LinkCommand = editor.commands.get( 'link' )!;
 
 		clipboardPipeline.on( 'inputTransformation', ( evt, data: ClipboardInputTransformationData ) => {
-			if ( !modelDocument.selection.isCollapsed ) {
+			if ( linkCommand.isEnabled && !modelDocument.selection.isCollapsed ) {
 				const textString = data.dataTransfer.getData( 'text/plain' );
 				const matches = textString.match( URL_REG_EXP );
+
+				// if there is a URL in the clipboard, and that URL is the whole clipboard
 				if ( matches && matches[ 2 ] === textString ) {
-					// the whole clipboard is a URL
 					linkCommand.execute( textString );
 					evt.stop();
 				}

--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -123,7 +123,8 @@ export default class AutoLink extends Plugin {
 		clipboardPipeline.on( 'inputTransformation', ( evt, data: ClipboardInputTransformationData ) => {
 			if ( !modelDocument.selection.isCollapsed ) {
 				const textString = data.dataTransfer.getData( 'text/plain' );
-				if ( URL_REG_EXP.test( textString ) ) {
+				const matches = textString.match( URL_REG_EXP );
+				if ( matches && matches[ 2 ] === textString ) {
 					// the whole clipboard is a URL
 					linkCommand.execute( textString );
 					evt.stop();

--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -13,8 +13,10 @@ import type { DocumentSelectionChangeEvent, Element, Model, Range } from 'ckedit
 import { Delete, TextWatcher, getLastTextLine, type TextWatcherMatchedDataEvent } from 'ckeditor5/src/typing';
 import type { EnterCommand, ShiftEnterCommand } from 'ckeditor5/src/enter';
 import { priorities } from 'ckeditor5/src/utils';
+import type LinkCommand from './linkcommand';
 
 import { addLinkProtocolIfApplicable, linkHasProtocol } from './utils';
+import LinkEditing from './linkediting';
 
 const MIN_LINK_LENGTH_WITH_SPACE_AT_END = 4; // Ie: "t.co " (length 5).
 
@@ -75,7 +77,7 @@ export default class AutoLink extends Plugin {
 	 * @inheritDoc
 	 */
 	public static get requires() {
-		return [ Delete ] as const;
+		return [ Delete, LinkEditing ] as const;
 	}
 
 	/**
@@ -116,12 +118,14 @@ export default class AutoLink extends Plugin {
 		const editor = this.editor;
 		const modelDocument = editor.model.document;
 		const clipboardPipeline: ClipboardPipeline = editor.plugins.get( 'ClipboardPipeline' );
+		const linkCommand: LinkCommand = editor.commands.get( 'link' )!;
 
 		clipboardPipeline.on( 'inputTransformation', ( evt, data: ClipboardInputTransformationData ) => {
 			if ( !modelDocument.selection.isCollapsed ) {
 				const textString = data.dataTransfer.getData( 'text/plain' );
 				if ( URL_REG_EXP.test( textString ) ) {
 					// the whole clipboard is a URL
+					linkCommand.execute( textString );
 					evt.stop();
 				}
 			}

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -86,6 +86,24 @@ describe( 'AutoLink', () => {
 			} );
 		} );
 
+		describe( 'pasting on a link', () => {
+			it( 'paste with entire link selected', () => {
+				setData( model, '<paragraph>some [<$text linkHref="http://hello.com">selected</$text>] text</paragraph>' );
+				pasteText( 'http://world.com' );
+				expect( getData( model ) ).to.equal(
+					'<paragraph>some [<$text linkHref="http://world.com">selected</$text>] text</paragraph>'
+				);
+			} );
+
+			it( 'paste with partially selected link updates the entire link', () => {
+				setData( model, '<paragraph><$text linkHref="http://hello.com">some [selected] text</$text></paragraph>' );
+				pasteText( 'http://world.com' );
+				expect( getData( model ) ).to.equal(
+					'<paragraph><$text linkHref="http://world.com">some [selected] text</$text></paragraph>'
+				);
+			} );
+		} );
+
 		function pasteText( text ) {
 			pasteData( {
 				'text/plain': text

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -73,6 +73,26 @@ describe( 'AutoLink', () => {
 					'<paragraph>some hello[] text</paragraph>'
 				);
 			} );
+
+			it( 'paste a HTML link', () => {
+				pasteData( {
+					'text/plain': 'http://hello.com',
+					'text/html': '<a href="http://hello.com">http://hello.com</a>'
+				} );
+				expect( getData( model ) ).to.equal(
+					'<paragraph>some [<$text linkHref="http://hello.com">selected</$text>] text</paragraph>'
+				);
+			} );
+
+			it( 'paste a HTML link that doesn not look like a link', () => {
+				pasteData( {
+					'text/plain': 'hello.com',
+					'text/html': '<a href="http://hello.com">hello.com</a>'
+				} );
+				expect( getData( model ) ).to.equal(
+					'<paragraph>some <$text linkHref="http://hello.com">hello.com</$text>[] text</paragraph>'
+				);
+			} );
 		} );
 
 		describe( 'pasting on collapsed selection', () => {
@@ -100,6 +120,15 @@ describe( 'AutoLink', () => {
 				pasteText( 'http://world.com' );
 				expect( getData( model ) ).to.equal(
 					'<paragraph><$text linkHref="http://world.com">some [selected] text</$text></paragraph>'
+				);
+			} );
+
+			it( 'paste with selection overlapping a link inserts a new link', () => {
+				setData( model, '<paragraph>[some <$text linkHref="http://hello.com">selected] text</$text></paragraph>' );
+				pasteText( 'http://world.com' );
+				expect( getData( model ) ).to.equal(
+					// eslint-disable-next-line max-len
+					'<paragraph>[<$text linkHref="http://world.com">some selected</$text>]<$text linkHref="http://hello.com"> text</$text></paragraph>'
 				);
 			} );
 		} );

--- a/packages/ckeditor5-link/tests/manual/autolink.md
+++ b/packages/ckeditor5-link/tests/manual/autolink.md
@@ -23,3 +23,10 @@
 3. Check if *only* created link was removed:
     - For "space" - the space after the text link should be preserved.
     - For "enter" - the new block or `<softBreak>` should be preserved.
+
+### Paste integration
+
+1. Copy a URL to the clipboard
+2. Select some content
+3. Paste
+4. Check the selected content is now a link using the copied URL.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (autolink): Links can now be applied by pasting a URL on selected text.

---

### Additional information

This is a feature request by @scofalik as my introduction to the CKE5 codebase. I've tried to cover tests, at least, I'm not sure if this needs an option to turn it off or perhaps should it be extracted to a new plugin.

There is a question in `autolink.ts` about use of `containsPosition` which will need to be resolved before merging. If I've used the correct approach I'll just delete the question.
