### PR TITLE
Added missing `ckeditor5-metadata.json` file for undo and improved me…

### DIFF
--- a/packages/ckeditor5-essentials/ckeditor5-metadata.json
+++ b/packages/ckeditor5-essentials/ckeditor5-metadata.json
@@ -5,18 +5,6 @@
 			"className": "Essentials",
 			"description": "Includes all essential editing features like the clipboard, <kbd>Enter</kbd> and <kbd>Shift</kbd>+<kbd>Enter</kbd> keystrokes, typing and the undo support.",
 			"path": "src/essentials.js",
-			"uiComponents": [
-				{
-					"type": "Button",
-					"name": "undo",
-					"iconPath": "@ckeditor/ckeditor5-undo/theme/icons/undo.svg"
-				},
-				{
-					"type": "Button",
-					"name": "redo",
-					"iconPath": "@ckeditor/ckeditor5-undo/theme/icons/redo.svg"
-				}
-			],
 			"htmlOutput": [
 				{
 					"elements": "br"

--- a/packages/ckeditor5-image/ckeditor5-metadata.json
+++ b/packages/ckeditor5-image/ckeditor5-metadata.json
@@ -23,7 +23,6 @@
 				{
 					"type": "Button",
 					"name": "imageTextAlternative",
-					"iconPath": "",
 					"toolbars": [
 						"image.toolbar"
 					]
@@ -57,7 +56,6 @@
 				{
 					"type": "Button",
 					"name": "imageTextAlternative",
-					"iconPath": "",
 					"toolbars": [
 						"image.toolbar"
 					]
@@ -97,7 +95,6 @@
 				{
 					"type": "Button",
 					"name": "toggleImageCaption",
-					"iconPath": "",
 					"toolbars": [
 						"image.toolbar"
 					]

--- a/packages/ckeditor5-image/ckeditor5-metadata.json
+++ b/packages/ckeditor5-image/ckeditor5-metadata.json
@@ -23,6 +23,7 @@
 				{
 					"type": "Button",
 					"name": "imageTextAlternative",
+					"iconPath": "@ckeditor/ckeditor5-core/theme/icons/text-alternative.svg",
 					"toolbars": [
 						"image.toolbar"
 					]
@@ -56,6 +57,7 @@
 				{
 					"type": "Button",
 					"name": "imageTextAlternative",
+					"iconPath": "@ckeditor/ckeditor5-core/theme/icons/text-alternative.svg",
 					"toolbars": [
 						"image.toolbar"
 					]
@@ -95,6 +97,7 @@
 				{
 					"type": "Button",
 					"name": "toggleImageCaption",
+					"iconPath": "@ckeditor/ckeditor5-core/theme/icons/caption.svg",
 					"toolbars": [
 						"image.toolbar"
 					]

--- a/packages/ckeditor5-undo/ckeditor5-metadata.json
+++ b/packages/ckeditor5-undo/ckeditor5-metadata.json
@@ -3,19 +3,19 @@
 		{
 			"name": "Undo",
 			"className": "Undo",
-			"description": "Inserts buttons with undo and redo functionality.",
+			"description": "Support the undo and redo functionalities.",
 			"docs": "features/undo-redo.html",
 			"path": "src/undo.js",
 			"uiComponents": [
 				{
 					"type": "Button",
 					"name": "undo",
-					"iconPath": "theme/icons/undo.svg"
+					"iconPath": "@ckeditor/ckeditor5-undo/theme/icons/undo.svg"
 				},
 				{
 					"type": "Button",
 					"name": "redo",
-					"iconPath": "theme/icons/redo.svg"
+					"iconPath": "@ckeditor/ckeditor5-undo/theme/icons/redo.svg"
 				}
 			]
 		}

--- a/packages/ckeditor5-undo/ckeditor5-metadata.json
+++ b/packages/ckeditor5-undo/ckeditor5-metadata.json
@@ -4,7 +4,7 @@
 			"name": "Undo",
 			"className": "Undo",
 			"description": "Inserts buttons with undo and redo functionality.",
-			"docs": "features/undo.html",
+			"docs": "features/undo-redo.html",
 			"path": "src/undo.js",
 			"uiComponents": [
 				{

--- a/packages/ckeditor5-undo/ckeditor5-metadata.json
+++ b/packages/ckeditor5-undo/ckeditor5-metadata.json
@@ -1,0 +1,23 @@
+{
+	"plugins": [
+		{
+			"name": "Undo",
+			"className": "Undo",
+			"description": "Inserts buttons with undo and redo functionality.",
+			"docs": "features/undo.html",
+			"path": "src/undo.js",
+			"uiComponents": [
+				{
+					"type": "Button",
+					"name": "undo",
+					"iconPath": "theme/icons/undo.svg"
+				},
+				{
+					"type": "Button",
+					"name": "redo",
+					"iconPath": "theme/icons/redo.svg"
+				}
+			]
+		}
+	]
+}

--- a/scripts/ci/validate-metadata-files.js
+++ b/scripts/ci/validate-metadata-files.js
@@ -145,11 +145,15 @@ function getMissingExports( packageData ) {
 function getMissingIcons( packageData, options ) {
 	return packageData.metadata.plugins
 		.filter( plugin => plugin.uiComponents )
-		.flatMap( plugin => plugin.uiComponents.map( uiComponent => ( { ...plugin, iconPath: uiComponent.iconPath } ) ) )
+		.flatMap( plugin => plugin.uiComponents.map( uiComponent => ( {
+			...plugin,
+			iconPath: uiComponent.iconPath,
+			uiComponentName: uiComponent.name
+		} ) ) )
 		.filter( ( { iconPath } ) => iconPath !== undefined )
-		.map( ( { iconPath, name } ) => {
+		.map( ( { iconPath, name, uiComponentName } ) => {
 			if ( iconPath === '' ) {
-				return `${ name } has an empty iconPath. Either define or remove it.`;
+				return `${ name } (\`${ uiComponentName }\`) has an empty \`iconPath\` value. Either define or remove it.`;
 			}
 
 			if ( iconPath.startsWith( '@ckeditor/' ) ) {

--- a/scripts/ci/validate-metadata-files.js
+++ b/scripts/ci/validate-metadata-files.js
@@ -145,9 +145,13 @@ function getMissingExports( packageData ) {
 function getMissingIcons( packageData, options ) {
 	return packageData.metadata.plugins
 		.filter( plugin => plugin.uiComponents )
-		.flatMap( plugin => plugin.uiComponents.map( uiComponent => uiComponent.iconPath ) )
-		.filter( Boolean )
-		.map( iconPath => {
+		.flatMap( plugin => plugin.uiComponents.map( uiComponent => ( { ...plugin, iconPath: uiComponent.iconPath } ) ) )
+		.filter( ( { iconPath } ) => iconPath !== undefined )
+		.map( ( { iconPath, name } ) => {
+			if ( iconPath === '' ) {
+				return `${ name } has an empty iconPath. Either define or remove it.`;
+			}
+
 			if ( iconPath.startsWith( '@ckeditor/' ) ) {
 				return iconPath;
 			}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other: The `undo` and `redo` toolbar components described in the `@ckeditor/ckeditor5-essentials/src/ckeditor5-metadata.json` file are now defined in the package that registers those buttons (`@ckeditor/ckeditor5-undo`). Closes #15414.

Internal: The metadata validator does not accept an empty value of the `iconPath` field when checking the availability of SVG icons in a package.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
