### PR TITLE
Return `undefined` to `Schema#addChildCheck()` calls

### DIFF
--- a/docs/_snippets/framework/tutorials/block-widget.js
+++ b/docs/_snippets/framework/tutorials/block-widget.js
@@ -108,6 +108,8 @@ class SimpleBoxEditing extends Plugin {
 			if ( context.endsWith( 'simpleBoxDescription' ) && childDefinition.name == 'simpleBox' ) {
 				return false;
 			}
+
+			return undefined;
 		} );
 	}
 

--- a/docs/examples/how-tos.md
+++ b/docs/examples/how-tos.md
@@ -367,6 +367,8 @@ class Forms extends Plugin {
 			) {
 				return false;
 			}
+
+			return undefined;
 		} );
 
 		// Data upcast. Convert a single element loaded by the editor to a structure of model elements.

--- a/docs/tutorials/widgets/implementing-a-block-widget.md
+++ b/docs/tutorials/widgets/implementing-a-block-widget.md
@@ -894,6 +894,8 @@ export default class SimpleBoxEditing extends Plugin {
 			if ( context.endsWith( 'simpleBoxDescription' ) && childDefinition.name == 'simpleBox' ) {
 				return false;
 			}
+
+			return undefined;
 		} );
 	}
 
@@ -1090,6 +1092,8 @@ class SimpleBoxEditing extends Plugin {
 			if ( context.endsWith( 'simpleBoxDescription' ) && childDefinition.name == 'simpleBox' ) {
 				return false;
 			}
+
+			return undefined;
 		} );
 	}
 

--- a/packages/ckeditor5-block-quote/docs/features/block-quote.md
+++ b/packages/ckeditor5-block-quote/docs/features/block-quote.md
@@ -75,6 +75,8 @@ function DisallowNestingBlockQuotes( editor ) {
 		if ( context.endsWith( 'blockQuote' ) && childDefinition.name == 'blockQuote' ) {
 			return false;
 		}
+
+		return undefined;
 	} );
 }
 

