### PR TITLE
Enabled pending issues support for stale bot

### DIFF
--- a/.circleci/.stale-bot.js
+++ b/.circleci/.stale-bot.js
@@ -12,7 +12,11 @@ module.exports = {
 	GITHUB_TOKEN: process.env.CKE5_GITHUB_TOKEN,
 	REPOSITORY_SLUG: 'ckeditor/ckeditor5',
 	DAYS_BEFORE_STALE: 365,
+	DAYS_BEFORE_STALE_PENDING_ISSUE: 14,
 	DAYS_BEFORE_CLOSE: 30,
+	PENDING_ISSUE_LABELS: [
+		'pending:feedback'
+	],
 	IGNORED_ISSUE_LABELS: [
 		'support:1',
 		'support:2',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Enabled support for pending issues in stale bot, so that they can be flagged sooner as stale ones. See #15697.

---

### Additional information

This PR requires https://github.com/ckeditor/ckeditor5-dev/pull/937.
