### PR TITLE
Dynamic multi-root editor toolbar

### DIFF
--- a/docs/_snippets/examples/multi-root-editor.js
+++ b/docs/_snippets/examples/multi-root-editor.js
@@ -28,6 +28,18 @@ MultiRootEditor
 					'|', 'link', 'uploadImage', 'insertTable', 'mediaEmbed',
 					'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 				]
+			},
+			rootsToolbars: {
+				leftSide: [
+					'undo', 'redo',
+					'|', 'heading',
+					'|', 'link'
+				],
+				rightSide: [
+					'undo', 'redo',
+					'|', 'heading',
+					'|', 'link'
+				]
 			}
 		}
 	)

--- a/docs/examples/builds/multi-root-editor.md
+++ b/docs/examples/builds/multi-root-editor.md
@@ -51,6 +51,18 @@ MultiRootEditor
 					'|', 'link', 'insertImage', 'insertTable', 'mediaEmbed',
 					'|', 'bulletedList', 'numberedList', 'outdent', 'indent'
 				]
+			},
+			rootsToolbars: {
+				leftSide: [
+					'undo', 'redo',
+					'|', 'heading',
+					'|', 'link'
+				],
+				rightSide: [
+					'undo', 'redo',
+					'|', 'heading',
+					'|', 'link'
+				]
 			}
 		}
 	)
@@ -88,10 +100,10 @@ MultiRootEditor
 	contenteditable="true" + contenteditable="false" elements
 	is required to provide proper caret handling when
 	using arrow keys at the start and end of an editable area.
-	
+
 	You can skip them if you don't want to move the
 	caret between editable areas using arrow keys.
-!--> 
+!-->
 <div contenteditable="true">
 	<div contenteditable="false">
 		<div id="header">

--- a/packages/ckeditor5-editor-multi-root/src/augmentation.ts
+++ b/packages/ckeditor5-editor-multi-root/src/augmentation.ts
@@ -4,6 +4,7 @@
  */
 
 import { type RootAttributes } from './multirooteditor.js';
