### PR TITLE
Prevented to images disappear after dragging (Windows OS in Chromium browsers).

### DIFF
--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -175,8 +175,7 @@ export default class AutoLink extends Plugin {
 
 			const matches = newLink.match( URL_REG_EXP );
 
-			// If the text in the clipboard has a URL, and that URL is the whole clipboard
-			// and there is now file in the clipboard (See: https://github.com/ckeditor/ckeditor5/issues/15700)
+			// If the text in the clipboard has a URL, and that URL is the whole clipboard.
 			if ( matches && matches[ 2 ] === newLink ) {
 				model.change( writer => {
 					this._selectEntireLinks( writer, selectedRange );

--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -154,7 +154,7 @@ export default class AutoLink extends Plugin {
 		const linkCommand = editor.commands.get( 'link' )!;
 
 		clipboardPipeline.on( 'inputTransformation', ( evt, data: ClipboardInputTransformationData ) => {
-			if ( !this.isEnabled || !linkCommand.isEnabled || selection.isCollapsed ) {
+			if ( !this.isEnabled || !linkCommand.isEnabled || selection.isCollapsed || data.method !== 'paste' ) {
 				// Abort if we are disabled or the selection is collapsed.
 				return;
 			}
@@ -173,13 +173,11 @@ export default class AutoLink extends Plugin {
 				return;
 			}
 
-			const isDataTransferContainingFiles = !!data.dataTransfer.files.length;
-
 			const matches = newLink.match( URL_REG_EXP );
 
 			// If the text in the clipboard has a URL, and that URL is the whole clipboard
 			// and there is now file in the clipboard (See: https://github.com/ckeditor/ckeditor5/issues/15700)
-			if ( matches && matches[ 2 ] === newLink && !isDataTransferContainingFiles ) {
+			if ( matches && matches[ 2 ] === newLink ) {
 				model.change( writer => {
 					this._selectEntireLinks( writer, selectedRange );
 					linkCommand.execute( newLink );

--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -173,10 +173,13 @@ export default class AutoLink extends Plugin {
 				return;
 			}
 
+			const isDataTransferContainingFiles = !!data.dataTransfer.files.length;
+
 			const matches = newLink.match( URL_REG_EXP );
 
-			// If the text in the clipboard has a URL, and that URL is the whole clipboard.
-			if ( matches && matches[ 2 ] === newLink ) {
+			// If the text in the clipboard has a URL, and that URL is the whole clipboard
+			// and there is now file in the clipboard (See: https://github.com/ckeditor/ckeditor5/issues/15700)
+			if ( matches && matches[ 2 ] === newLink && !isDataTransferContainingFiles ) {
 				model.change( writer => {
 					this._selectEntireLinks( writer, selectedRange );
 					linkCommand.execute( newLink );

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -102,6 +102,14 @@ describe( 'AutoLink', () => {
 					'<paragraph>some http://hello.com[] text</paragraph>'
 				);
 			} );
+
+			// Simulate browser behavior on Windows. See https://github.com/ckeditor/ckeditor5/issues/15700
+			it( 'paste link (clipboard files array not empty)', () => {
+				pasteText( 'http://hello.com', [ 1 ] );
+				expect( getData( model ) ).to.equal(
+					'<paragraph>some http://hello.com[] text</paragraph>'
+				);
+			} );
 		} );
 
 		describe( 'pasting on collapsed selection', () => {
@@ -189,14 +197,14 @@ describe( 'AutoLink', () => {
 			} );
 		} );
 
-		function pasteText( text ) {
+		function pasteText( text, files = [] ) {
 			pasteData( {
 				'text/plain': text
-			} );
+			}, files );
 		}
 
-		function pasteData( data ) {
-			const dataTransferMock = createDataTransfer( data );
+		function pasteData( data, files = [] ) {
+			const dataTransferMock = createDataTransfer( data, files );
 			viewDocument.fire( 'paste', {
 				dataTransfer: dataTransferMock,
 				preventDefault() {},
@@ -204,8 +212,9 @@ describe( 'AutoLink', () => {
 			} );
 		}
 
-		function createDataTransfer( data ) {
+		function createDataTransfer( data, files = [] ) {
 			return {
+				files,
 				getData( type ) {
 					return data[ type ];
 				}

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -103,9 +103,8 @@ describe( 'AutoLink', () => {
 				);
 			} );
 
-			// Simulate browser behavior on Windows. See https://github.com/ckeditor/ckeditor5/issues/15700
-			it( 'paste link (clipboard files array not empty)', () => {
-				pasteText( 'http://hello.com', [ 1 ] );
+			it( 'should omit the `drop` clipboard method', () => {
+				pasteText( 'http://hello.com', 'drop' );
 				expect( getData( model ) ).to.equal(
 					'<paragraph>some http://hello.com[] text</paragraph>'
 				);
@@ -197,24 +196,23 @@ describe( 'AutoLink', () => {
 			} );
 		} );
 
-		function pasteText( text, files = [] ) {
+		function pasteText( text, method = 'paste' ) {
 			pasteData( {
 				'text/plain': text
-			}, files );
+			}, method );
 		}
 
-		function pasteData( data, files = [] ) {
-			const dataTransferMock = createDataTransfer( data, files );
-			viewDocument.fire( 'paste', {
+		function pasteData( data, method = 'paste' ) {
+			const dataTransferMock = createDataTransfer( data );
+			viewDocument.fire( method, {
 				dataTransfer: dataTransferMock,
 				preventDefault() {},
 				stopPropagation() {}
 			} );
 		}
 
-		function createDataTransfer( data, files = [] ) {
+		function createDataTransfer( data ) {
 			return {
-				files,
 				getData( type ) {
 					return data[ type ];
 				}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (link): Image should not disappear after dragging in Windows OS in Chromium browsers. #15700.

---

### Additional information

OS differences:
```js
data.dataTransfer.getData( 'text/plain' )
```
dragged image on Windows OS returns:
```plaintext
http://127.0.0.1:8125/ckeditor5-clipboard/tests/manual/sample.jpg
```
on MacOS there is empty string.

