### PR TITLE
Do not use element reference in DifferItemInsert and DifferItemRemove

### DIFF
--- a/packages/ckeditor5-engine/src/model/differ.ts
+++ b/packages/ckeditor5-engine/src/model/differ.ts
@@ -38,8 +38,6 @@ export default class Differ {
 	/**
 	 * Priority of the {@link ~Differ#_elementState element states}. States on higher indexes of the array can overwrite states on the lower
 	 * indexes.
-	 *
-	 * @private
 	 */
 	private static readonly _statesPriority = [ undefined, 'refresh', 'rename', 'move' ];
 
@@ -536,8 +534,8 @@ export default class Differ {
 			// Generate diff instructions based on changes done in the element/root.
 			const diffInstructions = _generateDiffInstructionsFromChanges( childrenBefore.length, changes );
 
-			let i = 0; // Iterator in `elementChildren` array -- iterates through current children of element.
-			let j = 0; // Iterator in `snapshotChildren` array -- iterates through old children of element.
+			let i = 0; // Iterator in `childrenAfter` array -- iterates through current children of element.
+			let j = 0; // Iterator in `childrenBefore` array -- iterates through old children of element.
 
 			// Process every action.
 			for ( const instruction of diffInstructions ) {
@@ -572,6 +570,7 @@ export default class Differ {
 					// Generate diff items for this change (there might be multiple attributes changed and
 					// there is a single diff for each of them) and insert them into the diff set.
 					const diffItems = this._getAttributesDiff( range, beforeAttributes, afterAttributes );
+
 					diffSet.push( ...diffItems );
 
 					i++;

--- a/packages/ckeditor5-engine/src/model/differ.ts
+++ b/packages/ckeditor5-engine/src/model/differ.ts
@@ -1555,6 +1555,7 @@ function _changesInGraveyardFilter( entry: DiffItem ) {
  * A snapshot is representing state of a given element before the first change was applied on that element.
  */
 export interface DifferSnapshot {
+
 	/**
 	 * Node for which was snapshot was made.
 	 */

--- a/packages/ckeditor5-engine/src/model/differ.ts
+++ b/packages/ckeditor5-engine/src/model/differ.ts
@@ -1251,7 +1251,7 @@ export default class Differ {
 			action
 		};
 
-		if ( action == 'rename' && elementSnapshotBefore ) {
+		if ( action != 'insert' && elementSnapshotBefore ) {
 			diffItem.before = {
 				name: elementSnapshotBefore.name,
 				attributes: new Map( elementSnapshotBefore.attributes )
@@ -1628,8 +1628,8 @@ export interface DiffItemInsert {
 	 * For example, when `<paragraph textAlign="right">` was changed to `<codeBlock language="plaintext">`,
 	 * `before.name` will be equal to `'paragraph'` and `before.attributes` map will have one entry: `'textAlign' -> 'right'`.
 	 *
-	 * The property is available only if the insertion change was due to element rename (when `action` property is `'rename'`).
-	 * As such, `before` property is never available for text node changes.
+	 * The property is available only if the insertion change was due to element rename or refresh (when `action` property is `'rename'`
+	 * or `'refresh'`). As such, `before` property is never available for text node changes.
 	 */
 	before?: {
 

--- a/packages/ckeditor5-engine/src/model/differ.ts
+++ b/packages/ckeditor5-engine/src/model/differ.ts
@@ -49,19 +49,46 @@ export default class Differ {
 	private readonly _changesInElement: Map<Element | DocumentFragment, Array<ChangeItem>> = new Map();
 
 	/**
-	 * A map that stores "element's children snapshots". A snapshot is representing children of a given element before
-	 * the first change was applied on that element. Snapshot items are objects with two properties: `name`,
-	 * containing the element name (or `'$text'` for a text node) and `attributes` which is a map of the node's attributes.
+	 * Stores snapshots for the models nodes that might have changed.
+	 *
+	 * See also {@link ~DifferSnapshot}.
 	 */
-	private readonly _elementSnapshots: Map<Element | DocumentFragment, Array<DifferSnapshot>> = new Map();
+	private readonly _elementSnapshots: Map<Node | DocumentFragment, DifferSnapshot> = new Map();
+
+	/**
+	 * Stores snapshots of child nodes list for the elements or document fragments inside which there was a change.
+	 *
+	 * See also {@link ~DifferSnapshot}.
+	 */
+	private readonly _elementChildrenSnapshots: Map<Element | DocumentFragment, Array<DifferSnapshot>> = new Map();
+
+	/**
+	 * Keeps the state for a given element, describing how the element was changed so far. It is used to evaluate a `action` property
+	 * of diff items returned by {@link ~Differ#getChanges()}.
+	 *
+	 * Possible values, in the order from the lowest priority to the highest priority:
+	 *
+	 * * `'refresh'` - element was refreshed,
+	 * * `'rename'` - element was renamed,
+	 * * `'move'` - element was moved (or, usually, removed, that is moved to the graveyard).
+	 *
+	 * Element that was refreshed, may change its state to `'rename'` if it was later renamed, or to `'move'` if it was removed.
+	 * But the element cannot change its state from `'move'` to `'rename'`, or from `'rename'` to `'refresh'`.
+	 *
+	 * Only already existing elements are registered in `_elementState`. If a new element was inserted as a result of a buffered operation,
+	 * it is not be registered in `_elementState`.
+	 */
+	private readonly _elementState: Map<Element, 'rename' | 'refresh' | 'move'> = new Map();
 
 	/**
 	 * A map that stores all changed markers.
 	 *
 	 * The keys of the map are marker names.
+	 *
 	 * The values of the map are objects with the following properties:
-	 * - `oldMarkerData`,
-	 * - `newMarkerData`.
+	 *
+	 * * `oldMarkerData`,
+	 * * `newMarkerData`.
 	 */
 	private readonly _changedMarkers: Map<string, { newMarkerData: MarkerData; oldMarkerData: MarkerData }> = new Map();
 
@@ -118,7 +145,7 @@ export default class Differ {
 	}
 
 	/**
-	 * Buffers the given operation. An operation has to be buffered before it is executed.
+	 * Buffers the given operation. **An operation has to be buffered before it is executed.**
 	 *
 	 * @param operationToBuffer An operation to buffer.
 	 */
@@ -187,6 +214,13 @@ export default class Differ {
 					this._markInsert( operation.targetPosition.parent, operation.getMovedRangeStart().offset, operation.howMany );
 				}
 
+				// Remember -- operation is buffered before it is executed. So, it was not executed yet.
+				const range = Range._createFromPositionAndShift( operation.sourcePosition, operation.howMany );
+
+				for ( const node of range.getItems( { shallow: true } ) ) {
+					this._setElementState( node, 'move' );
+				}
+
 				break;
 			}
 			case 'rename': {
@@ -205,6 +239,8 @@ export default class Differ {
 					this.bufferMarkerChange( marker.name, markerData, markerData );
 				}
 
+				this._setElementState( operation.position.nodeAfter!, 'rename' );
+
 				break;
 			}
 			case 'split': {
@@ -213,6 +249,13 @@ export default class Differ {
 				// Mark that children of the split element were removed.
 				if ( !this._isInInsertedElement( splitElement ) ) {
 					this._markRemove( splitElement, operation.splitPosition.offset, operation.howMany );
+
+					// Remember -- operation is buffered before it is executed. So, it was not executed yet.
+					const range = Range._createFromPositionAndShift( operation.splitPosition, operation.howMany );
+
+					for ( const node of range.getItems( { shallow: true } ) ) {
+						this._setElementState( node, 'move' );
+					}
 				}
 
 				// Mark that the new element (split copy) was inserted.
@@ -223,16 +266,18 @@ export default class Differ {
 				// If the split took the element from the graveyard, mark that the element from the graveyard was removed.
 				if ( operation.graveyardPosition ) {
 					this._markRemove( operation.graveyardPosition.parent, operation.graveyardPosition.offset, 1 );
+
+					this._setElementState( operation.graveyardPosition.nodeAfter!, 'move' );
 				}
 
 				break;
 			}
 			case 'merge': {
 				// Mark that the merged element was removed.
-				const mergedElement = operation.sourcePosition.parent;
+				const mergedElement = operation.sourcePosition.parent as Element;
 
 				if ( !this._isInInsertedElement( mergedElement.parent! ) ) {
-					this._markRemove( mergedElement.parent!, ( mergedElement as any ).startOffset, 1 );
+					this._markRemove( mergedElement.parent!, mergedElement.startOffset!, 1 );
 				}
 
 				// Mark that the merged element was inserted into graveyard.
@@ -240,11 +285,20 @@ export default class Differ {
 
 				this._markInsert( graveyardParent, operation.graveyardPosition.offset, 1 );
 
+				this._setElementState( mergedElement, 'move' );
+
 				// Mark that children of merged element were inserted at new parent.
 				const mergedIntoElement = operation.targetPosition.parent;
 
 				if ( !this._isInInsertedElement( mergedIntoElement ) ) {
 					this._markInsert( mergedIntoElement, operation.targetPosition.offset, mergedElement.maxOffset );
+
+					// Remember -- operation is buffered before it is executed. So, it was not executed yet.
+					const range = Range._createFromPositionAndShift( operation.sourcePosition, operation.howMany );
+
+					for ( const node of range.getItems( { shallow: true } ) ) {
+						this._setElementState( node, 'move' );
+					}
 				}
 
 				break;
@@ -413,6 +467,59 @@ export default class Differ {
 	}
 
 	/**
+	 * Tries to set given state for given item.
+	 *
+	 * This method does simple validation (it sets the state only for model elements, not for text proxy nodes). It also follows state
+	 * setting rules, that is, `'refresh'` cannot overwrite `'rename'`, and `'rename'` cannot overwrite `'move'`.
+	 */
+	private _setElementState( node: Item, state: 'refresh' | 'rename' | 'move' ) {
+		if ( !node.is( 'element' ) ) {
+			return;
+		}
+
+		// Priority of states. States on the right will overwrite states on the left.
+		const statesPriority = [ undefined, 'refresh', 'rename', 'move' ];
+		const currentStatePriority = statesPriority.indexOf( this._elementState.get( node ) );
+		const newStatePriority = statesPriority.indexOf( state );
+
+		if ( newStatePriority > currentStatePriority ) {
+			this._elementState.set( node, state );
+		}
+	}
+
+	/**
+	 * Returns correct value for {@link ~DifferItemAction `action`} property for diff items returned by {@link ~Differ#getChanges()}.
+	 * This method aims to return `'rename'` or `'refresh'` when it should, and `diffItemType` ("default action") in all other cases.
+	 *
+	 * It bases on a few factors:
+	 *
+	 * * for text nodes, the method always returns `diffItemType`,
+	 * * for newly inserted element, the method returns `diffItemType`,
+	 * * if {@link ~Differ#_elementState element state} was not recorded, the method returns `diffItemType`,
+	 * * if state was recorded, and it was `'move'` (default action), the method returns `diffItemType`,
+	 * * finally, if state was `'refresh'` or `'rename'`, the method returns the state value.
+	 */
+	private _getDiffActionForNode( node: Node, diffItemType: 'insert' | 'remove' ): DifferItemAction {
+		if ( !node.is( 'element' ) ) {
+			// Text node.
+			return diffItemType;
+		}
+
+		if ( !this._elementSnapshots.has( node ) ) {
+			// Newly inserted element.
+			return diffItemType;
+		}
+
+		const state = this._elementState.get( node );
+
+		if ( !state || state == 'move' ) {
+			return diffItemType;
+		}
+
+		return state;
+	}
+
+	/**
 	 * Calculates the diff between the old model tree state (the state before the first buffered operations since the last {@link #reset}
 	 * call) and the new model tree state (actual one). It should be called after all buffered operations are executed.
 	 *
@@ -443,9 +550,9 @@ export default class Differ {
 		// Will contain returned results.
 		let diffSet: Array<DiffItem & DiffItemInternal> = [];
 
-		// Check all changed elements.
+		// Check all changed elements/roots.
 		for ( const element of this._changesInElement.keys() ) {
-			// Get changes for this element and sort them.
+			// Get changes inside this element/root and sort them.
 			const changes = this._changesInElement.get( element )!.sort( ( a, b ) => {
 				if ( a.offset === b.offset ) {
 					if ( a.type != b.type ) {
@@ -462,35 +569,40 @@ export default class Differ {
 			} );
 
 			// Get children of this element before any change was applied on it.
-			const snapshotChildren = this._elementSnapshots.get( element )!;
+			const childrenBefore = this._elementChildrenSnapshots.get( element )!;
 			// Get snapshot of current element's children.
-			const elementChildren = _getChildrenSnapshot( element.getChildren() );
+			const childrenAfter = _getChildrenSnapshots( element.getChildren() );
 
-			// Generate actions basing on changes done on element.
-			const actions = _generateActionsFromChanges( snapshotChildren.length, changes );
+			// Generate diff instructions based on changes done in the element/root.
+			const diffInstructions = _generateDiffInstructionsFromChanges( childrenBefore.length, changes );
 
 			let i = 0; // Iterator in `elementChildren` array -- iterates through current children of element.
 			let j = 0; // Iterator in `snapshotChildren` array -- iterates through old children of element.
 
 			// Process every action.
-			for ( const action of actions ) {
-				if ( action === 'i' ) {
-					// Generate diff item for this element and insert it into the diff set.
-					diffSet.push( this._getInsertDiff( element, i, elementChildren[ i ] ) );
+			for ( const instruction of diffInstructions ) {
+				if ( instruction === 'i' ) {
+					const action = this._getDiffActionForNode( childrenAfter[ i ].node, 'insert' );
+					const childSnapshotBefore = this._elementSnapshots.get( childrenAfter[ i ].node );
+					const diffItem = this._getInsertDiff( element, i, action, childrenAfter[ i ], childSnapshotBefore );
+
+					diffSet.push( diffItem );
 
 					i++;
-				} else if ( action === 'r' ) {
-					// Generate diff item for this element and insert it into the diff set.
-					diffSet.push( this._getRemoveDiff( element, i, snapshotChildren[ j ] ) );
+				} else if ( instruction === 'r' ) {
+					const action = this._getDiffActionForNode( childrenBefore[ j ].node, 'remove' );
+					const diffItem = this._getRemoveDiff( element, i, action, childrenBefore[ j ] );
+
+					diffSet.push( diffItem );
 
 					j++;
-				} else if ( action === 'a' ) {
+				} else if ( instruction === 'a' ) {
 					// Take attributes from saved and current children.
-					const elementAttributes = elementChildren[ i ].attributes;
-					const snapshotAttributes = snapshotChildren[ j ].attributes;
+					const beforeAttributes = childrenBefore[ j ].attributes;
+					const afterAttributes = childrenAfter[ i ].attributes;
 					let range;
 
-					if ( elementChildren[ i ].name == '$text' ) {
+					if ( childrenAfter[ i ].name == '$text' ) {
 						range = new Range( Position._createAt( element, i ), Position._createAt( element, i + 1 ) );
 					} else {
 						const index = element.offsetToIndex( i );
@@ -499,7 +611,8 @@ export default class Differ {
 
 					// Generate diff items for this change (there might be multiple attributes changed and
 					// there is a single diff for each of them) and insert them into the diff set.
-					diffSet.push( ...this._getAttributesDiff( range, snapshotAttributes, elementAttributes ) );
+					const diffItems = this._getAttributesDiff( range, beforeAttributes, afterAttributes );
+					diffSet.push( ...diffItems );
 
 					i++;
 					j++;
@@ -632,10 +745,12 @@ export default class Differ {
 	 */
 	public reset(): void {
 		this._changesInElement.clear();
+		this._elementChildrenSnapshots.clear();
 		this._elementSnapshots.clear();
+		this._elementState.clear();
 		this._changedMarkers.clear();
 		this._changedRoots.clear();
-		this._refreshedItems = new Set();
+		this._refreshedItems.clear();
 		this._cachedChanges = null;
 	}
 
@@ -721,6 +836,7 @@ export default class Differ {
 		this._markInsert( item.parent!, item.startOffset!, item.offsetSize );
 
 		this._refreshedItems.add( item );
+		this._setElementState( item, 'refresh' );
 
 		const range = Range._createOn( item );
 
@@ -816,8 +932,8 @@ export default class Differ {
 	 * Saves and handles a model change.
 	 */
 	private _markChange( parent: Element | DocumentFragment, changeItem: ChangeItem ): void {
-		// First, make a snapshot of this parent's children (it will be made only if it was not made before).
-		this._makeSnapshot( parent );
+		// First, make a snapshot of the parent and its children (it will be made only if it was not made before).
+		this._makeSnapshots( parent );
 
 		// Then, get all changes that already were done on the element (empty array if this is the first change).
 		const changes = this._getChangesForElement( parent );
@@ -857,11 +973,19 @@ export default class Differ {
 	}
 
 	/**
-	 * Saves a children snapshot for a given element.
+	 * Creates and saves a snapshot for all children of the given element.
 	 */
-	private _makeSnapshot( element: Element | DocumentFragment ): void {
-		if ( !this._elementSnapshots.has( element ) ) {
-			this._elementSnapshots.set( element, _getChildrenSnapshot( element.getChildren() ) );
+	private _makeSnapshots( element: Element | DocumentFragment ): void {
+		if ( this._elementChildrenSnapshots.has( element ) ) {
+			return;
+		}
+
+		const childrenSnapshots = _getChildrenSnapshots( element.getChildren() );
+
+		this._elementChildrenSnapshots.set( element, childrenSnapshots );
+
+		for ( const snapshot of childrenSnapshots ) {
+			this._elementSnapshots.set( snapshot.node, snapshot );
 		}
 	}
 
@@ -1094,23 +1218,36 @@ export default class Differ {
 	 *
 	 * @param parent The element in which the change happened.
 	 * @param offset The offset at which change happened.
-	 * @param elementSnapshot The snapshot of the removed element a character.
+	 * @param action Further specifies what kind of action led to generating this change.
+	 * @param elementSnapshot Snapshot of the inserted node after changes.
+	 * @param elementSnapshotBefore Snapshot of the inserted node before changes.
 	 * @returns The diff item.
 	 */
 	private _getInsertDiff(
 		parent: Element | DocumentFragment,
 		offset: number,
-		elementSnapshot: DifferSnapshot
+		action: DifferItemAction,
+		elementSnapshot: DifferSnapshot,
+		elementSnapshotBefore?: DifferSnapshot
 	): DiffItemInsert & DiffItemInternal {
-		return {
+		const diffItem: DiffItemInsert & DiffItemInternal = {
 			type: 'insert',
 			position: Position._createAt( parent, offset ),
 			name: elementSnapshot.name,
 			attributes: new Map( elementSnapshot.attributes ),
 			length: 1,
 			changeCount: this._changeCount++,
-			_element: elementSnapshot.element
+			action
 		};
+
+		if ( action == 'rename' && elementSnapshotBefore ) {
+			diffItem.before = {
+				name: elementSnapshotBefore.name,
+				attributes: new Map( elementSnapshotBefore.attributes )
+			};
+		}
+
+		return diffItem;
 	}
 
 	/**
@@ -1118,22 +1255,24 @@ export default class Differ {
 	 *
 	 * @param parent The element in which change happened.
 	 * @param offset The offset at which change happened.
-	 * @param elementSnapshot The snapshot of the removed element a character.
+	 * @param action Further specifies what kind of action led to generating this change.
+	 * @param elementSnapshot The snapshot of the removed node before changes.
 	 * @returns The diff item.
 	 */
 	private _getRemoveDiff(
 		parent: Element | DocumentFragment,
 		offset: number,
+		action: DifferItemAction,
 		elementSnapshot: DifferSnapshot
 	): DiffItemRemove & DiffItemInternal {
 		return {
 			type: 'remove',
+			action,
 			position: Position._createAt( parent, offset ),
 			name: elementSnapshot.name,
 			attributes: new Map( elementSnapshot.attributes ),
 			length: 1,
-			changeCount: this._changeCount++,
-			_element: elementSnapshot.element
+			changeCount: this._changeCount++
 		};
 	}
 
@@ -1231,7 +1370,7 @@ export default class Differ {
 
 		for ( const item of range.getItems( { shallow: true } ) ) {
 			if ( item.is( 'element' ) ) {
-				this._elementSnapshots.delete( item );
+				// this._elementChildrenSnapshots.delete( item );
 				this._changesInElement.delete( item );
 
 				this._removeAllNestedChanges( item, 0, item.maxOffset );
@@ -1240,45 +1379,61 @@ export default class Differ {
 	}
 }
 
+/**
+ * Further specifies what kind of action led to generating a change:
+ *
+ * * `'insert'` if element was inserted,
+ * * `'remove'` if element was removed,
+ * * `'rename'` if element got renamed (e.g. `writer.rename()`),
+ * * `'refresh'` if element got refreshed (e.g. `model.editing.reconvertItem()`).
+ */
+export type DifferItemAction = 'insert' | 'remove' | 'rename' | 'refresh';
+
 interface ChangeItem {
 	type: 'insert' | 'remove' | 'attribute';
 	offset: number;
 	howMany: number;
 	count: number;
 	nodesToHandle?: number;
+	action?: DifferItemAction;
+}
+
+/**
+ * Returns a snapshot for the specified child node. Text node snapshots have the `name` property set to `$text`.
+ */
+function _getSingleNodeSnapshot( node: Node | Element ): DifferSnapshot {
+	return	{
+		node,
+		name: node.is( '$text' ) ? '$text' : ( node as Element ).name,
+		attributes: new Map( node.getAttributes() )
+	};
 }
 
 /**
  * Returns an array that is a copy of passed child list with the exception that text nodes are split to one or more
  * objects, each representing one character and attributes set on that character.
  */
-function _getChildrenSnapshot( children: Iterable<Node> ): Array<DifferSnapshot> {
-	const snapshot: Array<DifferSnapshot> = [];
+function _getChildrenSnapshots( children: Iterable<Node> ): Array<DifferSnapshot> {
+	const snapshots: Array<DifferSnapshot> = [];
 
 	for ( const child of children ) {
 		if ( child.is( '$text' ) ) {
-			for ( let i = 0; i < child.data.length; i++ ) {
-				snapshot.push( {
-					name: '$text',
-					attributes: new Map( child.getAttributes() )
-				} );
+			for ( let i = 0; i < child.data.length; ++i ) {
+				snapshots.push( _getSingleNodeSnapshot( child ) );
 			}
 		} else {
-			snapshot.push( {
-				name: ( child as Element ).name,
-				attributes: new Map( child.getAttributes() ),
-				element: child as Element
-			} );
+			snapshots.push( _getSingleNodeSnapshot( child ) );
 		}
 	}
 
-	return snapshot;
+	return snapshots;
 }
 
 /**
- * Generates array of actions for given changes set.
- * It simulates what `diff` function does.
+ * Generates array of diff instructions for given changes set.
+ *
  * Generated actions are:
+ *
  * - 'e' for 'equal' - when item at that position did not change,
  * - 'i' for 'insert' - when item at that position was inserted,
  * - 'r' for 'remove' - when item at that position was removed,
@@ -1293,9 +1448,9 @@ function _getChildrenSnapshot( children: Iterable<Node> ): Array<DifferSnapshot>
  *			type: insert, offset: 2, howMany: 2
  *			type: attribute, offset: 4, howMany: 1
  *
- * expected actions: equal (f), remove (o), equal (o), insert (x), insert (y), attribute (b), equal (A), equal (R)
+ * Expected actions: equal (f), remove (o), equal (o), insert (x), insert (y), attribute (b), equal (A), equal (R)
  *
- * steps taken by th script:
+ * Steps taken by the script:
  *
  * 1. change = "type: remove, offset: 1, howMany: 1"; offset = 0; oldChildrenHandled = 0
  *    1.1 between this change and the beginning is one not-changed node, fill with one equal action, one old child has been handled
@@ -1322,8 +1477,8 @@ function _getChildrenSnapshot( children: Iterable<Node> ): Array<DifferSnapshot>
  *
  * The result actions are: equal, remove, equal, insert, insert, attribute, equal, equal.
  */
-function _generateActionsFromChanges( oldChildrenLength: number, changes: Array<ChangeItem> ) {
-	const actions: Array<string> = [];
+function _generateDiffInstructionsFromChanges( oldChildrenLength: number, changes: Array<ChangeItem> ) {
+	const diff: Array<string> = [];
 
 	let offset = 0;
 	let oldChildrenHandled = 0;
@@ -1333,7 +1488,7 @@ function _generateActionsFromChanges( oldChildrenLength: number, changes: Array<
 		// First, fill "holes" between changes with "equal" actions.
 		if ( change.offset > offset ) {
 			for ( let i = 0; i < change.offset - offset; i++ ) {
-				actions.push( 'e' );
+				diff.push( 'e' );
 			}
 
 			oldChildrenHandled += change.offset - offset;
@@ -1342,14 +1497,14 @@ function _generateActionsFromChanges( oldChildrenLength: number, changes: Array<
 		// Then, fill up actions accordingly to change type.
 		if ( change.type == 'insert' ) {
 			for ( let i = 0; i < change.howMany; i++ ) {
-				actions.push( 'i' );
+				diff.push( 'i' );
 			}
 
 			// The last handled offset is after inserted range.
 			offset = change.offset + change.howMany;
 		} else if ( change.type == 'remove' ) {
 			for ( let i = 0; i < change.howMany; i++ ) {
-				actions.push( 'r' );
+				diff.push( 'r' );
 			}
 
 			// The last handled offset is at the position where the nodes were removed.
@@ -1357,7 +1512,7 @@ function _generateActionsFromChanges( oldChildrenLength: number, changes: Array<
 			// We removed `howMany` old nodes, update `oldChildrenHandled`.
 			oldChildrenHandled += change.howMany;
 		} else {
-			actions.push( ...'a'.repeat( change.howMany ).split( '' ) );
+			diff.push( ...'a'.repeat( change.howMany ).split( '' ) );
 
 			// The last handled offset is at the position after the changed range.
 			offset = change.offset + change.howMany;
@@ -1370,15 +1525,15 @@ function _generateActionsFromChanges( oldChildrenLength: number, changes: Array<
 	// has not been changed / removed at the end of their parent.
 	if ( oldChildrenHandled < oldChildrenLength ) {
 		for ( let i = 0; i < oldChildrenLength - oldChildrenHandled - offset; i++ ) {
-			actions.push( 'e' );
+			diff.push( 'e' );
 		}
 	}
 
-	return actions;
+	return diff;
 }
 
 /**
- * Filter callback for Array.filter that filters out change entries that are in graveyard.
+ * Filter callback for `Array.filter` that filters out change entries that are in graveyard.
  */
 function _changesInGraveyardFilter( entry: DiffItem ) {
 	const posInGy = 'position' in entry && entry.position!.root.rootName == '$graveyard';
@@ -1387,9 +1542,23 @@ function _changesInGraveyardFilter( entry: DiffItem ) {
 	return !posInGy && !rangeInGy;
 }
 
-interface DifferSnapshot {
-	element?: Element;
+/**
+ * A snapshot is representing state of a given element before the first change was applied on that element.
+ */
+export interface DifferSnapshot {
+	/**
+	 * Node for which was snapshot was made.
+	 */
+	node: Node;
+
+	/**
+	 * Name of the element at the time when the snapshot was made. For text node snapshots, it is set to `'$text'`.
+	 */
 	name: string;
+
+	/**
+	 * Attributes of the node at the time when the snapshot was made.
+	 */
 	attributes: Map<string, unknown>;
 }
 
@@ -1415,13 +1584,9 @@ export interface DiffItemInsert {
 	type: 'insert';
 
 	/**
-	 * Reference to the model element that was inserted.
-	 *
-	 * Undefined if the diff item is related to text node insertion.
-	 *
-	 * @internal
+	 * Further specifies what kind of action led to generating this change.
 	 */
-	_element?: Element;
+	action: DifferItemAction;
 
 	/**
 	 * The name of the inserted elements or `'$text'` for a text node.
@@ -1429,7 +1594,7 @@ export interface DiffItemInsert {
 	name: string;
 
 	/**
-	 * Map of attributes that were set on the item while it was inserted.
+	 * Map of attributes of the inserted element.
 	 */
 	attributes: Map<string, unknown>;
 
@@ -1442,6 +1607,28 @@ export interface DiffItemInsert {
 	 * The length of an inserted text node. For elements, it is always 1 as each inserted element is counted as a one.
 	 */
 	length: number;
+
+	/**
+	 * Holds information about the element state before all changes happened.
+	 *
+	 * For example, when `<paragraph textAlign="right">` was changed to `<codeBlock language="plaintext">`,
+	 * `before.name` will be equal to `'paragraph'` and `before.attributes` map will have one entry: `'textAlign' -> 'right'`.
+	 *
+	 * The property is available only if the insertion change was due to element rename. As such, the property is never
+	 * available for text node changes.
+	 */
+	before?: {
+
+		/**
+		 * The name of the inserted element before all changes.
+		 */
+		name: string;
+
+		/**
+		 * Map of the attributes of the inserted element before all changes.
+		 */
+		attributes: Map<string, unknown>;
+	};
 }
 
 /**
@@ -1455,24 +1642,9 @@ export interface DiffItemRemove {
 	type: 'remove';
 
 	/**
-	 * Reference to the model element that was removed.
-	 *
-	 * Undefined if the diff item is related to text node deletion.
-	 *
-	 * Note that this element will have the state after all changes has been performed on the model, not before. For example, if a paragraph
-	 * was first renamed to `heading1`, and then removed, `element.name` will be `heading1`. Similarly, with attributes. Also, you should
-	 * not read the element's position, as it will no longer point to the original element position.
-	 *
-	 * Instead, you should use {@link ~DiffItemRemove#name `DiffItemRemove#name`},
-	 * {@link ~DiffItemRemove#attributes `DiffItemRemove#attributes`}, and {@link ~DiffItemRemove#position `DiffItemRemove#position`}.
-	 *
-	 * This property should be only used to check instance reference equality. For example, if you want to detect that some particular
-	 * element was removed, you can check `_element` property. You can use it together with {@link ~DiffItemInsert#_element `#_element`} on
-	 * insert diff items to detect move, refresh, or rename changes.
-	 *
-	 * @internal
+	 * Further specifies what kind of action led to generating this change.
 	 */
-	_element?: Element;
+	action: DifferItemAction;
 
 	/**
 	 * The name of the removed element or `'$text'` for a text node.

--- a/packages/ckeditor5-engine/src/model/differ.ts
+++ b/packages/ckeditor5-engine/src/model/differ.ts
@@ -63,7 +63,7 @@ export default class Differ {
 	 *
 	 * See also {@link ~DifferSnapshot}.
 	 */
-	private readonly _elementsSnapshots: Map<Node | DocumentFragment, DifferSnapshot> = new Map();
+	private readonly _elementsSnapshots: Map<Node, DifferSnapshot> = new Map();
 
 	/**
 	 * For each element or document fragment inside which there was a change, it stores a snapshot of the child nodes list (an array
@@ -1381,9 +1381,7 @@ export default class Differ {
 
 		for ( const item of range.getItems( { shallow: true } ) ) {
 			if ( item.is( 'element' ) ) {
-				// this._elementChildrenSnapshots.delete( item );
 				this._changesInElement.delete( item );
-
 				this._removeAllNestedChanges( item, 0, item.maxOffset );
 			}
 		}
@@ -1596,6 +1594,10 @@ export interface DiffItemInsert {
 
 	/**
 	 * Further specifies what kind of action led to generating this change.
+	 *
+	 * The action is set in relation to the document state before any change. It means that, for example, if an element was added and
+	 * then renamed (during the same {@link module:engine/model/batch~Batch batch}), the action will be set to `'insert'`, because when
+	 * compared to the document state before changes, a new element was inserted, and the renaming does not matter from this point of view.
 	 */
 	action: DifferItemAction;
 
@@ -1625,8 +1627,8 @@ export interface DiffItemInsert {
 	 * For example, when `<paragraph textAlign="right">` was changed to `<codeBlock language="plaintext">`,
 	 * `before.name` will be equal to `'paragraph'` and `before.attributes` map will have one entry: `'textAlign' -> 'right'`.
 	 *
-	 * The property is available only if the insertion change was due to element rename. As such, the property is never
-	 * available for text node changes.
+	 * The property is available only if the insertion change was due to element rename (when `action` property is `'rename'`).
+	 * As such, `before` property is never available for text node changes.
 	 */
 	before?: {
 
@@ -1654,6 +1656,10 @@ export interface DiffItemRemove {
 
 	/**
 	 * Further specifies what kind of action led to generating this change.
+	 *
+	 * The action is set in relation to the document state before any change. It means that, for example, if an element was renamed and
+	 * then removed (during the same {@link module:engine/model/batch~Batch batch}), the action will be set to `'remove'`, because when
+	 * compared to the document state before changes, the element was removed, and it does not matter that it was also renamed at one point.
 	 */
 	action: DifferItemAction;
 

--- a/packages/ckeditor5-engine/tests/model/differ.js
+++ b/packages/ckeditor5-engine/tests/model/differ.js
@@ -879,7 +879,7 @@ describe( 'Differ', () => {
 			model.change( () => {
 				rename( root.getChild( 1 ), 'listItem' );
 
-				const before = { name: 'paragraph', attributes: new Map() }
+				const before = { name: 'paragraph', attributes: new Map() };
 
 				expectChanges( [
 					{ type: 'remove', action: 'rename', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ) },
@@ -1034,7 +1034,7 @@ describe( 'Differ', () => {
 					{
 						type: 'remove',
 						action: 'remove', // Becomes `remove` as the end result is a remove, not a rename (remove overwrites rename).
-						name: 'paragraph', // Data before any change happened (the element was a paragraph before being renamed and removed).
+						name: 'paragraph', // Data before any change happened (the element was a paragraph before renamed and removed).
 						length: 1,
 						position: new Position( root, [ 1 ] ),
 						attributes: new Map( [] )

--- a/packages/ckeditor5-engine/tests/model/differ.js
+++ b/packages/ckeditor5-engine/tests/model/differ.js
@@ -3036,12 +3036,13 @@ describe( 'Differ', () => {
 	describe( '#_refreshItem()', () => {
 		it( 'should mark given element to be removed and added again', () => {
 			const p = root.getChild( 0 );
+			const before = { name: 'paragraph', attributes: new Map() };
 
 			differ._refreshItem( p );
 
 			expectChanges( [
 				{ type: 'remove', action: 'refresh', name: 'paragraph', length: 1, position: model.createPositionBefore( p ) },
-				{ type: 'insert', action: 'refresh', name: 'paragraph', length: 1, position: model.createPositionBefore( p ) }
+				{ type: 'insert', action: 'refresh', name: 'paragraph', length: 1, position: model.createPositionBefore( p ), before }
 			], true );
 
 			const refreshedItems = Array.from( differ.getRefreshedItems() );
@@ -3100,12 +3101,13 @@ describe( 'Differ', () => {
 
 			const markersToRefresh = [ 'markerA', 'markerB', 'markerC' ];
 			const element = root.getChild( 1 );
+			const before = { name: 'paragraph', attributes: new Map() };
 
 			differ._refreshItem( element );
 
 			expectChanges( [
 				{ type: 'remove', action: 'refresh', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ) },
-				{ type: 'insert', action: 'refresh', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ) }
+				{ type: 'insert', action: 'refresh', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), before }
 			] );
 
 			const markersToRemove = differ.getMarkersToRemove().map( entry => entry.name );
@@ -3131,7 +3133,8 @@ describe( 'Differ', () => {
 						name: 'paragraph',
 						length: 1,
 						position: new Position( root, [ 0 ] ),
-						attributes: new Map( [] )
+						attributes: new Map( [] ),
+						before: undefined
 					}
 				] );
 			} );

--- a/packages/ckeditor5-engine/tests/model/differ.js
+++ b/packages/ckeditor5-engine/tests/model/differ.js
@@ -46,7 +46,7 @@ describe( 'Differ', () => {
 				insert( element, position );
 
 				expectChanges( [
-					{ type: 'insert', name: 'imageBlock', length: 1, position, _element: element }
+					{ type: 'insert', name: 'imageBlock', length: 1, position, action: 'insert' }
 				] );
 			} );
 		} );
@@ -61,7 +61,7 @@ describe( 'Differ', () => {
 				const attributes = new Map( [ [ 'src', 'foo.jpg' ] ] );
 
 				expectChanges( [
-					{ type: 'insert', name: 'imageBlock', length: 1, position, attributes, _element: element }
+					{ type: 'insert', name: 'imageBlock', length: 1, position, attributes, action: 'insert' }
 				] );
 			} );
 		} );
@@ -75,8 +75,8 @@ describe( 'Differ', () => {
 				insert( [ image, paragraph ], position );
 
 				expectChanges( [
-					{ type: 'insert', name: 'imageBlock', length: 1, position, _element: image },
-					{ type: 'insert', name: 'paragraph', length: 1, position: position.getShiftedBy( 1 ), _element: paragraph }
+					{ type: 'insert', name: 'imageBlock', length: 1, position, action: 'insert' },
+					{ type: 'insert', name: 'paragraph', length: 1, position: position.getShiftedBy( 1 ), action: 'insert' }
 				] );
 			} );
 		} );
@@ -88,7 +88,7 @@ describe( 'Differ', () => {
 				insert( new Text( 'x' ), position );
 
 				expectChanges( [
-					{ type: 'insert', name: '$text', length: 1, position }
+					{ type: 'insert', name: '$text', length: 1, position, action: 'insert' }
 				] );
 			} );
 		} );
@@ -100,7 +100,7 @@ describe( 'Differ', () => {
 				insert( new Text( 'xyz' ), position );
 
 				expectChanges( [
-					{ type: 'insert', name: '$text', length: 3, position }
+					{ type: 'insert', name: '$text', length: 3, position, action: 'insert' }
 				] );
 			} );
 		} );
@@ -114,7 +114,7 @@ describe( 'Differ', () => {
 				insert( new Text( 'ab' ), position );
 
 				expectChanges( [
-					{ type: 'insert', name: '$text', length: 5, position }
+					{ type: 'insert', name: '$text', length: 5, position, action: 'insert' }
 				] );
 			} );
 		} );
@@ -127,8 +127,8 @@ describe( 'Differ', () => {
 				insert( new Text( 'z' ), position.getShiftedBy( 3 ) );
 
 				expectChanges( [
-					{ type: 'insert', name: '$text', length: 2, position },
-					{ type: 'insert', name: '$text', length: 1, position: position.getShiftedBy( 3 ) }
+					{ type: 'insert', name: '$text', length: 2, position, action: 'insert' },
+					{ type: 'insert', name: '$text', length: 1, position: position.getShiftedBy( 3 ), action: 'insert' }
 				] );
 			} );
 		} );
@@ -147,7 +147,7 @@ describe( 'Differ', () => {
 				insert( new Text( 'foo' ), Position._createAt( caption, 0 ) );
 
 				expectChanges( [
-					{ type: 'insert', name: 'imageBlock', length: 1, position, _element: image }
+					{ type: 'insert', name: 'imageBlock', length: 1, position, action: 'insert' }
 				] );
 			} );
 		} );
@@ -163,8 +163,25 @@ describe( 'Differ', () => {
 
 				// Note that since renamed element is removed and then re-inserted, there is no diff for text inserted inside it.
 				expectChanges( [
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), _element: element },
-					{ type: 'insert', name: 'listItem', length: 1, position: new Position( root, [ 0 ] ), _element: element }
+					{
+						type: 'remove',
+						action: 'rename',
+						name: 'paragraph',
+						length: 1,
+						position: new Position( root, [ 0 ] ),
+						attributes: new Map()
+					},
+					{
+						type: 'insert',
+						action: 'rename',
+						name: 'listItem',
+						length: 1,
+						position: new Position( root, [ 0 ] ),
+						before: {
+							name: 'paragraph',
+							attributes: new Map()
+						}
+					}
 				] );
 			} );
 		} );
@@ -184,7 +201,7 @@ describe( 'Differ', () => {
 				// so there is also a diff for text.
 				expectChanges( [
 					{ type: 'attribute', range: diffRange, attributeKey: 'align', attributeOldValue: null, attributeNewValue: 'center' },
-					{ type: 'insert', name: '$text', length: 3, position, attributes: new Map( [ [ 'bold', true ] ] ) }
+					{ type: 'insert', name: '$text', length: 3, position, attributes: new Map( [ [ 'bold', true ] ] ), action: 'insert' }
 				] );
 			} );
 		} );
@@ -195,7 +212,7 @@ describe( 'Differ', () => {
 				insert( new Text( 'yy' ), new Position( root, [ 0, 2 ] ) );
 
 				expectChanges( [
-					{ type: 'insert', position: new Position( root, [ 0, 1 ] ), length: 4, name: '$text' }
+					{ type: 'insert', position: new Position( root, [ 0, 1 ] ), length: 4, name: '$text', action: 'insert' }
 				] );
 			} );
 		} );
@@ -212,7 +229,7 @@ describe( 'Differ', () => {
 				const rangeAfter = new Range( Position._createAt( p1, 3 ), Position._createAt( p1, 5 ) );
 
 				expectChanges( [
-					{ type: 'insert', name: '$text', length: 2, position },
+					{ type: 'insert', name: '$text', length: 2, position, action: 'insert' },
 					{ type: 'attribute', range: rangeAfter, attributeKey: 'bold', attributeOldValue: null, attributeNewValue: true }
 				] );
 			} );
@@ -288,35 +305,31 @@ describe( 'Differ', () => {
 	describe( 'remove', () => {
 		it( 'an element', () => {
 			const position = new Position( root, [ 0 ] );
-			const element = position.nodeAfter;
 
 			model.change( () => {
 				remove( position, 1 );
 
 				expectChanges( [
-					{ type: 'remove', name: 'paragraph', length: 1, position, _element: element }
+					{ type: 'remove', name: 'paragraph', length: 1, position, action: 'remove' }
 				] );
 			} );
 		} );
 
 		it( 'multiple elements', () => {
 			const position = new Position( root, [ 0 ] );
-			const element1 = root.getChild( 0 );
-			const element2 = root.getChild( 1 );
 
 			model.change( () => {
 				remove( position, 2 );
 
 				expectChanges( [
-					{ type: 'remove', name: 'paragraph', length: 1, position, _element: element1 },
-					{ type: 'remove', name: 'paragraph', length: 1, position, _element: element2 }
+					{ type: 'remove', name: 'paragraph', length: 1, position, action: 'remove' },
+					{ type: 'remove', name: 'paragraph', length: 1, position, action: 'remove' }
 				] );
 			} );
 		} );
 
 		it( 'element with attributes', () => {
 			const position = new Position( root, [ 0 ] );
-			const element = position.nodeAfter;
 			const range = new Range( Position._createAt( root, 0 ), Position._createAt( root, 1 ) );
 
 			model.change( () => {
@@ -329,7 +342,7 @@ describe( 'Differ', () => {
 				const attributes = new Map( [ [ 'align', 'center' ] ] );
 
 				expectChanges( [
-					{ type: 'remove', name: 'paragraph', length: 1, position, attributes, _element: element }
+					{ type: 'remove', name: 'paragraph', length: 1, position, attributes, action: 'remove' }
 				] );
 			} );
 		} );
@@ -341,7 +354,7 @@ describe( 'Differ', () => {
 				remove( position, 1 );
 
 				expectChanges( [
-					{ type: 'remove', name: '$text', length: 1, position }
+					{ type: 'remove', name: '$text', length: 1, position, action: 'remove' }
 				] );
 			} );
 		} );
@@ -353,7 +366,7 @@ describe( 'Differ', () => {
 				remove( position, 2 );
 
 				expectChanges( [
-					{ type: 'remove', name: '$text', length: 2, position }
+					{ type: 'remove', name: '$text', length: 2, position, action: 'remove' }
 				] );
 			} );
 		} );
@@ -370,7 +383,7 @@ describe( 'Differ', () => {
 				remove( position, 2 );
 
 				expectChanges( [
-					{ type: 'remove', name: '$text', length: 2, position, attributes: new Map( [ [ 'bold', true ] ] ) }
+					{ type: 'remove', name: '$text', length: 2, position, attributes: new Map( [ [ 'bold', true ] ] ), action: 'remove' }
 				] );
 			} );
 		} );
@@ -384,7 +397,7 @@ describe( 'Differ', () => {
 				remove( position, 1 );
 
 				expectChanges( [
-					{ type: 'remove', name: '$text', length: 3, position }
+					{ type: 'remove', name: '$text', length: 3, position, action: 'remove' }
 				] );
 			} );
 		} );
@@ -397,8 +410,8 @@ describe( 'Differ', () => {
 				remove( position.getShiftedBy( 1 ), 1 );
 
 				expectChanges( [
-					{ type: 'remove', name: '$text', length: 1, position },
-					{ type: 'remove', name: '$text', length: 1, position: position.getShiftedBy( 1 ) }
+					{ type: 'remove', name: '$text', length: 1, position, action: 'remove' },
+					{ type: 'remove', name: '$text', length: 1, position: position.getShiftedBy( 1 ), action: 'remove' }
 				] );
 			} );
 		} );
@@ -413,8 +426,8 @@ describe( 'Differ', () => {
 				remove( removePosition, 1 );
 
 				expectChanges( [
-					{ type: 'remove', name: '$text', length: 1, position: removePosition },
-					{ type: 'insert', name: '$text', length: 1, position: removePosition }
+					{ type: 'remove', name: '$text', length: 1, position: removePosition, action: 'remove' },
+					{ type: 'insert', name: '$text', length: 1, position: removePosition, action: 'insert' }
 				] );
 			} );
 		} );
@@ -428,8 +441,8 @@ describe( 'Differ', () => {
 				remove( removePosition, 2 );
 
 				expectChanges( [
-					{ type: 'remove', name: '$text', length: 1, position: removePosition },
-					{ type: 'insert', name: '$text', length: 2, position: removePosition }
+					{ type: 'remove', name: '$text', length: 1, position: removePosition, action: 'remove' },
+					{ type: 'insert', name: '$text', length: 2, position: removePosition, action: 'insert' }
 				] );
 			} );
 		} );
@@ -443,8 +456,8 @@ describe( 'Differ', () => {
 				remove( removePosition, 3 );
 
 				expectChanges( [
-					{ type: 'insert', name: '$text', length: 1, position: insertPosition },
-					{ type: 'remove', name: '$text', length: 1, position: removePosition }
+					{ type: 'insert', name: '$text', length: 1, position: insertPosition, action: 'insert' },
+					{ type: 'remove', name: '$text', length: 1, position: removePosition, action: 'remove' }
 				] );
 			} );
 		} );
@@ -458,7 +471,7 @@ describe( 'Differ', () => {
 				remove( removePosition, 4 );
 
 				expectChanges( [
-					{ type: 'remove', name: '$text', length: 2, position: removePosition }
+					{ type: 'remove', name: '$text', length: 2, position: removePosition, action: 'remove' }
 				] );
 			} );
 		} );
@@ -472,8 +485,8 @@ describe( 'Differ', () => {
 				remove( removePositionB, 1 );
 
 				expectChanges( [
-					{ type: 'remove', name: '$text', length: 1, position: removePositionB },
-					{ type: 'remove', name: '$text', length: 1, position: new Position( root, [ 0, 1 ] ) }
+					{ type: 'remove', name: '$text', length: 1, position: removePositionB, action: 'remove' },
+					{ type: 'remove', name: '$text', length: 1, position: new Position( root, [ 0, 1 ] ), action: 'remove' }
 				] );
 			} );
 		} );
@@ -487,7 +500,7 @@ describe( 'Differ', () => {
 				remove( removePositionB, 2 );
 
 				expectChanges( [
-					{ type: 'remove', name: '$text', length: 3, position: removePositionB }
+					{ type: 'remove', name: '$text', length: 3, position: removePositionB, action: 'remove' }
 				] );
 			} );
 		} );
@@ -505,7 +518,7 @@ describe( 'Differ', () => {
 				const newRange = new Range( Position._createAt( p1, 1 ), Position._createAt( p1, 2 ) );
 
 				expectChanges( [
-					{ type: 'remove', name: '$text', length: 1, position },
+					{ type: 'remove', name: '$text', length: 1, position, action: 'remove' },
 					{
 						type: 'attribute',
 						range: newRange,
@@ -530,7 +543,7 @@ describe( 'Differ', () => {
 				const newRange = new Range( Position._createAt( p1, 0 ), Position._createAt( p1, 1 ) );
 
 				expectChanges( [
-					{ type: 'remove', name: '$text', length: 2, position },
+					{ type: 'remove', name: '$text', length: 2, position, action: 'remove' },
 					{
 						type: 'attribute',
 						range: newRange,
@@ -563,7 +576,7 @@ describe( 'Differ', () => {
 						attributeOldValue: null,
 						attributeNewValue: true
 					},
-					{ type: 'remove', name: '$text', length: 1, position },
+					{ type: 'remove', name: '$text', length: 1, position, action: 'remove' },
 					{
 						type: 'attribute',
 						range: rangeAfter,
@@ -595,7 +608,7 @@ describe( 'Differ', () => {
 						attributeOldValue: null,
 						attributeNewValue: true
 					},
-					{ type: 'remove', name: '$text', length: 2, position }
+					{ type: 'remove', name: '$text', length: 2, position, action: 'remove' }
 				] );
 			} );
 		} );
@@ -618,7 +631,7 @@ describe( 'Differ', () => {
 						attributeOldValue: null,
 						attributeNewValue: true
 					},
-					{ type: 'remove', name: '$text', length: 1, position }
+					{ type: 'remove', name: '$text', length: 1, position, action: 'remove' }
 				] );
 			} );
 		} );
@@ -634,6 +647,25 @@ describe( 'Differ', () => {
 				expectChanges( [] );
 			} );
 		} );
+
+		it( 'action is remove if the renamed element was removed', () => {
+			const position = new Position( root, [ 0 ] );
+			const element = root.getChild( 0 );
+
+			rename( element, 'listItem' );
+			remove( position, 1 );
+
+			expectChanges( [
+				{
+					type: 'remove',
+					action: 'remove',
+					name: 'paragraph',
+					position: new Position( root, [ 0 ] ),
+					attributes: new Map( [] ),
+					length: 1
+				}
+			] );
+		} );
 	} );
 
 	// The only main difference between remove operation and move operation is target position.
@@ -643,14 +675,13 @@ describe( 'Differ', () => {
 		it( 'an element to the same parent - target position is after source position', () => {
 			const sourcePosition = new Position( root, [ 0 ] );
 			const targetPosition = new Position( root, [ 2 ] );
-			const element = sourcePosition.nodeAfter;
 
 			model.change( () => {
 				move( sourcePosition, 1, targetPosition );
 
 				expectChanges( [
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), _element: element },
-					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), _element: element }
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), action: 'remove' },
+					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), action: 'insert' }
 				] );
 			} );
 		} );
@@ -658,14 +689,13 @@ describe( 'Differ', () => {
 		it( 'an element to the same parent - target position is before source position', () => {
 			const sourcePosition = new Position( root, [ 1 ] );
 			const targetPosition = new Position( root, [ 0 ] );
-			const element = sourcePosition.nodeAfter;
 
 			model.change( () => {
 				move( sourcePosition, 1, targetPosition );
 
 				expectChanges( [
-					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), _element: element },
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 2 ] ), _element: element }
+					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), action: 'insert' },
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 2 ] ), action: 'remove' }
 				] );
 			} );
 		} );
