### PR TITLE
Bump TypeScript version to 5.0

### DIFF
--- a/packages/ckeditor5-adapter-ckfinder/package.json
+++ b/packages/ckeditor5-adapter-ckfinder/package.json
@@ -30,7 +30,7 @@
     "@ckeditor/ckeditor5-typing": "40.2.0",
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-upload": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-alignment/package.json
+++ b/packages/ckeditor5-alignment/package.json
@@ -28,7 +28,7 @@
     "@ckeditor/ckeditor5-paragraph": "40.2.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-typing": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-autoformat/package.json
+++ b/packages/ckeditor5-autoformat/package.json
@@ -31,7 +31,7 @@
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-typing": "40.2.0",
     "@ckeditor/ckeditor5-undo": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-autosave/package.json
+++ b/packages/ckeditor5-autosave/package.json
@@ -23,7 +23,7 @@
     "@ckeditor/ckeditor5-paragraph": "40.2.0",
     "@ckeditor/ckeditor5-source-editing": "40.2.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-basic-styles/package.json
+++ b/packages/ckeditor5-basic-styles/package.json
@@ -25,7 +25,7 @@
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-ui": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-block-quote/package.json
+++ b/packages/ckeditor5-block-quote/package.json
@@ -29,7 +29,7 @@
     "@ckeditor/ckeditor5-table": "40.2.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-typing": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-build-balloon-block/package.json
+++ b/packages/ckeditor5-build-balloon-block/package.json
@@ -56,7 +56,7 @@
     "@ckeditor/ckeditor5-dev-utils": "^39.0.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "terser-webpack-plugin": "^4.2.3",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-build-balloon/package.json
+++ b/packages/ckeditor5-build-balloon/package.json
@@ -55,7 +55,7 @@
     "@ckeditor/ckeditor5-dev-utils": "^39.0.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "terser-webpack-plugin": "^4.2.3",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-build-classic/package.json
+++ b/packages/ckeditor5-build-classic/package.json
@@ -55,7 +55,7 @@
     "@ckeditor/ckeditor5-dev-utils": "^39.0.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "terser-webpack-plugin": "^4.2.3",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-build-decoupled-document/package.json
+++ b/packages/ckeditor5-build-decoupled-document/package.json
@@ -57,7 +57,7 @@
     "@ckeditor/ckeditor5-dev-utils": "^39.0.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "terser-webpack-plugin": "^4.2.3",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-build-inline/package.json
+++ b/packages/ckeditor5-build-inline/package.json
@@ -55,7 +55,7 @@
     "@ckeditor/ckeditor5-dev-utils": "^39.0.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "terser-webpack-plugin": "^4.2.3",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-build-multi-root/package.json
+++ b/packages/ckeditor5-build-multi-root/package.json
@@ -55,7 +55,7 @@
     "@ckeditor/ckeditor5-dev-utils": "^39.0.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "terser-webpack-plugin": "^4.2.3",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-ckbox/package.json
+++ b/packages/ckeditor5-ckbox/package.json
@@ -35,7 +35,7 @@
     "@ckeditor/ckeditor5-ui": "40.2.0",
     "@ckeditor/ckeditor5-upload": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-ckfinder/package.json
+++ b/packages/ckeditor5-ckfinder/package.json
@@ -28,7 +28,7 @@
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-ui": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-clipboard/package.json
+++ b/packages/ckeditor5-clipboard/package.json
@@ -55,7 +55,7 @@
     "@ckeditor/ckeditor5-table": "40.2.0",
     "@ckeditor/ckeditor5-typing": "40.2.0",
     "@ckeditor/ckeditor5-undo": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-cloud-services/package.json
+++ b/packages/ckeditor5-cloud-services/package.json
@@ -20,7 +20,7 @@
     "@ckeditor/ckeditor5-editor-classic": "40.2.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-code-block/package.json
+++ b/packages/ckeditor5-code-block/package.json
@@ -35,7 +35,7 @@
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-core/package.json
+++ b/packages/ckeditor5-core/package.json
@@ -43,7 +43,7 @@
     "@ckeditor/ckeditor5-paragraph": "40.2.0",
     "@ckeditor/ckeditor5-table": "40.2.0",
     "@ckeditor/ckeditor5-ui": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-easy-image/package.json
+++ b/packages/ckeditor5-easy-image/package.json
@@ -26,7 +26,7 @@
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-upload": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-editor-balloon/package.json
+++ b/packages/ckeditor5-editor-balloon/package.json
@@ -30,7 +30,7 @@
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
     "@ckeditor/ckeditor5-watchdog": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-editor-classic/package.json
