### PR TITLE
Clarified the accessibility help dialog description for the keystroke that executes buttons

### DIFF
--- a/packages/ckeditor5-core/lang/contexts.json
+++ b/packages/ckeditor5-core/lang/contexts.json
@@ -23,5 +23,5 @@
 	"Move focus between form fields (inputs, buttons, etc.)": "Keystroke description for assistive technologies: keystroke for moving between fields.",
 	"Move focus to the toolbar, navigate between toolbars": "Keystroke description for assistive technologies: keystroke for moving focus to the toolbar.",
 	"Navigate through the toolbar": "Keystroke description for assistive technologies: keystroke for navigating through the toolbar.",
-	"Execute the currently focused button": "Keystroke description for assistive technologies: keystroke for executing currently focused button."
+	"Execute the currently focused button. Executing buttons that interact with the editor content moves the focus back to the content.": "Keystroke description for assistive technologies: keystroke for executing currently focused button."
 }

--- a/packages/ckeditor5-core/src/accessibility.ts
+++ b/packages/ckeditor5-core/src/accessibility.ts
@@ -91,7 +91,8 @@ export default class Accessibility {
 							keystroke: [ [ 'arrowup' ], [ 'arrowright' ], [ 'arrowdown' ], [ 'arrowleft' ] ]
 						},
 						{
-							label: t( 'Execute the currently focused button' ),
+							// eslint-disable-next-line max-len
+							label: t( 'Execute the currently focused button. Executing buttons that interact with the editor content moves the focus back to the content.' ),
 							keystroke: [ [ 'Enter' ], [ 'Space' ] ]
 						}
 					]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (core): Clarified the accessibility help dialog description for the keystroke that executes buttons. 

---

### Additional information

Closes https://github.com/cksource/ckeditor5-commercial/issues/6025.
