### PR TITLE
Added equal value check to reduce double empty checks.

### DIFF
--- a/packages/ckeditor5-ui/src/input/inputbase.ts
+++ b/packages/ckeditor5-ui/src/input/inputbase.ts
@@ -149,8 +149,10 @@ export default abstract class InputBase<TElement extends HTMLInputElement | HTML
 		// Bind `this.value` to the DOM element's value.
 		// We cannot use `value` DOM attribute because removing it on Edge does not clear the DOM element's value property.
 		this.on<ObservableChangeEvent>( 'change:value', ( evt, name, value ) => {
-			this._setDomElementValue( value );
-			this._updateIsEmpty();
+			if ( !value || ( value.toString() !== this.element!.value ) ) {
+				this._setDomElementValue( value );
+				this._updateIsEmpty();
+			}
 		} );
 	}
 

--- a/packages/ckeditor5-ui/tests/input/inputbase.js
+++ b/packages/ckeditor5-ui/tests/input/inputbase.js
@@ -149,6 +149,22 @@ describe( 'InputBase', () => {
 				view.value = '';
 				expect( view.isEmpty ).to.be.true;
 			} );
+
+			it( 'should not update the dom value or #isEmpty property when the changed #value is the same as previous dom value', () => {
+				const updateIsEmptySpy = sinon.spy( view, '_updateIsEmpty' );
+
+				view.value = 'thesame';
+
+				expect( view.value ).to.equal( 'thesame' );
+				expect( view.element.value ).to.equal( 'thesame' );
+				sinon.assert.calledOnce( updateIsEmptySpy );
+
+				updateIsEmptySpy.resetHistory();
+
+				view.fire( 'change:value', 'value', 'thesame' );
+				expect( view.element.value ).to.equal( 'thesame' );
+				sinon.assert.notCalled( updateIsEmptySpy );
+			} );
 		} );
 
 		describe( 'id', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Added additional check to fix multiple `isEmpty` state updates on the input field. Closes #15848 .

---