+++ b/packages/ckeditor5-editor-classic/package.json
@@ -30,7 +30,7 @@
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
     "@ckeditor/ckeditor5-watchdog": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-editor-decoupled/package.json
+++ b/packages/ckeditor5-editor-decoupled/package.json
@@ -30,7 +30,7 @@
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
     "@ckeditor/ckeditor5-watchdog": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-editor-inline/package.json
+++ b/packages/ckeditor5-editor-inline/package.json
@@ -30,7 +30,7 @@
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
     "@ckeditor/ckeditor5-watchdog": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-editor-multi-root/package.json
+++ b/packages/ckeditor5-editor-multi-root/package.json
@@ -31,7 +31,7 @@
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
     "@ckeditor/ckeditor5-watchdog": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-engine/package.json
+++ b/packages/ckeditor5-engine/package.json
@@ -48,7 +48,7 @@
     "@ckeditor/ckeditor5-ui": "40.2.0",
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-widget": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-enter/package.json
+++ b/packages/ckeditor5-enter/package.json
@@ -25,7 +25,7 @@
     "@ckeditor/ckeditor5-paragraph": "40.2.0",
     "@ckeditor/ckeditor5-typing": "40.2.0",
     "@ckeditor/ckeditor5-undo": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-essentials/package.json
+++ b/packages/ckeditor5-essentials/package.json
@@ -26,7 +26,7 @@
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-typing": "40.2.0",
     "@ckeditor/ckeditor5-undo": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-find-and-replace/package.json
+++ b/packages/ckeditor5-find-and-replace/package.json
@@ -36,7 +36,7 @@
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-font/package.json
+++ b/packages/ckeditor5-font/package.json
@@ -27,7 +27,7 @@
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-ui": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-heading/package.json
+++ b/packages/ckeditor5-heading/package.json
@@ -34,7 +34,7 @@
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-upload": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-highlight/package.json
+++ b/packages/ckeditor5-highlight/package.json
@@ -29,7 +29,7 @@
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-typing": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-horizontal-line/package.json
+++ b/packages/ckeditor5-horizontal-line/package.json
@@ -27,7 +27,7 @@
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-ui": "40.2.0",
     "@ckeditor/ckeditor5-widget": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-html-embed/package.json
+++ b/packages/ckeditor5-html-embed/package.json
@@ -30,7 +30,7 @@
     "@ckeditor/ckeditor5-widget": "40.2.0",
     "lodash-es": "^4.17.15",
     "sanitize-html": "^2.1.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-html-support/package.json
+++ b/packages/ckeditor5-html-support/package.json
@@ -56,7 +56,7 @@
     "@ckeditor/ckeditor5-typing": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
     "@ckeditor/ckeditor5-widget": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-image/package.json
+++ b/packages/ckeditor5-image/package.json
@@ -50,7 +50,7 @@
     "@ckeditor/ckeditor5-utils": "40.2.0",
     "@ckeditor/ckeditor5-watchdog": "40.2.0",
     "@ckeditor/ckeditor5-widget": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-indent/package.json
+++ b/packages/ckeditor5-indent/package.json
@@ -25,7 +25,7 @@
     "@ckeditor/ckeditor5-paragraph": "40.2.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-ui": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-language/package.json
+++ b/packages/ckeditor5-language/package.json
@@ -23,7 +23,7 @@
     "@ckeditor/ckeditor5-paragraph": "40.2.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-ui": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-link/package.json
+++ b/packages/ckeditor5-link/package.json
@@ -37,7 +37,7 @@
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
     "@ckeditor/ckeditor5-widget": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-list/package.json
+++ b/packages/ckeditor5-list/package.json
@@ -51,7 +51,7 @@
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
     "@ckeditor/ckeditor5-widget": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-markdown-gfm/package.json
+++ b/packages/ckeditor5-markdown-gfm/package.json
@@ -43,7 +43,7 @@
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
     "@types/marked": "^4.0.8",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-media-embed/package.json
+++ b/packages/ckeditor5-media-embed/package.json
@@ -33,7 +33,7 @@
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
     "@ckeditor/ckeditor5-widget": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0",
     "lodash-es": "^4.17.15"

--- a/packages/ckeditor5-mention/package.json
+++ b/packages/ckeditor5-mention/package.json
@@ -36,7 +36,7 @@
     "@ckeditor/ckeditor5-utils": "40.2.0",
     "@ckeditor/ckeditor5-widget": "40.2.0",
     "lodash": "^4.17.15",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-minimap/package.json
