### PR TITLE
Docs: adding essentials package contents to predefined builds plugins list

### DIFF
--- a/docs/installation/getting-started/predefined-builds.md
+++ b/docs/installation/getting-started/predefined-builds.md
@@ -881,9 +881,8 @@ The table below presents the list of all plugins included in various builds. <!-
 				Includes:</br />
 				<ul>
 				<li><a href="https://ckeditor.com/docs/ckeditor5/latest/api/clipboard.html">Clipboard</a></li>
-				<li><a href="https://ckeditor.com/docs/ckeditor5/latest/api/enter.html">Enter</a></li>
+				<li><a href="https://ckeditor.com/docs/ckeditor5/latest/api/enter.html">Enter/ShiftEnter</a></li>
 				<li><a href="https://ckeditor.com/docs/ckeditor5/latest/api/select-all.html">SelectAll</a></li>
-				<li><a href="https://ckeditor.com/docs/ckeditor5/latest/api/module_enter_shiftenter-ShiftEnter.html">ShiftEnter</a></li>
 				<li><a href="https://ckeditor.com/docs/ckeditor5/latest/api/typing.html">Typing</a></li>
 				<li><a href="https://ckeditor.com/docs/ckeditor5/latest/api/undo.html">Undo</a></li>
 				</ul>

--- a/docs/installation/getting-started/predefined-builds.md
+++ b/docs/installation/getting-started/predefined-builds.md
@@ -877,7 +877,17 @@ The table below presents the list of all plugins included in various builds. <!-
 				<td style="text-align:center; width:70px">✅</td>
 			</tr>
 			<tr>
-				<td><a href="https://ckeditor.com/docs/ckeditor5/latest/api/essentials.html">Essentials</a> *</td>
+				<td><a href="https://ckeditor.com/docs/ckeditor5/latest/api/essentials.html">Essentials</a> *<br />
+				Includes:</br />
+				<ul>
+				<li><a href="https://ckeditor.com/docs/ckeditor5/latest/api/clipboard.html">Clipboard</a></li>
+				<li><a href="https://ckeditor.com/docs/ckeditor5/latest/api/enter.html">Enter</a></li>
+				<li><a href="https://ckeditor.com/docs/ckeditor5/latest/api/select-all.html">SelectAll</a></li>
+				<li><a href="https://ckeditor.com/docs/ckeditor5/latest/api/module_enter_shiftenter-ShiftEnter.html">ShiftEnter</a></li>
+				<li><a href="https://ckeditor.com/docs/ckeditor5/latest/api/typing.html">Typing</a></li>
+				<li><a href="https://ckeditor.com/docs/ckeditor5/latest/api/undo.html">Undo</a></li>
+				</ul>
+				</td>
 				<td style="text-align:center; width:70px">✅</td>
 				<td style="text-align:center; width:70px">✅</td>
 				<td style="text-align:center; width:70px">✅</td>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: adding the `essentials` package contents to the predefined builds plugins list. Closes https://github.com/ckeditor/ckeditor5/issues/15237

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
