### PR TITLE
Allowed for using an inline toolbar with multi-root editor

### DIFF
--- a/packages/ckeditor5-editor-inline/src/inlineeditor.ts
+++ b/packages/ckeditor5-editor-inline/src/inlineeditor.ts
@@ -18,6 +18,7 @@ import {
 	type EditorReadyEvent
 } from 'ckeditor5/src/core.js';
 import { getDataFromElement, CKEditorError } from 'ckeditor5/src/utils.js';
+import { InlineToolbar } from 'ckeditor5/src/ui.js';
 
 import { ContextWatchdog, EditorWatchdog } from 'ckeditor5/src/watchdog.js';
 
@@ -80,6 +81,13 @@ export default class InlineEditor extends DataApiMixin( ElementApiMixin( Editor 
 			this.config.set( 'initialData', getInitialData( sourceElementOrData ) );
 		}
 
+		// Inject the InlineToolbar plugin.
+		const plugins = this.config.get( 'plugins' )!;
+		plugins.push( InlineToolbar );
+		this.config.set( 'plugins', plugins );
+
+		this.config.define( 'inlineToolbar', this.config.get( 'toolbar' ) );
+
 		this.model.document.createRoot();
 
 		if ( isElement( sourceElementOrData ) ) {
@@ -87,11 +95,7 @@ export default class InlineEditor extends DataApiMixin( ElementApiMixin( Editor 
 			secureSourceElement( this, sourceElementOrData );
 		}
 
-		const shouldToolbarGroupWhenFull = !this.config.get( 'toolbar.shouldNotGroupWhenFull' );
-
-		const view = new InlineEditorUIView( this.locale, this.editing.view, this.sourceElement, {
-			shouldToolbarGroupWhenFull
-		} );
+		const view = new InlineEditorUIView( this.locale, this.editing.view, this.sourceElement );
 		this.ui = new InlineEditorUI( this, view );
 
 		attachToForm( this );

--- a/packages/ckeditor5-editor-inline/src/inlineeditorui.ts
+++ b/packages/ckeditor5-editor-inline/src/inlineeditorui.ts
@@ -13,9 +13,7 @@ import {
 
 import {
 	EditorUI,
-	normalizeToolbarConfig,
-	type EditorUIReadyEvent,
-	type EditorUIUpdateEvent
+	type EditorUIReadyEvent
 } from 'ckeditor5/src/ui.js';
 
 import { enablePlaceholder } from 'ckeditor5/src/engine.js';
@@ -34,11 +32,6 @@ export default class InlineEditorUI extends EditorUI {
 	public readonly view: InlineEditorUIView;
 
 	/**
-	 * A normalized `config.toolbar` object.
-	 */
-	private readonly _toolbarConfig: ReturnType<typeof normalizeToolbarConfig>;
-
-	/**
 	 * Creates an instance of the inline editor UI class.
 	 *
 	 * @param editor The editor instance.
@@ -48,7 +41,6 @@ export default class InlineEditorUI extends EditorUI {
 		super( editor );
 
 		this.view = view;
-		this._toolbarConfig = normalizeToolbarConfig( editor.config.get( 'toolbar' ) );
 	}
 
 	/**
@@ -96,7 +88,6 @@ export default class InlineEditorUI extends EditorUI {
 		editingView.attachDomRoot( editableElement );
 
 		this._initPlaceholder();
-		this._initToolbar();
 		this.fire<EditorUIReadyEvent>( 'ready' );
 	}
 
@@ -111,38 +102,6 @@ export default class InlineEditorUI extends EditorUI {
 
 		editingView.detachDomRoot( view.editable.name! );
 		view.destroy();
-	}
-
-	/**
-	 * Initializes the inline editor toolbar and its panel.
-	 */
-	private _initToolbar(): void {
-		const editor = this.editor;
-		const view = this.view;
-		const editableElement = view.editable.element!;
-		const toolbar = view.toolbar;
-
-		// Set–up the view#panel.
-		view.panel.bind( 'isVisible' ).to( this.focusTracker, 'isFocused' );
-
-		view.bind( 'viewportTopOffset' ).to( this, 'viewportOffset', ( { top } ) => top || 0 );
-
-		// https://github.com/ckeditor/ckeditor5-editor-inline/issues/4
-		view.listenTo<EditorUIUpdateEvent>( editor.ui, 'update', () => {
-			// Don't pin if the panel is not already visible. It prevents the panel
-			// showing up when there's no focus in the UI.
-			if ( view.panel.isVisible ) {
-				view.panel.pin( {
-					target: editableElement,
-					positions: view.panelPositions
-				} );
-			}
-		} );
-
-		toolbar.fillFromConfig( this._toolbarConfig, this.componentFactory );
-
-		// Register the toolbar so it becomes available for Alt+F10 and Esc navigation.
-		this.addToolbar( toolbar );
 	}
 
 	/**

--- a/packages/ckeditor5-editor-inline/src/inlineeditoruiview.ts
+++ b/packages/ckeditor5-editor-inline/src/inlineeditoruiview.ts
@@ -8,119 +8,20 @@
  */
 
 import {
-	BalloonPanelView,
 	EditorUIView,
-	InlineEditableUIView,
-	ToolbarView
+	InlineEditableUIView
 } from 'ckeditor5/src/ui.js';
-import {
-	Rect,
-	ResizeObserver,
-	toUnit,
-	type PositioningFunction,
-	type Locale
-} from 'ckeditor5/src/utils.js';
-import type {
-	View
-} from 'ckeditor5/src/engine.js';
-
-const toPx = toUnit( 'px' );
+import { type Locale } from 'ckeditor5/src/utils.js';
+import type { View } from 'ckeditor5/src/engine.js';
 
 /**
  * Inline editor UI view. Uses an nline editable and a floating toolbar.
  */
 export default class InlineEditorUIView extends EditorUIView {
 	/**
-	 * A floating toolbar view instance.
-	 */
-	public readonly toolbar: ToolbarView;
-
-	/**
-	 * The offset from the top edge of the web browser's viewport which makes the
-	 * UI become sticky. The default value is `0`, which means that the UI becomes
-	 * sticky when its upper edge touches the top of the page viewport.
-	 *
-	 * This attribute is useful when the web page has UI elements positioned to the top
-	 * either using `position: fixed` or `position: sticky`, which would cover the
-	 * UI or vice–versa (depending on the `z-index` hierarchy).
-	 *
-	 * Bound to {@link module:ui/editorui/editorui~EditorUI#viewportOffset `EditorUI#viewportOffset`}.
-	 *
-	 * If {@link module:core/editor/editorconfig~EditorConfig#ui `EditorConfig#ui.viewportOffset.top`} is defined, then
-	 * it will override the default value.
-	 *
-	 * @observable
-	 * @default 0
-	 */
-	declare public viewportTopOffset: number;
-
-	/**
-	 * A balloon panel view instance.
-	 */
-	public readonly panel: BalloonPanelView;
-
-	/**
-	 * A set of positioning functions used by the {@link #panel} to float around
-	 * {@link #element editableElement}.
-	 *
-	 * The positioning functions are as follows:
-	 *
-	 * * West:
-	 *
-	 * ```
-	 * [ Panel ]
-	 * +------------------+
-	 * | #editableElement |
-	 * +------------------+
-	 *
-	 * +------------------+
-	 * | #editableElement |
-	 * |[ Panel ]         |
-	 * |                  |
-	 * +------------------+
-	 *
-	 * +------------------+
-	 * | #editableElement |
-	 * +------------------+
-	 * [ Panel ]
-	 * ```
-	 *
-	 * * East:
-	 *
-	 * ```
-	 *            [ Panel ]
-	 * +------------------+
-	 * | #editableElement |
-	 * +------------------+
-	 *
-	 * +------------------+
-	 * | #editableElement |
-	 * |         [ Panel ]|
-	 * |                  |
-	 * +------------------+
-	 *
-	 * +------------------+
-	 * | #editableElement |
-	 * +------------------+
-	 *            [ Panel ]
-	 * ```
-	 *
-	 * See: {@link module:utils/dom/position~Options#positions}.
-	 */
-	public readonly panelPositions: Array<PositioningFunction>;
-
-	/**
 	 * Editable UI view.
 	 */
 	public readonly editable: InlineEditableUIView;
-
-	/**
-	 * An instance of the resize observer that helps dynamically determine the geometry of the toolbar
-	 * and manage items that do not fit into a single row.
-	 *
-	 * **Note:** Created in {@link #render}.
-	 */
-	private _resizeObserver: ResizeObserver | null;
 
 	/**
 	 * Creates an instance of the inline editor UI view.
@@ -129,46 +30,21 @@ export default class InlineEditorUIView extends EditorUIView {
 	 * @param editingView The editing view instance this view is related to.
 	 * @param editableElement The editable element. If not specified, it will be automatically created by
 	 * {@link module:ui/editableui/editableuiview~EditableUIView}. Otherwise, the given element will be used.
-	 * @param options Configuration options for the view instance.
-	 * @param options.shouldToolbarGroupWhenFull When set `true` enables automatic items grouping
-	 * in the main {@link module:editor-inline/inlineeditoruiview~InlineEditorUIView#toolbar toolbar}.
-	 * See {@link module:ui/toolbar/toolbarview~ToolbarOptions#shouldGroupWhenFull} to learn more.
 	 */
 	constructor(
 		locale: Locale,
 		editingView: View,
-		editableElement?: HTMLElement,
-		options: {
-			shouldToolbarGroupWhenFull?: boolean;
-		} = {}
+		editableElement?: HTMLElement
 	) {
 		super( locale );
 
 		const t = locale.t;
-
-		this.toolbar = new ToolbarView( locale, {
-			shouldGroupWhenFull: options.shouldToolbarGroupWhenFull,
-			isFloating: true
-		} );
-
-		this.set( 'viewportTopOffset', 0 );
-
-		this.panel = new BalloonPanelView( locale );
-		this.panelPositions = this._getPanelPositions();
-
-		this.panel.extendTemplate( {
-			attributes: {
-				class: 'ck-toolbar-container'
-			}
-		} );
 
 		this.editable = new InlineEditableUIView( locale, editingView, editableElement, {
 			label: editableView => {
 				return t( 'Rich Text Editor. Editing area: %0', editableView.name! );
 			}
 		} );
-
-		this._resizeObserver = null;
 	}
 
 	/**
@@ -177,87 +53,6 @@ export default class InlineEditorUIView extends EditorUIView {
 	public override render(): void {
 		super.render();
 
-		this.body.add( this.panel );
 		this.registerChild( this.editable );
-		this.panel.content.add( this.toolbar );
-
-		const options = this.toolbar.options;
-
-		// Set toolbar's max-width on the initialization and update it on the editable resize,
-		// if 'shouldToolbarGroupWhenFull' in config is set to 'true'.
-		if ( options.shouldGroupWhenFull ) {
-			const editableElement = this.editable.element!;
-
-			this._resizeObserver = new ResizeObserver( editableElement, () => {
-				this.toolbar.maxWidth = toPx( new Rect( editableElement ).width );
-			} );
-		}
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public override destroy(): void {
-		super.destroy();
-
-		if ( this._resizeObserver ) {
-			this._resizeObserver.destroy();
-		}
-	}
-
-	/**
-	 * Determines the panel top position of the {@link #panel} in {@link #panelPositions}.
-	 *
-	 * @param editableRect Rect of the {@link #element}.
-	 * @param panelRect Rect of the {@link #panel}.
-	 */
-	private _getPanelPositionTop( editableRect: Rect, panelRect: Rect ): number {
-		let top;
-
-		if ( editableRect.top > panelRect.height + this.viewportTopOffset ) {
-			top = editableRect.top - panelRect.height;
-		} else if ( editableRect.bottom > panelRect.height + this.viewportTopOffset + 50 ) {
-			top = this.viewportTopOffset;
-		} else {
-			top = editableRect.bottom;
-		}
-
-		return top;
-	}
-
-	/**
-	 * Returns the positions for {@link #panelPositions}.
-	 *
-	 * See: {@link module:utils/dom/position~Options#positions}.
-	 */
-	private _getPanelPositions(): Array<PositioningFunction> {
-		const positions: Array<PositioningFunction> = [
-			( editableRect, panelRect ) => {
-				return {
-					top: this._getPanelPositionTop( editableRect, panelRect ),
-					left: editableRect.left,
-					name: 'toolbar_west',
-					config: {
-						withArrow: false
-					}
-				};
-			},
-			( editableRect, panelRect ) => {
-				return {
-					top: this._getPanelPositionTop( editableRect, panelRect ),
-					left: editableRect.left + editableRect.width - panelRect.width,
-					name: 'toolbar_east',
-					config: {
-						withArrow: false
-					}
-				};
-			}
-		];
-
-		if ( this.locale.uiLanguageDirection === 'ltr' ) {
-			return positions;
-		} else {
-			return positions.reverse();
-		}
 	}
 }

--- a/packages/ckeditor5-editor-multi-root/tests/manual/inline-toolbar.html
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/inline-toolbar.html
@@ -1,0 +1,69 @@
+<div id="playground">
+	<div id="editor-known-roots">
+		<h2>Editor with known roots</h2>
+
+		<div class="editable-container">
+			<div class="short-toolbar"><p>This root has a short toolbar.</p></div>
+			<div class="long-toolbar"><p>This root has a very long toolbar.</p></div>
+			<div class="generic-toolbar"><p>This root uses generic config.toolbar</p></div>
+		</div>
+	</div>
+	<div id="known-and-dynamic">
+		<h2>Editor with known roots & dynamic roots</h2>
+
+		<div class="editable-container">
+			<div class="short-toolbar"><p>This root has a short toolbar.</p></div>
+			<div class="long-toolbar"><p>This root has a very long toolbar.</p></div>
+			<div class="generic-toolbar"><p>This root uses generic config.toolbar</p></div>
+		</div>
+	</div>
+</div>
+
+
+<style>
+	#playground {
+		display: grid;
+		grid-template-columns: 50% 50%;
+		grid-template-rows: 1fr;
+		grid-column-gap: 0px;
+		grid-row-gap: 0px;
+		grid-gap: 1em;
+	}
+
+	#playground > div:first-child { grid-area: 1 / 1 / 2 / 2; }
+	#playground > div:last-child { grid-area: 1 / 2 / 2 / 3; }
+
+	#playground > div > button {
+		margin-right: 10px;
+	}
+
+	.editable-container {
+		position: relative;
+		border: 1px solid red;
+		margin-bottom: 20px;
+	}
+
+	.editable-container::after {
+		content: attr(class);
+		position: absolute;
+		background: red;
+		color: #fff;
+		top: 0;
+		right: 0;
+		font: 10px/2 monospace;
+		padding: .1em .3em;
+	}
+
+	.editable-container {
+		padding: 1em;
+	}
+
+	.editable-container .ck-editor__editable {
+		padding: 1em;
+		border: 1px #D3D3D3 solid;
+		border-radius: var(--ck-border-radius);
+		background: white;
+		box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
+		margin-bottom: 1em;
+	}
+</style>

--- a/packages/ckeditor5-editor-multi-root/tests/manual/inline-toolbar.js
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/inline-toolbar.js
@@ -1,0 +1,108 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console:false, document, window, CKEditorInspector */
+
+import MultiRootEditor from '../../src/multirooteditor.js';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading.js';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold.js';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic.js';
+import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials.js';
+import { InlineToolbar } from '@ckeditor/ckeditor5-ui';
+
+function createEditor( name, playgroundContainer, rootsToolbarsConfig, onInit ) {
+	let editor;
+
+	const editorData = {
+		short: playgroundContainer.querySelector( '.short-toolbar' ),
+		long: playgroundContainer.querySelector( '.long-toolbar' ),
+		generic: playgroundContainer.querySelector( '.generic-toolbar' )
+	};
+
+	function initEditor() {
+		MultiRootEditor
+			.create( editorData, {
+				plugins: [ Essentials, Paragraph, Heading, Bold, Italic, InlineToolbar ],
+				toolbar: [ 'undo', 'redo', '|', 'heading', '|', 'bold', 'italic' ],
+				rootsToolbars: rootsToolbarsConfig
+			} )
+			.then( newEditor => {
+				console.log( `Editor "${ name }" was initialized`, newEditor );
+
+				window[ name ] = editor = newEditor;
+				window[ `${ name }-editables` ] = newEditor.ui.view.editables;
+
+				onInit && onInit( newEditor );
+
+				CKEditorInspector.attach( {
+					[ name ]: newEditor
+				} );
+			} )
+			.catch( err => {
+				console.error( err.stack );
+			} );
+	}
+
+	async function destroyEditor() {
+		await editor.destroy();
+
+		editor.ui.view.toolbar.element.remove();
+
+		window.editor = editor = null;
+		window.editables = null;
+
+		console.log( `Editor "${ name }" was destroyed` );
+	}
+
+	const initButton = document.createElement( 'button' );
+	initButton.textContent = 'Init editor';
+	initButton.addEventListener( 'click', initEditor );
+
+	const destroyButton = document.createElement( 'button' );
+	destroyButton.textContent = 'Destroy editor';
+	destroyButton.addEventListener( 'click', destroyEditor );
+
+	playgroundContainer.prepend( initButton );
+	playgroundContainer.prepend( destroyButton );
+
+	initEditor();
+}
+
+createEditor( 'known-roots', document.querySelector( '#editor-known-roots' ), {
+	short: [ 'undo', 'redo', '|', 'bold', 'italic' ],
+	long: [ 'undo', 'redo', '|', ...new Array( 40 ).fill( 'bold' ) ]
+} );
+
+createEditor( 'known-and-dynamic-roots', document.querySelector( '#known-and-dynamic' ), rootName => {
+	if ( rootName === 'short' ) {
+		return [ 'undo', 'redo', '|', 'bold', 'italic' ];
+	} else if ( rootName === 'long' ) {
+		return [ 'undo', 'redo', '|', ...new Array( 40 ).fill( 'bold' ) ];
+	} else if ( rootName.startsWith( 'dynamic' ) ) {
+		return [ 'undo', 'redo' ];
+	}
+}, newEditor => {
+	const addRootButton = document.createElement( 'button' );
+	addRootButton.textContent = 'Add dynamic root';
+
+	addRootButton.addEventListener( 'click', () => {
+		const uid = 'dynamic' + ( String( new Date().getTime() ) ).slice( -5 );
+
+		newEditor.addRoot( 'dynamic' + uid, {
+			isUndoable: true,
+			data: `<p>This root ("${ uid }") uses a dedicated toolbar for all dynamic roots.</p>`
+		} );
+	} );
+
+	newEditor.on( 'addRoot', ( evt, root ) => {
+		const domElement = newEditor.createEditable( root );
+
+		document.querySelector( '#known-and-dynamic .editable-container' ).appendChild( domElement );
+	} );
+
+	document.querySelector( '#known-and-dynamic > button:last-of-type' ).after( addRootButton );
+} );
+

--- a/packages/ckeditor5-editor-multi-root/tests/manual/inline-toolbar.md
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/inline-toolbar.md
@@ -1,0 +1,4 @@
+# Dynamic toolbar configuration
+
+1. Move the selection between editor roots.
+2. The toolbar should update and display items specific for the root only.

--- a/packages/ckeditor5-ui/src/augmentation.ts
+++ b/packages/ckeditor5-ui/src/augmentation.ts
@@ -7,6 +7,7 @@ import type {
 	BalloonToolbar,
 	BlockToolbar,
 	ContextualBalloon,
+	InlineToolbar,
 	Notification
 } from './index.js';
 
@@ -88,11 +89,17 @@ declare module '@ckeditor/ckeditor5-core' {
 		 * Read more about configuring the main editor toolbar in {@link module:core/editor/editorconfig~EditorConfig#toolbar}.
 		 */
 		blockToolbar?: ToolbarConfig;
+
+		/**
+		 * TODO: docs
+		 */
+		inlineToolbar?: ToolbarConfig;
 	}
 
 	interface PluginsMap {
 		[ BalloonToolbar.pluginName ]: BalloonToolbar;
 		[ BlockToolbar.pluginName ]: BlockToolbar;
+		[ InlineToolbar.pluginName ]: InlineToolbar;
 		[ ContextualBalloon.pluginName ]: ContextualBalloon;
 		[ Notification.pluginName ]: Notification;
 	}

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -99,6 +99,7 @@ export { default as ToolbarSeparatorView } from './toolbar/toolbarseparatorview.
 export { default as normalizeToolbarConfig } from './toolbar/normalizetoolbarconfig.js';
 export { default as BalloonToolbar, type BalloonToolbarShowEvent } from './toolbar/balloon/balloontoolbar.js';
 export { default as BlockToolbar } from './toolbar/block/blocktoolbar.js';
+export { default as InlineToolbar } from './toolbar/inline/inlinetoolbar.js';
 
 export { default as View, type UIViewRenderEvent } from './view.js';
 export { default as ViewCollection } from './viewcollection.js';

--- a/packages/ckeditor5-ui/src/toolbar/inline/inlinetoolbar.ts
+++ b/packages/ckeditor5-ui/src/toolbar/inline/inlinetoolbar.ts
@@ -1,0 +1,273 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import ToolbarView from '../toolbarview.js';
+import BalloonPanelView from '../../panel/balloon/balloonpanelview.js';
+import type { EditorUIUpdateEvent } from '../../editorui/editorui.js';
+import normalizeToolbarConfig from '../normalizetoolbarconfig.js';
+
+import { type Editor, Plugin } from '@ckeditor/ckeditor5-core';
+import { type PositioningFunction, Rect, ResizeObserver, toUnit } from '@ckeditor/ckeditor5-utils';
+
+const toPx = toUnit( 'px' );
+
+/**
+ * TODO
+ */
+export default class InlineToolbar extends Plugin {
+	/**
+	 * @inheritDoc
+	 */
+	public static get pluginName() {
+		return 'InlineToolbar' as const;
+	}
+
+	/**
+	 * A toolbar view instance.
+	 */
+	public readonly toolbarView: ToolbarView;
+
+	/**
+	 * A balloon panel view instance.
+	 */
+	public readonly panelView: BalloonPanelView;
+
+	/**
+	 * A set of positioning functions used by the {@link #panelView} to float around the editable elements.
+	 *
+	 * The positioning functions are as follows:
+	 *
+	 * * West:
+	 *
+	 * ```
+	 * [ Panel ]
+	 * +------------------+
+	 * | #editableElement |
+	 * +------------------+
+	 *
+	 * +------------------+
+	 * | #editableElement |
+	 * |[ Panel ]         |
+	 * |                  |
+	 * +------------------+
+	 *
+	 * +------------------+
+	 * | #editableElement |
+	 * +------------------+
+	 * [ Panel ]
+	 * ```
+	 *
+	 * * East:
+	 *
+	 * ```
+	 *            [ Panel ]
+	 * +------------------+
+	 * | #editableElement |
+	 * +------------------+
+	 *
+	 * +------------------+
+	 * | #editableElement |
+	 * |         [ Panel ]|
+	 * |                  |
+	 * +------------------+
+	 *
+	 * +------------------+
+	 * | #editableElement |
+	 * +------------------+
+	 *            [ Panel ]
+	 * ```
+	 *
+	 * See: {@link module:utils/dom/position~Options#positions}.
+	 */
+	public readonly panelPositions: Array<PositioningFunction>;
+
+	/**
+	 * An instance of the resize observer that helps dynamically determine the geometry of the toolbar
+	 * and manage items that do not fit into a single row.
+	 *
+	 * **Note:** Created on demand in {@link #init}.
+	 */
+	private _resizeObserver: ResizeObserver | null;
+
+	/**
+	 * @inheritDoc
+	 */
+	constructor( editor: Editor ) {
+		super( editor );
+
+		const locale = editor.locale;
+		const shouldGroupWhenFull = !editor.config.get( 'toolbar.shouldNotGroupWhenFull' );
+
+		this.toolbarView = new ToolbarView( locale, {
+			shouldGroupWhenFull,
+			isFloating: true
+		} );
+
+		this.panelView = new BalloonPanelView( locale );
+		this.panelPositions = this._getPanelPositions();
+		this.panelView.extendTemplate( {
+			attributes: {
+				class: 'ck-toolbar-container'
+			}
+		} );
+
+		this._resizeObserver = null;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public init(): void {
+		const editor = this.editor;
+
+		editor.ui.view.body.add( this.panelView );
+
+		this.panelView.content.add( this.toolbarView );
+		this.panelView.bind( 'isVisible' ).to( editor.ui.focusTracker, 'isFocused' );
+
+		this.editor.ui.focusTracker.on( 'change:focusedElement', () => {
+			// Set toolbar's max-width on the initialization and update it on the editable resize,
+			// if 'shouldToolbarGroupWhenFull' in config is set to 'true'.
+		} );
+
+		// https://github.com/ckeditor/ckeditor5-editor-inline/issues/4
+		this.listenTo<EditorUIUpdateEvent>( editor.ui, 'update', () => {
+			const focusedEditableElement = this._getFocusedEditableElement();
+
+			if ( this.toolbarView.options.shouldGroupWhenFull ) {
+				this._attachToolbarMaxWidthUpdater( focusedEditableElement );
+			}
+
+			// Don't pin if the panel is not already visible. It prevents the panel
+			// showing up when there's no focus in the UI.
+			if ( this.panelView.isVisible && focusedEditableElement ) {
+				this.panelView.pin( {
+					target: this._getFocusedEditableElement()!,
+					positions: this.panelPositions
+				} );
+			}
+		} );
+
+		// Register the toolbar so it becomes available for Alt+F10 and Esc navigation.
+		editor.ui.addToolbar( this.toolbarView );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public afterInit(): void {
+		const editor = this.editor;
+
+		this.toolbarView.fillFromConfig(
+			normalizeToolbarConfig( editor.config.get( 'inlineToolbar' ) ),
+			editor.ui.componentFactory
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public override destroy(): void {
+		super.destroy();
+
+		if ( this._resizeObserver ) {
+			this._resizeObserver.destroy();
+		}
+	}
+
+	/**
+	 * TODO
+	 */
+	private _getFocusedEditableElement(): HTMLElement | null {
+		const editor = this.editor;
+		const editableNames = editor.ui.getEditableElementsNames();
+
+		for ( const name of editableNames ) {
+			const editableElement = editor.ui.getEditableElement( name )!;
+
+			if ( editor.ui.focusTracker.focusedElement === editableElement ) {
+				return editableElement;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Determines the panel top position of the {@link #panel} in {@link #panelPositions}.
+	 *
+	 * @param editableRect Rect of the {@link #element}.
+	 * @param panelRect Rect of the {@link #panel}.
+	 */
+	private _getPanelPositionTop( editableRect: Rect, panelRect: Rect ): number {
+		const viewportTopOffset = this.editor.ui.viewportOffset.top || 0;
+		let top;
+
+		if ( editableRect.top > panelRect.height + viewportTopOffset ) {
+			top = editableRect.top - panelRect.height;
+		} else if ( editableRect.bottom > panelRect.height + viewportTopOffset + 50 ) {
+			top = viewportTopOffset;
+		} else {
+			top = editableRect.bottom;
+		}
+
+		return top;
+	}
+
+	/**
+	 * Returns the positions for {@link #panelPositions}.
+	 *
+	 * See: {@link module:utils/dom/position~Options#positions}.
+	 */
+	private _getPanelPositions(): Array<PositioningFunction> {
+		const positions: Array<PositioningFunction> = [
+			( editableRect, panelRect ) => {
+				return {
+					top: this._getPanelPositionTop( editableRect, panelRect ),
+					left: editableRect.left,
+					name: 'toolbar_west',
+					config: {
+						withArrow: false
+					}
+				};
+			},
+			( editableRect, panelRect ) => {
+				return {
+					top: this._getPanelPositionTop( editableRect, panelRect ),
+					left: editableRect.left + editableRect.width - panelRect.width,
+					name: 'toolbar_east',
+					config: {
+						withArrow: false
+					}
+				};
+			}
+		];
+
+		if ( this.editor.locale.uiLanguageDirection === 'ltr' ) {
+			return positions;
+		} else {
+			return positions.reverse();
+		}
+	}
+
+	/**
+	 * TODO
+	 */
+	private _attachToolbarMaxWidthUpdater( focusedEditableElement: HTMLElement | null ): void {
+		if ( this._resizeObserver ) {
+			this._resizeObserver.destroy();
+		}
+
+		if ( focusedEditableElement ) {
+			const setMaxWidth = () => {
+				this.toolbarView.maxWidth = toPx( new Rect( focusedEditableElement ).width );
+			};
+
+			setMaxWidth();
+
+			this._resizeObserver = new ResizeObserver( focusedEditableElement, setMaxWidth );
+		}
+	}
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

WIP: Message. Closes #000.

---

### Additional information

**This is built on top of https://github.com/ckeditor/ckeditor5/pull/15569**

* I extracted the inline toolbar logic from `InlineEditorUIView`
  * It's now a plugin, just like `BlockToolbar` or `BalloonToolbar`
  * This introduces some BCs to `InlineEditorUIView` class. Properties such as `#panel` or `#toolbar` are no longer there. Migration is easy, though, these properties are available in `editor.plugins.get( 'InlineToolbar' )`.
  * The ckeditor5-editor-inline package has less code.
  * The new `InlineToolbar` plugin is injected into editor plugins & configured by `InlineEditor` (the same happens in `BalloonEditor`) https://github.com/ckeditor/ckeditor5/blob/c86b6a99fb17f048f879953bef57ed558278db60/packages/ckeditor5-editor-inline/src/inlineeditor.ts#L85-L89 
* The `InlineToolbar` plugin supports multiple editor roots out of the box.
  * You can load it in your `MultiRootEditor.create()` and that's it.
* I decided not to couple `InlineToolbar` and `MultiRootEditor` directly (e.g. using a multi-root editor's config). 
   * I'm an advocate for feature composition. I'd rather let integrators choose their favorite toolbar by loading its plugin.
   * The con of this approach is that sometimes we have two toolbars: `MultiRootEditorUIView's` default and the `InlineToolbar`. Even if you don't inject the former into DOM, it still must be created and updated dynamically. 
     * Maybe we should have yet another toolbar-as-plugin named `StaticToolbar` you can load along with multi-root editor or decoupled editor? They're basically the same (static, must be injected manually into DOM). Then integrators pick any combination of the four: static, inline, balloon, block.
* `MultiRootEditorUI`'s [dynamic toolbar items logic](https://github.com/ckeditor/ckeditor5/pull/15569) now comes ready for the presence of the `InlineToolbar` https://github.com/ckeditor/ckeditor5/blob/c86b6a99fb17f048f879953bef57ed558278db60/packages/ckeditor5-editor-multi-root/src/multirooteditorui.ts#L228-L236
   * I have a love-hate relationship with this BC why don't we do the same for block and balloon toolbars out of the box?
      * Consistency would be nice.
      * But OTOH the whole point of different toolbar types with different toolbar configurations is letting integrators tailor their items in specific toolbars.
      * ...so maybe we could get rid of this coupling and, for instance, somehow do this externally? Like `MultiRootEditorUI` firing an event whenever it changes toolbar items so you can hook into it and fill whatever toolbar you like (inline/block/balloon/custom)?
      * This is related to my point about multi-root editor sometimes having two toolbars at once (default + `InlineToolbar`). 