@@ -679,8 +709,8 @@ describe( 'Differ', () => {
 				move( sourcePosition, 1, targetPosition.getShiftedBy( 1 ) );
 
 				expectChanges( [
-					{ type: 'remove', name: '$text', length: 2, position: sourcePosition },
-					{ type: 'insert', name: '$text', length: 2, position: targetPosition }
+					{ type: 'remove', name: '$text', length: 2, position: sourcePosition, action: 'remove' },
+					{ type: 'insert', name: '$text', length: 2, position: targetPosition, action: 'insert' }
 				] );
 			} );
 		} );
@@ -690,13 +720,12 @@ describe( 'Differ', () => {
 
 			const sourcePosition = new Position( doc.graveyard, [ 0 ] );
 			const targetPosition = new Position( root, [ 2 ] );
-			const element = sourcePosition.nodeAfter;
 
 			model.change( () => {
 				move( sourcePosition, 1, targetPosition );
 
 				expectChanges( [
-					{ type: 'insert', name: 'listItem', length: 1, position: targetPosition, _element: element }
+					{ type: 'insert', name: 'listItem', length: 1, position: targetPosition, action: 'insert' }
 				] );
 			} );
 		} );
@@ -749,14 +778,13 @@ describe( 'Differ', () => {
 
 			const sourcePosition = new Position( root, [ 0 ] );
 			const targetPosition = new Position( newRoot, [ 0 ] );
-			const element = sourcePosition.nodeAfter;
 
 			model.change( () => {
 				move( sourcePosition, 1, targetPosition );
 
 				expectChanges( [
 					// Only buffer "remove" from the loaded root.
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), _element: element }
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), action: 'remove' }
 				] );
 			} );
 		} );
