### PR TITLE
Fix (ckbox): use safer way for stringifying numbers

### DIFF
--- a/packages/ckeditor5-ckbox/src/ckboxutils.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxutils.ts
@@ -225,8 +225,8 @@ export default class CKBoxUtils extends Plugin {
 		function fetchCategories( offset: number ): Promise<{ totalCount: number; items: Array<AvailableCategory> }> {
 			const categoryUrl = new URL( 'categories', serviceOrigin );
 
-			categoryUrl.searchParams.set( 'limit', String(ITEMS_PER_REQUEST) );
-			categoryUrl.searchParams.set( 'offset', String(offset) );
+			categoryUrl.searchParams.set( 'limit', String( ITEMS_PER_REQUEST ) );
+			categoryUrl.searchParams.set( 'offset', String( offset ) );
 			categoryUrl.searchParams.set( 'workspaceId', workspaceId );
 
 			return sendHttpRequest( {

--- a/packages/ckeditor5-ckbox/src/ckboxutils.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxutils.ts
@@ -225,8 +225,8 @@ export default class CKBoxUtils extends Plugin {
 		function fetchCategories( offset: number ): Promise<{ totalCount: number; items: Array<AvailableCategory> }> {
 			const categoryUrl = new URL( 'categories', serviceOrigin );
 
-			categoryUrl.searchParams.set( 'limit', ITEMS_PER_REQUEST.toString() );
-			categoryUrl.searchParams.set( 'offset', offset.toString() );
+			categoryUrl.searchParams.set( 'limit', String(ITEMS_PER_REQUEST) );
+			categoryUrl.searchParams.set( 'offset', String(offset) );
 			categoryUrl.searchParams.set( 'workspaceId', workspaceId );
 
 			return sendHttpRequest( {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ckbox): use safer way for stringifying numbers. Closes #16040

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
