### PR TITLE
Handling textarea auto resize warnings

### DIFF
--- a/packages/ckeditor5-ui/src/textarea/textareaview.ts
+++ b/packages/ckeditor5-ui/src/textarea/textareaview.ts
@@ -7,7 +7,7 @@
  * @module ui/textarea/textareaview
  */
 
-import { Rect, type Locale, toUnit, getBorderWidths, global, CKEditorError } from '@ckeditor/ckeditor5-utils';
+import { Rect, type Locale, toUnit, getBorderWidths, global, CKEditorError, isVisible } from '@ckeditor/ckeditor5-utils';
 import InputBase from '../input/inputbase';
 
 import '../../theme/components/input/input.css';
@@ -107,8 +107,10 @@ export default class TextareaView extends InputBase<HTMLTextAreaElement> {
 		this.on( 'change:value', () => {
 			// The content needs to be updated by the browser after the value is changed. It takes a few ms.
 			global.window.requestAnimationFrame( () => {
-				this._updateAutoGrowHeight();
-				this.fire<TextareaViewUpdateEvent>( 'update' );
+				if ( isVisible( this.element ) ) {
+					this._updateAutoGrowHeight();
+					this.fire<TextareaViewUpdateEvent>( 'update' );
+				}
 			} );
 		} );
 	}

--- a/packages/ckeditor5-ui/tests/textarea/textareaview.js
+++ b/packages/ckeditor5-ui/tests/textarea/textareaview.js
@@ -133,6 +133,19 @@ describe( 'TextareaView', () => {
 			expect( view.element.style.height ).to.not.equal( initialHeight );
 		} );
 
+		it( 'should not resize the view on the #value change when the view element is not in DOM', async () => {
+			wrapper.removeChild( view.element );
+
+			const initialHeight = view.element.style.height;
+
+			view.value = 'foo\nbar\nbaz\nqux';
+
+			expect( view.element.style.height ).to.equal( initialHeight );
+
+			await requestAnimationFrame();
+			expect( view.element.style.height ).to.equal( initialHeight );
+		} );
+
 		describe( 'dynamic resizing', () => {
 			it( 'should respect #minRows and #maxRows', async () => {
 				// One row, it's less than default #minRows.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Textarea will no longer update the height when the element has been removed from DOM. It fixes the warnings thrown in the console.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
