### PR TITLE
Fix failing test from the `List` package

### DIFF
--- a/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
+++ b/packages/ckeditor5-list/tests/listproperties/listpropertiesui.js
@@ -509,6 +509,9 @@ describe( 'ListPropertiesUI', () => {
 						const listPropertiesView = numberedListDropdown.panelView.children.first;
 						const startIndexFieldView = listPropertiesView.startIndexFieldView;
 
+						// Force clear is necessary on CI.
+						listPropertiesView.focusTracker.focusedElement = null;
+
 						const spy = sinon.spy( startIndexFieldView, 'focus' );
 
 						numberedListDropdown.isOpen = true;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (list): Fix failing test.

---

### Additional information

This test only fails locally with the browser focused. Due to the test setup (dropdown lazy loading), the first list item is already focused when the dropdown is open for the second time. With the changes at the dialog feature branch, element is not re-focused if it's already focused, so the spy is not called. I added a hard reset on focus tracker at the end of the setup steps to make sure the testing scenario is the same in all envs.