+++ b/packages/ckeditor5-minimap/package.json
@@ -30,7 +30,7 @@
     "@ckeditor/ckeditor5-page-break": "40.2.0",
     "@ckeditor/ckeditor5-table": "40.2.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-page-break/package.json
+++ b/packages/ckeditor5-page-break/package.json
@@ -27,7 +27,7 @@
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-ui": "40.2.0",
     "@ckeditor/ckeditor5-widget": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-paragraph/package.json
+++ b/packages/ckeditor5-paragraph/package.json
@@ -27,7 +27,7 @@
     "@ckeditor/ckeditor5-link": "40.2.0",
     "@ckeditor/ckeditor5-typing": "40.2.0",
     "@ckeditor/ckeditor5-undo": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-paste-from-office/package.json
+++ b/packages/ckeditor5-paste-from-office/package.json
@@ -37,7 +37,7 @@
     "@ckeditor/ckeditor5-table": "40.2.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-remove-format/package.json
+++ b/packages/ckeditor5-remove-format/package.json
@@ -31,7 +31,7 @@
     "@ckeditor/ckeditor5-typing": "40.2.0",
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-restricted-editing/package.json
+++ b/packages/ckeditor5-restricted-editing/package.json
@@ -30,7 +30,7 @@
     "@ckeditor/ckeditor5-ui": "40.2.0",
     "@ckeditor/ckeditor5-undo": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-select-all/package.json
+++ b/packages/ckeditor5-select-all/package.json
@@ -26,7 +26,7 @@
     "@ckeditor/ckeditor5-paragraph": "40.2.0",
     "@ckeditor/ckeditor5-table": "40.2.0",
     "@ckeditor/ckeditor5-editor-classic": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-show-blocks/package.json
+++ b/packages/ckeditor5-show-blocks/package.json
@@ -58,7 +58,7 @@
     "@ckeditor/ckeditor5-special-characters": "40.2.0",
     "@ckeditor/ckeditor5-table": "40.2.0",
     "@ckeditor/ckeditor5-typing": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-source-editing/package.json
+++ b/packages/ckeditor5-source-editing/package.json
@@ -28,7 +28,7 @@
     "@ckeditor/ckeditor5-table": "40.2.0",
     "@ckeditor/ckeditor5-ui": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-special-characters/package.json
+++ b/packages/ckeditor5-special-characters/package.json
@@ -26,7 +26,7 @@
     "@ckeditor/ckeditor5-typing": "40.2.0",
     "@ckeditor/ckeditor5-ui": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-style/package.json
+++ b/packages/ckeditor5-style/package.json
@@ -53,7 +53,7 @@
     "@ckeditor/ckeditor5-ui": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
     "@ckeditor/ckeditor5-word-count": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-table/package.json
+++ b/packages/ckeditor5-table/package.json
@@ -43,7 +43,7 @@
     "@ckeditor/ckeditor5-widget": "40.2.0",
     "@ckeditor/ckeditor5-source-editing": "40.2.0",
     "json-diff": "^0.5.4",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-table/src/commands/mergecellcommand.ts
