### PR TITLE
Integrate source editing with dialogs

### DIFF
--- a/packages/ckeditor5-source-editing/src/sourceediting.ts
+++ b/packages/ckeditor5-source-editing/src/sourceediting.ts
@@ -134,6 +134,7 @@ export default class SourceEditing extends Plugin {
 		if ( this._isAllowedToHandleSourceEditingMode() ) {
 			this.on( 'change:isSourceEditingMode', ( evt, name, isSourceEditingMode ) => {
 				if ( isSourceEditingMode ) {
+					this._hideVisibleDialog();
 					this._showSourceEditing();
 					this._disableCommands();
 				} else {
@@ -368,6 +369,15 @@ export default class SourceEditing extends Plugin {
 
 		// Checks, if the editor's editable belongs to the editor's DOM tree.
 		return editable && !editable.hasExternalElement;
+	}
+
+	/**
+	 * If any {@link module:ui/dialog/dialogview~DialogView editor dialog} is currently visible, hide it.
+	 */
+	private _hideVisibleDialog(): void {
+		if ( this.editor.plugins.has( 'Dialog' ) && this.editor.plugins.get( 'Dialog' ).isOpen ) {
+			this.editor.plugins.get( 'Dialog' ).hide();
+		}
 	}
 }
 

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -374,47 +374,58 @@ describe( 'SourceEditing', () => {
 			expect( domRoot.classList.contains( 'ck-hidden' ) ).to.be.true;
 		} );
 
-		it( 'should hide the open dialog after switching to the source editing mode', () => {
-			const dialog = editor.plugins.get( 'Dialog' );
+		describe( 'integration with the Dialog plugin', () => {
+			it( 'should hide the open dialog after switching to the source editing mode', () => {
+				const dialog = editor.plugins.get( 'Dialog' );
 
-			dialog.show( {} );
+				dialog.show( {} );
 
-			const spy = sinon.spy( dialog, 'hide' );
+				const spy = sinon.spy( dialog, 'hide' );
 
-			button.fire( 'execute' );
+				button.fire( 'execute' );
 
-			sinon.assert.calledOnce( spy );
-		} );
-
-		it( 'should not throw if the Dialog plugin is not loaded', async () => {
-			const tempEditorElement = document.body.appendChild( document.createElement( 'div' ) );
-
-			const tempEditor = await ClassicTestEditor.create( tempEditorElement, {
-				plugins: [ SourceEditing, Paragraph, Essentials ],
-				initialData: '<p>Foo</p>'
+				sinon.assert.calledOnce( spy );
 			} );
 
-			plugin = tempEditor.plugins.get( 'SourceEditing' );
-			button = tempEditor.ui.componentFactory.create( 'sourceEditing' );
+			it( 'should not attempt to hide a hidden dialog after switching to the source editing mode', () => {
+				const dialog = editor.plugins.get( 'Dialog' );
+				const spy = sinon.spy( dialog, 'hide' );
 
-			expect( () => button.fire( 'execute' ) ).to.not.throw();
+				button.fire( 'execute' );
 
-			tempEditorElement.remove();
-			return tempEditor.destroy();
-		} );
+				sinon.assert.notCalled( spy );
+			} );
 
-		it( 'should not show the previously open dialog after switching back from the source editing mode', () => {
-			const dialog = editor.plugins.get( 'Dialog' );
+			it( 'should not throw if the Dialog plugin is not loaded', async () => {
+				const tempEditorElement = document.body.appendChild( document.createElement( 'div' ) );
 
-			dialog.show( {} );
+				const tempEditor = await ClassicTestEditor.create( tempEditorElement, {
+					plugins: [ SourceEditing, Paragraph, Essentials ],
+					initialData: '<p>Foo</p>'
+				} );
 
-			const spy = sinon.spy( dialog, 'show' );
+				plugin = tempEditor.plugins.get( 'SourceEditing' );
+				button = tempEditor.ui.componentFactory.create( 'sourceEditing' );
 
-			// Exit and reenter the source editing mode.
-			button.fire( 'execute' );
-			button.fire( 'execute' );
+				expect( () => button.fire( 'execute' ) ).to.not.throw();
 
-			sinon.assert.notCalled( spy );
+				tempEditorElement.remove();
+				return tempEditor.destroy();
+			} );
+
+			it( 'should not show the previously open dialog after switching back from the source editing mode', () => {
+				const dialog = editor.plugins.get( 'Dialog' );
+
+				dialog.show( {} );
+
+				const spy = sinon.spy( dialog, 'show' );
+
+				// Exit and reenter the source editing mode.
+				button.fire( 'execute' );
+				button.fire( 'execute' );
+
+				sinon.assert.notCalled( spy );
+			} );
 		} );
 
 		it( 'should show the editing root after switching back from the source editing mode', () => {

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -23,6 +23,7 @@ import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
 import { _getEmitterListenedTo, _getEmitterId } from '@ckeditor/ckeditor5-utils/src/emittermixin.js';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard.js';
+import { Dialog } from '@ckeditor/ckeditor5-ui';
 
 describe( 'SourceEditing', () => {
 	let editor, editorElement, plugin, button;
@@ -33,7 +34,7 @@ describe( 'SourceEditing', () => {
 		editorElement = document.body.appendChild( document.createElement( 'div' ) );
 
 		editor = await ClassicTestEditor.create( editorElement, {
-			plugins: [ SourceEditing, Paragraph, Essentials ],
+			plugins: [ SourceEditing, Paragraph, Essentials, Dialog ],
 			initialData: '<p>Foo</p>'
 		} );
 
@@ -371,6 +372,49 @@ describe( 'SourceEditing', () => {
 			const domRoot = editor.editing.view.getDomRoot();
 
 			expect( domRoot.classList.contains( 'ck-hidden' ) ).to.be.true;
+		} );
+
+		it( 'should hide the open dialog after switching to the source editing mode', () => {
+			const dialog = editor.plugins.get( 'Dialog' );
+
+			dialog.show( {} );
+
+			const spy = sinon.spy( dialog, 'hide' );
+
+			button.fire( 'execute' );
+
+			sinon.assert.calledOnce( spy );
+		} );
+
+		it( 'should not throw if the Dialog plugin is not loaded', async () => {
+			const tempEditorElement = document.body.appendChild( document.createElement( 'div' ) );
+
+			const tempEditor = await ClassicTestEditor.create( tempEditorElement, {
+				plugins: [ SourceEditing, Paragraph, Essentials ],
+				initialData: '<p>Foo</p>'
+			} );
+
+			plugin = tempEditor.plugins.get( 'SourceEditing' );
+			button = tempEditor.ui.componentFactory.create( 'sourceEditing' );
+
+			expect( () => button.fire( 'execute' ) ).to.not.throw();
+
+			tempEditorElement.remove();
+			return tempEditor.destroy();
+		} );
+
+		it( 'should not show the previously open dialog after switching back from the source editing mode', () => {
+			const dialog = editor.plugins.get( 'Dialog' );
+
+			dialog.show( {} );
+
+			const spy = sinon.spy( dialog, 'show' );
+
+			// Exit and reenter the source editing mode.
+			button.fire( 'execute' );
+			button.fire( 'execute' );
+
+			sinon.assert.notCalled( spy );
 		} );
 
 		it( 'should show the editing root after switching back from the source editing mode', () => {

--- a/packages/ckeditor5-ui/tests/manual/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/tests/manual/dialog/dialog.ts
@@ -201,7 +201,7 @@ function initEditor( editorName, editorClass, direction = 'ltr', customCallback?
 		],
 		toolbar: {
 			items: [
-				'heading', 'bold', 'italic', 'link',
+				'heading', 'bold', 'italic', 'link', 'sourceediting',
 				'-',
 				'findAndReplace', 'modalWithText', ...POSSIBLE_DIALOG_POSITIONS
 			],


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal(source-editing): Hide the visible dialog when switching to the source editing mode.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._