@@ -768,14 +796,13 @@ describe( 'Differ', () => {
 
 			const sourcePosition = new Position( root, [ 0 ] );
 			const targetPosition = new Position( newRoot, [ 0 ] );
-			const element = sourcePosition.nodeAfter;
 
 			model.change( () => {
 				move( sourcePosition, 1, targetPosition );
 
 				expectChanges( [
 					// Only buffer "insert" to the loaded root.
-					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( newRoot, [ 0 ] ), _element: element }
+					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( newRoot, [ 0 ] ), action: 'insert' }
 				] );
 			} );
 		} );
@@ -785,12 +812,34 @@ describe( 'Differ', () => {
 		it( 'an element', () => {
 			model.change( () => {
 				const element = root.getChild( 1 );
+				const before = {
+					name: 'paragraph',
+					attributes: new Map()
+				};
 
 				rename( element, 'listItem' );
 
 				expectChanges( [
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), _element: element },
-					{ type: 'insert', name: 'listItem', length: 1, position: new Position( root, [ 1 ] ), _element: element }
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), action: 'rename' },
+					{ type: 'insert', name: 'listItem', length: 1, position: new Position( root, [ 1 ] ), action: 'rename', before }
+				] );
+			} );
+		} );
+
+		it( 'element double rename', () => {
+			model.change( () => {
+				const element = root.getChild( 1 );
+				const before = {
+					name: 'paragraph',
+					attributes: new Map()
+				};
+
+				rename( element, 'listItem' );
+				rename( element, 'heading' );
+
+				expectChanges( [
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), action: 'rename' },
+					{ type: 'insert', name: 'heading', length: 1, position: new Position( root, [ 1 ] ), action: 'rename', before }
 				] );
 			} );
 		} );
