### PR TITLE
Do not paste the marker when it exists in the document

### DIFF
--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -279,7 +279,9 @@ export default class ClipboardMarkersUtils extends Plugin {
 
 	/**
 	 * Returns array of markers that can be copied in specified selection.
-	 * It marker cannot be copied partially ( according to `skipPartiallySelected` configuration flag ) it will be skipped.
+	 *
+	 * If marker cannot be copied partially ( according to `skipPartiallySelected` configuration flag ) and
+	 * is not present entirely in any selection range then it will be skipped.
 	 *
 	 * @param writer An instance of the model writer.
 	 * @param selection  Selection which will be checked.

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -336,13 +336,13 @@ export default class ClipboardMarkersUtils extends Plugin {
 				return false;
 			}
 
-			// Checks if configuration disallows to copy marker only if part of it is selected.
+			// Checks if configuration disallows to copy marker only if part of its content is selected.
 			//
 			// Example:
 			// 	<marker-a> Hello [ World ] </marker-a>
 			//					     ^ selection
 			//
-			// In this scenario `marker-a` will be not copied because selection does not overlaps it's content entirely.
+			// In this scenario `marker-a` won't be copied because selection doesn't overlap its content entirely.
 			const { withPartiallySelected } = this._getMarkerClipboardConfig( marker.name )!;
 
 			if ( !withPartiallySelected ) {

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -184,15 +184,21 @@ export default class ClipboardMarkersUtils extends Plugin {
 		const copyableMarkers = this._getCopyableMarkersFromRangeMap( markers );
 
 		return this.editor.model.change( writer => {
+			// Inserts fake markers into source fragment / element that is later transformed inside `getPastedDocumentElement`.
 			const sourceFragmentFakeMarkers = this._insertFakeMarkersElements( writer, copyableMarkers );
+
+			// Modifies document fragment ( for example clone of table cells is performed ) and then inserts it into document.
 			const transformedElement = getPastedDocumentElement( writer );
+
+			// Removes markers in pasted and transformed fragment in root document.
 			const removedFakeMarkers = this._removeFakeMarkersInsideElement( writer, transformedElement );
 
-			// Cleanup fake markers inserted into transformed element.
+			// Cleanup fake markers inserted into source fragment ( that one before transformation which is not pasted ).
 			for ( const element of Object.values( sourceFragmentFakeMarkers ).flat() ) {
 				writer.remove( element );
 			}
 
+			// Inserts to root document fake markers.
 			for ( const [ markerName, range ] of Object.entries( removedFakeMarkers ) ) {
 				const uniqueName = writer.model.markers.has( markerName ) ? this._getUniqueMarkerName( markerName ) : markerName;
 

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -165,15 +165,13 @@ export default class ClipboardMarkersUtils extends Plugin {
 
 			// Inserts to root document fake markers.
 			for ( const [ markerName, range ] of Object.entries( removedFakeMarkers ) ) {
-				if ( writer.model.markers.has( markerName ) ) {
-					continue;
+				if ( !writer.model.markers.has( markerName ) ) {
+					writer.addMarker( markerName, {
+						usingOperation: true,
+						affectsData: true,
+						range
+					} );
 				}
-
-				writer.addMarker( markerName, {
-					usingOperation: true,
-					affectsData: true,
-					range
-				} );
 			}
 
 			return transformedElement;

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -18,7 +18,8 @@ import {
 	type DocumentFragment,
 	type DocumentSelection,
 	type Selection,
-	type Writer
+	type Writer,
+	type Marker
 } from '@ckeditor/ckeditor5-engine';
 
 /**
@@ -33,7 +34,7 @@ export default class ClipboardMarkersUtils extends Plugin {
 	 *
 	 * @internal
 	 */
-	private _markersToCopy: Map<string, Array<ClipboardMarkerRestrictedAction>> = new Map();
+	private _markersToCopy: Map<string, ClipboardMarkerConfiguration> = new Map();
 
 	/**
 	 * @inheritDoc
@@ -46,17 +47,19 @@ export default class ClipboardMarkersUtils extends Plugin {
 	 * Registers marker name as copyable in clipboard pipeline.
 	 *
 	 * @param markerName Name of marker that can be copied.
-	 * @param restrictions Preset or specified array of actions that can be performed on specified marker name.
+	 * @param presetOrConfig Preset or configuration that describes what can be performed on specified marker.
 	 * @internal
 	 */
 	public _registerMarkerToCopy(
 		markerName: string,
-		restrictions: ClipboardMarkerRestrictionsPreset | Array<ClipboardMarkerRestrictedAction>
+		presetOrConfig: ClipboardMarkerActionsPreset | ClipboardMarkerConfiguration
 	): void {
-		const allowedActions = Array.isArray( restrictions ) ? restrictions : this._mapRestrictionPresetToActions( restrictions );
+		const config = typeof presetOrConfig === 'string' ? {
+			allowedActions: this._getAllowedActionsInPreset( presetOrConfig )
+		} : presetOrConfig;
 
-		if ( allowedActions.length ) {
-			this._markersToCopy.set( markerName, allowedActions );
+		if ( config.allowedActions.length ) {
+			this._markersToCopy.set( markerName, config );
 		}
 	}
 
@@ -66,7 +69,7 @@ export default class ClipboardMarkersUtils extends Plugin {
 	 * @param preset Restrictions preset to be mapped to actions
 	 * @internal
 	 */
-	private _mapRestrictionPresetToActions( preset: ClipboardMarkerRestrictionsPreset ): Array<ClipboardMarkerRestrictedAction> {
+	private _getAllowedActionsInPreset( preset: ClipboardMarkerActionsPreset ): Array<ClipboardMarkerRestrictedAction> {
 		switch ( preset ) {
 			case 'always':
 				return [ 'copy', 'cut', 'dragstart' ];
@@ -81,6 +84,7 @@ export default class ClipboardMarkersUtils extends Plugin {
 				// Skip unrecognized type.
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
 				const unreachable: never = preset;
+
 				return [];
 			}
 		}
@@ -212,12 +216,16 @@ export default class ClipboardMarkersUtils extends Plugin {
 	 *
 	 * @param markerName Which markers should be copied.
 	 * @param executor Callback executed.
+	 * @param config Additional configuration flags used by copy (such as partial copy flag).
 	 * @internal
 	 */
-	public _forceMarkersCopy( markerName: string, executor: VoidFunction ): void {
+	public _forceMarkersCopy( markerName: string, executor: VoidFunction, config?: ClipboardMarkerConfiguration ): void {
 		const before = this._markersToCopy.get( markerName );
 
-		this._markersToCopy.set( markerName, this._mapRestrictionPresetToActions( 'always' ) );
+		this._markersToCopy.set( markerName, {
+			allowedActions: this._getAllowedActionsInPreset( 'always' ),
+			...config
+		} );
 
 		executor();
 
@@ -235,16 +243,31 @@ export default class ClipboardMarkersUtils extends Plugin {
 	 * @param action Type of clipboard action. If null then checks only if marker is registered as copyable.
 	 * @internal
 	 */
-	public _canPerformMarkerClipboardAction( markerName: string, action: ClipboardMarkerRestrictedAction | null ): boolean {
-		const [ markerNamePrefix ] = markerName.split( ':' );
+	public _isMarkerCopyable( markerName: string, action: ClipboardMarkerRestrictedAction | null ): boolean {
+		const config = this._getMarkerClipboardConfig( markerName );
 
-		if ( !action ) {
-			return this._markersToCopy.has( markerNamePrefix );
+		if ( !config ) {
+			return false;
 		}
 
-		const possibleActions = this._markersToCopy.get( markerNamePrefix ) || [];
+		// If there is no action provided then only presence of marker is checked.
+		if ( !action ) {
+			return true;
+		}
 
-		return possibleActions.includes( action );
+		return config.allowedActions.includes( action );
+	}
+
+	/**
+	 * Returns marker's `allowedActions` and other flags passed during registration.
+	 *
+	 * @param markerName Name of marker that should be returned.
+	 * @internal
+	 */
+	public _getMarkerClipboardConfig( markerName: string ): ClipboardMarkerConfiguration | null {
+		const [ markerNamePrefix ] = markerName.split( ':' );
+
+		return this._markersToCopy.get( markerNamePrefix ) || null;
 	}
 
 	/**
@@ -284,6 +307,7 @@ export default class ClipboardMarkersUtils extends Plugin {
 
 	/**
 	 * Returns array of markers that can be copied in specified selection.
+	 * It marker cannot be copied partially ( according to `skipPartiallySelected` configuration flag ) it will be skipped.
 	 *
 	 * @param writer An instance of the model writer.
 	 * @param selection  Selection which will be checked.
@@ -294,10 +318,45 @@ export default class ClipboardMarkersUtils extends Plugin {
 		selection: Selection | DocumentSelection,
 		action: ClipboardMarkerRestrictedAction | null
 	): Array<CopyableMarker> {
+		const selectionRanges = Array.from( selection.getRanges()! );
+
+		// Picks all markers in provided ranges. Makes sure that there are no duplications if
+		// there are multiple ranges that intersects with the same marker.
+		const markersInRanges = new Set(
+			selectionRanges.flatMap(
+				selectionRange => Array.from( writer.model.markers.getMarkersIntersectingRange( selectionRange ) )
+			)
+		);
+
+		const isSelectionMarkerCopyable = ( marker: Marker ) => {
+			// Check if marker exists in configuration and provided action can be performed on it.
+			const isCopyable = this._isMarkerCopyable( marker.name, action );
+
+			if ( !isCopyable ) {
+				return false;
+			}
+
+			// Checks if configuration disallows to copy marker only if part of it is selected.
+			//
+			// Example:
+			// 	<marker-a> Hello [ World ] </marker-a>
+			//					     ^ selection
+			//
+			// In this scenario `marker-a` will be not copied because selection does not overlaps it's content entirely.
+			const { withPartiallySelected } = this._getMarkerClipboardConfig( marker.name )!;
+
+			if ( !withPartiallySelected ) {
+				const markerRange = marker.getRange();
+
+				return selectionRanges.some( selectionRange => selectionRange.containsRange( markerRange, true ) );
+			}
+
+			return true;
+		};
+
 		return Array
-			.from( selection.getRanges()! )
-			.flatMap( selectionRange => Array.from( writer.model.markers.getMarkersIntersectingRange( selectionRange ) ) )
-			.filter( marker => this._canPerformMarkerClipboardAction( marker.name, action ) )
+			.from( markersInRanges )
+			.filter( isSelectionMarkerCopyable )
 			.map( ( marker ): CopyableMarker => ( {
 				name: marker.name,
 				range: marker.getRange()
@@ -321,7 +380,7 @@ export default class ClipboardMarkersUtils extends Plugin {
 				name: markerName,
 				range
 			} ) )
-			.filter( marker => this._canPerformMarkerClipboardAction( marker.name, action ) );
+			.filter( marker => this._isMarkerCopyable( marker.name, action ) );
 	}
 
 	/**
@@ -545,7 +604,17 @@ export type ClipboardMarkerRestrictedAction = 'copy' | 'cut' | 'dragstart';
  *
  * @internal
  */
-export type ClipboardMarkerRestrictionsPreset = 'default' | 'always' | 'never';
+export type ClipboardMarkerActionsPreset = 'default' | 'always' | 'never';
+
+/**
+ * Specifies behavior of markers during clipboard actions.
+ *
+ * @internal
+ */
+export type ClipboardMarkerConfiguration = {
+	allowedActions: Array<ClipboardMarkerRestrictedAction>;
+	withPartiallySelected?: boolean; // If false, do not copy marker when only part of its content is selected.
+};
 
 /**
  * Marker descriptor type used to revert markers into tree node.

--- a/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
@@ -275,11 +275,7 @@ export default class ClipboardPipeline extends Plugin {
 		}, { priority: 'low' } );
 
 		this.listenTo<ClipboardContentInsertionEvent>( this, 'contentInsertion', ( evt, data ) => {
-			clipboardMarkersUtils._setUniqueMarkerNamesInFragment( data.content );
-		}, { priority: 'highest' } );
-
-		this.listenTo<ClipboardContentInsertionEvent>( this, 'contentInsertion', ( evt, data ) => {
-			data.resultRange = model.insertContent( data.content );
+			data.resultRange = clipboardMarkersUtils._pasteFragmentWithMarkers( data.content );
 		}, { priority: 'low' } );
 	}
 

--- a/packages/ckeditor5-clipboard/src/index.ts
+++ b/packages/ckeditor5-clipboard/src/index.ts
@@ -21,7 +21,6 @@ export {
 
 export {
 	default as ClipboardMarkersUtils,
-	type ClipboardMarkerActionsPreset,
 	type ClipboardMarkerRestrictedAction
 } from './clipboardmarkersutils.js';
 

--- a/packages/ckeditor5-clipboard/src/index.ts
+++ b/packages/ckeditor5-clipboard/src/index.ts
@@ -21,7 +21,7 @@ export {
 
 export {
 	default as ClipboardMarkersUtils,
-	type ClipboardMarkerRestrictionsPreset,
+	type ClipboardMarkerActionsPreset,
 	type ClipboardMarkerRestrictedAction
 } from './clipboardmarkersutils.js';
 

--- a/packages/ckeditor5-clipboard/src/index.ts
+++ b/packages/ckeditor5-clipboard/src/index.ts
@@ -21,7 +21,8 @@ export {
 
 export {
 	default as ClipboardMarkersUtils,
-	type ClipboardMarkerRestrictedAction
+	type ClipboardMarkerRestrictedAction,
+	type ClipboardMarkerConfiguration
 } from './clipboardmarkersutils.js';
 
 export type {

--- a/packages/ckeditor5-clipboard/tests/clipboardmarkersutils.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardmarkersutils.js
@@ -500,9 +500,7 @@ describe( 'Clipboard Markers Utils', () => {
 				expect( model.markers.has( 'comment:test:pasted' ) ).to.false;
 			} );
 		}
-	} );
 
-	describe( 'Copy if partially selected flag', () => {
 		for ( const preset of [ 'always', 'default' ] ) {
 			it( `should not copy partially selected markers in ${ preset } preset`, () => {
 				clipboardMarkersUtils._registerMarkerToCopy( 'comment', preset );
@@ -751,7 +749,9 @@ describe( 'Clipboard Markers Utils', () => {
 
 	describe( '_pasteMarkersIntoTransformedElement', () => {
 		beforeEach( () => {
-			clipboardMarkersUtils._registerMarkerToCopy( 'comment', 'always' );
+			clipboardMarkersUtils._registerMarkerToCopy( 'comment', {
+				allowedActions: 'all'
+			} );
 		} );
 
 		it( 'should preserve original marker name if it is not duplicated', () => {

--- a/packages/ckeditor5-core/src/index.ts
+++ b/packages/ckeditor5-core/src/index.ts
@@ -17,7 +17,7 @@ export { default as Context, type ContextConfig } from './context.js';
 export { default as ContextPlugin, type ContextPluginDependencies } from './contextplugin.js';
 export { type EditingKeystrokeCallback } from './editingkeystrokehandler.js';
 
-export type { PartialBy } from './typings.js';
+export type { PartialBy, NonEmptyArray } from './typings.js';
 
 export { default as Editor, type EditorReadyEvent, type EditorDestroyEvent } from './editor/editor.js';
 export type {

--- a/packages/ckeditor5-core/src/typings.ts
+++ b/packages/ckeditor5-core/src/typings.ts
@@ -8,3 +8,7 @@
  */
 
 export type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+export type NonEmptyArray<A> = Array<A> & {
+	0: A;
+  };

--- a/packages/ckeditor5-engine/src/model/utils/insertcontent.ts
+++ b/packages/ckeditor5-engine/src/model/utils/insertcontent.ts
@@ -188,7 +188,7 @@ export default function insertContent(
 			for ( const [ name, [ start, end ] ] of Object.entries( markersData ) ) {
 				// For now, we ignore markers if they are included in the filtered-out content.
 				// In the future implementation we will improve that case to create markers that are not filtered out completely.
-				if ( start && end && start.root === end.root && start.root.document ) {
+				if ( start && end && start.root === end.root && start.root.document && !writer.model.markers.has( name ) ) {
 					writer.addMarker( name, {
 						usingOperation: true,
 						affectsData: true,

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -4076,10 +4076,19 @@ describe( 'table clipboard', () => {
 		beforeEach( async () => {
 			await createEditor();
 
-			clipboardMarkersUtils._registerMarkerToCopy( 'comment', { allowedActions: [ 'copy' ] } );
+			clipboardMarkersUtils._registerMarkerToCopy( 'comment', {
+				allowedActions: [ 'copy' ]
+			} );
+
 			sinon
 				.stub( clipboardMarkersUtils, '_getUniqueMarkerName' )
-				.callsFake( markerName => `${ markerName }:uniq` );
+				.callsFake( markerName => {
+					if ( markerName.endsWith( 'uniq' ) ) {
+						return markerName;
+					}
+
+					return `${ markerName }:uniq`;
+				} );
 
 			markerConversion();
 		} );
@@ -4097,7 +4106,7 @@ describe( 'table clipboard', () => {
 
 			const paragraph = modelRoot.getNodeByPath( [ 1, 0, 0, 0 ] );
 
-			checkMarker( 'comment:paste:uniq', model.createRangeIn( paragraph ) );
+			checkMarker( 'comment:paste', model.createRangeIn( paragraph ) );
 		} );
 
 		it( 'should paste table with multiple markers to multiple cells', () => {
@@ -4126,8 +4135,8 @@ describe( 'table clipboard', () => {
 				model.createPositionFromPath( modelRoot, [ 1, 0, 1, 0, 6 ] )
 			);
 
-			checkMarker( 'comment:pre:uniq', prePosition );
-			checkMarker( 'comment:post:uniq', postPosition );
+			checkMarker( 'comment:pre', prePosition );
+			checkMarker( 'comment:post', postPosition );
 		} );
 
 		it( 'should paste table with multiple markers to single cell', () => {
@@ -4157,8 +4166,8 @@ describe( 'table clipboard', () => {
 				model.createPositionFromPath( modelRoot, [ 1, 0, 0, 0, 34 ] )
 			);
 
-			checkMarker( 'comment:pre:uniq', prePosition );
-			checkMarker( 'comment:post:uniq', postPosition );
+			checkMarker( 'comment:pre', prePosition );
+			checkMarker( 'comment:post', postPosition );
 		} );
 
 		it( 'should handle paste markers that contain markers', () => {
@@ -4175,12 +4184,12 @@ describe( 'table clipboard', () => {
 				[ [ outerMarker ] ]
 			);
 
-			checkMarker( 'comment:outer:uniq', model.createRange(
+			checkMarker( 'comment:outer', model.createRange(
 				model.createPositionFromPath( modelRoot, [ 1, 0, 0, 0, 0 ] ),
 				model.createPositionFromPath( modelRoot, [ 1, 0, 0, 0, 11 ] )
 			) );
 
-			checkMarker( 'comment:inner:uniq', model.createRange(
+			checkMarker( 'comment:inner', model.createRange(
 				model.createPositionFromPath( modelRoot, [ 1, 0, 0, 0, 1 ] ),
 				model.createPositionFromPath( modelRoot, [ 1, 0, 0, 0, 5 ] )
 			) );

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -4076,7 +4076,7 @@ describe( 'table clipboard', () => {
 		beforeEach( async () => {
 			await createEditor();
 
-			clipboardMarkersUtils._registerMarkerToCopy( 'comment', [ 'copy' ] );
+			clipboardMarkersUtils._registerMarkerToCopy( 'comment', { allowedActions: [ 'copy' ] } );
 			sinon
 				.stub( clipboardMarkersUtils, '_getUniqueMarkerName' )
 				.callsFake( markerName => `${ markerName }:uniq` );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (clipboard):  Add `regenerateMarkerIdsOnPaste` to marker clipboard copy marker configuration. Closes https://github.com/ckeditor/ckeditor5/issues/15966 . Related to https://github.com/ckeditor/ckeditor5/pull/15968 .


