### PR TITLE
 Inline image resizing miscalculations / Resizing an image to make it smaller sometimes does the opposite 

### DIFF
--- a/packages/ckeditor5-image/src/imageresize/imageresizehandles.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizehandles.ts
@@ -104,11 +104,11 @@ export default class ImageResizeHandles extends Plugin {
 						// Return the model image element parent to avoid setting an inline element (<a>/<span>) as a resize host.
 						return domConverter.mapViewToDom( mapper.toViewElement( imageModel.parent as Element )! ) as HTMLElement;
 					},
-					// TODO consider other positions.
+
 					isCentered() {
 						const imageStyle = imageModel.getAttribute( 'imageStyle' );
 
-						return !imageStyle || imageStyle == 'block' || imageStyle == 'alignCenter';
+						return imageStyle == 'alignCenter';
 					},
 
 					onCommit( newValue ) {

--- a/packages/ckeditor5-image/tests/imageresize/imageresizehandles.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizehandles.js
@@ -87,7 +87,7 @@ describe( 'ImageResizeHandles', () => {
 				resizerMouseSimulator.dragTo( editor, domParts.resizeHandle, finalPointerPosition );
 
 				expect( spy.calledOnce ).to.be.true;
-				expect( spy.args[ 0 ][ 0 ] ).to.deep.equal( { width: '80px' } );
+				expect( spy.args[ 0 ][ 0 ] ).to.deep.equal( { width: '90px' } );
 			} );
 
 			it( 'disables the resizer if the command is disabled', async () => {
@@ -146,7 +146,7 @@ describe( 'ImageResizeHandles', () => {
 				resizerMouseSimulator.dragTo( editor, domParts.resizeHandle, finalPointerPosition );
 
 				expect( stub.calledOnce ).to.be.true;
-				expect( stub.args[ 0 ][ 0 ] ).to.deep.equal( { width: '80px' } );
+				expect( stub.args[ 0 ][ 0 ] ).to.deep.equal( { width: '90px' } );
 
 				expect( widget.hasClass( 'image_resized' ), 'CSS class' ).to.be.false;
 				expect( widget.hasStyle( 'width' ), 'width style' ).to.be.false;
@@ -564,7 +564,7 @@ describe( 'ImageResizeHandles', () => {
 				resizerMouseSimulator.dragTo( editor, domParts.resizeHandle, finalPointerPosition );
 
 				expect( spy.calledOnce ).to.be.true;
-				expect( spy.args[ 0 ][ 0 ] ).to.deep.equal( { width: '80px' } );
+				expect( spy.args[ 0 ][ 0 ] ).to.deep.equal( { width: '90px' } );
 			} );
 
 			it( 'disables the resizer if the command is disabled', async () => {
@@ -807,7 +807,7 @@ describe( 'ImageResizeHandles', () => {
 
 			resizerMouseSimulator.dragTo( editor, domParts.resizeHandle, finalPointerPosition );
 
-			sinon.assert.calledWithExactly( spy.firstCall, { width: '80px' } );
+			sinon.assert.calledWithExactly( spy.firstCall, { width: '90px' } );
 
 			await editor.destroy();
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (image):  Inline image resizing miscalculations / Resizing an image to make it smaller sometimes does the opposite. Closes #10267.

