### PR TITLE
Add pending action when image is being processed

### DIFF
--- a/packages/ckeditor5-ckbox/lang/contexts.json
+++ b/packages/ckeditor5-ckbox/lang/contexts.json
@@ -3,5 +3,5 @@
   "Cannot determine a category for the uploaded file.": "A message is displayed when CKEditor 5 cannot associate an image with any of the categories defined in CKBox while uploading an asset.",
   "Cannot access default workspace.": "A message is displayed when the user is not authorised to access the CKBox workspace configured as default one.",
   "Edit image": "Image toolbar button tooltip for opening a dialog to manipulate the image.",
-  "Processing the edited image.": "A message that image editing is in progress."
+  "Processing the edited image.": "A message stating that image editing is in progress."
 }

--- a/packages/ckeditor5-ckbox/lang/contexts.json
+++ b/packages/ckeditor5-ckbox/lang/contexts.json
@@ -3,5 +3,5 @@
   "Cannot determine a category for the uploaded file.": "A message is displayed when CKEditor 5 cannot associate an image with any of the categories defined in CKBox while uploading an asset.",
   "Cannot access default workspace.": "A message is displayed when the user is not authorised to access the CKBox workspace configured as default one.",
   "Edit image": "Image toolbar button tooltip for opening a dialog to manipulate the image.",
-  "Edited image is processing.": "A message that a file upload is in progress."
+  "Processing the edited image.": "A message that a image editing is in progress."
 }

--- a/packages/ckeditor5-ckbox/lang/contexts.json
+++ b/packages/ckeditor5-ckbox/lang/contexts.json
@@ -2,5 +2,6 @@
   "Open file manager": "A toolbar button tooltip for opening the file browser that allows inserting an image or a file to the editor.",
   "Cannot determine a category for the uploaded file.": "A message is displayed when CKEditor 5 cannot associate an image with any of the categories defined in CKBox while uploading an asset.",
   "Cannot access default workspace.": "A message is displayed when the user is not authorised to access the CKBox workspace configured as default one.",
-  "Edit image": "Image toolbar button tooltip for opening a dialog to manipulate the image."
+  "Edit image": "Image toolbar button tooltip for opening a dialog to manipulate the image.",
+  "Edited image is processing.": "A message is displayed when user try to close page while image is not processed yet on server."
 }

--- a/packages/ckeditor5-ckbox/lang/contexts.json
+++ b/packages/ckeditor5-ckbox/lang/contexts.json
@@ -3,5 +3,5 @@
   "Cannot determine a category for the uploaded file.": "A message is displayed when CKEditor 5 cannot associate an image with any of the categories defined in CKBox while uploading an asset.",
   "Cannot access default workspace.": "A message is displayed when the user is not authorised to access the CKBox workspace configured as default one.",
   "Edit image": "Image toolbar button tooltip for opening a dialog to manipulate the image.",
-  "Edited image is processing.": "A message is displayed when user try to close page while image is not processed yet on server."
+  "Edited image is processing.": "A message that a file upload is in progress."
 }

--- a/packages/ckeditor5-ckbox/lang/contexts.json
+++ b/packages/ckeditor5-ckbox/lang/contexts.json
@@ -3,5 +3,5 @@
   "Cannot determine a category for the uploaded file.": "A message is displayed when CKEditor 5 cannot associate an image with any of the categories defined in CKBox while uploading an asset.",
   "Cannot access default workspace.": "A message is displayed when the user is not authorised to access the CKBox workspace configured as default one.",
   "Edit image": "Image toolbar button tooltip for opening a dialog to manipulate the image.",
-  "Processing the edited image.": "A message that a image editing is in progress."
+  "Processing the edited image.": "A message that image editing is in progress."
 }

