### PR TITLE
Fix sticky cursor resulting in reverse typing if the editable is not the activeElement in the document.

### DIFF
--- a/packages/ckeditor5-engine/src/view/observer/inputobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/inputobserver.ts
@@ -39,6 +39,7 @@ export default class InputObserver extends DomEventObserver<'beforeinput'> {
 		// DOM `activeElement`, but the editable is somehow still in focus.
 		// In other words, the editable visually appears to be in focus, but it is not.
 		if ( !this.view.document.isFocused ) {
+			// The current target is assumed to be the editable
 			domEvent.currentTarget?.dispatchEvent( new FocusEvent( 'focus' ) );
 		}
 		const domTargetRanges = domEvent.getTargetRanges();

--- a/packages/ckeditor5-engine/src/view/observer/inputobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/inputobserver.ts
@@ -35,6 +35,12 @@ export default class InputObserver extends DomEventObserver<'beforeinput'> {
 		// @if CK_DEBUG_TYPING // 	);
 		// @if CK_DEBUG_TYPING // }
 
+		// Handles reverse typing cases where the current document is not seen as the
+		// DOM `activeElement`, but the editable is somehow still in focus.
+		// In other words, the editable visually appears to be in focus, but it is not.
+		if ( !this.view.document.isFocused ) {
+			domEvent.currentTarget?.dispatchEvent( new FocusEvent( 'focus' ) );
+		}
 		const domTargetRanges = domEvent.getTargetRanges();
 		const view = this.view;
 		const viewDocument = view.document;

--- a/packages/ckeditor5-engine/tests/view/observer/inputobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/inputobserver.js
@@ -59,6 +59,34 @@ describe( 'InputObserver', () => {
 		sinon.assert.calledOnce( beforeInputSpy );
 	} );
 
+	it( 'should not dispatch focus event if the document has focus', () => {
+		viewDocument.isFocused = true;
+
+		const mockDispatchEvent = sinon.spy();
+		fireMockNativeBeforeInput( {
+			inputType: 'foo',
+			currentTarget: {
+				dispatchEvent: mockDispatchEvent
+			}
+		} );
+
+		expect( mockDispatchEvent.callCount ).to.equal( 0 );
+	} );
+
+	it( 'should dispatch focus event if the document does not have focus', () => {
+		viewDocument.isFocused = false;
+
+		const mockDispatchEvent = sinon.spy();
+		fireMockNativeBeforeInput( {
+			inputType: 'foo',
+			currentTarget: {
+				dispatchEvent: mockDispatchEvent
+			}
+		} );
+
+		expect( mockDispatchEvent.callCount ).to.equal( 1 );
+	} );
+
 	describe( 'event data', () => {
 		it( 'should contain #eventType', () => {
 			fireMockNativeBeforeInput( {


### PR DESCRIPTION
This PR attempts to fix an issue with cases where "reverse typing" effect still occurs. This is caused by a selection not being updated when an input event occurs. The selection seems to not be updated because the `document.activeElement` in DOM is not the correct element. 

There are cases where the editable visually looks focused, but in reality the active element is some other element as it may have stole focus while the editable was active at some point. This can be caused by a manual dispatch of a `blur` event for example. 

We can actually simulate it like this:
```js
setTimeout(() => { 
	const editable = document.querySelector("div[contenteditable=true]");
	editable.dispatchEvent(new FocusEvent("blur"));

	console.log("BLUR!")
}, 5000);
```

If the editable is currently in focus, but the `blur` happens later, the active element in the `document` is not updated properly, and can end up having a selection which is out of sync with the characters being rendered into the editable. (It just sticks and never moves forward).

An example: 
![274956696-3bd80cd7-cf19-4776-ab76-d1a026b4dd5f](https://github.com/ckeditor/ckeditor5/assets/1388415/d5f5fea8-e554-4377-a0d2-59d43bf8fcdd)

Something like this can also be seen in the Safari web browser where a a `button` click can cause the issue to occur:
![257527157-b3218162-a52b-453b-b0e5-9263952871ec](https://github.com/ckeditor/ckeditor5/assets/1388415/571ad95c-a388-49b0-b083-d57653cd3146)
[Source](https://github.com/ckeditor/ckeditor5/issues/14702#issuecomment-1660318476)

After fix:
![fix](https://github.com/ckeditor/ckeditor5/assets/1388415/f38ba4c2-265c-46e0-9050-8874d63434ca)

Browsers tested on web (manual):
* Google Chrome
* Safari
* Firefox

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Type: (engine): Force the editable to be focused if the active element is not the editable when an input event occurs. Closes #15182, #14702 .

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
