### PR TITLE
Dialogs - single instance, `isOn` button state, recreating instead of resetting the view

### DIFF
--- a/packages/ckeditor5-editor-classic/src/classiceditorui.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditorui.ts
@@ -114,7 +114,7 @@ export default class ClassicEditorUI extends EditorUI {
 
 		this._initPlaceholder();
 		this._initToolbar();
-		// this._initDialogPluginIntegration();
+		this._initDialogPluginIntegration();
 		this.fire<EditorUIReadyEvent>( 'ready' );
 	}
 
@@ -228,22 +228,24 @@ export default class ClassicEditorUI extends EditorUI {
 			return;
 		}
 
-		const dialogView = Dialog.view;
-
 		const stickyPanel = this.view.stickyPanel;
 
-		dialogView.on<DialogViewMoveToEvent>( 'moveTo', ( evt, data ) => {
-			// Engage only when the panel is sticky, and the dialog is using one of default positions.
-			if ( !stickyPanel.isSticky || dialogView.wasMoved ) {
-				return;
-			}
+		this.editor.plugins.get( 'Dialog' ).on( 'show', () => {
+			const dialogView = Dialog.view;
 
-			const stickyPanelContentRect = new Rect( stickyPanel.contentPanel );
+			dialogView.on<DialogViewMoveToEvent>( 'moveTo', ( evt, data ) => {
+				// Engage only when the panel is sticky, and the dialog is using one of default positions.
+				if ( !stickyPanel.isSticky || dialogView.wasMoved ) {
+					return;
+				}
 
-			if ( data[ 1 ] < stickyPanelContentRect.bottom + DialogView.defaultOffset ) {
-				data[ 1 ] = stickyPanelContentRect.bottom + DialogView.defaultOffset;
-			}
-		}, { priority: 'high' } );
+				const stickyPanelContentRect = new Rect( stickyPanel.contentPanel );
+
+				if ( data[ 1 ] < stickyPanelContentRect.bottom + DialogView.defaultOffset ) {
+					data[ 1 ] = stickyPanelContentRect.bottom + DialogView.defaultOffset;
+				}
+			}, { priority: 'high' } );
+		}, { priority: 'low' } );
 	}
 }
 

