### PR TITLE
BlockToolbar and BalloonToolbar should init after all plugins are init-ed (and afterInit-ed).

### DIFF
--- a/packages/ckeditor5-ckbox/src/ckboxediting.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxediting.ts
@@ -70,7 +70,7 @@ export default class CKBoxEditing extends Plugin {
 		this._checkImagePlugins();
 
 		// Registering the `ckbox` command makes sense only if the CKBox library is loaded, as the `ckbox` command opens the CKBox dialog.
-		if ( this._isLibraryLoaded() ) {
+		if ( isLibraryLoaded() ) {
 			editor.commands.add( 'ckbox', new CKBoxCommand( editor ) );
 		}
 	}
@@ -102,11 +102,7 @@ export default class CKBoxEditing extends Plugin {
 		const editor = this.editor;
 		const hasConfiguration = !!editor.config.get( 'ckbox' );
 
-		return hasConfiguration || this._isLibraryLoaded();
-	}
-
-	private _isLibraryLoaded(): boolean {
-		return !!window.CKBox;
+		return hasConfiguration || isLibraryLoaded();
 	}
 
 	/**
@@ -442,4 +438,11 @@ function shouldUpcastAttributeForNode( node: Node ) {
 	}
 
 	return false;
+}
+
+/**
+ * Returns true if the CKBox library is loaded, false otherwise.
+ */
+function isLibraryLoaded(): boolean {
+	return !!window.CKBox;
 }

--- a/packages/ckeditor5-ckbox/src/ckboxui.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxui.ts
@@ -31,10 +31,9 @@ export default class CKBoxUI extends Plugin {
 	public afterInit(): void {
 		const editor = this.editor;
 
-		const command: CKBoxCommand | undefined = editor.commands.get( 'ckbox' );
-
 		// Do not register the `ckbox` button if the command does not exist.
-		if ( !command ) {
+		// This might happen when CKBox library is not loaded on the page.
+		if ( !editor.commands.get( 'ckbox' ) ) {
 			return;
 		}
 
@@ -42,6 +41,7 @@ export default class CKBoxUI extends Plugin {
 		const componentFactory = editor.ui.componentFactory;
 
 		componentFactory.add( 'ckbox', locale => {
+			const command: CKBoxCommand = editor.commands.get( 'ckbox' )!;
 			const button = new ButtonView( locale );
 
 			button.set( {
@@ -64,7 +64,7 @@ export default class CKBoxUI extends Plugin {
 
 			imageInsertUI.registerIntegration( {
 				name: 'assetManager',
-				observable: command,
+				observable: () => editor.commands.get( 'ckbox' )!,
 
 				buttonViewCreator: () => {
 					const button = this.editor.ui.componentFactory.create( 'ckbox' ) as ButtonView;

--- a/packages/ckeditor5-ckbox/tests/ckboxediting.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxediting.js
@@ -187,6 +187,36 @@ describe( 'CKBoxEditing', () => {
 
 			await editor.destroy();
 		} );
+
+		describe( 'CKBox loaded before the ImageBlock and ImageInline plugins', () => {
+			let editor, model, originalCKBox;
+
+			beforeEach( async () => {
+				TokenMock.initialToken = 'ckbox-token';
+
+				originalCKBox = window.CKBox;
+				window.CKBox = {};
+
+				editor = await createTestEditor( {
+					ckbox: {
+						tokenUrl: 'http://cs.example.com'
+					}
+				}, true );
+
+				model = editor.model;
+			} );
+
+			afterEach( async () => {
+				window.CKBox = originalCKBox;
+				await editor.destroy();
+			} );
+
+			// https://github.com/ckeditor/ckeditor5/issues/15581
+			it( 'should extend the schema rules for imageBlock and imageInline', () => {
+				expect( model.schema.checkAttribute( [ '$root', 'imageBlock' ], 'ckboxImageId' ) ).to.be.true;
+				expect( model.schema.checkAttribute( [ '$root', '$block', 'imageInline' ], 'ckboxImageId' ) ).to.be.true;
+			} );
+		} );
 	} );
 
 	describe( 'conversion', () => {
@@ -1802,22 +1832,29 @@ describe( 'CKBoxEditing', () => {
 	} );
 } );
 
-function createTestEditor( config = {} ) {
+function createTestEditor( config = {}, loadCKBoxFirst = false ) {
+	const plugins = [
+		Paragraph,
+		ImageBlockEditing,
+		ImageInlineEditing,
+		ImageCaptionEditing,
+		LinkEditing,
+		LinkImageEditing,
+		PictureEditing,
+		ImageUploadEditing,
+		ImageUploadProgress,
+		CloudServices,
+		CKBoxUploadAdapter
+	];
+
+	if ( loadCKBoxFirst ) {
+		plugins.unshift( CKBoxEditing );
+	} else {
+		plugins.push( CKBoxEditing );
+	}
+
 	return VirtualTestEditor.create( {
-		plugins: [
-			Paragraph,
-			ImageBlockEditing,
-			ImageInlineEditing,
-			ImageCaptionEditing,
-			LinkEditing,
-			LinkImageEditing,
-			PictureEditing,
-			ImageUploadEditing,
-			ImageUploadProgress,
-			CloudServices,
-			CKBoxUploadAdapter,
-			CKBoxEditing
-		],
+		plugins,
 		substitutePlugins: [
 			CloudServicesCoreMock
 		],

--- a/packages/ckeditor5-ckfinder/src/ckfinderui.ts
+++ b/packages/ckeditor5-ckfinder/src/ckfinderui.ts
@@ -55,11 +55,10 @@ export default class CKFinderUI extends Plugin {
 
 		if ( editor.plugins.has( 'ImageInsertUI' ) ) {
 			const imageInsertUI: ImageInsertUI = editor.plugins.get( 'ImageInsertUI' );
-			const command: CKFinderCommand = editor.commands.get( 'ckfinder' )!;
 
 			imageInsertUI.registerIntegration( {
 				name: 'assetManager',
-				observable: command,
+				observable: () => editor.commands.get( 'ckfinder' )!,
 
 				buttonViewCreator: () => {
 					const button = this.editor.ui.componentFactory.create( 'ckfinder' ) as ButtonView;

--- a/packages/ckeditor5-image/src/imageinsert/imageinsertui.ts
+++ b/packages/ckeditor5-image/src/imageinsert/imageinsertui.ts
@@ -114,11 +114,11 @@ export default class ImageInsertUI extends Plugin {
 		requiresForm
 	}: {
 		name: string;
-		observable: Observable & { isEnabled: boolean };
+		observable: Observable & { isEnabled: boolean } | ( () => Observable & { isEnabled: boolean } );
 		buttonViewCreator: ( isOnlyOne: boolean ) => ButtonView;
 		formViewCreator: ( isOnlyOne: boolean ) => FocusableView;
 		requiresForm?: boolean;
-} ): void {
+	} ): void {
 		if ( this._integrations.has( name ) ) {
 			/**
 			 * There are two insert-image integrations registered with the same name.
@@ -174,7 +174,7 @@ export default class ImageInsertUI extends Plugin {
 		}
 
 		const dropdownView = this.dropdownView = createDropdown( locale, dropdownButton );
-		const observables = integrations.map( ( { observable } ) => observable );
+		const observables = integrations.map( ( { observable } ) => typeof observable == 'function' ? observable() : observable );
 
 		dropdownView.bind( 'isEnabled' ).toMany( observables, 'isEnabled', ( ...isEnabled ) => (
 			isEnabled.some( isEnabled => isEnabled )
@@ -250,7 +250,7 @@ export default class ImageInsertUI extends Plugin {
 }
 
 type IntegrationData = {
-	observable: Observable & { isEnabled: boolean };
+	observable: Observable & { isEnabled: boolean } | ( () => Observable & { isEnabled: boolean } );
 	buttonViewCreator: ( isOnlyOne: boolean ) => ButtonView;
 	formViewCreator: ( isOnlyOne: boolean ) => FocusableView;
 	requiresForm: boolean;

--- a/packages/ckeditor5-image/src/imageinsert/imageinsertviaurlui.ts
+++ b/packages/ckeditor5-image/src/imageinsert/imageinsertviaurlui.ts
@@ -45,11 +45,10 @@ export default class ImageInsertViaUrlUI extends Plugin {
 	 */
 	public afterInit(): void {
 		this._imageInsertUI = this.editor.plugins.get( 'ImageInsertUI' );
-		const insertImageCommand: InsertImageCommand = this.editor.commands.get( 'insertImage' )!;
 
 		this._imageInsertUI.registerIntegration( {
 			name: 'url',
-			observable: insertImageCommand,
+			observable: () => this.editor.commands.get( 'insertImage' )!,
 			requiresForm: true,
 			buttonViewCreator: isOnlyOne => this._createInsertUrlButton( isOnlyOne ),
 			formViewCreator: isOnlyOne => this._createInsertUrlView( isOnlyOne )

--- a/packages/ckeditor5-image/src/imageupload/imageuploadui.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadui.ts
@@ -72,11 +72,10 @@ export default class ImageUploadUI extends Plugin {
 
 		if ( editor.plugins.has( 'ImageInsertUI' ) ) {
 			const imageInsertUI: ImageInsertUI = editor.plugins.get( 'ImageInsertUI' );
-			const command: UploadImageCommand = editor.commands.get( 'uploadImage' )!;
 
 			imageInsertUI.registerIntegration( {
 				name: 'upload',
-				observable: command,
+				observable: () => editor.commands.get( 'uploadImage' )!,
 
 				buttonViewCreator: () => {
 					const uploadImageButton = editor.ui.componentFactory.create( 'uploadImage' ) as FileDialogButtonView;

--- a/packages/ckeditor5-image/tests/imageinsert/imageinsertui.js
+++ b/packages/ckeditor5-image/tests/imageinsert/imageinsertui.js
@@ -296,6 +296,22 @@ describe( 'ImageInsertUI', () => {
 			} );
 		} );
 
+		describe( 'single integration with form view required and observalbe as a function', () => {
+			beforeEach( async () => {
+				registerUrlIntegration( true );
+			} );
+
+			it( 'should bind isEnabled state to observable', () => {
+				const dropdown = editor.ui.componentFactory.create( 'insertImage' );
+
+				observableUrl.isEnabled = false;
+				expect( dropdown.isEnabled ).to.be.false;
+
+				observableUrl.isEnabled = true;
+				expect( dropdown.isEnabled ).to.be.true;
+			} );
+		} );
+
 		describe( 'multiple integrations', () => {
 			beforeEach( async () => {
 				registerUploadIntegration();
@@ -365,12 +381,39 @@ describe( 'ImageInsertUI', () => {
 			} );
 		} );
 
-		function registerUrlIntegration() {
+		describe( 'multiple integrations and observalbe as a function', () => {
+			beforeEach( async () => {
+				registerUploadIntegration( true );
+				registerUrlIntegration( true );
+			} );
+
+			it( 'should bind isEnabled state to observables', () => {
+				const dropdown = editor.ui.componentFactory.create( 'insertImage' );
+
+				observableUrl.isEnabled = false;
+				observableUpload.isEnabled = false;
+				expect( dropdown.isEnabled ).to.be.false;
+
+				observableUrl.isEnabled = true;
+				observableUpload.isEnabled = false;
+				expect( dropdown.isEnabled ).to.be.true;
+
+				observableUrl.isEnabled = false;
+				observableUpload.isEnabled = true;
+				expect( dropdown.isEnabled ).to.be.true;
+
+				observableUrl.isEnabled = true;
+				observableUpload.isEnabled = true;
+				expect( dropdown.isEnabled ).to.be.true;
+			} );
+		} );
+
+		function registerUrlIntegration( observableAsFunc ) {
 			observableUrl = new Model( { isEnabled: true } );
 
 			insertImageUI.registerIntegration( {
 				name: 'url',
-				observable: observableUrl,
+				observable: observableAsFunc ? () => observableUrl : observableUrl,
 				requiresForm: true,
 				buttonViewCreator( isOnlyOne ) {
 					const button = new ButtonView( editor.locale );
@@ -389,12 +432,12 @@ describe( 'ImageInsertUI', () => {
 			} );
 		}
 
-		function registerUploadIntegration() {
+		function registerUploadIntegration( observableAsFunc ) {
 			observableUpload = new Model( { isEnabled: true } );
 
 			insertImageUI.registerIntegration( {
 				name: 'upload',
-				observable: observableUpload,
+				observable: observableAsFunc ? () => observableUpload : observableUpload,
 				buttonViewCreator( isOnlyOne ) {
 					const button = new ButtonView( editor.locale );
 

--- a/packages/ckeditor5-ui/src/toolbar/balloon/balloontoolbar.ts
+++ b/packages/ckeditor5-ui/src/toolbar/balloon/balloontoolbar.ts
@@ -192,16 +192,12 @@ export default class BalloonToolbar extends Plugin {
 		this.listenTo<ToolbarViewGroupedItemsUpdateEvent>( this.toolbarView, 'groupedItemsUpdate', () => {
 			this._updatePosition();
 		} );
-	}
 
-	/**
-	 * Creates toolbar components based on given configuration.
-	 * This needs to be done when all plugins are ready.
-	 */
-	public afterInit(): void {
-		const factory = this.editor.ui.componentFactory;
-
-		this.toolbarView.fillFromConfig( this._balloonConfig, factory );
+		// Creates toolbar components based on given configuration.
+		// This needs to be done when all plugins are ready.
+		editor.ui.once<EditorUIReadyEvent>( 'ready', () => {
+			this.toolbarView.fillFromConfig( this._balloonConfig, this.editor.ui.componentFactory );
+		} );
 	}
 
 	/**

--- a/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
+++ b/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
@@ -30,7 +30,7 @@ import clickOutsideHandler from '../../bindings/clickoutsidehandler.js';
 import normalizeToolbarConfig from '../normalizetoolbarconfig.js';
 
 import type { ButtonExecuteEvent } from '../../button/button.js';
-import type { EditorUIUpdateEvent } from '../../editorui/editorui.js';
+import type { EditorUIReadyEvent, EditorUIUpdateEvent } from '../../editorui/editorui.js';
 
 const toPx = toUnit( 'px' );
 
@@ -191,20 +191,17 @@ export default class BlockToolbar extends Plugin {
 			beforeFocus: () => this._showPanel(),
 			afterBlur: () => this._hidePanel()
 		} );
-	}
 
-	/**
-	 * Fills the toolbar with its items based on the configuration.
-	 *
-	 * **Note:** This needs to be done after all plugins are ready.
-	 */
-	public afterInit(): void {
-		this.toolbarView.fillFromConfig( this._blockToolbarConfig, this.editor.ui.componentFactory );
+		// Fills the toolbar with its items based on the configuration.
+		// This needs to be done after all plugins are ready.
+		editor.ui.once<EditorUIReadyEvent>( 'ready', () => {
+			this.toolbarView.fillFromConfig( this._blockToolbarConfig, this.editor.ui.componentFactory );
 
-		// Hide panel before executing each button in the panel.
-		for ( const item of this.toolbarView.items ) {
-			item.on<ButtonExecuteEvent>( 'execute', () => this._hidePanel( true ), { priority: 'high' } );
-		}
+			// Hide panel before executing each button in the panel.
+			for ( const item of this.toolbarView.items ) {
+				item.on<ButtonExecuteEvent>( 'execute', () => this._hidePanel( true ), { priority: 'high' } );
+			}
+		} );
 	}
 
 	/**

--- a/packages/ckeditor5-ui/tests/toolbar/balloon/balloontoolbar.js
+++ b/packages/ckeditor5-ui/tests/toolbar/balloon/balloontoolbar.js
@@ -9,6 +9,7 @@ import BalloonToolbar from '../../../src/toolbar/balloon/balloontoolbar.js';
 import ContextualBalloon from '../../../src/panel/balloon/contextualballoon.js';
 import BalloonPanelView from '../../../src/panel/balloon/balloonpanelview.js';
 import ToolbarView from '../../../src/toolbar/toolbarview.js';
+import ButtonView from '../../../src/button/buttonview.js';
 import FocusTracker from '@ckeditor/ckeditor5-utils/src/focustracker.js';
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin.js';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold.js';
@@ -790,6 +791,36 @@ describe( 'BalloonToolbar', () => {
 
 			balloonToolbar.show();
 			sinon.assert.notCalled( balloonAddSpy );
+		} );
+	} );
+
+	describe( 'BalloonToolbar plugin load order', () => {
+		it( 'should add a button registered in the afterInit of Foo when BalloonToolbar is loaded before Foo', () => {
+			class Foo extends Plugin {
+				afterInit() {
+					this.editor.ui.componentFactory.add( 'foo', () => {
+						const button = new ButtonView();
+
+						button.set( { label: 'Foo' } );
+
+						return button;
+					} );
+				}
+			}
+
+			return ClassicTestEditor
+				.create( editorElement, {
+					plugins: [ BalloonToolbar, Foo ],
+					balloonToolbar: [ 'foo' ]
+				} )
+				.then( editor => {
+					const items = editor.plugins.get( BalloonToolbar ).toolbarView.items;
+
+					expect( items.length ).to.equal( 1 );
+					expect( items.first.label ).to.equal( 'Foo' );
+
+					return editor.destroy();
+				} );
 		} );
 	} );
 

--- a/packages/ckeditor5-ui/tests/toolbar/block/blocktoolbar.js
+++ b/packages/ckeditor5-ui/tests/toolbar/block/blocktoolbar.js
@@ -13,6 +13,7 @@ import BlockToolbar from '../../../src/toolbar/block/blocktoolbar.js';
 import ToolbarView from '../../../src/toolbar/toolbarview.js';
 import BalloonPanelView from '../../../src/panel/balloon/balloonpanelview.js';
 import BlockButtonView from '../../../src/toolbar/block/blockbuttonview.js';
+import ButtonView from '../../../src/button/buttonview.js';
 
 import Heading from '@ckeditor/ckeditor5-heading/src/heading.js';
 import HeadingButtonsUI from '@ckeditor/ckeditor5-heading/src/headingbuttonsui.js';
@@ -23,6 +24,7 @@ import ImageCaption from '@ckeditor/ckeditor5-image/src/imagecaption.js';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global.js';
 import ResizeObserver from '@ckeditor/ckeditor5-utils/src/dom/resizeobserver.js';
 import DragDropBlockToolbar from '@ckeditor/ckeditor5-clipboard/src/dragdropblocktoolbar.js';
+import Plugin from '@ckeditor/ckeditor5-core/src/plugin.js';
 
 import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard.js';
@@ -949,6 +951,36 @@ describe( 'BlockToolbar', () => {
 			elBar.remove();
 
 			return multiRootEditor.destroy();
+		} );
+	} );
+
+	describe( 'BlockToolbar plugin load order', () => {
+		it( 'should add a button registered in the afterInit of Foo when BlockToolbar is loaded before Foo', () => {
+			class Foo extends Plugin {
+				afterInit() {
+					this.editor.ui.componentFactory.add( 'foo', () => {
+						const button = new ButtonView();
+
+						button.set( { label: 'Foo' } );
+
+						return button;
+					} );
+				}
+			}
+
+			return ClassicTestEditor
+				.create( element, {
+					plugins: [ BlockToolbar, Foo ],
+					blockToolbar: [ 'foo' ]
+				} )
+				.then( editor => {
+					const items = editor.plugins.get( BlockToolbar ).toolbarView.items;
+
+					expect( items.length ).to.equal( 1 );
+					expect( items.first.label ).to.equal( 'Foo' );
+
+					return editor.destroy();
+				} );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ckbox): Plugin order should not matter when it comes to registering schema for `ckboxImageId` attribute. Closes #15581.

Fix (ui): BlockToolbar and BalloonToolbar plugins order should not matter when it comes to registering toolbar items. Closes #15581.

MINOR BREAKING CHANGE (ui): The contents of the `BlockToolbar` and `BalloonToolbar` are now filled on the `EditorUIReadyEvent` instead of `afterInit()`.

---

### Additional information

This PR solves actually 3 issues:

1.  When adding the `CKBox` plugin before the  `ImageBlock` and `ImageInline` plugins, the schema for schema for `ckboxImageId` attribute was not registered.
2.  Loading `BlockToolbar` (or `BalloonToolbar`) before `CKBox` (or actually any other plugin that registers toolbar buttons in `afterInit()`) resulted in the button not being registered.
3.  Because the `InsertImage` integration sometimes happens in `init()`, and it is possible to load the plugin `ui` part before `editing`, it could happen that when the `ui` was loaded first, the command was not yet created, resulting in an error saying that it was not possible to bind dropdown's `isEnabled` to the observable (the command) - because the command was undefined. So we added the ability to pass a function to the integration registration instead, and we used that in all of our integrations. This way we always make sure that the command is there when we bind it.