### PR TITLE
Error after trying to add alternative text to edited image.

### DIFF
--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
@@ -377,10 +377,10 @@ export default class CKBoxImageEditCommand extends Command {
 				source: {
 					src: imageFallbackUrl,
 					sources: imageSources,
-					alt: element.getAttribute( 'alt' ),
 					width: imageWidth,
 					height: imageHeight,
-					...( imagePlaceholder ? { placeholder: imagePlaceholder } : null )
+					...( imagePlaceholder ? { placeholder: imagePlaceholder } : null ),
+					...( element.getAttribute( 'alt' ) ? { alt: element.getAttribute( 'alt' ) } : null )
 				}
 			} );
 

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
@@ -791,6 +791,26 @@ describe( 'CKBoxImageEditCommand', () => {
 				);
 			} );
 
+			it( 'should not be alt attribute if there is no one in the original image', () => {
+				setModelData( model, '[<imageBlock ' +
+						'ckboxImageId="example-id" height="50" src="/assets/sample.png" width="50">' +
+					'</imageBlock>]' );
+
+				const imageElement = editor.model.document.selection.getSelectedElement();
+
+				command._replaceImage( imageElement, dataMock );
+
+				expect( getModelData( model ) ).to.equal(
+					'[<imageBlock ' +
+						'ckboxImageId="image-id1" ' +
+						'height="100" ' +
+						'sources="[object Object]" ' +
+						'src="https://example.com/workspace1/assets/image-id1/images/100.png" ' +
+						'width="100">' +
+					'</imageBlock>]'
+				);
+			} );
+
 			it( 'should replace image with saved one (with blurHash placeholder) after it is processed', () => {
 				const placeholder = blurHashToDataUrl( dataWithBlurHashMock.data.metadata.blurHash );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ckbox): After image editing should be possible to change alt attribute. Closes #000.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
