### PR TITLE
Rename export of the Model class.

### DIFF
--- a/docs/updating/update-to-41.md
+++ b/docs/updating/update-to-41.md
@@ -139,6 +139,7 @@ The following icons were moved to the `@ckeditor/ckeditor5-core` package: `brows
 Some exports names were changed due to possibility of name conflicts:
 
 * We renamed the default export of `View` from the `@ckeditor/ckeditor5-engine` package to `EditingView`,
+* We renamed the default export of `Model` from the `@ckeditor/ckeditor5-ui` package to `ViewModel`,
 * We renamed the default export of `UploadAdapter` from the `@ckeditor/ckeditor5-adapter-ckfinder` package to `CKFinderUploadAdapter`,
 * We renamed the interface export of `Position` from the `@ckeditor/ckeditor5-utils` package to `DomPoint`,
 * We moved the `findOptimalInsertionRange` function to the `Schema` class as a method within the `@ckeditor/ckeditor5-engine` package.

--- a/packages/ckeditor5-code-block/src/codeblockui.ts
+++ b/packages/ckeditor5-code-block/src/codeblockui.ts
@@ -9,7 +9,7 @@
 
 import { icons, Plugin } from 'ckeditor5/src/core.js';
 import { Collection } from 'ckeditor5/src/utils.js';
-import { Model, SplitButtonView, createDropdown, addListToDropdown, type ListDropdownItemDefinition } from 'ckeditor5/src/ui.js';
+import { ViewModel, SplitButtonView, createDropdown, addListToDropdown, type ListDropdownItemDefinition } from 'ckeditor5/src/ui.js';
 
 import { getNormalizedAndLocalizedLanguageDefinitions } from './utils.js';
 
@@ -98,7 +98,7 @@ export default class CodeBlockUI extends Plugin {
 		for ( const languageDef of normalizedLanguageDefs ) {
 			const definition: ListDropdownItemDefinition = {
 				type: 'button',
-				model: new Model( {
+				model: new ViewModel( {
 					_codeBlockLanguage: languageDef.language,
 					label: languageDef.label,
 					role: 'menuitemradio',

--- a/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.ts
+++ b/packages/ckeditor5-find-and-replace/src/ui/findandreplaceformview.ts
@@ -13,7 +13,7 @@ import {
 	FormHeaderView,
 	LabeledFieldView,
 
-	Model,
+	ViewModel,
 	FocusCycler,
 	createLabeledInputText,
 	submitHandler,
@@ -591,7 +591,7 @@ export default class FindAndReplaceFormView extends View {
 			tooltip: true
 		} );
 
-		const matchCaseModel = new Model( {
+		const matchCaseModel = new ViewModel( {
 			withText: true,
 			label: t( 'Match case' ),
 
@@ -599,7 +599,7 @@ export default class FindAndReplaceFormView extends View {
 			_isMatchCaseSwitch: true
 		} );
 
-		const wholeWordsOnlyModel = new Model( {
+		const wholeWordsOnlyModel = new ViewModel( {
 			withText: true,
 			label: t( 'Whole words only' )
 		} );

--- a/packages/ckeditor5-font/src/fontfamily/fontfamilyui.ts
+++ b/packages/ckeditor5-font/src/fontfamily/fontfamilyui.ts
@@ -9,7 +9,7 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import { Collection } from 'ckeditor5/src/utils.js';
-import { Model, createDropdown, addListToDropdown, type ListDropdownItemDefinition } from 'ckeditor5/src/ui.js';
+import { ViewModel, createDropdown, addListToDropdown, type ListDropdownItemDefinition } from 'ckeditor5/src/ui.js';
 
 import { normalizeOptions } from './utils.js';
 import { FONT_FAMILY } from '../utils.js';
@@ -110,7 +110,7 @@ function _prepareListOptions( options: Array<FontFamilyOption>, command: FontFam
 	for ( const option of options ) {
 		const def = {
 			type: 'button' as const,
-			model: new Model( {
+			model: new ViewModel( {
 				commandName: FONT_FAMILY,
 				commandParam: option.model,
 				label: option.title,

--- a/packages/ckeditor5-font/src/fontsize/fontsizeui.ts
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeui.ts
@@ -9,7 +9,7 @@
 
 import { Plugin } from 'ckeditor5/src/core.js';
 import {
-	Model,
+	ViewModel,
 	createDropdown,
 	addListToDropdown,
 	type ListDropdownItemDefinition
@@ -128,7 +128,7 @@ function _prepareListOptions( options: Array<FontSizeOption>, command: FontSizeC
 	for ( const option of options ) {
 		const def = {
 			type: 'button' as const,
-			model: new Model( {
+			model: new ViewModel( {
 				commandName: FONT_SIZE,
 				commandParam: option.model,
 				label: option.title,

--- a/packages/ckeditor5-heading/src/headingui.ts
+++ b/packages/ckeditor5-heading/src/headingui.ts
@@ -9,7 +9,7 @@
 
 import { Plugin, type Command } from 'ckeditor5/src/core.js';
 import {
-	Model,
+	ViewModel,
 	createDropdown,
 	addListToDropdown,
 	type ButtonExecuteEvent,
@@ -57,7 +57,7 @@ export default class HeadingUI extends Plugin {
 			for ( const option of options ) {
 				const def: ListDropdownItemDefinition = {
 					type: 'button',
-					model: new Model( {
+					model: new ViewModel( {
 						label: option.title,
 						class: option.class,
 						role: 'menuitemradio',

--- a/packages/ckeditor5-image/src/imageresize/imageresizebuttons.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizebuttons.ts
@@ -11,7 +11,7 @@ import { Plugin, icons, type Editor } from 'ckeditor5/src/core.js';
 import {
 	ButtonView,
 	DropdownButtonView,
-	Model,
+	ViewModel,
 	createDropdown,
 	addListToDropdown,
 	type ListDropdownItemDefinition
@@ -236,7 +236,7 @@ export default class ImageResizeButtons extends Plugin {
 			const optionValueWithUnit = option.value ? option.value + this._resizeUnit : null;
 			const definition: ListDropdownItemDefinition = {
 				type: 'button',
-				model: new Model( {
+				model: new ViewModel( {
 					commandName: 'resizeImage',
 					commandValue: optionValueWithUnit,
 					label: this._getOptionLabelValue( option ),

--- a/packages/ckeditor5-language/src/textpartlanguageui.ts
+++ b/packages/ckeditor5-language/src/textpartlanguageui.ts
@@ -8,7 +8,7 @@
  */
 
 import { Plugin } from 'ckeditor5/src/core.js';
-import { Model, createDropdown, addListToDropdown, type ListDropdownItemDefinition } from 'ckeditor5/src/ui.js';
+import { ViewModel, createDropdown, addListToDropdown, type ListDropdownItemDefinition } from 'ckeditor5/src/ui.js';
 import { Collection } from 'ckeditor5/src/utils.js';
 import { stringifyLanguageAttribute } from './utils.js';
 import type TextPartLanguageCommand from './textpartlanguagecommand.js';
@@ -47,7 +47,7 @@ export default class TextPartLanguageUI extends Plugin {
 			// Item definition with false `languageCode` will behave as remove lang button.
 			itemDefinitions.add( {
 				type: 'button',
-				model: new Model( {
+				model: new ViewModel( {
 					label: removeTitle,
 					languageCode: false,
 					withText: true
@@ -61,7 +61,7 @@ export default class TextPartLanguageUI extends Plugin {
 			for ( const option of options ) {
 				const def = {
 					type: 'button' as const,
-					model: new Model( {
+					model: new ViewModel( {
 						label: option.title,
 						languageCode: option.languageCode,
 						role: 'menuitemradio',

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
@@ -12,7 +12,7 @@ import {
 	type Command
 } from 'ckeditor5/src/core.js';
 import {
-	Model,
+	ViewModel,
 	createDropdown,
 	addListToDropdown,
 	type ButtonExecuteEvent,
@@ -90,7 +90,7 @@ export default class RestrictedEditingModeUI extends Plugin {
 		const command: Command = editor.commands.get( commandName )!;
 		const definition = {
 			type: 'button' as const,
-			model: new Model( {
+			model: new ViewModel( {
 				label,
 				withText: true,
 				keystroke,

--- a/packages/ckeditor5-special-characters/src/ui/specialcharactersnavigationview.ts
+++ b/packages/ckeditor5-special-characters/src/ui/specialcharactersnavigationview.ts
@@ -11,7 +11,7 @@ import { Collection, type Locale } from 'ckeditor5/src/utils.js';
 import {
 	addListToDropdown,
 	createDropdown,
-	Model,
+	ViewModel,
 	FormHeaderView,
 	type DropdownView,
 	type ListDropdownButtonDefinition
@@ -86,7 +86,7 @@ export default class SpecialCharactersNavigationView extends FormHeaderView {
 		} );
 
 		dropdown.on( 'execute', evt => {
-			dropdown.value = ( evt.source as Model ).name as string;
+			dropdown.value = ( evt.source as ViewModel ).name as string;
 		} );
 
 		dropdown.delegate( 'execute' ).to( this );
@@ -113,7 +113,7 @@ export default class SpecialCharactersNavigationView extends FormHeaderView {
 		const groupDefs = new Collection<ListDropdownButtonDefinition>();
 
 		for ( const [ name, label ] of groupNames ) {
-			const model = new Model( {
+			const model = new ViewModel( {
 				name,
 				label,
 				withText: true,

--- a/packages/ckeditor5-table/src/tableui.ts
+++ b/packages/ckeditor5-table/src/tableui.ts
@@ -11,7 +11,7 @@ import { icons, Plugin, type Command, type Editor } from 'ckeditor5/src/core.js'
 import {
 	addListToDropdown,
 	createDropdown,
-	Model,
+	ViewModel,
 	SplitButtonView,
 	SwitchButtonView,
 	type DropdownView,
@@ -346,7 +346,7 @@ function addListOption(
 	itemDefinitions: Collection<ListDropdownItemDefinition>
 ) {
 	if ( option.type === 'button' || option.type === 'switchbutton' ) {
-		const model = option.model = new Model( option.model );
+		const model = option.model = new ViewModel( option.model );
 		const { commandName, bindIsOn } = option.model;
 		const command = editor.commands.get( commandName as string )!;
 

--- a/packages/ckeditor5-table/src/utils/ui/table-properties.ts
+++ b/packages/ckeditor5-table/src/utils/ui/table-properties.ts
@@ -9,7 +9,7 @@
 
 import {
 	ButtonView,
-	Model,
+	ViewModel,
 	type ColorOption,
 	type LabeledFieldView,
 	type ListDropdownItemDefinition,
@@ -122,7 +122,7 @@ export function getBorderStyleDefinitions(
 	for ( const style in styleLabels ) {
 		const definition: ListDropdownItemDefinition = {
 			type: 'button',
-			model: new Model( {
+			model: new ViewModel( {
 				_borderStyleValue: style,
 				label: styleLabels[ style ],
 				role: 'menuitemradio',

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -75,7 +75,7 @@ export { default as ListView } from './list/listview.js';
 
 export { default as Notification } from './notification/notification.js';
 
-export { default as Model } from './model.js';
+export { default as ViewModel } from './model.js';
 export { default as BalloonPanelView } from './panel/balloon/balloonpanelview.js';
 export { default as ContextualBalloon } from './panel/balloon/contextualballoon.js';
 export { default as StickyPanelView } from './panel/sticky/stickypanelview.js';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other(ui): Rename export of the `Model` class to `ViewModel`. Closes #15661.

MINOR BREAKING CHANGE (ui): Rename export of the `Model` class to `ViewModel`. See https://github.com/ckeditor/ckeditor5/issues/15661.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
