### PR TITLE
Properly display editor widgets next to floated objects.

### DIFF
--- a/packages/ckeditor5-horizontal-line/theme/horizontalline.css
+++ b/packages/ckeditor5-horizontal-line/theme/horizontalline.css
@@ -4,11 +4,6 @@
  */
 
 
-.ck-editor__editable .ck-horizontal-line {
-	/* Necessary to render properly next to floated objects, e.g. side image case. */
-	display: flow-root;
-}
-
 .ck-content hr {
 	margin: 15px 0;
 	height: 4px;

--- a/packages/ckeditor5-html-embed/theme/htmlembed.css
+++ b/packages/ckeditor5-html-embed/theme/htmlembed.css
@@ -10,7 +10,6 @@
 	to avoid the content jumping (See https://github.com/ckeditor/ckeditor5/issues/9825). */
 	margin: 0.9em auto;
 	position: relative;
-	display: flow-root;
 
 	/* Give the html embed some minimal width in the content to prevent them
 	from being "squashed" in tight spaces, e.g. in table cells (https://github.com/ckeditor/ckeditor5/issues/8331) */

--- a/packages/ckeditor5-widget/theme/widget.css
+++ b/packages/ckeditor5-widget/theme/widget.css
@@ -89,3 +89,8 @@
 		transform: translate(-50%);
 	}
 }
+
+.ck-editor__editable .ck-widget {
+	/* Necessary to render properly next to floated objects, e.g. side image case. */
+	display: flow-root;
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix(widget): Should properly display editor widgets next to side align elements. Closes https://github.com/cksource/ckeditor5-commercial/issues/5703.

---

### Additional information

Tested with widgets:

<img width="865" alt="Screenshot 2023-11-13 at 08 24 09" src="https://github.com/ckeditor/ckeditor5/assets/7074833/a976d0a4-bad8-450b-b298-de19ea317f15">

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
