### PR TITLE
Content minimap steals focus

### DIFF
--- a/packages/ckeditor5-minimap/src/minimapiframeview.ts
+++ b/packages/ckeditor5-minimap/src/minimapiframeview.ts
@@ -54,6 +54,7 @@ export default class MinimapIframeView extends IframeView {
 
 		this.extendTemplate( {
 			attributes: {
+				tabindex: -1,
 				class: [
 					'ck-minimap__iframe'
 				],


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (minimap): Add missing `tabindex` to minimap iframe element. Closes https://github.com/cksource/ckeditor5-commercial/issues/6020.
