### PR TITLE
Closes #15368 - col and colgroup remove from markup when enabled with GHS but TableResize plugin not enabled

### DIFF
--- a/packages/ckeditor5-html-support/tests/manual/ghs-all-features.html
+++ b/packages/ckeditor5-html-support/tests/manual/ghs-all-features.html
@@ -111,6 +111,28 @@
 				</tbody>
 			</table>
 
+			<table>
+				<colgroup style="background:blue; color: white;">
+					<col>
+					<col>
+					<col>
+				</colgroup>
+				<thead>
+					<tr>
+						<th>h1</th>
+						<th>h2</th>
+						<th>h3</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>colgroup styled</td>
+						<td>colgroup styled</td>
+						<td>colgroup styled</td>
+					</tr>
+				</tbody>
+			</table>
+
 			<figure class="table" style="width:100%;">
 				<table class="ck-table-resized">
 					<colgroup>

--- a/packages/ckeditor5-html-support/tests/manual/ghs-no-features.html
+++ b/packages/ckeditor5-html-support/tests/manual/ghs-no-features.html
@@ -14,6 +14,11 @@
 		[contenteditable="true"] :not([data-validation-allow]):not(.html-object-embed) {
 			border: 1px solid red !important;
 		}
+		/* Border on colgroup and col elements must be 2px or it would obscured by the 1px black border on the th/td */
+		[contenteditable="true"] colgroup:not([data-validation-allow]),
+		[contenteditable="true"] col:not([data-validation-allow]) {
+			border-width: 2px;
+		}
 	</style>
 		<!--
             For a totally unknown reason, Travis cannot fetch an image from the `via.placeholder.com` service.
@@ -29,49 +34,49 @@
 			<p><acronym>Acronym inline element</acronym></p>
 
 			<p><tt>Tt inline element</tt></p>
-			 
+
 			<p><font>Font inline element</font></p>
-			 
+
 			<p><var>Var inline element</var></p>
-			 
+
 			<p><big>Big inline element</big></p>
 
 			<p><small>Small inline element</small></p>
-			 
+
 			<p><samp>Samp inline element</samp></p>
 
 			<p><q>Q inline element</q></p>
-			 
+
 			<p><output>Output inline element</output></p>
 
 			<p><kbd>Kbd inline element</kbd></p>
-			 
+
 			<p><bdi>Bdi inline element</bdi></p>
-			 
+
 			<p><bdo>Bdo inline element</bdo></p>
-			 
+
 			<p><abbr>Abbr inline element</abbr></p>
 
 			<p><a href="#">A inline element</a></p>
-			 
+
 			<p><strong>Strong inline element</strong></p>
 
 			<p><b>B inline element</b></p>
-			 
+
 			<p><i>I inline element</i></p>
 
 			<p><em>Em inline element</em></p>
-			 
+
 			<p><s>S inline element</s></p>
 
 			<p><del>Del inline element</del></p>
-			 
+
 			<p><ins>Ins inline element</ins></p>
 
 			<p><u>U inline element</u></p>
 
 			<p><sub>Sub inline element</sub></p>
-			 
+
 			<p><sup>Sup inline element</sup></p>
 
 			<p><code>Code inline element</code></p>
@@ -155,6 +160,11 @@
 
 			<table>
 				<caption>Caption</caption>
+				<colgroup>
+					<col>
+					<col>
+					<col>
+				</colgroup>
 				<thead>
 					<th><p>TH</p></th>
 					<th><p>TH</p></th>

--- a/packages/ckeditor5-html-support/tests/manual/table-no-resize.html
+++ b/packages/ckeditor5-html-support/tests/manual/table-no-resize.html
@@ -1,0 +1,59 @@
+<head>
+	<meta http-equiv="Content-Security-Policy"
+		  content="script-src 'self' https://ckeditor.com 'unsafe-inline' 'unsafe-eval'">
+</head>
+
+<style>
+[contenteditable="true"] [data-validation-allow]{
+	border: 1px solid blue !important;
+}
+
+[contenteditable="true"] [data-validation-disallow]{
+	border: 1px solid red !important;
+}
+</style>
+
+<div id="editor">
+	<figure class="table">
+		<table>
+			<colgroup>
+				<col>
+			</colgroup>
+			<colgroup>
+				<col>
+				<col>
+			</colgroup>
+			<caption>caption</caption>
+			<thead>
+				<tr>
+					<th>1</th>
+					<th>2</th>
+					<th>3</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>1.1</td>
+					<td>1.2</td>
+					<td>1.3</td>
+				</tr>
+				<tr>
+					<td>2.1</td>
+					<td>2.2</td>
+					<td>2.3</td>
+				</tr>
+				<tr>
+					<td>3.1</td>
+					<td>3.2</td>
+					<td>3.3</td>
+				</tr>
+			</tbody>
+		</table>
+	</figure>
+</div>
+<script>
+	document.getElementById( 'editor' ).querySelectorAll( 'col, colgroup' ).forEach( node => {
+		node.setAttribute( 'data-validation-allow', true );
+		node.setAttribute( 'data-validation-disallow', true );
+	} );
+</script>

