### PR TITLE
Handle insert markers edge cases

### DIFF
--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -305,7 +305,7 @@ export default class ClipboardMarkersUtils extends Plugin {
 	}
 
 	/**
-	 * Returns object that contains mapping between marker names and corresponding `$marker` elements.
+	 * Returns array that contains list of fake markers with corresponding `$marker` elements.
 	 *
 	 * For each marker, there can be two `$marker` elements or only one (if the document fragment contained
 	 * only the beginning or only the end of a marker).

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -90,14 +90,13 @@ export default class ClipboardMarkersUtils extends Plugin {
 	 * Performs copy markers on provided selection and paste it to fragment returned from `getCopiedFragment`.
 	 *
 	 * 	1. Picks all markers in provided selection.
-	 * 	2. Inserts fake markers inside provided selection.
-	 * 	3. Gets copied selection fragment.
-	 * 	4. Removes fake elements from fragment.
-	 * 	5. Inserts markers on position of fake markers.
+	 * 	2. Inserts fake markers to document.
+	 * 	3. Gets copied selection fragment from document.
+	 * 	4. Removes fake elements from fragment and document.
+	 * 	5. Inserts markers in the place of removed fake markers.
 	 *
-	 * Due to selection modification when elements are inserted the `getCopiedFragment` must *always*
-	 * operate on `writer.model.document.selection`. Do not use any other custom selection object inside
-	 * such callback because it will lead to out-of-bounds exceptions in rare scenarios.
+	 * Due to selection modification, when inserting items, `getCopiedFragment` must *always* operate on `writer.model.document.selection'.
+	 * Do not use any other custom selection object within callback, as this will lead to out-of-bounds exceptions in rare scenarios.
 	 *
 	 * @param action Type of clipboard action.
 	 * @param writer An instance of the model writer.
@@ -146,14 +145,14 @@ export default class ClipboardMarkersUtils extends Plugin {
 	 * Performs paste of markers on already pasted element.
 	 *
 	 * 	1. Inserts fake markers that are present in pasted fragment element.
-	 * 	2. Calls `getTransformedElement` and gets transformed by this callback previous step fragment element.
+	 * 	2. Calls `getTransformedElement` and gets transformed previous step fragment element.
 	 * 	3. Removes all fake markers present in transformed element.
 	 * 	4. Inserts new markers with removed fake markers ranges into pasted fragment.
 	 *
 	 * There are multiple edge cases that have to be considered before calling this function:
 	 *
 	 * 	* `markers` are inserted into the same element that must be later transformed inside `getTransformedElement`.
-	 * 	* Fake markers elements inside `getTransformedElement` can be cloned but their ranges cannot overlap.
+	 * 	* Fake marker elements inside `getTransformedElement` can be cloned, but their ranges cannot overlap.
 	 *
 	 * @param action Type of clipboard action.
 	 * @param markers Object that maps marker name to corresponding range.

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -275,12 +275,10 @@ export default class ClipboardMarkersUtils extends Plugin {
 	 * @param rootElement The element to be checked.
 	 */
 	private _removeFakeMarkersInsideElement( writer: Writer, rootElement: Element | DocumentFragment ): Record<string, Range> {
-		type ReducedMarkersMap = Record<string, { start: Position | null; end: Position | null }>;
-
 		const fakeMarkersElements = this._getAllFakeMarkersFromElement( writer, rootElement );
 		const fakeMarkersRanges = fakeMarkersElements
-			.reduce<ReducedMarkersMap>( ( acc, fakeMarker ) => {
-				const position = fakeMarker.markerElement ? writer.createPositionBefore( fakeMarker.markerElement ) : null;
+			.reduce<Record<string, { start: Position | null; end: Position | null }>>( ( acc, fakeMarker ) => {
+				const position = fakeMarker.markerElement && writer.createPositionBefore( fakeMarker.markerElement );
 
 				acc[ fakeMarker.name ] = {
 					...acc[ fakeMarker.name ],
@@ -297,11 +295,11 @@ export default class ClipboardMarkersUtils extends Plugin {
 		return Object.fromEntries(
 			Object
 				.entries( fakeMarkersRanges )
-				.map( ( [ markerName, maybeRange ] ) => [
+				.map( ( [ markerName, range ] ) => [
 					markerName,
 					new Range(
-						maybeRange.start || writer.createPositionFromPath( rootElement, [ 0 ] ),
-						maybeRange.end || writer.createPositionAt( rootElement, 'end' ) )
+						range.start || writer.createPositionFromPath( rootElement, [ 0 ] ),
+						range.end || writer.createPositionAt( rootElement, 'end' ) )
 				] )
 		);
 	}
@@ -313,7 +311,7 @@ export default class ClipboardMarkersUtils extends Plugin {
 	 * only the beginning or only the end of a marker).
 	 *
 	 * @param writer An instance of the model writer.
-	 * @param element The element to be checked.
+	 * @param rootElement The element to be checked.
 	 */
 	private _getAllFakeMarkersFromElement( writer: Writer, rootElement: Element | DocumentFragment ): Array<FakeMarker> {
 		const foundFakeMarkers = Array

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -158,7 +158,7 @@ export default class ClipboardMarkersUtils extends Plugin {
 	/**
 	 * Performs paste of markers on already pasted element.
 	 *
-	 * 	1. Inserts fake markers that are present in pasted fragment element.
+	 * 	1. Inserts fake markers that are present in fragment element (such fragment will be processed in `getPastedDocumentElement`).
 	 * 	2. Calls `getPastedDocumentElement` and gets element that is inserted into root model.
 	 * 	3. Removes all fake markers present in transformed element.
 	 * 	4. Inserts new markers with removed fake markers ranges into pasted fragment.

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -540,7 +540,7 @@ export type ClipboardMarkerRestrictedAction = 'copy' | 'cut' | 'dragstart';
  * it will disallow copy, cut or paste of marker in clipboard.
  *
  * 	* `'default'` - the markers will be preserved on cut-paste and drag and drop actions only.
-* 	* `'always'` - the markers will be preserved on all clipboard actions (cut, copy, drag and drop).
+ * 	* `'always'` - the markers will be preserved on all clipboard actions (cut, copy, drag and drop).
  * 	* `'never'` - the markers will be ignored by clipboard.
  *
  * @internal

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -318,12 +318,6 @@ export default class ClipboardMarkersUtils extends Plugin {
 						type
 					}
 				];
-			} )
-			.sort( ( fakeMarkerA, fakeMarkerB ) => {
-				const posA = writer.createPositionBefore( fakeMarkerA.markerElement! );
-				const posB = writer.createPositionBefore( fakeMarkerB.markerElement! );
-
-				return posA.isBefore( posB ) ? -1 : 1;
 			} );
 
 		const prependFakeMarkers: Array<FakeMarker> = [];

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -95,6 +95,10 @@ export default class ClipboardMarkersUtils extends Plugin {
 	 * 	4. Removes fake elements from fragment.
 	 * 	5. Inserts markers on position of fake markers.
 	 *
+	 * Due to selection modification when elements are inserted the `getCopiedFragment` must *always*
+	 * operate on `writer.model.document.selection`. Do not use any other custom selection object inside
+	 * such callback because it will lead to out-of-bounds exceptions in rare scenarios.
+	 *
 	 * @param action Type of clipboard action.
 	 * @param writer An instance of the model writer.
 	 * @param selection Selection to be checked.
@@ -148,8 +152,8 @@ export default class ClipboardMarkersUtils extends Plugin {
 	 *
 	 * There are multiple edge cases that have to be considered before calling this function:
 	 *
-	 * 	1  The same `markers` map must be present in element that was transformed inside `getTransformedElement`.
-	 * 	2. Fake markers elements inside `getTransformedElement` can be cloned but their ranges cannot overlap.
+	 * 	* `markers` are inserted into the same element that must be later transformed inside `getTransformedElement`.
+	 * 	* Fake markers elements inside `getTransformedElement` can be cloned but their ranges cannot overlap.
 	 *
 	 * @param action Type of clipboard action.
 	 * @param markers Object that maps marker name to corresponding range.

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -406,6 +406,14 @@ export default class ClipboardMarkersUtils extends Plugin {
 			return acc;
 		}, {} );
 
+		// We cannot construct ranges directly in previous reduce because element ranges can overlap.
+		// In other words lets assume we have such scenario:
+
+		// <fake-marker-start /> <paragraph /> <fake-marker-2-start /> <fake-marker-end /> <fake-marker-2-end />
+		//
+		// We have to remove `fake-marker-start` firstly and then remove `fake-marker-2-start`.
+		// Removal of `fake-marker-2-start` affects `fake-marker-end` position so we cannot create
+		// connection between `fake-marker-start` and `fake-marker-end` without iterating whole set firstly.
 		return mapValues(
 			fakeMarkersRanges,
 			range => new Range(
@@ -531,8 +539,8 @@ export type ClipboardMarkerRestrictedAction = 'copy' | 'cut' | 'dragstart';
  * Specifies copy, paste or move marker restrictions in clipboard. Depending on specified mode
  * it will disallow copy, cut or paste of marker in clipboard.
  *
- * 	* `'default'` - the markers will be preserved on cut-paste and move actions only.
- * 	* `'always'` - the markers will be preserved on any clipboard action (cut-paste, copy, move).
+ * 	* `'default'` - the markers will be preserved on cut-paste and drag and drop actions only.
+* 	* `'always'` - the markers will be preserved on all clipboard actions (cut, copy, drag and drop).
  * 	* `'never'` - the markers will be ignored by clipboard.
  *
  * @internal

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -539,7 +539,7 @@ export type ClipboardMarkerRestrictedAction = 'copy' | 'cut' | 'dragstart';
  * Specifies copy, paste or move marker restrictions in clipboard. Depending on specified mode
  * it will disallow copy, cut or paste of marker in clipboard.
  *
- * 	* `'default'` - the markers will be preserved on cut-paste action only.
+ * 	* `'default'` - the markers will be preserved on cut-paste and move actions only.
  * 	* `'always'` - the markers will be preserved on any clipboard action (cut-paste, copy, move).
  * 	* `'never'` - the markers will be ignored by clipboard.
  *

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -352,7 +352,7 @@ export default class ClipboardMarkersUtils extends Plugin {
 				// Handle scenario when tables clone cells with the same fake node. Example:
 				//
 				// <cell><fake-marker-a></cell> <cell><fake-marker-a></cell> <cell><fake-marker-a></cell>
-				//                                          ^ cloned                    & cloned
+				//                                          ^ cloned                    ^ cloned
 				//
 				// The easiest way to bypass this issue is to rename already existing in map nodes and
 				// set them new unique name.

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -45,9 +45,8 @@ export default class ClipboardMarkersUtils extends Plugin {
 	/**
 	 * Registers marker name as copyable in clipboard pipeline.
 	 *
-	 * @param markerName	Name of marker that can be copied.
-	 * @param restrictions	Restrictions preset that specify when marker should be copied.
-	 * 						If array is passed specific clipboard actions should be passed.
+	 * @param markerName Name of marker that can be copied.
+	 * @param restrictions Preset or specified array of actions that can be performed on specified marker name.
 	 * @internal
 	 */
 	public _registerMarkerToCopy(
@@ -537,9 +536,9 @@ export type ClipboardMarkerRestrictedAction = 'copy' | 'cut' | 'dragstart';
  * Specifies copy, paste or move marker restrictions in clipboard. Depending on specified mode
  * it will disallow copy, cut or paste of marker in clipboard.
  *
- * 	`default` allows marker to be cut only.
- * 	`always` allows marker to be copied, moved or cut.
- * 	'never' no clipboard operations will be performed on marker.
+ * 	* `'default'` - the markers will be preserved on cut-paste action only.
+ * 	* `'always'` - the markers will be preserved on any clipboard action (cut-paste, copy, move).
+ * 	* `'never'` - the markers will be ignored by clipboard.
  *
  * @internal
  */

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -209,12 +209,13 @@ export default class ClipboardMarkersUtils extends Plugin {
 	 * Checks if marker can be copied.
 	 *
 	 * @param markerName Name of checked marker.
+	 * @param action Type of clipboard action. If null then checks only if marker is registered as copyable.
 	 * @internal
 	 */
-	public _canPerformMarkerClipboardAction( markerName: string, action: ClipboardMarkerRestrictedAction ): boolean {
+	public _canPerformMarkerClipboardAction( markerName: string, action: ClipboardMarkerRestrictedAction | null ): boolean {
 		const [ markerNamePrefix ] = markerName.split( ':' );
 
-		if ( action === 'any' ) {
+		if ( !action ) {
 			return this._markersToCopy.has( markerNamePrefix );
 		}
 
@@ -293,12 +294,12 @@ export default class ClipboardMarkersUtils extends Plugin {
 	 *
 	 * @param writer An instance of the model writer.
 	 * @param selection  Selection which will be checked.
-	 * @param action Type of clipboard action.
+	 * @param action Type of clipboard action. If null then checks only if marker is registered as copyable.
 	 */
 	private _getCopyableMarkersFromSelection(
 		writer: Writer,
 		selection: Selection | DocumentSelection,
-		action: ClipboardMarkerRestrictedAction
+		action: ClipboardMarkerRestrictedAction | null
 	): Array<CopyableMarker> {
 		return Array
 			.from( selection.getRanges()! )
@@ -313,12 +314,12 @@ export default class ClipboardMarkersUtils extends Plugin {
 	/**
 	 * Picks all markers from markers map that can be copied.
 	 *
-	 * @param action Type of clipboard action. If not provided then copy marker if registered in `_markersToCopy`.
 	 * @param markers Object that maps marker name to corresponding range.
+	 * @param action Type of clipboard action. If null then checks only if marker is registered as copyable.
 	 */
 	private _getCopyableMarkersFromRangeMap(
 		markers: Record<string, Range>,
-		action: ClipboardMarkerRestrictedAction = 'any'
+		action: ClipboardMarkerRestrictedAction | null = null
 	): Array<CopyableMarker> {
 		return Object
 			.entries( markers )
@@ -530,7 +531,7 @@ export default class ClipboardMarkersUtils extends Plugin {
  *
  * @internal
  */
-export type ClipboardMarkerRestrictedAction = 'copy' | 'cut' | 'dragstart' | 'any';
+export type ClipboardMarkerRestrictedAction = 'copy' | 'cut' | 'dragstart';
 
 /**
  * Specifies copy, paste or move marker restrictions in clipboard. Depending on specified mode

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -72,7 +72,7 @@ export default class ClipboardMarkersUtils extends Plugin {
 				return [ 'copy', 'cut', 'dragstart' ];
 
 			case 'default':
-				return [ 'cut' ];
+				return [ 'cut', 'dragstart' ];
 
 			case 'never':
 				return [];

--- a/packages/ckeditor5-clipboard/src/index.ts
+++ b/packages/ckeditor5-clipboard/src/index.ts
@@ -21,7 +21,8 @@ export {
 
 export {
 	default as ClipboardMarkersUtils,
-	type ClipboardMarkerAction
+	type ClipboardMarkerRestrictionsPreset,
+	type ClipboardMarkerRestrictedAction
 } from './clipboardmarkersutils.js';
 
 export type {

--- a/packages/ckeditor5-clipboard/tests/clipboardmarkersutils.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardmarkersutils.js
@@ -5,9 +5,13 @@
 
 /* globals document */
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
+import DocumentFragment from '@ckeditor/ckeditor5-engine/src/model/documentfragment.js';
+import Position from '@ckeditor/ckeditor5-engine/src/model/position.js';
+import Range from '@ckeditor/ckeditor5-engine/src/model/range.js';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
-import { setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
+import { parse, setData as setModelData, getData as getModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
+import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view.js';
 
 import Clipboard from '../src/clipboard.js';
 
@@ -354,40 +358,7 @@ describe( 'Clipboard Markers Utils', () => {
 		} );
 	} );
 
-	describe( '_canPerformMarkerClipboardAction', () => {
-		it( 'returns false on non existing clipboard markers', () => {
-			const result = clipboardMarkersUtils._canPerformMarkerClipboardAction( 'Hello', 'cut' );
-
-			expect( result ).to.false;
-		} );
-	} );
-
-	describe( '_getUniqueMarkerName', () => {
-		it( 'replaces only ID part of three segmented marker name', () => {
-			getUniqueMarkerNameStub.restore();
-
-			const firstResult = clipboardMarkersUtils._getUniqueMarkerName( 'comment:thread:123123' );
-			const secondResult = clipboardMarkersUtils._getUniqueMarkerName( 'comment:thread:123123' );
-
-			expect( firstResult.startsWith( 'comment:thread:' ) ).to.be.true;
-			expect( firstResult ).not.to.eq( 'comment:thread:123123' );
-
-			expect( firstResult ).not.to.eq( secondResult );
-		} );
-
-		it( 'replaces only ID part of two segmented marker name', () => {
-			getUniqueMarkerNameStub.restore();
-
-			const firstResult = clipboardMarkersUtils._getUniqueMarkerName( 'comment:thread' );
-			const secondResult = clipboardMarkersUtils._getUniqueMarkerName( 'comment:thread' );
-
-			expect( firstResult.startsWith( 'comment:thread' ) ).to.be.true;
-			expect( firstResult ).not.to.eq( 'comment:thread' );
-			expect( firstResult ).not.to.eq( secondResult );
-		} );
-	} );
-
-	describe( 'restrictions', () => {
+	describe( 'Restrictions', () => {
 		it( 'should not be possible to copy and paste with restrictions', () => {
 			setModelData(
 				model,
@@ -498,6 +469,365 @@ describe( 'Clipboard Markers Utils', () => {
 		} );
 	} );
 
+	describe( 'Presets', () => {
+		it( 'should not copy marker in default preset', () => {
+			clipboardMarkersUtils._registerMarkerToCopy( 'comment', 'default' );
+
+			setModelData(
+				model,
+				wrapWithTag( 'paragraph', 'Hello World' ) + wrapWithTag( 'paragraph', '' )
+			);
+
+			appendMarker( 'comment:test', { start: [ 0, 0 ], end: [ 0, 3 ] } );
+
+			model.change( writer => {
+				writer.setSelection(
+					writer.createRangeOn( editor.model.document.getRoot().getChild( 0 ) ),
+					0
+				);
+			} );
+
+			const data = {
+				dataTransfer: createDataTransfer(),
+				preventDefault: () => {},
+				stopPropagation: () => {}
+			};
+
+			viewDocument.fire( 'copy', data );
+
+			model.change( writer => {
+				writer.setSelection(
+					writer.createRangeIn( editor.model.document.getRoot().getChild( 1 ) ),
+					0
+				);
+			} );
+
+			viewDocument.fire( 'paste', data );
+
+			expect( model.markers.has( 'comment:test:pasted' ) ).to.false;
+		} );
+
+		it( 'should cut marker in default preset', () => {
+			clipboardMarkersUtils._registerMarkerToCopy( 'comment', 'default' );
+
+			setModelData(
+				model,
+				wrapWithTag( 'paragraph', 'Hello World' ) + wrapWithTag( 'paragraph', '' )
+			);
+
+			appendMarker( 'comment:test', { start: [ 0, 0 ], end: [ 0, 3 ] } );
+
+			model.change( writer => {
+				writer.setSelection(
+					writer.createRangeOn( editor.model.document.getRoot().getChild( 0 ) ),
+					0
+				);
+			} );
+
+			const data = {
+				dataTransfer: createDataTransfer(),
+				preventDefault: () => {},
+				stopPropagation: () => {}
+			};
+
+			viewDocument.fire( 'cut', data );
+
+			model.change( writer => {
+				writer.setSelection(
+					writer.createRangeIn( editor.model.document.getRoot().getChild( 1 ) ),
+					0
+				);
+			} );
+
+			viewDocument.fire( 'paste', data );
+			expect( model.markers.has( 'comment:test:pasted' ) ).to.true;
+		} );
+
+		for ( const emptyPreset of [ 'never', 'dummy' ] ) {
+			it( `should not cut marker in ${ emptyPreset } preset`, () => {
+				clipboardMarkersUtils._registerMarkerToCopy( 'comment', emptyPreset );
+
+				setModelData(
+					model,
+					wrapWithTag( 'paragraph', 'Hello World' ) + wrapWithTag( 'paragraph', '' )
+				);
+
+				appendMarker( 'comment:test', { start: [ 0, 0 ], end: [ 0, 3 ] } );
+
+				model.change( writer => {
+					writer.setSelection(
+						writer.createRangeOn( editor.model.document.getRoot().getChild( 0 ) ),
+						0
+					);
+				} );
+
+				const data = {
+					dataTransfer: createDataTransfer(),
+					preventDefault: () => {},
+					stopPropagation: () => {}
+				};
+
+				viewDocument.fire( 'cut', data );
+
+				model.change( writer => {
+					writer.setSelection(
+						writer.createRangeIn( editor.model.document.getRoot().getChild( 1 ) ),
+						0
+					);
+				} );
+
+				viewDocument.fire( 'paste', data );
+				expect( model.markers.has( 'comment:test:pasted' ) ).to.false;
+			} );
+		}
+	} );
+
+	describe( '_removeFakeMarkersInsideElement', () => {
+		it( 'should handle duplicated fake-markers in element', () => {
+			model.change( writer => {
+				const fragment = new DocumentFragment( [
+					...createFakeMarkerElements( writer, 'comment:123', [
+						writer.createElement( 'paragraph' )
+					] ),
+					writer.createElement( 'paragraph' ),
+					...createFakeMarkerElements( writer, 'comment:123', [
+						writer.createElement( 'paragraph' )
+					] )
+				] );
+
+				const markers = clipboardMarkersUtils._removeFakeMarkersInsideElement( writer, fragment );
+
+				expect( Object.keys( markers ) ).deep.equal( [ 'comment:123', 'comment:123:pasted' ] );
+			} );
+		} );
+
+		function createFakeMarkerElements( writer, name, content = [] ) {
+			return [
+				writer.createElement( '$marker', { 'data-type': 'start', 'data-name': name } ),
+				...content,
+				writer.createElement( '$marker', { 'data-type': 'end', 'data-name': name } )
+			];
+		}
+	} );
+
+	describe( '_forceMarkersCopy', () => {
+		it( 'properly reverts old marker restricted actions', () => {
+			clipboardMarkersUtils._registerMarkerToCopy( 'comment', [ 'cut' ] );
+
+			expect( getMarkerRestrictions() ).deep.equal( [ 'cut' ] );
+
+			clipboardMarkersUtils._forceMarkersCopy( 'comment', () => {
+				expect( getMarkerRestrictions() ).deep.equal( clipboardMarkersUtils._mapRestrictionPresetToActions( 'always' ) );
+			} );
+
+			expect( getMarkerRestrictions() ).deep.equal( [ 'cut' ] );
+		} );
+
+		function getMarkerRestrictions() {
+			return clipboardMarkersUtils._markersToCopy.get( 'comment' );
+		}
+	} );
+
+	describe( '_canPerformMarkerClipboardAction', () => {
+		it( 'returns false on non existing clipboard markers', () => {
+			const result = clipboardMarkersUtils._canPerformMarkerClipboardAction( 'Hello', 'cut' );
+
+			expect( result ).to.false;
+		} );
+	} );
+
+	describe( '_getCopyableMarkersFromRangeMap', () => {
+		it( 'properly filters markers Map instance', () => {
+			clipboardMarkersUtils._registerMarkerToCopy( 'comment', [ 'cut' ] );
+
+			const { markers } = createFragmentWithMarkers(
+				wrapWithTag( 'paragraph', 'Hello world' ),
+				{
+					'comment:a': { start: [ 0, 0 ], end: [ 0, 6 ] },
+					'comment:b': { start: [ 0, 0 ], end: [ 0, 7 ] }
+				}
+			);
+
+			let result = clipboardMarkersUtils._getCopyableMarkersFromRangeMap( markers, 'copy' );
+			expect( result ).be.deep.equal( [] );
+
+			result = clipboardMarkersUtils._getCopyableMarkersFromRangeMap( markers, 'cut' );
+			expect( result ).be.deep.equal( [
+				{ name: 'comment:a', range: markers.get( 'comment:a' ) },
+				{ name: 'comment:b', range: markers.get( 'comment:b' ) }
+			] );
+		} );
+
+		it( 'properly filters markers Record instance', () => {
+			clipboardMarkersUtils._registerMarkerToCopy( 'comment', [ 'cut' ] );
+
+			const markers = Object.fromEntries(
+				createFragmentWithMarkers(
+					wrapWithTag( 'paragraph', 'Hello world' ),
+					{
+						'comment:a': { start: [ 0, 0 ], end: [ 0, 6 ] },
+						'comment:b': { start: [ 0, 0 ], end: [ 0, 7 ] }
+					}
+				).markers.entries()
+			);
+
+			let result = clipboardMarkersUtils._getCopyableMarkersFromRangeMap( markers, 'copy' );
+			expect( result ).be.deep.equal( [] );
+
+			result = clipboardMarkersUtils._getCopyableMarkersFromRangeMap( markers, 'cut' );
+			expect( result ).be.deep.equal( [
+				{ name: 'comment:a', range: markers[ 'comment:a' ] },
+				{ name: 'comment:b', range: markers[ 'comment:b' ] }
+			] );
+		} );
+	} );
+
+	describe( '_getUniqueMarkerName', () => {
+		it( 'replaces only ID part of three segmented marker name', () => {
+			getUniqueMarkerNameStub.restore();
+
+			const firstResult = clipboardMarkersUtils._getUniqueMarkerName( 'comment:thread:123123' );
+			const secondResult = clipboardMarkersUtils._getUniqueMarkerName( 'comment:thread:123123' );
+
+			expect( firstResult.startsWith( 'comment:thread:' ) ).to.be.true;
+			expect( firstResult ).not.to.eq( 'comment:thread:123123' );
+
+			expect( firstResult ).not.to.eq( secondResult );
+		} );
+
+		it( 'replaces only ID part of two segmented marker name', () => {
+			getUniqueMarkerNameStub.restore();
+
+			const firstResult = clipboardMarkersUtils._getUniqueMarkerName( 'comment:thread' );
+			const secondResult = clipboardMarkersUtils._getUniqueMarkerName( 'comment:thread' );
+
+			expect( firstResult.startsWith( 'comment:thread' ) ).to.be.true;
+			expect( firstResult ).not.to.eq( 'comment:thread' );
+			expect( firstResult ).not.to.eq( secondResult );
+		} );
+	} );
+
+	describe( '_pasteMarkersIntoTransformedElement', () => {
+		beforeEach( () => {
+			clipboardMarkersUtils._registerMarkerToCopy( 'comment', 'always' );
+		} );
+
+		it( 'should preserve original marker name if it is not duplicated', () => {
+			const copiedFragment = createFragmentWithMarkers(
+				wrapWithTag( 'paragraph', 'Hello world' ),
+				{
+					'comment:a': { start: [ 0, 0 ], end: [ 0, 6 ] },
+					'comment:b': { start: [ 0, 0 ], end: [ 0, 7 ] }
+				}
+			);
+
+			clipboardMarkersUtils._pasteMarkersIntoTransformedElement(
+				copiedFragment.markers,
+				writer => {
+					writer.insert( copiedFragment, modelRoot, 0 );
+					writer.removeMarker( 'comment:a' );
+					writer.removeMarker( 'comment:b' );
+
+					return editor.model.document.getRoot().getChild( 0 );
+				}
+			);
+
+			checkMarker( 'comment:a', model.createRange(
+				model.createPositionFromPath( modelRoot, [ 0, 0 ] ),
+				model.createPositionFromPath( modelRoot, [ 0, 6 ] )
+			) );
+
+			checkMarker( 'comment:b', model.createRange(
+				model.createPositionFromPath( modelRoot, [ 0, 0 ] ),
+				model.createPositionFromPath( modelRoot, [ 0, 7 ] )
+			) );
+		} );
+
+		it( 'should add real markers to pasted fragment (overlap at the start)', () => {
+			const copiedFragment = createFragmentWithMarkers(
+				wrapWithTag( 'paragraph', 'Hello world' ),
+				{
+					'comment:a': { start: [ 0, 0 ], end: [ 0, 6 ] },
+					'comment:b': { start: [ 0, 0 ], end: [ 0, 7 ] }
+				}
+			);
+
+			clipboardMarkersUtils._pasteMarkersIntoTransformedElement(
+				copiedFragment.markers,
+				writer => {
+					writer.insert( copiedFragment, modelRoot, 0 );
+					return editor.model.document.getRoot().getChild( 0 );
+				}
+			);
+
+			checkMarker( 'comment:a:pasted', model.createRange(
+				model.createPositionFromPath( modelRoot, [ 0, 0 ] ),
+				model.createPositionFromPath( modelRoot, [ 0, 6 ] )
+			) );
+
+			checkMarker( 'comment:b:pasted', model.createRange(
+				model.createPositionFromPath( modelRoot, [ 0, 0 ] ),
+				model.createPositionFromPath( modelRoot, [ 0, 7 ] )
+			) );
+		} );
+
+		it( 'should add real markers to pasted fragment (overlap at the end)', () => {
+			const copiedFragment = createFragmentWithMarkers(
+				wrapWithTag( 'paragraph', 'Hello world' ),
+				{
+					'comment:a': { start: [ 0, 5 ], end: [ 0, 11 ] },
+					'comment:b': { start: [ 0, 4 ], end: [ 0, 11 ] }
+				}
+			);
+
+			clipboardMarkersUtils._pasteMarkersIntoTransformedElement(
+				copiedFragment.markers,
+				writer => {
+					writer.insert( copiedFragment, modelRoot, 0 );
+					return editor.model.document.getRoot().getChild( 0 );
+				}
+			);
+
+			checkMarker( 'comment:a:pasted', model.createRange(
+				model.createPositionFromPath( modelRoot, [ 0, 5 ] ),
+				model.createPositionFromPath( modelRoot, [ 0, 11 ] )
+			) );
+
+			checkMarker( 'comment:b:pasted', model.createRange(
+				model.createPositionFromPath( modelRoot, [ 0, 4 ] ),
+				model.createPositionFromPath( modelRoot, [ 0, 11 ] )
+			) );
+		} );
+
+		it( 'should add real markers to pasted fragment (overlap at center)', () => {
+			const copiedFragment = createFragmentWithMarkers(
+				wrapWithTag( 'paragraph', 'Hello world' ),
+				{
+					'comment:a': { start: [ 0, 4 ], end: [ 0, 8 ] },
+					'comment:b': { start: [ 0, 0 ], end: [ 0, 11 ] }
+				}
+			);
+
+			clipboardMarkersUtils._pasteMarkersIntoTransformedElement(
+				copiedFragment.markers,
+				writer => {
+					writer.insert( copiedFragment, modelRoot, 0 );
+					return editor.model.document.getRoot().getChild( 0 );
+				}
+			);
+
+			checkMarker( 'comment:a:pasted', model.createRange(
+				model.createPositionFromPath( modelRoot, [ 0, 4 ] ),
+				model.createPositionFromPath( modelRoot, [ 0, 8 ] )
+			) );
+
+			checkMarker( 'comment:b:pasted', model.createRange(
+				model.createPositionFromPath( modelRoot, [ 0, 0 ] ),
+				model.createPositionFromPath( modelRoot, [ 0, 11 ] )
+			) );
+		} );
+	} );
+
 	async function createEditor() {
 		editor = await ClassicTestEditor.create( element, {
 			plugins: [ Paragraph, Clipboard ]
@@ -565,5 +895,29 @@ describe( 'Clipboard Markers Utils', () => {
 				return store.get( type );
 			}
 		};
+	}
+
+	function createFragmentWithMarkers( content, markers ) {
+		let parsedContent = parse( content, model.schema, {
+			context: [ '$clipboardHolder' ]
+		} );
+
+		if ( markers && !parsedContent.is( 'documentFragment' ) ) {
+			parsedContent = new DocumentFragment( [ parsedContent ] );
+		}
+
+		if ( markers ) {
+			const markersMap = new Map();
+
+			for ( const [ name, value ] of Object.entries( markers ) ) {
+				markersMap.set( name, new Range(
+					new Position( parsedContent, value.start ), new Position( parsedContent, value.end )
+				) );
+			}
+
+			parsedContent.markers = markersMap;
+		}
+
+		return parsedContent;
 	}
 } );

--- a/packages/ckeditor5-clipboard/tests/clipboardmarkersutils.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardmarkersutils.js
@@ -229,6 +229,129 @@ describe( 'Clipboard Markers Utils', () => {
 				model.createPositionFromPath( modelRoot, [ 1, 14 ] )
 			) );
 		} );
+
+		it( 'copy and paste fake marker that is inside another fake marker aligned to right', () => {
+			setModelData(
+				model,
+				wrapWithTag( 'paragraph', 'Fake Marker' ) + wrapWithTag( 'paragraph', '' )
+			);
+
+			appendMarker( 'comment:test', { start: [ 0, 2 ], end: [ 0, 11 ] } );
+			appendMarker( 'comment:test2', { start: [ 0, 6 ], end: [ 0, 11 ] } );
+
+			model.change( writer => {
+				writer.setSelection( writer.createRangeIn( editor.model.document.getRoot().getChild( 0 ) ) );
+			} );
+
+			const data = {
+				dataTransfer: createDataTransfer(),
+				preventDefault: () => {},
+				stopPropagation: () => {}
+			};
+
+			viewDocument.fire( 'copy', data );
+
+			model.change( writer => {
+				writer.setSelection(
+					writer.createRangeIn( editor.model.document.getRoot().getChild( 1 ) ),
+					0
+				);
+			} );
+
+			viewDocument.fire( 'paste', data );
+
+			checkMarker( 'comment:test:pasted', model.createRange(
+				model.createPositionFromPath( modelRoot, [ 1, 2 ] ),
+				model.createPositionFromPath( modelRoot, [ 1, 11 ] )
+			) );
+
+			checkMarker( 'comment:test2:pasted', model.createRange(
+				model.createPositionFromPath( modelRoot, [ 1, 6 ] ),
+				model.createPositionFromPath( modelRoot, [ 1, 11 ] )
+			) );
+		} );
+
+		it( 'copy and paste fake marker that is inside another fake marker aligned to left', () => {
+			setModelData(
+				model,
+				wrapWithTag( 'paragraph', 'Fake Marker' ) + wrapWithTag( 'paragraph', '' )
+			);
+
+			appendMarker( 'comment:test', { start: [ 0, 0 ], end: [ 0, 11 ] } );
+			appendMarker( 'comment:test2', { start: [ 0, 0 ], end: [ 0, 5 ] } );
+
+			model.change( writer => {
+				writer.setSelection( writer.createRangeIn( editor.model.document.getRoot().getChild( 0 ) ) );
+			} );
+
+			const data = {
+				dataTransfer: createDataTransfer(),
+				preventDefault: () => {},
+				stopPropagation: () => {}
+			};
+
+			viewDocument.fire( 'copy', data );
+
+			model.change( writer => {
+				writer.setSelection(
+					writer.createRangeIn( editor.model.document.getRoot().getChild( 1 ) ),
+					0
+				);
+			} );
+
+			viewDocument.fire( 'paste', data );
+
+			checkMarker( 'comment:test:pasted', model.createRange(
+				model.createPositionFromPath( modelRoot, [ 1, 0 ] ),
+				model.createPositionFromPath( modelRoot, [ 1, 11 ] )
+			) );
+
+			checkMarker( 'comment:test2:pasted', model.createRange(
+				model.createPositionFromPath( modelRoot, [ 1, 0 ] ),
+				model.createPositionFromPath( modelRoot, [ 1, 5 ] )
+			) );
+		} );
+
+		it( 'copy and paste fake marker that is inside another larger fake marker', () => {
+			setModelData(
+				model,
+				wrapWithTag( 'paragraph', 'Fake Marker' ) + wrapWithTag( 'paragraph', '' )
+			);
+
+			appendMarker( 'comment:test', { start: [ 0, 0 ], end: [ 0, 11 ] } );
+			appendMarker( 'comment:test2', { start: [ 0, 5 ], end: [ 0, 8 ] } );
+
+			model.change( writer => {
+				writer.setSelection( writer.createRangeIn( editor.model.document.getRoot().getChild( 0 ) ) );
+			} );
+
+			const data = {
+				dataTransfer: createDataTransfer(),
+				preventDefault: () => {},
+				stopPropagation: () => {}
+			};
+
+			viewDocument.fire( 'copy', data );
+
+			model.change( writer => {
+				writer.setSelection(
+					writer.createRangeIn( editor.model.document.getRoot().getChild( 1 ) ),
+					0
+				);
+			} );
+
+			viewDocument.fire( 'paste', data );
+
+			checkMarker( 'comment:test:pasted', model.createRange(
+				model.createPositionFromPath( modelRoot, [ 1, 0 ] ),
+				model.createPositionFromPath( modelRoot, [ 1, 11 ] )
+			) );
+
+			checkMarker( 'comment:test2:pasted', model.createRange(
+				model.createPositionFromPath( modelRoot, [ 1, 5 ] ),
+				model.createPositionFromPath( modelRoot, [ 1, 8 ] )
+			) );
+		} );
 	} );
 
 	describe( '_canPerformMarkerClipboardAction', () => {
@@ -413,13 +536,13 @@ describe( 'Clipboard Markers Utils', () => {
 	}
 
 	function appendMarker( name, { start, end } ) {
-		editor.model.change( writer => {
+		return editor.model.change( writer => {
 			const range = model.createRange(
 				model.createPositionFromPath( modelRoot, start ),
 				model.createPositionFromPath( modelRoot, end )
 			);
 
-			writer.addMarker( name, { usingOperation: false, affectsData: true, range } );
+			return writer.addMarker( name, { usingOperation: false, affectsData: true, range } );
 		} );
 	}
 

--- a/packages/ckeditor5-clipboard/tests/clipboardmarkersutils.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardmarkersutils.js
@@ -10,8 +10,7 @@ import Position from '@ckeditor/ckeditor5-engine/src/model/position.js';
 import Range from '@ckeditor/ckeditor5-engine/src/model/range.js';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
-import { parse, setData as setModelData, getData as getModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
-import { getData as getViewData } from '@ckeditor/ckeditor5-engine/src/dev-utils/view.js';
+import { parse, setData as setModelData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 
 import Clipboard from '../src/clipboard.js';
 

--- a/packages/ckeditor5-table/src/tableclipboard.ts
+++ b/packages/ckeditor5-table/src/tableclipboard.ts
@@ -7,8 +7,7 @@
  * @module table/tableclipboard
  */
 
-import { chunk } from 'lodash-es';
-import { uid, type EventInfo } from 'ckeditor5/src/utils.js';
+import type { EventInfo } from 'ckeditor5/src/utils.js';
 
 import {
 	ClipboardPipeline,
@@ -21,18 +20,17 @@ import {
 
 import { Plugin } from 'ckeditor5/src/core.js';
 
-import {
-	Range,
-	type DocumentFragment,
-	type DocumentSelection,
-	type DomEventData,
-	type Element,
-	type Item,
-	type Model,
-	type ModelInsertContentEvent,
-	type Position,
-	type Selection,
-	type Writer
+import type {
+	DocumentFragment,
+	DocumentSelection,
+	DomEventData,
+	Element,
+	Item,
+	Model,
+	ModelInsertContentEvent,
+	Position,
+	Selection,
+	Writer
 } from 'ckeditor5/src/engine.js';
 
 import TableSelection from './tableselection.js';
@@ -142,6 +140,7 @@ export default class TableClipboard extends Plugin {
 
 		const model = this.editor.model;
 		const tableUtils = this.editor.plugins.get( TableUtils );
+		const clipboardMarkersUtils = this.editor.plugins.get( ClipboardMarkersUtils );
 
 		// We might need to crop table before inserting so reference might change.
 		const pastedTable = this.getTableIfOnlyTableInContent( content, model )!;
@@ -161,17 +160,17 @@ export default class TableClipboard extends Plugin {
 		// Override default model.insertContent() handling at this point.
 		evt.stop();
 
-		this.editor.model.change( writer => {
-			if ( content.is( 'documentFragment' ) ) {
-				this._convertMarkersToElements( content.markers, writer );
-			}
-
-			const replacedCells = this._replaceSelectedCells( pastedTable, selectedTableCells, writer );
-
-			if ( content.is( 'documentFragment' ) && content.markers.size ) {
-				this._convertElementsToMarkers( replacedCells, writer );
-			}
-		} );
+		if ( content.is( 'documentFragment' ) ) {
+			clipboardMarkersUtils._pasteMarkersIntoTransformedElement(
+				'copy',
+				Object.fromEntries( content.markers.entries() ),
+				writer => this._replaceSelectedCells( pastedTable, selectedTableCells, writer )
+			);
+		} else {
+			this.editor.model.change( writer => {
+				this._replaceSelectedCells( pastedTable, selectedTableCells, writer );
+			} );
+		}
 	}
 
 	/**
@@ -225,92 +224,7 @@ export default class TableClipboard extends Plugin {
 			writer.setSelection( cellsToSelect[ 0 ], 0 );
 		}
 
-		return cellsToSelect;
-	}
-
-	/**
-	 * Inserts a marker map into the tree in the form of fake `$marker` elements (at the beginning of the marker range and at the end).
-	 * The fake elements will be used in further steps to restore the markers after table modifications.
-	 */
-	private _convertMarkersToElements( markers: Map<string, Range>, writer: Writer ) {
-		const sortedMarkers = [ ...markers.entries() ]
-			.flatMap( ( [ name, { start, end } ] ) => [
-				{ position: start, name },
-				{ position: end, name }
-			] )
-			// Markers position is sorted backwards to ensure that the insertion of fake markers will not change
-			// the position of the next markers.
-			.sort( ( { position: posA }, { position: posB } ) => posA.isBefore( posB ) ? 1 : -1 );
-
-		for ( const { position, name } of sortedMarkers ) {
-			const fakeMarker = writer.createElement( '$marker', { 'data-name': name } );
-
-			writer.insert( fakeMarker, position );
-		}
-	}
-
-	/**
-	 * Restores the markers to the tree after the table modifications are finished.
-	 * It inserts them in place of each fake element (which are then removed).
-	 */
-	private _convertElementsToMarkers( replacedCells: Array<Element>, writer: Writer ) {
-		const markersFakeElements = replacedCells
-			.flatMap( cell => Array.from( writer.createRangeOn( cell ) ) )
-			.reduce<Record<string, Array<Item>>>(
-				( acc, { item: cellItem } ) => {
-					const markerAttribute = cellItem.getAttribute( 'data-name' ) as string | undefined;
-
-					if ( !markerAttribute ) {
-						return acc;
-					}
-
-					if ( !acc[ markerAttribute ] ) {
-						acc[ markerAttribute ] = [];
-					}
-
-					acc[ markerAttribute ].push( cellItem );
-					return acc;
-				},
-				{}
-			);
-
-		// Sometimes fake markers are duplicated and there is more than two elements in array.
-		// It can happen if you copy column from first table with single marker and then paste
-		// it as row to second table.
-		for ( const [ markerName, positions ] of Object.entries( markersFakeElements ) ) {
-			const positionsChunks = chunk( positions, 2 );
-
-			for ( let chunkOffset = 0; chunkOffset < positionsChunks.length; ++chunkOffset ) {
-				const [ startNode, endNode ] = positionsChunks[ chunkOffset ];
-
-				if ( endNode ) {
-					const range = new Range(
-						writer.createPositionAt( startNode, 'before' ),
-						writer.createPositionAt( endNode, 'before' )
-					);
-
-					// if copy is performed and some of markers are duplicated
-					// we have to reassign their custom id to prevent incorrect
-					// cell selection after pasting to second table.
-					// TODO: Remove it after refactoring `updateMarkersIds` function.
-					const chunkMarkerName = chunkOffset > 0 ?
-						`${ markerName.slice( 0, markerName.lastIndexOf( ':' ) ) }:${ uid() }` : markerName;
-
-					writer.addMarker( chunkMarkerName, {
-						// We are inserting some content saved in the document fragment, so these
-						// markers must affect data if they were put into the document fragment
-						usingOperation: true,
-						// All markers affecting data must use operations.
-						affectsData: true,
-						range
-					} );
-
-					writer.remove( endNode );
-				}
-
-				writer.remove( startNode );
-			}
-		}
+		return selectedTable;
 	}
 
 	/**

--- a/packages/ckeditor5-table/src/tableclipboard.ts
+++ b/packages/ckeditor5-table/src/tableclipboard.ts
@@ -162,7 +162,7 @@ export default class TableClipboard extends Plugin {
 
 		if ( content.is( 'documentFragment' ) ) {
 			clipboardMarkersUtils._pasteMarkersIntoTransformedElement(
-				Object.fromEntries( content.markers.entries() ),
+				content.markers,
 				writer => this._replaceSelectedCells( pastedTable, selectedTableCells, writer )
 			);
 		} else {

--- a/packages/ckeditor5-table/src/tableclipboard.ts
+++ b/packages/ckeditor5-table/src/tableclipboard.ts
@@ -162,7 +162,6 @@ export default class TableClipboard extends Plugin {
 
 		if ( content.is( 'documentFragment' ) ) {
 			clipboardMarkersUtils._pasteMarkersIntoTransformedElement(
-				'copy',
 				Object.fromEntries( content.markers.entries() ),
 				writer => this._replaceSelectedCells( pastedTable, selectedTableCells, writer )
 			);


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (clipboard): Fix incorrect copy and paste behavior when copied marker is present in another marker. Closes [#15942](https://github.com/ckeditor/ckeditor5/issues/15942).

Internal (clipboard): Fix disappearing widgets with markers after move. Closes [#15952](https://github.com/ckeditor/ckeditor5/issues/15952).