### PR TITLE
Simplified focus cycling in dialogs

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
@@ -12,9 +12,7 @@ import {
 	Dialog,
 	ButtonView,
 	CssTransitionDisablerMixin,
-	type ViewWithCssTransitionDisabler,
-	type FocusCyclerForwardCycleEvent,
-	type FocusCyclerBackwardCycleEvent
+	type ViewWithCssTransitionDisabler
 } from 'ckeditor5/src/ui';
 import FindAndReplaceFormView from './ui/findandreplaceformview';
 
@@ -126,7 +124,6 @@ export default class FindAndReplaceUI extends Plugin {
 		const findAndReplaceEditing: FindAndReplaceEditing = this.editor.plugins.get( 'FindAndReplaceEditing' );
 		const editingState = findAndReplaceEditing.state!;
 		const sortMapping = { before: -1, same: 0, after: 1, different: 1 };
-		const dialog = this.editor.plugins.get( 'Dialog' );
 
 		// Let the form know which result is being highlighted.
 		formView.bind( 'highlightOffset' ).to( editingState, 'highlightedResult', highlightedResult => {
@@ -168,16 +165,6 @@ export default class FindAndReplaceUI extends Plugin {
 			if ( isDirty ) {
 				this.fire( 'searchReseted' );
 			}
-		} );
-
-		formView.focusCycler.on<FocusCyclerForwardCycleEvent>( 'forwardCycle', evt => {
-			dialog.view.focusNext();
-			evt.stop();
-		} );
-
-		formView.focusCycler.on<FocusCyclerBackwardCycleEvent>( 'backwardCycle', evt => {
-			dialog.view.focusPrevious();
-			evt.stop();
 		} );
 	}
 }

--- a/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.ts
+++ b/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.ts
@@ -343,24 +343,14 @@ export default class FindAndReplaceFormView extends View {
 	}
 
 	/**
-	 * Focuses the fist {@link #_focusables} in the form.
+	 * @inheritDoc
 	 */
