### PR TITLE
Fix(list): Preserve HTML comments inside lists

### DIFF
--- a/packages/ckeditor5-html-support/tests/manual/htmlcomment.html
+++ b/packages/ckeditor5-html-support/tests/manual/htmlcomment.html
@@ -10,14 +10,16 @@
 		</tr>
 	</table>
 	<ol>
-		<li><!-- C7 -->Item #1<!-- C8 --></li>
+		<!-- C7 -->
+		<li><!-- C8 -->Item #1<!-- C9 --></li>
 		<li>Item #2</li>
 		<li>Item #3
 			<ul>
-				<li><!-- C9 -->Nested item #3.1<!-- C10 --></li>
+				<li><!-- C10 -->Nested item #3.1<!-- C11 --></li>
 				<li>Nested item #3.2</li>
 				<li>Nested item #3.3</li>
 			</ul>
 		</li>
+		<!-- C12 -->
 	</ol>
 </div>

--- a/packages/ckeditor5-html-support/tests/manual/htmlcomment.js
+++ b/packages/ckeditor5-html-support/tests/manual/htmlcomment.js
@@ -6,14 +6,27 @@
 /* global document, window, console */
 
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor.js';
-import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset.js';
+import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials.js';
+import BlockQuote from '@ckeditor/ckeditor5-block-quote/src/blockquote.js';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold.js';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading.js';
+import Image from '@ckeditor/ckeditor5-image/src/image.js';
+import ImageCaption from '@ckeditor/ckeditor5-image/src/imagecaption.js';
+import ImageStyle from '@ckeditor/ckeditor5-image/src/imagestyle.js';
+import ImageToolbar from '@ckeditor/ckeditor5-image/src/imagetoolbar.js';
+import Indent from '@ckeditor/ckeditor5-indent/src/indent.js';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic.js';
+import Link from '@ckeditor/ckeditor5-link/src/link.js';
+import MediaEmbed from '@ckeditor/ckeditor5-media-embed/src/mediaembed.js';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
+import Table from '@ckeditor/ckeditor5-table/src/table.js';
+import TableToolbar from '@ckeditor/ckeditor5-table/src/tabletoolbar.js';
 import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices.js';
 import EasyImage from '@ckeditor/ckeditor5-easy-image/src/easyimage.js';
 import ImageUpload from '@ckeditor/ckeditor5-image/src/imageupload.js';
 import PasteFromOffice from '@ckeditor/ckeditor5-paste-from-office/src/pastefromoffice.js';
 import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting.js';
-import Table from '@ckeditor/ckeditor5-table/src/table.js';
-import TableToolbar from '@ckeditor/ckeditor5-table/src/tabletoolbar.js';
+import List from '@ckeditor/ckeditor5-list/src/list.js';
 import TodoList from '@ckeditor/ckeditor5-list/src/todolist.js';
 
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config.js';
@@ -23,7 +36,20 @@ import HtmlComment from '../../src/htmlcomment.js';
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [
-			ArticlePluginSet,
+			Essentials,
+			BlockQuote,
+			Bold,
+			Heading,
+			Image,
+			ImageCaption,
+			ImageStyle,
+			ImageToolbar,
+			Indent,
+			Italic,
+			Link,
+			MediaEmbed,
+			Paragraph,
+			List,
 			CloudServices,
 			EasyImage,
 			ImageUpload,

--- a/packages/ckeditor5-html-support/tests/manual/htmlcomment.md
+++ b/packages/ckeditor5-html-support/tests/manual/htmlcomment.md
@@ -1,6 +1,6 @@
 ## HTML comment
 
-1. Toggle the source editing mode and verify that all comments are present. There should be 10 comments: from `C1` to `C10`.
+1. Toggle the source editing mode and verify that all comments are present. There should be 12 comments: from `C1` to `C12`.
 1. In source editing mode add and remove some comments. Please note that, currently, the comment support is on a basic level. See the **Known limitations** section below containing missing functionalities.
 1. Copy & paste some content from Word and Google Docs. Content should be parsed without errors and displayed correctly.
 

--- a/packages/ckeditor5-list/tests/list/converters-htmlcomment.js
+++ b/packages/ckeditor5-list/tests/list/converters-htmlcomment.js
@@ -1,0 +1,59 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import ListEditing from '../../src/list/listediting.js';
+
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
+import HtmlComment from '@ckeditor/ckeditor5-html-support/src/htmlcomment.js';
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
+
+import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor.js';
+import { setupTestHelpers } from './_utils/utils.js';
+import stubUid from './_utils/uid.js';
+
+describe( 'ListEditing - converters - preserve HTML comments', () => {
+	let editor, test;
+
+	testUtils.createSinonSandbox();
+
+	beforeEach( async () => {
+		editor = await VirtualTestEditor.create( {
+			plugins: [ Paragraph, ListEditing, HtmlComment ]
+		} );
+
+		stubUid();
+		test = setupTestHelpers( editor );
+	} );
+
+	afterEach( async () => {
+		await editor.destroy();
+	} );
+
+	describe( 'flat lists', () => {
+		it( 'preserves html comments', () => {
+			test.data(
+				'<ul>' +
+					'<li>a</li>' +
+					'<!--<li>b</li>-->' +
+					'<li>c</li>' +
+					'<!--<li>d</li>-->' +
+				'</ul>' +
+				'<p>c</p>',
+
+				'<paragraph listIndent="0" listItemId="a00" listType="bulleted">a</paragraph>' +
+				'<paragraph listIndent="0" listItemId="a01" listType="bulleted">c</paragraph>' +
+				'<paragraph>c</paragraph>',
+
+				'<ul>' +
+					'<li>a</li>' +
+					'<!--<li>b</li>-->' +
+					'<li>c</li>' +
+				'</ul>' +
+				'<!--<li>d</li>-->' +
+				'<p>c</p>'
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix(list): Preserve HTML comments inside lists. See #10118.

---

### Additional information

This does not address repositioning at all, but does resolve the data loss portion of #10118, unless there are other similar cases that have not been found yet.

The behaviour with nested lists is not ideal (HTML comments will be nested inside a new paragraph outside of the list indentation), I believe this is related to #14944. In my testing this behaviour is consistent whether or not you have the AdjacentListsSupport plugin enabled.

Remaining TODO:
- [x] Write automated test coverage

---

### Credits

This work was sponsored by @ongov.