### PR TITLE
Internal (ckeditor5): Upgrade eslint to v8.

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "chalk": "^4.1.0",
     "coveralls": "^3.1.0",
     "date-fns": "^2.30.0",
-    "eslint": "^7.19.0",
+    "eslint": "^8.57.0",
     "eslint-config-ckeditor5": "^5.3.0",
     "fs-extra": "^11.1.1",
     "glob": "^10.2.5",

--- a/scripts/eslint-formatter.js
+++ b/scripts/eslint-formatter.js
@@ -8,11 +8,12 @@
 /* eslint-env node */
 
 // See: https://eslint.org/docs/user-guide/formatters/#stylish.
-const eslintStylishFormatter = require( 'eslint/lib/cli-engine/formatters/stylish' );
 const chalk = require( 'chalk' );
+const { ESLint } = require( 'eslint' );
 
 // eslint-disable-next-line max-len
-const CODE_STYLE_URL = 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#ckeditor-5-custom-eslint-rules';
+const CODE_STYLE_URL =
+	'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#ckeditor-5-custom-eslint-rules';
 
 /**
  * Overwrite the default ESLint formatter. If CKEditor 5 related error occurred,
@@ -20,8 +21,11 @@ const CODE_STYLE_URL = 'https://ckeditor.com/docs/ckeditor5/latest/framework/con
  *
  * @param {Array} results
  */
-module.exports = results => {
-	console.log( eslintStylishFormatter( results ) );
+module.exports = async results => {
+	const eslint = new ESLint();
+	const stylish = await eslint.loadFormatter();
+
+	console.log( stylish.format( results ) );
 
 	const hasCKEditorErrors = results.some( item => {
 		if ( !Array.isArray( item.messages ) ) {


### PR DESCRIPTION
Change how eslint formatter is created so it's compatible with eslint v8. This should allow to update eslint in ckeditor5-linters-config later. More info at
https://github.com/eslint/eslint/blob/main/docs/src/use/migrate-to-8.0.0.md#remove-cliengine