-	public focus(): void {
-		this.focusFirst();
-	}
-
-	/**
-	 * TODO
-	 */
-	public focusFirst(): void {
-		this.focusCycler.focusFirst();
-	}
-
-	/**
-	 * TODO
-	 */
-	public focusLast(): void {
-		this.focusCycler.focusLast();
+	public focus( direction?: 1 | -1 ): void {
+		if ( direction === -1 ) {
+			this.focusCycler.focusLast();
+		} else {
+			this.focusCycler.focusFirst();
+		}
 	}
 
 	/**

--- a/packages/ckeditor5-media-embed/src/mediaembedui.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedui.ts
@@ -12,8 +12,6 @@ import {
 	ButtonView,
 	CssTransitionDisablerMixin,
 	Dialog,
-	type FocusCyclerBackwardCycleEvent,
-	type FocusCyclerForwardCycleEvent,
 	type ViewWithCssTransitionDisabler
 } from 'ckeditor5/src/ui';
 
@@ -143,16 +141,6 @@ export default class MediaEmbedUI extends Plugin {
 
 		// Form elements should be read-only when corresponding commands are disabled.
 		form.urlInputView.bind( 'isEnabled' ).to( command, 'isEnabled' );
-
-		form.focusCycler.on<FocusCyclerForwardCycleEvent>( 'forwardCycle', evt => {
-			dialog.view.focusNext();
-			evt.stop();
-		} );
-
-		form.focusCycler.on<FocusCyclerBackwardCycleEvent>( 'backwardCycle', evt => {
-			dialog.view.focusPrevious();
-			evt.stop();
-		} );
 	}
 }
 

--- a/packages/ckeditor5-special-characters/src/specialcharacters.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharacters.ts
@@ -11,9 +11,7 @@ import { Plugin, type Editor } from 'ckeditor5/src/core';
 import { Typing } from 'ckeditor5/src/typing';
 import {
 	Dialog,
-	ButtonView,
-	type FocusCyclerBackwardCycleEvent,
-	type FocusCyclerForwardCycleEvent
+	ButtonView
 } from 'ckeditor5/src/ui';
 import { CKEditorError, type Locale } from 'ckeditor5/src/utils';
 import CharacterGridView, {
@@ -116,16 +114,6 @@ export default class SpecialCharacters extends Plugin {
 						editor.execute( 'insertText', { text: data.character } );
 						dialog.hide();
 						editor.editing.view.focus();
-					} );
-
-					specialCharactersView.focusCycler.on<FocusCyclerForwardCycleEvent>( 'forwardCycle', evt => {
-						dialog.view.focusNext();
-						evt.stop();
-					} );
-
-					specialCharactersView.focusCycler.on<FocusCyclerBackwardCycleEvent>( 'backwardCycle', evt => {
-						dialog.view.focusPrevious();
-						evt.stop();
 					} );
 				}
 

--- a/packages/ckeditor5-special-characters/src/ui/specialcharactersview.ts
+++ b/packages/ckeditor5-special-characters/src/ui/specialcharactersview.ts
@@ -128,23 +128,13 @@ export default class SpecialCharactersView extends View<HTMLDivElement> {
 	}
 
 	/**
-	 * Focuses the first focusable in {@link #items}.
+	 * @inheritDoc
 	 */
-	public focus(): void {
-		this.focusFirst();
-	}
-
-	/**
-	 * TODO
-	 */
-	public focusFirst(): void {
-		this.focusCycler.focusFirst();
-	}
-
-	/**
-	 * TODO
-	 */
-	public focusLast(): void {
-		this.focusCycler.focusLast();
+	public focus( direction?: 1 | -1 ): void {
+		if ( direction === -1 ) {
+			this.focusCycler.focusLast();
+		} else {
+			this.focusCycler.focusFirst();
+		}
 	}
 }

--- a/packages/ckeditor5-ui/src/dialog/dialogactionsview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogactionsview.ts
@@ -126,24 +126,14 @@ export default class DialogActionsView extends View {
 	}
 
 	/**
-	 * TODO
+	 * @inheritDoc
 	 */
-	public focus(): void {
-		this.focusFirst();
-	}
-
-	/**
-	 * TODO
-	 */
-	public focusFirst(): void {
-		this.focusCycler.focusFirst();
-	}
-
-	/**
-	 * TODO
-	 */
-	public focusLast(): void {
-		this.focusCycler.focusLast();
+	public focus( direction?: 1 | -1 ): void {
+		if ( direction === -1 ) {
+			this.focusCycler.focusLast();
+		} else {
+			this.focusCycler.focusFirst();
+		}
 	}
 
 	/**

--- a/packages/ckeditor5-ui/src/dialog/dialogview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogview.ts
@@ -18,7 +18,7 @@ import ViewCollection from '../viewcollection';
 import View from '../view';
 import FormHeaderView from '../formheader/formheaderview';
 import ButtonView from '../button/buttonview';
-import FocusCycler, { type FocusCyclerBackwardCycleEvent, type FocusCyclerForwardCycleEvent } from '../focuscycler';
+import FocusCycler, { isViewWithFocusCycler, type FocusCyclerBackwardCycleEvent, type FocusCyclerForwardCycleEvent } from '../focuscycler';
 import DraggableViewMixin, { type DraggableView, type DraggableViewDragEvent } from '../bindings/draggableviewmixin';
 import DialogActionsView, { type DialogActionButtonDefinition } from './dialogactionsview';
 
@@ -244,7 +244,7 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 	 */
 	public setActionButtons( definitions: Array<DialogActionButtonDefinition> ): void {
 		if ( !this.actionsView ) {
-			this.actionsView = this._createActionsView();
+			this.actionsView = new DialogActionsView( this.locale );
 			this._updateFocusCycleableItems();
 		}
 
@@ -286,6 +286,11 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 	private _updateFocusCycleableItems() {
 		for ( const focusable of this.focusables ) {
 			this.focusTracker.remove( focusable.element! );
+
+			if ( isViewWithFocusCycler( focusable ) ) {
+				this.stopListening( focusable.focusCycler, 'forwardCycle' );
+				this.stopListening( focusable.focusCycler, 'backwardCycle' );
+			}
 		}
 
 		this.focusables.clear();
@@ -300,9 +305,21 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 			focusables.push( this.closeButtonView );
 		}
 
-		focusables.forEach( v => {
-			this.focusables.add( v );
-			this.focusTracker.add( v.element! );
+		focusables.forEach( focusable => {
+			this.focusables.add( focusable );
+			this.focusTracker.add( focusable.element! );
+
+			if ( isViewWithFocusCycler( focusable ) ) {
+				this.listenTo<FocusCyclerForwardCycleEvent>( focusable.focusCycler, 'forwardCycle', evt => {
+					this.focusNext();
+					evt.stop();
+				} );
+
+				this.listenTo<FocusCyclerBackwardCycleEvent>( focusable.focusCycler, 'backwardCycle', evt => {
+					this.focusPrevious();
+					evt.stop();
+				} );
+			}
 		} );
 	}
 
@@ -335,25 +352,6 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 		headerView.children.add( this.closeButtonView );
 
 		return headerView;
-	}
-
-	/**
-	 * TODO
-	 */
-	private _createActionsView(): DialogActionsView {
-		const actionsView = new DialogActionsView( this.locale );
-
-		actionsView.focusCycler.on<FocusCyclerForwardCycleEvent>( 'forwardCycle', evt => {
-			this.focusCycler.focusNext();
-			evt.stop();
-		} );
-
-		actionsView.focusCycler.on<FocusCyclerBackwardCycleEvent>( 'backwardCycle', evt => {
-			this.focusCycler.focusPrevious();
-			evt.stop();
-		} );
-
-		return actionsView;
 	}
 
 	/**

--- a/packages/ckeditor5-ui/src/focuscycler.ts
+++ b/packages/ckeditor5-ui/src/focuscycler.ts
@@ -344,6 +344,13 @@ export type FocusableView = View & {
 	focus( direction?: 1 | -1 ): void;
 };
 
+/**
+ * A view that hosts one or more of focusable children being managed by a focus cycler instance.
+ */
+export type ViewWithFocusCycler = FocusableView & {
+	focusCycler: FocusCycler;
+};
+
 export interface FocusCyclerActions {
 	focusFirst?: ArrayOrItem<string>;
 	focusLast?: ArrayOrItem<string>;
@@ -380,4 +387,13 @@ export type FocusCyclerBackwardCycleEvent = {
  */
 function isFocusable( view: View ): view is FocusableView {
 	return !!( 'focus' in view && isVisible( view.element ) );
+}
+
+/**
+ * Checks whether a view is an instance of {@link ~ViewWithFocusCycler}.
+ *
+ * @param view A view to be checked.
+ */
+export function isViewWithFocusCycler( view: View ): view is ViewWithFocusCycler {
+	return 'focusCycler' in view && view.focusCycler instanceof FocusCycler;
 }

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -52,8 +52,10 @@ export { default as FormHeaderView } from './formheader/formheaderview';
 export {
 	default as FocusCycler,
 	type FocusableView,
+	type ViewWithFocusCycler,
 	type FocusCyclerForwardCycleEvent,
-	type FocusCyclerBackwardCycleEvent
+	type FocusCyclerBackwardCycleEvent,
+	isViewWithFocusCycler
 } from './focuscycler';
 
 export { default as IconView } from './icon/iconview';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Made focus cycling in various dialogs easier by moving the generic integration code to the DialogView class.
