### PR TITLE
Docs: adding the PbC label to demos.

### DIFF
--- a/docs/_snippets/features/mathtype.js
+++ b/docs/_snippets/features/mathtype.js
@@ -9,7 +9,6 @@ import { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
 import { CloudServices } from '@ckeditor/ckeditor5-cloud-services';
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
-// import { EasyImage } from '@ckeditor/ckeditor5-easy-image';
 import { ImageInsert, ImageUpload, PictureEditing } from '@ckeditor/ckeditor5-image';
 import MathType from '@wiris/mathtype-ckeditor5';
 import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
@@ -21,7 +20,6 @@ ClassicEditor
 			CKBox,
 			CKBoxImageEdit,
 			PictureEditing,
-			// EasyImage,
 			ImageUpload,
 			ImageInsert,
 			CloudServices,

--- a/docs/_snippets/features/mathtype.js
+++ b/docs/_snippets/features/mathtype.js
@@ -9,7 +9,7 @@ import { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
 import { CloudServices } from '@ckeditor/ckeditor5-cloud-services';
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
-import { EasyImage } from '@ckeditor/ckeditor5-easy-image';
+// import { EasyImage } from '@ckeditor/ckeditor5-easy-image';
 import { ImageInsert, ImageUpload, PictureEditing } from '@ckeditor/ckeditor5-image';
 import MathType from '@wiris/mathtype-ckeditor5';
 import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
@@ -21,7 +21,7 @@ ClassicEditor
 			CKBox,
 			CKBoxImageEdit,
 			PictureEditing,
-			EasyImage,
+			// EasyImage,
 			ImageUpload,
 			ImageInsert,
 			CloudServices,
@@ -34,6 +34,9 @@ ClassicEditor
 				'|', 'link', 'insertImage', 'insertTable', 'mediaEmbed', '|', 'MathType', 'ChemType',
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
+		},
+		ckbox: {
+			forceDemoLabel: true
 		},
 		ui: {
 			viewportOffset: {

--- a/docs/_snippets/features/placeholder-build.js
+++ b/docs/_snippets/features/placeholder-build.js
@@ -5,11 +5,11 @@
 
 /* globals window */
 
-import { CKBox } from '@ckeditor/ckeditor5-ckbox';
+import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageInsert, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 import ClassicEditor from '../build-classic';
 
-ClassicEditor.builtinPlugins.push( CKBox );
+ClassicEditor.builtinPlugins.push( CKBox, CKBoxImageEdit );
 ClassicEditor.builtinPlugins.push( PictureEditing, ImageInsert, ImageResize, AutoImage );
 
 window.ClassicEditor = ClassicEditor;

--- a/docs/_snippets/features/placeholder-custom.js
+++ b/docs/_snippets/features/placeholder-custom.js
@@ -16,6 +16,15 @@ ClassicEditor
 			'|', 'link', 'insertImage', 'insertTable', 'mediaEmbed',
 			'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
 		],
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', '|', 'ckboxImageEdit'
+			]
+		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/placeholder.js
+++ b/docs/_snippets/features/placeholder.js
@@ -16,6 +16,15 @@ ClassicEditor
 			'|', 'link', 'insertImage', 'insertTable', 'mediaEmbed',
 			'|', 'bulletedList', 'numberedList', '|', 'outdent', 'indent'
 		],
