### PR TITLE
Fixed the filtering of root elements attributes

### DIFF
--- a/packages/ckeditor5-engine/src/model/schema.ts
+++ b/packages/ckeditor5-engine/src/model/schema.ts
@@ -880,7 +880,13 @@ export default class Schema extends ObservableMixin() {
 				for ( const position of positionsInRange ) {
 					const item = position.nodeBefore || position.parent;
 
-					removeDisallowedAttributeFromNode( this, item as any, writer );
+					// Root elements can contain attributes that are not registered in their schema and
+					// should be ignored during the filtering process.
+					//
+					// See: https://github.com/ckeditor/ckeditor5/issues/15246.
+					if ( !item.is( 'rootElement' ) ) {
+						removeDisallowedAttributeFromNode( this, item as any, writer );
+					}
 				}
 			}
 		}

--- a/packages/ckeditor5-engine/tests/model/schema.js
+++ b/packages/ckeditor5-engine/tests/model/schema.js
@@ -2063,6 +2063,22 @@ describe( 'Schema', () => {
 					.to.equal( '<div><$text a="1">foo</$text>bar<$text a="1">biz</$text></div>' );
 			} );
 		} );
+
+		it( 'should do not filter out root elements', () => {
+			const foo = new Text( 'foo' );
+			const div = new Element( 'div', [], [ foo ] );
+
+			root._appendChild( [ div ] );
+
+			model.change( writer => {
+				writer.setAttribute( 'test', 'value', root );
+
+				schema.removeDisallowedAttributes( [ root ], writer );
+
+				expect( getData( model, { withoutSelection: true } ) ).to.equal( '<div>foo</div>' );
+				expect( root.getAttribute( 'test' ) ).to.equal( 'value' );
+			} );
+		} );
 	} );
 
 	describe( 'getAttributesWithProperty()', () => {

--- a/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-elements.js
+++ b/packages/ckeditor5-watchdog/tests/manual/watchdog-multi-root-elements.js
@@ -69,6 +69,10 @@ const editorConfig = {
 			'mergeTableCells'
 		]
 	},
+	rootsAttributes: {
+		header: { foo: 'bar' },
+		content: { foo: 'bar' }
+	},
 	lazyRoots
 };
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (engine): Fixed the issue of losing root element attributes after pasting the content. Closes #15246.

