### PR TITLE
Unify header styles with the new dialog headers

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dialog/dialog.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dialog/dialog.css
@@ -29,14 +29,6 @@
 	max-height: var(--ck-dialog-max-height);
 	max-width: var(--ck-dialog-max-width);
 	border: 1px solid var(--ck-color-base-border);
-
-	& .ck.ck-form__header  {
-		--ck-form-header-height: 44px;
-
-		& .ck-form__header__label {
-			--ck-font-size-base: 15px;
-		}
-	}
 }
 
 @keyframes ck-dialog-fade-in {

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/formheader/formheader.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/formheader/formheader.css
@@ -6,7 +6,7 @@
 @import "@ckeditor/ckeditor5-ui/theme/mixins/_dir.css";
 
 :root {
-	--ck-form-header-height: 38px;
+	--ck-form-header-height: 44px;
 }
 
 .ck.ck-form__header {
@@ -26,6 +26,7 @@
 	}
 
 	& .ck-form__header__label {
+		--ck-font-size-base: 15px;
 		font-weight: bold;
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal(ui): Changed the header sizes.

---

### Additional information

Note that UIs that do not use the `FormHeaderView` (like comments archive) are unaffected by this change.