### PR TITLE
Schema addChildCheck/addAttributeCheck filtering

### DIFF
--- a/packages/ckeditor5-ckbox/src/ckboxediting.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxediting.ts
@@ -140,13 +140,12 @@ export default class CKBoxEditing extends Plugin {
 			schema.extend( 'imageInline', { allowAttributes: [ 'ckboxImageId', 'ckboxLinkId' ] } );
 		}
 
-		schema.addAttributeCheck( ( context, attributeName ) => {
-			const isLink = !!context.last.getAttribute( 'linkHref' );
-
-			if ( !isLink && attributeName === 'ckboxLinkId' ) {
+		schema.addAttributeCheck( context => {
+			// Don't allow `ckboxLinkId` on elements which do not have `linkHref` attribute.
+			if ( !context.last.getAttribute( 'linkHref' ) ) {
 				return false;
 			}
-		} );
+		}, 'ckboxLinkId' );
 	}
 
 	/**

--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -105,7 +105,8 @@ export type {
 	SchemaAttributeCheckCallback,
 	SchemaChildCheckCallback,
 	AttributeProperties,
-	SchemaItemDefinition
+	SchemaItemDefinition,
+	SchemaContext
 } from './model/schema.js';
 export type { default as Selection, Selectable } from './model/selection.js';
 export type { default as TypeCheckable } from './model/typecheckable.js';

--- a/packages/ckeditor5-engine/src/model/model.ts
+++ b/packages/ckeditor5-engine/src/model/model.ts
@@ -146,11 +146,7 @@ export default class Model extends /* #__PURE__ */ ObservableMixin() {
 		// at the end of the conversion. `UpcastDispatcher` or at least `Conversion` class looks like a
 		// better place for this registration but both know nothing about `Schema`.
 		this.schema.register( '$marker' );
-		this.schema.addChildCheck( ( context, childDefinition ) => {
-			if ( childDefinition.name === '$marker' ) {
-				return true;
-			}
-		} );
+		this.schema.addChildCheck( () => true, '$marker' ); // Allow everywhere.
 
 		injectSelectionPostFixer( this );
 

--- a/packages/ckeditor5-engine/src/model/schema.ts
+++ b/packages/ckeditor5-engine/src/model/schema.ts
@@ -1083,7 +1083,7 @@ export default class Schema extends /* #__PURE__ */ ObservableMixin() {
 
 		// If the item is allowed, recursively verify the rest of the `context`.
 		const parentItemDefinition = this.getDefinition( parentItem );
-		const parentContext = context.pop();
+		const parentContext = context.trimLast();
 
 		// One of the items in the original `context` did not have a definition specified. In this case, the whole context is disallowed.
 		if ( !parentItemDefinition ) {
@@ -1120,8 +1120,8 @@ export default class Schema extends /* #__PURE__ */ ObservableMixin() {
 	}
 
 	/**
-	 * Calls child check callbacks to decide whether `def` is allowed in `context`. It uses both generic and specific (defined for `def`
-	 * item) callbacks. If neither callback makes a decision, `undefined` is returned.
+	 * Calls attribute check callbacks to decide whether `attributeName` can be set on the last element of `context`. It uses both
+	 * generic and specific (defined for `attributeName`) callbacks. If neither callback makes a decision, `undefined` is returned.
 	 *
 	 * Note that the first callback that makes a decision "wins", i.e., if any callback returns `true` or `false`, then the processing
 	 * is over and that result is returned.
@@ -1866,13 +1866,13 @@ export class SchemaContext implements Iterable<SchemaContextItem> {
 	 *
 	 * ```ts
 	 * const ctxParagraph = new SchemaContext( [ '$root', 'blockQuote', 'paragraph' ] );
-	 * const ctxBlockQuote = ctxParagraph.pop(); // Items in `ctxBlockQuote` are: `$root` an `blockQuote`.
-	 * const ctxRoot = ctxBlockQuote.pop(); // Items in `ctxRoot` are: `$root`.
+	 * const ctxBlockQuote = ctxParagraph.trimLast(); // Items in `ctxBlockQuote` are: `$root` an `blockQuote`.
+	 * const ctxRoot = ctxBlockQuote.trimLast(); // Items in `ctxRoot` are: `$root`.
 	 * ```
 	 *
 	 * @returns A new reduced schema context instance.
 	 */
-	public pop(): SchemaContext {
+	public trimLast(): SchemaContext {
 		const ctx = new SchemaContext( [] );
 
 		ctx._items = this._items.slice( 0, -1 );

--- a/packages/ckeditor5-engine/src/model/schema.ts
+++ b/packages/ckeditor5-engine/src/model/schema.ts
@@ -42,6 +42,28 @@ export default class Schema extends /* #__PURE__ */ ObservableMixin() {
 	 * A dictionary containing attribute properties.
 	 */
 	private readonly _attributeProperties: Record<string, AttributeProperties> = {};
+
+	/**
+	 * Stores additional callbacks registered for schema items, which are evaluated when {@link ~Schema#checkChild} is called.
+	 *
+	 * Keys are schema item names for which the callbacks are registered. Values are arrays with the callbacks.
+	 *
+	 * Some checks are added under {@link ~Schema#_genericCheckSymbol} key, these are evaluated for every {@link ~Schema#checkChild} call.
+	 */
+	private readonly _customChildChecks: Map<string | symbol, Array<SchemaChildCheckCallback>> = new Map();
+
+	/**
+	 * Stores additional callbacks registered for attribute names, which are evaluated when {@link ~Schema#checkAttribute} is called.
+	 *
+	 * Keys are schema attribute names for which the callbacks are registered. Values are arrays with the callbacks.
+	 *
+	 * Some checks are added under {@link ~Schema#_genericCheckSymbol} key, these are evaluated for every
+	 * {@link ~Schema#checkAttribute} call.
+	 */
+	private readonly _customAttributeChecks: Map<string | symbol, Array<SchemaAttributeCheckCallback>> = new Map();
+
+	private readonly _genericCheckSymbol = Symbol( '$generic' );
+
 	private _compiledDefinitions?: Record<string, SchemaCompiledItemDefinition> | null;
 
 	/**
@@ -363,7 +385,7 @@ export default class Schema extends /* #__PURE__ */ ObservableMixin() {
 	}
 
 	/**
-	 * Checks whether the given node (`child`) can be a child of the given context.
+	 * Checks whether the given node can be a child of the given context.
 	 *
 	 * ```ts
 	 * schema.checkChild( model.document.getRoot(), paragraph ); // -> false
@@ -371,30 +393,36 @@ export default class Schema extends /* #__PURE__ */ ObservableMixin() {
 	 * schema.register( 'paragraph', {
 	 * 	allowIn: '$root'
 	 * } );
+	 *
 	 * schema.checkChild( model.document.getRoot(), paragraph ); // -> true
 	 * ```
 	 *
-	 * Note: When verifying whether the given node can be a child of the given context, the
-	 * schema also verifies the entire context &ndash; from its root to its last element. Therefore, it is possible
-	 * for `checkChild()` to return `false` even though the context's last element can contain the checked child.
-	 * It happens if one of the context's elements does not allow its child.
+	 * Both {@link module:engine/model/schema~Schema#addChildCheck callback checks} and declarative rules (added when
+	 * {@link module:engine/model/schema~Schema#register registering} and {@link module:engine/model/schema~Schema#extend extending} items)
+	 * are evaluated when this method is called.
+	 *
+	 * Note that callback checks have bigger priority than declarative rules checks and may overwrite them.
+	 *
+	 * Note that when verifying whether the given node can be a child of the given context, the schema also verifies the entire
+	 * context &ndash; from its root to its last element. Therefore, it is possible for `checkChild()` to return `false` even though
+	 * the `context` last element can contain the checked child. It happens if one of the `context` elements does not allow its child.
+	 * When `context` is verified, {@link module:engine/model/schema~Schema#addChildCheck custom checks} are considered as well.
 	 *
 	 * @fires checkChild
 	 * @param context The context in which the child will be checked.
 	 * @param def The child to check.
 	 */
 	public checkChild( context: SchemaContextDefinition, def: string | Node | DocumentFragment ): boolean {
-		// Note: context and child are already normalized here to a SchemaContext and SchemaCompiledItemDefinition.
+		// Note: `context` and `def` are already normalized here to `SchemaContext` and `SchemaCompiledItemDefinition`.
 		if ( !def ) {
 			return false;
 		}
 
-		return this._checkContextMatch( def as any, context as any );
+		return this._checkContextMatch( context as SchemaContext, def as unknown as SchemaCompiledItemDefinition );
 	}
 
 	/**
-	 * Checks whether the given attribute can be applied in the given context (on the last
-	 * item of the context).
+	 * Checks whether the given attribute can be applied in the given context (on the last item of the context).
 	 *
 	 * ```ts
 	 * schema.checkAttribute( textNode, 'bold' ); // -> false
@@ -402,20 +430,34 @@ export default class Schema extends /* #__PURE__ */ ObservableMixin() {
 	 * schema.extend( '$text', {
 	 * 	allowAttributes: 'bold'
 	 * } );
+	 *
 	 * schema.checkAttribute( textNode, 'bold' ); // -> true
 	 * ```
 	 *
+	 * Both {@link module:engine/model/schema~Schema#addAttributeCheck callback checks} and declarative rules (added when
+	 * {@link module:engine/model/schema~Schema#register registering} and {@link module:engine/model/schema~Schema#extend extending} items)
+	 * are evaluated when this method is called.
+	 *
+	 * Note that callback checks have bigger priority than declarative rules checks and may overwrite them.
+	 *
 	 * @fires checkAttribute
 	 * @param context The context in which the attribute will be checked.
+	 * @param attributeName Name of attribute to check in the given context.
 	 */
 	public checkAttribute( context: SchemaContextDefinition, attributeName: string ): boolean {
-		const def = this.getDefinition( ( context as any ).last );
+		// Note: `context` is already normalized here to `SchemaContext`.
+		const def = this.getDefinition( ( context as SchemaContext ).last );
 
 		if ( !def ) {
 			return false;
 		}
 
-		return def.allowAttributes.includes( attributeName );
+		// First, check all attribute checks declared as callbacks.
+		// Note that `_evaluateAttributeChecks()` will return `undefined` if neither child check was applicable (no decision was made).
+		const isAllowed = this._evaluateAttributeChecks( context as SchemaContext, attributeName );
+
+		// If the decision was not made inside attribute check callbacks, then use declarative rules.
+		return isAllowed ?? def.allowAttributes.includes( attributeName );
 	}
 
 	public checkMerge( position: Position ): boolean;
@@ -486,60 +528,72 @@ export default class Schema extends /* #__PURE__ */ ObservableMixin() {
 	 *
 	 * Callbacks allow you to implement rules which are not otherwise possible to achieve
 	 * by using the declarative API of {@link module:engine/model/schema~SchemaItemDefinition}.
-	 * For example, by using this method you can disallow elements in specific contexts.
 	 *
-	 * This method is a shorthand for using the {@link #event:checkChild} event. For even better control,
-	 * you can use that event instead.
+	 * Note that callback checks have bigger priority than declarative rules checks and may overwrite them.
 	 *
-	 * Example:
+	 * For example, by using this method you can disallow elements in specific contexts:
 	 *
 	 * ```ts
-	 * // Disallow heading1 directly inside a blockQuote.
+	 * // Disallow `heading1` inside a `blockQuote` that is inside a table.
 	 * schema.addChildCheck( ( context, childDefinition ) => {
-	 * 	if ( context.endsWith( 'blockQuote' ) && childDefinition.name == 'heading1' ) {
+	 * 	if ( context.endsWith( 'tableCell blockQuote' ) ) {
 	 * 		return false;
+	 * 	}
+	 * }, 'heading1' );
+	 * ```
+	 *
+	 * You can skip the optional `itemName` parameter to evaluate the callback for every `checkChild()` call.
+	 *
+	 * ```ts
+	 * // Inside specific custom element, allow only children, which allows for a specific attribute.
+	 * schema.addChildCheck( ( context, childDefinition ) => {
+	 * 	if ( context.endsWith( 'myElement' ) ) {
+	 * 		return childDefinition.allowAttributes.includes( 'myAttribute' );
 	 * 	}
 	 * } );
 	 * ```
 	 *
-	 * Which translates to:
+	 * Please note that the generic callbacks may affect the editor performance and should be avoided if possible.
+	 *
+	 * When one of the callbacks makes a decision (returns `true` or `false`) the processing is finished and other callbacks are not fired.
+	 * Callbacks are fired in the order they were added, however generic callbacks are fired before callbacks added for a specified item.
+	 *
+	 * You can also use `checkChild` event, if you need even better control. The result from the example above could also be
+	 * achieved with following event callback:
 	 *
 	 * ```ts
 	 * schema.on( 'checkChild', ( evt, args ) => {
 	 * 	const context = args[ 0 ];
 	 * 	const childDefinition = args[ 1 ];
 	 *
-	 * 	if ( context.endsWith( 'blockQuote' ) && childDefinition && childDefinition.name == 'heading1' ) {
+	 * 	if ( context.endsWith( 'myElement' ) ) {
 	 * 		// Prevent next listeners from being called.
 	 * 		evt.stop();
-	 * 		// Set the checkChild()'s return value.
-	 * 		evt.return = false;
+	 * 		// Set the `checkChild()` return value.
+	 * 		evt.return = childDefinition.allowAttributes.includes( 'myAttribute' );
 	 * 	}
 	 * }, { priority: 'high' } );
 	 * ```
 	 *
+	 * Note that the callback checks and declarative rules checks are processed on `normal` priority.
+	 *
+	 * Adding callbacks this way can also negatively impact editor performance.
+	 *
 	 * @param callback The callback to be called. It is called with two parameters:
 	 * {@link module:engine/model/schema~SchemaContext} (context) instance and
-	 * {@link module:engine/model/schema~SchemaCompiledItemDefinition} (child-to-check definition).
-	 * The callback may return `true/false` to override `checkChild()`'s return value. If it does not return
-	 * a boolean value, the default algorithm (or other callbacks) will define `checkChild()`'s return value.
+	 * {@link module:engine/model/schema~SchemaCompiledItemDefinition} (definition). The callback may return `true/false` to override
+	 * `checkChild()`'s return value. If it does not return a boolean value, the default algorithm (or other callbacks) will define
+	 * `checkChild()`'s return value.
+	 * @param itemName Name of the schema item for which the callback is registered. If specified, the callback will be run only for
+	 * `checkChild()` calls which `def` parameter matches the `itemName`. Otherwise, the callback will run for every `checkChild` call.
 	 */
-	public addChildCheck( callback: SchemaChildCheckCallback ): void {
-		this.on<SchemaCheckChildEvent>( 'checkChild', ( evt, [ ctx, childDef ] ) => {
-			// checkChild() was called with a non-registered child.
-			// In 99% cases such check should return false, so not to overcomplicate all callbacks
-			// don't even execute them.
-			if ( !childDef ) {
-				return;
-			}
+	public addChildCheck( callback: SchemaChildCheckCallback, itemName?: string ): void {
+		const key = itemName ?? this._genericCheckSymbol;
 
-			const retValue = callback( ctx, childDef );
+		const checks = this._customChildChecks.get( key ) || [];
+		checks.push( callback );
 
-			if ( typeof retValue == 'boolean' ) {
-				evt.stop();
-				evt.return = retValue;
-			}
-		}, { priority: 'high' } );
+		this._customChildChecks.set( key, checks );
 	}
 
 	/**
@@ -547,53 +601,71 @@ export default class Schema extends /* #__PURE__ */ ObservableMixin() {
 	 *
 	 * Callbacks allow you to implement rules which are not otherwise possible to achieve
 	 * by using the declarative API of {@link module:engine/model/schema~SchemaItemDefinition}.
-	 * For example, by using this method you can disallow attribute if node to which it is applied
-	 * is contained within some other element (e.g. you want to disallow `bold` on `$text` within `heading1`).
 	 *
-	 * This method is a shorthand for using the {@link #event:checkAttribute} event. For even better control,
-	 * you can use that event instead.
+	 * Note that callback checks have bigger priority than declarative rules checks and may overwrite them.
 	 *
-	 * Example:
+	 * For example, by using this method you can disallow setting attributes on nodes in specific contexts:
 	 *
 	 * ```ts
-	 * // Disallow bold on $text inside heading1.
+	 * // Disallow setting `bold` on text inside `heading1` element:
+	 * schema.addAttributeCheck( context => {
+	 * 	if ( context.endsWith( 'heading1 $text' ) ) {
+	 * 		return false;
+	 * 	}
+	 * }, 'bold' );
+	 * ```
+	 *
+	 * You can skip the optional `attributeName` parameter to evaluate the callback for every `checkAttribute()` call.
+	 *
+	 * ```ts
+	 * // Disallow formatting attributes on text inside custom `myTitle` element:
 	 * schema.addAttributeCheck( ( context, attributeName ) => {
-	 * 	if ( context.endsWith( 'heading1 $text' ) && attributeName == 'bold' ) {
+	 * 	if ( context.endsWith( 'myTitle $text' ) && schema.getAttributeProperties( attributeName ).isFormatting ) {
 	 * 		return false;
 	 * 	}
 	 * } );
 	 * ```
 	 *
-	 * Which translates to:
+	 * Please note that the generic callbacks may affect the editor performance and should be avoided if possible.
+	 *
+	 * When one of the callbacks makes a decision (returns `true` or `false`) the processing is finished and other callbacks are not fired.
+	 * Callbacks are fired in the order they were added, however generic callbacks are fired before callbacks added for a specified item.
+	 *
+	 * You can also use {@link #event:checkAttribute} event, if you need even better control. The result from the example above could also
+	 * be achieved with following event callback:
 	 *
 	 * ```ts
 	 * schema.on( 'checkAttribute', ( evt, args ) => {
 	 * 	const context = args[ 0 ];
 	 * 	const attributeName = args[ 1 ];
 	 *
-	 * 	if ( context.endsWith( 'heading1 $text' ) && attributeName == 'bold' ) {
+	 * 	if ( context.endsWith( 'myTitle $text' ) && schema.getAttributeProperties( attributeName ).isFormatting ) {
 	 * 		// Prevent next listeners from being called.
 	 * 		evt.stop();
-	 * 		// Set the checkAttribute()'s return value.
+	 * 		// Set the `checkAttribute()` return value.
 	 * 		evt.return = false;
 	 * 	}
 	 * }, { priority: 'high' } );
 	 * ```
 	 *
+	 * Note that the callback checks and declarative rules checks are processed on `normal` priority.
+	 *
+	 * Adding callbacks this way can also negatively impact editor performance.
+	 *
 	 * @param callback The callback to be called. It is called with two parameters:
-	 * {@link module:engine/model/schema~SchemaContext} (context) instance and attribute name.
-	 * The callback may return `true/false` to override `checkAttribute()`'s return value. If it does not return
-	 * a boolean value, the default algorithm (or other callbacks) will define `checkAttribute()`'s return value.
+	 * {@link module:engine/model/schema~SchemaContext `context`} and attribute name. The callback may return `true` or `false`, to
+	 * override `checkAttribute()`'s return value. If it does not return a boolean value, the default algorithm (or other callbacks)
+	 * will define `checkAttribute()`'s return value.
+	 * @param attributeName Name of the attribute for which the callback is registered. If specified, the callback will be run only for
+	 * `checkAttribute()` calls with matching `attributeName`. Otherwise, the callback will run for every `checkAttribute()` call.
 	 */
-	public addAttributeCheck( callback: SchemaAttributeCheckCallback ): void {
-		this.on<SchemaCheckAttributeEvent>( 'checkAttribute', ( evt, [ ctx, attributeName ] ) => {
-			const retValue = callback( ctx, attributeName );
+	public addAttributeCheck( callback: SchemaAttributeCheckCallback, attributeName?: string ): void {
+		const key = attributeName ?? this._genericCheckSymbol;
 
-			if ( typeof retValue == 'boolean' ) {
-				evt.stop();
-				evt.return = retValue;
-			}
-		}, { priority: 'high' } );
+		const checks = this._customAttributeChecks.get( key ) || [];
+		checks.push( callback );
+
+		this._customAttributeChecks.set( key, checks );
 	}
 
 	/**
@@ -994,23 +1066,76 @@ export default class Schema extends /* #__PURE__ */ ObservableMixin() {
 		this._compiledDefinitions = compileDefinitions( definitions );
 	}
 
-	private _checkContextMatch(
-		def: SchemaCompiledItemDefinition,
-		context: SchemaContext,
-		contextItemIndex: number = context.length - 1
-	): boolean {
-		const contextItem = context.getItem( contextItemIndex );
+	private _checkContextMatch( context: SchemaContext, def: SchemaCompiledItemDefinition ): boolean {
+		const parentItem = context.last;
 
-		if ( def.allowIn.includes( contextItem.name ) ) {
-			if ( contextItemIndex == 0 ) {
-				return true;
-			} else {
-				const parentRule = this.getDefinition( contextItem );
+		// First, check all child checks declared as callbacks.
+		// Note that `_evaluateChildChecks()` will return `undefined` if neither child check was applicable (no decision was made).
+		let isAllowed = this._evaluateChildChecks( context, def );
 
-				return this._checkContextMatch( parentRule!, context, contextItemIndex - 1 );
-			}
-		} else {
+		// If the decision was not made inside child check callbacks, then use declarative rules.
+		isAllowed = isAllowed ?? def.allowIn.includes( parentItem.name );
+
+		// If the item is not allowed in the `context`, return `false`.
+		if ( !isAllowed ) {
 			return false;
+		}
+
+		// If the item is allowed, recursively verify the rest of the `context`.
+		const parentItemDefinition = this.getDefinition( parentItem );
+		const parentContext = context.pop();
+
+		// One of the items in the original `context` did not have a definition specified. In this case, the whole context is disallowed.
+		if ( !parentItemDefinition ) {
+			return false;
+		}
+
+		// Whole `context` was verified and passed checks.
+		if ( parentContext.length == 0 ) {
+			return true;
+		}
+
+		// Verify "truncated" parent context. The last item of the original context is now the definition to check.
+		return this._checkContextMatch( parentContext, parentItemDefinition );
+	}
+
+	/**
+	 * Calls child check callbacks to decide whether `def` is allowed in `context`. It uses both generic and specific (defined for `def`
+	 * item) callbacks. If neither callback makes a decision, `undefined` is returned.
+	 *
+	 * Note that the first callback that makes a decision "wins", i.e., if any callback returns `true` or `false`, then the processing
+	 * is over and that result is returned.
+	 */
+	private _evaluateChildChecks( context: SchemaContext, def: SchemaCompiledItemDefinition ): boolean | undefined {
+		const genericChecks = this._customChildChecks.get( this._genericCheckSymbol ) || [];
+		const childChecks = this._customChildChecks.get( def.name ) || [];
+
+		for ( const check of [ ...genericChecks, ...childChecks ] ) {
+			const result = check( context, def );
+
+			if ( result !== undefined ) {
+				return result;
+			}
+		}
+	}
+
+	/**
+	 * Calls child check callbacks to decide whether `def` is allowed in `context`. It uses both generic and specific (defined for `def`
+	 * item) callbacks. If neither callback makes a decision, `undefined` is returned.
+	 *
+	 * Note that the first callback that makes a decision "wins", i.e., if any callback returns `true` or `false`, then the processing
+	 * is over and that result is returned.
+	 */
+	private _evaluateAttributeChecks( context: SchemaContext, attributeName: string ): boolean | undefined {
+		const genericChecks = this._customAttributeChecks.get( this._genericCheckSymbol ) || [];
+		const childChecks = this._customAttributeChecks.get( attributeName ) || [];
+
+		for ( const check of [ ...genericChecks, ...childChecks ] ) {
+			const result = check( context, attributeName );
+
+			if ( result !== undefined ) {
+				return result;
+			}
 		}
 	}
 
@@ -1463,26 +1588,36 @@ export interface SchemaItemDefinition {
 
 	/**
 	 * Inherits "allowed children" from other items.
+	 *
+	 * Note that the item's "own" rules take precedence over "inherited" rules and can overwrite them.
 	 */
 	allowContentOf?: string | Array<string>;
 
 	/**
 	 * Inherits "allowed in" from other items.
+	 *
+	 * Note that the item's "own" rules take precedence over "inherited" rules and can overwrite them.
 	 */
 	allowWhere?: string | Array<string>;
 
 	/**
 	 * Inherits "allowed attributes" from other items.
+	 *
+	 * Note that the item's "own" rules take precedence over "inherited" rules and can overwrite them.
 	 */
 	allowAttributesOf?: string | Array<string>;
 
 	/**
 	 * Inherits `is*` properties of other items.
+	 *
+	 * Note that the item's "own" rules take precedence over "inherited" rules and can overwrite them.
 	 */
 	inheritTypesFrom?: string | Array<string>;
 
 	/**
 	 * A shorthand for `allowContentOf`, `allowWhere`, `allowAttributesOf`, `inheritTypesFrom`.
+	 *
+	 * Note that the item's "own" rules take precedence over "inherited" rules and can overwrite them.
 	 */
 	inheritAllFrom?: string;
 
@@ -1727,6 +1862,25 @@ export class SchemaContext implements Iterable<SchemaContextItem> {
 	}
 
 	/**
+	 * Returns a new schema context that is based on this context but has the last item removed.
+	 *
+	 * ```ts
+	 * const ctxParagraph = new SchemaContext( [ '$root', 'blockQuote', 'paragraph' ] );
+	 * const ctxBlockQuote = ctxParagraph.pop(); // Items in `ctxBlockQuote` are: `$root` an `blockQuote`.
+	 * const ctxRoot = ctxBlockQuote.pop(); // Items in `ctxRoot` are: `$root`.
+	 * ```
+	 *
+	 * @returns A new reduced schema context instance.
+	 */
+	public pop(): SchemaContext {
+		const ctx = new SchemaContext( [] );
+
+		ctx._items = this._items.slice( 0, -1 );
+
+		return ctx;
+	}
+
+	/**
 	 * Gets an item on the given index.
 	 */
 	public getItem( index: number ): SchemaContextItem {
@@ -1787,7 +1941,7 @@ export class SchemaContext implements Iterable<SchemaContextItem> {
  * * By defining an **array of node names** (potentially, mixed with real nodes) – The same as **name of node**
  * but it is possible to create a path.
  * * By defining a {@link module:engine/model/schema~SchemaContext} instance - in this case the same instance as provided
- * will be return.
+ * will be returned.
  *
  * Examples of context definitions passed to the {@link module:engine/model/schema~Schema#checkChild `Schema#checkChild()`}
  * method:

--- a/packages/ckeditor5-engine/src/model/schema.ts
+++ b/packages/ckeditor5-engine/src/model/schema.ts
@@ -457,7 +457,7 @@ export default class Schema extends /* #__PURE__ */ ObservableMixin() {
 		const isAllowed = this._evaluateAttributeChecks( context as SchemaContext, attributeName );
 
 		// If the decision was not made inside attribute check callbacks, then use declarative rules.
-		return isAllowed ?? def.allowAttributes.includes( attributeName );
+		return isAllowed !== undefined ? isAllowed : def.allowAttributes.includes( attributeName );
 	}
 
 	public checkMerge( position: Position ): boolean;
@@ -588,7 +588,7 @@ export default class Schema extends /* #__PURE__ */ ObservableMixin() {
 	 * `checkChild()` calls which `def` parameter matches the `itemName`. Otherwise, the callback will run for every `checkChild` call.
 	 */
 	public addChildCheck( callback: SchemaChildCheckCallback, itemName?: string ): void {
-		const key = itemName ?? this._genericCheckSymbol;
+		const key = itemName !== undefined ? itemName : this._genericCheckSymbol;
 
 		const checks = this._customChildChecks.get( key ) || [];
 		checks.push( callback );
@@ -660,7 +660,7 @@ export default class Schema extends /* #__PURE__ */ ObservableMixin() {
 	 * `checkAttribute()` calls with matching `attributeName`. Otherwise, the callback will run for every `checkAttribute()` call.
 	 */
 	public addAttributeCheck( callback: SchemaAttributeCheckCallback, attributeName?: string ): void {
-		const key = attributeName ?? this._genericCheckSymbol;
+		const key = attributeName !== undefined ? attributeName : this._genericCheckSymbol;
 
 		const checks = this._customAttributeChecks.get( key ) || [];
 		checks.push( callback );
@@ -1074,7 +1074,7 @@ export default class Schema extends /* #__PURE__ */ ObservableMixin() {
 		let isAllowed = this._evaluateChildChecks( context, def );
 
 		// If the decision was not made inside child check callbacks, then use declarative rules.
-		isAllowed = isAllowed ?? def.allowIn.includes( parentItem.name );
+		isAllowed = isAllowed !== undefined ? isAllowed : def.allowIn.includes( parentItem.name );
 
 		// If the item is not allowed in the `context`, return `false`.
 		if ( !isAllowed ) {

--- a/packages/ckeditor5-engine/tests/model/model.js
+++ b/packages/ckeditor5-engine/tests/model/model.js
@@ -96,15 +96,14 @@ describe( 'Model', () => {
 			expect( schema.checkChild( [ '$documentFragment' ], '$block' ) ).to.be.true;
 		} );
 
-		it( 'registers $marker to the schema', () => {
-			model.document.createRoot( '$anywhere', 'anywhere' );
-			schema.register( 'anything' );
+		it( 'registers $marker to the schema and allows it in all registered elements', () => {
+			schema.register( '$otherRoot' );
 
 			expect( schema.isRegistered( '$marker' ) ).to.be.true;
 			expect( schema.checkChild( [ '$root' ], '$marker' ) ).to.be.true;
 			expect( schema.checkChild( [ '$block' ], '$marker' ) ).to.be.true;
-			expect( schema.checkChild( [ '$anywhere' ], '$marker' ) ).to.be.true;
-			expect( schema.checkChild( [ 'anything' ], '$marker' ) ).to.be.true;
+			expect( schema.checkChild( [ '$otherRoot' ], '$marker' ) ).to.be.true;
+			expect( schema.checkChild( [ 'foo' ], '$marker' ) ).to.be.false;
 		} );
 	} );
 

--- a/packages/ckeditor5-engine/tests/model/schema.js
+++ b/packages/ckeditor5-engine/tests/model/schema.js
@@ -695,6 +695,28 @@ describe( 'Schema', () => {
 
 			schema.checkChild( root1, r1p1 );
 		} );
+
+		it( 'fires custom callback for each item in the context - generic callback', () => {
+			schema.register( 'div' );
+
+			const stub = sinon.stub().returns( true );
+
+			schema.addChildCheck( stub );
+
+			schema.checkChild( [ '$root', 'div', 'paragraph' ], '$text' );
+
+			expect( stub.callCount ).to.equal( 3 ); // $text, paragraph, div. Not called for top-level parent ($root in this case).
+		} );
+
+		it( 'returns false if any of context items is not defined', () => {
+			// Force all elements to be allowed.
+			schema.addChildCheck( () => true );
+
+			// ... but div is not registered.
+			const result = schema.checkChild( [ '$root', 'div', 'paragraph' ], '$text' );
+
+			expect( result ).to.be.false;
+		} );
 	} );
 
 	describe( 'checkAttribute()', () => {
@@ -768,59 +790,69 @@ describe( 'Schema', () => {
 	describe( 'addChildCheck()', () => {
 		beforeEach( () => {
 			schema.register( '$root' );
-			schema.register( 'paragraph', {
-				allowIn: '$root'
-			} );
+			schema.register( 'paragraph', { allowIn: '$root' } );
+			schema.register( 'blockQuote', { allowIn: '$root' } );
+			schema.register( 'foo' );
 		} );
 
-		it( 'adds a high-priority listener', () => {
+		it( 'supports generic and specific checks', () => {
+			const spyGeneric = sinon.spy();
+			const spySpecificP = sinon.spy();
+			const spySpecificBar = sinon.spy();
+
+			schema.addChildCheck( spyGeneric );
+			schema.addChildCheck( spySpecificP, 'paragraph' );
+			schema.addChildCheck( spySpecificBar, 'bar' );
+
+			schema.checkChild( [ '$root' ], 'paragraph' );
+
+			expect( spyGeneric.calledOnce ).to.be.true;
+			expect( spySpecificP.calledOnce ).to.be.true;
+			expect( spySpecificBar.called ).to.be.false;
+		} );
+
+		it( 'proper checks order', () => {
 			const order = [];
 
-			schema.on( 'checkChild', () => {
-				order.push( 'checkChild:high-before' );
-			}, { priority: 'high' } );
+			schema.addChildCheck( () => {
+				order.push( 'addChildCheckSpecific' );
+			}, 'paragraph' );
 
 			schema.addChildCheck( () => {
-				order.push( 'addChildCheck' );
+				order.push( 'addChildCheckGeneric' );
 			} );
 
 			schema.on( 'checkChild', () => {
-				order.push( 'checkChild:high-after' );
+				order.push( 'checkChild:high' );
 			}, { priority: 'high' } );
 
 			schema.checkChild( root1, r1p1 );
 
-			expect( order.join() ).to.equal( 'checkChild:high-before,addChildCheck,checkChild:high-after' );
+			expect( order.join() ).to.equal( 'checkChild:high,addChildCheckGeneric,addChildCheckSpecific' );
 		} );
 
-		it( 'stops the event and overrides the return value when callback returned true', () => {
-			schema.register( '$text' );
+		it( 'overrides the declarative check - force allow', () => {
+			expect( schema.checkChild( [ '$root' ], 'foo' ) ).to.be.false;
 
-			expect( schema.checkChild( root1, '$text' ) ).to.be.false;
+			schema.addChildCheck( () => true, 'foo' );
 
-			schema.addChildCheck( () => {
-				return true;
-			} );
-
-			schema.on( 'checkChild', () => {
-				throw new Error( 'the event should be stopped' );
-			}, { priority: 'high' } );
-
-			expect( schema.checkChild( root1, '$text' ) ).to.be.true;
+			expect( schema.checkChild( [ '$root' ], 'foo' ) ).to.be.true;
 		} );
 
-		it( 'stops the event and overrides the return value when callback returned false', () => {
-			expect( schema.checkChild( root1, r1p1 ) ).to.be.true;
+		it( 'overrides the declarative check - force disallow', () => {
+			expect( schema.checkChild( [ '$root' ], 'paragraph' ) ).to.be.true;
 
-			schema.addChildCheck( () => {
-				return false;
-			} );
+			schema.addChildCheck( () => false, 'paragraph' );
 
-			schema.on( 'checkChild', () => {
-				throw new Error( 'the event should be stopped' );
-			}, { priority: 'high' } );
+			expect( schema.checkChild( [ '$root' ], 'paragraph' ) ).to.be.false;
+		} );
 
-			expect( schema.checkChild( root1, r1p1 ) ).to.be.false;
+		it( 'uses declarative check when undefined is returned', () => {
+			expect( schema.checkChild( [ '$root' ], 'paragraph' ) ).to.be.true;
+
+			schema.addChildCheck( () => {}, 'paragraph' );
+
+			expect( schema.checkChild( [ '$root' ], 'paragraph' ) ).to.be.true;
 		} );
 
 		it( 'receives context and child definition as params', () => {
@@ -833,67 +865,74 @@ describe( 'Schema', () => {
 		} );
 
 		it( 'is not called when checking a non-registered element', () => {
-			expect( schema.getDefinition( 'foo' ) ).to.be.undefined;
+			expect( schema.getDefinition( 'bar' ) ).to.be.undefined;
 
 			schema.addChildCheck( () => {
 				throw new Error( 'callback should not be called' );
 			} );
 
-			expect( schema.checkChild( root1, 'foo' ) ).to.be.false;
+			expect( schema.checkChild( root1, 'bar' ) ).to.be.false;
 		} );
 	} );
 
 	describe( 'addAttributeCheck()', () => {
 		beforeEach( () => {
-			schema.register( 'paragraph', {
-				allowAttributes: 'foo'
-			} );
+			schema.register( '$root' );
+			schema.register( 'paragraph', { allowIn: '$root', allowAttributes: [ 'foo' ] } );
 		} );
 
-		it( 'adds a high-priority listener', () => {
+		it( 'supports generic and specific checks', () => {
+			const spyGeneric = sinon.spy();
+			const spySpecificX = sinon.spy();
+			const spySpecificBar = sinon.spy();
+
+			schema.addAttributeCheck( spyGeneric );
+			schema.addAttributeCheck( spySpecificX, 'x' );
+			schema.addAttributeCheck( spySpecificBar, 'bar' );
+
+			schema.checkAttribute( [ '$root', 'paragraph' ], 'x' );
+
+			expect( spyGeneric.calledOnce ).to.be.true;
+			expect( spySpecificX.calledOnce ).to.be.true;
+			expect( spySpecificBar.called ).to.be.false;
+		} );
+
+		it( 'proper checks order', () => {
 			const order = [];
 
-			schema.on( 'checkAttribute', () => {
-				order.push( 'checkAttribute:high-before' );
-			}, { priority: 'high' } );
+			schema.addAttributeCheck( () => {
+				order.push( 'addAttributeCheckSpecific' );
+			}, 'foo' );
 
 			schema.addAttributeCheck( () => {
-				order.push( 'addAttributeCheck' );
+				order.push( 'addAttributeCheckGeneric' );
 			} );
 
 			schema.on( 'checkAttribute', () => {
-				order.push( 'checkAttribute:high-after' );
+				order.push( 'checkAttribute:high' );
 			}, { priority: 'high' } );
 
 			schema.checkAttribute( r1p1, 'foo' );
 
-			expect( order.join() ).to.equal( 'checkAttribute:high-before,addAttributeCheck,checkAttribute:high-after' );
+			expect( order.join() ).to.equal( 'checkAttribute:high,addAttributeCheckGeneric,addAttributeCheckSpecific' );
 		} );
 
-		it( 'stops the event and overrides the return value when callback returned true', () => {
+		it( 'overrides the return value when callback returned true', () => {
 			expect( schema.checkAttribute( r1p1, 'bar' ) ).to.be.false;
 
 			schema.addAttributeCheck( () => {
 				return true;
 			} );
 
-			schema.on( 'checkAttribute', () => {
-				throw new Error( 'the event should be stopped' );
-			}, { priority: 'high' } );
-
 			expect( schema.checkAttribute( r1p1, 'bar' ) ).to.be.true;
 		} );
 
-		it( 'stops the event and overrides the return value when callback returned false', () => {
+		it( 'overrides the return value when callback returned false', () => {
 			expect( schema.checkAttribute( r1p1, 'foo' ) ).to.be.true;
 
 			schema.addAttributeCheck( () => {
 				return false;
 			} );
-
-			schema.on( 'checkAttribute', () => {
-				throw new Error( 'the event should be stopped' );
-			}, { priority: 'high' } );
 
 			expect( schema.checkAttribute( r1p1, 'foo' ) ).to.be.false;
 		} );

--- a/packages/ckeditor5-engine/tests/model/schema.js
+++ b/packages/ckeditor5-engine/tests/model/schema.js
@@ -4177,6 +4177,19 @@ describe( 'SchemaContext', () => {
 		} );
 	} );
 
+	describe( 'trimLast()', () => {
+		it( 'creates new SchemaContext instance without the last item - #string', () => {
+			const ctx = new SchemaContext( [ 'a', 'b', 'c' ] );
+
+			const newCtx = ctx.trimLast();
+
+			expect( newCtx ).to.instanceof( SchemaContext );
+			expect( newCtx ).to.not.equal( ctx );
+			expect( Array.from( newCtx.getNames() ) ).to.deep.equal( [ 'a', 'b' ] );
+			expect( Array.from( ctx.getNames() ) ).to.deep.equal( [ 'a', 'b', 'c' ] );
+		} );
+	} );
+
 	describe( 'getNames()', () => {
 		it( 'returns an iterator', () => {
 			const ctx = new SchemaContext( [ 'a', 'b', 'c' ] );

--- a/packages/ckeditor5-list/src/todolist/todolistediting.ts
+++ b/packages/ckeditor5-list/src/todolist/todolistediting.ts
@@ -85,17 +85,14 @@ export default class TodoListEditing extends Plugin {
 
 		model.schema.extend( '$listItem', { allowAttributes: 'todoListChecked' } );
 
-		model.schema.addAttributeCheck( ( context, attributeName ) => {
+		model.schema.addAttributeCheck( context => {
 			const item = context.last;
 
-			if ( attributeName != 'todoListChecked' ) {
-				return;
-			}
-
+			// Don't allow `todoListChecked` attribute on elements which are not todo list items.
 			if ( !item.getAttribute( 'listItemId' ) || item.getAttribute( 'listType' ) != 'todo' ) {
 				return false;
 			}
-		} );
+		}, 'todoListChecked' );
 
 		editor.conversion.for( 'upcast' ).add( dispatcher => {
 			// Upcast of to-do list item is based on a checkbox at the beginning of a <li> to keep compatibility with markdown input.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (engine): `Schema#addChildCheck()` and `Schema#addAttributeCheck()` can now register a callback for specific item or attribute, which should improve performance when using custom callback checks. Callback checks should be added only for specific item or attribute if possible. See the API reference. Closes #15834.

Fix (engine): `Schema#checkChild()` will now correctly check custom callback checks for each item in the context.

Other (engine): Introduced `Schema#trimLast()`.

Internal: Used specific callback checks in some of the features.

Docs (engine): Improved schema deep dive guide and added missing section related to attributes custom callback checks.

MINOR BREAKING CHANGE: `Schema` callbacks added through `addChildCheck()` will no longer add event listeners with `high` priority and will no longer stop `checkChild` event. Instead, these callbacks are now handled on `normal` priority, as a part of the default `checkChild()` call. This also means that listeners added to `checkChild` event on `high` priority will fire before any callbacks added by `checkChild()`. Earlier they would fire in registration order. This may impact you if you implemented custom schema callback using both `addChildCheck()` and direct listener to `checkChild` event. All above is also true for `addAttributeCheck()` and `checkAttribute` event and callbacks.

---

### Additional information