### PR TITLE
Do not regenerate name of markers that are not copyable

### DIFF
--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -259,7 +259,6 @@ export default class ClipboardMarkersUtils extends Plugin {
 		fragment.markers.clear();
 
 		for ( const [ name, range ] of markers ) {
-			/* istanbul ignore next -- @preserve */
 			const newName = this._canPerformMarkerClipboardAction( name, null ) ? this._getUniqueMarkerName( name ) : name;
 
 			fragment.markers.set( newName, range );

--- a/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardmarkersutils.ts
@@ -259,7 +259,10 @@ export default class ClipboardMarkersUtils extends Plugin {
 		fragment.markers.clear();
 
 		for ( const [ name, range ] of markers ) {
-			fragment.markers.set( this._getUniqueMarkerName( name ), range );
+			/* istanbul ignore next -- @preserve */
+			const newName = this._canPerformMarkerClipboardAction( name, null ) ? this._getUniqueMarkerName( name ) : name;
+
+			fragment.markers.set( newName, range );
 		}
 	}
 

--- a/packages/ckeditor5-clipboard/tests/clipboardmarkersutils.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardmarkersutils.js
@@ -827,6 +827,30 @@ describe( 'Clipboard Markers Utils', () => {
 		} );
 	} );
 
+	describe( '_setUniqueMarkerNamesInFragment', () => {
+		beforeEach( () => {
+			clipboardMarkersUtils._registerMarkerToCopy( 'comment', 'always' );
+		} );
+
+		it( 'do not regenerate name of marker if not copyable', () => {
+			const fragment = createFragmentWithMarkers( '<paragraph>ABC</paragraph>', {
+				'comment:1123:1': {
+					start: [ 0 ],
+					end: [ 1 ]
+				},
+				'marker-1': {
+					start: [ 0 ],
+					end: [ 1 ]
+				}
+			} );
+
+			clipboardMarkersUtils._setUniqueMarkerNamesInFragment( fragment );
+
+			expect( fragment.markers.has( 'comment:1123:1:pasted' ) ).to.be.true;
+			expect( fragment.markers.has( 'marker-1' ) ).to.be.true;
+		} );
+	} );
+
 	async function createEditor() {
 		editor = await ClassicTestEditor.create( element, {
 			plugins: [ Paragraph, Clipboard ]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (clipboard): The imported Word document that contains suggestions will no longer cause errors. 

Closes https://github.com/cksource/ckeditor5-commercial/issues/6081. 
