### PR TITLE
Docs: An entry about moving icons in commercial repository in update to 41.x guide.

### DIFF
--- a/docs/updating/update-to-41.md
+++ b/docs/updating/update-to-41.md
@@ -159,6 +159,12 @@ The following icons were moved to the `@ckeditor/ckeditor5-core` package:
 * `todolist`
 * `undo`
 
+The following icons were moved to the `ckeditor5-collaboration` package:
+* `robot-pencil`
+* `table-of-contents`
+* `paint-roller`
+* `template`
+
 ### Exports renamed
 
 Some export names were changed due to the possibility of name conflicts:


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Added an entry about moving several icons in a commercial repository.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._