### PR TITLE
Set focus on the editor after inserting from or closing CKBox.

### DIFF
--- a/packages/ckeditor5-ckbox/src/ckboxcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxcommand.ts
@@ -187,6 +187,8 @@ export default class CKBoxCommand extends Command {
 
 			this._wrapper!.remove();
 			this._wrapper = null;
+
+			editor.editing.view.focus();
 		} );
 
 		// Handle choosing the assets.
@@ -224,6 +226,8 @@ export default class CKBoxCommand extends Command {
 					}
 				}
 			} );
+
+			editor.editing.view.focus();
 		} );
 
 		// Clean up after the editor is destroyed.

--- a/packages/ckeditor5-ckbox/tests/ckboxcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxcommand.js
@@ -268,6 +268,24 @@ describe( 'CKBoxCommand', () => {
 				expect( spy.callCount ).to.equal( 1 );
 				expect( command._wrapper ).to.equal( null );
 			} );
+
+			it( 'should focus view after closing the CKBox dialog', () => {
+				const focusSpy = testUtils.sinon.spy( editor.editing.view, 'focus' );
+
+				const openSpy = sinon.spy();
+				const closeSpy = sinon.spy();
+
+				command.on( 'ckbox:open', openSpy );
+				command.execute();
+
+				command.on( 'ckbox:close', closeSpy );
+				onClose();
+
+				expect( openSpy.callCount ).to.equal( 1 );
+				expect( closeSpy.callCount ).to.equal( 1 );
+
+				sinon.assert.calledOnce( focusSpy );
+			} );
 		} );
 
 		describe( 'choosing assets ("ckbox:choose")', () => {
@@ -905,6 +923,14 @@ describe( 'CKBoxCommand', () => {
 
 				expect( command._chosenAssets.size ).to.equal( 0 );
 				expect( command._wrapper ).to.equal( null );
+			} );
+
+			it( 'should focus view after assets were chosen', () => {
+				const focusSpy = testUtils.sinon.spy( editor.editing.view, 'focus' );
+
+				onChoose( [ ...assets.images, ...assets.links ] );
+
+				sinon.assert.calledOnce( focusSpy );
 			} );
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other(ckbox): Should focus the editor after choosing an asset or closing CKBox. Closes #15091.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