@@ -802,7 +851,7 @@ describe( 'Differ', () => {
 				rename( root.getChild( 2 ).getChild( 0 ), 'listItem' );
 
 				expectChanges( [
-					{ type: 'insert', name: 'blockQuote', length: 1, position: new Position( root, [ 2 ] ) }
+					{ type: 'insert', name: 'blockQuote', length: 1, position: new Position( root, [ 2 ] ), action: 'insert' }
 				] );
 			} );
 		} );
@@ -830,9 +879,11 @@ describe( 'Differ', () => {
 			model.change( () => {
 				rename( root.getChild( 1 ), 'listItem' );
 
+				const before = { name: 'paragraph', attributes: new Map() }
+
 				expectChanges( [
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ) },
-					{ type: 'insert', name: 'listItem', length: 1, position: new Position( root, [ 1 ] ) }
+					{ type: 'remove', action: 'rename', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ) },
+					{ type: 'insert', action: 'rename', name: 'listItem', length: 1, position: new Position( root, [ 1 ] ), before }
 				] );
 
 				const markersToRemove = differ.getMarkersToRemove().map( entry => entry.name );
@@ -850,6 +901,145 @@ describe( 'Differ', () => {
 				rename( root.getChild( 1 ), 'listItem' );
 
 				expectChanges( [] );
+			} );
+		} );
+
+		it( 'data of the renamed node is available for insert diff item', () => {
+			const element = root.getChild( 0 );
+
+			model.change( writer => {
+				writer.setAttribute( 'test', 123, element );
+			} );
+
+			model.change( writer => {
+				rename( element, 'listItem' );
+				writer.setAttribute( 'test', 777, element );
+
+				expectChanges( [
+					{
+						type: 'remove',
+						action: 'rename',
+						name: 'paragraph',
+						length: 1,
+						position: new Position( root, [ 0 ] ),
+						attributes: new Map( [ [ 'test', 123 ] ] )
+					},
+					{
+						type: 'insert',
+						action: 'rename',
+						name: 'listItem',
+						length: 1,
+						position: new Position( root, [ 0 ] ),
+						attributes: new Map( [ [ 'test', 777 ] ] ),
+						before: {
+							name: 'paragraph',
+							attributes: new Map( [ [ 'test', 123 ] ] )
+						}
+					}
+				] );
+			} );
+		} );
+
+		it( 'inserted element is renamed', () => {
+			const element = new Element( 'paragraph' );
+			const position = new Position( root, [ 0 ] );
+
+			model.change( () => {
+				insert( element, position );
+				rename( element, 'listItem' );
+
+				expectChanges( [
+					{
+						type: 'insert',
+						action: 'insert', // Stays as `insert`, as the end result is an insert, even though the element was renamed too.
+						before: undefined, // Not available since this is not marked as `rename` but as `insert`.
+						name: 'listItem', // This is the value after changes, so it is `'listItem'` after being renamed from `'paragraph'`.
+						length: 1,
+						position: new Position( root, [ 0 ] ),
+						attributes: new Map( [] )
+					}
+				] );
+			} );
+		} );
+
+		it( 'refreshed element is renamed', () => {
+			model.change( () => {
+				const element = root.getChild( 1 );
+				differ._refreshItem( element );
+
+				rename( element, 'listItem' );
+
+				expectChanges( [
+					{
+						type: 'remove',
+						action: 'rename',
+						name: 'paragraph', // Data before any change happened.
+						length: 1,
+						position: new Position( root, [ 1 ] ),
+						attributes: new Map( [] )
+					},
+					{
+						type: 'insert',
+						action: 'rename', // Becomes `rename` as the end result is a rename, not a refresh (rename overwrites refresh).
+						before: { name: 'paragraph', attributes: new Map() }, // Data before any change happened.
+						name: 'listItem', // This is the value after changes, so it is `'listItem'` after being renamed from `'paragraph'`.
+						length: 1,
+						position: new Position( root, [ 1 ] ),
+						attributes: new Map( [] )
+					}
+				] );
+			} );
+		} );
+
+		it( 'renamed element is refreshed', () => {
+			// This is the same case as above but the changes are done in a reverse order.
+			// The expected changes are the same as above.
+			model.change( () => {
+				const element = root.getChild( 1 );
+
+				rename( element, 'listItem' );
+
+				differ._refreshItem( element );
+
+				expectChanges( [
+					{
+						type: 'remove',
+						action: 'rename',
+						name: 'paragraph', // Data before any change happened.
+						length: 1,
+						position: new Position( root, [ 1 ] ),
+						attributes: new Map( [] )
+					},
+					{
+						type: 'insert',
+						action: 'rename', // Becomes `rename` as the end result is a rename, not a refresh (rename overwrites refresh).
+						before: { name: 'paragraph', attributes: new Map() }, // Data before any change happened.
+						name: 'listItem', // This is the value after changes, so it is `'listItem'` after being renamed from `'paragraph'`.
+						length: 1,
+						position: new Position( root, [ 1 ] ),
+						attributes: new Map( [] )
+					}
+				] );
+			} );
+		} );
+
+		it( 'renamed element is removed', () => {
+			model.change( () => {
+				const element = root.getChild( 1 );
+
+				rename( element, 'listItem' );
+				remove( new Position( root, [ 1 ] ), 1 );
+
+				expectChanges( [
+					{
+						type: 'remove',
+						action: 'remove', // Becomes `remove` as the end result is a remove, not a rename (remove overwrites rename).
+						name: 'paragraph', // Data before any change happened (the element was a paragraph before being renamed and removed).
+						length: 1,
+						position: new Position( root, [ 1 ] ),
+						attributes: new Map( [] )
+					}
+				] );
 			} );
 		} );
 	} );
