### PR TITLE
Fix (ckeditor5-engine): use content.appendChild for templates

### DIFF
--- a/packages/ckeditor5-engine/src/view/domconverter.ts
+++ b/packages/ckeditor5-engine/src/view/domconverter.ts
@@ -460,7 +460,11 @@ export default class DomConverter {
 
 			if ( options.withChildren !== false ) {
 				for ( const child of this.viewChildrenToDom( viewElementOrFragment, options ) ) {
-					domElement.appendChild( child );
+					if ( domElement instanceof HTMLTemplateElement ) {
+						domElement.content.appendChild( child );
+					} else {
+						domElement.appendChild( child );
+					}
 				}
 			}
 

--- a/packages/ckeditor5-engine/src/view/domconverter.ts
+++ b/packages/ckeditor5-engine/src/view/domconverter.ts
@@ -738,8 +738,16 @@ export default class DomConverter {
 		options: Parameters<DomConverter[ 'domToView' ]>[ 1 ] = {},
 		inlineNodes: Array<ViewNode> = []
 	): IterableIterator<ViewNode> {
-		for ( let i = 0; i < domElement.childNodes.length; i++ ) {
-			const domChild = domElement.childNodes[ i ];
+		// Get child nodes from content document fragment if element is template
+		let childNodes: Array<ChildNode> = [];
+		if ( domElement instanceof HTMLTemplateElement ) {
+			childNodes = [ ...domElement.content.childNodes ];
+		} else {
+			childNodes = [ ...domElement.childNodes ];
+		}
+
+		for ( let i = 0; i < childNodes.length; i++ ) {
+			const domChild = childNodes[ i ];
 			const generator = this._domToView( domChild, options, inlineNodes );
 
 			// Get the first yielded value or a returned value.

--- a/packages/ckeditor5-engine/src/view/domconverter.ts
+++ b/packages/ckeditor5-engine/src/view/domconverter.ts
@@ -740,6 +740,7 @@ export default class DomConverter {
 	): IterableIterator<ViewNode> {
 		// Get child nodes from content document fragment if element is template
 		let childNodes: Array<ChildNode> = [];
+
 		if ( domElement instanceof HTMLTemplateElement ) {
 			childNodes = [ ...domElement.content.childNodes ];
 		} else {

--- a/packages/ckeditor5-engine/tests/controller/datacontroller.js
+++ b/packages/ckeditor5-engine/tests/controller/datacontroller.js
@@ -134,6 +134,20 @@ describe( 'DataController', () => {
 
 			expect( stringify( output ) ).to.equal( 'foo' );
 		} );
+
+		it( 'should parse template with children', () => {
+			schema.register( 'container', { inheritAllFrom: '$block' } );
+			schema.register( 'paragraph', { inheritAllFrom: '$block' } );
+			schema.extend( 'paragraph', { allowIn: [ 'container' ] } );
+
+			upcastHelpers.elementToElement( { view: 'template', model: 'container' } );
+			upcastHelpers.elementToElement( { view: 'p', model: 'paragraph' } );
+
+			const output = data.parse( '<template><p>foo</p></template>' );
+
+			expect( output ).to.instanceof( ModelDocumentFragment );
+			expect( stringify( output ) ).to.equal( '<container><paragraph>foo</paragraph></container>' );
+		} );
 	} );
 
 	describe( 'toModel()', () => {

--- a/packages/ckeditor5-engine/tests/controller/datacontroller.js
+++ b/packages/ckeditor5-engine/tests/controller/datacontroller.js
@@ -590,6 +590,19 @@ describe( 'DataController', () => {
 
 			console.warn.restore();
 		} );
+
+		it( 'should get template with children', () => {
+			schema.register( 'container', { inheritAllFrom: '$block' } );
+			schema.extend( 'paragraph', { allowIn: [ 'container' ] } );
+			setData( model, '<container><paragraph>foo</paragraph></container>' );
+
+			downcastHelpers.elementToElement( {
+				model: 'container',
+				view: 'template'
+			} );
+
+			expect( data.get() ).to.equal( '<template><p>foo</p></template>' );
+		} );
 	} );
 
 	describe( 'stringify()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Type: Message. Closes #000.

---

### Additional information

We are using CKEditor5 to create templates for documents. We use the editor's data to render the document with AlpineJS to do additional logic like inserting variable values or conditionally rendering blocks.

For certain features like the latter we need to use template elements.

We used the following converter to downcast to a template tag based on an attribute being present:
```typescript
conversion.for('downcast').attributeToElement({
  model: 'condition',
  view: (value, { writer }) => {
    return writer.createAttributeElement('template', {
      'x-if': value,
    });
  },
});
```

This works fine for the view, elements with the attribute (e.g. a paragraph) get wrapped with a `template` tag as expected.

But when we try to get the editors data using `editor.getData()` the children of the `template` are always missing. If we replace the `template` tag with other tags like a `div`, it works as expected.

After looking into it and it seems like the cause is inside `domconverter.ts` which always appends the children using `appendChild`. This does not work when the dom element is a `template` since you need to append the children to `content`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of different DOM elements in the editor to improve content structuring.
	- Improved data parsing in the editor for templates with nested elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->