### PR TITLE
Fix cycling in dialog actions

### DIFF
--- a/packages/ckeditor5-ui/src/dialog/dialogview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogview.ts
@@ -633,12 +633,20 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 			if ( isViewWithFocusCycler( focusable ) ) {
 				this.listenTo<FocusCyclerForwardCycleEvent>( focusable.focusCycler, 'forwardCycle', evt => {
 					this._focusCycler.focusNext();
-					evt.stop();
+
+					// Stop the event propagation only if there are more focusables.
+					if ( this._focusCycler.next !== this._focusCycler.focusables.get( this._focusCycler.current! ) ) {
+						evt.stop();
+					}
 				} );
 
 				this.listenTo<FocusCyclerBackwardCycleEvent>( focusable.focusCycler, 'backwardCycle', evt => {
 					this._focusCycler.focusPrevious();
-					evt.stop();
+
+					// Stop the event propagation only if there are more focusables.
+					if ( this._focusCycler.previous !== this._focusCycler.focusables.get( this._focusCycler.current! ) ) {
+						evt.stop();
+					}
 				} );
 			}
 		} );

--- a/packages/ckeditor5-ui/tests/dialog/dialogview.js
+++ b/packages/ckeditor5-ui/tests/dialog/dialogview.js
@@ -266,6 +266,51 @@ describe( 'DialogView', () => {
 
 					sinon.assert.calledOnce( focusSpies.childA );
 				} );
