### PR TITLE
Fix (image): Fix typo in imagecaption css variable (highligted -> highlighted)

### DIFF
--- a/packages/ckeditor5-image/theme/imagecaption.css
+++ b/packages/ckeditor5-image/theme/imagecaption.css
@@ -6,7 +6,7 @@
 :root {
 	--ck-color-image-caption-background: hsl(0, 0%, 97%);
 	--ck-color-image-caption-text: hsl(0, 0%, 20%);
-	--ck-color-image-caption-highligted-background: hsl(52deg 100% 50%);
+	--ck-color-image-caption-highlighted-background: hsl(52deg 100% 50%);
 }
 
 /* Content styles */
@@ -28,7 +28,7 @@
 
 @keyframes ck-image-caption-highlight {
 	0% {
-		background-color: var(--ck-color-image-caption-highligted-background);
+		background-color: var(--ck-color-image-caption-highlighted-background);
 	}
 
 	100% {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (image): Typo in imagecaption css variable.

---

### Additional information

For CSS variable `--ck-color-image-caption-highligted-background` in [imagecaption.css](https://github.com/ckeditor/ckeditor5/blob/44deaa14/packages/ckeditor5-image/theme/imagecaption.css#L9)