### PR TITLE
Allow URLs with custom protocols in links 

### DIFF
--- a/packages/ckeditor5-link/docs/features/link.md
+++ b/packages/ckeditor5-link/docs/features/link.md
@@ -185,7 +185,7 @@ ClassicEditor
 
 #### Adding custom protocols in links
 
-By default, a minimal set of protocols is allowed to be used in the links, and any link with an unrecognized protocol will fallback to `#`. You can overwrite the list of protocols by using {@link module:link/linkconfig~LinkConfig#allowedProtocols `config.link.allowedProtocols`}.
+By default, a minimal set of protocols is allowed to be used in the links, and any link with an unrecognized protocol will be removed from the element. You can overwrite the list of protocols by using {@link module:link/linkconfig~LinkConfig#allowedProtocols `config.link.allowedProtocols`}.
 
 See a configuration example:
 

--- a/packages/ckeditor5-link/docs/features/link.md
+++ b/packages/ckeditor5-link/docs/features/link.md
@@ -185,7 +185,7 @@ ClassicEditor
 
 #### Adding custom protocols in links
 
-By default, a minimal set of protocols is allowed to be used in the links, and any link with an unrecognized protocol will be removed from the element. You can overwrite the list of protocols by using {@link module:link/linkconfig~LinkConfig#allowedProtocols `config.link.allowedProtocols`}.
+By default, a minimal set of protocols is allowed to be used in the links. Any URL with an unrecognized protocol will be changed to '#'. You can overwrite the list of protocols by using {@link module:link/linkconfig~LinkConfig#allowedProtocols `config.link.allowedProtocols`}.
 
 See a configuration example:
 

--- a/packages/ckeditor5-link/docs/features/link.md
+++ b/packages/ckeditor5-link/docs/features/link.md
@@ -183,6 +183,30 @@ ClassicEditor
 	When enabled, this feature also provides the **email address autodetection** feature. When you submit `hello@example.com` in your content, the plugin will automatically change it to `mailto:hello@example.com`.
 </info-box>
 
+#### Adding custom protocols in links
+
+By default, a minimal set of protocols is allowed to be used in the links, and any link with an unrecognized protocol will fallback to `#`. You can overwrite the list of protocols by using {@link module:link/linkconfig~LinkConfig#allowedProtocols `config.link.allowedProtocols`}.
+
+See a configuration example:
+
+```js
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		link: {
+			// You can use `s?` suffix like below to allow both `http` and `https` protocols at the same time.
+			allowedProtocols: [ 'https?', 'tel', 'sms', 'sftp', 'smb', 'slack' ]
+		}
+		// More of the editor's configuration.
+ 		// ...
+	} )
+	.then( /* ... */ )
+	.catch( /* ... */ );
+```
+
+<info-box warning>
+	Please keep in mind that customizing this list is at your own risk - adding unsafe protocols like `javascript` can lead to serious security vulnerabilities!
+</info-box>
+
 #### Adding attributes to links based on predefined rules (automatic decorators)
 
 Automatic link decorators match all links in the editor content against a {@link module:link/linkconfig~LinkDecoratorAutomaticDefinition function} which decides whether the link should receive some set of attributes, considering the URL (`href`) of the link. These decorators work silently and the editor applies them during the {@link framework/architecture/editing-engine#conversion data downcast}.

--- a/packages/ckeditor5-link/src/linkconfig.ts
+++ b/packages/ckeditor5-link/src/linkconfig.ts
@@ -21,6 +21,7 @@ export enum COMMON_PROTOCOLS {
 	SSH = 'ssh',
 	GIT = 'git',
 	SVN = 'svn',
+	SAMBA = 'smb',
 	XMPP = 'xmpp',
 	SKYPE = 'skype',
 	SLACK = 'slack',
@@ -29,6 +30,14 @@ export enum COMMON_PROTOCOLS {
 	ZOOMMTG = 'zoommtg',
 	ZOOMUS = 'zoomus'
 }
+
+export const DEFAULT_LINK_PROTOCOLS = [
+	COMMON_PROTOCOLS.HTTPS,
+	COMMON_PROTOCOLS.FTPS,
+	COMMON_PROTOCOLS.TEL,
+	COMMON_PROTOCOLS.SMS,
+	COMMON_PROTOCOLS.MAIL
+];
 
 /**
  * The configuration of the {@link module:link/link~Link link feature}.

--- a/packages/ckeditor5-link/src/linkconfig.ts
+++ b/packages/ckeditor5-link/src/linkconfig.ts
@@ -9,6 +9,27 @@
 
 import type { ArrayOrItem } from 'ckeditor5/src/utils.js';
 
+export enum COMMON_PROTOCOLS {
+	HTTPS = 'https?',
+	FTPS = 'ftps?',
+	HTTPS_ONLY = 'https',
+	SFTP = 'sftp',
+	TEL = 'tel',
+	SMS = 'sms',
+	MAIL = 'mailto',
+	LOCALHOST = 'localhost',
+	SSH = 'ssh',
+	GIT = 'git',
+	SVN = 'svn',
+	XMPP = 'xmpp',
+	SKYPE = 'skype',
+	SLACK = 'slack',
+	VIBER = 'viber',
+	JABBER = 'jabber',
+	ZOOMMTG = 'zoommtg',
+	ZOOMUS = 'zoomus'
+}
+
 /**
  * The configuration of the {@link module:link/link~Link link feature}.
  *
@@ -47,6 +68,13 @@ export interface LinkConfig {
 	 * **NOTE:** If no configuration is provided, the editor will not auto-fix the links.
 	 */
 	defaultProtocol?: string;
+
+	/**
+	 * This is a protocols whitelist that can be used in links.
+	 * When not set, the editor will use a standard list of allowed protocols.
+	 * You can use common allowed protocols from the set of constants here (link to constants)
+	 */
+	allowedProtocols?: Array<string>;
 
 	/**
 	 * When set to `true`, the form will accept an empty value in the URL field, creating a link with an empty `href` (`<a href="">`).

--- a/packages/ckeditor5-link/src/linkconfig.ts
+++ b/packages/ckeditor5-link/src/linkconfig.ts
@@ -10,41 +10,12 @@
 import type { ArrayOrItem } from 'ckeditor5/src/utils.js';
 
 /**
- * This is a list of most commonly used protocols to make the link custom configuration a bit easier.
- * The {@link module:link/linkconfig~LinkConfig#allowedProtocols `allowedProtocols` } list
- * can also contain other values than enlisted here.
- */
-export enum COMMON_PROTOCOLS {
-	HTTPS = 'https?',
-	FTPS = 'ftps?',
-	HTTPS_ONLY = 'https',
-	SFTP = 'sftp',
-	TEL = 'tel',
-	SMS = 'sms',
-	MAIL = 'mailto',
-	SSH = 'ssh',
-	GIT = 'git',
-	SVN = 'svn',
-	SAMBA = 'smb',
-	XMPP = 'xmpp',
-	SKYPE = 'skype',
-	SLACK = 'slack',
-	VIBER = 'viber',
-	JABBER = 'jabber',
-	ZOOMMTG = 'zoommtg',
-	ZOOMUS = 'zoomus'
-}
-
-/**
  * @internal
  */
 export const DEFAULT_LINK_PROTOCOLS = [
-	COMMON_PROTOCOLS.HTTPS,
-	COMMON_PROTOCOLS.FTPS,
-	COMMON_PROTOCOLS.SFTP,
-	COMMON_PROTOCOLS.TEL,
-	COMMON_PROTOCOLS.SMS,
-	COMMON_PROTOCOLS.MAIL
+	'https?',
+	'ftps?',
+	'mailto'
 ];
 
 /**
@@ -89,7 +60,6 @@ export interface LinkConfig {
 	/**
 	 * This is a protocols whitelist that can be used in links, defined as an array of strings.
 	 * When not set, the editor will use a default list of allowed protocols.
-	 * You can use the {@link module:link/linkconfig~COMMON_PROTOCOLS common protocols list} for help.
 	 *
 	 * **Note:** Use this with caution and at your own risk - adding unsafe protocols like `javascript:`
 	 * can result in serious security vulnerabilities!
@@ -98,7 +68,7 @@ export interface LinkConfig {
 	 * ClassicEditor
 	 * 	.create( editorElement, {
 	 * 		link: {
-	 * 			allowedProtocols: ['http', 'https', 'ftp', 'tel', 'mailto', 'ssh']
+	 * 			allowedProtocols: [ 'http', 'https', 'ftp', 'tel', 'mailto', 'ssh' ]
 	 * 		}
 	 * 	} )
 	 * 	.then( ... )

--- a/packages/ckeditor5-link/src/linkconfig.ts
+++ b/packages/ckeditor5-link/src/linkconfig.ts
@@ -41,6 +41,7 @@ export enum COMMON_PROTOCOLS {
 export const DEFAULT_LINK_PROTOCOLS = [
 	COMMON_PROTOCOLS.HTTPS,
 	COMMON_PROTOCOLS.FTPS,
+	COMMON_PROTOCOLS.SFTP,
 	COMMON_PROTOCOLS.TEL,
 	COMMON_PROTOCOLS.SMS,
 	COMMON_PROTOCOLS.MAIL
@@ -89,6 +90,9 @@ export interface LinkConfig {
 	 * This is a protocols whitelist that can be used in links, defined as an array of strings.
 	 * When not set, the editor will use a default list of allowed protocols.
 	 * You can use the {@link module:link/linkconfig~COMMON_PROTOCOLS common protocols list} for help.
+	 *
+	 * **Note:** Use this with caution and at your own risk - adding unsafe protocols like `javascript:`
+	 * can result in serious security vulnerabilities!
 	 *
 	 * ```ts
 	 * ClassicEditor

--- a/packages/ckeditor5-link/src/linkconfig.ts
+++ b/packages/ckeditor5-link/src/linkconfig.ts
@@ -10,15 +10,6 @@
 import type { ArrayOrItem } from 'ckeditor5/src/utils.js';
 
 /**
- * @internal
- */
-export const DEFAULT_LINK_PROTOCOLS = [
-	'https?',
-	'ftps?',
-	'mailto'
-];
-
-/**
  * The configuration of the {@link module:link/link~Link link feature}.
  *
  * ```ts

--- a/packages/ckeditor5-link/src/linkconfig.ts
+++ b/packages/ckeditor5-link/src/linkconfig.ts
@@ -9,6 +9,11 @@
 
 import type { ArrayOrItem } from 'ckeditor5/src/utils.js';
 
+/**
+ * This is a list of most commonly used protocols to make the link custom configuration a bit easier.
+ * The {@link module:link/linkconfig~LinkConfig#allowedProtocols `allowedProtocols` } list
+ * can also contain other values than enlisted here.
+ */
 export enum COMMON_PROTOCOLS {
 	HTTPS = 'https?',
 	FTPS = 'ftps?',
@@ -17,7 +22,6 @@ export enum COMMON_PROTOCOLS {
 	TEL = 'tel',
 	SMS = 'sms',
 	MAIL = 'mailto',
-	LOCALHOST = 'localhost',
 	SSH = 'ssh',
 	GIT = 'git',
 	SVN = 'svn',
@@ -31,6 +35,9 @@ export enum COMMON_PROTOCOLS {
 	ZOOMUS = 'zoomus'
 }
 
+/**
+ * @internal
+ */
 export const DEFAULT_LINK_PROTOCOLS = [
 	COMMON_PROTOCOLS.HTTPS,
 	COMMON_PROTOCOLS.FTPS,
@@ -79,9 +86,21 @@ export interface LinkConfig {
 	defaultProtocol?: string;
 
 	/**
-	 * This is a protocols whitelist that can be used in links.
-	 * When not set, the editor will use a standard list of allowed protocols.
-	 * You can use common allowed protocols from the set of constants here (link to constants)
+	 * This is a protocols whitelist that can be used in links, defined as an array of strings.
+	 * When not set, the editor will use a default list of allowed protocols.
+	 * You can use the {@link module:link/linkconfig~COMMON_PROTOCOLS common protocols list} for help.
+	 *
+	 * ```ts
+	 * ClassicEditor
+	 * 	.create( editorElement, {
+	 * 		link: {
+	 * 			allowedProtocols: ['http', 'https', 'ftp', 'tel', 'mailto', 'ssh']
+	 * 		}
+	 * 	} )
+	 * 	.then( ... )
+	 * 	.catch( ... );
+	 * ```
+	 *
 	 */
 	allowedProtocols?: Array<string>;
 

--- a/packages/ckeditor5-link/src/linkediting.ts
+++ b/packages/ckeditor5-link/src/linkediting.ts
@@ -90,6 +90,7 @@ export default class LinkEditing extends Plugin {
 	 */
 	public init(): void {
 		const editor = this.editor;
+		const allowedProtocols = this.editor.config.get( 'link.allowedProtocols' );
 
 		// Allow link attribute on all inline nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: 'linkHref' } );
@@ -99,7 +100,7 @@ export default class LinkEditing extends Plugin {
 
 		editor.conversion.for( 'editingDowncast' )
 			.attributeToElement( { model: 'linkHref', view: ( href, conversionApi ) => {
-				return createLinkElement( ensureSafeUrl( href ), conversionApi );
+				return createLinkElement( ensureSafeUrl( href, allowedProtocols ), conversionApi );
 			} } );
 
 		editor.conversion.for( 'upcast' )

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -153,7 +153,7 @@ export default class LinkUI extends Plugin {
 	 */
 	private _createActionsView(): LinkActionsView {
 		const editor = this.editor;
-		const actionsView = new LinkActionsView( editor.locale );
+		const actionsView = new LinkActionsView( editor.locale, editor.config.get( 'link' ) );
 		const linkCommand: LinkCommand = editor.commands.get( 'link' )!;
 		const unlinkCommand: UnlinkCommand = editor.commands.get( 'unlink' )!;
 

--- a/packages/ckeditor5-link/src/ui/linkactionsview.ts
+++ b/packages/ckeditor5-link/src/ui/linkactionsview.ts
@@ -19,6 +19,7 @@ import '@ckeditor/ckeditor5-ui/theme/components/responsive-form/responsiveform.c
 import '../../theme/linkactions.css';
 
 import unlinkIcon from '../../theme/icons/unlink.svg';
+import type { LinkConfig } from '../linkconfig.js';
 
 /**
  * The link actions view class. This view displays the link preview, allows
@@ -67,12 +68,14 @@ export default class LinkActionsView extends View {
 	 */
 	private readonly _focusCycler: FocusCycler;
 
+	private readonly _linkConfig: LinkConfig;
+
 	declare public t: LocaleTranslate;
 
 	/**
 	 * @inheritDoc
 	 */
-	constructor( locale: Locale ) {
+	constructor( locale: Locale, linkConfig: LinkConfig = {} ) {
 		super( locale );
 
 		const t = locale.t;
@@ -82,6 +85,8 @@ export default class LinkActionsView extends View {
 		this.editButtonView = this._createButton( t( 'Edit link' ), icons.pencil, 'edit' );
 
 		this.set( 'href', undefined );
+
+		this._linkConfig = linkConfig;
 
 		this._focusCycler = new FocusCycler( {
 			focusables: this._focusables,
@@ -202,7 +207,7 @@ export default class LinkActionsView extends View {
 					'ck',
 					'ck-link-actions__preview'
 				],
-				href: bind.to( 'href', href => href && ensureSafeUrl( href ) ),
+				href: bind.to( 'href', href => href && ensureSafeUrl( href, this._linkConfig.allowedProtocols ) ),
 				target: '_blank',
 				rel: 'noopener noreferrer'
 			}

--- a/packages/ckeditor5-link/src/utils.ts
+++ b/packages/ckeditor5-link/src/utils.ts
@@ -19,11 +19,10 @@ import type {
 } from 'ckeditor5/src/engine.js';
 import type { LocaleTranslate } from 'ckeditor5/src/utils.js';
 
-import {
-	DEFAULT_LINK_PROTOCOLS,
-	type LinkDecoratorAutomaticDefinition,
-	type LinkDecoratorDefinition,
-	type LinkDecoratorManualDefinition
+import type {
+	LinkDecoratorAutomaticDefinition,
+	LinkDecoratorDefinition,
+	LinkDecoratorManualDefinition
 } from './linkconfig.js';
 
 import { upperFirst } from 'lodash-es';

--- a/packages/ckeditor5-link/src/utils.ts
+++ b/packages/ckeditor5-link/src/utils.ts
@@ -30,16 +30,7 @@ import { upperFirst } from 'lodash-es';
 
 const ATTRIBUTE_WHITESPACES = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205f\u3000]/g; // eslint-disable-line no-control-regex
 
-/* Building a link checking regex in parts for readability's sake. */
-
-// Part 1: basically any allowed protocol followed by ':' and any set of next characters (min. 1).
-const SAFE_PROTOCOLS_PLACEHOLDER = '(?:<protocols>):(?:\\S+)';
-// Part 2: any set of non-whitespace characters that doesn't include a ':' colon.
-const SAFE_URL_WITHOUT_COLONS = '(?:[^\\s:]+)';
-// Part 3: case for URLS which have port numbers after their hostnames, optionally with a following path/hash/query.
-const SAFE_URL_WITH_ALLOWED_COLON_FORMAT = '((?:[^\\s:]+)(?::\\d{2,5})(?:[/#?]\\S*)?)';
-
-const SAFE_URL_BASE = `^(?:${ SAFE_PROTOCOLS_PLACEHOLDER }|${ SAFE_URL_WITHOUT_COLONS }|${ SAFE_URL_WITH_ALLOWED_COLON_FORMAT })$`;
+const SAFE_URL_TEMPLATE = '^(?:(?:<protocols>):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))';
 
 // Simplified email test - should be run over previously found URL.
 const EMAIL_REG_EXP = /^[\S]+@((?![-_])(?:[-\w\u00a1-\uffff]{0,63}[^-_]\.))+(?:[a-z\u00a1-\uffff]{2,})$/i;
@@ -85,7 +76,7 @@ export function ensureSafeUrl( url: unknown, allowedProtocols: Array<string> = D
 	const urlString = String( url );
 
 	const protocolsList = allowedProtocols.join( '|' );
-	const customSafeRegex = new RegExp( `${ SAFE_URL_BASE.replace( '<protocols>', protocolsList ) }`, 'i' );
+	const customSafeRegex = new RegExp( `${ SAFE_URL_TEMPLATE.replace( '<protocols>', protocolsList ) }`, 'i' );
 
 	return isSafeUrl( urlString, customSafeRegex ) ? urlString : '#';
 }

--- a/packages/ckeditor5-link/src/utils.ts
+++ b/packages/ckeditor5-link/src/utils.ts
@@ -29,7 +29,6 @@ import {
 import { upperFirst } from 'lodash-es';
 
 const ATTRIBUTE_WHITESPACES = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205f\u3000]/g; // eslint-disable-line no-control-regex
-const SAFE_URL = /^(?:(?:https?|ftps?|mailto):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i;
 
 /* Building a link checking regex in parts for readability's sake. */
 
@@ -84,12 +83,9 @@ export function createLinkElement( href: string, { writer }: DowncastConversionA
  */
 export function ensureSafeUrl( url: unknown, allowedProtocols: Array<string> = DEFAULT_LINK_PROTOCOLS ): string {
 	const urlString = String( url );
-	let customSafeRegex;
 
-	if ( allowedProtocols ) {
-		const protocolsList = allowedProtocols.join( '|' );
-		customSafeRegex = new RegExp( `${ SAFE_URL_BASE.replace( '<protocols>', protocolsList ) }`, 'i' );
-	}
+	const protocolsList = allowedProtocols.join( '|' );
+	const customSafeRegex = new RegExp( `${ SAFE_URL_BASE.replace( '<protocols>', protocolsList ) }`, 'i' );
 
 	return isSafeUrl( urlString, customSafeRegex ) ? urlString : '#';
 }
@@ -97,10 +93,10 @@ export function ensureSafeUrl( url: unknown, allowedProtocols: Array<string> = D
 /**
  * Checks whether the given URL is safe for the user (does not contain any malicious code).
  */
-function isSafeUrl( url: string, customRegexp?: RegExp ): boolean {
+function isSafeUrl( url: string, customRegexp: RegExp ): boolean {
 	const normalizedUrl = url.replace( ATTRIBUTE_WHITESPACES, '' );
 
-	return !!normalizedUrl.match( customRegexp || SAFE_URL );
+	return !!normalizedUrl.match( customRegexp );
 }
 
 /**

--- a/packages/ckeditor5-link/src/utils.ts
+++ b/packages/ckeditor5-link/src/utils.ts
@@ -39,6 +39,12 @@ const EMAIL_REG_EXP = /^[\S]+@((?![-_])(?:[-\w\u00a1-\uffff]{0,63}[^-_]\.))+(?:[
 // or non-word characters at the beginning of the link ('/', '#' etc.).
 const PROTOCOL_REG_EXP = /^((\w+:(\/{2,})?)|(\W))/i;
 
+const DEFAULT_LINK_PROTOCOLS = [
+	'https?',
+	'ftps?',
+	'mailto'
+];
+
 /**
  * A keystroke used by the {@link module:link/linkui~LinkUI link UI feature}.
  */

--- a/packages/ckeditor5-link/src/utils.ts
+++ b/packages/ckeditor5-link/src/utils.ts
@@ -30,6 +30,8 @@ import { upperFirst } from 'lodash-es';
 const ATTRIBUTE_WHITESPACES = /[\u0000-\u0020\u00A0\u1680\u180E\u2000-\u2029\u205f\u3000]/g; // eslint-disable-line no-control-regex
 const SAFE_URL = /^(?:(?:https?|ftps?|mailto):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))/i;
 
+const SAFE_URL_BASE = '^(?:(?:<protocols>):|[^a-z]|[a-z+.-]+(?:[^a-z+.:-]|$))';
+
 // Simplified email test - should be run over previously found URL.
 const EMAIL_REG_EXP = /^[\S]+@((?![-_])(?:[-\w\u00a1-\uffff]{0,63}[^-_]\.))+(?:[a-z\u00a1-\uffff]{2,})$/i;
 
@@ -70,8 +72,15 @@ export function createLinkElement( href: string, { writer }: DowncastConversionA
  *
  * @internal
  */
-export function ensureSafeUrl( url: unknown ): string {
+export function ensureSafeUrl( url: unknown, allowedProtocols?: Array<string> ): string {
 	const urlString = String( url );
+
+	if ( allowedProtocols ) {
+		const protocolsList = allowedProtocols.join( '|' );
+		const customSafeRegex = new RegExp( `${ SAFE_URL_BASE.replace( '<protocols>', protocolsList ) }`, 'i' );
+		console.log( customSafeRegex );
+		// Make a regex out of allowedProtocols.
+	}
 
 	return isSafeUrl( urlString ) ? urlString : '#';
 }

--- a/packages/ckeditor5-link/tests/linkediting.js
+++ b/packages/ckeditor5-link/tests/linkediting.js
@@ -168,7 +168,7 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
-				'foo<$text linkHref="ckeditor.com" linkIsExternal="true">INSERTED</$text>[]' +
+					'foo<$text linkHref="ckeditor.com" linkIsExternal="true">INSERTED</$text>[]' +
 				'</paragraph>'
 			);
 
@@ -184,8 +184,8 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
-				'<$text linkHref="ckeditor.com">foo</$text>' +
-				'<$text bold="true">INSERTED[]</$text>' +
+					'<$text linkHref="ckeditor.com">foo</$text>' +
+					'<$text bold="true">INSERTED[]</$text>' +
 				'</paragraph>'
 			);
 
@@ -220,9 +220,9 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
-				'foo' +
-				'<$text bold="true">INSERTED</$text>[]' +
-				'<$text linkHref="ckeditor.com">bar</$text>' +
+					'foo' +
+					'<$text bold="true">INSERTED</$text>[]' +
+					'<$text linkHref="ckeditor.com">bar</$text>' +
 				'</paragraph>'
 			);
 
@@ -239,9 +239,9 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
-				'<$text linkHref="ckeditor.com">f</$text>' +
-				'<$text linkHref="http://INSERTED">INSERTED</$text>[]' +
-				'<$text linkHref="ckeditor.com">oo</$text>' +
+					'<$text linkHref="ckeditor.com">f</$text>' +
+					'<$text linkHref="http://INSERTED">INSERTED</$text>[]' +
+					'<$text linkHref="ckeditor.com">oo</$text>' +
 				'</paragraph>'
 			);
 
@@ -259,8 +259,8 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
-				'<$text linkHref="http://INSERTED">INSERTED</$text>[]' +
-				'<$text linkHref="ckeditor.com">foo</$text>' +
+					'<$text linkHref="http://INSERTED">INSERTED</$text>[]' +
+					'<$text linkHref="ckeditor.com">foo</$text>' +
 				'</paragraph>'
 			);
 
@@ -282,7 +282,7 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
-				'<$text linkHref="ckeditor.com">fbar[]oo</$text>' +
+					'<$text linkHref="ckeditor.com">fbar[]oo</$text>' +
 				'</paragraph>'
 			);
 		} );
@@ -398,7 +398,7 @@ describe( 'LinkEditing', () => {
 
 			setModelData( model,
 				'<paragraph>' +
-				'<$text linkHref="url">a</$text><$text foo="true" linkHref="url">b</$text><$text linkHref="url">c</$text>' +
+					'<$text linkHref="url">a</$text><$text foo="true" linkHref="url">b</$text><$text linkHref="url">c</$text>' +
 				'</paragraph>' );
 
 			expect( editor.getData() ).to.equal( '<p><a href="url">a<f>b</f>c</a></p>' );
@@ -927,9 +927,9 @@ describe( 'LinkEditing', () => {
 
 				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
 					'<paragraph>' +
-					'<$text linkHref="url" linkIsDownloadable="true" linkIsExternal="true">Foo</$text>' +
-					'<$text linkHref="example.com" linkIsFile="true">Bar</$text>' +
-					'<$text linkHref="example.com" linkIsDownloadable="true">Baz</$text>' +
+						'<$text linkHref="url" linkIsDownloadable="true" linkIsExternal="true">Foo</$text>' +
+						'<$text linkHref="example.com" linkIsFile="true">Bar</$text>' +
+						'<$text linkHref="example.com" linkIsDownloadable="true">Baz</$text>' +
 					'</paragraph>'
 				);
 
@@ -966,8 +966,8 @@ describe( 'LinkEditing', () => {
 
 				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
 					'<paragraph>' +
-					'<$text linkHref="url">Foo</$text>' +
-					'<$text linkHref="example.com">Bar</$text>' +
+						'<$text linkHref="url">Foo</$text>' +
+						'<$text linkHref="example.com">Bar</$text>' +
 					'</paragraph>'
 				);
 
@@ -2060,11 +2060,11 @@ describe( 'LinkEditing', () => {
 		it( 'should not preserve the `linkHref` attribute when deleting content after the link (decorators check)', () => {
 			setModelData( model,
 				'<paragraph>' +
-				'This is ' +
-				'<$text linkIsFoo="true" linkIsBar="true" linkHref="foo">Foo</$text>' +
-				' []from ' +
-				'<$text linkHref="bar">Bar</$text>' +
-				'.' +
+					'This is ' +
+					'<$text linkIsFoo="true" linkIsBar="true" linkHref="foo">Foo</$text>' +
+					' []from ' +
+					'<$text linkHref="bar">Bar</$text>' +
+					'.' +
 				'</paragraph>'
 			);
 
@@ -2096,11 +2096,11 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
-				'This is ' +
-				'<$text linkHref="foo" linkIsBar="true" linkIsFoo="true">Fo</$text>' +
-				'[]from ' +
-				'<$text linkHref="bar">Bar</$text>' +
-				'.' +
+					'This is ' +
+					'<$text linkHref="foo" linkIsBar="true" linkIsFoo="true">Fo</$text>' +
+					'[]from ' +
+					'<$text linkHref="bar">Bar</$text>' +
+					'.' +
 				'</paragraph>'
 			);
 		} );

--- a/packages/ckeditor5-link/tests/linkediting.js
+++ b/packages/ckeditor5-link/tests/linkediting.js
@@ -101,7 +101,7 @@ describe( 'LinkEditing', () => {
 			// So let's simulate the `keydown` event.
 			editor.editing.view.document.fire( 'keydown', {
 				keyCode: keyCodes.arrowright,
-				preventDefault: () => {},
+				preventDefault: () => { },
 				domTarget: document.body
 			} );
 
@@ -132,7 +132,7 @@ describe( 'LinkEditing', () => {
 			// So let's simulate the `keydown` event.
 			editor.editing.view.document.fire( 'keydown', {
 				keyCode: keyCodes.arrowleft,
-				preventDefault: () => {},
+				preventDefault: () => { },
 				domTarget: document.body
 			} );
 
@@ -168,7 +168,7 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
-					'foo<$text linkHref="ckeditor.com" linkIsExternal="true">INSERTED</$text>[]' +
+				'foo<$text linkHref="ckeditor.com" linkIsExternal="true">INSERTED</$text>[]' +
 				'</paragraph>'
 			);
 
@@ -184,8 +184,8 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
-					'<$text linkHref="ckeditor.com">foo</$text>' +
-					'<$text bold="true">INSERTED[]</$text>' +
+				'<$text linkHref="ckeditor.com">foo</$text>' +
+				'<$text bold="true">INSERTED[]</$text>' +
 				'</paragraph>'
 			);
 
@@ -208,7 +208,7 @@ describe( 'LinkEditing', () => {
 
 			view.document.fire( 'keydown', {
 				keyCode: keyCodes.arrowright,
-				preventDefault: () => {},
+				preventDefault: () => { },
 				domTarget: document.body
 			} );
 
@@ -220,9 +220,9 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
-					'foo' +
-					'<$text bold="true">INSERTED</$text>[]' +
-					'<$text linkHref="ckeditor.com">bar</$text>' +
+				'foo' +
+				'<$text bold="true">INSERTED</$text>[]' +
+				'<$text linkHref="ckeditor.com">bar</$text>' +
 				'</paragraph>'
 			);
 
@@ -239,9 +239,9 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
-					'<$text linkHref="ckeditor.com">f</$text>' +
-					'<$text linkHref="http://INSERTED">INSERTED</$text>[]' +
-					'<$text linkHref="ckeditor.com">oo</$text>' +
+				'<$text linkHref="ckeditor.com">f</$text>' +
+				'<$text linkHref="http://INSERTED">INSERTED</$text>[]' +
+				'<$text linkHref="ckeditor.com">oo</$text>' +
 				'</paragraph>'
 			);
 
@@ -259,8 +259,8 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
-					'<$text linkHref="http://INSERTED">INSERTED</$text>[]' +
-					'<$text linkHref="ckeditor.com">foo</$text>' +
+				'<$text linkHref="http://INSERTED">INSERTED</$text>[]' +
+				'<$text linkHref="ckeditor.com">foo</$text>' +
 				'</paragraph>'
 			);
 
@@ -282,7 +282,7 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
-					'<$text linkHref="ckeditor.com">fbar[]oo</$text>' +
+				'<$text linkHref="ckeditor.com">fbar[]oo</$text>' +
 				'</paragraph>'
 			);
 		} );
@@ -398,7 +398,7 @@ describe( 'LinkEditing', () => {
 
 			setModelData( model,
 				'<paragraph>' +
-					'<$text linkHref="url">a</$text><$text foo="true" linkHref="url">b</$text><$text linkHref="url">c</$text>' +
+				'<$text linkHref="url">a</$text><$text foo="true" linkHref="url">b</$text><$text linkHref="url">c</$text>' +
 				'</paragraph>' );
 
 			expect( editor.getData() ).to.equal( '<p><a href="url">a<f>b</f>c</a></p>' );
@@ -409,6 +409,38 @@ describe( 'LinkEditing', () => {
 
 			expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
 				.to.equal( '<p><a href="#">foo</a>bar</p>' );
+		} );
+
+		describe( 'links with custom protocols', () => {
+			let editor, model;
+
+			beforeEach( async () => {
+				editor = await ClassicTestEditor.create( element, {
+					plugins: [ Paragraph, LinkEditing, Enter ],
+					link: {
+						allowedProtocols: [ 'https', 'custom' ]
+					}
+				} );
+
+				model = editor.model;
+				view = editor.editing.view;
+
+				model.schema.extend( '$text', {
+					allowIn: '$root',
+					allowAttributes: [ 'linkIsFoo', 'linkIsBar' ]
+				} );
+			} );
+
+			afterEach( async () => {
+				await editor.destroy();
+			} );
+
+			it( 'should render a link with a custom protocol, if provided in the custom allowed protocols', () => {
+				setModelData( model, '<paragraph><$text linkHref="custom:address.in.app">[]foo</$text>bar[]</paragraph>' );
+
+				expect( getViewData( editor.editing.view, { withoutSelection: true } ) )
+					.to.equal( '<p><a href="custom:address.in.app">foo</a>bar</p>' );
+			} );
 		} );
 	} );
 
@@ -895,9 +927,9 @@ describe( 'LinkEditing', () => {
 
 				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
 					'<paragraph>' +
-						'<$text linkHref="url" linkIsDownloadable="true" linkIsExternal="true">Foo</$text>' +
-						'<$text linkHref="example.com" linkIsFile="true">Bar</$text>' +
-						'<$text linkHref="example.com" linkIsDownloadable="true">Baz</$text>' +
+					'<$text linkHref="url" linkIsDownloadable="true" linkIsExternal="true">Foo</$text>' +
+					'<$text linkHref="example.com" linkIsFile="true">Bar</$text>' +
+					'<$text linkHref="example.com" linkIsDownloadable="true">Baz</$text>' +
 					'</paragraph>'
 				);
 
@@ -934,8 +966,8 @@ describe( 'LinkEditing', () => {
 
 				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
 					'<paragraph>' +
-						'<$text linkHref="url">Foo</$text>' +
-						'<$text linkHref="example.com">Bar</$text>' +
+					'<$text linkHref="url">Foo</$text>' +
+					'<$text linkHref="example.com">Bar</$text>' +
 					'</paragraph>'
 				);
 
@@ -1152,7 +1184,7 @@ describe( 'LinkEditing', () => {
 					keyCode: keyCodes.enter,
 					domEvent: {
 						keyCode: keyCodes.enter,
-						preventDefault: () => {},
+						preventDefault: () => { },
 						target: document.body,
 						...options
 					},
@@ -2006,7 +2038,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( false );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => {}
+				preventDefault: () => { }
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2015,7 +2047,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( false );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => {}
+				preventDefault: () => { }
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2028,11 +2060,11 @@ describe( 'LinkEditing', () => {
 		it( 'should not preserve the `linkHref` attribute when deleting content after the link (decorators check)', () => {
 			setModelData( model,
 				'<paragraph>' +
-					'This is ' +
-					'<$text linkIsFoo="true" linkIsBar="true" linkHref="foo">Foo</$text>' +
-					' []from ' +
-					'<$text linkHref="bar">Bar</$text>' +
-					'.' +
+				'This is ' +
+				'<$text linkIsFoo="true" linkIsBar="true" linkHref="foo">Foo</$text>' +
+				' []from ' +
+				'<$text linkHref="bar">Bar</$text>' +
+				'.' +
 				'</paragraph>'
 			);
 
@@ -2041,7 +2073,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial "linkHref" state' ).to.equal( false );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => {}
+				preventDefault: () => { }
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2052,7 +2084,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link ("linkHref")' ).to.equal( false );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => {}
+				preventDefault: () => { }
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2064,11 +2096,11 @@ describe( 'LinkEditing', () => {
 
 			expect( getModelData( model ) ).to.equal(
 				'<paragraph>' +
-					'This is ' +
-					'<$text linkHref="foo" linkIsBar="true" linkIsFoo="true">Fo</$text>' +
-					'[]from ' +
-					'<$text linkHref="bar">Bar</$text>' +
-					'.' +
+				'This is ' +
+				'<$text linkHref="foo" linkIsBar="true" linkIsFoo="true">Fo</$text>' +
+				'[]from ' +
+				'<$text linkHref="bar">Bar</$text>' +
+				'.' +
 				'</paragraph>'
 			);
 		} );
@@ -2079,7 +2111,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( true );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => {}
+				preventDefault: () => { }
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2088,7 +2120,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( true );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => {}
+				preventDefault: () => { }
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2104,7 +2136,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( true );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => {}
+				preventDefault: () => { }
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2113,7 +2145,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( true );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => {}
+				preventDefault: () => { }
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2127,14 +2159,14 @@ describe( 'LinkEditing', () => {
 			setModelData( model, '<paragraph>Foo <$text bold="true">Bolded.</$text> []Bar</paragraph>' );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => {}
+				preventDefault: () => { }
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
 			} ) );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => {}
+				preventDefault: () => { }
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2149,7 +2181,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( false );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => {}
+				preventDefault: () => { }
 			}, {
 				direction: 'forward',
 				selectionToRemove: view.document.selection
@@ -2166,7 +2198,7 @@ describe( 'LinkEditing', () => {
 			getData( type ) {
 				return data[ type ];
 			},
-			setData() {}
+			setData() { }
 		};
 	}
 } );

--- a/packages/ckeditor5-link/tests/linkediting.js
+++ b/packages/ckeditor5-link/tests/linkediting.js
@@ -101,7 +101,7 @@ describe( 'LinkEditing', () => {
 			// So let's simulate the `keydown` event.
 			editor.editing.view.document.fire( 'keydown', {
 				keyCode: keyCodes.arrowright,
-				preventDefault: () => { },
+				preventDefault: () => {},
 				domTarget: document.body
 			} );
 
@@ -132,7 +132,7 @@ describe( 'LinkEditing', () => {
 			// So let's simulate the `keydown` event.
 			editor.editing.view.document.fire( 'keydown', {
 				keyCode: keyCodes.arrowleft,
-				preventDefault: () => { },
+				preventDefault: () => {},
 				domTarget: document.body
 			} );
 
@@ -208,7 +208,7 @@ describe( 'LinkEditing', () => {
 
 			view.document.fire( 'keydown', {
 				keyCode: keyCodes.arrowright,
-				preventDefault: () => { },
+				preventDefault: () => {},
 				domTarget: document.body
 			} );
 
@@ -1184,7 +1184,7 @@ describe( 'LinkEditing', () => {
 					keyCode: keyCodes.enter,
 					domEvent: {
 						keyCode: keyCodes.enter,
-						preventDefault: () => { },
+						preventDefault: () => {},
 						target: document.body,
 						...options
 					},
@@ -2038,7 +2038,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( false );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => { }
+				preventDefault: () => {}
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2047,7 +2047,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( false );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => { }
+				preventDefault: () => {}
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2073,7 +2073,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial "linkHref" state' ).to.equal( false );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => { }
+				preventDefault: () => {}
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2084,7 +2084,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link ("linkHref")' ).to.equal( false );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => { }
+				preventDefault: () => {}
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2111,7 +2111,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( true );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => { }
+				preventDefault: () => {}
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2120,7 +2120,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( true );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => { }
+				preventDefault: () => {}
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2136,7 +2136,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( true );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => { }
+				preventDefault: () => {}
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2145,7 +2145,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'removing space after the link' ).to.equal( true );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => { }
+				preventDefault: () => {}
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2159,14 +2159,14 @@ describe( 'LinkEditing', () => {
 			setModelData( model, '<paragraph>Foo <$text bold="true">Bolded.</$text> []Bar</paragraph>' );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => { }
+				preventDefault: () => {}
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
 			} ) );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => { }
+				preventDefault: () => {}
 			}, {
 				direction: 'backward',
 				selectionToRemove: view.document.selection
@@ -2181,7 +2181,7 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.hasAttribute( 'linkHref' ), 'initial state' ).to.equal( false );
 
 			view.document.fire( 'delete', new DomEventData( view.document, {
-				preventDefault: () => { }
+				preventDefault: () => {}
 			}, {
 				direction: 'forward',
 				selectionToRemove: view.document.selection
@@ -2198,7 +2198,7 @@ describe( 'LinkEditing', () => {
 			getData( type ) {
 				return data[ type ];
 			},
-			setData() { }
+			setData() {}
 		};
 	}
 } );

--- a/packages/ckeditor5-link/tests/ui/linkactionsview.js
+++ b/packages/ckeditor5-link/tests/ui/linkactionsview.js
@@ -64,6 +64,21 @@ describe( 'LinkActionsView', () => {
 			expect( view._focusables ).to.be.instanceOf( ViewCollection );
 		} );
 
+		it( 'should create #_linkConfig as empty object by default', () => {
+			expect( view._linkConfig ).to.be.empty;
+		} );
+
+		it( 'should create #_linkConfig containing config object passed as argument', () => {
+			const customConfig = { allowedProtocols: [ 'https', 'ftps', 'tel', 'sms' ] };
+
+			const view = new LinkActionsView( { t: () => { } }, customConfig );
+			view.render();
+
+			expect( view._linkConfig ).to.equal( customConfig );
+
+			view.destroy();
+		} );
+
 		it( 'should fire `edit` event on editButtonView#execute', () => {
 			const spy = sinon.spy();
 

--- a/packages/ckeditor5-link/tests/utils.js
+++ b/packages/ckeditor5-link/tests/utils.js
@@ -82,28 +82,31 @@ describe( 'utils', () => {
 			expect( ensureSafeUrl( url ) ).to.equal( url );
 		} );
 
-		it( 'returns the same absolute sftp URL', () => {
-			const url = 'sftp://xx.yy/zz';
-
-			expect( ensureSafeUrl( url ) ).to.equal( url );
-		} );
-
 		it( 'returns the same absolute mailto URL', () => {
 			const url = 'mailto://foo@bar.com';
 
 			expect( ensureSafeUrl( url ) ).to.equal( url );
 		} );
 
-		it( 'returns the same absolute tel URL', () => {
+		it( 'returns the same absolute tel URL (if allowed in config)', () => {
 			const url = 'tel:+48123456789';
+			const allowedCustomProtocols = [ 'tel' ];
 
-			expect( ensureSafeUrl( url ) ).to.equal( url );
+			expect( ensureSafeUrl( url, allowedCustomProtocols ) ).to.equal( url );
 		} );
 
-		it( 'returns the same absolute sms URL', () => {
+		it( 'returns the same absolute sms URL (if allowed in config)', () => {
 			const url = 'sms:+48987654321';
+			const allowedCustomProtocols = [ 'sms' ];
 
-			expect( ensureSafeUrl( url ) ).to.equal( url );
+			expect( ensureSafeUrl( url, allowedCustomProtocols ) ).to.equal( url );
+		} );
+
+		it( 'returns the same absolute sftp URL (if allowed in config)', () => {
+			const url = 'sftp://xx.yy/zz';
+			const allowedCustomProtocols = [ 'sftp' ];
+
+			expect( ensureSafeUrl( url, allowedCustomProtocols ) ).to.equal( url );
 		} );
 
 		it( 'returns the same relative URL (starting with a dot)', () => {
@@ -175,6 +178,12 @@ describe( 'utils', () => {
 		it( 'accepts non string values', () => {
 			expect( ensureSafeUrl( undefined ) ).to.equal( 'undefined' );
 			expect( ensureSafeUrl( null ) ).to.equal( 'null' );
+		} );
+
+		it( 'returns safe URL when there is character junk in the URL', () => {
+			const url = '::%^#.foo.com';
+
+			expect( ensureSafeUrl( url ) ).to.equal( '#' );
 		} );
 
 		it( 'returns safe URL when a malicious URL starts with javascript:', () => {

--- a/packages/ckeditor5-link/tests/utils.js
+++ b/packages/ckeditor5-link/tests/utils.js
@@ -82,8 +82,26 @@ describe( 'utils', () => {
 			expect( ensureSafeUrl( url ) ).to.equal( url );
 		} );
 
+		it( 'returns the same absolute sftp URL', () => {
+			const url = 'sftp://xx.yy/zz';
+
+			expect( ensureSafeUrl( url ) ).to.equal( url );
+		} );
+
 		it( 'returns the same absolute mailto URL', () => {
 			const url = 'mailto://foo@bar.com';
+
+			expect( ensureSafeUrl( url ) ).to.equal( url );
+		} );
+
+		it( 'returns the same absolute tel URL', () => {
+			const url = 'tel:+48123456789';
+
+			expect( ensureSafeUrl( url ) ).to.equal( url );
+		} );
+
+		it( 'returns the same absolute sms URL', () => {
+			const url = 'sms:+48987654321';
 
 			expect( ensureSafeUrl( url ) ).to.equal( url );
 		} );
@@ -118,6 +136,12 @@ describe( 'utils', () => {
 			expect( ensureSafeUrl( url ) ).to.equal( url );
 		} );
 
+		it( 'returns the same relative URL (starting with hash)', () => {
+			const url = '#thatsection1';
+
+			expect( ensureSafeUrl( url ) ).to.equal( url );
+		} );
+
 		it( 'returns the same URL even if it contains whitespaces', () => {
 			const url = '  ./xx/ yyy\t';
 
@@ -126,6 +150,24 @@ describe( 'utils', () => {
 
 		it( 'returns the same URL even if it contains non ASCII characters', () => {
 			const url = 'https://kłącze.yy/źdźbło';
+
+			expect( ensureSafeUrl( url ) ).to.equal( url );
+		} );
+
+		it( 'returns the same URL even if it contains a :port part', () => {
+			const url = 'localhost:12345';
+
+			expect( ensureSafeUrl( url ) ).to.equal( url );
+		} );
+
+		it( 'returns the same URL even if it contains a :port and a path after it', () => {
+			const url = 'localhost:678/pathafterwards';
+
+			expect( ensureSafeUrl( url ) ).to.equal( url );
+		} );
+
+		it( 'returns the same URL even if it starts with an IP address', () => {
+			const url = '192.178.10.123/subpath';
 
 			expect( ensureSafeUrl( url ) ).to.equal( url );
 		} );
@@ -143,6 +185,19 @@ describe( 'utils', () => {
 
 		it( 'returns safe URL when a malicious URL starts with an unknown protocol', () => {
 			const url = 'foo:alert(1)';
+
+			expect( ensureSafeUrl( url ) ).to.equal( '#' );
+		} );
+
+		it( 'returns the same URL when the URL contains a custom protocol defined in the allowedProtocols parameter', () => {
+			const url = 'foo:customurl.resource';
+			const allowedCustomProtocols = [ 'https', 'http', 'foo' ];
+
+			expect( ensureSafeUrl( url, allowedCustomProtocols ) ).to.equal( url );
+		} );
+
+		it( 'returns safe URL when a malicious URL starts with an unknown protocol (with numbers & dots)', () => {
+			const url = 'foo2bar.baz:alert(1)';
 
 			expect( ensureSafeUrl( url ) ).to.equal( '#' );
 		} );

--- a/packages/ckeditor5-link/tests/utils.js
+++ b/packages/ckeditor5-link/tests/utils.js
@@ -157,18 +157,6 @@ describe( 'utils', () => {
 			expect( ensureSafeUrl( url ) ).to.equal( url );
 		} );
 
-		it( 'returns the same URL even if it contains a :port part', () => {
-			const url = 'localhost:12345';
-
-			expect( ensureSafeUrl( url ) ).to.equal( url );
-		} );
-
-		it( 'returns the same URL even if it contains a :port and a path after it', () => {
-			const url = 'localhost:678/pathafterwards';
-
-			expect( ensureSafeUrl( url ) ).to.equal( url );
-		} );
-
 		it( 'returns the same URL even if it starts with an IP address', () => {
 			const url = '192.178.10.123/subpath';
 
@@ -178,12 +166,6 @@ describe( 'utils', () => {
 		it( 'accepts non string values', () => {
 			expect( ensureSafeUrl( undefined ) ).to.equal( 'undefined' );
 			expect( ensureSafeUrl( null ) ).to.equal( 'null' );
-		} );
-
-		it( 'returns safe URL when there is character junk in the URL', () => {
-			const url = '::%^#.foo.com';
-
-			expect( ensureSafeUrl( url ) ).to.equal( '#' );
 		} );
 
 		it( 'returns safe URL when a malicious URL starts with javascript:', () => {
@@ -203,12 +185,6 @@ describe( 'utils', () => {
 			const allowedCustomProtocols = [ 'https', 'http', 'foo' ];
 
 			expect( ensureSafeUrl( url, allowedCustomProtocols ) ).to.equal( url );
-		} );
-
-		it( 'returns safe URL when a malicious URL starts with an unknown protocol (with numbers & dots)', () => {
-			const url = 'foo2bar.baz:alert(1)';
-
-			expect( ensureSafeUrl( url ) ).to.equal( '#' );
 		} );
 
 		it( 'returns safe URL when a malicious URL contains spaces', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))


Feature (link): Added the ability to specify allowed URL protocols by introducing the `link.allowedProtocols` configuration property. Closes #14304.

---

### Additional information

I'm unsure which is better: whether the `allowedProtocols` should override the default protocols list or merge with it, when set.

Kept the old regex intact (only added replace tag for the custom list), but there's definitely room for improvement there, I described it at https://github.com/ckeditor/ckeditor5/issues/15915