### PR TITLE
Fix Finnish translation for table caption

### DIFF
--- a/packages/ckeditor5-table/lang/translations/fi.po
+++ b/packages/ckeditor5-table/lang/translations/fi.po
@@ -251,12 +251,12 @@ msgstr "Värin valitsin"
 
 msgctxt "The button label for the table toolbar hiding caption attached to the table."
 msgid "Toggle caption off"
-msgstr "Ota tekstitykset pois päältä"
+msgstr "Poista taulukon kuvaus"
 
 msgctxt "The button label for the table toolbar showing caption attached to the table."
 msgid "Toggle caption on"
-msgstr "Ota tekstitys käyttöön"
+msgstr "Lisää taulukon kuvaus"
 
 msgctxt "The placeholder text for the table caption displayed when the caption is empty."
 msgid "Enter table caption"
-msgstr "Ota taulukon tekstitys käyttöön"
+msgstr "Syötä taulukon kuvaus"


### PR DESCRIPTION
In Finnish, there are two separate words for caption in table-context and for caption in tv subtitle-context. Currently this  "Enter table caption" translation is saying "Take table subtitles in use" which is nonsensical.

This translation fix changes the caption translations to make more sense in Finnish. Source: It's my native language.

There are many Finnish public sector websites that are using Drupal and as such CKEditor on their platform. I'm currently working on the Finnish capital (Helsinki) website and came across this problem. We'd appreciate very much if this could be fixed. :)

I tried to add this via transifex, but I do not have time to wait for approval process and bureaucracy for this simple fix I wanted to upstream. I might be able to add these changes at a later date if I'm approved to the project, but the friction is getting quite big on such a simple fix.