+
+				it( 'should cycle forward correctly if there are only action buttons', async () => {
+					const newView = new DialogView( locale, {
+						getCurrentDomRoot: getCurrentDomRootStub,
+						getViewportOffset: getViewportOffsetStub
+					} );
+
+					newView.render();
+					newView.isVisible = true;
+
+					document.body.appendChild( newView.element );
+
+					newView.setupParts( {
+						actionButtons: [
+							{ label: 'foo' },
+							{ label: 'bar' }
+						]
+					} );
+
+					// The view gets focused when #isVisible is set to true. Let's wait for the focus to move and
+					// then start the spies
+					await wait( 10 );
+
+					focusSpies = {
+						actionFoo: testUtils.sinon.spy( newView.actionsView.children.first, 'focus' ),
+						actionBar: testUtils.sinon.spy( newView.actionsView.children.last, 'focus' )
+					};
+
+					newView.actionsView.keystrokes.press( keyEvtData );
+					await wait( 10 );
+
+					sinon.assert.calledOnce( focusSpies.actionBar );
+
+					newView.actionsView.keystrokes.press( keyEvtData );
+					await wait( 10 );
+
+					sinon.assert.calledOnce( focusSpies.actionFoo );
+
+					newView.actionsView.keystrokes.press( keyEvtData );
+					await wait( 10 );
+
+					sinon.assert.calledTwice( focusSpies.actionBar );
+
+					newView.element.remove();
+				} );
 			} );
 
 			describe( 'upon pressing Shift+Tab', () => {
@@ -303,6 +348,51 @@ describe( 'DialogView', () => {
 					await wait( 10 );
 
 					sinon.assert.calledOnce( focusSpies.childA );
+				} );
+
+				it( 'should cycle backwards correctly if there are only action buttons', async () => {
+					const newView = new DialogView( locale, {
+						getCurrentDomRoot: getCurrentDomRootStub,
+						getViewportOffset: getViewportOffsetStub
+					} );
+
+					newView.render();
+					newView.isVisible = true;
+
+					document.body.appendChild( newView.element );
+
+					newView.setupParts( {
+						actionButtons: [
+							{ label: 'foo' },
+							{ label: 'bar' }
+						]
+					} );
+
+					// The view gets focused when #isVisible is set to true. Let's wait for the focus to move and
+					// then start the spies
+					await wait( 10 );
+
+					focusSpies = {
+						actionFoo: testUtils.sinon.spy( newView.actionsView.children.first, 'focus' ),
+						actionBar: testUtils.sinon.spy( newView.actionsView.children.last, 'focus' )
+					};
+
+					newView.actionsView.keystrokes.press( keyEvtData );
+					await wait( 10 );
+
+					sinon.assert.calledOnce( focusSpies.actionBar );
+
+					newView.actionsView.keystrokes.press( keyEvtData );
+					await wait( 10 );
+
+					sinon.assert.calledOnce( focusSpies.actionFoo );
+
+					newView.actionsView.keystrokes.press( keyEvtData );
+					await wait( 10 );
+
+					sinon.assert.calledTwice( focusSpies.actionBar );
+
+					newView.element.remove();
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-ui/tests/manual/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/tests/manual/dialog/dialog.ts
@@ -84,9 +84,9 @@ class ModalWithText extends Plugin {
 
 				dialog.show( {
 					isModal: true,
-					title: t( 'Modal with text and without close button' ),
+					// title: t( 'Modal with text and without close button' ),
 					hasCloseButton: false,
-					content: textView,
+					// content: textView,
 					actionButtons: [
 						{
 							label: t( 'Let\'s do this!' ),

--- a/packages/ckeditor5-ui/tests/manual/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/tests/manual/dialog/dialog.ts
@@ -84,9 +84,8 @@ class ModalWithText extends Plugin {
 
 				dialog.show( {
 					isModal: true,
-					// title: t( 'Modal with text and without close button' ),
-					hasCloseButton: false,
-					// content: textView,
+					title: t( 'Modal with text' ),
+					content: textView,
 					actionButtons: [
 						{
 							label: t( 'Let\'s do this!' ),
@@ -115,6 +114,51 @@ class ModalWithText extends Plugin {
 						},
 						{
 							label: t( 'Cancel' ),
+							withText: true,
+							onExecute: () => dialog.hide()
+						}
+					]
+				} );
+			} );
+
+			return buttonView;
+		} );
+	}
+}
+
+class YesNoModal extends Plugin {
+	public static get requires() {
+		return [ Dialog ] as const;
+	}
+
+	public init(): void {
+		const t = this.editor.locale.t;
+
+		this.editor.ui.componentFactory.add( 'yesNoModal', locale => {
+			const buttonView = new ButtonView( locale );
+
+			buttonView.set( {
+				label: t( 'Yes/no modal' ),
+				tooltip: true,
+				withText: true
+			} );
+
+			buttonView.on( 'execute', () => {
+				const dialog = this.editor.plugins.get( 'Dialog' );
+
+				dialog.show( {
+					isModal: true,
+					title: 'Are you sure you want to do this?',
+					hasCloseButton: false,
+					actionButtons: [
+						{
+							label: t( 'Yes' ),
+							class: 'ck-button-action',
+							withText: true,
+							onExecute: () => dialog.hide()
+						},
+						{
+							label: t( 'No' ),
 							withText: true,
 							onExecute: () => dialog.hide()
 						}
@@ -198,13 +242,14 @@ function initEditor( editorName, editorClass, direction = 'ltr', customCallback?
 			SpecialCharactersEmoji,
 			SourceEditing,
 			ModalWithText,
-			MinimalisticDialogs
+			MinimalisticDialogs,
+			YesNoModal
 		],
 		toolbar: {
 			items: [
 				'heading', 'bold', 'italic', 'link', 'sourceediting',
 				'-',
-				'findAndReplace', 'modalWithText', ...POSSIBLE_DIALOG_POSITIONS
+				'findAndReplace', 'modalWithText', 'yesNoModal', ...POSSIBLE_DIALOG_POSITIONS
 			],
 			shouldNotGroupWhenFull: true
 		},
@@ -451,13 +496,14 @@ MultiRootEditor
 			SourceEditing,
 			ModalWithText,
 			MinimalisticDialogs,
+			YesNoModal,
 			MultiRootEditorIntegration
 		],
 		toolbar: {
 			items: [
 				'heading', 'bold', 'italic', 'link',
 				'-',
-				'findAndReplace', 'modalWithText', ...POSSIBLE_DIALOG_POSITIONS,
+				'findAndReplace', 'modalWithText', 'yesNoModal', ...POSSIBLE_DIALOG_POSITIONS,
 				{
 					label: 'Multi-root',
 					withText: true,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal(ui): Fix tab cycling in dialog that only has action buttons.

---

### Additional information

Addresses https://github.com/ckeditor/ckeditor5/pull/15577#discussion_r1434025222.