### PR TITLE
LinkImage should not crash if initialized before Image

### DIFF
--- a/packages/ckeditor5-html-support/tests/integrations/image.js
+++ b/packages/ckeditor5-html-support/tests/integrations/image.js
@@ -2474,10 +2474,10 @@ describe( 'ImageElementSupport', () => {
 						'alt',
 						'src',
 						'srcset',
-						'linkHref',
 						'width',
 						'height',
 						'placeholder',
+						'linkHref',
 						'htmlImgAttributes',
 						'htmlFigureAttributes',
 						'htmlLinkAttributes'

--- a/packages/ckeditor5-link/src/linkimageediting.ts
+++ b/packages/ckeditor5-link/src/linkimageediting.ts
@@ -53,7 +53,7 @@ export default class LinkImageEditing extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public init(): void {
+	public afterInit(): void {
 		const editor = this.editor;
 		const schema = editor.model.schema;
 

--- a/packages/ckeditor5-link/tests/linkimage-integration.js
+++ b/packages/ckeditor5-link/tests/linkimage-integration.js
@@ -10,6 +10,7 @@ import Enter from '@ckeditor/ckeditor5-enter/src/enter.js';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
 import Typing from '@ckeditor/ckeditor5-typing/src/typing.js';
 import Link from '../src/link.js';
+import LinkImage from '../src/linkimage.js';
 
 import { getData as getModelData, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global.js';
@@ -66,6 +67,23 @@ describe( 'LinkImage integration', () => {
 			);
 
 			expect( editor.commands.get( 'unlink' ).isEnabled ).to.equal( true );
+		} );
+	} );
+
+	describe( 'with Image plugin', () => {
+		it( 'should not crash when Image plugin is loaded after LinkImage', async () => {
+			const editorElement = global.document.createElement( 'div' );
+			global.document.body.appendChild( editorElement );
+
+			const editor = await ClassicEditor
+				.create( editorElement, {
+					plugins: [
+						Enter, Typing, Paragraph, LinkImage, Image
+					]
+				} );
+
+			await editor.destroy();
+			editorElement.remove();
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (link): Fixed the editor crash using the `LinkImage` plugin loaded before `Image`, which ends with extending the schema definitions before they are registered. Closes #15617.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
