### PR TITLE
angular.md: update error event text (include init errors)

### DIFF
--- a/docs/installation/integrations/angular.md
+++ b/docs/installation/integrations/angular.md
@@ -534,7 +534,11 @@ It is fired with an object containing the editor and the CKEditor&nbsp;5 `focus`
 
 ### `error`
 
-Fired when the editor crashes (except of crashes during the editor initialization). Once the editor is crashed, the internal watchdog mechanism restarts the editor and fires the [ready](#ready) event.
+Fired when the editor crashes. Once the editor is crashed, the internal watchdog mechanism restarts the editor and fires the [ready](#ready) event.
+
+<info-box>
+	Prior to ckeditor5-angular v7.0.1, this event did not include crashes during the editor initialization.
+</info-box>
 
 ## Styling
 

--- a/docs/installation/integrations/angular.md
+++ b/docs/installation/integrations/angular.md
@@ -537,7 +537,7 @@ It is fired with an object containing the editor and the CKEditor&nbsp;5 `focus`
 Fired when the editor crashes. Once the editor is crashed, the internal watchdog mechanism restarts the editor and fires the [ready](#ready) event.
 
 <info-box>
-	Prior to ckeditor5-angular v7.0.1, this event did not include crashes during the editor initialization.
+	Prior to ckeditor5-angular `v7.0.1`, this event was not fired for crashes during the editor initialization.
 </info-box>
 
 ## Styling


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Update angular error event documentation

---

### Additional information

Since [this issue](https://github.com/ckeditor/ckeditor5-angular/issues/392)  ([PR](https://github.com/ckeditor/ckeditor5-angular/pull/390)) initialization errors are included in this event.
This updates the documentation to reflect that.
