### PR TITLE
Moved the toggle caption on/off labels to core package.

### DIFF
--- a/packages/ckeditor5-core/lang/contexts.json
+++ b/packages/ckeditor5-core/lang/contexts.json
@@ -11,5 +11,7 @@
 	"Insert with file manager": "The label for the insert image with the file manager toolbar button with visible label in insert image dropdown.",
 	"Replace with file manager": "The label for the replace image with the file manager toolbar button with visible label in insert image dropdown.",
 	"Insert image with file manager": "The label for the insert image with the file manager toolbar button.",
-	"Replace image with file manager": "The label for the replace image with the file manager toolbar button."
+	"Replace image with file manager": "The label for the replace image with the file manager toolbar button.",
+	"Toggle caption off": "The button label for the object (e.g. image, table) toolbar hiding caption attached to it.",
+	"Toggle caption on": "The button label for the object (e.g. image, table) toolbar showing caption attached to it."
 }

--- a/packages/ckeditor5-core/lang/contexts.json
+++ b/packages/ckeditor5-core/lang/contexts.json
@@ -12,6 +12,6 @@
 	"Replace with file manager": "The label for the replace image with the file manager toolbar button with visible label in insert image dropdown.",
 	"Insert image with file manager": "The label for the insert image with the file manager toolbar button.",
 	"Replace image with file manager": "The label for the replace image with the file manager toolbar button.",
-	"Toggle caption off": "The button label for the object (e.g. image, table) toolbar hiding caption attached to it.",
-	"Toggle caption on": "The button label for the object (e.g. image, table) toolbar showing caption attached to it."
+	"Toggle caption off": "The button label for the object (e.g. image, table) toolbar for hiding the attached caption.",
+	"Toggle caption on": "The button label for the object (e.g. image, table) toolbar for showing the attached caption."
 }

--- a/packages/ckeditor5-table/lang/contexts.json
+++ b/packages/ckeditor5-table/lang/contexts.json
@@ -57,7 +57,5 @@
 	"The color is invalid. Try \"#FF0000\" or \"rgb(255,0,0)\" or \"red\".": "The localized error string that can be displayed next to color (background, border) fields that have an invalid value",
 	"The value is invalid. Try \"10px\" or \"2em\" or simply \"2\".": "The localized error string that can be displayed next to length (padding, border width) fields that have an invalid value.",
 	"Color picker": "The label used by assistive technologies describing a button that opens a color picker, where user can choose a configured color for a certain properties (eg.: background color, color, border-color etc.).",
-	"Toggle caption off": "The button label for the table toolbar hiding caption attached to the table.",
-	"Toggle caption on": "The button label for the table toolbar showing caption attached to the table.",
 	"Enter table caption": "The placeholder text for the table caption displayed when the caption is empty."
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (ckeditor5): Moved translation keys for Toggle caption off & Toggle caption on to core, changed for a more generic purpose (for more than table).
Closes #15397.

---

### Additional information

This will result in more accurate translations which will also respect objects other than table.