--- a/packages/ckeditor5-html-support/tests/manual/table-no-resize.js
+++ b/packages/ckeditor5-html-support/tests/manual/table-no-resize.js
@@ -1,0 +1,54 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console:false, window, document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
+import Table from '@ckeditor/ckeditor5-table/src/table';
+import TableCaption from '@ckeditor/ckeditor5-table/src/tablecaption';
+import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
+
+import GeneralHtmlSupport from '../../src/generalhtmlsupport';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [
+			Bold,
+			Essentials,
+			GeneralHtmlSupport,
+			Italic,
+			Paragraph,
+			SourceEditing,
+			Strikethrough,
+			Table,
+			TableCaption
+		],
+		toolbar: [ 'insertTable', '|', 'bold', 'italic', 'strikethrough', '|', 'sourceEditing' ],
+		htmlSupport: {
+			allow: [
+				{
+					name: /^(colgroup|col)$/,
+					attributes: [ 'data-validation-allow', 'data-validation-disallow' ]
+				}
+			],
+			disallow: [
+				{
+					name: /^(colgroup|col)$/,
+					attributes: 'data-validation-disallow'
+				}
+			]
+		}
+	} )
+	.then( editor => {
+		window.editor = editor;
+	} )
+	.catch( err => {
+		console.error( err.stack );
+	} );

--- a/packages/ckeditor5-html-support/tests/manual/table-no-resize.md
+++ b/packages/ckeditor5-html-support/tests/manual/table-no-resize.md
@@ -1,0 +1,7 @@
+## Table
+
+Verify if col and colgroup elements are retained when `TableResize` plugin is not enabled:
+
+**Case 1:** Has its own `data-validation-allow` attribute and blue border.
+
+**Case 2:** Doesn't have `data-validation-disallow` attribute or red border.

--- a/packages/ckeditor5-html-support/tests/manual/table.html
+++ b/packages/ckeditor5-html-support/tests/manual/table.html
@@ -11,11 +11,27 @@
 [contenteditable="true"] [data-validation-disallow]{
 	border: 1px solid red !important;
 }
+
+/* col and colgroup borders must be thicker that their child elements to be visible. */
+[contenteditable="true"] col[data-validation-allow],
+[contenteditable="true"] col[data-validation-disallow] {
+	border-width: 2px !important;
+}
+
+[contenteditable="true"] colgroup[data-validation-allow],
+[contenteditable="true"] colgroup[data-validation-disallow] {
+	border-width: 3px !important;
+}
 </style>
 
 <div id="editor">
 	<figure class="table">
 		<table>
+			<colgroup>
+				<col>
+				<col>
+				<col>
+			</colgroup>
 			<caption>caption</caption>
 			<thead>
 				<tr>
@@ -46,6 +62,11 @@
 
 	<figure class="table">
 		<table>
+			<colgroup>
+				<col>
+				<col>
+				<col>
+			</colgroup>
 			<thead>
 				<tr>
 					<th>1</th>
@@ -75,7 +96,7 @@
 	</figure>
 </div>
 <script>
-	document.getElementById( 'editor' ).querySelectorAll( 'figure, table, caption, figcaption, tbody, thead, tr, th, td' ).forEach( node => {
+	document.getElementById( 'editor' ).querySelectorAll( 'figure, table, caption, figcaption, tbody, thead, tr, th, td, colgroup, col' ).forEach( node => {
 		node.setAttribute( 'data-validation-allow', true );
 		node.setAttribute( 'data-validation-disallow', true );
 	} );

--- a/packages/ckeditor5-html-support/tests/manual/table.js
+++ b/packages/ckeditor5-html-support/tests/manual/table.js
@@ -13,6 +13,7 @@ import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
 import Strikethrough from '@ckeditor/ckeditor5-basic-styles/src/strikethrough';
 import Table from '@ckeditor/ckeditor5-table/src/table';
 import TableCaption from '@ckeditor/ckeditor5-table/src/tablecaption';
+import TableColumnResize from '@ckeditor/ckeditor5-table/src/tablecolumnresize';
 import SourceEditing from '@ckeditor/ckeditor5-source-editing/src/sourceediting';
 
 import GeneralHtmlSupport from '../../src/generalhtmlsupport';
@@ -28,19 +29,20 @@ ClassicEditor
 			SourceEditing,
 			Strikethrough,
 			Table,
-			TableCaption
+			TableCaption,
+			TableColumnResize
 		],
 		toolbar: [ 'insertTable', '|', 'bold', 'italic', 'strikethrough', '|', 'sourceEditing' ],
 		htmlSupport: {
 			allow: [
 				{
-					name: /^(figure|table|tbody|thead|tr|th|td|caption|figcaption)$/,
+					name: /^(figure|table|tbody|thead|tr|th|td|caption|figcaption|colgroup|col)$/,
 					attributes: [ 'data-validation-allow', 'data-validation-disallow' ]
 				}
 			],
 			disallow: [
 				{
-					name: /^(figure|table|tbody|thead|tr|th|td|caption|figcaption)$/,
+					name: /^(figure|table|tbody|thead|tr|th|td|caption|figcaption|colgroup|col)$/,
 					attributes: 'data-validation-disallow'
 				}
 			]

--- a/packages/ckeditor5-html-support/tests/manual/table.md
+++ b/packages/ckeditor5-html-support/tests/manual/table.md
@@ -11,6 +11,8 @@ Verify if every table structure element:
 * `tr`
 * `th`
 * `td`
+* `colgroup`
+* `col`
 
 **Case 1:** Has its own `data-validation-allow` attribute and blue border.
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix: Col and colgroup element support by GHS when TableResize is not enabled. Closes #15368.

---

### Additional information

WIP - not ready, only tests to show the issue
