### PR TITLE
Add max-width for multiline tooltips

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/tooltip/tooltip.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/tooltip/tooltip.css
@@ -25,6 +25,7 @@
 		white-space: break-spaces;
 		display: inline-block;
 		padding: var(--ck-tooltip-text-padding) 0;
+		max-width: 200px;
 	}
 
 	/* Reset balloon panel styles */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (ui): Mutli-line tooltips will now have `max-width` set to `200px` by default.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._