### PR TITLE
Add menu bar integration to revision history

### DIFF
--- a/packages/ckeditor5-ui/src/menubar/utils.ts
+++ b/packages/ckeditor5-ui/src/menubar/utils.ts
@@ -599,7 +599,8 @@ export const DefaultMenuBarItems: DeepReadonly<MenuBarConfigObject[ 'items' ]> =
 			{
 				groupId: 'tools',
 				items: [
-					'menuBar:commentsArchive'
+					'menuBar:commentsArchive',
+					'menuBar:revisionHistory'
 				]
 			}
 		]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (revision-history): Add menu bar integration. Related to https://github.com/ckeditor/ckeditor5/issues/15894.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
