### PR TITLE
Fix ability to change found text while the dialog is open

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/findandreplace.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplace.ts
@@ -58,7 +58,7 @@ export default class FindAndReplace extends Plugin {
 			// Data is contained only for the "find" button.
 			if ( data ) {
 				state.searchText = data.searchText;
-				this.editor.execute( 'find', data.searchText, data );
+				findAndReplaceEditing.find( data.searchText, data );
 			} else {
 				// Find next arrow button press.
 				this.editor.execute( 'findNext' );
@@ -67,7 +67,7 @@ export default class FindAndReplace extends Plugin {
 
 		ui.on<FindPreviousEvent>( 'findPrevious', ( event, data ) => {
 			if ( data && state.searchText !== data.searchText ) {
-				this.editor.execute( 'find', data.searchText );
+				findAndReplaceEditing.find( data.searchText );
 			} else {
 				// Subsequent calls.
 				this.editor.execute( 'findPrevious' );
@@ -76,7 +76,7 @@ export default class FindAndReplace extends Plugin {
 
 		ui.on<ReplaceEvent>( 'replace', ( event, data ) => {
 			if ( state.searchText !== data.searchText ) {
-				this.editor.execute( 'find', data.searchText );
+				findAndReplaceEditing.find( data.searchText );
 			}
 
 			const highlightedResult = state.highlightedResult;
@@ -89,7 +89,7 @@ export default class FindAndReplace extends Plugin {
 		ui.on<ReplaceAllEvent>( 'replaceAll', ( event, data ) => {
 			// The state hadn't been yet built for this search text.
 			if ( state.searchText !== data.searchText ) {
-				this.editor.execute( 'find', data.searchText );
+				findAndReplaceEditing.find( data.searchText );
 			}
 
 			this.editor.execute( 'replaceAll', data.replaceText, state.results );

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceediting.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceediting.ts
@@ -7,8 +7,8 @@
  * @module find-and-replace/findandreplaceediting
  */
 
-import { Plugin, type Editor } from 'ckeditor5/src/core.js';
-import type { DiffItem, DiffItemAttribute, Element, Item, Node } from 'ckeditor5/src/engine.js';
+import { Plugin } from 'ckeditor5/src/core.js';
+import type { DiffItem, DiffItemAttribute, Element, Node } from 'ckeditor5/src/engine.js';
 import {
 	scrollViewportToShowTarget,
 	type Collection,
@@ -16,12 +16,12 @@ import {
 	type ObservableChangeEvent
 } from 'ckeditor5/src/utils.js';
 
-import FindCommand from './findcommand.js';
+import FindCommand, { type FindAttributes } from './findcommand.js';
 import ReplaceCommand from './replacecommand.js';
 import ReplaceAllCommand from './replaceallcommand.js';
 import FindNextCommand from './findnextcommand.js';
 import FindPreviousCommand from './findpreviouscommand.js';
-import FindAndReplaceState from './findandreplacestate.js';
+import FindAndReplaceState, { type FindCallback } from './findandreplacestate.js';
 import FindAndReplaceUtils from './findandreplaceutils.js';
 import type { ResultType } from './findandreplace.js';
 
@@ -30,66 +30,6 @@ import { debounce } from 'lodash-es';
 import '../theme/findandreplace.css';
 
 const HIGHLIGHT_CLASS = 'ck-find-result_selected';
-
-/**
- * Reacts to document changes in order to update search list.
- */
-function onDocumentChange(
-	results: Collection<ResultType>,
-	editor: Editor,
-	searchCallback: ( ( { item, text }: { item: Item; text: string } ) => Array<ResultType> )
-) {
-	const changedNodes = new Set<Node>();
-	const removedMarkers = new Set<string>();
-	const model = editor.model;
-
-	const changes = model.document.differ.getChanges() as Array<Exclude<DiffItem, DiffItemAttribute>>;
-
-	// Get nodes in which changes happened to re-run a search callback on them.
-	changes.forEach( change => {
-		if ( change.name === '$text' || model.schema.isInline( change.position.nodeAfter! ) ) {
-			changedNodes.add( change.position.parent as Element );
-
-			[ ...model.markers.getMarkersAtPosition( change.position ) ].forEach( markerAtChange => {
-				removedMarkers.add( markerAtChange.name );
-			} );
-		} else if ( change.type === 'insert' ) {
-			changedNodes.add( change.position.nodeAfter! );
-		}
-	} );
-
-	// Get markers from removed nodes also.
-	model.document.differ.getChangedMarkers().forEach( ( { name, data: { newRange } } ) => {
-		if ( newRange && newRange.start.root.rootName === '$graveyard' ) {
-			removedMarkers.add( name );
-		}
-	} );
-
-	// Get markers from the updated nodes and remove all (search will be re-run on these nodes).
-	changedNodes.forEach( node => {
-		const markersInNode = [ ...model.markers.getMarkersIntersectingRange( model.createRangeIn( node as Element ) ) ];
-
-		markersInNode.forEach( marker => removedMarkers.add( marker.name ) );
-	} );
-
-	// Remove results & markers from the changed part of content.
-	model.change( writer => {
-		removedMarkers.forEach( markerName => {
-			// Remove the result first - in order to prevent rendering a removed marker.
-			if ( results.has( markerName ) ) {
-				results.remove( markerName );
-			}
-
-			writer.removeMarker( markerName );
-		} );
-	} );
-
-	// Run search callback again on updated nodes.
-	changedNodes.forEach( nodeToCheck => {
-		const findAndReplaceUtils: FindAndReplaceUtils = editor.plugins.get( 'FindAndReplaceUtils' );
-		findAndReplaceUtils.updateFindResultFromRange( model.createRangeOn( nodeToCheck ), model, searchCallback, results );
-	} );
-}
 
 /**
  * Implements the editing part for find and replace plugin. For example conversion, commands etc.
@@ -110,27 +50,25 @@ export default class FindAndReplaceEditing extends Plugin {
 	}
 
 	/**
-	 * The collection of currently highlighted search results.
-	 *
-	 * @private
-	 * @member {module:utils/collection~Collection} #_activeResults
-	 */
-	private _activeResults?: Collection<ResultType> | null;
-
-	/**
 	 * An object storing the find and replace state within a given editor instance.
-	 *
-	 * @member {module:find-and-replace/findandreplacestate~FindAndReplaceState} #state
 	 */
 	public state?: FindAndReplaceState;
+
+	/**
+	 * A flag that indicates that the user has started a search and the editor is listening for changes
+	 * to the text on which it will perform an automatic search. Among other things, the mode is activated
+	 * when the user first clicks 'Find' button and then later deactivated when the modal or search dropdown is closed.
+	 *
+	 * @internal
+	 */
+	public declare _isSearchActive: boolean;
 
 	/**
 	 * @inheritDoc
 	 */
 	public init(): void {
-		this._activeResults = null;
-
 		this.state = new FindAndReplaceState( this.editor.model );
+		this.set( '_isSearchActive', false );
 
 		this._defineConverters();
 		this._defineCommands();
@@ -179,40 +117,32 @@ export default class FindAndReplaceEditing extends Plugin {
 		// It's possible that the editor will get destroyed before debounced call kicks in.
 		// This would result with accessing a view three that is no longer in DOM.
 		this.listenTo( this.editor, 'destroy', debouncedScrollListener.cancel );
+
+		this.on<ObservableChangeEvent<boolean>>( 'change:_isSearchActive', ( evt, name, isSearchActive ) => {
+			if ( isSearchActive ) {
+				this.listenTo( this.editor.model.document, 'change:data', this._onDocumentChange );
+			} else {
+				this.stopListening( this.editor.model.document, 'change:data', this._onDocumentChange );
+			}
+		} );
 	}
 
 	/**
 	 * Initiate a search.
 	 */
-	public find(
-		callbackOrText: string | ( ( { item, text }: { item: Item; text: string } ) => Array<ResultType> )
-	): Collection<ResultType> {
-		const { editor } = this;
-		const { model } = editor;
+	public find( callbackOrText: string | FindCallback, findAttributes?: FindAttributes ): Collection<ResultType> {
+		this._isSearchActive = true;
+		this.editor.execute( 'find', callbackOrText, findAttributes );
 
-		const { findCallback, results } = editor.execute( 'find', callbackOrText );
-
-		this._activeResults = results;
-
-		// @todo: handle this listener, another copy is in findcommand.js file.
-		this.listenTo( model.document, 'change:data', () => onDocumentChange( this._activeResults!, editor, findCallback ) );
-
-		return this._activeResults;
+		return this.state!.results;
 	}
 
 	/**
 	 * Stops active results from updating, and clears out the results.
 	 */
 	public stop(): void {
-		if ( !this._activeResults ) {
-			return;
-		}
-
-		this.stopListening( this.editor.model.document );
-
 		this.state!.clear( this.editor.model );
-
-		this._activeResults = null;
+		this._isSearchActive = false;
 	}
 
 	/**
@@ -269,4 +199,93 @@ export default class FindAndReplaceEditing extends Plugin {
 			}
 		} );
 	}
+
+	/**
+	 * Reacts to document changes in order to update search list.
+	 */
+	private _onDocumentChange = () => {
+		const changedNodes = new Set<Node>();
+		const removedMarkers = new Set<string>();
+		const model = this.editor.model;
+		const { results } = this.state!;
+
+		const changes = model.document.differ.getChanges() as Array<Exclude<DiffItem, DiffItemAttribute>>;
+		const changedMarkers = model.document.differ.getChangedMarkers();
+
+		// Get nodes in which changes happened to re-run a search callback on them.
+		changes.forEach( change => {
+			if ( !change.position ) {
+				return;
+			}
+
+			if ( change.name === '$text' || ( change.position.nodeAfter && model.schema.isInline( change.position.nodeAfter ) ) ) {
+				changedNodes.add( change.position.parent as Element );
+
+				[ ...model.markers.getMarkersAtPosition( change.position ) ].forEach( markerAtChange => {
+					removedMarkers.add( markerAtChange.name );
+				} );
+			} else if ( change.type === 'insert' && change.position.nodeAfter ) {
+				changedNodes.add( change.position.nodeAfter );
+			}
+		} );
+
+		// Get markers from removed nodes also.
+		changedMarkers.forEach( ( { name, data: { newRange } } ) => {
+			if ( newRange && newRange.start.root.rootName === '$graveyard' ) {
+				removedMarkers.add( name );
+			}
+		} );
+
+		// Get markers from the updated nodes and remove all (search will be re-run on these nodes).
+		changedNodes.forEach( node => {
+			const markersInNode = [ ...model.markers.getMarkersIntersectingRange( model.createRangeIn( node as Element ) ) ];
+
+			markersInNode.forEach( marker => removedMarkers.add( marker.name ) );
+		} );
+
+		// Remove results from the changed part of content.
+		removedMarkers.forEach( markerName => {
+			if ( !results.has( markerName ) ) {
+				return;
+			}
+
+			if ( results.get( markerName ) === this.state!.highlightedResult ) {
+				this.state!.highlightedResult = null;
+			}
+
+			results.remove( markerName );
+		} );
+
+		// Run search callback again on updated nodes.
+		const changedSearchResults: Array<ResultType> = [];
+		const findAndReplaceUtils: FindAndReplaceUtils = this.editor.plugins.get( 'FindAndReplaceUtils' );
+
+		changedNodes.forEach( nodeToCheck => {
+			const changedNodeSearchResults = findAndReplaceUtils.updateFindResultFromRange(
+				model.createRangeOn( nodeToCheck ), model, this.state!.lastSearchCallback!, results
+			);
+
+			changedSearchResults.push( ...changedNodeSearchResults );
+		} );
+
+		changedMarkers.forEach( markerToCheck => {
+			// Handle search result highlight update when T&C plugin is active.
+			// Lookup is performed only on newly inserted markers.
+			if ( markerToCheck.data.newRange ) {
+				const changedNodeSearchResults = findAndReplaceUtils.updateFindResultFromRange(
+					markerToCheck.data.newRange, model, this.state!.lastSearchCallback!, results
+				);
+
+				changedSearchResults.push( ...changedNodeSearchResults );
+			}
+		} );
+
+		if ( !this.state!.highlightedResult && changedSearchResults.length ) {
+			// If there are found phrases but none is selected, select the first one.
+			this.state!.highlightedResult = changedSearchResults[ 0 ];
+		} else {
+			// If there is already highlight item then refresh highlight offset after appending new items.
+			this.state!.refreshHighlightOffset();
+		}
+	};
 }

--- a/packages/ckeditor5-find-and-replace/src/findandreplacestate.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplacestate.ts
@@ -7,8 +7,8 @@
  * @module find-and-replace/findandreplacestate
  */
 
-import type { Model } from 'ckeditor5/src/engine.js';
-import { ObservableMixin, Collection, type CollectionChangeEvent } from 'ckeditor5/src/utils.js';
+import type { Model, Item } from 'ckeditor5/src/engine.js';
+import { ObservableMixin, Collection, type CollectionChangeEvent, type ObservableChangeEvent } from 'ckeditor5/src/utils.js';
 import type { ResultType } from './findandreplace.js';
 
 /**
@@ -31,12 +31,29 @@ export default class FindAndReplaceState extends ObservableMixin() {
 	declare public highlightedResult: ResultType | null;
 
 	/**
+	 * Currently highlighted search result offset in {@link #results matched results}.
+	 *
+	 * @readonly
+	 * @observable
+	 */
+	declare public highlightedOffset: number;
+
+	/**
 	 * Searched text value.
 	 *
 	 * @readonly
 	 * @observable
 	 */
 	declare public searchText: string;
+
+	/**
+	 *  The most recent search callback used by the feature to find matches.
+	 *  It is used to re-run the search when user modifies the editor content.
+	 *
+	 * @readonly
+	 * @observable
+	 */
+	declare public lastSearchCallback: FindCallback | null;
 
 	/**
 	 * Replace text value.
@@ -70,8 +87,10 @@ export default class FindAndReplaceState extends ObservableMixin() {
 
 		this.set( 'results', new Collection() );
 		this.set( 'highlightedResult', null );
+		this.set( 'highlightedOffset', 0 );
 		this.set( 'searchText', '' );
 		this.set( 'replaceText', '' );
+		this.set( 'lastSearchCallback', null );
 		this.set( 'matchCase', false );
 		this.set( 'matchWholeWords', false );
 
@@ -96,6 +115,10 @@ export default class FindAndReplaceState extends ObservableMixin() {
 					this.highlightedResult = this.results.get( nextHighlightedIndex );
 				}
 			}
+		} );
+
+		this.on<ObservableChangeEvent<ResultType | null>>( 'change:highlightedResult', ( ) => {
+			this.refreshHighlightOffset();
 		} );
 	}
 
@@ -122,5 +145,25 @@ export default class FindAndReplaceState extends ObservableMixin() {
 
 		this.results.clear();
 	}
+
+	/**
+	 * Refreshes the highlight result offset based on it's index within the result list.
+	 */
+	public refreshHighlightOffset(): void {
+		const { highlightedResult, results } = this;
+		const sortMapping = { before: -1, same: 0, after: 1, different: 1 };
+
+		if ( highlightedResult ) {
+			this.highlightedOffset = Array.from( results )
+				.sort( ( a, b ) => sortMapping[ a.marker!.getStart().compareWith( b.marker!.getStart() ) ] )
+				.indexOf( highlightedResult ) + 1;
+		} else {
+			this.highlightedOffset = 0;
+		}
+	}
 }
 
+/**
+ * The callback function used to find matches in the document.
+ */
+export type FindCallback = ( ( { item, text }: { item: Item; text: string } ) => Array<ResultType> );

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
@@ -224,18 +224,8 @@ export default class FindAndReplaceUI extends Plugin {
 		const commands = editor.commands;
 		const findAndReplaceEditing: FindAndReplaceEditing = this.editor.plugins.get( 'FindAndReplaceEditing' );
 		const editingState = findAndReplaceEditing.state!;
-		const sortMapping = { before: -1, same: 0, after: 1, different: 1 };
 
-		// Let the form know which result is being highlighted.
-		formView.bind( 'highlightOffset' ).to( editingState, 'highlightedResult', highlightedResult => {
-			if ( !highlightedResult ) {
-				return 0;
-			}
-
-			return Array.from( editingState.results )
-				.sort( ( a, b ) => sortMapping[ a.marker!.getStart().compareWith( b.marker!.getStart() ) ] )
-				.indexOf( highlightedResult ) + 1;
-		} );
+		formView.bind( 'highlightOffset' ).to( editingState, 'highlightedOffset' );
 
 		// Let the form know how many results were found in total.
 		formView.listenTo( editingState.results, 'change', () => {

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceutils.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceutils.ts
@@ -52,6 +52,17 @@ export default class FindAndReplaceUtils extends Plugin {
 	): Collection<ResultType> {
 		const results = startResults || new Collection();
 
+		const checkIfResultAlreadyOnList = ( marker: Marker ) => results.find(
+			markerItem => {
+				const { marker: resultsMarker } = markerItem;
+
+				const resultRange = resultsMarker!.getRange();
+				const markerRange = marker.getRange();
+
+				return resultRange.isEqual( markerRange );
+			}
+		);
+
 		model.change( writer => {
 			[ ...range ].forEach( ( { type, item } ) => {
 				if ( type === 'elementStart' ) {
@@ -78,14 +89,16 @@ export default class FindAndReplaceUtils extends Plugin {
 
 							const index = findInsertIndex( results, marker );
 
-							results.add(
-								{
-									id: resultId,
-									label: foundItem.label,
-									marker
-								},
-								index
-							);
+							if ( !checkIfResultAlreadyOnList( marker ) ) {
+								results.add(
+									{
+										id: resultId,
+										label: foundItem.label,
+										marker
+									},
+									index
+								);
+							}
 						} );
 					}
 				}

--- a/packages/ckeditor5-find-and-replace/src/findcommand.ts
+++ b/packages/ckeditor5-find-and-replace/src/findcommand.ts
@@ -7,11 +7,10 @@
  * @module find-and-replace/findcommand
 */
 
-import type { Item } from 'ckeditor5/src/engine.js';
 import { Command, type Editor } from 'ckeditor5/src/core.js';
 import type { Collection } from 'ckeditor5/src/utils.js';
 
-import type FindAndReplaceState from './findandreplacestate.js';
+import type { default as FindAndReplaceState, FindCallback } from './findandreplacestate.js';
 import type { ResultType } from './findandreplace.js';
 import type FindAndReplaceUtils from './findandreplaceutils.js';
 
@@ -53,14 +52,14 @@ export default class FindCommand extends Command {
 	 * @fires execute
 	 */
 	public override execute(
-		callbackOrText: string | ( ( { item, text }: { item: Item; text: string } ) => Array<ResultType> ),
-		{ matchCase, wholeWords }: { matchCase?: boolean; wholeWords?: boolean } = {}
-	): { results: Collection<ResultType>; findCallback: ( ( { item, text }: { item: Item; text: string } ) => Array<ResultType> ) } {
+		callbackOrText: string | FindCallback,
+		{ matchCase, wholeWords }: FindAttributes = {}
+	): { results: Collection<ResultType>; findCallback: FindCallback } {
 		const { editor } = this;
 		const { model } = editor;
 		const findAndReplaceUtils: FindAndReplaceUtils = editor.plugins.get( 'FindAndReplaceUtils' );
 
-		let findCallback: ( ( { item, text }: { item: Item; text: string } ) => Array<ResultType> ) | undefined;
+		let findCallback: FindCallback | undefined;
 
 		// Allow to execute `find()` on a plugin with a keyword only.
 		if ( typeof callbackOrText === 'string' ) {
@@ -88,6 +87,10 @@ export default class FindCommand extends Command {
 			this._state.searchText = callbackOrText;
 		}
 
+		if ( findCallback ) {
+			this._state.lastSearchCallback = findCallback;
+		}
+
 		this._state.matchCase = !!matchCase;
 		this._state.matchWholeWords = !!wholeWords;
 
@@ -97,3 +100,8 @@ export default class FindCommand extends Command {
 		};
 	}
 }
+
+/**
+ * The options object for the find command.
+ */
+export type FindAttributes = { matchCase?: boolean; wholeWords?: boolean };

--- a/packages/ckeditor5-find-and-replace/tests/findandreplaceutils.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplaceutils.js
@@ -1,0 +1,66 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global document */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor.js';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
+import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials.js';
+import BoldEditing from '@ckeditor/ckeditor5-basic-styles/src/bold/boldediting.js';
+import { Collection } from 'ckeditor5/src/utils.js';
+
+import FindAndReplace from '../src/findandreplace.js';
+import FindAndReplaceUI from '../src/findandreplaceui.js';
+import FindAndReplaceEditing from '../src/findandreplaceediting.js';
+
+describe( 'FindAndReplace', () => {
+	let editor, findAndReplaceUtils, model, editorElement, root;
+
+	beforeEach( async () => {
+		editorElement = document.createElement( 'div' );
+
+		document.body.appendChild( editorElement );
+
+		editor = await ClassicEditor.create( editorElement, {
+			plugins: [ Essentials, Paragraph, BoldEditing, FindAndReplace, FindAndReplaceUI, FindAndReplaceEditing ],
+			toolbar: [ 'findAndReplace' ]
+		} );
+
+		model = editor.model;
+		root = model.document.getRoot();
+		findAndReplaceUtils = editor.plugins.get( 'FindAndReplaceUtils' );
+	} );
+
+	it( 'should not append duplicated search result in updateFindResultFromRange if already present in startResults', () => {
+		editor.setData( 'Test Test Test' );
+
+		const findCallback = findAndReplaceUtils.findByTextCallback( 'Test', {} );
+		const results = new Collection();
+
+		findAndReplaceUtils.updateFindResultFromRange(
+			model.createRangeIn( root ),
+			model,
+			findCallback,
+			results
+		);
+
+		expect( results.length ).to.equal( 3 );
+
+		findAndReplaceUtils.updateFindResultFromRange(
+			model.createRangeIn( root ),
+			model,
+			findCallback,
+			results
+		);
+
+		expect( results.length ).to.equal( 3 );
+	} );
+
+	afterEach( async () => {
+		await editor.destroy();
+
+		editorElement.remove();
+	} );
+} );

--- a/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
+++ b/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
@@ -949,6 +949,62 @@ describe( 'FindAndReplaceFormView', () => {
 				findButton.fire( 'execute' );
 				expect( matchCounterElement.textContent ).to.equal( '1 of 3' );
 			} );
+
+			it( 'hitting "Find" with no result should watch document modifications and update highlighted item if not present', () => {
+				editor.setData( '' );
+				toggleDialog();
+
+				findInput.fieldView.value = 'CupCake';
+				findButton.fire( 'execute' );
+
+				expect( matchCounterElement.textContent ).to.equal( '0 of 0' );
+
+				editor.setData( 'CupCake' );
+				expect( matchCounterElement.textContent ).to.equal( '1 of 1' );
+
+				editor.setData( 'CupCake CupCake' );
+				expect( matchCounterElement.textContent ).to.equal( '1 of 2' );
+
+				editor.setData( '' );
+				expect( matchCounterElement.textContent ).to.equal( '0 of 0' );
+			} );
+
+			it( 'hitting "Find" and toggling "matchCase" affects search results', () => {
+				editor.setData( '<p>MatCH casE test</P' );
+				toggleDialog();
+
+				findInput.fieldView.value = 'match';
+				matchCaseSwitch.fire( 'execute' );
+
+				findButton.fire( 'execute' );
+				expect( matchCounterElement.textContent ).to.equal( '0 of 0' );
+
+				// try again
+				findButton.fire( 'execute' );
+				expect( matchCounterElement.textContent ).to.equal( '0 of 0' );
+
+				// toggle switch
+				matchCaseSwitch.fire( 'execute' );
+				findButton.fire( 'execute' );
+
+				expect( matchCounterElement.textContent ).to.equal( '1 of 1' );
+			} );
+
+			it( 'hitting "Find" and toggling "wholeWords" affects search results', () => {
+				editor.setData( '<p>MatCH casE test</P' );
+				toggleDialog();
+
+				findInput.fieldView.value = 'matc';
+				findButton.fire( 'execute' );
+
+				expect( matchCounterElement.textContent ).to.equal( '1 of 1' );
+
+				// toggle switch
+				wholeWordsOnlySwitch.fire( 'execute' );
+				findButton.fire( 'execute' );
+
+				expect( matchCounterElement.textContent ).to.equal( '0 of 0' );
+			} );
 		} );
 
 		describe( 'find results navigation using previous/next buttons', () => {
@@ -1230,7 +1286,7 @@ describe( 'FindAndReplaceFormView', () => {
 				expect( matchCounterElement.textContent ).to.equal( '2 of 3' );
 
 				replaceButton.fire( 'execute' );
-				expect( matchCounterElement.textContent ).to.equal( '2 of 2' );
+				expect( matchCounterElement.textContent ).to.equal( '1 of 2' );
 
 				replaceButton.fire( 'execute' );
 				expect( matchCounterElement.textContent ).to.equal( '1 of 1' );
@@ -1245,6 +1301,9 @@ describe( 'FindAndReplaceFormView', () => {
 
 				findInput.fieldView.value = 'A';
 				findButton.fire( 'execute' );
+
+				expect( matchCounterElement.textContent ).to.equal( '1 of 3' );
+
 				findNextButton.fire( 'execute' );
 
 				expect( matchCounterElement.textContent ).to.equal( '2 of 3' );
@@ -1269,6 +1328,34 @@ describe( 'FindAndReplaceFormView', () => {
 				replaceAllButton.fire( 'execute' );
 
 				sinon.assert.calledOnce( spy );
+			} );
+
+			it( 'replace items and using undo should set proper hits counter value', () => {
+				editor.setData( '<p>Test Test Test</p><p>Test</p>' );
+				toggleDialog();
+
+				findInput.fieldView.value = 'Test';
+				findButton.fire( 'execute' );
+
+				expect( matchCounterElement.textContent ).to.equal( '1 of 4' );
+
+				replaceButton.fire( 'execute' );
+				expect( matchCounterElement.textContent ).to.equal( '1 of 3' );
+
+				replaceButton.fire( 'execute' );
+				expect( matchCounterElement.textContent ).to.equal( '1 of 2' );
+
+				replaceButton.fire( 'execute' );
+				expect( matchCounterElement.textContent ).to.equal( '1 of 1' );
+
+				editor.execute( 'undo' );
+				expect( matchCounterElement.textContent ).to.equal( '2 of 2' );
+
+				editor.execute( 'undo' );
+				expect( matchCounterElement.textContent ).to.equal( '3 of 3' );
+
+				editor.execute( 'undo' );
+				expect( matchCounterElement.textContent ).to.equal( '4 of 4' );
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix(find-and-replace): Highlighted search result is no longer highlighted if the user has modified part of the found phrase in the text editor. 

---

### Additional information

Closes #15680 
