### PR TITLE
Internal: Fix error caused by eslint rule not having `ruleId`

### DIFF
--- a/scripts/eslint-formatter.js
+++ b/scripts/eslint-formatter.js
@@ -29,7 +29,7 @@ module.exports = results => {
 		}
 
 		return item.messages.some( message => {
-			return message.ruleId && message.ruleId.startsWith( 'ckeditor5-rules' );
+			return message.ruleId?.startsWith( 'ckeditor5-rules' );
 		} );
 	} );
 

--- a/scripts/eslint-formatter.js
+++ b/scripts/eslint-formatter.js
@@ -29,7 +29,7 @@ module.exports = results => {
 		}
 
 		return item.messages.some( message => {
-			return message.ruleId.startsWith( 'ckeditor5-rules' );
+			return message.ruleId && message.ruleId.startsWith( 'ckeditor5-rules' );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Fix error caused by eslint rule not having `ruleId`. Related to #5731.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
