### PR TITLE
Allow registering translations in the `defaultConfig`

### DIFF
--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -280,7 +280,10 @@ export default abstract class Editor extends ObservableMixin() {
 
 		// We don't pass translations to the config, because its behavior of splitting keys
 		// with dots (e.g. `resize.width` => `resize: { width }`) breaks the translations.
-		const { translations, ...rest } = config;
+		const {
+			translations = ( constructor.defaultConfig && constructor.defaultConfig.translations ),
+			...rest
+		} = config;
 
 		this._context = config.context || new Context( { language, translations } );
 		this._context._addEditor( this, !config.context );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (core): Use `translations` from the `defaultConfig` if they were not provided in the `create` method. Closes #15902.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
