### PR TITLE
The dropdown panel view's `#isVisible` property should be bound earlier

### DIFF
--- a/packages/ckeditor5-ui/src/dropdown/dropdownview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/dropdownview.ts
@@ -209,6 +209,9 @@ export default class DropdownView extends View<HTMLDivElement> {
 		this.set( 'id', undefined );
 		this.set( 'panelPosition', 'auto' );
 
+		// Toggle the visibility of the panel when the dropdown becomes open.
+		this.panelView.bind( 'isVisible' ).to( this, 'isOpen' );
+
 		this.keystrokes = new KeystrokeHandler();
 		this.focusTracker = new FocusTracker();
 
@@ -255,9 +258,6 @@ export default class DropdownView extends View<HTMLDivElement> {
 		this.listenTo<DropdownButtonOpenEvent>( this.buttonView, 'open', () => {
 			this.isOpen = !this.isOpen;
 		} );
-
-		// Toggle the visibility of the panel when the dropdown becomes open.
-		this.panelView.bind( 'isVisible' ).to( this, 'isOpen' );
 
 		// Let the dropdown control the position of the panel. The position must
 		// be updated every time the dropdown is open.

--- a/packages/ckeditor5-ui/tests/dropdown/dropdownview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/dropdownview.js
@@ -110,7 +110,10 @@ describe( 'DropdownView', () => {
 			} );
 
 			describe( 'view.panelView#isVisible to view#isOpen', () => {
-				it( 'is activated', () => {
+				it( 'is activated before the view gets rendered', () => {
+					const panelView = new DropdownPanelView( locale );
+					const buttonView = new ButtonView( locale );
+					const view = new DropdownView( locale, buttonView, panelView );
 					const values = [];
 
 					view.listenTo( view.panelView, 'change:isVisible', () => {
@@ -122,6 +125,10 @@ describe( 'DropdownView', () => {
 					view.isOpen = true;
 
 					expect( values ).to.have.members( [ true, false, true ] );
+
+					view.destroy();
+					buttonView.destroy();
+					panelView.destroy();
 				} );
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): The dropdown panel view's `#isVisible` property should be bound to the parent before rendering to allow other listeners' callbacks act when the panel is already visible.

---

### Additional information

**Backstory**: The AI assistant UI plugin creates the commands dropdown and brings some `dropdownView.on( 'change:isOpen', .. )` behavior while registering in the component factory. I couldn't get my head around the fact that when `isOpen` changes to `true`, the panel is not visible in DOM yet, though. My intuition says that any listener attached (with normal priority) after the component has been created (`DropdownView#constructor()`) should execute after default component behaviors, such as displaying the panel as soon as `isOpen` is `true`. To my surprise, the binding was set in `DropdownView#render()` which means it got activated late when the dropdown was rendered (e.g. injected into some view collection/parent). This order of things is unnatural and I'm addressing it here.