### PR TITLE
Fix bottom margin jump on focus

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/editorui/editorui.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/editorui/editorui.css
@@ -41,11 +41,8 @@
 	}
 
 	/* https://github.com/ckeditor/ckeditor5/issues/847 */
-	& > *:last-child {
-		/*
-		 * This value should match with the default margins of the block elements (like .media or .image)
-		 * to avoid a content jumping when the fake selection container shows up (See https://github.com/ckeditor/ckeditor5/issues/9825).
-		 */
+	& > *:last-child,
+	& > *:has(+ .ck-fake-selection-container:last-child) {
 		margin-bottom: var(--ck-spacing-large);
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))
Fix: Bottom margin jumps on focus. Closes #15859

---

### Additional information

This fixes a bug where the bottom padding of the editor will jump on focus, because the `.ck-fake-selection-container` element is added, which is fixed-positioned, but drops the `margin-bottom` styling from whatever was the `:last-child`.

It uses the `:has` selector, which is [widely available](https://caniuse.com/css-has) now.

Related issues:

- #847
- #9825