@@ -1193,7 +1383,7 @@ describe( 'Differ', () => {
 
 				expectChanges( [
 					{ type: 'attribute', range: rangeBefore, attributeKey, attributeOldValue, attributeNewValue },
-					{ type: 'insert', name: '$text', length: 2, position }
+					{ type: 'insert', name: '$text', length: 2, position, action: 'insert' }
 				] );
 			} );
 		} );
@@ -1209,7 +1399,7 @@ describe( 'Differ', () => {
 				attribute( range, attributeKey, attributeOldValue, attributeNewValue );
 
 				expectChanges( [
-					{ type: 'insert', name: '$text', length: 3, position }
+					{ type: 'insert', name: '$text', length: 3, position, action: 'insert' }
 				] );
 			} );
 		} );
@@ -1226,7 +1416,7 @@ describe( 'Differ', () => {
 				attribute( range, attributeKey, attributeOldValue, attributeNewValue );
 
 				expectChanges( [
-					{ type: 'insert', name: 'paragraph', length: 1, position }
+					{ type: 'insert', name: 'paragraph', length: 1, position, action: 'insert' }
 				] );
 			} );
 		} );
@@ -1244,7 +1434,7 @@ describe( 'Differ', () => {
 				const rangeAfter = new Range( Position._createAt( p1, 3 ), Position._createAt( p1, 4 ) );
 
 				expectChanges( [
-					{ type: 'insert', name: '$text', length: 2, position },
+					{ type: 'insert', name: '$text', length: 2, position, action: 'insert' },
 					{ type: 'attribute', range: rangeAfter, attributeKey, attributeOldValue, attributeNewValue }
 				] );
 			} );
