### PR TITLE
Fixes #15862: Handle newline-suppressed scenarios (e.g. limit elements) in AutoLink plugin

### DIFF
--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -240,11 +240,13 @@ export default class AutoLink extends Plugin {
 		enterCommand.on( 'execute', () => {
 			const position = model.document.selection.getFirstPosition()!;
 
-			if ( !position.parent.previousSibling ) {
-				return;
-			}
+			let rangeToCheck: Range;
 
-			const rangeToCheck = model.createRangeIn( position.parent.previousSibling as Element );
+			if ( position.parent.previousSibling?.is( 'element' ) ) {
+				rangeToCheck = model.createRangeIn( position.parent.previousSibling );
+			} else {
+				rangeToCheck = model.createRange( model.createPositionAt( position.parent, 0 ), position );
+			}
 
 			this._checkAndApplyAutoLinkOnRange( rangeToCheck );
 		} );

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -409,6 +409,36 @@ describe( 'AutoLink', () => {
 			);
 		} );
 
+		// https://github.com/ckeditor/ckeditor5/issues/15862
+		it( 'adds linkHref to a text link inside a limit element on enter', () => {
+			editor.model.schema.register( 'limit', {
+				isLimit: true,
+				allowIn: '$block',
+				allowChildren: '$text'
+			} );
+			editor.conversion.elementToElement( {
+				model: 'limit',
+				view: {
+					name: 'span',
+					classes: 'limit'
+				}
+			} );
+
+			setData( model,
+				'<paragraph>outer text' +
+				'<limit>inner text https://www.cksource.com[] inner text</limit>' +
+				'outer text</paragraph>'
+			);
+
+			editor.execute( 'enter' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph>outer text' +
+				'<limit>inner text <$text linkHref="https://www.cksource.com">https://www.cksource.com[]</$text> inner text</limit>' +
+				'outer text</paragraph>'
+			);
+		} );
+
 		it( 'adds "mailto:" to link of detected email addresses', () => {
 			simulateTyping( 'newsletter@cksource.com ' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix: Handle newline-suppressed scenarios (e.g. limit elements) in AutoLink plugin. Closes #15862.
