### PR TITLE
Added `MultiRootEditor#registerRootAttribute()`

### DIFF
--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -188,7 +188,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 				}
 
 				for ( const key of Object.keys( attributes ) ) {
-					this._registeredRootsAttributesKeys.add( key );
+					this.registerRootAttribute( key );
 				}
 			}
 
@@ -386,9 +386,10 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	 * editor.addRoot( 'myRoot', { attributes: { isCollapsed: true, index: 4 } } );
 	 * ```
 	 *
-	 * See also {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes `rootsAttributes` configuration option}.
+	 * Note that attributes added together with a root are automatically registered.
 	 *
-	 * Note that attributes keys of attributes added in `attributes` option are also included in {@link #getRootsAttributes} return value.
+	 * See also {@link ~#registerRootAttribute `MultiRootEditor#registerRootAttribute()`} and
+	 * {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes `config.rootsAttributes` configuration option}.
 	 *
 	 * By setting `isUndoable` flag to `true`, you can allow for detaching the root using the undo feature.
 	 *
@@ -414,26 +415,23 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 		rootName: string,
 		{ data = '', attributes = {}, elementName = '$root', isUndoable = false }: AddRootOptions = {}
 	): void {
-		const dataController = this.data;
-		const registeredKeys = this._registeredRootsAttributesKeys;
+		const _addRoot = ( writer: Writer ) => {
+			const root = writer.addRoot( rootName, elementName );
+
+			if ( data ) {
+				writer.insert( this.data.parse( data, root ), root, 0 );
+			}
+
+			for ( const key of Object.keys( attributes ) ) {
+				this.registerRootAttribute( key );
+				writer.setAttribute( key, attributes[ key ], root );
+			}
+		}
 
 		if ( isUndoable ) {
 			this.model.change( _addRoot );
 		} else {
 			this.model.enqueueChange( { isUndoable: false }, _addRoot );
-		}
-
-		function _addRoot( writer: Writer ) {
-			const root = writer.addRoot( rootName, elementName );
-
-			if ( data ) {
-				writer.insert( dataController.parse( data, root ), root, 0 );
-			}
-
-			for ( const key of Object.keys( attributes ) ) {
-				registeredKeys.add( key );
-				writer.setAttribute( key, attributes[ key ], root );
-			}
 		}
 	}
 