--- a/packages/ckeditor5-block-quote/tests/blockquotecommand.js
+++ b/packages/ckeditor5-block-quote/tests/blockquotecommand.js
@@ -120,6 +120,8 @@ describe( 'BlockQuoteCommand', () => {
 					if ( childDef.name == 'blockQuote' ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				setModelData( model, '<paragraph>x[]x</paragraph>' );
@@ -382,6 +384,8 @@ describe( 'BlockQuoteCommand', () => {
 					if ( ctx.endsWith( 'blockQuote' ) && childDef.name == 'fooBlock' ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				editor.conversion.for( 'downcast' ).elementToElement( { model: 'fooBlock', view: 'fooblock' } );

--- a/packages/ckeditor5-block-quote/tests/blockquoteediting.js
+++ b/packages/ckeditor5-block-quote/tests/blockquoteediting.js
@@ -160,6 +160,8 @@ describe( 'BlockQuoteEditing', () => {
 				if ( ctx.endsWith( 'blockQuote' ) && childDef.name == 'blockQuote' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 		} );
 

--- a/packages/ckeditor5-block-quote/tests/manual/blockquotenonesting.js
+++ b/packages/ckeditor5-block-quote/tests/manual/blockquotenonesting.js
@@ -13,6 +13,8 @@ function DisallowNestingBlockQuotes( editor ) {
 		if ( context.endsWith( 'blockQuote' ) && childDefinition.name == 'blockQuote' ) {
 			return false;
 		}
+
+		return undefined;
 	} );
 }
 

--- a/packages/ckeditor5-ckfinder/tests/ckfindercommand.js
+++ b/packages/ckeditor5-ckfinder/tests/ckfindercommand.js
@@ -85,6 +85,8 @@ describe( 'CKFinderCommand', () => {
 				if ( childDefinition.name === 'imageBlock' && context.last.name === 'block' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 
 			editor.conversion.for( 'downcast' ).elementToElement( { model: 'block', view: 'block' } );
@@ -384,6 +386,8 @@ describe( 'CKFinderCommand', () => {
 				if ( childDefinition.name === 'imageBlock' && context.last.name === 'block' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 
 			editor.conversion.for( 'downcast' ).elementToElement( { model: 'block', view: 'block' } );

--- a/packages/ckeditor5-code-block/src/codeblockediting.ts
+++ b/packages/ckeditor5-code-block/src/codeblockediting.ts
@@ -153,6 +153,8 @@ export default class CodeBlockEditing extends Plugin {
 			if ( context.endsWith( 'codeBlock' ) && childDefinition.isObject ) {
 				return false;
 			}
+
+			return undefined;
 		} );
 
 		// Conversion.

--- a/packages/ckeditor5-code-block/tests/codeblockcommand.js
+++ b/packages/ckeditor5-code-block/tests/codeblockcommand.js
@@ -130,6 +130,8 @@ describe( 'CodeBlockCommand', () => {
 				if ( context.endsWith( 'blockQuote' ) && childDef.name === 'codeBlock' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 
 			setModelData( model, '<blockQuote><paragraph>f[o]o</paragraph></blockQuote>' );

--- a/packages/ckeditor5-engine/docs/_snippets/framework/element-reconversion-demo.js
+++ b/packages/ckeditor5-engine/docs/_snippets/framework/element-reconversion-demo.js
@@ -277,6 +277,8 @@ class ComplexBox extends Plugin {
 			if ( [ ...context.getNames() ].includes( 'sideCard' ) && childDefinition.name === 'sideCard' ) {
 				return false;
 			}
+
+			return undefined;
 		} );
 
 		// A text-only title.

--- a/packages/ckeditor5-engine/docs/framework/deep-dive/schema.md
+++ b/packages/ckeditor5-engine/docs/framework/deep-dive/schema.md
@@ -629,6 +629,8 @@ schema.addChildCheck( ( context, childDefinition ) => {
 	if ( context.endsWith( 'blockQuote' ) && childDefinition.name == 'blockQuote' ) {
 		return false;
 	}
+
+	return undefined;
 } );
 ```
 <!--

--- a/packages/ckeditor5-engine/src/model/model.ts
+++ b/packages/ckeditor5-engine/src/model/model.ts
@@ -150,6 +150,8 @@ export default class Model extends ObservableMixin() {
 			if ( childDefinition.name === '$marker' ) {
 				return true;
 			}
+
+			return undefined;
 		} );
 
 		injectSelectionPostFixer( this );

--- a/packages/ckeditor5-engine/src/model/schema.ts
+++ b/packages/ckeditor5-engine/src/model/schema.ts
@@ -491,7 +491,9 @@ export default class Schema extends ObservableMixin() {
 	 * 	if ( context.endsWith( 'blockQuote' ) && childDefinition.name == 'heading1' ) {
 	 * 		return false;
 	 * 	}
-	 * } );
+	 *
+	 * 	 return undefined;
+	 * 	} );
 	 * ```
 	 *
 	 * Which translates to:

--- a/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
+++ b/packages/ckeditor5-engine/tests/conversion/upcasthelpers.js
@@ -1183,6 +1183,8 @@ describe( 'upcast-converters', () => {
 				if ( ( childDef.name == '$text' || childDef.name == 'paragraph' ) && ctx.endsWith( '$root' ) ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 
 			const viewText = new ViewText( viewDocument, 'foobar' );
@@ -1206,6 +1208,8 @@ describe( 'upcast-converters', () => {
 				if ( ( childDef.name == '$text' ) && ctx.endsWith( '$root' ) ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 
 			const viewText = new ViewText( viewDocument, 'foobar' );
@@ -1230,6 +1234,8 @@ describe( 'upcast-converters', () => {
 				if ( childDef.name == '$text' && ctx.endsWith( '$root' ) ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 
 			const viewText = new ViewText( viewDocument, 'foobar' );

--- a/packages/ckeditor5-engine/tests/manual/tickets/1088/1.js
+++ b/packages/ckeditor5-engine/tests/manual/tickets/1088/1.js
@@ -65,6 +65,8 @@ ClassicEditor
 			if ( ctx.endsWith( '$root' ) && childDef.name == 'heading3' ) {
 				return false;
 			}
+
+			return undefined;
 		} );
 	} )
 	.catch( err => {

--- a/packages/ckeditor5-engine/tests/model/schema.js
+++ b/packages/ckeditor5-engine/tests/model/schema.js
@@ -3142,6 +3142,8 @@ describe( 'Schema', () => {
 					if ( childDef.name == 'blockQuote' && ctx.endsWith( 'blockQuote' ) ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 			},
 			() => {

--- a/packages/ckeditor5-engine/tests/model/utils/insertcontent.js
+++ b/packages/ckeditor5-engine/tests/model/utils/insertcontent.js
@@ -432,6 +432,8 @@ describe( 'DataController utils', () => {
 					if ( childDef.name == 'paragraph' && ctx.endsWith( '$root' ) ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				const content = new DocumentFragment( [

--- a/packages/ckeditor5-horizontal-line/tests/horizontallinecommand.js
+++ b/packages/ckeditor5-horizontal-line/tests/horizontallinecommand.js
@@ -103,6 +103,8 @@ describe( 'HorizontalLineCommand', () => {
 				if ( childDefinition.name === 'horizontalLine' && context.last.name === 'block' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 			editor.conversion.for( 'downcast' ).elementToElement( { model: 'block', view: 'block' } );
 
@@ -139,6 +141,8 @@ describe( 'HorizontalLineCommand', () => {
 				if ( childDefinition.name === 'paragraph' && context.last.name === '$root' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 
 			setModelData( model, '[]' );

--- a/packages/ckeditor5-horizontal-line/tests/horizontallineediting.js
+++ b/packages/ckeditor5-horizontal-line/tests/horizontallineediting.js
@@ -81,6 +81,8 @@ describe( 'HorizontalLineEditing', () => {
 					if ( ctx.endsWith( '$root' ) && childDef.name == 'horizontalLine' ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				editor.conversion.elementToElement( { model: 'div', view: 'div' } );

--- a/packages/ckeditor5-html-embed/tests/htmlembedcommand.js
+++ b/packages/ckeditor5-html-embed/tests/htmlembedcommand.js
@@ -102,6 +102,8 @@ describe( 'HtmlEmbedCommand', () => {
 				if ( childDefinition.name === 'rawHtml' && context.last.name === 'block' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 			editor.conversion.for( 'downcast' ).elementToElement( { model: 'block', view: 'block' } );
 
@@ -159,6 +161,8 @@ describe( 'HtmlEmbedCommand', () => {
 					if ( childDefinition.name === 'paragraph' && context.last.name === '$root' ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				setModelData( model, '[]' );

--- a/packages/ckeditor5-html-embed/tests/htmlembedediting.js
+++ b/packages/ckeditor5-html-embed/tests/htmlembedediting.js
@@ -191,6 +191,8 @@ describe( 'HtmlEmbedEditing', () => {
 					if ( ctx.endsWith( '$root' ) && childDef.name == 'rawHtml' ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				editor.conversion.elementToElement( { model: 'div', view: 'div' } );

--- a/packages/ckeditor5-html-support/tests/datafilter.js
+++ b/packages/ckeditor5-html-support/tests/datafilter.js
@@ -1560,6 +1560,8 @@ describe( 'DataFilter', () => {
 				if ( context.endsWith( 'paragraph' ) && childDefinition.isObject ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 			dataFilter.allowEmptyElement( 'i' );
 			dataFilter.allowElement( 'i' );

--- a/packages/ckeditor5-image/src/image/imageinlineediting.ts
+++ b/packages/ckeditor5-image/src/image/imageinlineediting.ts
@@ -72,6 +72,8 @@ export default class ImageInlineEditing extends Plugin {
 			if ( context.endsWith( 'caption' ) && childDefinition.name === 'imageInline' ) {
 				return false;
 			}
+
+			return undefined;
 		} );
 
 		this._setupConversion();

--- a/packages/ckeditor5-image/tests/image/imageblockediting.js
+++ b/packages/ckeditor5-image/tests/image/imageblockediting.js
@@ -243,6 +243,8 @@ describe( 'ImageBlockEditing', () => {
 					if ( ctx.endsWith( '$root' ) && childDef.name == 'imageBlock' ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				editor.conversion.elementToElement( { model: 'div', view: 'div' } );

--- a/packages/ckeditor5-image/tests/image/imageediting.js
+++ b/packages/ckeditor5-image/tests/image/imageediting.js
@@ -328,6 +328,8 @@ describe( 'ImageEditing', () => {
 					if ( ctx.endsWith( '$root' ) && childDef.name == 'imageBlock' ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				editor.conversion.elementToElement( { model: 'div', view: 'div' } );
@@ -341,6 +343,8 @@ describe( 'ImageEditing', () => {
 					if ( childDef.name == 'imageInline' ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				editor.conversion.elementToElement( { model: 'div', view: 'div' } );

--- a/packages/ckeditor5-image/tests/image/imageinlineediting.js
+++ b/packages/ckeditor5-image/tests/image/imageinlineediting.js
@@ -234,6 +234,8 @@ describe( 'ImageInlineEditing', () => {
 					if ( childDef.name == 'imageInline' ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				editor.conversion.elementToElement( { model: 'div', view: 'div' } );

--- a/packages/ckeditor5-image/tests/image/imagetypecommand.js
+++ b/packages/ckeditor5-image/tests/image/imagetypecommand.js
@@ -232,6 +232,8 @@ describe( 'ImageTypeCommand', () => {
 					if ( childDefinition.name == 'imageBlock' ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				setModelData( model, `<paragraph>[<imageInline src="${ imgSrc }"></imageInline>]</paragraph>` );
@@ -491,6 +493,8 @@ describe( 'ImageTypeCommand', () => {
 					if ( childDefinition.name == 'imageInline' ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				setModelData( model, `<block>[<imageBlock src="${ imgSrc }"></imageBlock>]</block>` );

--- a/packages/ckeditor5-image/tests/image/insertimagecommand.js
+++ b/packages/ckeditor5-image/tests/image/insertimagecommand.js
@@ -114,6 +114,8 @@ describe( 'InsertImageCommand', () => {
 				if ( childDefinition.name === 'imageInline' && context.last.name === 'paragraph' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 			editor.conversion.for( 'downcast' ).elementToElement( { model: 'block', view: 'block' } );
 

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
@@ -376,6 +376,8 @@ describe( 'ImageUploadEditing', () => {
 			if ( childDefinition.name.startsWith( 'imageBlock' ) && context.last.name === 'other' ) {
 				return false;
 			}
+
+			return undefined;
 		} );
 
 		editor.conversion.elementToElement( { model: 'other', view: 'p' } );

--- a/packages/ckeditor5-image/tests/imageupload/uploadimagecommand.js
+++ b/packages/ckeditor5-image/tests/imageupload/uploadimagecommand.js
@@ -132,6 +132,8 @@ describe( 'UploadImageCommand', () => {
 				if ( childDefinition.name === 'imageInline' && context.last.name === 'paragraph' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 			editor.conversion.for( 'downcast' ).elementToElement( { model: 'block', view: 'block' } );
 

--- a/packages/ckeditor5-image/tests/imageutils.js
+++ b/packages/ckeditor5-image/tests/imageutils.js
@@ -464,6 +464,8 @@ describe( 'ImageUtils plugin', () => {
 				if ( childDefinition.name === 'imageInline' && context.last.name === 'paragraph' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 			editor.conversion.for( 'downcast' ).elementToElement( { model: 'block', view: 'block' } );
 

--- a/packages/ckeditor5-link/tests/linkimageediting.js
+++ b/packages/ckeditor5-link/tests/linkimageediting.js
@@ -242,6 +242,8 @@ describe( 'LinkImageEditing', () => {
 						if ( ctx.endsWith( '$root' ) && childDef.name == 'imageBlock' ) {
 							return false;
 						}
+
+						return undefined;
 					} );
 
 					editor.conversion.elementToElement( { model: 'div', view: 'div' } );
@@ -320,6 +322,8 @@ describe( 'LinkImageEditing', () => {
 						if ( ctx.endsWith( '$root' ) && childDef.name == 'imageBlock' ) {
 							return false;
 						}
+
+						return undefined;
 					} );
 
 					editor.conversion.elementToElement( { model: 'div', view: 'div' } );

--- a/packages/ckeditor5-list/tests/list/listcommand.js
+++ b/packages/ckeditor5-list/tests/list/listcommand.js
@@ -35,6 +35,8 @@ describe( 'ListCommand', () => {
 			if ( ctx.endsWith( 'widget' ) && childDef.name == 'listItem' ) {
 				return false;
 			}
+
+			return undefined;
 		} );
 
 		setData(

--- a/packages/ckeditor5-media-embed/tests/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedediting.js
@@ -607,6 +607,8 @@ describe( 'MediaEmbedEditing', () => {
 							if ( ctx.endsWith( '$root' ) && childDef.name == 'media' ) {
 								return false;
 							}
+
+							return undefined;
 						} );
 
 						editor.conversion.elementToElement( { model: 'blockquote', view: 'blockquote' } );
@@ -809,6 +811,8 @@ describe( 'MediaEmbedEditing', () => {
 							if ( ctx.endsWith( '$root' ) && childDef.name == 'media' ) {
 								return false;
 							}
+
+							return undefined;
 						} );
 
 						editor.conversion.elementToElement( { model: 'blockquote', view: 'blockquote' } );
@@ -982,6 +986,8 @@ describe( 'MediaEmbedEditing', () => {
 								if ( ctx.endsWith( '$root' ) && childDef.name == 'media' ) {
 									return false;
 								}
+
+								return undefined;
 							} );
 
 							editor.conversion.elementToElement( { model: 'div', view: 'div' } );

--- a/packages/ckeditor5-page-break/tests/pagebreakcommand.js
+++ b/packages/ckeditor5-page-break/tests/pagebreakcommand.js
@@ -101,6 +101,8 @@ describe( 'PageBreakCommand', () => {
 				if ( childDefinition.name === 'pageBreak' && context.last.name === 'block' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 			editor.conversion.for( 'downcast' ).elementToElement( { model: 'block', view: 'block' } );
 
@@ -137,6 +139,8 @@ describe( 'PageBreakCommand', () => {
 				if ( childDefinition.name === 'paragraph' && context.last.name === '$root' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 
 			setModelData( model, '[]' );

--- a/packages/ckeditor5-page-break/tests/pagebreakediting.js
+++ b/packages/ckeditor5-page-break/tests/pagebreakediting.js
@@ -110,6 +110,8 @@ describe( 'PageBreakEditing', () => {
 					if ( ctx.endsWith( '$root' ) && childDef.name == 'pageBreak' ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				editor.conversion.elementToElement( { model: 'div', view: 'div' } );

--- a/packages/ckeditor5-paragraph/tests/insertparagraphcommand.js
+++ b/packages/ckeditor5-paragraph/tests/insertparagraphcommand.js
@@ -205,6 +205,8 @@ describe( 'InsertParagraphCommand', () => {
 				if ( context.endsWith( '$root' ) && childDefinition.name == 'paragraph' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 
 			setData( model, '<heading1>foo[]</heading1>' );

--- a/packages/ckeditor5-paragraph/tests/paragraph.js
+++ b/packages/ckeditor5-paragraph/tests/paragraph.js
@@ -183,6 +183,8 @@ describe( 'Paragraph feature', () => {
 					if ( ctx.endsWith( '$root paragraph' ) && childDef.name == '$text' ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				const modelFragment = editor.data.parse( 'foo' );
@@ -422,6 +424,8 @@ describe( 'Paragraph feature', () => {
 				if ( ctx.endsWith( '$root' ) && childDef.name == 'paragraph' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 
 			model.change( writer => {

--- a/packages/ckeditor5-paragraph/tests/paragraphcommand.js
+++ b/packages/ckeditor5-paragraph/tests/paragraphcommand.js
@@ -122,6 +122,8 @@ describe( 'ParagraphCommand', () => {
 				if ( ctx.endsWith( 'restricted' ) && childDef.name == 'paragraph' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 
 			setData(

--- a/packages/ckeditor5-table/docs/features/tables.md
+++ b/packages/ckeditor5-table/docs/features/tables.md
@@ -359,6 +359,8 @@ function DisallowNestingTables( editor ) {
 		if ( childDefinition.name == 'table' && Array.from( context.getNames() ).includes( 'table' ) ) {
 			return false;
 		}
+
+		return undefined;
 	} );
 }
 

--- a/packages/ckeditor5-table/tests/converters/upcasttable.js
+++ b/packages/ckeditor5-table/tests/converters/upcasttable.js
@@ -378,6 +378,8 @@ describe( 'upcastTable()', () => {
 			if ( childDefinition.name == 'table' && Array.from( context.getNames() ).includes( 'table' ) ) {
 				return false;
 			}
+
+			return undefined;
 		} );
 
 		editor.setData(

--- a/packages/ckeditor5-table/tests/manual/tablenonesting.js
+++ b/packages/ckeditor5-table/tests/manual/tablenonesting.js
@@ -13,6 +13,8 @@ function DisallowNestingTables( editor ) {
 		if ( childDefinition.name == 'table' && Array.from( context.getNames() ).includes( 'table' ) ) {
 			return false;
 		}
+
+		return undefined;
 	} );
 }
 

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -397,6 +397,8 @@ describe( 'table properties', () => {
 								if ( childDefinition.name == 'table' && Array.from( context.getNames() ).includes( 'table' ) ) {
 									return false;
 								}
+
+								return undefined;
 							} );
 						} );
 

--- a/packages/ckeditor5-typing/tests/deletecommand.js
+++ b/packages/ckeditor5-typing/tests/deletecommand.js
@@ -339,6 +339,8 @@ describe( 'DeleteCommand', () => {
 				if ( ctx.endsWith( '$root' ) && childDef.name == 'paragraph' ) {
 					return false;
 				}
+
+				return undefined;
 			} );
 
 			setData( model, '<heading1>[]</heading1>' );
@@ -383,6 +385,8 @@ describe( 'DeleteCommand', () => {
 					if ( ctx.endsWith( '$root' ) && childDef.name == 'paragraph' ) {
 						return false;
 					}
+
+					return undefined;
 				} );
 
 				setData( model, '<heading1>[]</heading1><heading1>foo</heading1>' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Return `undefined` to `Schema#addChildCheck()` calls

Other: Return `undefined` to `Schema#addChildCheck()` calls

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._

Hi everyone, sorry maybe I should have opened an issue first, but I thought this will be faster by directly opening the PR.

So, I was following the [Implementing a Block Widget tutorial](https://ckeditor.com/docs/ckeditor5/latest/tutorials/widgets/implementing-a-block-widget.html) and I got stuck on an incomprehensible issue (sorry I don't remember it, I'm not on my professional PC, I will edit this message tomorrow) and I was completely lost about what was happening.

After a lot of debbuging, trying many things, I found the problem was caused by my `schema.addChildCheck()` call.

I use ESLint, with the [consistent-return](https://eslint.org/docs/latest/rules/consistent-return) rule, and it was screaming that `return` calls were not consistent: 
```js
schema.addChildCheck( ( context, childDefinition ) => {
    if ( /* ... */ ) {
        return false;
    }

    // ESLint scream about no `return` here
} );
```

So I've updated the code to add a `return true` after the `if`, I was like "since we can return `false`, maybe we should return `true` otherwise? :shrug:", but that's what caused my downfall 😬 (because I didn't read the method description)

After many tries, I've found that using `return undefined` resolved my issue and makes ESLint happy.

I really think this PR can be a nice improvment, at least for the documentation, I'm sure it will save a lot of time and headache for others.

WDYT? Thanks :)