### PR TITLE
Fix (ckeditor5-core): Added optional to PluginInterface.destroy

### DIFF
--- a/packages/ckeditor5-core/src/plugin.ts
+++ b/packages/ckeditor5-core/src/plugin.ts
@@ -211,7 +211,7 @@ export interface PluginInterface {
 	 *
 	 * **Note:** This method is optional. A plugin instance does not need to have it defined.
 	 */
-	destroy(): Promise<unknown> | null | undefined | void;
+	destroy?(): Promise<unknown> | null | undefined | void;
 }
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ckeditor5-core): Adds optional to the PluginInterface.destroy function.

---

### Additional information

* TextTransformation plugin does not implement destroy function and therefore is not assignable to variable of type PluginConstructor.
