### PR TITLE
Add support for dai.ly urls in MediaEmbedEditing

### DIFF
--- a/packages/ckeditor5-media-embed/src/mediaembedediting.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedediting.ts
@@ -45,7 +45,10 @@ export default class MediaEmbedEditing extends Plugin {
 			providers: [
 				{
 					name: 'dailymotion',
-					url: /^dailymotion\.com\/video\/(\w+)/,
+					url: [
+						/^dailymotion\.com\/video\/(\w+)/,
+						/^dai.ly\/(\w+)/
+					],
 					html: match => {
 						const id = match[ 1 ];
 

--- a/packages/ckeditor5-media-embed/tests/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedediting.js
@@ -147,7 +147,9 @@ describe( 'MediaEmbedEditing', () => {
 							testMediaUpcast( [
 								'https://www.dailymotion.com/video/foo',
 								'www.dailymotion.com/video/foo',
-								'dailymotion.com/video/foo'
+								'dailymotion.com/video/foo',
+								'https://dai.ly/foo',
+								'dai.ly/foo'
 							],
 							'<div style="position: relative; padding-bottom: 100%; height: 0; ">' +
 								'<iframe src="https://www.dailymotion.com/embed/video/foo" ' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature: Add support for short Dailymotion URLs (`dai.ly`) in media-embed. 

---

### Additional information

Short Dailymotion URLs can be found in you share the video through the dedicated sharing button:

Example: https://www.dailymotion.com/video/x8ks8y1 
<img width="133" alt="image" src="https://github.com/ckeditor/ckeditor5/assets/2103975/6210229d-2e0f-420b-ae1d-b66aad9f2015">
<img width="388" alt="image" src="https://github.com/ckeditor/ckeditor5/assets/2103975/ca7fd60f-5a8c-4d70-8010-a36880655597">