@@ -550,6 +548,11 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	 *
 	 * This method is {@link module:utils/observablemixin~Observable#decorate decorated}.
 	 *
+	 * Note that attributes loaded together with a root are automatically registered.
+	 *
+	 * See also {@link ~#registerRootAttribute `MultiRootEditor#registerRootAttribute()`} and
+	 * {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes `config.rootsAttributes` configuration option}.
+	 *
 	 * When this method is used in real-time collaboration environment, its effects become asynchronous as the editor will first synchronize
 	 * with the remote editing session, before the root is added to the editor.
 	 *
@@ -572,7 +575,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 			}
 
 			for ( const key of Object.keys( attributes ) ) {
-				this._registeredRootsAttributesKeys.add( key );
+				this.registerRootAttribute( key );
 
 				writer.setAttribute( key, attributes[ key ], root );
 			}
@@ -606,8 +609,8 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	/**
 	 * Returns attributes for all attached roots.
 	 *
-	 * Note: only attributes specified in {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes `rootsAttributes`}
-	 * configuration option will be returned.
+	 * Note: all and only {@link ~#registerRootAttribute registered} roots attributes will be returned. If a registered root attribute
+	 * is not set for a given root, `null` will be returned.
 	 *
 	 * @returns Object with roots attributes. Keys are roots names, while values are attributes set on given root.
 	 */
@@ -624,10 +627,8 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	/**
 	 * Returns attributes for the specified root.
 	 *
-	 * Note: only attributes specified in {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes `rootsAttributes`}
-	 * configuration option will be returned.
-	 *
-	 * @param rootName
+	 * Note: all and only {@link ~#registerRootAttribute registered} roots attributes will be returned. If a registered root attribute
+	 * is not set for a given root, `null` will be returned.
 	 */
 	public getRootAttributes( rootName: string ): RootAttributes {
 		const rootAttributes: RootAttributes = {};
@@ -638,6 +639,23 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 		}
 
 		return rootAttributes;
+	}
+
+	/**
+	 * Registers given string as a root attribute key. Registered root attributes are added to
+	 * {@link module:engine/model/schema~Schema schema}, and also returned by
+	 * {@link ~#getRootAttributes `getRootAttributes`} and {@link ~#getRootsAttributes `getRootsAttributes`}.
+	 *
+	 * Note: attributes passed in {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes `config.rootsAttributes`} are
+	 * automatically registered as the editor is initialized. However, registering the same attribute twice does not have any negative
+	 * impact, so it is recommended to use this method in any feature that uses roots attributes.
+	 */
+	public registerRootAttribute( key: string ): void {
+		if ( !this._registeredRootsAttributesKeys.has( key ) ) {
+			this._registeredRootsAttributesKeys.add( key );
+		}
+
+		this.editing.model.schema.extend( '$root', { allowAttributes: key } );
 	}
 
 	/**

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -426,7 +426,7 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 				this.registerRootAttribute( key );
 				writer.setAttribute( key, attributes[ key ], root );
 			}
-		}
+		};
 
 		if ( isUndoable ) {
 			this.model.change( _addRoot );

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -644,17 +644,18 @@ export default class MultiRootEditor extends DataApiMixin( Editor ) {
 	/**
 	 * Registers given string as a root attribute key. Registered root attributes are added to
 	 * {@link module:engine/model/schema~Schema schema}, and also returned by
-	 * {@link ~#getRootAttributes `getRootAttributes`} and {@link ~#getRootsAttributes `getRootsAttributes`}.
+	 * {@link ~#getRootAttributes `getRootAttributes()`} and {@link ~#getRootsAttributes `getRootsAttributes()`}.
 	 *
 	 * Note: attributes passed in {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes `config.rootsAttributes`} are
 	 * automatically registered as the editor is initialized. However, registering the same attribute twice does not have any negative
 	 * impact, so it is recommended to use this method in any feature that uses roots attributes.
 	 */
 	public registerRootAttribute( key: string ): void {
-		if ( !this._registeredRootsAttributesKeys.has( key ) ) {
-			this._registeredRootsAttributesKeys.add( key );
+		if ( this._registeredRootsAttributesKeys.has( key ) ) {
+			return;
 		}
 
+		this._registeredRootsAttributesKeys.add( key );
 		this.editing.model.schema.extend( '$root', { allowAttributes: key } );
 	}
 

--- a/packages/ckeditor5-engine/tests/model/schema.js
+++ b/packages/ckeditor5-engine/tests/model/schema.js
@@ -2063,6 +2063,21 @@ describe( 'Schema', () => {
 					.to.equal( '<div><$text a="1">foo</$text>bar<$text a="1">biz</$text></div>' );
 			} );
 		} );
+
+		// Related to https://github.com/ckeditor/ckeditor5/issues/15246.
+		it( 'should filter out only non-allowed root attributes', () => {
+			schema.extend( '$root', { allowAttributes: 'allowed' } );
+
+			model.change( writer => {
+				writer.setAttribute( 'allowed', 'value', root );
+				writer.setAttribute( 'other', true, root );
+
+				schema.removeDisallowedAttributes( [ root ], writer );
+			} );
+
+			expect( root.getAttribute( 'allowed' ) ).to.equal( 'value' );
+			expect( root.getAttribute( 'other' ) ).to.be.undefined;
+		} );
 	} );
 
 	describe( 'getAttributesWithProperty()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (editor-multi-root): Added `MultiRootEditor#registerRootAttribute()`. All roots attributes used by features should now be registered. Roots attributes passed in editor config are now automatically registered. Closes #15246.

MINOR BREAKING CHANGE (editor-multi-root): If you use a custom plugin that uses roots attributes, it is recommended to use newly added `MultiRootEditor#registerRootAttribute()` to register the custom root attribute.