### PR TITLE
Vale: Fix the remaining errors in the CKEditor 5 repository

### DIFF
--- a/packages/ckeditor5-build-balloon/CHANGELOG.md
+++ b/packages/ckeditor5-build-balloon/CHANGELOG.md
@@ -824,7 +824,7 @@ Major releases (contain breaking changes):
 
 ## [1.0.0-beta.3](https://github.com/ckeditor/ckeditor5-build-balloon/compare/v1.0.0-beta.2...v1.0.0-beta.3) (April 10, 2018)
 
-### NOTE
+### Note
 
 This release followed `v1.0.0-beta.2` immediately to fix the issue mentioned below. Therefore, when upgrading from `v1.0.0-beta.1` make sure to also check [`v1.0.0-beta.2` release notes](https://github.com/ckeditor/ckeditor5-build-balloon/releases/tag/v1.0.0-beta.2).
 
@@ -994,7 +994,7 @@ Major releases (possible breaking changes):
 
 Besides changes in the dependencies, this build also contains these bug fixes:
 
-* It will be possible to configure toolbar offset without overriding preconfigured toolbar items. See [ckeditor/ckeditor5#572](https://github.com/ckeditor/ckeditor5/issues/572). ([c2485d6](https://github.com/ckeditor/ckeditor5-build-balloon/commit/c2485d6))
+* It will be possible to configure toolbar offset without overriding pre-configured toolbar items. See [ckeditor/ckeditor5#572](https://github.com/ckeditor/ckeditor5/issues/572). ([c2485d6](https://github.com/ckeditor/ckeditor5-build-balloon/commit/c2485d6))
 
 ### Features
 

--- a/packages/ckeditor5-build-classic/CHANGELOG.md
+++ b/packages/ckeditor5-build-classic/CHANGELOG.md
@@ -826,7 +826,7 @@ Major releases (contain breaking changes):
 
 ## [1.0.0-beta.3](https://github.com/ckeditor/ckeditor5-build-classic/compare/v1.0.0-beta.2...v1.0.0-beta.3) (April 10, 2018)
 
-### NOTE
+### Note
 
 This release followed `v1.0.0-beta.2` immediately to fix the issue mentioned below. Therefore, when upgrading from `v1.0.0-beta.1` make sure to also check [`v1.0.0-beta.2` release notes](https://github.com/ckeditor/ckeditor5-build-classic/releases/tag/v1.0.0-beta.2).
 
@@ -997,7 +997,7 @@ Major releases (possible breaking changes):
 
 Besides changes in the dependencies, this build also contains these bug fixes:
 
-* It will be possible to configure toolbar offset without overriding preconfigured toolbar items. See [ckeditor/ckeditor5#572](https://github.com/ckeditor/ckeditor5/issues/572). ([e7fbda9](https://github.com/ckeditor/ckeditor5-build-classic/commit/e7fbda9))
+* It will be possible to configure toolbar offset without overriding pre-configured toolbar items. See [ckeditor/ckeditor5#572](https://github.com/ckeditor/ckeditor5/issues/572). ([e7fbda9](https://github.com/ckeditor/ckeditor5-build-classic/commit/e7fbda9))
 
 ### Features
 

--- a/packages/ckeditor5-build-decoupled-document/CHANGELOG.md
+++ b/packages/ckeditor5-build-decoupled-document/CHANGELOG.md
@@ -896,20 +896,20 @@ Major releases (contain breaking changes):
 
 ### Other changes
 
-* Image styles's default configuration has been changed to: left-aligned, right-aligned image and full-size image (instead of the typical: side-image and full-size image). This change makes content previously created with this build incompatible with the new setup.
+* The default configuration of the image styles was changed to: left-aligned, right-aligned image and full-size image (instead of the typical: side-image and full-size image). This change makes content previously created with this build incompatible with the new setup.
 
-   You can [configure image styles](https://ckeditor.com/docs/ckeditor5/latest/features/image.html#image-styles) in order to bring back the old setting (`[ 'full', 'side' ]`).
+   You can [configure image styles](https://ckeditor.com/docs/ckeditor5/latest/features/image.html#image-styles) to bring back the old setting (`[ 'full', 'side' ]`).
 
    Closes [#10](https://github.com/ckeditor/ckeditor5-build-decoupled-document/issues/10). ([75855d9](https://github.com/ckeditor/ckeditor5-build-decoupled-document/commit/75855d9))
 
 ### BREAKING CHANGES
 
-* The default image styles configuration has been changed (see the section above for more information).
+* The default image styles configuration was changed (see the section above for more information).
 
 
 ## [1.0.0-beta.3](https://github.com/ckeditor/ckeditor5-build-decoupled-document/compare/v1.0.0-beta.2...v1.0.0-beta.3) (April 10, 2018)
 
-### NOTE
+### Note
 
 This release followed `v1.0.0-beta.2` immediately to fix the issue mentioned below. Therefore, when upgrading from `v1.0.0-beta.1` make sure to also check [`v1.0.0-beta.2` release notes](https://github.com/ckeditor/ckeditor5-build-decoupled-document/releases/tag/v1.0.0-beta.2).
 
@@ -962,7 +962,7 @@ Major releases (contain breaking changes):
 ### BREAKING CHANGES
 
 * The global variable exported by the build is now called `DecoupledEditor` instead of `DecoupledDocumentEditor`. See [#6](https://github.com/ckeditor/ckeditor5-build-decoupled-document/issues/6).
-* The config options `config.toolbarContainer` and `config.editableContainer` have been removed. Please refer to the `DecoupledEditor` class API documentation to learn about possible methods of bootstrapping the UI.
+* The configuration options `config.toolbarContainer` and `config.editableContainer` have been removed. Refer to the `DecoupledEditor` class API documentation to learn about possible methods of bootstrapping the UI.
 
 
 ## [1.0.0-beta.1](https://github.com/ckeditor/ckeditor5-build-decoupled-document/compare/v0.0.1...v1.0.0-beta.1) (March 15, 2018)

--- a/packages/ckeditor5-build-inline/CHANGELOG.md
+++ b/packages/ckeditor5-build-inline/CHANGELOG.md
@@ -824,7 +824,7 @@ Major releases (contain breaking changes):
 
 ## [1.0.0-beta.3](https://github.com/ckeditor/ckeditor5-build-inline/compare/v1.0.0-beta.2...v1.0.0-beta.3) (April 10, 2018)
 
-### NOTE
+### Note
 
 This release followed `v1.0.0-beta.2` immediately to fix the issue mentioned below. Therefore, when upgrading from `v1.0.0-beta.1` make sure to also check [`v1.0.0-beta.2` release notes](https://github.com/ckeditor/ckeditor5-build-inline/releases/tag/v1.0.0-beta.2).
 
@@ -995,7 +995,7 @@ Major releases (possible breaking changes):
 
 Besides changes in the dependencies, this build also contains these bug fixes:
 
-* It will be possible to configure toolbar offset without overriding preconfigured toolbar items. See [ckeditor/ckeditor5#572](https://github.com/ckeditor/ckeditor5/issues/572). ([f974881](https://github.com/ckeditor/ckeditor5-build-inline/commit/f974881))
+* It will be possible to configure toolbar offset without overriding pre-configured toolbar items. See [ckeditor/ckeditor5#572](https://github.com/ckeditor/ckeditor5/issues/572). ([f974881](https://github.com/ckeditor/ckeditor5-build-inline/commit/f974881))
 
 ### Features
 

--- a/scripts/vale/styles/CKEditor/Terms.yml
+++ b/scripts/vale/styles/CKEditor/Terms.yml
@@ -83,6 +83,7 @@ swap:
   regex: regular expression
   repo: repository
   right click: right-click
+  rule set: ruleset
   SAAS: SaaS
   sanity (?:check|test): check for completeness
   semver: SemVer


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Fixed the remaining errors in the CKEditor 5 repository reported by Vale. Closes cksource/ckeditor5-internal#3649.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._