### PR TITLE
TableUtils#getColumns() should exclude elements other than `tableCell` (e.g. marker elements) while counting.

### DIFF
--- a/packages/ckeditor5-table/src/tableutils.ts
+++ b/packages/ckeditor5-table/src/tableutils.ts
@@ -799,11 +799,14 @@ export default class TableUtils extends Plugin {
 		// that table will have only tableRow model elements at the beginning.
 		const row = table.getChild( 0 ) as Element;
 
-		return [ ...row.getChildren() ].reduce( ( columns, row ) => {
-			const columnWidth = parseInt( row.getAttribute( 'colspan' ) as string || '1' );
+		return [ ...row.getChildren() ]
+			// $marker elements can also be children of a row too (when TrackChanges is on). Don't include them in the count.
+			.filter( node => node.is( 'element', 'tableCell' ) )
+			.reduce( ( columns, row ) => {
+				const columnWidth = parseInt( row.getAttribute( 'colspan' ) as string || '1' );
 
-			return columns + columnWidth;
-		}, 0 );
+				return columns + columnWidth;
+			}, 0 );
 	}
 
 	/**

--- a/packages/ckeditor5-table/tests/tableutils.js
+++ b/packages/ckeditor5-table/tests/tableutils.js
@@ -1170,6 +1170,22 @@ describe( 'TableUtils', () => {
 
 			expect( tableUtils.getColumns( root.getNodeByPath( [ 0 ] ) ) ).to.equal( 5 );
 		} );
+
+		it( 'should ignore elements other than tableCell (e.g. $marker elements) when counting', () => {
+			setData( model, modelTable( [
+				[ '00', '02', '03' ]
+			] ) );
+
+			model.change( writer => {
+				const markerFakeStartElement = writer.createElement( 'fakeMarkerStart' );
+				const markerFakeEndElement = writer.createElement( 'fakeMarkerEnd' );
+
+				writer.insert( markerFakeStartElement, writer.createPositionAt( root.getNodeByPath( [ 0, 0 ] ), 0 ) );
+				writer.insert( markerFakeEndElement, writer.createPositionAt( root.getNodeByPath( [ 0, 0 ] ), 3 ) );
+			} );
+
+			expect( tableUtils.getColumns( root.getNodeByPath( [ 0 ] ) ) ).to.equal( 3 );
+		} );
 	} );
 
 	describe( 'getRows()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (table): `TableUtils#getColumns()` should exclude elements other than `tableCell` (e.g. marker elements) while counting. Closes cksource/ckeditor5-commercial#5968.

---

### Additional information

This PR is an improvement over https://github.com/ckeditor/ckeditor5/pull/15843.
