### PR TITLE
I/14911 PoC for supporting multiple tbody elements in tables

### DIFF
--- a/packages/ckeditor5-table/src/converters/downcast.ts
+++ b/packages/ckeditor5-table/src/converters/downcast.ts
@@ -35,30 +35,9 @@ export function downcastTable( tableUtils: TableUtils, options: DowncastTableOpt
 			);
 		}
 
-		// Group rows.
-		const tableRowElements = Array.from( table.getChildren() )
-			.filter( child => child.is( 'element', 'tableRow' ) && child.index! >= headingRows );
-		const rowGroupMap = new Map();
-		let currentGroup = 0;
-
-		tableRowElements.forEach( trElement => {
-			// Ensure a rowGroup exists.
-			// This is a workaround / idea - currently if a row is inserted, it won't have the rowGroup attribute.
-			// Currently just putting it into the previous row group, although this won't always be intentional.
-			// If this approach to row groups in general is accepted this could be resolved in tableUtils.insertRows by
-			// copying the rewGroup from the row used as reference.
-			currentGroup = trElement.hasAttribute( 'rowGroup' ) ? Number( trElement.getAttribute( 'rowGroup' ) ) : currentGroup;
-			trElement._setAttribute( 'rowGroup', currentGroup );
-
-			if ( !rowGroupMap.has( currentGroup ) ) {
-				rowGroupMap.set( currentGroup, [] );
-			}
-
-			rowGroupMap.get( currentGroup ).push( trElement );
-		} );
-
 		// Table body slots.
 		if ( headingRows < tableUtils.getRows( table ) ) {
+			const rowGroupMap = tableUtils.getGroupedRows( table );
 			for ( const key of rowGroupMap.keys() ) {
 				writer.insert(
 					writer.createPositionAt( tableElement, 'end' ),

--- a/packages/ckeditor5-table/src/converters/downcast.ts
+++ b/packages/ckeditor5-table/src/converters/downcast.ts
@@ -136,7 +136,9 @@ export function downcastCell( options: { asWidget?: boolean } = {} ): ElementCre
 		// We need to iterate over a table in order to get proper row & column values from a walker.
 		for ( const tableSlot of tableWalker ) {
 			if ( tableSlot.cell == tableCell ) {
-				const isHeading = tableSlot.row < headingRows || tableSlot.column < headingColumns;
+				const isHeading = tableSlot.row < headingRows ||
+					tableSlot.column < headingColumns ||
+					tableCell.getAttribute( 'role' ) == 'heading';
 				const cellElementName = isHeading ? 'th' : 'td';
 
 				result = options.asWidget ?

--- a/packages/ckeditor5-table/src/converters/upcasttable.ts
+++ b/packages/ckeditor5-table/src/converters/upcasttable.ts
@@ -223,7 +223,7 @@ function scanTable( viewTable: ViewElement ) {
 	// Only the first <thead> from the view will be used as a heading row and the others will be converted to body rows.
 	let firstTheadElement;
 
-	for ( const tableChild of Array.from( viewTable.getChildren() as IterableIterator<ViewElement> ) ) {
+	for ( const [ index, tableChild ] of Array.from( viewTable.getChildren() as IterableIterator<ViewElement> ).entries() ) {
 		// Only `<thead>`, `<tbody>` & `<tfoot>` from allowed table children can have `<tr>`s.
 		// The else is for future purposes (mainly `<caption>`).
 		if ( tableChild.name !== 'tbody' && tableChild.name !== 'thead' && tableChild.name !== 'tfoot' ) {
@@ -242,6 +242,8 @@ function scanTable( viewTable: ViewElement ) {
 		);
 
 		for ( const tr of trs ) {
+			// Set a custom attribute of rowGroup to allow multiple tbody elements.
+			tr._setCustomProperty( 'rowGroup', index );
 			// This <tr> is a child of a first <thead> element.
 			if (
 				( firstTheadElement && tableChild === firstTheadElement ) ||

--- a/packages/ckeditor5-table/src/tableediting.ts
+++ b/packages/ckeditor5-table/src/tableediting.ts
@@ -84,6 +84,7 @@ export default class TableEditing extends Plugin {
 
 		schema.register( 'tableRow', {
 			allowIn: 'table',
+			allowAttributes: [ 'rowGroup' ],
 			isLimit: true
 		} );
 
@@ -122,7 +123,12 @@ export default class TableEditing extends Plugin {
 		} );
 
 		// Table row conversion.
-		conversion.for( 'upcast' ).elementToElement( { model: 'tableRow', view: 'tr' } );
+		conversion.for( 'upcast' ).elementToElement( {
+			view: 'tr',
+			model: ( viewElement, { writer } ) => {
+				return writer.createElement( 'tableRow', { rowGroup: viewElement.getCustomProperty( 'rowGroup' ) } );
+			}
+		} );
 		conversion.for( 'upcast' ).add( skipEmptyTableRow() );
 
 		conversion.for( 'downcast' ).elementToElement( {

--- a/packages/ckeditor5-table/src/tableediting.ts
+++ b/packages/ckeditor5-table/src/tableediting.ts
@@ -91,7 +91,7 @@ export default class TableEditing extends Plugin {
 		schema.register( 'tableCell', {
 			allowContentOf: '$container',
 			allowIn: 'tableRow',
-			allowAttributes: [ 'colspan', 'rowspan' ],
+			allowAttributes: [ 'colspan', 'rowspan', 'role' ],
 			isLimit: true,
 			isSelectable: true
 		} );
@@ -137,8 +137,16 @@ export default class TableEditing extends Plugin {
 		} );
 
 		// Table cell conversion.
-		conversion.for( 'upcast' ).elementToElement( { model: 'tableCell', view: 'td' } );
-		conversion.for( 'upcast' ).elementToElement( { model: 'tableCell', view: 'th' } );
+		conversion.for( 'upcast' ).elementToElement( {
+			model: ( viewElement, { writer } ) => {
+				return writer.createElement( 'tableCell', { role: 'data' } );
+			}, view: 'td'
+		} );
+		conversion.for( 'upcast' ).elementToElement( {
+			model: ( viewElement, { writer } ) => {
+				return writer.createElement( 'tableCell', { role: 'heading' } );
+			}, view: 'th'
+		} );
 		conversion.for( 'upcast' ).add( ensureParagraphInTableCell( 'td' ) );
 		conversion.for( 'upcast' ).add( ensureParagraphInTableCell( 'th' ) );
 

--- a/packages/ckeditor5-table/src/tableutils.ts
+++ b/packages/ckeditor5-table/src/tableutils.ts
@@ -822,6 +822,41 @@ export default class TableUtils extends Plugin {
 	}
 
 	/**
+	 * Returns the rows for a given table grouped by their rowGroup attribute.
+	 *
+	 * ```ts
+	 * editor.plugins.get( 'TableUtils' ).getGroupedRows( table );
+	 * ```
+	 *
+	 * @param table The table to analyze.
+	 */
+	public getGroupedRows( table: Element ): Map<number, Array<Element>> {
+		const headingRows = table.getAttribute( 'headingRows' ) || 0;
+		const tableRowElements = Array.from( table.getChildren() )
+			.filter( child => child.is( 'element', 'tableRow' ) && child.index! >= headingRows );
+		const rowGroupMap = new Map();
+		let currentGroup = 0;
+
+		tableRowElements.forEach( trElement => {
+			// Ensure a rowGroup exists.
+			// This is a workaround / idea - currently if a row is inserted, it won't have the rowGroup attribute.
+			// Currently just putting it into the previous row group, although this won't always be intentional.
+			// If this approach to row groups in general is accepted this could be resolved in tableUtils.insertRows by
+			// copying the rewGroup from the row used as reference.
+			currentGroup = trElement.hasAttribute( 'rowGroup' ) ? Number( trElement.getAttribute( 'rowGroup' ) ) : currentGroup;
+			trElement._setAttribute( 'rowGroup', currentGroup );
+
+			if ( !rowGroupMap.has( currentGroup ) ) {
+				rowGroupMap.set( currentGroup, [] );
+			}
+
+			rowGroupMap.get( currentGroup ).push( trElement );
+		} );
+
+		return rowGroupMap;
+	}
+
+	/**
 	 * Creates an instance of the table walker.
 	 *
 	 * The table walker iterates internally by traversing the table from row index = 0 and column index = 0.

--- a/packages/ckeditor5-table/tests/manual/tickets/14911.html
+++ b/packages/ckeditor5-table/tests/manual/tickets/14911.html
@@ -1,0 +1,62 @@
+<div id="editor">
+	<table>
+		<thead>
+		<tr>
+			<th scope="col">Col Header 1</th>
+			<th scope="col">Col Header 2</th>
+			<th scope="col">Col Header 3</th>
+		</tr>
+		</thead>
+		<tbody>
+		<tr>
+			<th scope="rowgroup">Rowgroup Header 1</th>
+			<td></td>
+			<td></td>
+		</tr>
+		<tr>
+			<th scope="row">Row Header 1</th>
+			<th scope="row">Row Subheader 1</th>
+			<td>Data 1,1</td>
+		</tr>
+		</tbody>
+		<tbody>
+		<tr>
+			<th scope="row">Row Header 2</th>
+			<th scope="row">Row Subheader 2</th>
+			<td>Data 1,2</td>
+		</tr>
+		<tr>
+			<th scope="row">Row Header 3</th>
+			<th scope="row">Row Subheader 3</th>
+			<td>Data 1,3</td>
+		</tr>
+		</tbody>
+		<tbody>
+		<tr>
+			<th scope="rowgroup">Rowgroup Header 2</th>
+			<td></td>
+			<td></td>
+		</tr>
+		<tr>
+			<th scope="row">Row Header 4</th>
+			<th scope="row">Row Subheader 4</th>
+			<td>Data 1,4</td>
+		</tr>
+		</tbody>
+	</table>
+</div>
+
+<style>
+	.editor-output {
+		margin-top: 30px;
+	}
+
+	#editor-data {
+		width: 100%;
+	}
+</style>
+
+<div class="editor-output">
+	<h5>Editor data</h5>
+	<pre id="editor-data" rows="20"></pre>
+</div>

--- a/packages/ckeditor5-table/tests/manual/tickets/14911.js
+++ b/packages/ckeditor5-table/tests/manual/tickets/14911.js
@@ -1,0 +1,59 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console, document, window */
+
+import { formatHtml } from '@ckeditor/ckeditor5-source-editing/src/utils/formathtml';
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+import GeneralHtmlSupport from '@ckeditor/ckeditor5-html-support/src/generalhtmlsupport';
+import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		image: { toolbar: [ 'toggleImageCaption', 'imageTextAlternative' ] },
+		plugins: [ ArticlePluginSet, GeneralHtmlSupport, SourceEditing ],
+		toolbar: [
+			'heading',
+			'|',
+			'insertTable',
+			'|',
+			'bold',
+			'italic',
+			'bulletedList',
+			'numberedList',
+			'blockQuote',
+			'undo',
+			'redo',
+			'sourceEditing'
+		],
+		table: {
+			contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ],
+			tableToolbar: [ 'bold', 'italic' ]
+		},
+		htmlSupport: {
+			allow: [
+				{
+					name: /^(table|tbody|thead|tr|td|th|caption)$/,
+					attributes: true,
+					classes: true,
+					styles: true
+				}
+			]
+		}
+	} )
+	.then( editor => {
+		window.editor = editor;
+
+		const element = document.getElementById( 'editor-data' );
+		element.innerText = formatHtml( editor.getData() );
+
+		editor.model.document.on( 'change:data', () => {
+			element.innerText = formatHtml( editor.getData() );
+		} );
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-table/tests/manual/tickets/14911.md
+++ b/packages/ckeditor5-table/tests/manual/tickets/14911.md
@@ -1,0 +1,7 @@
+# Ticket test: [#14911](https://github.com/ckeditor/ckeditor5/issues/14911)
+
+This is a work in progress to get feedback on a potential approach for [#14911](https://github.com/ckeditor/ckeditor5/issues/14911)
+
+This uses the example table `Table 3` from the issue and currently only focuses
+on allowing multiple tbody elements.
+


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix: Retain multiple tbody elements in table. Closes #14911.

---

### Additional information

This is a Proof of Concept / idea for retaining / supporting multiple `tbody` elements inside a table.

This is just one of the issues detailed in #14911 

Currently markup from Table 3 from the issue is included in manual test http://localhost:8125/ckeditor5-table/tests/manual/tickets/14911.html