+		image: {
+			toolbar: [
+				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
+				'toggleImageCaption', 'imageTextAlternative', '|', 'ckboxImageEdit'
+			]
+		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/read-only-hide-toolbar.js
+++ b/docs/_snippets/features/read-only-hide-toolbar.js
@@ -22,8 +22,11 @@ ClassicEditor
 		image: {
 			toolbar: [
 				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
-				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+				'toggleImageCaption', 'imageTextAlternative', '|', 'ckboxImageEdit'
 			]
+		},
+		ckbox: {
+			forceDemoLabel: true
 		},
 		ui: {
 			viewportOffset: {

--- a/docs/_snippets/features/read-only.js
+++ b/docs/_snippets/features/read-only.js
@@ -22,8 +22,11 @@ ClassicEditor
 		image: {
 			toolbar: [
 				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
-				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+				'toggleImageCaption', 'imageTextAlternative', '|', 'ckboxImageEdit'
 			]
+		},
+		ckbox: {
+			forceDemoLabel: true
 		},
 		ui: {
 			viewportOffset: {

--- a/docs/_snippets/features/toolbar-basic.js
+++ b/docs/_snippets/features/toolbar-basic.js
@@ -23,6 +23,9 @@ ClassicEditor
 				'|', 'toggleImageCaption', 'imageTextAlternative', '|', 'ckboxImageEdit' ]
 		},
 		cloudServices: CS_CONFIG,
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/toolbar-breakpoint.js
+++ b/docs/_snippets/features/toolbar-breakpoint.js
@@ -22,6 +22,9 @@ ClassicEditor
 			],
 			shouldNotGroupWhenFull: true
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/toolbar-grouping.js
+++ b/docs/_snippets/features/toolbar-grouping.js
@@ -19,6 +19,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/toolbar-nested-icon.js
+++ b/docs/_snippets/features/toolbar-nested-icon.js
@@ -46,6 +46,9 @@ ClassicEditor
 				'|', 'toggleImageCaption', 'imageTextAlternative', '|', 'ckboxImageEdit' ]
 		},
 		cloudServices: CS_CONFIG,
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/toolbar-nested-label.js
+++ b/docs/_snippets/features/toolbar-nested-label.js
@@ -22,6 +22,12 @@ ClassicEditor
 				label: 'Basic styles',
 				withText: true,
 				items: [ 'bold', 'italic', 'strikethrough', 'superscript', 'subscript' ]
+			},
+			'|',
+			{
+				label: 'Inserting',
+				withText: true,
+				items: [ 'insertImage', 'insertTable' ]
 			}
 		],
 		image: {

--- a/docs/_snippets/features/toolbar-nested-label.js
+++ b/docs/_snippets/features/toolbar-nested-label.js
@@ -29,6 +29,9 @@ ClassicEditor
 				'|', 'toggleImageCaption', 'imageTextAlternative', '|', 'ckboxImageEdit' ]
 		},
 		cloudServices: CS_CONFIG,
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/toolbar-nested-simple.js
+++ b/docs/_snippets/features/toolbar-nested-simple.js
@@ -36,6 +36,9 @@ ClassicEditor
 				'|', 'toggleImageCaption', 'imageTextAlternative', '|', 'ckboxImageEdit' ]
 		},
 		cloudServices: CS_CONFIG,
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/toolbar-nested-simple.js
+++ b/docs/_snippets/features/toolbar-nested-simple.js
@@ -29,7 +29,9 @@ ClassicEditor
 				withText: true,
 				icon: false,
 				items: [ 'bulletedList', 'numberedList', 'todoList' ]
