### PR TITLE
Docs: adding missing image toolbars.

### DIFF
--- a/docs/_snippets/features/build-ui-language-source.html
+++ b/docs/_snippets/features/build-ui-language-source.html
@@ -1,0 +1,1 @@
+<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>

--- a/docs/_snippets/features/build-ui-language-source.js
+++ b/docs/_snippets/features/build-ui-language-source.js
@@ -8,8 +8,15 @@
 /* config { "additionalLanguages": [ "ar", "es" ] } */
 
 import { Superscript } from '@ckeditor/ckeditor5-basic-styles';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
+import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import ClassicEditor from '../build-classic';
 
 ClassicEditor.builtinPlugins.push( Superscript );
+ClassicEditor.builtinPlugins.push( CKBox );
+ClassicEditor.builtinPlugins.push( CKBoxImageEdit );
+ClassicEditor.builtinPlugins.push( PictureEditing );
+ClassicEditor.builtinPlugins.push( ImageResize );
+ClassicEditor.builtinPlugins.push( AutoImage );
 
 window.ClassicEditor = ClassicEditor;

--- a/docs/_snippets/features/placeholder.html
+++ b/docs/_snippets/features/placeholder.html
@@ -1,3 +1,4 @@
+<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="snippet-placeholder">
 	<p></p>
 </div>

--- a/docs/_snippets/features/placeholder.js
+++ b/docs/_snippets/features/placeholder.js
@@ -3,20 +3,9 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals window, document, console */
+/* globals console, window, document, ClassicEditor */
 
-import { Superscript } from '@ckeditor/ckeditor5-basic-styles';
-import { TextPartLanguage } from '@ckeditor/ckeditor5-language';
-import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
-import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
-import { LinkImage } from '@ckeditor/ckeditor5-link';
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
-
-// Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
-import ClassicEditor from '../build-classic';
-
-ClassicEditor.builtinPlugins.push( TextPartLanguage, Superscript, PictureEditing,
-	ImageResize, AutoImage, LinkImage, CKBox, CKBoxImageEdit );
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-placeholder' ), {
@@ -27,12 +16,6 @@ ClassicEditor
 			'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 			'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 		],
-		image: {
-			toolbar: [
-				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
-				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
-			]
-		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/placeholder.js
+++ b/docs/_snippets/features/placeholder.js
@@ -3,9 +3,20 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals console, window, document, ClassicEditor */
+/* globals window, document, console */
 
+import { Superscript } from '@ckeditor/ckeditor5-basic-styles';
+import { TextPartLanguage } from '@ckeditor/ckeditor5-language';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
+import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
+import { LinkImage } from '@ckeditor/ckeditor5-link';
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
+
+// Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
+import ClassicEditor from '../build-classic';
+
+ClassicEditor.builtinPlugins.push( TextPartLanguage, Superscript, PictureEditing,
+	ImageResize, AutoImage, LinkImage, CKBox, CKBoxImageEdit );
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-placeholder' ), {
@@ -16,6 +27,12 @@ ClassicEditor
 			'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 			'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 		],
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/read-only-build.js
+++ b/docs/_snippets/features/read-only-build.js
@@ -8,10 +8,17 @@
 import { FindAndReplace } from '@ckeditor/ckeditor5-find-and-replace';
 import { ExportPdf } from '@ckeditor/ckeditor5-export-pdf';
 import { ExportWord } from '@ckeditor/ckeditor5-export-word';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
+import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import ClassicEditor from '../build-classic';
 
 ClassicEditor.builtinPlugins.push( FindAndReplace );
 ClassicEditor.builtinPlugins.push( ExportPdf );
 ClassicEditor.builtinPlugins.push( ExportWord );
+ClassicEditor.builtinPlugins.push( CKBox );
+ClassicEditor.builtinPlugins.push( CKBoxImageEdit );
+ClassicEditor.builtinPlugins.push( PictureEditing );
+ClassicEditor.builtinPlugins.push( ImageResize );
+ClassicEditor.builtinPlugins.push( AutoImage );
 
 window.ClassicEditor = ClassicEditor;

