### PR TITLE
Internal (link): Fix focus when link form is opened for editing

### DIFF
--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -351,20 +351,20 @@ export default class LinkUI extends Plugin {
 			position: this._getBalloonPositionData()
 		} );
 
-		// Select input when form view is currently visible.
-		if ( this._balloon.visibleView === this.formView ) {
-			this.formView!.urlInputView.fieldView.select();
-		}
-
-		this.formView!.enableCssTransitions();
-
 		// Make sure that each time the panel shows up, the URL field remains in sync with the value of
 		// the command. If the user typed in the input, then canceled the balloon (`urlInputView.fieldView#value` stays
 		// unaltered) and re-opened it without changing the value of the link command (e.g. because they
 		// clicked the same link), they would see the old value instead of the actual value of the command.
 		// https://github.com/ckeditor/ckeditor5-link/issues/78
 		// https://github.com/ckeditor/ckeditor5-link/issues/123
-		this.formView!.urlInputView.fieldView.element!.value = linkCommand.value || '';
+		this.formView!.urlInputView.fieldView.value = linkCommand.value || '';
+
+		// Select input when form view is currently visible.
+		if ( this._balloon.visibleView === this.formView ) {
+			this.formView!.urlInputView.fieldView.select();
+		}
+
+		this.formView!.enableCssTransitions();
 	}
 
 	/**

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -272,12 +272,22 @@ describe( 'LinkUI', () => {
 
 			setModelData( editor.model, '<paragraph><$text linkHref="url">f[]oo</$text></paragraph>' );
 
-			// Mock some leftover value **in DOM**, e.g. after previous editing.
-			formView.urlInputView.fieldView.element.value = 'leftover';
-
+			// Open the link balloon.
 			linkUIFeature._showUI();
+
+			// Simulate clicking the "edit" button.
 			actionsView.fire( 'edit' );
 
+			// Change text in the URL field.
+			formView.urlInputView.fieldView.element.value = 'to-be-discarded';
+
+			// Cancel link editing.
+			formView.fire( 'cancel' );
+
+			// Open the editing panel again.
+			actionsView.fire( 'edit' );
+
+			// Expect original value in the URL field.
 			expect( formView.urlInputView.fieldView.element.value ).to.equal( 'url' );
 		} );
 

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -289,6 +289,13 @@ describe( 'LinkUI', () => {
 
 			// Expect original value in the URL field.
 			expect( formView.urlInputView.fieldView.element.value ).to.equal( 'url' );
+
+			// Expect "save" button to be enabled, despite not making any changes.
+			expect( formView.saveButtonView.isEnabled ).to.equal( true );
+
+			// Expect entire content of the URL field to be selected.
+			const elem = formView.urlInputView.fieldView.element;
+			expect( elem.value.substring( elem.selectionStart, elem.selectionEnd ) ).to.equal( 'url' );
 		} );
 
 		// https://github.com/ckeditor/ckeditor5-link/issues/123


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (link): Fix focus when link form is opened for editing. Closes #15664.

Internal (link): If URL field is not empty, allow saving form even if no change was made. See #15664.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