@@ -1265,7 +1455,7 @@ describe( 'Differ', () => {
 
 				expectChanges( [
 					{ type: 'attribute', range: rangeBefore, attributeKey, attributeOldValue, attributeNewValue },
-					{ type: 'insert', name: '$text', length: 2, position },
+					{ type: 'insert', name: '$text', length: 2, position, action: 'insert' },
 					{ type: 'attribute', range: rangeAfter, attributeKey, attributeOldValue, attributeNewValue }
 				] );
 			} );
@@ -1417,7 +1607,8 @@ describe( 'Differ', () => {
 						type: 'insert',
 						position: Position._createAt( p, 3 ),
 						length: 4,
-						name: '$text'
+						name: '$text',
+						action: 'insert'
 					}
 				] );
 			} );
@@ -1491,7 +1682,8 @@ describe( 'Differ', () => {
 						type: 'remove',
 						position,
 						length: 1,
-						name: '$text'
+						name: '$text',
+						action: 'remove'
 					},
 					{
 						type,
@@ -1524,11 +1716,9 @@ describe( 'Differ', () => {
 			model.change( () => {
 				split( position );
 
-				const element = position.parent.nextSibling;
-
 				expectChanges( [
-					{ type: 'remove', name: '$text', length: 1, position },
-					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), _element: element }
+					{ type: 'remove', name: '$text', length: 1, position, action: 'remove' },
+					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), action: 'insert' }
 				] );
 			} );
 		} );