+++ b/packages/ckeditor5-table/src/commands/mergecellcommand.ts
@@ -164,7 +164,7 @@ function getHorizontalCell( tableCell: Element, direction: ArrowKeyCodeDirection
 	const tableRow = tableCell.parent!;
 	const table = tableRow.parent as Element;
 	const horizontalCell = direction == 'right' ? tableCell.nextSibling : tableCell.previousSibling;
-	const hasHeadingColumns = ( table.getAttribute( 'headingColumns' ) || 0 ) > 0;
+	const hasHeadingColumns = ( table.getAttribute( 'headingColumns' ) as number || 0 ) > 0;
 
 	if ( !horizontalCell ) {
 		return;

--- a/packages/ckeditor5-table/src/converters/downcast.ts
+++ b/packages/ckeditor5-table/src/converters/downcast.ts
@@ -19,7 +19,7 @@ import type { AdditionalSlot } from '../tableediting.js';
  */
 export function downcastTable( tableUtils: TableUtils, options: DowncastTableOptions ): ElementCreatorFunction {
 	return ( table, { writer } ) => {
-		const headingRows = table.getAttribute( 'headingRows' ) || 0;
+		const headingRows = table.getAttribute( 'headingRows' ) as number || 0;
 		const tableElement = writer.createContainerElement( 'table', null, [] );
 		const figureElement = writer.createContainerElement( 'figure', { class: 'table' }, tableElement );
 

--- a/packages/ckeditor5-table/src/converters/table-headings-refresh-handler.ts
+++ b/packages/ckeditor5-table/src/converters/table-headings-refresh-handler.ts
@@ -52,8 +52,8 @@ export default function tableHeadingsRefreshHandler( model: Model, editing: Edit
 			continue;
 		}
 
-		const headingRows = table.getAttribute( 'headingRows' ) || 0;
-		const headingColumns = table.getAttribute( 'headingColumns' ) || 0;
+		const headingRows = table.getAttribute( 'headingRows' ) as number || 0;
+		const headingColumns = table.getAttribute( 'headingColumns' ) as number || 0;
 
 		const tableWalker = new TableWalker( table );
 

--- a/packages/ckeditor5-table/src/plaintableoutput.ts
+++ b/packages/ckeditor5-table/src/plaintableoutput.ts
@@ -71,7 +71,7 @@ export default class PlainTableOutput extends Plugin {
  * @returns Created element.
  */
 function downcastTableElement( table: Element, { writer }: { writer: DowncastWriter } ) {
-	const headingRows = table.getAttribute( 'headingRows' ) || 0;
+	const headingRows = table.getAttribute( 'headingRows' ) as number || 0;
 
 	// Table head rows slot.
 	const headRowsSlot = writer.createSlot( ( element: Node ) =>

--- a/packages/ckeditor5-typing/package.json
+++ b/packages/ckeditor5-typing/package.json
@@ -36,7 +36,7 @@
     "@ckeditor/ckeditor5-paragraph": "40.2.0",
     "@ckeditor/ckeditor5-table": "40.2.0",
     "@ckeditor/ckeditor5-undo": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-ui/package.json
+++ b/packages/ckeditor5-ui/package.json
@@ -42,7 +42,7 @@
     "@ckeditor/ckeditor5-table": "40.2.0",
     "@ckeditor/ckeditor5-typing": "40.2.0",
     "@types/color-convert": "2.0.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-undo/package.json
+++ b/packages/ckeditor5-undo/package.json
@@ -27,7 +27,7 @@
     "@ckeditor/ckeditor5-typing": "40.2.0",
     "@ckeditor/ckeditor5-table": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-upload/package.json
+++ b/packages/ckeditor5-upload/package.json
@@ -17,7 +17,7 @@
     "@ckeditor/ckeditor5-ui": "40.2.0"
   },
   "devDependencies": {
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-utils/package.json
+++ b/packages/ckeditor5-utils/package.json
@@ -20,7 +20,7 @@
     "@ckeditor/ckeditor5-core": "40.2.0",
     "@ckeditor/ckeditor5-engine": "40.2.0",
     "@types/lodash-es": "^4.17.6",
-    "typescript": "^4.8.4"
+    "typescript": "5.0.4"
   },
   "depcheckIgnore": [
     "typescript"

--- a/packages/ckeditor5-watchdog/package.json
+++ b/packages/ckeditor5-watchdog/package.json
@@ -23,7 +23,7 @@
     "@ckeditor/ckeditor5-utils": "40.2.0",
     "@ckeditor/ckeditor5-track-changes": "40.2.0",
     "ckeditor5": "40.2.0",
-    "typescript": "^4.8.4"
+    "typescript": "5.0.4"
   },
   "author": "CKSource (http://cksource.com/)",
   "license": "GPL-2.0-or-later",

--- a/packages/ckeditor5-widget/package.json
+++ b/packages/ckeditor5-widget/package.json
@@ -35,7 +35,7 @@
     "@ckeditor/ckeditor5-paragraph": "40.2.0",
     "@ckeditor/ckeditor5-table": "40.2.0",
     "@ckeditor/ckeditor5-undo": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },

--- a/packages/ckeditor5-word-count/package.json
+++ b/packages/ckeditor5-word-count/package.json
@@ -32,7 +32,7 @@
     "@ckeditor/ckeditor5-table": "40.2.0",
     "@ckeditor/ckeditor5-theme-lark": "40.2.0",
     "@ckeditor/ckeditor5-utils": "40.2.0",
-    "typescript": "^4.8.4",
+    "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"
   },


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other: Bump `TypeScript` version to 5.0. Closes #15452 .

MINOR BREAKING CHANGE (core): Bump `TypeScript` version to 5.0. See #15452.

---

### Additional information