### PR TITLE
Metadata: Replace the `Image` dependency with "oneOf" (`ImageBlock` or `ImageInline`)

### DIFF
--- a/packages/ckeditor5-ckbox/ckeditor5-metadata.json
+++ b/packages/ckeditor5-ckbox/ckeditor5-metadata.json
@@ -9,7 +9,10 @@
 			"requires": [
 				"CloudServices",
 				"Link",
-				"Image",
+				[
+					"ImageBlock",
+					"ImageInline"
+				],
 				"ImageUpload",
 				"PictureEditing"
 			],

--- a/packages/ckeditor5-ckfinder/ckeditor5-metadata.json
+++ b/packages/ckeditor5-ckfinder/ckeditor5-metadata.json
@@ -9,7 +9,10 @@
 			"requires": [
 				"CKFinderUploadAdapter",
 				"Link",
-				"Image"
+				[
+					"ImageBlock",
+					"ImageInline"
+				]
 			],
 			"uiComponents": [
 				{

--- a/packages/ckeditor5-easy-image/ckeditor5-metadata.json
+++ b/packages/ckeditor5-easy-image/ckeditor5-metadata.json
@@ -8,7 +8,10 @@
 			"path": "src/easyimage.js",
 			"requires": [
 				"CloudServices",
-				"Image",
+				[
+					"ImageBlock",
+					"ImageInline"
+				],
 				"ImageUpload"
 			]
 		}

--- a/packages/ckeditor5-link/ckeditor5-metadata.json
+++ b/packages/ckeditor5-link/ckeditor5-metadata.json
@@ -55,10 +55,7 @@
 			"path": "src/linkimage.js",
 			"requires": [
 				"Link",
-				[
-					"ImageBlock",
-					"ImageInline"
-				]
+				"ImageBlock"
 			],
 			"uiComponents": [
 				{

--- a/packages/ckeditor5-link/ckeditor5-metadata.json
+++ b/packages/ckeditor5-link/ckeditor5-metadata.json
@@ -55,7 +55,10 @@
 			"path": "src/linkimage.js",
 			"requires": [
 				"Link",
-				"Image"
+				[
+					"ImageBlock",
+					"ImageInline"
+				]
 			],
 			"uiComponents": [
 				{


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ckbox, ckfinder, easy-image, link): The metadata structures were redefined so that plugins requiring the `Image` plugin work with `ImageBlock`, `ImageInline`, or both. Hence, it isn't necessary to load the entire plugin. Closes #15992.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
