### PR TITLE
Mapper bindings are removed too late when reconversion is involved

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/downcastdispatcher.ts
+++ b/packages/ckeditor5-engine/src/conversion/downcastdispatcher.ts
@@ -188,6 +188,10 @@ export default class DowncastDispatcher extends EmitterMixin() {
 			}
 		}
 
+		// Remove mappings for all removed view elements.
+		// Remove these mappings as soon as they are not needed (https://github.com/ckeditor/ckeditor5/issues/15411).
+		conversionApi.mapper.flushDeferredBindings();
+
 		for ( const markerName of conversionApi.mapper.flushUnboundMarkerNames() ) {
 			const markerRange = markers.get( markerName )!.getRange();
 
@@ -199,9 +203,6 @@ export default class DowncastDispatcher extends EmitterMixin() {
 		for ( const change of differ.getMarkersToAdd() ) {
 			this._convertMarkerAdd( change.name, change.range, conversionApi );
 		}
-
-		// Remove mappings for all removed view elements.
-		conversionApi.mapper.flushDeferredBindings();
 
 		// Verify if all insert consumables were consumed.
 		conversionApi.consumable.verifyAllConsumed( 'insert' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (engine): Fixed crash happening in a very peculiar scenario involving reconversion of an element containing a marker. Closes #15411.