### PR TITLE
Source editing should not add white spaces to pre-formatted code lines

### DIFF
--- a/packages/ckeditor5-source-editing/src/utils/formathtml.ts
+++ b/packages/ckeditor5-source-editing/src/utils/formathtml.ts
@@ -79,7 +79,7 @@ export function formatHtml( input: string ): string {
 		.split( '\n' );
 
 	let indentCount = 0;
-	let isPreformattedLine: 'first' | 'last' | 'middle' | false = false;
+	let isPreformattedLine: ReturnType<typeof isPreformattedBlockLine> = false;
 
 	return lines
 		.filter( line => line.length )

--- a/packages/ckeditor5-source-editing/src/utils/formathtml.ts
+++ b/packages/ckeditor5-source-editing/src/utils/formathtml.ts
@@ -79,16 +79,23 @@ export function formatHtml( input: string ): string {
 		.split( '\n' );
 
 	let indentCount = 0;
+	let isPreformattedLine: 'first' | 'last' | 'middle' | false = false;
 
 	return lines
 		.filter( line => line.length )
 		.map( line => {
+			isPreformattedLine = isPreformattedBlockLine( line, isPreformattedLine );
+
 			if ( isNonVoidOpeningTag( line, elementsToFormat ) ) {
 				return indentLine( line, indentCount++ );
 			}
 
 			if ( isClosingTag( line, elementsToFormat ) ) {
 				return indentLine( line, --indentCount );
+			}
+
+			if ( isPreformattedLine === 'middle' || isPreformattedLine === 'last' ) {
+				return line;
 			}
 
 			return indentLine( line, indentCount );
@@ -138,6 +145,24 @@ function isClosingTag( line: string, elementsToFormat: Array<ElementToFormat> ):
 function indentLine( line: string, indentCount: number, indentChar: string = '    ' ): string {
 	// More about Math.max() here in https://github.com/ckeditor/ckeditor5/issues/10698.
 	return `${ indentChar.repeat( Math.max( 0, indentCount ) ) }${ line }`;
+}
+
+/**
+ * Checks whether a line belongs to a preformatted (`<pre>`) block.
+ *
+ * @param line Line to check.
+ * @param isPreviousLinePreFormatted Information on whether the previous line was preformatted (and how).
+ */
+function isPreformattedBlockLine( line: string, isPreviousLinePreFormatted: 'first' | 'last' | 'middle' | false ) {
+	if ( new RegExp( '<pre( .*?)?>' ).test( line ) ) {
+		return 'first';
+	} else if ( new RegExp( '</pre>' ).test( line ) ) {
+		return 'last';
+	} else if ( isPreviousLinePreFormatted === 'first' || isPreviousLinePreFormatted === 'middle' ) {
+		return 'middle';
+	} else {
+		return false;
+	}
 }
 
 /**

--- a/packages/ckeditor5-source-editing/tests/utils/formathtml.js
+++ b/packages/ckeditor5-source-editing/tests/utils/formathtml.js
@@ -227,6 +227,30 @@ describe( 'SourceEditing utils', () => {
 			expect( formatHtml( source ) ).to.equal( sourceFormatted );
 		} );
 
+		it( 'should not inject extra white spaces at the beginning of preformatted lines in <pre> (deep structure)', () => {
+			const source = '' +
+				'<blockquote>' +
+					'<blockquote>' +
+						'<pre><code>foo\n' +
+						'bar\n' +
+						'abc\n' +
+						'baz</code></pre>' +
+					'</blockquote>' +
+				'</blockquote>';
+
+			const sourceFormatted = '' +
+				'<blockquote>\n' +
+				'    <blockquote>\n' +
+				'        <pre><code>foo\n' +
+				'bar\n' +
+				'abc\n' +
+				'baz</code></pre>\n' +
+				'    </blockquote>\n' +
+				'</blockquote>';
+
+			expect( formatHtml( source ) ).to.equal( sourceFormatted );
+		} );
+
 		it( 'should keep all attributes unchanged', () => {
 			const source = '' +
 				'<p id="foo" class="class1 class2" data-value="bar" onclick="fn();">' +

--- a/packages/ckeditor5-source-editing/tests/utils/formathtml.js
+++ b/packages/ckeditor5-source-editing/tests/utils/formathtml.js
@@ -207,6 +207,26 @@ describe( 'SourceEditing utils', () => {
 			expect( formatHtml( source ) ).to.equal( sourceFormatted );
 		} );
 
+		it( 'should not inject extra white spaces at the beginning of preformatted lines in <pre>', () => {
+			const source = '' +
+				'<blockquote>' +
+					'<pre><code>foo\n' +
+					'bar\n' +
+					'abc\n' +
+					'baz</code></pre>' +
+				'</blockquote>';
+
+			const sourceFormatted = '' +
+				'<blockquote>\n' +
+				'    <pre><code>foo\n' +
+				'bar\n' +
+				'abc\n' +
+				'baz</code></pre>\n' +
+				'</blockquote>';
+
+			expect( formatHtml( source ) ).to.equal( sourceFormatted );
+		} );
+
 		it( 'should keep all attributes unchanged', () => {
 			const source = '' +
 				'<p id="foo" class="class1 class2" data-value="bar" onclick="fn();">' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (source-editing): Source editing should not add white spaces to pre-formatted code lines. Closes #15084.

---

### Additional information

I don't like our approach in this helper. Using RegExp to manipulate HTML was not the best idea in the first place and there's always a risk of the whole thing breaking up. A parser would be a better choice but that would mean a re-write of the helper. I briefly researched how `DOMParser` could help us and this only confirmed my suspicion that a lot of work is necessary. We could also use an external library to prettify the source output.