### PR TITLE
Image caption should stay after image editing

### DIFF
--- a/packages/ckeditor5-ckbox/package.json
+++ b/packages/ckeditor5-ckbox/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "src/index.ts",
   "dependencies": {
-    "ckeditor5": "40.0.0",
+    "ckeditor5": "40.1.0",
     "blurhash": "^2.0.5",
     "lodash-es": "4.17.21"
   },

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
@@ -315,7 +315,13 @@ export default class CKBoxImageEditCommand extends Command {
 				}
 			} );
 
+			const previousChildren = element.getChildren();
+
 			element = editor.model.document.selection.getSelectedElement()!;
+
+			for ( const child of previousChildren ) {
+				writer.append( child, element );
+			}
 
 			writer.setAttribute( 'ckboxImageId', asset.data.id, element );
 

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
@@ -626,6 +626,44 @@ describe( 'CKBoxImageEditCommand', () => {
 					} );
 			} );
 
+			it( 'should keep caption after image replace', () => {
+				editor.model.schema.register( 'caption', {
+					allowIn: 'imageBlock',
+					allowContentOf: '$block',
+					isLimit: true
+				} );
+
+				editor.conversion.elementToElement( {
+					view: 'caption',
+					model: 'caption'
+				} );
+
+				setModelData( model, '[<imageBlock ' +
+						'alt="alt text" ckboxImageId="example-id" height="50" src="/assets/sample.png" width="50">' +
+							'<caption>' +
+								'caption' +
+							'</caption>' +
+					'</imageBlock>]' );
+
+				const imageElement = editor.model.document.selection.getSelectedElement();
+
+				command._replaceImage( imageElement, dataMock );
+
+				expect( getModelData( model ) ).to.equal(
+					'[<imageBlock ' +
+						'alt="alt text" ' +
+						'ckboxImageId="image-id1" ' +
+						'height="100" ' +
+						'sources="[object Object]" ' +
+						'src="https://example.com/workspace1/assets/image-id1/images/100.png" ' +
+						'width="100">' +
+							'<caption>' +
+								'caption' +
+							'</caption>' +
+					'</imageBlock>]'
+				);
+			} );
+
 			it( 'should not replace image with saved one before it is processed', () => {
 				const modelData =
 					'[<imageBlock ' +
@@ -635,7 +673,7 @@ describe( 'CKBoxImageEditCommand', () => {
 
 				setModelData( model, modelData );
 
-				command.fire( 'ckboxImageEditor:save', dataMock );
+				command.execute();
 
 				expect( getModelData( model ) ).to.equal( modelData );
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ckbox): Image caption should stay after image editing. Closes [#5686](https://github.com/cksource/ckeditor5-commercial/issues/5686).

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