--- a/packages/ckeditor5-editor-classic/src/classiceditorui.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditorui.ts
@@ -231,7 +231,7 @@ export default class ClassicEditorUI extends EditorUI {
 		const stickyPanel = this.view.stickyPanel;
 
 		this.editor.plugins.get( 'Dialog' ).on( 'show', () => {
-			const dialogView = Dialog.view;
+			const dialogView = this.editor.plugins.get( 'Dialog' ).view!;
 
 			dialogView.on<DialogViewMoveToEvent>( 'moveTo', ( evt, data ) => {
 				// Engage only when the panel is sticky, and the dialog is using one of default positions.

--- a/packages/ckeditor5-editor-classic/src/classiceditorui.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditorui.ts
@@ -13,8 +13,7 @@ import {
 	normalizeToolbarConfig,
 	type EditorUIReadyEvent,
 	type DialogViewMoveToEvent,
-	DialogView,
-	Dialog
+	DialogView
 } from 'ckeditor5/src/ui';
 import {
 	enablePlaceholder,

--- a/packages/ckeditor5-editor-classic/src/classiceditorui.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditorui.ts
@@ -13,7 +13,8 @@ import {
 	normalizeToolbarConfig,
 	type EditorUIReadyEvent,
 	type DialogViewMoveToEvent,
-	DialogView
+	DialogView,
+	Dialog
 } from 'ckeditor5/src/ui';
 import {
 	enablePlaceholder,
@@ -113,7 +114,7 @@ export default class ClassicEditorUI extends EditorUI {
 
 		this._initPlaceholder();
 		this._initToolbar();
-		this._initDialogPluginIntegration();
+		// this._initDialogPluginIntegration();
 		this.fire<EditorUIReadyEvent>( 'ready' );
 	}
 
@@ -227,7 +228,8 @@ export default class ClassicEditorUI extends EditorUI {
 			return;
 		}
 
-		const dialogView = this.editor.plugins.get( 'Dialog' ).view;
+		const dialogView = Dialog.view;
+
 		const stickyPanel = this.view.stickyPanel;
 
 		dialogView.on<DialogViewMoveToEvent>( 'moveTo', ( evt, data ) => {

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
@@ -82,6 +82,9 @@ export default class FindAndReplaceUI extends Plugin {
 			// Button should be disabled when in source editing mode. See #10001.
 			buttonView.bind( 'isEnabled' ).to( editor.commands.get( 'find' )! );
 
+			// Button should be on when the find and replace dialog is opened.
+			buttonView.bind( 'isOn' ).to( dialog, 'isOpen', isOpen => isOpen && dialog.id === 'findAndReplace' );
+
 			// Every time a dialog is opened, the search text field should get focused and selected for better UX.
 			// Each time a dialog is closed, move the focus back to the find and replace toolbar button
 			// and let the find and replace editing feature know that all search results can be invalidated

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
@@ -90,22 +90,26 @@ export default class FindAndReplaceUI extends Plugin {
 			// and let the find and replace editing feature know that all search results can be invalidated
 			// and no longer should be marked in the content.
 			buttonView.on( 'execute', () => {
-				dialog.show( {
-					id: 'findAndReplace',
-					title: t( 'Find and replace' ),
-					content: formView,
-					position: DialogViewPosition.EDITOR_TOP_SIDE,
-					onShow: () => {
-						formView.disableCssTransitions();
-						formView.reset();
-						formView._findInputView.fieldView.select();
-						formView.enableCssTransitions();
-					},
+				if ( buttonView.isOn ) {
+					dialog.hide();
+				} else {
+					dialog.show( {
+						id: 'findAndReplace',
+						title: t( 'Find and replace' ),
+						content: formView,
+						position: DialogViewPosition.EDITOR_TOP_SIDE,
+						onShow: () => {
+							formView.disableCssTransitions();
+							formView.reset();
+							formView._findInputView.fieldView.select();
+							formView.enableCssTransitions();
+						},
 
-					onHide: () => {
-						this.fire( 'searchReseted' );
-					}
-				} );
+						onHide: () => {
+							this.fire( 'searchReseted' );
+						}
+					} );
+				}
 			} );
 
 			editor.keystrokes.set( 'Ctrl+F', ( data, cancelEvent ) => {

--- a/packages/ckeditor5-ui/src/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialog.ts
@@ -7,7 +7,7 @@
  * @module ui/dialog/dialog
  */
 
-import View from '../view';
+import type View from '../view';
 import { type Editor, Plugin } from '@ckeditor/ckeditor5-core';
 import DialogView, { type DialogViewCloseEvent, DialogViewPosition } from './dialogview';
 import type { DialogActionButtonDefinition } from './dialogactionsview';
@@ -108,12 +108,13 @@ export default class Dialog extends Plugin {
 	}: DialogDefinition ) {
 		const editor = this.editor;
 
-		Dialog.visibleDialogPlugin = this;
-
-		this.view = new DialogView( editor.locale, () => {
-			return editor.editing.view.getDomRoot( editor.model.document.selection.anchor!.root.rootName )!;
-		}, () => {
-			return editor.ui.viewportOffset;
+		this.view = new DialogView( editor.locale, {
+			getCurrentDomRoot: () => {
+				return editor.editing.view.getDomRoot( editor.model.document.selection.anchor!.root.rootName )!;
+			},
+			getViewportOffset: () => {
+				return editor.ui.viewportOffset;
+			}
 		} );
 
 		this.view.on<DialogViewCloseEvent>( 'close', () => {
@@ -136,30 +137,20 @@ export default class Dialog extends Plugin {
 			isModal
 		} );
 
+		this.view.setupParts( {
+			title,
+			content,
+			actionButtons
+		} );
+
 		if ( id ) {
 			this.id = id;
 		}
 
-		if ( title ) {
-			this.view.showHeader( title );
-		}
-
-		if ( content ) {
-			// Normalize the content specified in the arguments.
-			if ( content instanceof View ) {
-				content = [ content ];
-			}
-
-			this.view.addContentPart( content );
-		}
-
-		if ( actionButtons ) {
-			this.view.setActionButtons( actionButtons );
-		}
-
 		this.isOpen = true;
-
 		this._onHide = onHide;
+
+		Dialog.visibleDialogPlugin = this;
 	}
 
 	/**

--- a/packages/ckeditor5-ui/src/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialog.ts
@@ -115,6 +115,13 @@ export default class Dialog extends Plugin {
 			this.hide();
 		} );
 
+		// If the dialog was closed by opening in another editor instance,
+		// we need to update the state in the previous instance manually.
+		Dialog.view.on( 'destroy', () => {
+			this.id = '';
+			this.isOpen = false;
+		} );
+
 		editor.ui.view.body.add( Dialog.view );
 		editor.ui.focusTracker.add( Dialog.view.element! );
 

--- a/packages/ckeditor5-ui/src/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialog.ts
@@ -51,6 +51,8 @@ export default class Dialog extends Plugin {
 	constructor( editor: Editor ) {
 		super( editor );
 
+		this._initShowHideListeners();
+
 		this.set( 'isOpen', false );
 	}
 
@@ -81,26 +83,9 @@ export default class Dialog extends Plugin {
 	 * TODO
 	 */
 	public show( dialogDefinition: DialogDefinition ): void {
-		this._initShowHideListeners();
-
 		if ( this.isOpen || Dialog.view ) {
 			this.hide();
 		}
-
-		const editor = this.editor;
-
-		Dialog.view = new DialogView( editor.locale, () => {
-			return editor.editing.view.getDomRoot( editor.model.document.selection.anchor!.root.rootName )!;
-		}, () => {
-			return editor.ui.viewportOffset;
-		} );
-
-		Dialog.view.on<DialogViewCloseEvent>( 'close', () => {
-			this.hide();
-		} );
-
-		editor.ui.view.body.add( Dialog.view );
-		editor.ui.focusTracker.add( Dialog.view.element! );
 
 		this.fire( dialogDefinition.id ? `show:${ dialogDefinition.id }` : 'show', dialogDefinition );
 	}
@@ -118,6 +103,21 @@ export default class Dialog extends Plugin {
 		position,
 		onHide
 	}: DialogDefinition ) {
+		const editor = this.editor;
+
+		Dialog.view = new DialogView( editor.locale, () => {
+			return editor.editing.view.getDomRoot( editor.model.document.selection.anchor!.root.rootName )!;
+		}, () => {
+			return editor.ui.viewportOffset;
+		} );
+
+		Dialog.view.on<DialogViewCloseEvent>( 'close', () => {
+			this.hide();
+		} );
+
+		editor.ui.view.body.add( Dialog.view );
+		editor.ui.focusTracker.add( Dialog.view.element! );
+
 		// Unless the user specified a position, modals should always be centered on the screen.
 		// Otherwise, let's keep dialogs centered in the editing root by default.
 		if ( !position ) {

--- a/packages/ckeditor5-ui/src/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialog.ts
@@ -75,16 +75,14 @@ export default class Dialog extends Plugin {
 		this.on<DialogHideEvent>( 'hide', () => {
 			this._onHide?.( this );
 		}, { priority: 'low' } );
-
-		Dialog.view.on<DialogViewCloseEvent>( 'close', () => {
-			this.hide();
-		} );
 	}
 
 	/**
 	 * TODO
 	 */
 	public show( dialogDefinition: DialogDefinition ): void {
+		this._initShowHideListeners();
+
 		if ( this.isOpen || Dialog.view ) {
 			this.hide();
 		}
@@ -97,7 +95,9 @@ export default class Dialog extends Plugin {
 			return editor.ui.viewportOffset;
 		} );
 
-		this._initShowHideListeners();
+		Dialog.view.on<DialogViewCloseEvent>( 'close', () => {
+			this.hide();
+		} );
 
 		editor.ui.view.body.add( Dialog.view );
 		editor.ui.focusTracker.add( Dialog.view.element! );

--- a/packages/ckeditor5-ui/src/dialog/dialogactionsview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogactionsview.ts
@@ -108,6 +108,8 @@ export default class DialogActionsView extends View {
 	 * TODO
 	 */
 	public setButtons( definitions: Array<DialogActionButtonDefinition> ): void {
+		this.reset();
+
 		for ( const definition of definitions ) {
 			const button = new ButtonView( this.locale );
 

--- a/packages/ckeditor5-ui/src/dialog/dialogactionsview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogactionsview.ts
@@ -10,8 +10,7 @@
 import {
 	FocusTracker,
 	KeystrokeHandler,
-	type Locale,
-	type CollectionChangeEvent
+	type Locale
 } from '@ckeditor/ckeditor5-utils';
 import type Button from '../button/button';
 import ButtonView from '../button/buttonview';
@@ -55,7 +54,6 @@ export default class DialogActionsView extends View {
 		super( locale );
 
 		this.children = this.createCollection<ButtonView>();
-		this.children.on<CollectionChangeEvent>( 'change', this._updateFocusCycleableItems.bind( this ) );
 		this.keystrokes = new KeystrokeHandler();
 		this._focusTracker = new FocusTracker();
 		this._focusables = new ViewCollection();
@@ -90,26 +88,13 @@ export default class DialogActionsView extends View {
 	public override render(): void {
 		super.render();
 
-		this._updateFocusCycleableItems();
-
 		this.keystrokes.listenTo( this.element! );
 	}
 
 	/**
 	 * TODO
 	 */
-	public reset(): void {
-		while ( this.children.length ) {
-			this.children.remove( 0 );
-		}
-	}
-
-	/**
-	 * TODO
-	 */
 	public setButtons( definitions: Array<DialogActionButtonDefinition> ): void {
-		this.reset();
-
 		for ( const definition of definitions ) {
 			const button = new ButtonView( this.locale );
 
@@ -125,6 +110,8 @@ export default class DialogActionsView extends View {
 
 			this.children.add( button );
 		}
+
+		this._updateFocusCyclableItems();
 	}
 
 	/**
@@ -141,13 +128,7 @@ export default class DialogActionsView extends View {
 	/**
 	 * TODO
 	 */
-	private _updateFocusCycleableItems() {
-		for ( const focusable of this._focusables ) {
-			this._focusTracker.remove( focusable.element! );
-		}
-
-		this._focusables.clear();
-
+	private _updateFocusCyclableItems() {
 		Array.from( this.children ).forEach( v => {
 			this._focusables.add( v );
 			this._focusTracker.add( v.element! );

--- a/packages/ckeditor5-ui/src/dialog/dialogactionsview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogactionsview.ts
@@ -36,12 +36,12 @@ export default class DialogActionsView extends View {
 	/**
 	 * TODO
 	 */
-	private readonly _focusTracker: FocusTracker;
+	public readonly focusCycler: FocusCycler;
 
 	/**
 	 * TODO
 	 */
-	private readonly _focusCycler: FocusCycler;
+	private readonly _focusTracker: FocusTracker;
 
 	/**
 	 * TODO
@@ -59,7 +59,7 @@ export default class DialogActionsView extends View {
 		this.keystrokes = new KeystrokeHandler();
 		this._focusTracker = new FocusTracker();
 		this._focusables = new ViewCollection();
-		this._focusCycler = new FocusCycler( {
+		this.focusCycler = new FocusCycler( {
 			focusables: this._focusables,
 			focusTracker: this._focusTracker,
 			keystrokeHandler: this.keystrokes,
@@ -132,9 +132,9 @@ export default class DialogActionsView extends View {
 	 */
 	public focus( direction?: 1 | -1 ): void {
 		if ( direction === -1 ) {
-			this._focusCycler.focusLast();
+			this.focusCycler.focusLast();
 		} else {
-			this._focusCycler.focusFirst();
+			this.focusCycler.focusFirst();
 		}
 	}
 

--- a/packages/ckeditor5-ui/src/dialog/dialogview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogview.ts
@@ -277,11 +277,6 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 		} );
 
 		this.keystrokes.listenTo( this.element! );
-
-		// When a dialog is closed by opening a dialog in another editor instance,
-		// the original editor instance is not aware of that.
-		// That is why we need to listen to the destroy event.
-		this.decorate( 'destroy' );
 	}
 
 	/**
@@ -293,15 +288,6 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 		} else {
 			return null;
 		}
-	}
-
-	/**
-	 * TODO
-	 */
-	public override destroy(): void {
-		this.element?.remove();
-
-		super.destroy();
 	}
 
 	/**

--- a/packages/ckeditor5-ui/src/dialog/dialogview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogview.ts
@@ -373,7 +373,8 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 			top = viewportRect.top;
 		}
 
-		// TODO: The same for the bottom edge?
+		// Note: We don't do the same for the bottom edge to allow users to resize the window vertically
+		// and let the dialog to stay put instead of covering the editing root.
 
 		this._moveTo( left, top );
 	}

--- a/packages/ckeditor5-ui/src/dialog/dialogview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogview.ts
@@ -620,12 +620,16 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 
 		const focusables = [ ...this.children ];
 
-		if ( this.actionsView ) {
-			focusables.push( this.actionsView );
-		}
-
 		if ( this.closeButtonView ) {
 			focusables.push( this.closeButtonView );
+		}
+
+		if ( this.contentView ) {
+			focusables.push( this.contentView );
+		}
+
+		if ( this.actionsView ) {
+			focusables.push( this.actionsView );
 		}
 
 		focusables.forEach( focusable => {

--- a/packages/ckeditor5-ui/src/dialog/dialogview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogview.ts
@@ -280,6 +280,11 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 		} );
 
 		this.keystrokes.listenTo( this.element! );
+
+		// When a dialog is closed by opening a dialog in another editor instance,
+		// the original editor instance is not aware of that.
+		// That is why we need to listen to the destroy event.
+		this.decorate( 'destroy' );
 	}
 
 	/**

--- a/packages/ckeditor5-ui/src/dialog/dialogview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogview.ts
@@ -249,14 +249,14 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 		// Update dialog position upon window resize, if the position was not changed manually.
 		this.listenTo( global.window, 'resize', () => {
 			if ( this.isVisible && !this.wasMoved ) {
-				this._moveToConfiguredPosition();
+				this.updatePosition();
 			}
 		} );
 
 		// Update dialog position upon document scroll, if the position was not changed manually.
 		this.listenTo( global.document, 'scroll', () => {
 			if ( this.isVisible && !this.wasMoved ) {
-				this._moveToConfiguredPosition();
+				this.updatePosition();
 			}
 		} );
 
@@ -269,7 +269,7 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 
 				// FYI: RAF is too short. We need to wait a bit longer.
 				setTimeout( () => {
-					this._moveToConfiguredPosition();
+					this.updatePosition();
 
 					this.isTransparent = false;
 
@@ -403,7 +403,7 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 	/**
 	 * TODO
 	 */
-	private _moveToConfiguredPosition(): void {
+	public updatePosition(): void {
 		const viewportRect = this._getViewportRect();
 		const defaultOffset = DialogView.defaultOffset;
 

--- a/packages/ckeditor5-ui/src/dialog/dialogview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogview.ts
@@ -296,6 +296,15 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 	/**
 	 * TODO
 	 */
+	public override destroy(): void {
+		this.element?.remove();
+
+		super.destroy();
+	}
+
+	/**
+	 * TODO
+	 */
 	public reset(): void {
 		while ( this.children.length ) {
 			this.children.remove( 0 );
@@ -335,11 +344,11 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 		if ( !this.contentView ) {
 			this.contentView = this._createContentView();
 			this._updateFocusCycleableItems();
+			this.parts.add( this.contentView );
 		} else {
 			this.contentView.reset();
 		}
 
-		this.parts.add( this.contentView );
 		this.contentView.children.addMany( content );
 	}
 
@@ -350,9 +359,9 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 		if ( !this.actionsView ) {
 			this.actionsView = new DialogActionsView( this.locale );
 			this._updateFocusCycleableItems();
+			this.parts.add( this.actionsView );
 		}
 
-		this.parts.add( this.actionsView );
 		this.actionsView.setButtons( definitions );
 	}
 

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
@@ -784,11 +784,11 @@ class DynamicGrouping implements ToolbarBehavior {
 		// Only those items that were not grouped are visible to the user.
 		view.itemsView.children.bindTo( this.ungroupedItems ).using( item => item );
 
-		// Make sure all #items visible in the main space of the toolbar are "focuscycleable".
-		this.ungroupedItems.on<CollectionChangeEvent>( 'change', this._updateFocusCycleableItems.bind( this ) );
+		// Make sure all #items visible in the main space of the toolbar are "focuscyclable".
+		this.ungroupedItems.on<CollectionChangeEvent>( 'change', this._updateFocusCyclableItems.bind( this ) );
 
 		// Make sure the #groupedItemsDropdown is also included in cycling when it appears.
-		view.children.on<CollectionChangeEvent>( 'change', this._updateFocusCycleableItems.bind( this ) );
+		view.children.on<CollectionChangeEvent>( 'change', this._updateFocusCyclableItems.bind( this ) );
 
 		// ToolbarView#items is dynamic. When an item is added or removed, it should be automatically
 		// represented in either grouped or ungrouped items at the right index.
@@ -1053,7 +1053,7 @@ class DynamicGrouping implements ToolbarBehavior {
 	}
 
 	/**
-	 * Updates the {@link module:ui/toolbar/toolbarview~ToolbarView#focusables focus–cycleable items}
+	 * Updates the {@link module:ui/toolbar/toolbarview~ToolbarView#focusables focus–cyclable items}
 	 * collection so it represents the up–to–date state of the UI from the perspective of the user.
 	 *
 	 * For instance, the {@link #groupedItemsDropdown} can show up and hide but when it is visible,
@@ -1062,7 +1062,7 @@ class DynamicGrouping implements ToolbarBehavior {
 	 * See the {@link module:ui/toolbar/toolbarview~ToolbarView#focusables collection} documentation
 	 * to learn more about the purpose of this method.
 	 */
-	private _updateFocusCycleableItems() {
+	private _updateFocusCyclableItems() {
 		this.viewFocusables.clear();
 
 		this.ungroupedItems.map( item => {

--- a/packages/ckeditor5-ui/tests/manual/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/tests/manual/dialog/dialog.ts
@@ -97,7 +97,7 @@ class ModalWithText extends Plugin {
 							icon: icons.colorPaletteIcon,
 							withText: true,
 							onExecute: () => {
-								// dialog.setTitle( 'New title' );
+								dialog.view!.headerView!.label = 'New title';
 							}
 						},
 						{


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

*   Allow only one dialog instance across all the editor instances (opening a dialog in another editor closes and destroys the old one).
*   Introduce `isOn` state for the buttons using the dialog.
*   Destroy and recreate the `DialogView` instead of resetting it.
    *  But make sure the integrator's view is not destroyed in the process and can be re-used next time the dialog shows up.
* Ensured the correct part of the dialog gets focused when the dialog shows up. 
* Maintained the correct focus cycling order after code refactoring.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._