### PR TITLE
Inserting a mention should not add extra white spaces

### DIFF
--- a/packages/ckeditor5-mention/src/mentioncommand.ts
+++ b/packages/ckeditor5-mention/src/mentioncommand.ts
@@ -191,7 +191,9 @@ export default class MentionCommand extends Command {
 				isInsertedInBrackets = isPrecededByOpeningBracket && isFollowedByBracketClosure;
 			}
 
-			// Don't add a white space if there's already one after the mention or if the mention was inserted in brackets.
+			// Don't add a white space if either of the following is true:
+			// * there's already one after the mention;
+			// * the mention was inserted in the empty matching brackets.
 			// https://github.com/ckeditor/ckeditor5/issues/4651
 			if ( !isInsertedInBrackets && !isFollowedByWhiteSpace ) {
 				model.insertContent( writer.createText( ' ', currentAttributes ), range!.start.getShiftedBy( mentionText.length ) );

--- a/packages/ckeditor5-mention/src/mentioncommand.ts
+++ b/packages/ckeditor5-mention/src/mentioncommand.ts
@@ -13,6 +13,12 @@ import { CKEditorError, toMap } from 'ckeditor5/src/utils.js';
 
 import { _addMentionAttributes } from './mentionediting.js';
 
+const BRACKET_PAIRS = {
+	'(': ')',
+	'[': ']',
+	'{': '}'
+} as const;
+
 /**
  * The mention command.
  *
@@ -168,8 +174,28 @@ export default class MentionCommand extends Command {
 			attributesWithMention.set( 'mention', mention );
 
 			// Replace a range with the text with a mention.
-			model.insertContent( writer.createText( mentionText, attributesWithMention ), range );
-			model.insertContent( writer.createText( ' ', currentAttributes ), range!.start.getShiftedBy( mentionText.length ) );
+			const insertionRange = model.insertContent( writer.createText( mentionText, attributesWithMention ), range );
+			const nodeBefore = insertionRange.start.nodeBefore;
+			const nodeAfter = insertionRange.end.nodeAfter;
+
+			const isFollowedByWhiteSpace = nodeAfter && nodeAfter.is( '$text' ) && nodeAfter.data.startsWith( ' ' );
+			let isInsertedInBrackets = false;
+
+			if ( nodeBefore && nodeAfter && nodeBefore.is( '$text' ) && nodeAfter.is( '$text' ) ) {
+				const precedingCharacter = nodeBefore.data.slice( -1 );
+				const isPrecededByOpeningBracket = precedingCharacter in BRACKET_PAIRS;
+				const isFollowedByBracketClosure = isPrecededByOpeningBracket && nodeAfter.data.startsWith(
+					BRACKET_PAIRS[ precedingCharacter as keyof typeof BRACKET_PAIRS ]
+				);
+
+				isInsertedInBrackets = isPrecededByOpeningBracket && isFollowedByBracketClosure;
+			}
+
+			// Don't add a white space if there's already one after the mention or if the mention was inserted in brackets.
+			// https://github.com/ckeditor/ckeditor5/issues/4651
+			if ( !isInsertedInBrackets && !isFollowedByWhiteSpace ) {
+				model.insertContent( writer.createText( ' ', currentAttributes ), range!.start.getShiftedBy( mentionText.length ) );
+			}
 		} );
 	}
 }

--- a/packages/ckeditor5-mention/tests/mentioncommand.js
+++ b/packages/ckeditor5-mention/tests/mentioncommand.js
@@ -4,7 +4,7 @@
  */
 
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor.js';
-import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
+import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 
 import MentionCommand from '../src/mentioncommand.js';
 
@@ -176,6 +176,49 @@ describe( 'MentionCommand', () => {
 			for ( const options of testCases ) {
 				expectToThrowCKEditorError( () => command.execute( options ), /mentioncommand-incorrect-id/, editor );
 			}
+		} );
+
+		it( 'should not insert a white space if the mention was already followed by one', () => {
+			setData( model, '<paragraph>foo [] bar</paragraph>' );
+
+			command.execute( {
+				marker: '@',
+				mention: '@John'
+			} );
+
+			assertMention( doc.getRoot().getChild( 0 ).getChild( 1 ), '@John' );
+
+			expect( getData( model ) ).to.match(
+				/<paragraph>foo <\$text mention="{"uid":"[^"]+","_text":"@John","id":"@John"}">@John\[\]<\/\$text> bar<\/paragraph>/
+			);
+		} );
+
+		[ [ '(', ')' ], [ '[', ']' ], [ '{', '}' ] ].forEach( ( [ openingBracket, closingBracket ] ) => {
+			it( `should not insert a white space if the mention injected in "${ openingBracket }${ closingBracket }" brackets`, () => {
+				model.change( writer => {
+					const paragraph = writer.createElement( 'paragraph' );
+					const text = writer.createText( `${ openingBracket }${ closingBracket }` );
+
+					writer.append( text, paragraph );
+					writer.append( paragraph, model.document.getRoot() );
+
+					writer.setSelection( paragraph, 1 );
+				} );
+
+				command.execute( {
+					marker: '@',
+					mention: '@John'
+				} );
+
+				assertMention( doc.getRoot().getChild( 0 ).getChild( 1 ), '@John' );
+
+				expect( getData( model ) ).to.match(
+					new RegExp( '<paragraph>\\' + openingBracket +
+						'<\\$text mention="{"uid":"[^"]+","_text":"@John","id":"@John"}">@John\\[\\]</\\$text>\\' +
+						closingBracket + '</paragraph>'
+					)
+				);
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (mention): Inserting a mention should not add an extra white space if there was one already. A white space should not follow a mention inserted in brackets. Closes #4651.

---

### Additional information

In this PR I addressed two issues:
* The original one from https://github.com/ckeditor/ckeditor5/issues/4651 
  * ( `foo [] bar` -> `mention` -> `foo @mention[] bar` instead of `foo @mention [] bar`)
* An extra one that I figured out was cheap to implement and would benefit the users
  * `([])` -> `mention` -> `(@mention)` instead of `(@mention )`

I think there are many improvements left related to inserting mentions in different places, for instance, I would expect `"[]` -> type a mention -> `"@mention ` -> type `"` -> `"@mention"` but this one falls into text transformation category.