+import { type ToolbarConfigItem } from 'ckeditor5/src/core.js';
 
 declare module '@ckeditor/ckeditor5-core' {
 	interface EditorConfig {
@@ -79,6 +80,47 @@ declare module '@ckeditor/ckeditor5-core' {
 		 * ```
 		 */
 		rootsAttributes?: Record<string, RootAttributes>;
+
+		/**
+		 * UI toolbar configurations for the document roots.
+		 *
+		 * **Note: This configuration option is supported only by the
+		 * {@link module:editor-multi-root/multirooteditor~MultiRootEditor multi-root} editor type.**
+		 *
+		 * **Note: This configuration does not limit what kind of content the user is allowed to create
+		 * (write, paste, etc.) in a specific root. It affects only the presentation of the toolbar.**
+		 *
+		 * When specified, the main editor toolbar will change its items dynamically depending on in which the user
+		 * selection is anchored. This allows for targeted editing experience, e.g. to declutter the toolbars for
+		 * roots that contain only a specific kind of content.
+		 *
+		 * Please keep in mind that behaviors such as {@link module:core/editor/editorconfig~EditorConfig#toolbar `shouldGroupWhenFull`}
+		 * are inherited by individual root toolbars from the main editor toolbar configuration.
+		 *
+		 * ```ts
+		 * MultiRootEditor.create(
+		 * 	// Roots for the editor:
+		 * 	{
+		 * 		uid1: document.querySelector( '#uid1' ),
+		 * 		uid2: document.querySelector( '#uid2' ),
+		 * 		uid3: document.querySelector( '#uid3' ),
+		 * 		uid4: document.querySelector( '#uid4' )
+		 * 	},
+		 * 	// Config:
+		 * 	{
+		 * 		// Specific toolbar configurations for individual roots.
+		 * 		rootsToolbars: {
+		 * 			uid1: [ 'bold', 'italic', '|', 'undo', 'redo' ].
+		 * 			uid3: [ 'bold', 'italic', 'underline', '|', 'undo', 'redo' ].
+		 * 		},
+		 * 		// Roots not specified in rootsToolbars use this global toolbar configuration.
+		 * 		toolbar: [ 'bold', 'italic' ]
+		 * 	}
+		 * )
+		 * .then( ... )
+		 * .catch( ... );
+		 */
+		rootsToolbars?: Record<string, Array<ToolbarConfigItem>>;
 
 		/**
 		 * A list of names of all the roots that exist in the document but are not initially loaded by the editor.

--- a/packages/ckeditor5-editor-multi-root/src/augmentation.ts
+++ b/packages/ckeditor5-editor-multi-root/src/augmentation.ts
@@ -88,14 +88,15 @@ declare module '@ckeditor/ckeditor5-core' {
 		 * {@link module:editor-multi-root/multirooteditor~MultiRootEditor multi-root} editor type.**
 		 *
 		 * **Note: This configuration does not limit what kind of content the user is allowed to create
-		 * (write, paste, etc.) in a specific root. It affects only the presentation of the toolbar.**
+		 * (write, paste, etc.) in a specific editor root. It affects only the presentation of the toolbar.**
 		 *
-		 * When specified, the main editor toolbar will change its items dynamically depending on in which the user
+		 * When specified, the main editor toolbar will change its items dynamically depending on in which root the user
 		 * selection is anchored. This allows for targeted editing experience, e.g. to declutter the toolbars for
 		 * roots that contain only a specific kind of content.
 		 *
-		 * Please keep in mind that behaviors such as {@link module:core/editor/editorconfig~EditorConfig#toolbar `shouldGroupWhenFull`}
-		 * are inherited by individual root toolbars from the main editor toolbar configuration.
+		 * Please keep in mind that properties such as {@link module:core/editor/editorconfig~EditorConfig#toolbar `shouldGroupWhenFull`}
+		 * or {@link module:core/editor/editorconfig~EditorConfig#toolbar `removeItems`} are inherited by individual root toolbars
+		 * from the main {@link module:core/editor/editorconfig~EditorConfig#toolbar toolbar configuration}.
 		 *
 		 * ```ts
 		 * MultiRootEditor.create(
@@ -110,17 +111,55 @@ declare module '@ckeditor/ckeditor5-core' {
 		 * 	{
 		 * 		// Specific toolbar configurations for individual roots.
 		 * 		rootsToolbars: {
-		 * 			uid1: [ 'bold', 'italic', '|', 'undo', 'redo' ].
-		 * 			uid3: [ 'bold', 'italic', 'underline', '|', 'undo', 'redo' ].
+		 * 			uid1: [ 'bold', 'italic', '|', 'undo', 'redo' ],
+		 * 			uid3: [ 'bold', 'italic', 'underline', '|', 'undo', 'redo' ]
 		 * 		},
-		 * 		// Roots not specified in rootsToolbars use this global toolbar configuration.
+		 * 		// Toolbars for roots not specified in config.rootsToolbars use the global toolbar configuration.
 		 * 		toolbar: [ 'bold', 'italic' ]
 		 * 	}
 		 * )
 		 * .then( ... )
 		 * .catch( ... );
+		 * ```
+		 *
+		 * Alternatively, you can specify this configuration as a function that returns toolbar items for a given root name.
+		 * This approach comes in handy when the roots are
+		 * {@link module:editor-multi-root/multirooteditor~MultiRootEditor#addRoot added or re-added} on the fly and you want their toolbar
+		 * items to be customizable.
+		 *
+		 * ```ts
+		 * MultiRootEditor.create(
+		 * 	// Roots for the editor:
+		 * 	{
+		 * 		uid1: document.querySelector( '#uid1' ),
+		 * 		uid2: document.querySelector( '#uid2' ),
+		 * 		uid3: document.querySelector( '#uid3' ),
+		 * 		uid4: document.querySelector( '#uid4' )
+		 * 	},
+		 * 	// Config:
+		 * 	{
+		 * 		rootsToolbars: rootName => {
+		 * 			// A specific toolbar configuration for initial roots.
+		 * 			if ( rootName === 'uid1' ) {
+		 * 				return [ 'bold', 'italic', '|', 'undo', 'redo' ];
+		 * 			} else if ( rootName === 'uid3' ) {
+		 * 				return [ 'bold', 'italic', 'underline', '|', 'undo', 'redo' ];
+		 * 			}
+		 * 			// A specific group of new roots will use this unique toolbar configuration.
+		 * 			else if ( rootName.startsWith( 'dynamicUid' ) ) {
+		 * 				return [ 'undo', 'redo' ];
+		 * 			}
+		 * 		},
+		 *
+		 * 		// Roots omitted in config.rootsToolbars use the global toolbar configuration.
+		 * 		toolbar: [ 'bold', 'italic' ]
+		 * 	}
+		 * )
+		 * .then( ... )
+		 * .catch( ... );
+		 * ```
 		 */
-		rootsToolbars?: Record<string, Array<ToolbarConfigItem>>;
+		rootsToolbars?: Record<string, Array<ToolbarConfigItem>> | ( ( rootName: string ) => Array<ToolbarConfigItem> | undefined );
 
 		/**
 		 * A list of names of all the roots that exist in the document but are not initially loaded by the editor.

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditorui.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditorui.ts
@@ -8,6 +8,8 @@
  */
 
 import {
+	type EditorConfig,
+	type ToolbarConfigItem,
 	type Editor
 } from 'ckeditor5/src/core.js';
 
@@ -223,18 +225,18 @@ export default class MultiRootEditorUI extends EditorUI {
 	 * {@link module:core/editor/editorconfig~EditorConfig#toolbar}.
 	 */
 	private _loadToolbarItemsForRoot( rootName: string ) {
-		const editor = this.editor;
 		const toolbarView = this.view.toolbar;
-		const globalToolbarConfig = normalizeToolbarConfig( editor.config.get( 'toolbar' ) );
-		const rootsToolbarsConfig = editor.config.get( 'rootsToolbars' ) || {};
 		let itemsToLoad: Array<View>;
 
 		if ( !this._rootToolbarItems.has( rootName ) ) {
+			const editor = this.editor;
+			const globalToolbarConfig = normalizeToolbarConfig( editor.config.get( 'toolbar' ) );
+			const getRootToolbarConfig = normalizeRootsToolbarsConfig( editor.config.get( 'rootsToolbars' ) );
 			let rootToolbarConfig;
 
-			if ( rootsToolbarsConfig[ rootName ] ) {
+			if ( getRootToolbarConfig( rootName ) ) {
 				rootToolbarConfig = {
-					...normalizeToolbarConfig( rootsToolbarsConfig[ rootName ] ),
+					...normalizeToolbarConfig( getRootToolbarConfig( rootName ) ),
 					...omit( globalToolbarConfig, 'items' )
 				};
 			} else {
@@ -281,4 +283,21 @@ export default class MultiRootEditorUI extends EditorUI {
 			keepOnFocus: true
 		} );
 	}
+}
+
+/**
+ * Converts `config.rootsToolbars` into a function form if not one already.
+ */
+function normalizeRootsToolbarsConfig(
+	rootsToolbarsConfig: EditorConfig[ 'rootsToolbars' ] | undefined
+): ( ( rootName: string ) => Array<ToolbarConfigItem> | undefined ) {
+	if ( typeof rootsToolbarsConfig === 'function' ) {
+		return rootsToolbarsConfig;
+	}
+
+	return ( rootName: string ) => {
+		if ( rootsToolbarsConfig ) {
+			return rootsToolbarsConfig[ rootName ];
+		}
+	};
 }

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditorui.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditorui.ts
@@ -40,6 +40,12 @@ export default class MultiRootEditorUI extends EditorUI {
 	 */
 	private _lastFocusedEditableElement: HTMLElement | null;
 
+	/**
+	 * A cached map of toolbar items for each individual root. It saves time on recreating the
+	 * toolbar items every time the user moves their selection between roots.
+	 *
+	 * See {@link #_loadToolbarItemsForRoot}.
+	 */
 	private _rootToolbarItems = new Map<string, Array<View>>();
 
 	/**
@@ -206,28 +212,29 @@ export default class MultiRootEditorUI extends EditorUI {
 	}
 
 	/**
-	 * TODO
+	 * Loads {@link module:editor-multi-root/multirooteditoruiview~MultiRootEditorUIView#toolbar} items
+	 * according to the toolbar configuration of a root.
+	 *
+	 * The configuration is either read from {@link module:core/editor/editorconfig~EditorConfig#rootsAttributes} or
+	 * {@link module:core/editor/editorconfig~EditorConfig#toolbar}.
 	 */
 	private _loadToolbarItemsForRoot( rootName: string ) {
 		const editor = this.editor;
 		const toolbarView = this.view.toolbar;
 		const globalToolbarConfig = normalizeToolbarConfig( editor.config.get( 'toolbar' ) );
-		const multiRootToolbarConfig = editor.config.get( 'multiRoot' ) || {};
-		let items: Array<View>;
+		const rootsToolbarsConfig = editor.config.get( 'rootsToolbars' ) || {};
+		let itemsToLoad: Array<View>;
 
 		if ( !this._rootToolbarItems.has( rootName ) ) {
-			items = toolbarView.createItemsFromConfig(
-				multiRootToolbarConfig[ rootName ] || globalToolbarConfig,
-				this.componentFactory
-			);
-
-			this._rootToolbarItems.set( rootName, items );
+			const rootToolbarConfig = rootsToolbarsConfig[ rootName ] || globalToolbarConfig;
+			itemsToLoad = toolbarView.createItemsFromConfig( rootToolbarConfig, this.componentFactory );
+			this._rootToolbarItems.set( rootName, itemsToLoad );
 		} else {
-			items = this._rootToolbarItems.get( rootName )!;
+			itemsToLoad = this._rootToolbarItems.get( rootName )!;
 		}
 
 		toolbarView.items.clear();
-		toolbarView.items.addMany( items );
+		toolbarView.items.addMany( itemsToLoad );
 	}
 
 	/**

--- a/packages/ckeditor5-editor-multi-root/tests/manual/dynamic-toolbar.html
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/dynamic-toolbar.html
@@ -1,23 +1,49 @@
-<p>
-	<button id="destroyEditor">Destroy editor</button>
-	<button id="initEditor">Init editor</button>
-</p>
+<div id="playground">
+	<div id="editor-known-roots">
+		<h2>Editor with known roots</h2>
 
-<h2>The toolbar</h2>
-<div class="toolbar-container"></div>
+		<div class="toolbar-container"></div>
+		<div class="editable-container">
+			<div class="short-toolbar"><p>This root has a short toolbar.</p></div>
+			<div class="long-toolbar"><p>This root has a very long toolbar.</p></div>
+			<div class="generic-toolbar"><p>This root uses generic config.toolbar</p></div>
+		</div>
+	</div>
+	<div id="known-and-dynamic">
+		<h2>Editor with known roots & dynamic roots</h2>
 
-<h2>The editable</h2>
-<div class="editable-container">
-	<div id="editor-intro"><p><strong>Exciting</strong> intro text to an article.</p></div>
-	<div id="editor-content"><h2>Exciting news!</h2><p>Lorem ipsum dolor sit amet.</p></div>
-	<div id="editor-outro"><p>Closing text.</p></div>
+		<div class="toolbar-container"></div>
+		<div class="editable-container">
+			<div class="short-toolbar"><p>This root has a short toolbar.</p></div>
+			<div class="long-toolbar"><p>This root has a very long toolbar.</p></div>
+			<div class="generic-toolbar"><p>This root uses generic config.toolbar</p></div>
+		</div>
+	</div>
 </div>
 
+
 <style>
+	#playground {
+		display: grid;
+		grid-template-columns: 50% 50%;
+		grid-template-rows: 1fr;
+		grid-column-gap: 0px;
+		grid-row-gap: 0px;
+		grid-gap: 1em;
+	}
+
+	#playground > div:first-child { grid-area: 1 / 1 / 2 / 2; }
+	#playground > div:last-child { grid-area: 1 / 2 / 2 / 3; }
+
+	#playground > div > button {
+		margin-right: 10px;
+	}
+
 	.editable-container,
 	.toolbar-container {
 		position: relative;
 		border: 1px solid red;
+		margin-bottom: 20px;
 	}
 
 	.editable-container::after,
@@ -32,22 +58,20 @@
 		padding: .1em .3em;
 	}
 
-	.toolbar-container{
+	.toolbar-container {
 		padding: 1em;
 	}
 
 	.editable-container {
-		padding: 3em;
-		overflow-y: scroll;
-		max-height: 300px;
+		padding: 1em;
 	}
 
 	.editable-container .ck-editor__editable {
-		padding: 2em;
+		padding: 1em;
 		border: 1px #D3D3D3 solid;
 		border-radius: var(--ck-border-radius);
 		background: white;
 		box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
-		margin-bottom: 20px;
+		margin-bottom: 1em;
 	}
 </style>

--- a/packages/ckeditor5-editor-multi-root/tests/manual/dynamic-toolbar.html
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/dynamic-toolbar.html
@@ -1,0 +1,53 @@
+<p>
+	<button id="destroyEditor">Destroy editor</button>
+	<button id="initEditor">Init editor</button>
+</p>
+
+<h2>The toolbar</h2>
+<div class="toolbar-container"></div>
+
+<h2>The editable</h2>
+<div class="editable-container">
+	<div id="editor-intro"><p><strong>Exciting</strong> intro text to an article.</p></div>
+	<div id="editor-content"><h2>Exciting news!</h2><p>Lorem ipsum dolor sit amet.</p></div>
+	<div id="editor-outro"><p>Closing text.</p></div>
+</div>
+
+<style>
+	.editable-container,
+	.toolbar-container {
+		position: relative;
+		border: 1px solid red;
+	}
+
+	.editable-container::after,
+	.toolbar-container::after {
+		content: attr(class);
+		position: absolute;
+		background: red;
+		color: #fff;
+		top: 0;
+		right: 0;
+		font: 10px/2 monospace;
+		padding: .1em .3em;
+	}
+
+	.toolbar-container{
+		padding: 1em;
+	}
+
+	.editable-container {
+		padding: 3em;
+		overflow-y: scroll;
+		max-height: 300px;
+	}
+
+	.editable-container .ck-editor__editable {
+		padding: 2em;
+		border: 1px #D3D3D3 solid;
+		border-radius: var(--ck-border-radius);
+		background: white;
+		box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+		margin-bottom: 20px;
+	}
+</style>

--- a/packages/ckeditor5-editor-multi-root/tests/manual/dynamic-toolbar.js
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/dynamic-toolbar.js
@@ -1,0 +1,61 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console:false, document, window */
+
+import MultiRootEditor from '../../src/multirooteditor.js';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading.js';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold.js';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic.js';
+import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials.js';
+
+const editorData = {
+	intro: document.querySelector( '#editor-intro' ),
+	content: document.querySelector( '#editor-content' ),
+	outro: document.querySelector( '#editor-outro' )
+};
+
+let editor;
+
+function initEditor() {
+	MultiRootEditor
+		.create( editorData, {
+			plugins: [ Essentials, Paragraph, Heading, Bold, Italic ],
+			toolbar: [ 'undo', 'redo', '|', 'heading', '|', 'bold', 'italic' ],
+			multiRoot: {
+				'intro': [ 'undo', 'redo', '|', 'bold', 'italic' ],
+				'content': [ 'undo', 'redo', '|', ...new Array( 40 ).fill( 'bold' ) ]
+			}
+		} )
+		.then( newEditor => {
+			console.log( 'Editor was initialized', newEditor );
+
+			document.querySelector( '.toolbar-container' ).appendChild( newEditor.ui.view.toolbar.element );
+
+			window.editor = editor = newEditor;
+			window.editables = newEditor.ui.view.editables;
+		} )
+		.catch( err => {
+			console.error( err.stack );
+		} );
+}
+
+function destroyEditor() {
+	editor.destroy()
+		.then( () => {
+			editor.ui.view.toolbar.element.remove();
+
+			window.editor = editor = null;
+			window.editables = null;
+
+			console.log( 'Editor was destroyed' );
+		} );
+}
+
+document.getElementById( 'initEditor' ).addEventListener( 'click', initEditor );
+document.getElementById( 'destroyEditor' ).addEventListener( 'click', destroyEditor );
+
+initEditor();

--- a/packages/ckeditor5-editor-multi-root/tests/manual/dynamic-toolbar.js
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/dynamic-toolbar.js
@@ -25,7 +25,7 @@ function initEditor() {
 		.create( editorData, {
 			plugins: [ Essentials, Paragraph, Heading, Bold, Italic ],
 			toolbar: [ 'undo', 'redo', '|', 'heading', '|', 'bold', 'italic' ],
-			multiRoot: {
+			rootsToolbars: {
 				'intro': [ 'undo', 'redo', '|', 'bold', 'italic' ],
 				'content': [ 'undo', 'redo', '|', ...new Array( 40 ).fill( 'bold' ) ]
 			}

--- a/packages/ckeditor5-editor-multi-root/tests/manual/dynamic-toolbar.js
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/dynamic-toolbar.js
@@ -26,8 +26,8 @@ function initEditor() {
 			plugins: [ Essentials, Paragraph, Heading, Bold, Italic ],
 			toolbar: [ 'undo', 'redo', '|', 'heading', '|', 'bold', 'italic' ],
 			rootsToolbars: {
-				'intro': [ 'undo', 'redo', '|', 'bold', 'italic' ],
-				'content': [ 'undo', 'redo', '|', ...new Array( 40 ).fill( 'bold' ) ]
+				intro: [ 'undo', 'redo', '|', 'bold', 'italic' ],
+				content: [ 'undo', 'redo', '|', ...new Array( 40 ).fill( 'bold' ) ]
 			}
 		} )
 		.then( newEditor => {

--- a/packages/ckeditor5-editor-multi-root/tests/manual/dynamic-toolbar.js
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/dynamic-toolbar.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals console:false, document, window */
+/* globals console:false, document, window, CKEditorInspector */
 
 import MultiRootEditor from '../../src/multirooteditor.js';
 import Heading from '@ckeditor/ckeditor5-heading/src/heading.js';
@@ -12,50 +12,96 @@ import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold.js';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic.js';
 import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials.js';
 
-const editorData = {
-	intro: document.querySelector( '#editor-intro' ),
-	content: document.querySelector( '#editor-content' ),
-	outro: document.querySelector( '#editor-outro' )
-};
+function createEditor( name, playgroundContainer, rootsToolbarsConfig, onInit ) {
+	let editor;
 
-let editor;
+	const editorData = {
+		short: playgroundContainer.querySelector( '.short-toolbar' ),
+		long: playgroundContainer.querySelector( '.long-toolbar' ),
+		generic: playgroundContainer.querySelector( '.generic-toolbar' )
+	};
 
-function initEditor() {
-	MultiRootEditor
-		.create( editorData, {
-			plugins: [ Essentials, Paragraph, Heading, Bold, Italic ],
-			toolbar: [ 'undo', 'redo', '|', 'heading', '|', 'bold', 'italic' ],
-			rootsToolbars: {
-				intro: [ 'undo', 'redo', '|', 'bold', 'italic' ],
-				content: [ 'undo', 'redo', '|', ...new Array( 40 ).fill( 'bold' ) ]
-			}
-		} )
-		.then( newEditor => {
-			console.log( 'Editor was initialized', newEditor );
+	function initEditor() {
+		MultiRootEditor
+			.create( editorData, {
+				plugins: [ Essentials, Paragraph, Heading, Bold, Italic ],
+				toolbar: [ 'undo', 'redo', '|', 'heading', '|', 'bold', 'italic' ],
+				rootsToolbars: rootsToolbarsConfig
+			} )
+			.then( newEditor => {
+				console.log( `Editor "${ name }" was initialized`, newEditor );
 
-			document.querySelector( '.toolbar-container' ).appendChild( newEditor.ui.view.toolbar.element );
+				playgroundContainer.querySelector( '.toolbar-container' ).appendChild( newEditor.ui.view.toolbar.element );
 
-			window.editor = editor = newEditor;
-			window.editables = newEditor.ui.view.editables;
-		} )
-		.catch( err => {
-			console.error( err.stack );
-		} );
+				window[ name ] = editor = newEditor;
+				window[ `${ name }-editables` ] = newEditor.ui.view.editables;
+
+				onInit && onInit( newEditor );
+
+				CKEditorInspector.attach( {
+					[ name ]: newEditor
+				} );
+			} )
+			.catch( err => {
+				console.error( err.stack );
+			} );
+	}
+
+	async function destroyEditor() {
+		await editor.destroy();
+
+		editor.ui.view.toolbar.element.remove();
+
+		window.editor = editor = null;
+		window.editables = null;
+
+		console.log( `Editor "${ name }" was destroyed` );
+	}
+
+	const initButton = document.createElement( 'button' );
+	initButton.textContent = 'Init editor';
+	initButton.addEventListener( 'click', initEditor );
+
+	const destroyButton = document.createElement( 'button' );
+	destroyButton.textContent = 'Destroy editor';
+	destroyButton.addEventListener( 'click', destroyEditor );
+
+	playgroundContainer.prepend( initButton );
+	playgroundContainer.prepend( destroyButton );
 }
 
-function destroyEditor() {
-	editor.destroy()
-		.then( () => {
-			editor.ui.view.toolbar.element.remove();
+createEditor( 'known-roots', document.querySelector( '#editor-known-roots' ), {
+	short: [ 'undo', 'redo', '|', 'bold', 'italic' ],
+	long: [ 'undo', 'redo', '|', ...new Array( 40 ).fill( 'bold' ) ]
+} );
 
-			window.editor = editor = null;
-			window.editables = null;
+createEditor( 'known-and-dynamic-roots', document.querySelector( '#known-and-dynamic' ), rootName => {
+	if ( rootName === 'short' ) {
+		return [ 'undo', 'redo', '|', 'bold', 'italic' ];
+	} else if ( rootName === 'long' ) {
+		return [ 'undo', 'redo', '|', ...new Array( 40 ).fill( 'bold' ) ];
+	} else if ( rootName.startsWith( 'dynamic' ) ) {
+		return [ 'undo', 'redo' ];
+	}
+}, newEditor => {
+	const addRootButton = document.createElement( 'button' );
+	addRootButton.textContent = 'Add dynamic root';
 
-			console.log( 'Editor was destroyed' );
+	addRootButton.addEventListener( 'click', () => {
+		const uid = 'dynamic' + ( String( new Date().getTime() ) ).slice( -5 );
+
+		newEditor.addRoot( 'dynamic' + uid, {
+			isUndoable: true,
+			data: `<p>This root ("${ uid }") uses a dedicated toolbar for all dynamic roots.</p>`
 		} );
-}
+	} );
 
-document.getElementById( 'initEditor' ).addEventListener( 'click', initEditor );
-document.getElementById( 'destroyEditor' ).addEventListener( 'click', destroyEditor );
+	newEditor.on( 'addRoot', ( evt, root ) => {
+		const domElement = newEditor.createEditable( root );
 
-initEditor();
+		document.querySelector( '#known-and-dynamic .editable-container' ).appendChild( domElement );
+	} );
+
+	document.querySelector( '#known-and-dynamic > button:last-of-type' ).after( addRootButton );
+} );
+

--- a/packages/ckeditor5-editor-multi-root/tests/manual/dynamic-toolbar.md
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/dynamic-toolbar.md
@@ -1,0 +1,4 @@
+# Dynamic toolbar configuration
+
+1. Move the selection between editor roots.
+2. The toolbar should update and display items specific for the root only.

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
@@ -336,7 +336,8 @@ export default class ToolbarView extends View implements DropdownPanelFocusable 
 	): Array<View> {
 		const config = normalizeToolbarConfig( itemsOrConfig );
 		const normalizedRemoveItems = removeItems || config.removeItems;
-		const itemsToAdd = this._cleanItemsConfiguration( config.items, factory, normalizedRemoveItems )
+
+		return this._cleanItemsConfiguration( config.items, factory, normalizedRemoveItems )
 			.map( item => {
 				if ( isObject( item ) ) {
 					return this._createNestedToolbarDropdown( item, factory, normalizedRemoveItems );
@@ -349,8 +350,6 @@ export default class ToolbarView extends View implements DropdownPanelFocusable 
 				return factory.create( item );
 			} )
 			.filter( ( item ): item is View => !!item );
-
-		return itemsToAdd;
 	}
 
 	/**
@@ -1028,7 +1027,8 @@ class DynamicGrouping implements ToolbarBehavior {
 	}
 
 	/**
-	 * Removed the dropdown that hosts {@link #groupedItems} from the {@link #viewChildren} collection.
+	 * Removes the {@link #groupedItemsDropdown dropdown} that hosts {@link #groupedItems} from the
+	 * {@link #viewChildren} collection.
 	 */
 	private _removeGroupedItemsDropdown(): void {
 		if ( !this.viewChildren.has( this.groupedItemsDropdown ) ) {

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
@@ -318,7 +318,7 @@ export default class ToolbarView extends View implements DropdownPanelFocusable 
 		factory: ComponentFactory,
 		removeItems?: Array<string>
 	): void {
-		this.items.addMany( this._buildItemsFromConfig( itemsOrConfig, factory, removeItems ) );
+		this.items.addMany( this.createItemsFromConfig( itemsOrConfig, factory, removeItems ) );
 	}
 
 	/**
@@ -329,7 +329,7 @@ export default class ToolbarView extends View implements DropdownPanelFocusable 
 	 * @param removeItems An array of items names to be removed from the configuration. When present, applies
 	 * to this toolbar and all nested ones as well.
 	 */
-	private _buildItemsFromConfig(
+	public createItemsFromConfig(
 		itemsOrConfig: ToolbarConfig | undefined,
 		factory: ComponentFactory,
 		removeItems?: Array<string>
@@ -549,7 +549,7 @@ export default class ToolbarView extends View implements DropdownPanelFocusable 
 		}
 
 		addToolbarToDropdown( dropdownView, () => (
-			dropdownView.toolbarView!._buildItemsFromConfig( items, componentFactory, removeItems )
+			dropdownView.toolbarView!.createItemsFromConfig( items, componentFactory, removeItems )
 		) );
 
 		return dropdownView;
@@ -919,6 +919,10 @@ class DynamicGrouping implements ToolbarBehavior {
 			}
 		}
 
+		if ( !this.groupedItems.length ) {
+			this._removeGroupedItemsDropdown();
+		}
+
 		if ( this.groupedItems.length !== initialGroupedItemsCount ) {
 			this.view.fire<ToolbarViewGroupedItemsUpdateEvent>( 'groupedItemsUpdate' );
 		}
@@ -1019,10 +1023,21 @@ class DynamicGrouping implements ToolbarBehavior {
 		this.ungroupedItems.add( this.groupedItems.remove( this.groupedItems.first! ) );
 
 		if ( !this.groupedItems.length ) {
-			this.viewChildren.remove( this.groupedItemsDropdown );
-			this.viewChildren.remove( this.viewChildren.last! );
-			this.viewFocusTracker.remove( this.groupedItemsDropdown.element! );
+			this._removeGroupedItemsDropdown();
 		}
+	}
+
+	/**
+	 * Removed the dropdown that hosts {@link #groupedItems} from the {@link #viewChildren} collection.
+	 */
+	private _removeGroupedItemsDropdown(): void {
+		if ( !this.viewChildren.has( this.groupedItemsDropdown ) ) {
+			return;
+		}
+
+		this.viewChildren.remove( this.groupedItemsDropdown );
+		this.viewChildren.remove( this.viewChildren.last! );
+		this.viewFocusTracker.remove( this.groupedItemsDropdown.element! );
 	}
 
 	/**

--- a/packages/ckeditor5-ui/tests/manual/toolbar/grouping.html
+++ b/packages/ckeditor5-ui/tests/manual/toolbar/grouping.html
@@ -10,15 +10,26 @@
 	<p>Editor content</p>
 </div>
 
-
 <h2>Editor with RTL UI</h2>
 
 <div id="editor-rtl">
 	<p>Editor content</p>
 </div>
 
+<h2>Grouping playground</h2>
+
+<div id="playground">
+	<button type="button" id="add">Add new button</button>
+	<button type="button" id="remove">Remove button</button>
+	<button type="button" id="clear">Clear</button>
+	<br>
+	<br>
+</div>
+
+
 <style>
-	.ck.ck-editor {
+	.ck.ck-editor,
+	#playground {
 		margin-left: 200px;
 		margin-right: 200px;
 	}

--- a/packages/ckeditor5-ui/tests/manual/toolbar/grouping.js
+++ b/packages/ckeditor5-ui/tests/manual/toolbar/grouping.js
@@ -7,10 +7,48 @@
 
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor.js';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset.js';
+import { ButtonView, ToolbarView } from '../../../src/index.js';
+import { Locale } from '@ckeditor/ckeditor5-utils';
 
 createEditor( '#editor-ltr', 'en', 'en' );
 createEditor( '#editor-rtl-mixed', 'ar', 'en' );
 createEditor( '#editor-rtl', 'ar', 'ar' );
+setupPlayground();
+
+function setupPlayground() {
+	const playgroundToolbarView = new ToolbarView( new Locale(), {
+		shouldGroupWhenFull: true
+	} );
+
+	playgroundToolbarView.render();
+
+	function createButton( label ) {
+		const button = new ButtonView();
+
+		button.set( {
+			label,
+			withText: true
+		} );
+
+		return button;
+	}
+
+	playgroundToolbarView.items.addMany( new Array( 15 ).fill( 0 ).map( ( i, index ) => createButton( index ) ) );
+
+	document.querySelector( '#add' ).addEventListener( 'click', () => {
+		playgroundToolbarView.items.add( createButton( playgroundToolbarView.items.length ) );
+	} );
+
+	document.querySelector( '#remove' ).addEventListener( 'click', () => {
+		playgroundToolbarView.items.remove( playgroundToolbarView.items.length - 1 );
+	} );
+
+	document.querySelector( '#clear' ).addEventListener( 'click', () => {
+		playgroundToolbarView.items.clear();
+	} );
+
+	document.querySelector( '#playground' ).appendChild( playgroundToolbarView.element );
+}
 
 function createEditor( selector, language, uiLanguageCode ) {
 	ClassicEditor

--- a/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
+++ b/packages/ckeditor5-ui/tests/toolbar/toolbarview.js
@@ -1289,6 +1289,29 @@ describe( 'ToolbarView', () => {
 			expect( view.children.get( 0 ) ).to.equal( view.itemsView );
 		} );
 
+		it( 'removes the dropdown with grouped items if visible but items#clear() was called that emptied the toolbar', () => {
+			const itemA = focusable();
+			const itemB = focusable();
+			const itemC = focusable();
+			const itemD = focusable();
+
+			view.items.add( itemA );
+			view.items.add( itemB );
+			view.items.add( itemC );
+			view.items.add( itemD );
+
+			expect( ungroupedItems.map( i => i ) ).to.have.ordered.members( [ itemA ] );
+			expect( groupedItems.map( i => i ) ).to.have.ordered.members( [ itemB, itemC, itemD ] );
+
+			expect( view.children.has( groupedItemsDropdown ) ).to.be.true;
+
+			view.items.clear();
+
+			expect( view.children.has( groupedItemsDropdown ) ).to.be.false;
+			expect( ungroupedItems ).to.have.length( 0 );
+			expect( groupedItems ).to.have.length( 0 );
+		} );
+
 		describe( 'render()', () => {
 			let view, groupedItems, ungroupedItems;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (editor-multi-root): Added support for the toolbar items changing dynamically as the user moves their selection between editor roots. Allowed per-root toolbar configuration. See #13391.

Fix (ui): `ToolbarView` should hide the dropdown containing items that didn't fit upon clearing its `items` collection. See #13391.

Feature (ui): Added the new `ToolbarView#createItemsFromConfig()` method that translates a toolbar configuration into an array of UI components. See #13391.

---

### Additional information

**TODOs**:
* ~Support for dynamic toolbar for roots created on the fly.~
