### PR TITLE
Stop calling function `data.get()` when it's not needed while destroying the editor instance.

### DIFF
--- a/packages/ckeditor5-core/src/editor/utils/elementapimixin.ts
+++ b/packages/ckeditor5-core/src/editor/utils/elementapimixin.ts
@@ -52,7 +52,7 @@ export default function ElementApiMixin<Base extends Constructor<Editor>>( base:
 				return;
 			}
 
-			const dataToSet = data || this.data.get();
+			const dataToSet = typeof data === 'string' ? data : this.data.get();
 
 			setDataInElement( this.sourceElement, dataToSet );
 		}

--- a/packages/ckeditor5-core/src/editor/utils/elementapimixin.ts
+++ b/packages/ckeditor5-core/src/editor/utils/elementapimixin.ts
@@ -23,7 +23,7 @@ export default function ElementApiMixin<Base extends Constructor<Editor>>( base:
 	abstract class Mixin extends base implements ElementApi {
 		public sourceElement: HTMLElement | undefined;
 
-		public updateSourceElement( data: string = this.data.get() ): void {
+		public updateSourceElement( data?: string ): void {
 			if ( !this.sourceElement ) {
 				/**
 				 * Cannot update the source element of a detached editor.
@@ -44,7 +44,7 @@ export default function ElementApiMixin<Base extends Constructor<Editor>>( base:
 
 			// The data returned by the editor might be unsafe, so we want to prevent rendering
 			// unsafe content inside the source element different than <textarea>, which is considered
-			// secure. This behaviour could be changed by setting the `updateSourceElementOnDestroy`
+			// secure. This behavior could be changed by setting the `updateSourceElementOnDestroy`
 			// configuration option to `true`.
 			if ( !shouldUpdateSourceElement && !isSourceElementTextArea ) {
 				setDataInElement( this.sourceElement, '' );
@@ -52,7 +52,9 @@ export default function ElementApiMixin<Base extends Constructor<Editor>>( base:
 				return;
 			}
 
-			setDataInElement( this.sourceElement, data );
+			const dataToSet = data || this.data.get();
+
+			setDataInElement( this.sourceElement, dataToSet );
 		}
 	}
 
@@ -78,7 +80,9 @@ export interface ElementApi {
 	sourceElement: HTMLElement | undefined;
 
 	/**
-	 * Updates the {@link #sourceElement editor source element}'s content with the data.
+	 * Updates the {@link #sourceElement editor source element}'s content with the data if the
+	 * {@link module:core/editor/editorconfig~EditorConfig#updateSourceElementOnDestroy `updateSourceElementOnDestroy`}
+	 * configuration option is set to `true`.
 	 */
 	updateSourceElement( data?: string ): void;
 }

--- a/packages/ckeditor5-core/src/editor/utils/elementapimixin.ts
+++ b/packages/ckeditor5-core/src/editor/utils/elementapimixin.ts
@@ -83,6 +83,8 @@ export interface ElementApi {
 	 * Updates the {@link #sourceElement editor source element}'s content with the data if the
 	 * {@link module:core/editor/editorconfig~EditorConfig#updateSourceElementOnDestroy `updateSourceElementOnDestroy`}
 	 * configuration option is set to `true`.
+	 *
+	 * @param data Data that the {@link #sourceElement editor source element} should be updated with.
 	 */
 	updateSourceElement( data?: string ): void;
 }

--- a/packages/ckeditor5-core/tests/editor/utils/elementapimixin.js
+++ b/packages/ckeditor5-core/tests/editor/utils/elementapimixin.js
@@ -53,7 +53,7 @@ describe( 'ElementApiMixin', () => {
 			sinon.assert.notCalled( dataGetSpy );
 		} );
 
-		it( 'sets data to editor element (div)', () => {
+		it( 'sets data to editor element without passing it as an argument (div)', () => {
 			const editorElement = document.createElement( 'div' );
 
 			const dataGetSpy = testUtils.sinon.spy( editor.data, 'get' );
@@ -72,7 +72,7 @@ describe( 'ElementApiMixin', () => {
 			sinon.assert.calledOnce( dataGetSpy );
 		} );
 
-		it( 'sets data passed as a function `updateSourceElement` argument to editor element (div)', () => {
+		it( 'sets data to editor element with passing it as an argument (div)', () => {
 			const editorElement = document.createElement( 'div' );
 
 			const dataGetSpy = testUtils.sinon.spy( editor.data, 'get' );
@@ -93,7 +93,7 @@ describe( 'ElementApiMixin', () => {
 			sinon.assert.notCalled( dataGetSpy );
 		} );
 
-		it( 'sets empty string as a data passed as a function `updateSourceElement` argument to editor element (div)', () => {
+		it( 'sets data to editor element with passing it as an argument using empty string (div)', () => {
 			const editorElement = document.createElement( 'div' );
 
 			const dataGetSpy = testUtils.sinon.spy( editor.data, 'get' );

--- a/packages/ckeditor5-core/tests/editor/utils/elementapimixin.js
+++ b/packages/ckeditor5-core/tests/editor/utils/elementapimixin.js
@@ -93,6 +93,29 @@ describe( 'ElementApiMixin', () => {
 			sinon.assert.notCalled( dataGetSpy );
 		} );
 
+		it( 'sets empty string as a data passed as a function `updateSourceElement` argument to editor element (div)', () => {
+			const editorElement = document.createElement( 'div' );
+
+			const dataGetSpy = testUtils.sinon.spy( editor.data, 'get' );
+
+			// Adding `updateSourceElementOnDestroy` config to the editor allows setting the data
+			// back to the source element.
+			editor.config.set( 'updateSourceElementOnDestroy', true );
+			editor.data.set( 'foo bar' );
+
+			editorElement.innerHTML = 'foo bar';
+
+			editor.sourceElement = editorElement;
+
+			expect( editorElement.innerHTML ).to.equal( 'foo bar' );
+
+			editor.updateSourceElement( '' );
+
+			expect( editorElement.innerHTML ).to.equal( '' );
+
+			sinon.assert.notCalled( dataGetSpy );
+		} );
+
 		it( 'sets data to editor element (textarea)', () => {
 			const editorElement = document.createElement( 'textarea' );
 

--- a/packages/ckeditor5-core/tests/editor/utils/elementapimixin.js
+++ b/packages/ckeditor5-core/tests/editor/utils/elementapimixin.js
@@ -7,6 +7,7 @@
 
 import ElementApiMixin from '../../../src/editor/utils/elementapimixin';
 import Editor from '../../../src/editor/editor';
+import testUtils from '../../_utils/utils';
 import { expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
 
 describe( 'ElementApiMixin', () => {
@@ -39,6 +40,8 @@ describe( 'ElementApiMixin', () => {
 		it( 'don\'t set the data to editor element', () => {
 			const editorElement = document.createElement( 'div' );
 
+			const dataGetSpy = testUtils.sinon.spy( editor.data, 'get' );
+
 			editor.data.set( 'foo bar' );
 
 			editor.sourceElement = editorElement;
@@ -46,10 +49,14 @@ describe( 'ElementApiMixin', () => {
 			editor.updateSourceElement();
 
 			expect( editorElement.innerHTML ).to.equal( '' );
+
+			sinon.assert.notCalled( dataGetSpy );
 		} );
 
 		it( 'sets data to editor element (div)', () => {
 			const editorElement = document.createElement( 'div' );
+
+			const dataGetSpy = testUtils.sinon.spy( editor.data, 'get' );
 
 			// Adding `updateSourceElementOnDestroy` config to the editor allows setting the data
 			// back to the source element.
@@ -61,10 +68,35 @@ describe( 'ElementApiMixin', () => {
 			editor.updateSourceElement();
 
 			expect( editorElement.innerHTML ).to.equal( 'foo bar' );
+
+			sinon.assert.calledOnce( dataGetSpy );
+		} );
+
+		it( 'sets data passed as a function `updateSourceElement` argument to editor element (div)', () => {
+			const editorElement = document.createElement( 'div' );
+
+			const dataGetSpy = testUtils.sinon.spy( editor.data, 'get' );
+
+			// Adding `updateSourceElementOnDestroy` config to the editor allows setting the data
+			// back to the source element.
+			editor.config.set( 'updateSourceElementOnDestroy', true );
+			editor.data.set( '' );
+
+			editor.sourceElement = editorElement;
+
+			expect( editorElement.innerHTML ).to.equal( '' );
+
+			editor.updateSourceElement( 'foo bar' );
+
+			expect( editorElement.innerHTML ).to.equal( 'foo bar' );
+
+			sinon.assert.notCalled( dataGetSpy );
 		} );
 
 		it( 'sets data to editor element (textarea)', () => {
 			const editorElement = document.createElement( 'textarea' );
+
+			const dataGetSpy = testUtils.sinon.spy( editor.data, 'get' );
 
 			editor.data.set( 'foo bar' );
 
@@ -73,6 +105,26 @@ describe( 'ElementApiMixin', () => {
 			editor.updateSourceElement();
 
 			expect( editorElement.innerHTML ).to.equal( 'foo bar' );
+
+			sinon.assert.calledOnce( dataGetSpy );
+		} );
+
+		it( 'sets data passed as a function `updateSourceElement` argument to editor element (textarea)', () => {
+			const editorElement = document.createElement( 'textarea' );
+
+			const dataGetSpy = testUtils.sinon.spy( editor.data, 'get' );
+
+			editor.data.set( '' );
+
+			editor.sourceElement = editorElement;
+
+			expect( editorElement.innerHTML ).to.equal( '' );
+
+			editor.updateSourceElement( 'foo bar' );
+
+			expect( editorElement.innerHTML ).to.equal( 'foo bar' );
+
+			sinon.assert.notCalled( dataGetSpy );
 		} );
 
 		it( 'throws an error if "sourceElement" has not been set', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other(core): Should stop calling function `data.get()` when it's not needed while destroying the editor instance. Closes #15009 .

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