@@ -1540,11 +1730,9 @@ describe( 'Differ', () => {
 				insert( element, new Position( root, [ 0 ] ) );
 				split( new Position( root, [ 0, 1 ] ) );
 
-				const sibling = element.nextSibling;
-
 				expectChanges( [
-					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), _element: element },
-					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), _element: sibling }
+					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), action: 'insert' },
+					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), action: 'insert' }
 				] );
 			} );
 		} );
@@ -1557,7 +1745,32 @@ describe( 'Differ', () => {
 				split( new Position( root, [ 0, 0, 1 ] ) );
 
 				expectChanges( [
-					{ type: 'insert', name: 'blockQuote', length: 1, position: new Position( root, [ 0 ] ), _element: blockQuote }
+					{ type: 'insert', name: 'blockQuote', length: 1, position: new Position( root, [ 0 ] ), action: 'insert' }
+				] );
+			} );
+		} );
+
+		it( 'split an element with renamed element after split position', () => {
+			const elA = new Element( 'paragraph', null, new Text( 'A' ) );
+			const elB = new Element( 'paragraph', null, new Text( 'B' ) );
+
+			model.change( () => {
+				insert( new Element( 'blockQuote', null, [ elA, elB ] ), new Position( root, [ 0 ] ) );
+			} );
+
+			model.change( () => {
+				rename( elB, 'listItem' );
+				split( new Position( root, [ 0, 1 ] ) );
+
+				expectChanges( [
+					{
+						type: 'remove',
+						name: 'paragraph', // Element name before any changes.
+						length: 1,
+						position: new Position( root, [ 0, 1 ] ),
+						action: 'remove' // The end result is the `paragraph` was removed from the blockquote (split overwrites rename).
+					},
+					{ type: 'insert', name: 'blockQuote', length: 1, position: new Position( root, [ 1 ] ), action: 'insert' }
 				] );
 			} );
 		} );
@@ -1572,15 +1785,14 @@ describe( 'Differ', () => {
 				const insertionPosition = SplitOperation.getInsertionPosition( position );
 
 				const gyPosition = new Position( doc.graveyard, [ 0 ] );
-				const gyElement = gyPosition.nodeAfter;
 				const operation = new SplitOperation( position, 3, insertionPosition, gyPosition, doc.version );
 
 				model.applyOperation( operation );
 
 				expectChanges( [
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( doc.graveyard, [ 0 ] ), _element: gyElement },
-					{ type: 'remove', name: '$text', length: 3, position: new Position( root, [ 0, 3 ] ) },
-					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), _element: gyElement }
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( doc.graveyard, [ 0 ] ), action: 'remove' },
+					{ type: 'remove', name: '$text', length: 3, position: new Position( root, [ 0, 3 ] ), action: 'remove' },
+					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), action: 'insert' }
 				], true );
 			} );
 		} );
@@ -1601,13 +1813,11 @@ describe( 'Differ', () => {
 	describe( 'merge', () => {
 		it( 'merge two elements', () => {
 			model.change( () => {
-				const element = root.getChild( 1 );
-
 				merge( new Position( root, [ 1, 0 ] ), new Position( root, [ 0, 3 ] ) );
 
 				expectChanges( [
-					{ type: 'insert', name: '$text', length: 3, position: new Position( root, [ 0, 3 ] ) },
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), _element: element }
+					{ type: 'insert', name: '$text', length: 3, position: new Position( root, [ 0, 3 ] ), action: 'insert' },
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), action: 'remove' }
 				] );
 			} );
 		} );
@@ -1618,7 +1828,7 @@ describe( 'Differ', () => {
 				merge( new Position( root, [ 1, 0 ] ), new Position( root, [ 0, 3 ] ) );
 
 				expectChanges( [
-					{ type: 'insert', name: '$text', length: 2, position: new Position( root, [ 0, 3 ] ) }
+					{ type: 'insert', name: '$text', length: 2, position: new Position( root, [ 0, 3 ] ), action: 'insert' }
 				] );
 			} );
 		} );
@@ -1628,14 +1838,11 @@ describe( 'Differ', () => {
 				const newP = new Element( 'paragraph', null, new Text( 'Ab' ) );
 
 				insert( newP, new Position( root, [ 0 ] ) );
-
-				const oldP = root.getChild( 1 );
-
 				merge( new Position( root, [ 1, 0 ] ), new Position( root, [ 0, 2 ] ) );
 
 				expectChanges( [
-					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), _element: newP },
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), _element: oldP }
+					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), action: 'insert' },
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), action: 'remove' }
 				] );
 			} );
 		} );
@@ -1652,21 +1859,84 @@ describe( 'Differ', () => {
 				merge( new Position( root, [ 0, 1, 0 ] ), new Position( root, [ 0, 0, 2 ] ) );
 
 				expectChanges( [
-					{ type: 'insert', name: 'blockQuote', length: 1, position: new Position( root, [ 0 ] ), _element: blockQuote }
+					{ type: 'insert', name: 'blockQuote', length: 1, position: new Position( root, [ 0 ] ), action: 'insert' }
+				] );
+			} );
+		} );
+
+		it( 'merge element with renamed item inside', () => {
+			const elA = new Element( 'paragraph', null, new Text( 'A' ) );
+			const elB = new Element( 'paragraph', null, new Text( 'B' ) );
+
+			model.change( () => {
+				insert( new Element( 'blockQuote', null, [ elA ] ), new Position( root, [ 0 ] ) );
+				insert( new Element( 'blockQuote', null, [ elB ] ), new Position( root, [ 1 ] ) );
+			} );
+
+			// Model is:
+			// <blockQuote><paragraph>A</paragraph></blockQuote><blockQuote><paragraph>B</paragraph></blockQuote>
+			//
+			// We rename second paragraph to `listItem` and merge `blockQuote`s.
+			//
+			model.change( () => {
+				rename( elB, 'listItem' );
+				merge( new Position( root, [ 1, 0 ] ), new Position( root, [ 0, 1 ] ) );
+
+				expectChanges( [
+					{
+						type: 'insert',
+						name: 'listItem',
+						length: 1,
+						position: new Position( root, [ 0, 1 ] ),
+						action: 'insert', // The end result is a new `listItem` inserted to the first blockquote (merge overwrites rename).
+						before: undefined // Since this is marked as action `'insert'`, `before` is not available.
+					},
+					{ type: 'remove', name: 'blockQuote', length: 1, position: new Position( root, [ 1 ] ), action: 'remove' }
+				] );
+			} );
+		} );
+
+		it( 'merge element with refreshed item inside', () => {
+			// This is the same case as above but refresh is used instead of rename.
+			const elA = new Element( 'paragraph', null, new Text( 'A' ) );
+			const elB = new Element( 'paragraph', null, new Text( 'B' ) );
+
+			model.change( () => {
+				insert( new Element( 'blockQuote', null, [ elA ] ), new Position( root, [ 0 ] ) );
+				insert( new Element( 'blockQuote', null, [ elB ] ), new Position( root, [ 1 ] ) );
+			} );
+
+			// Model is:
+			// <blockQuote><paragraph>A</paragraph></blockQuote><blockQuote><paragraph>B</paragraph></blockQuote>
+			//
+			// We rename second paragraph to `listItem` and merge `blockQuote`s.
+			//
+			model.change( () => {
+				differ._refreshItem( elB );
+				merge( new Position( root, [ 1, 0 ] ), new Position( root, [ 0, 1 ] ) );
+
+				expectChanges( [
+					{
+						type: 'insert',
+						name: 'paragraph',
+						length: 1,
+						position: new Position( root, [ 0, 1 ] ),
+						action: 'insert', // The end result is a new `listItem` inserted to the first blockquote (merge overwrites refresh).
+						before: undefined // Since this is marked as action `'insert'`, `before` is not available.
+					},
+					{ type: 'remove', name: 'blockQuote', length: 1, position: new Position( root, [ 1 ] ), action: 'remove' }
 				] );
 			} );
 		} );
 
 		it( 'should correctly mark a change in graveyard', () => {
 			model.change( () => {
-				const p = root.getChild( 1 );
-
 				merge( new Position( root, [ 1, 0 ] ), new Position( root, [ 0, 3 ] ) );
 
 				expectChanges( [
-					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( doc.graveyard, [ 0 ] ), _element: p },
-					{ type: 'insert', name: '$text', length: 3, position: new Position( root, [ 0, 3 ] ) },
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), _element: p }
+					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( doc.graveyard, [ 0 ] ), action: 'insert' },
+					{ type: 'insert', name: '$text', length: 3, position: new Position( root, [ 0, 3 ] ), action: 'insert' },
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), action: 'remove' }
 				], true );
 			} );
 		} );
