### PR TITLE
Additional attributes for link element should not be copied on enter.

### DIFF
--- a/packages/ckeditor5-html-support/package.json
+++ b/packages/ckeditor5-html-support/package.json
@@ -49,6 +49,7 @@
     "@ckeditor/ckeditor5-paste-from-office": "40.0.0",
     "@ckeditor/ckeditor5-remove-format": "40.0.0",
     "@ckeditor/ckeditor5-source-editing": "40.0.0",
+    "@ckeditor/ckeditor5-style": "40.0.0",
     "@ckeditor/ckeditor5-table": "40.0.0",
     "@ckeditor/ckeditor5-theme-lark": "40.0.0",
     "@ckeditor/ckeditor5-typing": "40.0.0",

--- a/packages/ckeditor5-html-support/src/schemadefinitions.ts
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.ts
@@ -673,10 +673,7 @@ export default {
 			model: 'htmlA',
 			view: 'a',
 			priority: 5,
-			coupledAttribute: 'linkHref',
-			attributeProperties: {
-				copyOnEnter: true
-			}
+			coupledAttribute: 'linkHref'
 		},
 		{
 			model: 'htmlStrong',

--- a/packages/ckeditor5-html-support/tests/tickets/14683.js
+++ b/packages/ckeditor5-html-support/tests/tickets/14683.js
@@ -1,0 +1,55 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global document */
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import LinkEditing from '@ckeditor/ckeditor5-link/src/linkediting';
+import Style from '@ckeditor/ckeditor5-style/src/styleediting';
+import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import GeneralHtmlSupport from '../../src/generalhtmlsupport';
+
+describe( 'bug #14683', () => {
+	let editor, model, editorElement;
+
+	beforeEach( async () => {
+		editorElement = document.createElement( 'div' );
+		document.body.appendChild( editorElement );
+
+		editor = await ClassicTestEditor.create( editorElement, {
+			plugins: [ Paragraph, LinkEditing, GeneralHtmlSupport, Style ],
+			style: {
+				definitions: [
+					{
+						name: 'Button',
+						element: 'a',
+						classes: [ 'button' ]
+					}
+				]
+			}
+		} );
+
+		model = editor.model;
+	} );
+
+	afterEach( async () => {
+		editorElement.remove();
+
+		await editor.destroy();
+	} );
+
+	it( 'should not copy additional attributes for the link element after pressing Enter', () => {
+		setData( model, '<paragraph><$text linkHref="example.com">foo[]</$text></paragraph>' );
+
+		editor.commands.get( 'style' ).execute( { styleName: 'Button' } );
+		editor.commands.get( 'enter' ).execute();
+
+		expect( getData( model ) ).to.equal(
+			'<paragraph><$text htmlA="{"classes":["button"]}" linkHref="example.com">foo</$text></paragraph>' +
+			'<paragraph>[]</paragraph>'
+		);
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (html-support): Additional attributes for the link element (e.g. CSS class) should not be applied after pressing Enter. Closes #14683.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
