### PR TITLE
Encode the ampersand character when pasting link address

### DIFF
--- a/packages/ckeditor5-clipboard/src/utils/plaintexttohtml.ts
+++ b/packages/ckeditor5-clipboard/src/utils/plaintexttohtml.ts
@@ -15,11 +15,11 @@
  */
 export default function plainTextToHtml( text: string ): string {
 	text = text
+		// Encode &.
+		.replace( /&/g, '&amp;' )
 		// Encode <>.
 		.replace( /</g, '&lt;' )
 		.replace( />/g, '&gt;' )
-		// Encode &.
-		.replace( /&/g, '&amp;' )
 		// Creates a paragraph for each double line break.
 		.replace( /\r?\n\r?\n/g, '</p><p>' )
 		// Creates a line break for each single line break.

--- a/packages/ckeditor5-clipboard/src/utils/plaintexttohtml.ts
+++ b/packages/ckeditor5-clipboard/src/utils/plaintexttohtml.ts
@@ -18,6 +18,8 @@ export default function plainTextToHtml( text: string ): string {
 		// Encode <>.
 		.replace( /</g, '&lt;' )
 		.replace( />/g, '&gt;' )
+		// Encode &.
+		.replace( /&/g, '&amp;' )
 		// Creates a paragraph for each double line break.
 		.replace( /\r?\n\r?\n/g, '</p><p>' )
 		// Creates a line break for each single line break.

--- a/packages/ckeditor5-clipboard/tests/pasting-integration.js
+++ b/packages/ckeditor5-clipboard/tests/pasting-integration.js
@@ -191,11 +191,38 @@ describe( 'Pasting – integration', () => {
 				} );
 		} );
 	} );
+
+	describe( 'links', () => {
+		// See https://github.com/ckeditor/ckeditor5/issues/15036.
+		it( 'should not convert parts of the link address which look like HTML entities', () => {
+			return ClassicTestEditor
+				.create( element, { plugins: [ Clipboard, Paragraph, Bold, Italic, Link ] } )
+				.then( editor => {
+					setData( editor.model, '<paragraph>[]</paragraph>' );
+
+					pasteText( editor, 'https://example.com?x=1&quot=2&timestamp=t' );
+
+					expect( getData( editor.model ) ).to.equal(
+						'<paragraph>https://example.com?x=1&quot=2&timestamp=t[]</paragraph>' // keeps "&quot" and "&times" unchanged
+					);
+
+					return editor.destroy();
+				} );
+		} );
+	} );
 } );
 
 function pasteHtml( editor, html ) {
 	editor.editing.view.document.fire( 'paste', {
 		dataTransfer: createDataTransfer( { 'text/html': html } ),
+		stopPropagation() {},
+		preventDefault() {}
+	} );
+}
+
+function pasteText( editor, text ) {
+	editor.editing.view.document.fire( 'paste', {
+		dataTransfer: createDataTransfer( { 'text/plain': text } ),
 		stopPropagation() {},
 		preventDefault() {}
 	} );

--- a/packages/ckeditor5-clipboard/tests/utils/plaintexttohtml.js
+++ b/packages/ckeditor5-clipboard/tests/utils/plaintexttohtml.js
@@ -10,6 +10,10 @@ describe( 'plainTextToHtml()', () => {
 		expect( plainTextToHtml( 'x y <z>' ) ).to.equal( 'x y &lt;z&gt;' );
 	} );
 
+	it( 'encodes &', () => {
+		expect( plainTextToHtml( 'x=1&y=2&z=3' ) ).to.equal( 'x=1&amp;y=2&amp;z=3' );
+	} );
+
 	it( 'turns double line breaks into paragraphs (Linux/Mac EOL style)', () => {
 		expect( plainTextToHtml( 'x\n\ny\n\nz' ) ).to.equal( '<p>x</p><p>y</p><p>z</p>' );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (clipboard): Pasting a link address should not convert its parts that look like HTML entities. Closes #15036.

---

### Additional information

To reproduce the issue:

1. Create (or use the below one) HTML link that contains HTML entity (like `&times`, `&para`, `&quot` etc.) in its href, e.g. https://example.com?x=1&quot=2&timestamp=t
2. Right-click the link and choose the **Copy Link Address** option.
3. Paste into the editor.

Without this fix, the parts `&quot` and `&times` are replaced with corresponding characters.


