### PR TITLE
Fix #15430 - ckeditor5-link - ckeditor in dialog box where main window is scrolled down - Position of link edit dialog

### DIFF
--- a/packages/ckeditor5-ui/tests/editorui/poweredby.js
+++ b/packages/ckeditor5-ui/tests/editorui/poweredby.js
@@ -189,7 +189,7 @@ describe( 'PoweredBy', () => {
 
 				// Stub textarea's client rect.
 				testUtils.sinon.stub( HTMLElement.prototype, 'getBoundingClientRect' ).callsFake( function() {
-					if ( this.parentNode.classList.contains( 'ck-source-editing-area' ) ) {
+					if ( typeof(this.parentNode.classList) === 'undefined' || this.parentNode.classList.contains( 'ck-source-editing-area' ) ) {
 						return {
 							top: 0,
 							left: 0,

--- a/packages/ckeditor5-ui/tests/editorui/poweredby.js
+++ b/packages/ckeditor5-ui/tests/editorui/poweredby.js
@@ -189,7 +189,8 @@ describe( 'PoweredBy', () => {
 
 				// Stub textarea's client rect.
 				testUtils.sinon.stub( HTMLElement.prototype, 'getBoundingClientRect' ).callsFake( function() {
-					if ( typeof(this.parentNode.classList) === 'undefined' || this.parentNode.classList.contains( 'ck-source-editing-area' ) ) {
+					if ( typeof ( this.parentNode.classList ) === 'undefined' ||
+						this.parentNode.classList.contains( 'ck-source-editing-area' ) ) {
 						return {
 							top: 0,
 							left: 0,

--- a/packages/ckeditor5-utils/src/dom/rect.ts
+++ b/packages/ckeditor5-utils/src/dom/rect.ts
@@ -385,6 +385,8 @@ export default class Rect {
 			}
 		}
 
+		shiftRectToCompensatePositionedAncestor( absoluteRect, document.documentElement );
+
 		return absoluteRect;
 	}
 


### PR DESCRIPTION
### Fix ckeditor5-link - ckeditor in dialog box where main window is scrolled down - Position of link edit dialog

Type: Message. Closes #15430.

---

### Additional information

* Changed LoC provided by @oleq in #15430
* All tests passed
* Ran manual test for Link library
* Manual tested with angular using test framework provided in #15430
