### PR TITLE
Use serviceOrigin in image editing

### DIFF
--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
@@ -176,6 +176,7 @@ export default class CKBoxImageEditCommand extends Command {
 				allowOverwrite: false
 			},
 			tokenUrl: ckboxConfig.tokenUrl,
+			...( ckboxConfig.serviceOrigin && { serviceOrigin: ckboxConfig.serviceOrigin } ),
 			onClose: () => this._handleImageEditorClose(),
 			onSave: ( asset: CKBoxRawAssetDefinition ) => this._handleImageEditorSave( state, asset )
 		};

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
@@ -234,6 +234,7 @@ describe( 'CKBoxImageEditCommand', () => {
 				} );
 
 				expect( options ).to.have.property( 'assetId', ckboxImageId );
+				expect( options ).to.have.property( 'serviceOrigin', CKBOX_API_URL );
 				expect( options ).to.have.property( 'tokenUrl', 'foo' );
 				expect( options.imageEditing.allowOverwrite ).to.be.false;
 				expect( options.onSave ).to.be.a( 'function' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ckbox): In on-premises should use serviceOrigin in image-editing. Closes [#5834](https://github.com/cksource/ckeditor5-commercial/issues/5834).

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
