### PR TITLE
FocusCycler's #focusables collection should only contain FocusableView instances

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.ts
+++ b/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.ts
@@ -19,6 +19,7 @@ import {
 
 	type Template,
 	type InputView,
+	type FocusableView,
 	SwitchButtonView,
 	CollapsibleView
 } from 'ckeditor5/src/ui.js';
@@ -210,7 +211,7 @@ export default class FindAndReplaceFormView extends View {
 	/**
 	 * A collection of views that can be focused in the form.
 	 */
-	private readonly _focusables: ViewCollection;
+	private readonly _focusables: ViewCollection<FocusableView>;
 
 	/**
 	 * Helps cycling over {@link #_focusables} in the form.

--- a/packages/ckeditor5-image/src/imageinsert/ui/imageinsertformview.ts
+++ b/packages/ckeditor5-image/src/imageinsert/ui/imageinsertformview.ts
@@ -14,7 +14,8 @@ import {
 	FocusCycler,
 	CollapsibleView,
 	type FocusCyclerForwardCycleEvent,
-	type FocusCyclerBackwardCycleEvent
+	type FocusCyclerBackwardCycleEvent,
+	type FocusableView
 } from 'ckeditor5/src/ui.js';
 import { FocusTracker, KeystrokeHandler, type Locale } from 'ckeditor5/src/utils.js';
 
@@ -39,7 +40,7 @@ export default class ImageInsertFormView extends View {
 	/**
 	 * A collection of views that can be focused in the form.
 	 */
-	protected readonly _focusables: ViewCollection;
+	protected readonly _focusables: ViewCollection<FocusableView>;
 
 	/**
 	 * Helps cycling over {@link #_focusables} in the form.
@@ -49,7 +50,7 @@ export default class ImageInsertFormView extends View {
 	/**
 	 * A collection of the defined integrations for inserting the images.
 	 */
-	private readonly children: ViewCollection;
+	private readonly children: ViewCollection<FocusableView>;
 
 	/**
 	 * Creates a view for the dropdown panel of {@link module:image/imageinsert/imageinsertui~ImageInsertUI}.
@@ -57,7 +58,7 @@ export default class ImageInsertFormView extends View {
 	 * @param locale The localization services instance.
 	 * @param integrations An integrations object that contains components (or tokens for components) to be shown in the panel view.
 	 */
-	constructor( locale: Locale, integrations: Array<View> = [] ) {
+	constructor( locale: Locale, integrations: Array<FocusableView> = [] ) {
 		super( locale );
 
 		this.focusTracker = new FocusTracker();

--- a/packages/ckeditor5-image/src/imageinsert/ui/imageinserturlview.ts
+++ b/packages/ckeditor5-image/src/imageinsert/ui/imageinserturlview.ts
@@ -15,7 +15,8 @@ import {
 	FocusCycler,
 	LabeledFieldView,
 	createLabeledInputText,
-	type InputTextView
+	type InputTextView,
+	type FocusableView
 } from 'ckeditor5/src/ui.js';
 import { FocusTracker, KeystrokeHandler, type Locale } from 'ckeditor5/src/utils.js';
 
@@ -79,7 +80,7 @@ export default class ImageInsertUrlView extends View {
 	/**
 	 * A collection of views that can be focused in the form.
 	 */
-	private readonly _focusables: ViewCollection;
+	private readonly _focusables: ViewCollection<FocusableView>;
 
 	/**
 	 * Creates a view for the dropdown panel of {@link module:image/imageinsert/imageinsertui~ImageInsertUI}.

--- a/packages/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview.ts
+++ b/packages/ckeditor5-image/src/imagetextalternative/ui/textalternativeformview.ts
@@ -15,7 +15,8 @@ import {
 	ViewCollection,
 	createLabeledInputText,
 	submitHandler,
-	type InputView
+	type InputView,
+	type FocusableView
 } from 'ckeditor5/src/ui.js';
 import { FocusTracker, KeystrokeHandler, type Locale } from 'ckeditor5/src/utils.js';
 import { icons } from 'ckeditor5/src/core.js';
@@ -58,7 +59,7 @@ export default class TextAlternativeFormView extends View {
 	/**
 	 * A collection of views which can be focused in the form.
 	 */
-	protected readonly _focusables: ViewCollection;
+	protected readonly _focusables: ViewCollection<FocusableView>;
 
 	/**
 	 * Helps cycling over {@link #_focusables} in the form.

--- a/packages/ckeditor5-link/src/ui/linkactionsview.ts
+++ b/packages/ckeditor5-link/src/ui/linkactionsview.ts
@@ -7,7 +7,7 @@
  * @module link/ui/linkactionsview
  */
 
-import { ButtonView, View, ViewCollection, FocusCycler } from 'ckeditor5/src/ui.js';
+import { ButtonView, View, ViewCollection, FocusCycler, type FocusableView } from 'ckeditor5/src/ui.js';
 import { FocusTracker, KeystrokeHandler, type LocaleTranslate, type Locale } from 'ckeditor5/src/utils.js';
 import { icons } from 'ckeditor5/src/core.js';
 
@@ -38,7 +38,7 @@ export default class LinkActionsView extends View {
 	/**
 	 * The href preview view.
 	 */
-	public previewButtonView: View;
+	public previewButtonView: ButtonView;
 
 	/**
 	 * The unlink button view.
@@ -60,7 +60,7 @@ export default class LinkActionsView extends View {
 	/**
 	 * A collection of views that can be focused in the view.
 	 */
-	private readonly _focusables = new ViewCollection();
+	private readonly _focusables: ViewCollection<FocusableView> = new ViewCollection();
 
 	/**
 	 * Helps cycling over {@link #_focusables} in the view.

--- a/packages/ckeditor5-link/src/ui/linkformview.ts
+++ b/packages/ckeditor5-link/src/ui/linkformview.ts
@@ -16,7 +16,8 @@ import {
 	ViewCollection,
 	createLabeledInputText,
 	submitHandler,
-	type InputTextView
+	type InputTextView,
+	type FocusableView
 } from 'ckeditor5/src/ui.js';
 import {
 	FocusTracker,
@@ -70,7 +71,7 @@ export default class LinkFormView extends View {
 	 * which corresponds to {@link module:link/linkcommand~LinkCommand#manualDecorators manual decorators}
 	 * configured in the editor.
 	 */
-	private readonly _manualDecoratorSwitches: ViewCollection;
+	private readonly _manualDecoratorSwitches: ViewCollection<SwitchButtonView>;
 
 	/**
 	 * A collection of child views in the form.
@@ -80,7 +81,7 @@ export default class LinkFormView extends View {
 	/**
 	 * A collection of views that can be focused in the form.
 	 */
-	private readonly _focusables = new ViewCollection();
+	private readonly _focusables: ViewCollection<FocusableView> = new ViewCollection();
 
 	/**
 	 * Helps cycling over {@link #_focusables} in the form.
@@ -254,8 +255,8 @@ export default class LinkFormView extends View {
 	 * @param linkCommand A reference to the link command.
 	 * @returns ViewCollection of switch buttons.
 	 */
-	private _createManualDecoratorSwitches( linkCommand: LinkCommand ): ViewCollection {
-		const switches = this.createCollection();
+	private _createManualDecoratorSwitches( linkCommand: LinkCommand ): ViewCollection<SwitchButtonView> {
+		const switches = this.createCollection<SwitchButtonView>();
 
 		for ( const manualDecorator of linkCommand.manualDecorators ) {
 			const switchButton: SwitchButtonView & { name?: string } = new SwitchButtonView( this.locale );

--- a/packages/ckeditor5-list/src/listproperties/ui/listpropertiesview.ts
+++ b/packages/ckeditor5-list/src/listproperties/ui/listpropertiesview.ts
@@ -17,7 +17,8 @@ import {
 	addKeyboardHandlingForGrid,
 	CollapsibleView,
 	type ButtonView,
-	type InputNumberView
+	type InputNumberView,
+	type FocusableView
 } from 'ckeditor5/src/ui.js';
 
 import {
@@ -98,7 +99,7 @@ export default class ListPropertiesView extends View {
 	/**
 	 * A collection of views that can be focused in the properties view.
 	 */
-	public readonly focusables: ViewCollection = new ViewCollection();
+	public readonly focusables: ViewCollection<FocusableView> = new ViewCollection();
 
 	/**
 	 * Helps cycling over {@link #focusables} in the view.

--- a/packages/ckeditor5-media-embed/src/ui/mediaformview.ts
+++ b/packages/ckeditor5-media-embed/src/ui/mediaformview.ts
@@ -15,7 +15,8 @@ import {
 	View,
 	ViewCollection,
 	createLabeledInputText,
-	submitHandler
+	submitHandler,
+	type FocusableView
 } from 'ckeditor5/src/ui.js';
 import { FocusTracker, KeystrokeHandler, type Locale } from 'ckeditor5/src/utils.js';
 import { icons } from 'ckeditor5/src/core.js';
@@ -64,7 +65,7 @@ export default class MediaFormView extends View {
 	/**
 	 * A collection of views that can be focused in the form.
 	 */
-	private readonly _focusables: ViewCollection;
+	private readonly _focusables: ViewCollection<FocusableView>;
 
 	/**
 	 * Helps cycling over {@link #_focusables} in the form.

--- a/packages/ckeditor5-special-characters/src/ui/specialcharactersview.ts
+++ b/packages/ckeditor5-special-characters/src/ui/specialcharactersview.ts
@@ -7,7 +7,7 @@
  * @module special-characters/ui/specialcharactersview
  */
 
-import { View, FocusCycler, type ViewCollection } from 'ckeditor5/src/ui.js';
+import { View, FocusCycler, type ViewCollection, type FocusableView } from 'ckeditor5/src/ui.js';
 import { FocusTracker, KeystrokeHandler, type Locale } from 'ckeditor5/src/utils.js';
 import type CharacterGridView from './charactergridview.js';
 import type CharacterInfoView from './characterinfoview.js';
@@ -24,7 +24,7 @@ export default class SpecialCharactersView extends View<HTMLDivElement> {
 	/**
 	 * A collection of the focusable children of the view.
 	 */
-	public readonly items: ViewCollection;
+	public readonly items: ViewCollection<FocusableView>;
 
 	/**
 	 * Tracks information about the DOM focus in the view.

--- a/packages/ckeditor5-style/src/ui/stylegridview.ts
+++ b/packages/ckeditor5-style/src/ui/stylegridview.ts
@@ -7,7 +7,7 @@
  * @module style/ui/stylegridview
  */
 
-import { View, addKeyboardHandlingForGrid, type ViewCollection } from 'ckeditor5/src/ui.js';
+import { View, addKeyboardHandlingForGrid, type ViewCollection, type FocusableView } from 'ckeditor5/src/ui.js';
 import { FocusTracker, KeystrokeHandler, type Locale } from 'ckeditor5/src/utils.js';
 
 import StyleGridButtonView from './stylegridbuttonview.js';
@@ -19,7 +19,7 @@ import '../../theme/stylegrid.css';
  * A class representing a grid of styles ({@link module:style/ui/stylegridbuttonview~StyleGridButtonView buttons}).
  * Allows users to select a style.
  */
-export default class StyleGridView extends View<HTMLDivElement> {
+export default class StyleGridView extends View<HTMLDivElement> implements FocusableView {
 	/**
 	 * Tracks information about the DOM focus in the view.
 	 */

--- a/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/ui/tablecellpropertiesview.ts
@@ -200,12 +200,12 @@ export default class TableCellPropertiesView extends View {
 	/**
 	 * A toolbar with buttons that allow changing the horizontal text alignment in a table cell.
 	 */
-	public readonly horizontalAlignmentToolbar: View<HTMLElement>;
+	public readonly horizontalAlignmentToolbar: ToolbarView;
 
 	/**
 	 * A toolbar with buttons that allow changing the vertical text alignment in a table cell.
 	 */
-	public readonly verticalAlignmentToolbar: View<HTMLElement>;
+	public readonly verticalAlignmentToolbar: ToolbarView;
 
 	/**
 	 * The "Save" button view.
@@ -220,7 +220,7 @@ export default class TableCellPropertiesView extends View {
 	/**
 	 * A collection of views that can be focused in the form.
 	 */
-	protected readonly _focusables: ViewCollection;
+	protected readonly _focusables: ViewCollection<FocusableView>;
 
 	/**
 	 * Helps cycling over {@link #_focusables} in the form.

--- a/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.ts
+++ b/packages/ckeditor5-table/src/tableproperties/ui/tablepropertiesview.ts
@@ -25,7 +25,8 @@ import {
 	type NormalizedColorOption,
 	type ColorPickerConfig,
 	type FocusCyclerForwardCycleEvent,
-	type FocusCyclerBackwardCycleEvent
+	type FocusCyclerBackwardCycleEvent,
+	type FocusableView
 } from 'ckeditor5/src/ui.js';
 import { FocusTracker, KeystrokeHandler, type ObservableChangeEvent, type Locale } from 'ckeditor5/src/utils.js';
 import { icons } from 'ckeditor5/src/core.js';
@@ -207,7 +208,7 @@ export default class TablePropertiesView extends View {
 	/**
 	 * A collection of views that can be focused in the form.
 	 */
-	protected readonly _focusables: ViewCollection;
+	protected readonly _focusables: ViewCollection<FocusableView>;
 
 	/**
 	 * Helps cycling over {@link #_focusables} in the form.

--- a/packages/ckeditor5-table/src/ui/colorinputview.ts
+++ b/packages/ckeditor5-table/src/ui/colorinputview.ts
@@ -96,7 +96,7 @@ export default class ColorInputView extends View implements FocusableView {
 	/**
 	 * A collection of views that can be focused in the view.
 	 */
-	protected readonly _focusables: ViewCollection;
+	protected readonly _focusables: ViewCollection<FocusableView>;
 
 	/**
 	 * An instance of the dropdown allowing to select a color from a grid.

--- a/packages/ckeditor5-ui/src/collapsible/collapsibleview.ts
+++ b/packages/ckeditor5-ui/src/collapsible/collapsibleview.ts
@@ -12,6 +12,7 @@ import type { Locale } from '@ckeditor/ckeditor5-utils';
 import View from '../view.js';
 import ButtonView from '../button/buttonview.js';
 import type ViewCollection from '../viewcollection.js';
+import type { FocusableView } from '../focuscycler.js';
 
 import dropdownArrowIcon from '../../theme/icons/dropdown-arrow.svg';
 
@@ -57,7 +58,7 @@ export default class CollapsibleView extends View {
 	/**
 	 * A collection of the child views that can be collapsed by clicking the {@link #buttonView}.
 	 */
-	public readonly children: ViewCollection;
+	public readonly children: ViewCollection<FocusableView>;
 
 	/**
 	 * Creates an instance of the collapsible view.
@@ -65,7 +66,7 @@ export default class CollapsibleView extends View {
 	 * @param locale The {@link module:core/editor/editor~Editor#locale} instance.
 	 * @param childViews An optional array of initial child views to be inserted into the collapsible.
 	 */
-	constructor( locale: Locale, childViews?: Array<View> ) {
+	constructor( locale: Locale, childViews?: Array<FocusableView> ) {
 		super( locale );
 
 		const bind = this.bindTemplate;

--- a/packages/ckeditor5-ui/src/colorselector/colorgridsfragmentview.ts
+++ b/packages/ckeditor5-ui/src/colorselector/colorgridsfragmentview.ts
@@ -19,6 +19,7 @@ import DocumentColorCollection from './documentcolorcollection.js';
 import type { Model } from '@ckeditor/ckeditor5-engine';
 import type { FocusTracker, Locale } from '@ckeditor/ckeditor5-utils';
 import type ViewCollection from '../viewcollection.js';
+import type { FocusableView } from '../focuscycler.js';
 import type { ColorSelectorExecuteEvent, ColorSelectorColorPickerShowEvent } from './colorselectorview.js';
 
 import removeButtonIcon from '@ckeditor/ckeditor5-core/theme/icons/eraser.svg';
@@ -118,7 +119,7 @@ export default class ColorGridsFragmentView extends View {
 	 *
 	 * @readonly
 	 */
-	protected _focusables: ViewCollection;
+	protected _focusables: ViewCollection<FocusableView>;
 
 	/**
 	 * Document color section's label.
@@ -163,7 +164,7 @@ export default class ColorGridsFragmentView extends View {
 			documentColorsLabel?: string;
 			documentColorsCount?: number;
 			focusTracker: FocusTracker;
-			focusables: ViewCollection;
+			focusables: ViewCollection<FocusableView>;
 		}
 	) {
 		super( locale );

--- a/packages/ckeditor5-ui/src/colorselector/colorpickerfragmentview.ts
+++ b/packages/ckeditor5-ui/src/colorselector/colorpickerfragmentview.ts
@@ -10,6 +10,9 @@
 import View from '../view.js';
 import ButtonView from '../button/buttonview.js';
 import type ViewCollection from '../viewcollection.js';
+import type { FocusableView } from '../focuscycler.js';
+import type LabeledFieldView from '../labeledfield/labeledfieldview.js';
+import type InputTextView from '../inputtext/inputtextview.js';
 import {
 	default as ColorPickerView,
 	type ColorPickerColorSelectedEvent
@@ -84,7 +87,7 @@ export default class ColorPickerFragmentView extends View {
 	 *
 	 * @readonly
 	 */
-	protected _focusables: ViewCollection;
+	protected _focusables: ViewCollection<FocusableView>;
 
 	/**
 	 * A reference to the configuration of {@link #colorPickerView}. `false` when the view was
@@ -114,7 +117,7 @@ export default class ColorPickerFragmentView extends View {
 		}:
 		{
 			focusTracker: FocusTracker;
-			focusables: ViewCollection;
+			focusables: ViewCollection<FocusableView>;
 			keystrokes: KeystrokeHandler;
 			colorPickerViewConfig: ColorPickerViewConfig | false;
 		}
@@ -231,7 +234,7 @@ export default class ColorPickerFragmentView extends View {
 			this._focusables.add( slider );
 		}
 
-		const input = this.colorPickerView!.hexInputRow.children.get( 1 )!;
+		const input = this.colorPickerView!.hexInputRow.children.get( 1 )! as LabeledFieldView<InputTextView>;
 
 		if ( input.element! ) {
 			this.focusTracker.add( input.element );

--- a/packages/ckeditor5-ui/src/colorselector/colorpickerfragmentview.ts
+++ b/packages/ckeditor5-ui/src/colorselector/colorpickerfragmentview.ts
@@ -234,7 +234,7 @@ export default class ColorPickerFragmentView extends View {
 			this._focusables.add( slider );
 		}
 
-		const input = this.colorPickerView!.hexInputRow.children.get( 1 )! as LabeledFieldView<InputTextView>;
+		const input = this.colorPickerView!.hexInputRow.children.get( 1 ) as LabeledFieldView<InputTextView>;
 
 		if ( input.element! ) {
 			this.focusTracker.add( input.element );

--- a/packages/ckeditor5-ui/src/colorselector/colorselectorview.ts
+++ b/packages/ckeditor5-ui/src/colorselector/colorselectorview.ts
@@ -7,7 +7,7 @@
  * @module ui/colorselector/colorselectorview
  */
 
-import FocusCycler from '../focuscycler.js';
+import FocusCycler, { type FocusableView } from '../focuscycler.js';
 import View from '../view.js';
 import ViewCollection from '../viewcollection.js';
 import { FocusTracker, KeystrokeHandler, type Locale } from '@ckeditor/ckeditor5-utils';
@@ -126,7 +126,7 @@ export default class ColorSelectorView extends View {
 	 *
 	 * @readonly
 	 */
-	protected _focusables: ViewCollection;
+	protected _focusables: ViewCollection<FocusableView>;
 
 	/**
 	 * The configuration of color picker sub-component.

--- a/packages/ckeditor5-ui/src/dialog/dialogactionsview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogactionsview.ts
@@ -16,7 +16,7 @@ import type { default as Button, ButtonExecuteEvent } from '../button/button.js'
 import ButtonView from '../button/buttonview.js';
 import View from '../view.js';
 import ViewCollection from '../viewcollection.js';
-import FocusCycler from '../focuscycler.js';
+import FocusCycler, { type FocusableView } from '../focuscycler.js';
 
 import '../../theme/components/dialog/dialogactions.css';
 
@@ -27,7 +27,7 @@ export default class DialogActionsView extends View {
 	/**
 	 * A collection of button views.
 	 */
-	public readonly children: ViewCollection;
+	public readonly children: ViewCollection<FocusableView>;
 
 	/**
 	 * A keystroke handler instance.
@@ -47,7 +47,7 @@ export default class DialogActionsView extends View {
 	/**
 	 * A collection of focusable views.
 	 */
-	private readonly _focusables: ViewCollection;
+	private readonly _focusables: ViewCollection<FocusableView>;
 
 	/**
 	 * @inheritDoc

--- a/packages/ckeditor5-ui/src/dialog/dialogview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogview.ts
@@ -24,7 +24,9 @@ import ButtonView from '../button/buttonview.js';
 import { type ButtonExecuteEvent } from '../button/button.js';
 import FocusCycler, { isViewWithFocusCycler,
 	type FocusCyclerBackwardCycleEvent,
-	type FocusCyclerForwardCycleEvent
+	type FocusCyclerForwardCycleEvent,
+	type FocusableView,
+	isFocusable
 }
 	from '../focuscycler.js';
 import DraggableViewMixin, { type DraggableView, type DraggableViewDragEvent } from '../bindings/draggableviewmixin.js';
@@ -161,7 +163,7 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 	/**
 	 * The list of the focusable elements inside the dialog view.
 	 */
-	private readonly _focusables: ViewCollection;
+	private readonly _focusables: ViewCollection<FocusableView>;
 
 	/**
 	 * The focus cycler instance.
@@ -612,10 +614,14 @@ export default class DialogView extends DraggableViewMixin( View ) implements Dr
 	 * and adds them to the focus tracker and focus cycler.
 	 */
 	private _updateFocusCyclableItems() {
-		const focusables = [];
+		const focusables: Array<FocusableView> = [];
 
 		if ( this.contentView ) {
-			focusables.push( ...this.contentView.children );
+			for ( const child of this.contentView.children ) {
+				if ( isFocusable( child ) ) {
+					focusables.push( child );
+				}
+			}
 		}
 
 		if ( this.actionsView ) {

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -60,7 +60,8 @@ export {
 	type ViewWithFocusCycler,
 	type FocusCyclerForwardCycleEvent,
 	type FocusCyclerBackwardCycleEvent,
-	isViewWithFocusCycler
+	isViewWithFocusCycler,
+	isFocusable
 } from './focuscycler.js';
 
 export { default as IconView } from './icon/iconview.js';

--- a/packages/ckeditor5-ui/src/list/listview.ts
+++ b/packages/ckeditor5-ui/src/list/listview.ts
@@ -8,7 +8,7 @@
  */
 
 import View from '../view.js';
-import FocusCycler from '../focuscycler.js';
+import FocusCycler, { type FocusableView } from '../focuscycler.js';
 
 import ListItemView from './listitemview.js';
 import ListItemGroupView from './listitemgroupview.js';
@@ -35,7 +35,7 @@ export default class ListView extends View<HTMLUListElement> implements Dropdown
 	 * between the {@link module:ui/list/listitemview~ListItemView list items} and
 	 * {@link module:ui/list/listitemgroupview~ListItemGroupView list groups}.
 	 */
-	public readonly focusables: ViewCollection;
+	public readonly focusables: ViewCollection<FocusableView>;
 
 	/**
 	 * Collection of the child list views.

--- a/packages/ckeditor5-ui/src/search/searchresultsview.ts
+++ b/packages/ckeditor5-ui/src/search/searchresultsview.ts
@@ -28,7 +28,7 @@ export default class SearchResultsView extends View implements FocusableView {
 	 *
 	 * @readonly
 	 */
-	public children: ViewCollection;
+	public children: ViewCollection<FocusableView>;
 
 	/**
 	 * Provides the focus management (keyboard navigation) in the view.

--- a/packages/ckeditor5-ui/src/search/text/searchtextview.ts
+++ b/packages/ckeditor5-ui/src/search/text/searchtextview.ts
@@ -12,7 +12,7 @@ import View from '../../view.js';
 import { default as SearchTextQueryView, type SearchTextQueryViewConfig } from './searchtextqueryview.js';
 import SearchInfoView from '../searchinfoview.js';
 import SearchResultsView from '../searchresultsview.js';
-import FocusCycler from '../../focuscycler.js';
+import FocusCycler, { type FocusableView } from '../../focuscycler.js';
 import { escapeRegExp } from 'lodash-es';
 
 import type FilteredView from '../filteredview.js';
@@ -70,7 +70,7 @@ export default class SearchTextView<
 	/**
 	 * The view that displays the information about the search results.
 	 */
-	public infoView: View | undefined;
+	public infoView: FocusableView | undefined;
 
 	/**
 	 * The view that allows the user to enter the search query.
@@ -113,7 +113,7 @@ export default class SearchTextView<
 	 *
 	 * @readonly
 	 */
-	declare public readonly focusableChildren: ViewCollection;
+	declare public readonly focusableChildren: ViewCollection<FocusableView>;
 
 	public declare locale: Locale;
 
@@ -351,7 +351,7 @@ export interface SearchTextViewConfig<TConfigSearchField extends InputBase<HTMLI
 		 * The view that displays the information about the search results. If not specified,
 		 * {@link module:ui/search/searchinfoview~SearchInfoView} is used.
 		 */
-		instance?: View;
+		instance?: FocusableView;
 
 		/**
 		 * The configuration of text labels displayed in the {@link #infoView} in different states

--- a/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
+++ b/packages/ckeditor5-ui/src/toolbar/toolbarview.ts
@@ -8,7 +8,7 @@
  */
 
 import View from '../view.js';
-import FocusCycler from '../focuscycler.js';
+import FocusCycler, { isFocusable, type FocusableView } from '../focuscycler.js';
 import ToolbarSeparatorView from './toolbarseparatorview.js';
 import ToolbarLineBreakView from './toolbarlinebreakview.js';
 import preventDefault from '../bindings/preventdefault.js';
@@ -111,7 +111,7 @@ export default class ToolbarView extends View implements DropdownPanelFocusable 
 	 * some optional UI elements that also belong to the toolbar and should be focusable
 	 * by the user.
 	 */
-	public readonly focusables: ViewCollection;
+	public readonly focusables: ViewCollection<FocusableView>;
 
 	declare public locale: Locale;
 
@@ -626,7 +626,7 @@ class StaticLayout implements ToolbarBehavior {
 		view.itemsView.children.bindTo( view.items ).using( item => item );
 
 		// 1:1 pass–through binding, all ToolbarView#items are focusable.
-		view.focusables.bindTo( view.items ).using( item => item );
+		view.focusables.bindTo( view.items ).using( item => isFocusable( item ) ? item : null );
 
 		view.extendTemplate( {
 			attributes: {
@@ -681,7 +681,7 @@ class DynamicGrouping implements ToolbarBehavior {
 	/**
 	 * A collection of focusable toolbar elements.
 	 */
-	public readonly viewFocusables: ViewCollection;
+	public readonly viewFocusables: ViewCollection<FocusableView>;
 
 	/**
 	 * A view containing toolbar items.
@@ -1066,7 +1066,9 @@ class DynamicGrouping implements ToolbarBehavior {
 		this.viewFocusables.clear();
 
 		this.ungroupedItems.map( item => {
-			this.viewFocusables.add( item );
+			if ( isFocusable( item ) ) {
+				this.viewFocusables.add( item );
+			}
 		} );
 
 		if ( this.groupedItems.length ) {

--- a/packages/ckeditor5-ui/tests/focuscycler.js
+++ b/packages/ckeditor5-ui/tests/focuscycler.js
@@ -629,6 +629,7 @@ describe( 'FocusCycler', () => {
 			}
 		} );
 
+		view.focus = sinon.spy();
 		view.focusCycler = focusCycler;
 
 		return view;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (ui): `FocusCycler`'s `#focusables` collection should only contain `FocusableView` instances. Closes #14973.

MINOR BREAKING CHANGE (ui): The view collection required by [`FocusCycler#constructor()`](https://ckeditor.com/docs/ckeditor5/latest/api/module_ui_focuscycler-FocusCycler.html#function-constructor) must only contain views implementing the [`FocusableView`](https://ckeditor.com/docs/ckeditor5/latest/api/module_ui_focuscycler-FocusableView.html) interface. Failing to do so will result in a TypeScript error. Please make sure each and every view passed to this collection implements the `focus()` method.

---

### Additional information

**Requires https://github.com/cksource/ckeditor5-commercial/pull/5886**
