### PR TITLE
Make all tooltips visible over the dialog

### DIFF
--- a/packages/ckeditor5-ui/theme/components/tooltip/tooltip.css
+++ b/packages/ckeditor5-ui/theme/components/tooltip/tooltip.css
@@ -7,5 +7,5 @@
 	/* Keep tooltips transparent for any interactions. */
 	pointer-events: none;
 
-	z-index: calc( var(--ck-z-panel) + 100 );
+	z-index: calc( var(--ck-z-dialog) + 100 );
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal(ui): Increased tooltips z-index to make them visible over the dialog element.

---

### Additional information

Not only dialog tooltips will be displayed over it, but also e.g. toolbar buttons - but that's consistent with the industry standards.
![image](https://github.com/ckeditor/ckeditor5/assets/10883184/71a54d27-454a-40b9-b8d1-e73570f8c0d2)
