### PR TITLE
Update aspect-ratio on image replace

### DIFF
--- a/packages/ckeditor5-image/src/imagesizeattributes.ts
+++ b/packages/ckeditor5-image/src/imagesizeattributes.ts
@@ -158,9 +158,8 @@ export default class ImageSizeAttributes extends Plugin {
 
 				const width = data.item.getAttribute( 'width' );
 				const height = data.item.getAttribute( 'height' );
-				const aspectRatio = img.getStyle( 'aspect-ratio' );
 
-				if ( width && height && !aspectRatio ) {
+				if ( width && height ) {
 					viewWriter.setStyle( 'aspect-ratio', `${ width }/${ height }`, img );
 				}
 			} );

--- a/packages/ckeditor5-image/tests/imagesizeattributes.js
+++ b/packages/ckeditor5-image/tests/imagesizeattributes.js
@@ -3,10 +3,13 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+/* global setTimeout */
+
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 
+import ReplaceImageSourceCommand from '../src/image/replaceimagesourcecommand';
 import ImageBlockEditing from '../src/image/imageblockediting';
 import ImageInlineEditing from '../src/image/imageinlineediting';
 import ImageSizeAttributes from '../src/imagesizeattributes';
@@ -566,6 +569,30 @@ describe( 'ImageSizeAttributes', () => {
 					} );
 				} );
 			} );
+		} );
+
+		it( 'should set aspect-ration on replaced image', done => {
+			const imageUtils = editor.plugins.get( 'ImageUtils' );
+			const command = new ReplaceImageSourceCommand( editor );
+
+			setData( model, `[<imageBlock
+				src="foo/bar.jpg"
+				width="100"
+				height="200"
+			></imageBlock>]` );
+
+			const element = model.document.selection.getSelectedElement();
+			const viewElement = editor.editing.mapper.toViewElement( element );
+			const img = imageUtils.findViewImgElement( viewElement );
+
+			expect( img.getStyle( 'aspect-ratio' ) ).to.equal( '100/200' );
+
+			command.execute( { source: '/assets/sample.png' } );
+
+			setTimeout( () => {
+				expect( img.getStyle( 'aspect-ratio' ) ).to.equal( '96/96' );
+				done();
+			}, 100 );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (image): Aspect ratio should be updated on image replace. Closes #15179.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
