### PR TITLE
Rename ImageInsertViaUrlUI.init() to afterInit().

### DIFF
--- a/packages/ckeditor5-image/src/imageinsert/imageinsertviaurlui.ts
+++ b/packages/ckeditor5-image/src/imageinsert/imageinsertviaurlui.ts
@@ -43,7 +43,7 @@ export default class ImageInsertViaUrlUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public init(): void {
+	public afterInit(): void {
 		this._imageInsertUI = this.editor.plugins.get( 'ImageInsertUI' );
 		const insertImageCommand: InsertImageCommand = this.editor.commands.get( 'insertImage' )!;
 

--- a/packages/ckeditor5-image/tests/imageinsert/imageinsertviaurlui.js
+++ b/packages/ckeditor5-image/tests/imageinsert/imageinsertviaurlui.js
@@ -39,6 +39,15 @@ describe( 'ImageInsertViaUrlUI', () => {
 		expect( ImageInsertViaUrlUI.pluginName ).to.equal( 'ImageInsertViaUrlUI' );
 	} );
 
+	// https://github.com/ckeditor/ckeditor5/issues/15869
+	it( 'should work if ImageInsertViaUrl plugin is specified before Image', async () => {
+		await createEditor( {
+			plugins: [ ImageInsertViaUrl, Image ]
+		} );
+
+		editor.ui.componentFactory.create( 'insertImage' );
+	} );
+
 	describe( 'single integration', () => {
 		beforeEach( async () => {
 			await createEditor( {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (image): Fixes the initialization of `ImageInsertViaUrlUI` so it does not depend on configured plugins order. Closes #15869.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
