### PR TITLE
Export few more types and classes from mention package

### DIFF
--- a/packages/ckeditor5-mention/src/index.ts
+++ b/packages/ckeditor5-mention/src/index.ts
@@ -10,7 +10,7 @@
 export { default as Mention } from './mention.js';
 export { default as MentionEditing } from './mentionediting.js';
 export { default as MentionUI } from './mentionui.js';
-export { default as MentionView } from './ui/mentionsview.js';
+export { default as MentionsView } from './ui/mentionsview.js';
 export { default as MentionListItemView } from './ui/mentionlistitemview.js';
 export { default as DomWrapperView } from './ui/domwrapperview.js';
 

--- a/packages/ckeditor5-mention/src/index.ts
+++ b/packages/ckeditor5-mention/src/index.ts
@@ -10,8 +10,11 @@
 export { default as Mention } from './mention.js';
 export { default as MentionEditing } from './mentionediting.js';
 export { default as MentionUI } from './mentionui.js';
+export { default as MentionView } from './ui/mentionsview.js';
+export { default as MentionListItemView } from './ui/mentionlistitemview.js';
+export { default as DomWrapperView } from './ui/domwrapperview.js';
 
-export type { MentionConfig, MentionFeed, ItemRenderer } from './mentionconfig.js';
+export type { MentionConfig, MentionFeed, ItemRenderer, MentionFeedObjectItem } from './mentionconfig.js';
 export type { default as MentionCommand } from './mentioncommand.js';
 
 import './augmentation.js';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (mention): Export `MentionsView`, `MentionListItemView`, `DomWrapperView` classes and `MentionFeedObjectItem` type. Closes #16044.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
