### PR TITLE
Minimap: do not suppress TypeScript's possible null value

### DIFF
--- a/packages/ckeditor5-minimap/src/minimap.ts
+++ b/packages/ckeditor5-minimap/src/minimap.ts
@@ -205,7 +205,11 @@ export default class Minimap extends Plugin {
 
 		// The intersection helps to change the tracker height when there is a lot of padding around the root.
 		// Note: It is **essential** that the height is set first because the progress depends on the correct tracker height.
-		minimapView.setPositionTrackerHeight( scrollableRootAncestorRect.getIntersection( editingRootRect )!.height );
-		minimapView.setScrollProgress( scrollProgress );
+		const intersection = scrollableRootAncestorRect.getIntersection( editingRootRect );
+
+		if ( intersection ) {
+			minimapView.setPositionTrackerHeight( intersection.height );
+			minimapView.setScrollProgress( scrollProgress );
+		}
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (minimap): The Minimap feature should not emit an error while destroying an editor embedded into an iframe element.

Closes cksource/ckeditor5-commercial#5592.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
