### PR TITLE
Release - verify an entry point before publishing

### DIFF
--- a/scripts/release/publishpackages.js
+++ b/scripts/release/publishpackages.js
@@ -72,7 +72,11 @@ const tasks = new Listr( [
 						// Like in defaults, this package does not define features.
 						'ckeditor5-metadata.json'
 					]
-				}
+				},
+				requireEntryPoint: true,
+				optionalEntryPointPackages: [
+					'ckeditor5'
+				]
 			} );
 		},
 		retry: 3


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Verify if packages define an entry point before publishing a new release. See ckeditor/ckeditor5#15127.

### Additional information

- Requires: https://github.com/ckeditor/ckeditor5-dev/pull/926.