### PR TITLE
Make "UpcastEvent" visible in API docs

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/upcastdispatcher.ts
+++ b/packages/ckeditor5-engine/src/conversion/upcastdispatcher.ts
@@ -526,7 +526,7 @@ export type UpcastViewCleanupEvent = {
 	args: [ ViewElement | ViewDocumentFragment ];
 };
 
-type UpcastEvent<TName extends string, TItem extends ViewItem | ViewDocumentFragment> = {
+export type UpcastEvent<TName extends string, TItem extends ViewItem | ViewDocumentFragment> = {
 	name: TName | `${ TName }:${ string }`;
 	args: [ data: UpcastConversionData<TItem>, conversionApi: UpcastConversionApi ];
 };


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (engine): Make `UpcastEvent` visible in API docs. Closes #15424.