--- a/packages/ckeditor5-ckbox/package.json
+++ b/packages/ckeditor5-ckbox/package.json
@@ -16,6 +16,7 @@
     "blurhash": "^2.0.5"
   },
   "devDependencies": {
+    "@ckeditor/ckeditor5-autosave": "40.0.0",
     "@ckeditor/ckeditor5-basic-styles": "40.0.0",
     "@ckeditor/ckeditor5-core": "40.0.0",
     "@ckeditor/ckeditor5-clipboard": "40.0.0",

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
@@ -9,7 +9,7 @@
  * @module ckbox/ckboximageedit/ckboximageeditcommand
  */
 
-import { Command, type Editor } from 'ckeditor5/src/core';
+import { Command, PendingActions, type Editor } from 'ckeditor5/src/core';
 import { createElement, global, retry } from 'ckeditor5/src/utils';
 import CKBoxEditing from '../ckboxediting';
 
@@ -223,10 +223,16 @@ export default class CKBoxImageEditCommand extends Command {
 	 * @param asset Data about certain asset.
 	 */
 	private async _waitForAssetProcessed( asset: CKBoxRawAssetDefinition ): Promise<CKBoxRawAssetDataDefinition | undefined> {
+		const t = this.editor.locale.t;
+		const pendingActions = this.editor.plugins.get( PendingActions );
+		const action = pendingActions.add( t( 'Edited image is processing.' ) );
+
 		try {
 			return await retry( () => this._getAssetStatusFromServer( asset.data ) );
 		} catch ( err ) {
 			// TODO: Handle error;
+		} finally {
+			pendingActions.remove( action );
 		}
 	}
 }

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
@@ -225,7 +225,7 @@ export default class CKBoxImageEditCommand extends Command {
 	private async _waitForAssetProcessed( asset: CKBoxRawAssetDefinition ): Promise<CKBoxRawAssetDataDefinition | undefined> {
 		const t = this.editor.locale.t;
 		const pendingActions = this.editor.plugins.get( PendingActions );
-		const action = pendingActions.add( t( 'Edited image is processing.' ) );
+		const action = pendingActions.add( t( 'Processing the edited image.' ) );
 
 		try {
 			return await retry( () => this._getAssetStatusFromServer( asset.data ) );

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditediting.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditediting.ts
@@ -7,7 +7,7 @@
  * @module ckbox/ckboximageedit/ckboximageeditediting
  */
 
-import { Plugin } from 'ckeditor5/src/core';
+import { PendingActions, Plugin } from 'ckeditor5/src/core';
 import CKBoxImageEditCommand from './ckboximageeditcommand';
 
 /**
@@ -19,6 +19,13 @@ export default class CKBoxImageEditEditing extends Plugin {
 	 */
 	public static get pluginName() {
 		return 'CKBoxImageEditEditing' as const;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public static get requires() {
+		return [ PendingActions ] as const;
 	}
 
 	/**

--- a/packages/ckeditor5-ckbox/tests/manual/ckbox.js
+++ b/packages/ckeditor5-ckbox/tests/manual/ckbox.js
@@ -13,6 +13,7 @@ import LinkImageEditing from '@ckeditor/ckeditor5-link/src/linkimageediting';
 import PictureEditing from '@ckeditor/ckeditor5-image/src/pictureediting';
 import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices';
 import LinkImage from '@ckeditor/ckeditor5-link/src/linkimage';
+import AutoSave from '@ckeditor/ckeditor5-autosave/src/autosave';
 import { TOKEN_URL } from '../_utils/ckbox-config';
 import CKBox from '../../src/ckbox';
 import CKBoxImageEdit from '../../src/ckboximageedit';
@@ -21,7 +22,7 @@ ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [
 			ArticlePluginSet, PictureEditing, ImageUpload, LinkImageEditing,
-			ImageInsert, CloudServices, CKBox, LinkImage, CKBoxImageEdit
+			ImageInsert, CloudServices, CKBox, LinkImage, CKBoxImageEdit, AutoSave
 		],
 		toolbar: [
 			'heading',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ckbox): Should not allow leave page in case edited image is processed on server . Closes [#5700](https://github.com/cksource/ckeditor5-commercial/issues/5700).

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
