### PR TITLE
Fix incorrect focus order in pagination

### DIFF
--- a/packages/ckeditor5-ui/src/input/inputbase.ts
+++ b/packages/ckeditor5-ui/src/input/inputbase.ts
@@ -47,6 +47,13 @@ export default abstract class InputBase<TElement extends HTMLInputElement | HTML
 	declare public placeholder: string | undefined;
 
 	/**
+	 * The `tabindex` attribute of the input.
+	 *
+	 * @observable
+	 */
+	declare public tabIndex: number | undefined;
+
+	/**
 	 * Controls whether the input view is in read-only mode.
 	 *
 	 * @observable
@@ -98,6 +105,7 @@ export default abstract class InputBase<TElement extends HTMLInputElement | HTML
 		this.set( 'value', undefined );
 		this.set( 'id', undefined );
 		this.set( 'placeholder', undefined );
+		this.set( 'tabIndex', undefined );
 		this.set( 'isReadOnly', false );
 		this.set( 'hasError', false );
 		this.set( 'ariaDescribedById', undefined );
@@ -121,6 +129,7 @@ export default abstract class InputBase<TElement extends HTMLInputElement | HTML
 				],
 				id: bind.to( 'id' ),
 				placeholder: bind.to( 'placeholder' ),
+				tabindex: bind.to( 'tabIndex' ),
 				readonly: bind.to( 'isReadOnly' ),
 				'aria-invalid': bind.if( 'hasError', true ),
 				'aria-describedby': bind.to( 'ariaDescribedById' )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

fix (pagination): Incorrect focus order in pagination. Closes https://github.com/cksource/ckeditor5-commercial/issues/6032.