-			}
+			},
+			'|',
+			'insertImage', 'insertTable'
 		],
 		image: {
 			toolbar: [ 'imageStyle:inline', 'imageStyle:block', 'imageStyle:side',

--- a/docs/_snippets/features/toolbar-nested-tooltip.js
+++ b/docs/_snippets/features/toolbar-nested-tooltip.js
@@ -29,6 +29,9 @@ ClassicEditor
 				'|', 'toggleImageCaption', 'imageTextAlternative', '|', 'ckboxImageEdit' ]
 		},
 		cloudServices: CS_CONFIG,
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/toolbar-separator.js
+++ b/docs/_snippets/features/toolbar-separator.js
@@ -23,6 +23,9 @@ ClassicEditor
 				'|', 'toggleImageCaption', 'imageTextAlternative', '|', 'ckboxImageEdit' ]
 		},
 		cloudServices: CS_CONFIG,
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/toolbar-wrapping.js
+++ b/docs/_snippets/features/toolbar-wrapping.js
@@ -21,6 +21,9 @@ ClassicEditor
 			],
 			shouldNotGroupWhenFull: true
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/ui-language-content.js
+++ b/docs/_snippets/features/ui-language-content.js
@@ -28,6 +28,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/ui-language-rtl.js
+++ b/docs/_snippets/features/ui-language-rtl.js
@@ -26,6 +26,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/ui-language.js
+++ b/docs/_snippets/features/ui-language.js
@@ -26,6 +26,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/update-placeholder.js
+++ b/docs/_snippets/features/update-placeholder.js
@@ -16,6 +16,9 @@ ClassicEditor
 			'|', 'link', 'insertImage', 'insertTable', 'mediaEmbed',
 			'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 		],
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/docs/_snippets/features/wproofreader.js
+++ b/docs/_snippets/features/wproofreader.js
@@ -33,6 +33,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-options.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-options.js
@@ -33,6 +33,9 @@ ClassicEditor
 		alignment: {
 			options: [ 'left', 'right' ]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		cloudServices: CS_CONFIG
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-toolbar.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/custom-text-alignment-toolbar.js
@@ -30,6 +30,9 @@ ClassicEditor
 				top: window.getViewportTopOffsetConfig()
 			}
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		cloudServices: CS_CONFIG
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js
+++ b/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js
@@ -30,6 +30,9 @@ ClassicEditor
 				top: window.getViewportTopOffsetConfig()
 			}
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		cloudServices: CS_CONFIG
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.js
+++ b/packages/ckeditor5-autoformat/docs/_snippets/features/autoformat.js
@@ -53,6 +53,9 @@ ClassicEditor
 				top: window.getViewportTopOffsetConfig()
 			}
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		cloudServices: CS_CONFIG
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-basic-styles/docs/_snippets/features/basic-styles.js
+++ b/packages/ckeditor5-basic-styles/docs/_snippets/features/basic-styles.js
@@ -28,6 +28,9 @@ ClassicEditor
 				top: window.getViewportTopOffsetConfig()
 			}
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		cloudServices: CS_CONFIG
 	} )
 	.then( editor => {

--- a/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote-source.js
+++ b/packages/ckeditor5-block-quote/docs/_snippets/features/block-quote-source.js
@@ -32,6 +32,9 @@ ClassicEditor.defaultConfig = {
 			'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 		]
 	},
+	ckbox: {
+		forceDemoLabel: true
+	},
 	ui: {
 		viewportOffset: {
 			top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/build-drag-drop-source.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/build-drag-drop-source.js
@@ -124,6 +124,9 @@ const defaultConfig = {
 	table: {
 		contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ]
 	},
+	ckbox: {
+		forceDemoLabel: true
+	},
 	ui: {
 		viewportOffset: {
 			top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-clipboard/docs/_snippets/features/paste-plain-text.js
+++ b/packages/ckeditor5-clipboard/docs/_snippets/features/paste-plain-text.js
@@ -24,6 +24,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-code-block/docs/_snippets/features/code-block-custom-languages.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/code-block-custom-languages.js
@@ -24,6 +24,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-code-block/docs/_snippets/features/code-block.js
+++ b/packages/ckeditor5-code-block/docs/_snippets/features/code-block.js
@@ -24,6 +24,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
+++ b/packages/ckeditor5-find-and-replace/docs/_snippets/features/find-and-replace.js
@@ -24,6 +24,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-color-and-background-color-options.js
@@ -26,6 +26,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-family-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-family-options.js
@@ -26,6 +26,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-named-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-named-options.js
@@ -27,6 +27,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-numeric-options.js
+++ b/packages/ckeditor5-font/docs/_snippets/features/custom-font-size-numeric-options.js
@@ -27,6 +27,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-buttons.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-buttons.js
@@ -41,6 +41,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-elements.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-elements.js
@@ -47,6 +47,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-levels.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/custom-heading-levels.js
@@ -37,6 +37,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-heading/docs/_snippets/features/default-headings.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/default-headings.js
@@ -38,6 +38,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-heading/docs/_snippets/features/heading-buttons.js
+++ b/packages/ckeditor5-heading/docs/_snippets/features/heading-buttons.js
@@ -38,6 +38,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-inline.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-inline.js
@@ -24,6 +24,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-variables.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-colors-variables.js
@@ -24,6 +24,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-options.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/custom-highlight-options.js
@@ -24,6 +24,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-highlight/docs/_snippets/features/highlight-buttons.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/highlight-buttons.js
@@ -25,6 +25,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-highlight/docs/_snippets/features/highlight.js
+++ b/packages/ckeditor5-highlight/docs/_snippets/features/highlight.js
@@ -24,6 +24,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-horizontal-line/docs/_snippets/features/horizontal-line.js
+++ b/packages/ckeditor5-horizontal-line/docs/_snippets/features/horizontal-line.js
@@ -36,6 +36,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-html-embed/docs/_snippets/features/html-embed.js
+++ b/packages/ckeditor5-html-embed/docs/_snippets/features/html-embed.js
@@ -98,6 +98,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-html-support/docs/_snippets/features/full-page-html.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/full-page-html.js
@@ -24,6 +24,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support-source.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support-source.js
@@ -49,6 +49,9 @@ ClassicEditor.defaultConfig = {
 			'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 		]
 	},
+	ckbox: {
+		forceDemoLabel: true
+	},
 	ui: {
 		viewportOffset: {
 			top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support.js
+++ b/packages/ckeditor5-html-support/docs/_snippets/features/general-html-support.js
@@ -23,6 +23,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-caption.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-caption.js
@@ -32,6 +32,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-full.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-full.js
@@ -18,6 +18,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-insert-via-pasting-url-into-editor.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-insert-via-pasting-url-into-editor.js
@@ -20,6 +20,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-insert-via-url.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-insert-via-url.js
@@ -23,6 +23,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-link.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-link.js
@@ -19,6 +19,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons-dropdown.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons-dropdown.js
@@ -19,6 +19,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize-buttons.js
@@ -19,6 +19,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize-px.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize-px.js
@@ -40,6 +40,9 @@ ClassicEditor
 			],
 			toolbar: [ 'resizeImage', 'ckboxImageEdit' ]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-resize.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-resize.js
@@ -19,6 +19,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-semantical-style.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-semantical-style.js
@@ -10,6 +10,9 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 ClassicEditor
 	.create( document.querySelector( '#snippet-semantical-image-style-default' ), {
 		removePlugins: [ 'imageCaption' ],
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-style-custom.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-style-custom.js
@@ -15,6 +15,9 @@ import sideIcon from '@ckeditor/ckeditor5-image/docs/assets/img/icons/side.svg';
 ClassicEditor
 	.create( document.querySelector( '#snippet-image-semantical-style-custom' ), {
 		removePlugins: [ 'ImageResize' ],
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-style-presentational.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-style-presentational.js
@@ -47,6 +47,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-image/docs/_snippets/features/image-text-alternative.js
+++ b/packages/ckeditor5-image/docs/_snippets/features/image-text-alternative.js
@@ -32,6 +32,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-indent/docs/_snippets/features/custom-indent-block-classes.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/custom-indent-block-classes.js
@@ -24,6 +24,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-indent/docs/_snippets/features/indent.js
+++ b/packages/ckeditor5-indent/docs/_snippets/features/indent.js
@@ -24,6 +24,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-language/docs/_snippets/features/textpartlanguage.js
+++ b/packages/ckeditor5-language/docs/_snippets/features/textpartlanguage.js
@@ -45,6 +45,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-link/docs/_snippets/features/autolink.js
+++ b/packages/ckeditor5-link/docs/_snippets/features/autolink.js
@@ -19,6 +19,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-link/docs/_snippets/features/link.js
+++ b/packages/ckeditor5-link/docs/_snippets/features/link.js
@@ -23,6 +23,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-link/docs/_snippets/features/linkdecorators.js
+++ b/packages/ckeditor5-link/docs/_snippets/features/linkdecorators.js
@@ -22,6 +22,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-list/docs/_snippets/features/lists-basic.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/lists-basic.js
@@ -18,6 +18,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-list/docs/_snippets/features/lists-document.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/lists-document.js
@@ -21,6 +21,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-list/docs/_snippets/features/lists-index.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/lists-index.js
@@ -18,6 +18,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-list/docs/_snippets/features/lists-reversed.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/lists-reversed.js
@@ -18,6 +18,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-list/docs/_snippets/features/lists-style.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/lists-style.js
@@ -18,6 +18,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-list/docs/_snippets/features/todo-list.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/todo-list.js
@@ -22,7 +22,7 @@ ClassicEditor
 			items: [
 				'undo', 'redo', '|', 'heading',
 				'|', 'bold', 'italic',
-				'|', 'link', 'insertImage', 'insertTable', 'mediaEmbed',
+				'|', 'link', 'insertImage', 'ckbox', 'insertTable', 'mediaEmbed',
 				'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
 			]
 		},

--- a/packages/ckeditor5-list/docs/_snippets/features/todo-list.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/todo-list.js
@@ -32,6 +32,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-list/docs/_snippets/features/todo-list.js
+++ b/packages/ckeditor5-list/docs/_snippets/features/todo-list.js
@@ -7,13 +7,13 @@
 
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 import { TodoList } from '@ckeditor/ckeditor5-list';
-import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
+// import { CKBox, CKBoxImageEdit } from '@ckeditor/ckeditor5-ckbox';
 import { PictureEditing, ImageResize, AutoImage } from '@ckeditor/ckeditor5-image';
 
 // Umberto combines all `packages/*/docs` into the `docs/` directory. The import path must be valid after merging all directories.
 import ClassicEditor from '../build-classic';
 
-ClassicEditor.builtinPlugins.push( TodoList, CKBox, CKBoxImageEdit, PictureEditing, ImageResize, AutoImage );
+ClassicEditor.builtinPlugins.push( TodoList, /* CKBox, CKBoxImageEdit, */ PictureEditing, ImageResize, AutoImage );
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-todo-list' ), {
@@ -22,14 +22,15 @@ ClassicEditor
 			items: [
 				'undo', 'redo', '|', 'heading',
 				'|', 'bold', 'italic',
-				'|', 'link', 'insertImage', 'ckbox', 'insertTable', 'mediaEmbed',
+				'|', 'link', 'insertImage', 'insertTable', 'mediaEmbed',
 				'|', 'bulletedList', 'numberedList', 'todoList', 'outdent', 'indent'
 			]
 		},
 		image: {
 			toolbar: [
 				'imageStyle:inline', 'imageStyle:block', 'imageStyle:side', '|',
-				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
+				'toggleImageCaption', 'imageTextAlternative'
+				// '|', 'ckboxImageEdit'
 			]
 		},
 		ckbox: {

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.js
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/markdown.js
@@ -56,6 +56,9 @@ ClassicEditor
 			]
 		},
 		cloudServices: CS_CONFIG,
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-markdown-gfm/docs/_snippets/features/paste-from-markdown.js
+++ b/packages/ckeditor5-markdown-gfm/docs/_snippets/features/paste-from-markdown.js
@@ -69,6 +69,9 @@ ClassicEditor
 				{ language: 'php', label: 'PHP' }
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed-preview.js
+++ b/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed-preview.js
@@ -26,6 +26,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed.js
+++ b/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed.js
@@ -24,6 +24,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-mention/docs/_snippets/features/custom-mention-colors-variables.js
+++ b/packages/ckeditor5-mention/docs/_snippets/features/custom-mention-colors-variables.js
@@ -24,6 +24,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-mention/docs/_snippets/features/mention-customization.js
+++ b/packages/ckeditor5-mention/docs/_snippets/features/mention-customization.js
@@ -25,6 +25,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-mention/docs/_snippets/features/mention.js
+++ b/packages/ckeditor5-mention/docs/_snippets/features/mention.js
@@ -24,6 +24,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-minimap/docs/_snippets/features/minimap.js
+++ b/packages/ckeditor5-minimap/docs/_snippets/features/minimap.js
@@ -90,6 +90,9 @@ const config = {
 		extraClasses: 'live-snippet formatted'
 	},
 	cloudServices: CS_CONFIG,
+	ckbox: {
+		forceDemoLabel: true
+	},
 	ui: {
 		viewportOffset: {
 			top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-page-break/docs/_snippets/features/page-break.js
+++ b/packages/ckeditor5-page-break/docs/_snippets/features/page-break.js
@@ -36,6 +36,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-paste-from-office/docs/_snippets/features/paste-from-office.js
+++ b/packages/ckeditor5-paste-from-office/docs/_snippets/features/paste-from-office.js
@@ -20,6 +20,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-remove-format/docs/_snippets/features/remove-format.js
+++ b/packages/ckeditor5-remove-format/docs/_snippets/features/remove-format.js
@@ -28,6 +28,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-restricted-editing/docs/_snippets/features/restricted-editing.js
+++ b/packages/ckeditor5-restricted-editing/docs/_snippets/features/restricted-editing.js
@@ -72,6 +72,9 @@ async function startStandardEditingMode() {
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-select-all/docs/_snippets/features/select-all.js
+++ b/packages/ckeditor5-select-all/docs/_snippets/features/select-all.js
@@ -34,6 +34,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-show-blocks/docs/_snippets/features/show-blocks.js
+++ b/packages/ckeditor5-show-blocks/docs/_snippets/features/show-blocks.js
@@ -37,6 +37,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-imports.js
+++ b/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-imports.js
@@ -59,6 +59,9 @@ ClassicEditor.defaultConfig = {
 			'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 		]
 	},
+	ckbox: {
+		forceDemoLabel: true
+	},
 	ui: {
 		viewportOffset: {
 			top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-with-markdown.js
+++ b/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing-with-markdown.js
@@ -53,6 +53,9 @@ ClassicEditor
 				{ name: 'script' }
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing.js
+++ b/packages/ckeditor5-source-editing/docs/_snippets/features/source-editing.js
@@ -60,6 +60,9 @@ ClassicEditor
 				{ name: 'script' }
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-extended-category.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-extended-category.js
@@ -26,6 +26,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-limited-categories.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-limited-categories.js
@@ -18,6 +18,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-new-category.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters-new-category.js
@@ -28,6 +28,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters.js
+++ b/packages/ckeditor5-special-characters/docs/_snippets/features/special-characters.js
@@ -18,6 +18,9 @@ ClassicEditor
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-style/docs/_snippets/features/styles.js
+++ b/packages/ckeditor5-style/docs/_snippets/features/styles.js
@@ -111,6 +111,9 @@ ClassicEditor
 			]
 		},
 		cloudServices: CS_CONFIG,
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-table/docs/_snippets/features/build-table-source.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/build-table-source.js
@@ -33,6 +33,9 @@ ClassicEditor.defaultConfig = {
 			'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 		]
 	},
+	ckbox: {
+		forceDemoLabel: true
+	},
 	ui: {
 		viewportOffset: {
 			top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-table/docs/_snippets/features/table-caption.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-caption.js
@@ -23,6 +23,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-table/docs/_snippets/features/table-column-resize.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-column-resize.js
@@ -23,6 +23,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-table/docs/_snippets/features/table-default-headings.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-default-headings.js
@@ -23,6 +23,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-table/docs/_snippets/features/table-default-properties.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-default-properties.js
@@ -41,6 +41,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-table/docs/_snippets/features/table-nesting.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-nesting.js
@@ -116,6 +116,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-table/docs/_snippets/features/table-styling-colors.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-styling-colors.js
@@ -117,6 +117,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-table/docs/_snippets/features/table-styling.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/table-styling.js
@@ -26,6 +26,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-table/docs/_snippets/features/tables.js
+++ b/packages/ckeditor5-table/docs/_snippets/features/tables.js
@@ -29,6 +29,9 @@ ClassicEditor
 				'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation-extended.js
@@ -25,6 +25,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
+++ b/packages/ckeditor5-typing/docs/_snippets/features/text-transformation.js
@@ -25,6 +25,9 @@ ClassicEditor
 				'toggleImageCaption', 'imageTextAlternative', 'ckboxImageEdit'
 			]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-ui/docs/_snippets/features/blocktoolbar.js
+++ b/packages/ckeditor5-ui/docs/_snippets/features/blocktoolbar.js
@@ -138,7 +138,7 @@ BalloonEditor
 			'|',
 			'paragraph', 'heading1', 'heading2', 'heading3',
 			'|',
-			'uploadImage', 'blockQuote',
+			'insertImage', 'blockQuote',
 			'|',
 			'bulletedList', 'numberedList',
 			'|',

--- a/packages/ckeditor5-ui/docs/_snippets/features/blocktoolbar.js
+++ b/packages/ckeditor5-ui/docs/_snippets/features/blocktoolbar.js
@@ -125,6 +125,9 @@ BalloonEditor
 		toolbar: {
 			items: [ 'bold', 'italic', '|', 'link' ]
 		},
+		ckbox: {
+			forceDemoLabel: true
+		},
 		ui: {
 			viewportOffset: {
 				top: window.getViewportTopOffsetConfig()

--- a/packages/ckeditor5-undo/docs/_snippets/features/undo-redo.js
+++ b/packages/ckeditor5-undo/docs/_snippets/features/undo-redo.js
@@ -44,6 +44,7 @@ ClassicEditor
 			]
 		},
 		ckbox: {
+			forceDemoLabel: true,
 			tokenUrl: TOKEN_URL
 		},
 		table: {

--- a/packages/ckeditor5-word-count/docs/_snippets/features/word-count-update.js
+++ b/packages/ckeditor5-word-count/docs/_snippets/features/word-count-update.js
@@ -27,9 +27,12 @@ BalloonEditor
 				'undo', 'redo',
 				'|', 'heading',
 				'|', 'bold', 'italic',
-				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'link', 'insertImage', 'insertTable', 'mediaEmbed',
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
+		},
+		ckbox: {
+			forceDemoLabel: true
 		},
 		ui: {
 			viewportOffset: {

--- a/packages/ckeditor5-word-count/docs/_snippets/features/word-count.js
+++ b/packages/ckeditor5-word-count/docs/_snippets/features/word-count.js
@@ -15,9 +15,12 @@ ClassicEditor
 				'undo', 'redo',
 				'|', 'heading',
 				'|', 'bold', 'italic',
-				'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
+				'|', 'link', 'insertImage', 'insertTable', 'mediaEmbed',
 				'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 			]
+		},
+		ckbox: {
+			forceDemoLabel: true
 		},
 		ui: {
 			viewportOffset: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: adding the "Powered by CKBox" label to feature guides demos. Closes cksource/ckeditor5-commercial#5826

---

### Additional information

Includes:

- [x] PbC label added to CKBox in all demos in feature guides that have CKBox service attached
- [x] additional `insertImage` instances added where lacked
- [x] various minor fixes in the snippets where deemed applicable

_Merge together with https://github.com/cksource/ckeditor5-commercial/pull/5837_