@@ -2483,8 +2753,8 @@ describe( 'Differ', () => {
 				move( new Position( root, [ 0, 2 ] ), 1, new Position( root, [ 1, 0 ] ) );
 
 				expectChanges( [
-					{ type: 'insert', name: '$text', length: 1, position: new Position( root, [ 0, 2 ] ) },
-					{ type: 'insert', name: '$text', length: 1, position: new Position( root, [ 1, 0 ] ) }
+					{ type: 'insert', name: '$text', length: 1, position: new Position( root, [ 0, 2 ] ), action: 'insert' },
+					{ type: 'insert', name: '$text', length: 1, position: new Position( root, [ 1, 0 ] ), action: 'insert' }
 				] );
 			} );
 		} );
@@ -2519,9 +2789,9 @@ describe( 'Differ', () => {
 				remove( new Position( root, [ 1, 0 ] ), 1 );
 
 				expectChanges( [
-					{ type: 'insert', name: '$text', length: 2, position: new Position( root, [ 0, 3 ] ) },
-					{ type: 'remove', name: 'imageBlock', length: 1, position: new Position( root, [ 1 ] ), _element: imageBlock },
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 1, 0 ] ), _element: paragraph }
+					{ type: 'insert', name: '$text', length: 2, position: new Position( root, [ 0, 3 ] ), action: 'insert' },
+					{ type: 'remove', name: 'imageBlock', length: 1, position: new Position( root, [ 1 ] ), action: 'remove' },
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 1, 0 ] ), action: 'remove' }
 				] );
 			} );
 		} );
@@ -2546,8 +2816,8 @@ describe( 'Differ', () => {
 				insert( new Text( 'foo' ), new Position( root, [ 0, 0, 0 ] ) );
 
 				expectChanges( [
-					{ type: 'remove', name: 'imageBlock', length: 1, position: new Position( root, [ 0 ] ), _element: imageBlock },
-					{ type: 'insert', name: 'blockQuote', length: 1, position: new Position( root, [ 0 ] ), _element: blockQuote }
+					{ type: 'remove', name: 'imageBlock', length: 1, position: new Position( root, [ 0 ] ), action: 'remove' },
+					{ type: 'insert', name: 'blockQuote', length: 1, position: new Position( root, [ 0 ] ), action: 'insert' }
 				] );
 			} );
 		} );
@@ -2569,8 +2839,8 @@ describe( 'Differ', () => {
 				move( new Position( root, [ 0 ] ), 1, new Position( root, [ 1, 0 ] ) );
 
 				expectChanges( [
-					{ type: 'remove', name: 'imageBlock', length: 1, position: new Position( root, [ 0 ] ), _element: imageBlock },
-					{ type: 'insert', name: 'div', length: 1, position: new Position( root, [ 0 ] ), _element: div }
+					{ type: 'remove', name: 'imageBlock', length: 1, position: new Position( root, [ 0 ] ), action: 'remove' },
+					{ type: 'insert', name: 'div', length: 1, position: new Position( root, [ 0 ] ), action: 'insert' }
 				] );
 			} );
 		} );
@@ -2578,20 +2848,15 @@ describe( 'Differ', () => {
 		// #1392.
 		it( 'remove is correctly transformed by multiple affecting changes', () => {
 			root._appendChild( new Element( 'paragraph', null, new Text( 'xyz' ) ) );
-
-			const e1 = root.getChild( 0 );
-			const e2 = root.getChild( 1 );
-			const e3 = root.getChild( 2 );
-
 			model.change( writer => {
 				rename( root.getChild( 1 ), 'heading' );
 				rename( root.getChild( 2 ), 'heading' );
 				remove( writer.createPositionAt( root, 0 ), 3 );
 
 				expectChanges( [
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), _element: e1 },
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), _element: e2 },
-					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), _element: e3 }
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), action: 'remove' },
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), action: 'remove' },
+					{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 0 ] ), action: 'remove' }
 				] );
 			} );
 		} );
@@ -2639,8 +2904,8 @@ describe( 'Differ', () => {
 				differ._bufferRootLoad( newRoot );
 
 				expectChanges( [
-					{ type: 'insert', name: 'heading2', length: 1, position: new Position( newRoot, [ 0 ] ) },
-					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( newRoot, [ 1 ] ) }
+					{ type: 'insert', name: 'heading2', length: 1, position: new Position( newRoot, [ 0 ] ), action: 'insert' },
+					{ type: 'insert', name: 'paragraph', length: 1, position: new Position( newRoot, [ 1 ] ), action: 'insert' }
 				] );
 			} );
 		} );
@@ -2775,8 +3040,8 @@ describe( 'Differ', () => {
 			differ._refreshItem( p );
 
 			expectChanges( [
-				{ type: 'remove', name: 'paragraph', length: 1, position: model.createPositionBefore( p ), _element: p },
-				{ type: 'insert', name: 'paragraph', length: 1, position: model.createPositionBefore( p ), _element: p }
+				{ type: 'remove', action: 'refresh', name: 'paragraph', length: 1, position: model.createPositionBefore( p ) },
+				{ type: 'insert', action: 'refresh', name: 'paragraph', length: 1, position: model.createPositionBefore( p ) }
 			], true );
 
 			const refreshedItems = Array.from( differ.getRefreshedItems() );
@@ -2790,9 +3055,10 @@ describe( 'Differ', () => {
 
 			differ._refreshItem( textProxy );
 
+			// When text is refreshed its actions are still remove and insert.
 			expectChanges( [
-				{ type: 'remove', name: '$text', length: 3, position: model.createPositionAt( p, 0 ) },
-				{ type: 'insert', name: '$text', length: 3, position: model.createPositionAt( p, 0 ) }
+				{ type: 'remove', action: 'remove', name: '$text', length: 3, position: model.createPositionAt( p, 0 ) },
+				{ type: 'insert', action: 'insert', name: '$text', length: 3, position: model.createPositionAt( p, 0 ) }
 			], true );
 
 			const refreshedItems = Array.from( differ.getRefreshedItems() );
@@ -2809,7 +3075,7 @@ describe( 'Differ', () => {
 				differ._refreshItem( root.getChild( 2 ).getChild( 0 ) );
 
 				expectChanges( [
-					{ type: 'insert', name: 'blockQuote', length: 1, position: new Position( root, [ 2 ] ), _element: blockQuote }
+					{ type: 'insert', name: 'blockQuote', length: 1, position: new Position( root, [ 2 ] ), action: 'insert' }
 				] );
 
 				const refreshedItems = Array.from( differ.getRefreshedItems() );
@@ -2838,8 +3104,8 @@ describe( 'Differ', () => {
 			differ._refreshItem( element );
 
 			expectChanges( [
-				{ type: 'remove', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), _element: element },
-				{ type: 'insert', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ), _element: element }
+				{ type: 'remove', action: 'refresh', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ) },
+				{ type: 'insert', action: 'refresh', name: 'paragraph', length: 1, position: new Position( root, [ 1 ] ) }
 			] );
 
 			const markersToRemove = differ.getMarkersToRemove().map( entry => entry.name );
@@ -2847,6 +3113,49 @@ describe( 'Differ', () => {
 
 			expect( markersToRefresh ).to.deep.equal( markersToRemove );
 			expect( markersToRefresh ).to.deep.equal( markersToAdd );
+		} );
+
+		it( 'inserted element is refreshed', () => {
+			const element = new Element( 'paragraph' );
+			const position = new Position( root, [ 0 ] );
+
+			model.change( () => {
+				insert( element, position );
+
+				differ._refreshItem( element );
+
+				expectChanges( [
+					{
+						type: 'insert',
+						action: 'insert', // Stays as `insert`, as the end result is an insert, even though the element was refreshed too.
+						name: 'paragraph',
+						length: 1,
+						position: new Position( root, [ 0 ] ),
+						attributes: new Map( [] )
+					}
+				] );
+			} );
+		} );
+
+		it( 'refreshed element is removed', () => {
+			model.change( () => {
+				const p = root.getChild( 0 );
+
+				differ._refreshItem( p );
+
+				remove( new Position( root, [ 0 ] ), 1 );
+
+				expectChanges( [
+					{
+						type: 'remove',
+						action: 'remove', // The end result is `remove` (remove overwrites refresh).
+						name: 'paragraph',
+						length: 1,
+						position: new Position( root, [ 0 ] ),
+						attributes: new Map( [] )
+					}
+				] );
+			} );
 		} );
 	} );
 
@@ -3030,7 +3339,7 @@ describe( 'Differ', () => {
 				if ( Object.prototype.hasOwnProperty.call( expected[ i ], key ) ) {
 					if ( key == 'position' || key == 'range' ) {
 						expect( changes[ i ][ key ].isEqual( expected[ i ][ key ] ), `item ${ i }, key "${ key }"` ).to.be.true;
-					} else if ( key == 'attributes' ) {
+					} else if ( key == 'attributes' || key == 'before' || key == 'action' ) {
 						expect( changes[ i ][ key ], `item ${ i }, key "${ key }"` ).to.deep.equal( expected[ i ][ key ] );
 					} else {
 						expect( changes[ i ][ key ], `item ${ i }, key "${ key }"` ).to.equal( expected[ i ][ key ] );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (engine): Introduced `DiffItemInsert#action`, `DiffItemInsert#before` and `DiffItemRemove#action` which give more information about the change that happened in the model. Refer to the API docs to learn more. Closes #15800.