--- a/docs/_snippets/features/read-only-hide-toolbar.js
+++ b/docs/_snippets/features/read-only-hide-toolbar.js
@@ -19,6 +19,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/read-only.js
+++ b/docs/_snippets/features/read-only.js
@@ -19,6 +19,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/ui-language-content.js
+++ b/docs/_snippets/features/ui-language-content.js
@@ -22,6 +22,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/ui-language-rtl.js
+++ b/docs/_snippets/features/ui-language-rtl.js
@@ -20,6 +20,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/ui-language.js
+++ b/docs/_snippets/features/ui-language.js
@@ -20,6 +20,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/wproofreader.html
+++ b/docs/_snippets/features/wproofreader.html
@@ -1,3 +1,4 @@
+<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="ck ck-content" id="snippet-wproofreader">
 	<p>Warsaw is the capital adn largest city of Poland. The metropolis stands on the Vistula River in east-central Poland and its population is officially estimatd at 1.8 million residents within a greater metropolitan area of 3.1 million residents, which makes Warsaw the 7th most-populous capital city in the European Union. Warsaw is an alpha-global city, a major international tourist destination, and a significaant cultural, political, and economic hub. Its historical Old Town was designated a UNESCO World Heritage Site.</p>
 

--- a/docs/_snippets/features/wproofreader.js
+++ b/docs/_snippets/features/wproofreader.js
@@ -8,15 +8,15 @@
 import { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
 import { CloudServices } from '@ckeditor/ckeditor5-cloud-services';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
-import { EasyImage } from '@ckeditor/ckeditor5-easy-image';
-import { ImageUpload } from '@ckeditor/ckeditor5-image';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
+import { PictureEditing, ImageUpload } from '@ckeditor/ckeditor5-image';
 import WProofreader from '@webspellchecker/wproofreader-ckeditor5/src/wproofreader';
 
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-wproofreader' ), {
-		plugins: [ ArticlePluginSet, EasyImage, ImageUpload, CloudServices, WProofreader ],
+		plugins: [ ArticlePluginSet, PictureEditing, CKBox, CKBoxImageEdit, ImageUpload, CloudServices, WProofreader ],
 		wproofreader: {
 			serviceId: '1:Eebp63-lWHbt2-ASpHy4-AYUpy2-fo3mk4-sKrza1-NsuXy4-I1XZC2-0u2F54-aqYWd1-l3Qf14-umd',
 			lang: 'auto',
@@ -40,12 +40,8 @@ ClassicEditor
 		},
 		image: {
 			toolbar: [
-				'imageStyle:inline',
-				'imageStyle:wrapText',
-				'imageStyle:breakText',
-				'|',
-				'toggleImageCaption',
-				'imageTextAlternative'
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
 		table: {

--- a/docs/_snippets/installation/getting-and-setting-data/build-autosave-source.js
+++ b/docs/_snippets/installation/getting-and-setting-data/build-autosave-source.js
@@ -6,8 +6,15 @@
 /* globals window */
 
 import { Autosave } from '@ckeditor/ckeditor5-autosave';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
+import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import ClassicEditor from '../../build-classic';
 
 ClassicEditor.builtinPlugins.push( Autosave );
+ClassicEditor.builtinPlugins.push( CKBox );
+ClassicEditor.builtinPlugins.push( CKBoxImageEdit );
+ClassicEditor.builtinPlugins.push( PictureEditing );
+ClassicEditor.builtinPlugins.push( ImageResize );
+ClassicEditor.builtinPlugins.push( AutoImage );
 
 window.ClassicEditor = ClassicEditor;

--- a/docs/features/editor-placeholder.md
+++ b/docs/features/editor-placeholder.md
@@ -3,8 +3,6 @@ category: features
 meta-title: Editor placeholder | CKEditor 5 Documentation
 ---
 
-{@snippet build-classic-source}
-
 # Editor placeholder
 
 You can prompt the user to input content by displaying a configurable placeholder text when the editor is empty. This works similarly to the native DOM [`placeholder` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-placeholder) used by inputs. Not to be confused with {@link examples/framework/content-placeholder content placeholder}.

--- a/packages/ckeditor5-alignment/docs/_snippets/features/build-text-alignment-source.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/build-text-alignment-source.js
@@ -5,7 +5,7 @@
 
 /* globals window */
 
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 import { Alignment } from '@ckeditor/ckeditor5-alignment';
@@ -19,7 +19,8 @@ ClassicEditor.builtinPlugins.push(
 	AutoImage,
 	LinkImage,
 	Alignment,
-	CKBox
+	CKBox,
+	CKBoxImageEdit
 );
 
 window.ClassicEditor = ClassicEditor;

--- a/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-options.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-options.js
@@ -19,6 +19,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-toolbar.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-toolbar.js
@@ -19,6 +19,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js
@@ -19,6 +19,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.js
+++ b/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.js
@@ -9,7 +9,7 @@ import { Strikethrough, Code, Underline } from '@ckeditor/ckeditor5-basic-styles
 import { TodoList } from '@ckeditor/ckeditor5-list';
 import { CodeBlock } from '@ckeditor/ckeditor5-code-block';
 import { HorizontalLine } from '@ckeditor/ckeditor5-horizontal-line';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
@@ -30,7 +30,8 @@ ClassicEditor
 			ImageResize,
 			AutoImage,
 			LinkImage,
-			CKBox
+			CKBox,
+			CKBoxImageEdit
 		] ),
 		toolbar: {
 			items: [
@@ -38,6 +39,12 @@ ClassicEditor
 				'|', 'bold', 'italic', 'underline', 'strikethrough', 'code',
 				'|', 'link', 'uploadImage', 'insertTable', 'blockQuote', 'mediaEmbed', 'codeBlock', 'horizontalLine',
 				'|', 'bulletedList', 'numberedList', 'todolist', 'outdent', 'indent'
+			]
+		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-autosave/docs/_snippets/features/autosave.js
+++ b/packages/ckeditor5-autosave/docs/_snippets/features/autosave.js
@@ -22,6 +22,12 @@ document.querySelector( '#snippet-autosave-lag' ).addEventListener( 'change', ev
 ClassicEditor
 	.create( document.querySelector( '#snippet-autosave' ), {
 		cloudServices: CS_CONFIG,
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-autosave/docs/features/autosave.md
+++ b/packages/ckeditor5-autosave/docs/features/autosave.md
@@ -23,7 +23,7 @@ How to understand this demo:
 	* The editor is also busy when saving the content is in progress (the `save()`'s promise was not resolved).
 * The autosave feature has a throttling mechanism that groups frequent changes (e.g. typing) into batches.
 * The autosave itself does not check whether the data has actually changed. It bases on changes in the {@link framework/architecture/editing-engine#model model} that sometimes may not be "visible" in the data. You can add such a check yourself if you would like to avoid sending the same data to the server twice.
-* You will be asked whether you want to leave the page if an image is being uploaded or the data has not been saved successfully yet. You can test that by dropping a big image into the editor or changing the "HTTP server lag" to a high value (e.g. 9000ms) and typing something. These actions will make the editor busy for a longer time &mdash; try leaving the page then.
+* You will be asked whether you want to leave the page if an image is being uploaded or the data has not been saved successfully yet. You can test that by dropping a big image into the editor or changing the "HTTP server lag" to a high value (e.g. 9000ms) and typing something. These actions will make the editor busy for a longer time &ndash; try leaving the page then.
 
 <info-box info>
 	This demo only presents a limited set of features. Visit the {@link examples/builds/full-featured-editor feature-rich editor example} to see more in action.

--- a/packages/ckeditor5-basic-styles/docs/_snippets/features/basic-styles.js
+++ b/packages/ckeditor5-basic-styles/docs/_snippets/features/basic-styles.js
@@ -17,6 +17,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-basic-styles/docs/_snippets/features/build-basic-styles-source.js
+++ b/packages/ckeditor5-basic-styles/docs/_snippets/features/build-basic-styles-source.js
@@ -6,7 +6,7 @@
 /* globals window */
 
 import { Bold, Italic, Underline, Strikethrough, Subscript, Superscript, Code } from '@ckeditor/ckeditor5-basic-styles';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 import { RemoveFormat } from '@ckeditor/ckeditor5-remove-format';
@@ -15,6 +15,6 @@ import { RemoveFormat } from '@ckeditor/ckeditor5-remove-format';
 import ClassicEditor from '../build-classic';
 
 ClassicEditor.builtinPlugins.push( Bold, Italic, Underline, Strikethrough, Subscript, Superscript, Code, RemoveFormat,
-	PictureEditing, ImageResize, AutoImage, LinkImage, CKBox );
+	PictureEditing, ImageResize, AutoImage, LinkImage, CKBox, CKBoxImageEdit );
 
 window.ClassicEditor = ClassicEditor;

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/build-paste-source.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/build-paste-source.js
@@ -6,7 +6,7 @@
 /* globals window */
 
 import { Strikethrough, Underline } from '@ckeditor/ckeditor5-basic-styles';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 import { Font } from '@ckeditor/ckeditor5-font';
@@ -22,7 +22,8 @@ ClassicEditor.builtinPlugins.push(
 	ImageResize,
 	AutoImage,
 	LinkImage,
-	CKBox
+	CKBox,
+	CKBoxImageEdit
 );
 
 window.ClassicEditor = ClassicEditor;

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/paste-plain-text.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/paste-plain-text.js
@@ -18,6 +18,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-clipboard/docs/features/paste-plain-text.md
+++ b/packages/ckeditor5-clipboard/docs/features/paste-plain-text.md
@@ -25,7 +25,7 @@ Copy some text from one of the styled paragraphs below and press <kbd>Ctrl</kbd>
 
 The plain text pasting feature is implemented by the `PastePlainText` plugin which is a part of the `Clipboard` plugin.
 
-It detects the <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>V</kbd> keystroke during the paste and causes the pasted text to inherit the styles of the content it was pasted into. In this sense, the feature can also be described as "pasting without formatting" &mdash; the source formatting of the pasted text gets replaced with the target formatting of the text it was pasted into.
+It detects the <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>V</kbd> keystroke during the paste and causes the pasted text to inherit the styles of the content it was pasted into. In this sense, the feature can also be described as "pasting without formatting" &ndash; the source formatting of the pasted text gets replaced with the target formatting of the text it was pasted into.
 
 Pasting plain text with a double line break will turn the break into a paragraph. A single line break will instead be turned into a soft break upon pasting.
 

--- a/packages/ckeditor5-code-block/docs/_snippets/features/build-code-block-source.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/build-code-block-source.js
@@ -7,13 +7,13 @@
 
 import { Code } from '@ckeditor/ckeditor5-basic-styles';
 import { CodeBlock } from '@ckeditor/ckeditor5-code-block';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
 import ClassicEditor from '../build-classic';
 
-ClassicEditor.builtinPlugins.push( CodeBlock, Code, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox );
+ClassicEditor.builtinPlugins.push( CodeBlock, Code, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox, CKBoxImageEdit );
 
 window.ClassicEditor = ClassicEditor;

--- a/packages/ckeditor5-code-block/docs/_snippets/features/code-block-custom-languages.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/code-block-custom-languages.js
@@ -18,6 +18,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-code-block/docs/_snippets/features/code-block.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/code-block.js
@@ -18,6 +18,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-find-and-replace/docs/_snippets/features/build-find-and-replace-source.js
+++ b/packages/ckeditor5-find-and-replace/docs/_snippets/features/build-find-and-replace-source.js
@@ -7,13 +7,13 @@
 
 import { Underline } from '@ckeditor/ckeditor5-basic-styles';
 import { FindAndReplace } from '@ckeditor/ckeditor5-find-and-replace';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
 import ClassicEditor from '../build-classic';
 
-ClassicEditor.builtinPlugins.push( FindAndReplace, Underline, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox );
+ClassicEditor.builtinPlugins.push( FindAndReplace, Underline, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox, CKBoxImageEdit );
 
 window.ClassicEditor = ClassicEditor;

--- a/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
+++ b/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
@@ -18,6 +18,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-font/docs/_snippets/features/build-font-source.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/build-font-source.js
@@ -6,13 +6,13 @@
 /* globals window */
 
 import { Font } from '@ckeditor/ckeditor5-font';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
 import ClassicEditor from '../build-classic';
 
-ClassicEditor.builtinPlugins.push( Font, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox );
+ClassicEditor.builtinPlugins.push( Font, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox, CKBoxImageEdit );
 
 window.ClassicEditor = ClassicEditor;

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
@@ -20,6 +20,12 @@ ClassicEditor
 			],
 			shouldNotGroupWhenFull: true
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-family-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-family-options.js
@@ -20,6 +20,12 @@ ClassicEditor
 			],
 			shouldNotGroupWhenFull: true
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-named-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-named-options.js
@@ -21,6 +21,12 @@ ClassicEditor
 			],
 			shouldNotGroupWhenFull: true
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-numeric-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-numeric-options.js
@@ -21,6 +21,12 @@ ClassicEditor
 			],
 			shouldNotGroupWhenFull: true
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-font/docs/_snippets/features/font.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/font.js
@@ -20,6 +20,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-highlight/docs/_snippets/features/build-highlight-source.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/build-highlight-source.js
@@ -6,13 +6,13 @@
 /* globals window */
 
 import { Highlight } from '@ckeditor/ckeditor5-highlight';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
 import ClassicEditor from '../build-classic';
 
-ClassicEditor.builtinPlugins.push( Highlight, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox );
+ClassicEditor.builtinPlugins.push( Highlight, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox, CKBoxImageEdit );
 
 window.ClassicEditor = ClassicEditor;

--- a/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-inline.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-inline.js
@@ -18,6 +18,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-variables.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-variables.js
@@ -18,6 +18,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-options.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-options.js
@@ -18,6 +18,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-highlight/docs/_snippets/features/highlight-buttons.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/highlight-buttons.js
@@ -19,6 +19,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-highlight/docs/_snippets/features/highlight.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/highlight.js
@@ -18,6 +18,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-html-support/docs/_snippets/features/full-page-html.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/full-page-html.js
@@ -36,7 +36,8 @@ ClassicEditor
 				'imageStyle:breakText',
 				'|',
 				'toggleImageCaption',
-				'imageTextAlternative'
+				'imageTextAlternative',
+				'ckboxImageEdit'
 			]
 		},
 		table: {

--- a/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support-source.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support-source.js
@@ -8,13 +8,12 @@
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 
 import { Code } from '@ckeditor/ckeditor5-basic-styles';
-import { EasyImage } from '@ckeditor/ckeditor5-easy-image';
 import { ImageUpload, PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { CloudServices } from '@ckeditor/ckeditor5-cloud-services';
 import { SourceEditing } from '@ckeditor/ckeditor5-source-editing';
 import { FullPage, GeneralHtmlSupport, HtmlComment } from '@ckeditor/ckeditor5-html-support';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
@@ -23,14 +22,14 @@ import ClassicEditor from '../build-classic';
 ClassicEditor.builtinPlugins.push(
 	CloudServices,
 	Code,
-	EasyImage,
 	ImageUpload,
 	SourceEditing,
 	PictureEditing,
 	ImageResize,
 	AutoImage,
 	LinkImage,
-	CKBox
+	CKBox,
+	CKBoxImageEdit
 );
 
 ClassicEditor.defaultConfig = {
@@ -41,6 +40,12 @@ ClassicEditor.defaultConfig = {
 			'|', 'bold', 'italic',
 			'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 			'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+		]
+	},
+	image: {
+		toolbar: [
+			'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+			'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 		]
 	},
 	ui: {

--- a/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support.js
@@ -35,7 +35,8 @@ ClassicEditor
 				'imageStyle:breakText',
 				'|',
 				'toggleImageCaption',
-				'imageTextAlternative'
+				'imageTextAlternative',
+				'ckboxImageEdit'
 			]
 		},
 		table: {

--- a/packages/ckeditor5-html-support/docs/_snippets/features/html-comment.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/html-comment.js
@@ -15,7 +15,8 @@ ClassicEditor
 				'imageStyle:breakText',
 				'|',
 				'toggleImageCaption',
-				'imageTextAlternative'
+				'imageTextAlternative',
+				'ckboxImageEdit'
 			]
 		},
 		table: {

--- a/packages/ckeditor5-indent/docs/_snippets/features/build-indent-source.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/build-indent-source.js
@@ -7,13 +7,13 @@
 
 import { Code } from '@ckeditor/ckeditor5-basic-styles';
 import { Indent, IndentBlock } from '@ckeditor/ckeditor5-indent';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
 import ClassicEditor from '../build-classic';
 
-ClassicEditor.builtinPlugins.push( Indent, IndentBlock, Code, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox );
+ClassicEditor.builtinPlugins.push( Indent, IndentBlock, Code, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox, CKBoxImageEdit );
 
 window.ClassicEditor = ClassicEditor;

--- a/packages/ckeditor5-indent/docs/_snippets/features/custom-indent-block-classes.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/custom-indent-block-classes.js
@@ -18,6 +18,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-indent/docs/_snippets/features/indent.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/indent.js
@@ -18,6 +18,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-language/docs/_snippets/features/textpartlanguage.js
+++ b/packages/ckeditor5-language/docs/_snippets/features/textpartlanguage.js
@@ -7,7 +7,7 @@
 
 import { Superscript } from '@ckeditor/ckeditor5-basic-styles';
 import { TextPartLanguage } from '@ckeditor/ckeditor5-language';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
@@ -15,7 +15,8 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
 import ClassicEditor from '../build-classic';
 
-ClassicEditor.builtinPlugins.push( TextPartLanguage, Superscript, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox );
+ClassicEditor.builtinPlugins.push( TextPartLanguage, Superscript, PictureEditing,
+	ImageResize, AutoImage, LinkImage, CKBox, CKBoxImageEdit );
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-text-part-language' ), {
@@ -36,6 +37,12 @@ ClassicEditor
 				'|', 'textPartLanguage',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-link/docs/_snippets/features/build-link-source.js
+++ b/packages/ckeditor5-link/docs/_snippets/features/build-link-source.js
@@ -6,14 +6,14 @@
 /* globals window */
 
 import { AutoLink, LinkImage } from '@ckeditor/ckeditor5-link';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
 import ClassicEditor from '../build-classic';
 
-window.CKEditorPlugins = { AutoLink, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox };
+window.CKEditorPlugins = { AutoLink, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox, CKBoxImageEdit };
 
 window.ClassicEditor = ClassicEditor;
 window.CS_CONFIG = CS_CONFIG;

--- a/packages/ckeditor5-link/docs/_snippets/features/link.js
+++ b/packages/ckeditor5-link/docs/_snippets/features/link.js
@@ -16,6 +16,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-link/docs/_snippets/features/link.js
+++ b/packages/ckeditor5-link/docs/_snippets/features/link.js
@@ -3,10 +3,11 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals console, window, document, ClassicEditor, CS_CONFIG */
+/* globals console, window, document, ClassicEditor, CKEditorPlugins, CS_CONFIG */
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-link' ), {
+		extraPlugins: [ ...Object.values( CKEditorPlugins ) ],
 		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [

--- a/packages/ckeditor5-link/docs/_snippets/features/linkdecorators.js
+++ b/packages/ckeditor5-link/docs/_snippets/features/linkdecorators.js
@@ -16,6 +16,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-link/docs/features/link.md
+++ b/packages/ckeditor5-link/docs/features/link.md
@@ -6,7 +6,7 @@ category: features
 
 {@snippet features/build-link-source}
 
-The link feature lets you insert hyperlinks into your content and provides a UI to create and edit them. Thanks to the [autolink](#autolink-feature) plugin, typed or pasted URLs and e-mail addresses automatically turn into working links.
+The link feature lets you insert hyperlinks into your content and provides a UI to create and edit them. Thanks to the [autolink](#autolink-feature) plugin, typed or pasted URLs and email addresses automatically turn into working links.
 
 ## Demo
 

--- a/packages/ckeditor5-list/docs/_snippets/features/todo-list.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/todo-list.js
@@ -7,11 +7,12 @@
 
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 import { TodoList } from '@ckeditor/ckeditor5-list';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
 import ClassicEditor from '../build-classic';
 
-ClassicEditor.builtinPlugins.push( TodoList );
+ClassicEditor.builtinPlugins.push( TodoList, CKBox, CKBoxImageEdit );
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-todo-list' ), {
@@ -22,6 +23,12 @@ ClassicEditor
 				'|', 'bold', 'italic',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 				'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
+			]
+		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-list/docs/_snippets/features/todo-list.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/todo-list.js
@@ -8,11 +8,12 @@
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 import { TodoList } from '@ckeditor/ckeditor5-list';
 import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
+import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
 import ClassicEditor from '../build-classic';
 
-ClassicEditor.builtinPlugins.push( TodoList, CKBox, CKBoxImageEdit );
+ClassicEditor.builtinPlugins.push( TodoList, CKBox, CKBoxImageEdit, PictureEditing, ImageResize, AutoImage );
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-todo-list' ), {

--- a/packages/ckeditor5-media-embed/docs/_snippets/features/build-media-source.js
+++ b/packages/ckeditor5-media-embed/docs/_snippets/features/build-media-source.js
@@ -6,13 +6,13 @@
 /* globals window */
 
 import { MediaEmbed } from '@ckeditor/ckeditor5-media-embed';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
 import ClassicEditor from '../build-classic';
 
-ClassicEditor.builtinPlugins.push( MediaEmbed, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox );
+ClassicEditor.builtinPlugins.push( MediaEmbed, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox, CKBoxImageEdit );
 
 window.ClassicEditor = ClassicEditor;

--- a/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed-preview.js
+++ b/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed-preview.js
@@ -20,6 +20,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed.js
+++ b/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed.js
@@ -18,6 +18,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-mention/docs/_snippets/features/build-mention-source.js
+++ b/packages/ckeditor5-mention/docs/_snippets/features/build-mention-source.js
@@ -6,13 +6,13 @@
 /* globals window */
 
 import { Mention } from '@ckeditor/ckeditor5-mention';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
 import ClassicEditor from '../build-classic';
 
-ClassicEditor.builtinPlugins.push( Mention, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox );
+ClassicEditor.builtinPlugins.push( Mention, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox, CKBoxImageEdit );
 
 window.ClassicEditor = ClassicEditor;

--- a/packages/ckeditor5-mention/docs/_snippets/features/custom-mention-colors-variables.js
+++ b/packages/ckeditor5-mention/docs/_snippets/features/custom-mention-colors-variables.js
@@ -18,6 +18,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-mention/docs/_snippets/features/mention-customization.js
+++ b/packages/ckeditor5-mention/docs/_snippets/features/mention-customization.js
@@ -19,6 +19,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-mention/docs/_snippets/features/mention.js
+++ b/packages/ckeditor5-mention/docs/_snippets/features/mention.js
@@ -18,6 +18,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-minimap/docs/_snippets/features/minimap.html
+++ b/packages/ckeditor5-minimap/docs/_snippets/features/minimap.html
@@ -1,3 +1,4 @@
+<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <div class="document-container">
 	<div id="toolbar-container" class="toolbar-container"></div>
 	<div class="minimap-wrapper">

--- a/packages/ckeditor5-minimap/docs/_snippets/features/minimap.js
+++ b/packages/ckeditor5-minimap/docs/_snippets/features/minimap.js
@@ -10,10 +10,10 @@ import { Subscript, Superscript } from '@ckeditor/ckeditor5-basic-styles';
 import { CloudServices } from '@ckeditor/ckeditor5-cloud-services';
 import { CodeBlock } from '@ckeditor/ckeditor5-code-block';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
-import { EasyImage } from '@ckeditor/ckeditor5-easy-image';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { DecoupledEditor } from '@ckeditor/ckeditor5-editor-decoupled';
 import { FontBackgroundColor, FontColor, FontFamily, FontSize } from '@ckeditor/ckeditor5-font';
-import { ImageResize, ImageUpload } from '@ckeditor/ckeditor5-image';
+import { PictureEditing, ImageResize, ImageUpload } from '@ckeditor/ckeditor5-image';
 import { IndentBlock } from '@ckeditor/ckeditor5-indent';
 import { PageBreak } from '@ckeditor/ckeditor5-page-break';
 import { TableCellProperties, TableProperties } from '@ckeditor/ckeditor5-table';
@@ -41,7 +41,9 @@ const config = {
 		PageBreak,
 		CodeBlock,
 		Minimap,
-		EasyImage
+		PictureEditing,
+		CKBox,
+		CKBoxImageEdit
 	],
 	toolbar: [
 		'undo', 'redo', '|', 'heading',
@@ -56,7 +58,8 @@ const config = {
 			'imageStyle:side',
 			'|',
 			'imageTextAlternative',
-			'toggleImageCaption'
+			'toggleImageCaption',
+			'ckboxImageEdit'
 		],
 		styles: [
 			'inline',

--- a/packages/ckeditor5-remove-format/docs/_snippets/features/build-remove-format-source.js
+++ b/packages/ckeditor5-remove-format/docs/_snippets/features/build-remove-format-source.js
@@ -9,7 +9,7 @@ import { Bold, Italic, Code, Strikethrough, Underline, Subscript, Superscript } 
 import { RemoveFormat } from '@ckeditor/ckeditor5-remove-format';
 import { Alignment } from '@ckeditor/ckeditor5-alignment';
 import { Font } from '@ckeditor/ckeditor5-font';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 
@@ -31,6 +31,7 @@ ClassicEditor.builtinPlugins.push(
 	ImageResize,
 	AutoImage,
 	LinkImage,
-	CKBox );
+	CKBox,
+	CKBoxImageEdit );
 
 window.ClassicEditor = ClassicEditor;

--- a/packages/ckeditor5-remove-format/docs/_snippets/features/remove-format.js
+++ b/packages/ckeditor5-remove-format/docs/_snippets/features/remove-format.js
@@ -22,6 +22,12 @@ ClassicEditor
 			],
 			shouldNotGroupWhenFull: true
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-restricted-editing/docs/_snippets/features/restricted-editing.js
+++ b/packages/ckeditor5-restricted-editing/docs/_snippets/features/restricted-editing.js
@@ -7,7 +7,7 @@
 
 import { StandardEditingMode, RestrictedEditingMode } from '@ckeditor/ckeditor5-restricted-editing';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
@@ -23,7 +23,8 @@ ClassicEditor.builtinPlugins.push(
 	ImageResize,
 	AutoImage,
 	LinkImage,
-	CKBox );
+	CKBox,
+	CKBoxImageEdit );
 
 const restrictedModeButton = document.getElementById( 'mode-restricted' );
 const standardModeButton = document.getElementById( 'mode-standard' );
@@ -64,6 +65,12 @@ async function startStandardEditingMode() {
 				'mergeTableCells'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()
@@ -78,6 +85,12 @@ async function startRestrictedEditingMode() {
 		removePlugins: [ 'StandardEditingMode' ],
 		cloudServices: CS_CONFIG,
 		toolbar: [ 'restrictedEditing', '|', 'bold', 'italic', 'link', '|', 'undo', 'redo' ],
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-select-all/docs/_snippets/features/build-select-all-source.js
+++ b/packages/ckeditor5-select-all/docs/_snippets/features/build-select-all-source.js
@@ -6,13 +6,13 @@
 /* globals window */
 
 import { Underline } from '@ckeditor/ckeditor5-basic-styles';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
 import ClassicEditor from '../build-classic';
 
-ClassicEditor.builtinPlugins.push( Underline, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox );
+ClassicEditor.builtinPlugins.push( Underline, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox, CKBoxImageEdit );
 
 window.ClassicEditor = ClassicEditor;

--- a/packages/ckeditor5-select-all/docs/_snippets/features/select-all.js
+++ b/packages/ckeditor5-select-all/docs/_snippets/features/select-all.js
@@ -18,6 +18,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-show-blocks/docs/_snippets/features/show-blocks.js
+++ b/packages/ckeditor5-show-blocks/docs/_snippets/features/show-blocks.js
@@ -12,10 +12,10 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 import { GeneralHtmlSupport } from '@ckeditor/ckeditor5-html-support';
 import { ShowBlocks } from '@ckeditor/ckeditor5-show-blocks';
 import { SourceEditing } from '@ckeditor/ckeditor5-source-editing';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing } from '@ckeditor/ckeditor5-image';
 
-ClassicEditor.builtinPlugins.push( ShowBlocks, GeneralHtmlSupport, SourceEditing, CKBox, PictureEditing );
+ClassicEditor.builtinPlugins.push( ShowBlocks, GeneralHtmlSupport, SourceEditing, CKBox, CKBoxImageEdit, PictureEditing );
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-show-blocks' ), {
@@ -29,6 +29,12 @@ ClassicEditor
 				'|', 'bold', 'italic',
 				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
+			]
+		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
 		ui: {

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.html
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.html
@@ -1,3 +1,4 @@
+<script src="https://cdn.ckbox.io/ckbox/latest/ckbox.js"></script>
 <textarea class="ck ck-content" id="snippet-styles">
 	<h3 class="category">
 		Opinions

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.js
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.js
@@ -11,19 +11,19 @@ import { Code, Strikethrough } from '@ckeditor/ckeditor5-basic-styles';
 import { CloudServices } from '@ckeditor/ckeditor5-cloud-services';
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 import { CodeBlock } from '@ckeditor/ckeditor5-code-block';
-import { EasyImage } from '@ckeditor/ckeditor5-easy-image';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 import { Highlight } from '@ckeditor/ckeditor5-highlight';
 import { HorizontalLine } from '@ckeditor/ckeditor5-horizontal-line';
 import { GeneralHtmlSupport } from '@ckeditor/ckeditor5-html-support';
-import { Image, ImageCaption, ImageResize, ImageStyle, ImageToolbar, ImageUpload } from '@ckeditor/ckeditor5-image';
+import { PictureEditing, Image, ImageCaption, ImageResize, ImageStyle, ImageToolbar, ImageUpload } from '@ckeditor/ckeditor5-image';
 import { Style } from '@ckeditor/ckeditor5-style';
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-styles' ), {
 		plugins: [
-			ArticlePluginSet, CloudServices, EasyImage,
-			Image, ImageCaption, ImageResize, ImageStyle, ImageToolbar, ImageUpload,
+			ArticlePluginSet, CloudServices, CKBox, CKBoxImageEdit,
+			PictureEditing, Image, ImageCaption, ImageResize, ImageStyle, ImageToolbar, ImageUpload,
 			Code, CodeBlock, Strikethrough, HorizontalLine, GeneralHtmlSupport, Style, Highlight
 		],
 		toolbar: {
@@ -88,7 +88,10 @@ ClassicEditor
 			]
 		},
 		image: {
-			toolbar: [ 'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|', 'toggleImageCaption', 'imageTextAlternative' ]
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
 		},
 		codeBlock: {
 			languages: [

--- a/packages/ckeditor5-typing/docs/_snippets/features/build-text-transformation-source.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/build-text-transformation-source.js
@@ -6,13 +6,13 @@
 /* globals window */
 
 import { TextTransformation } from '@ckeditor/ckeditor5-typing';
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import { LinkImage } from '@ckeditor/ckeditor5-link';
 
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
 import ClassicEditor from '../build-classic';
 
-ClassicEditor.builtinPlugins.push( TextTransformation, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox );
+ClassicEditor.builtinPlugins.push( TextTransformation, PictureEditing, ImageResize, AutoImage, LinkImage, CKBox, CKBoxImageEdit );
 
 window.ClassicEditor = ClassicEditor;

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.js
@@ -19,6 +19,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
@@ -19,6 +19,12 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+			]
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: adding missing image toolbars. Part of https://github.com/ckeditor/ckeditor5/issues/15284

---

### Additional information

_Link demo - the code is pushed but still throws an error about missing component._

_Editor placeholder demo was not updated due to technical problem._
