### PR TITLE
Add missing type to example of addListToDropdown in ui/dropdown/utils.

### DIFF
--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -262,7 +262,7 @@ function addToolbarToOpenDropdown(
  * Adds an instance of {@link module:ui/list/listview~ListView} to a dropdown.
  *
  * ```ts
- * const items = new Collection();
+ * const items = new Collection<ListDropdownItemDefinition>();
  *
  * items.add( {
  * 	type: 'button',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs (ui): Adds correct type to example in `ckeditor5-ui/dropdown/utils.ts`. Closes #15533.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
