### PR TITLE
UI animations do not respect user's preferences on reduced motion

### DIFF
--- a/packages/ckeditor5-image/theme/imagecaption.css
+++ b/packages/ckeditor5-image/theme/imagecaption.css
@@ -24,6 +24,10 @@
 /* Editing styles */
 .ck.ck-editor__editable .image > figcaption.image__caption_highlighted {
 	animation: ck-image-caption-highlight .6s ease-out;
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
 }
 
 @keyframes ck-image-caption-highlight {

--- a/packages/ckeditor5-list/theme/todolist.css
+++ b/packages/ckeditor5-list/theme/todolist.css
@@ -42,6 +42,10 @@
 		border: 1px solid hsl(0, 0%, 20%);
 		border-radius: 2px;
 		transition: 250ms ease-in-out box-shadow;
+
+		@media (prefers-reduced-motion: reduce) {
+			transition: none;
+		}
 	}
 
 	&::after {

--- a/packages/ckeditor5-minimap/theme/minimap.css
+++ b/packages/ckeditor5-minimap/theme/minimap.css
@@ -38,6 +38,11 @@
 		z-index: 1;
 		transition: background 100ms ease-in-out;
 
+
+		@media (prefers-reduced-motion: reduce) {
+			transition: none;
+		}
+
 		&:hover {
 			background:hsla( var(--ck-color-minimap-tracker-background), .3 );
 		}
@@ -64,6 +69,11 @@
 			border-radius: 3px;
 			opacity: 0;
 			transition: opacity 100ms ease-in-out;
+
+
+			@media (prefers-reduced-motion: reduce) {
+				transition: none;
+			}
 		}
 	}
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadicon.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadicon.css
@@ -60,11 +60,15 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.ck-image-upload-complete-icon::after {
-		animation: none;
-		opacity: 1;
-		width: 0.3em;
-		height: 0.45em;
+	.ck-image-upload-complete-icon {
+		animation-duration: 0ms;
+
+		&::after {
+			animation: none;
+			opacity: 1;
+			width: 0.3em;
+			height: 0.45em;
+		}
 	}
 }
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadicon.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadicon.css
@@ -59,6 +59,15 @@
 	}
 }
 
+@media (prefers-reduced-motion: reduce) {
+	.ck-image-upload-complete-icon::after {
+		animation: none;
+		opacity: 1;
+		width: 0.3em;
+		height: 0.45em;
+	}
+}
+
 @keyframes ck-upload-complete-icon-show {
 	from {
 		opacity: 0;

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadicon.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadicon.css
@@ -57,10 +57,8 @@
 		/* #1095. While reset is not providing proper box-sizing for pseudoelements, we need to handle it. */
 		box-sizing: border-box;
 	}
-}
 
-@media (prefers-reduced-motion: reduce) {
-	.ck-image-upload-complete-icon {
+	@media (prefers-reduced-motion: reduce) {
 		animation-duration: 0ms;
 
 		&::after {

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadprogress.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadprogress.css
@@ -22,6 +22,20 @@
 	}
 }
 
+
+@media (prefers-reduced-motion: reduce) {
+	.ck.ck-editor__editable {
+		& .image,
+		& .image-inline {
+			/* Showing animation. */
+			&.ck-appear {
+				opacity: 1;
+				animation: none;
+			}
+		}
+	}
+}
+
 @keyframes fadeIn {
 	from { opacity: 0; }
 	to   { opacity: 1; }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadprogress.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-image/imageuploadprogress.css
@@ -9,6 +9,11 @@
 		/* Showing animation. */
 		&.ck-appear {
 			animation: fadeIn 700ms;
+
+			@media (prefers-reduced-motion: reduce) {
+				opacity: 1;
+				animation: none;
+			}
 		}
 	}
 
@@ -19,20 +24,6 @@
 		width: 0;
 		background: var(--ck-color-upload-bar-background);
 		transition: width 100ms;
-	}
-}
-
-
-@media (prefers-reduced-motion: reduce) {
-	.ck.ck-editor__editable {
-		& .image,
-		& .image-inline {
-			/* Showing animation. */
-			&.ck-appear {
-				opacity: 1;
-				animation: none;
-			}
-		}
 	}
 }
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-restricted-editing/restrictedediting.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-restricted-editing/restrictedediting.css
@@ -25,6 +25,10 @@
 		var(--ck-color-restricted-editing-exception-brackets) 100%
 	) 1;
 
+	@media (prefers-reduced-motion: reduce) {
+		transition: none;
+	}
+
 	&.restricted-editing-exception_selected {
 		background-color: var(--ck-color-restricted-editing-selected-exception-background);
 		border-image: linear-gradient(

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-special-characters/charactergrid.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-special-characters/charactergrid.css
@@ -40,6 +40,10 @@
 		transition: .2s ease box-shadow;
 		border: 0;
 
+		@media (prefers-reduced-motion: reduce) {
+			transition: none;
+		}
+
 		&:focus:not( .ck-disabled ),
 		&:hover:not( .ck-disabled ) {
 			/* Disable the default .ck-button's border ring. */

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/inserttable.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/inserttable.css
@@ -30,6 +30,10 @@
 	outline: none;
 	transition: none;
 
+	@media (prefers-reduced-motion: reduce) {
+		transition: none;
+	}
+
 	&:focus {
 		box-shadow: none;
 	}

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableform.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableform.css
@@ -66,18 +66,16 @@
 			}
 
 			animation: ck-table-form-labeled-view-status-appear .15s ease both;
+
+			@media (prefers-reduced-motion: reduce) {
+				animation: none;
+			}
 		}
 
 		/* Hide the error balloon when the field is blurred. Makes the experience much more clear. */
 		& .ck-input.ck-error:not(:focus) + .ck.ck-labeled-field-view__status {
 			display: none;
 		}
-	}
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.ck.ck-table-form .ck.ck-labeled-field-view .ck.ck-labeled-field-view__status {
-		animation: none;
 	}
 }
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableform.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableform.css
@@ -75,6 +75,12 @@
 	}
 }
 
+@media (prefers-reduced-motion: reduce) {
+	.ck.ck-table-form .ck.ck-labeled-field-view .ck.ck-labeled-field-view__status {
+		animation: none;
+	}
+}
+
 @keyframes ck-table-form-labeled-view-status-appear {
 	0% {
 		opacity: 0;

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/button.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/button.css
@@ -41,6 +41,10 @@ a.ck.ck-button {
 	/* https://github.com/ckeditor/ckeditor5-theme-lark/issues/189 */
 	-webkit-appearance: none;
 
+	@media (prefers-reduced-motion: reduce) {
+		transition: none;
+	}
+
 	&:active,
 	&:focus {
 		@mixin ck-focus-ring;

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/switchbutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/switchbutton.css
@@ -76,6 +76,10 @@ of the component, floating–point numbers have been used which, for the default
 
 			/* Gently animate the inner part of the toggle switch */
 			transition: all 300ms ease;
+
+			@media (prefers-reduced-motion: reduce) {
+				transition: none;
+			}
 		}
 
 		&:hover {

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/colorgrid/colorgrid.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/colorgrid/colorgrid.css
@@ -28,6 +28,10 @@
 	transition: .2s ease box-shadow;
 	border: 0;
 
+	@media (prefers-reduced-motion: reduce) {
+		transition: none;
+	}
+
 	&.ck-disabled {
 		cursor: unset;
 		transition: unset;

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/input/input.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/input/input.css
@@ -28,6 +28,10 @@
 	/* Apply some smooth transition to the box-shadow and border. */
 	transition: box-shadow .1s ease-in-out, border .1s ease-in-out;
 
+	@media (prefers-reduced-motion: reduce) {
+		transition: none;
+	}
+
 	&:focus {
 		@mixin ck-focus-ring;
 		@mixin ck-box-shadow var(--ck-focus-outer-shadow);

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/input/input.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/input/input.css
@@ -54,6 +54,12 @@
 	}
 }
 
+@media (prefers-reduced-motion: reduce) {
+	.ck.ck-input.ck-error {
+		animation: none;
+	}
+}
+
 @keyframes ck-input-shake {
 	20% {
 		transform: translateX(-2px);

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/input/input.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/input/input.css
@@ -48,15 +48,13 @@
 		border-color: var(--ck-color-input-error-border);
 		animation: ck-input-shake .3s ease both;
 
+		@media (prefers-reduced-motion: reduce) {
+			animation: none;
+		}
+
 		&:focus {
 			@mixin ck-box-shadow var(--ck-focus-error-outer-shadow);
 		}
-	}
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.ck.ck-input.ck-error {
-		animation: none;
 	}
 }
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/labeledfield/labeledfieldview.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/labeledfield/labeledfieldview.css
@@ -53,6 +53,10 @@
 				transform var(--ck-labeled-field-view-transition),
 				padding var(--ck-labeled-field-view-transition),
 				background var(--ck-labeled-field-view-transition);
+
+			@media (prefers-reduced-motion: reduce) {
+				transition: none;
+			}
 		}
 	}
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/spinner/spinner.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/spinner/spinner.css
@@ -27,3 +27,8 @@
 	}
 }
 
+@media (prefers-reduced-motion: reduce) {
+	.ck.ck-spinner-container {
+		animation-duration: 3s;
+	}
+}

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/spinner/spinner.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/spinner/spinner.css
@@ -11,6 +11,10 @@
 	width: var(--ck-toolbar-spinner-size);
 	height: var(--ck-toolbar-spinner-size);
 	animation: 1.5s infinite rotate linear;
+
+	@media (prefers-reduced-motion: reduce) {
+		animation-duration: 3s;
+	}
 }
 
 .ck.ck-spinner {
@@ -24,11 +28,5 @@
 @keyframes rotate {
 	to {
 		transform: rotate(360deg)
-	}
-}
-
-@media (prefers-reduced-motion: reduce) {
-	.ck.ck-spinner-container {
-		animation-duration: 3s;
 	}
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widget.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widget.css
@@ -78,6 +78,10 @@
 		left: calc(0px - var(--ck-widget-outline-thickness));
 		top: 0;
 
+		@media (prefers-reduced-motion: reduce) {
+			transition: none;
+		}
+
 		& .ck-icon {
 			/* Make sure the dimensions of the icon are independent of the fon-size of the content. */
 			width: var(--ck-widget-handler-icon-size);
@@ -90,6 +94,10 @@
 
 				/* Note: The animation is longer on purpose. Simply feels better. */
 				transition: opacity 300ms var(--ck-widget-handler-animation-curve);
+
+				@media (prefers-reduced-motion: reduce) {
+					transition: none;
+				}
 			}
 		}
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widget.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widget.css
@@ -24,6 +24,10 @@
 	outline-color: transparent;
 	transition: outline-color var(--ck-widget-handler-animation-duration) var(--ck-widget-handler-animation-curve);
 
+	@media (prefers-reduced-motion: reduce) {
+		transition: none;
+	}
+
 	&.ck-widget_selected,
 	&.ck-widget_selected:hover {
 		outline: var(--ck-widget-outline-thickness) solid var(--ck-color-focus-border);

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
@@ -36,6 +36,10 @@
 
 		@mixin ck-widget-type-around-button-hidden;
 
+		@media (prefers-reduced-motion: reduce) {
+			transition: none;
+		}
+
 		& svg {
 			width: 10px;
 			height: 8px;

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
@@ -85,6 +85,20 @@
 					animation: ck-widget-type-around-arrow-tip-dash 2s linear;
 				}
 			}
+
+			@media (prefers-reduced-motion: reduce) {
+				animation: none;
+
+				& svg {
+					& polyline {
+						animation: none;
+					}
+
+					& line {
+						animation: none;
+					}
+				}
+			}
 		}
 	}
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widgettypearound.css
@@ -43,6 +43,10 @@
 			transition: transform .5s ease;
 			margin-top: 1px;
 
+			@media (prefers-reduced-motion: reduce) {
+				transition: none;
+			}
+
 			& * {
 				stroke-dasharray: 10;
 				stroke-dashoffset: 0;

--- a/packages/ckeditor5-utils/src/env.ts
+++ b/packages/ckeditor5-utils/src/env.ts
@@ -66,6 +66,11 @@ export interface EnvType {
 	readonly isBlink: boolean;
 
 	/**
+	 * Indicates that "prefer reduced motion" browser setting is active.
+	 */
+	readonly isMotionReduced: boolean;
+
+	/**
 	 * Environment features information.
 	 */
 	readonly features: EnvFeaturesType;
@@ -98,6 +103,10 @@ const env: EnvType = {
 	isAndroid: isAndroid( userAgent ),
 
 	isBlink: isBlink( userAgent ),
+
+	get isMotionReduced() {
+		return isMotionReduced();
+	},
 
 	features: {
 		isRegExpUnicodePropertySupported: isRegExpUnicodePropertySupported()
@@ -198,4 +207,11 @@ export function isRegExpUnicodePropertySupported(): boolean {
 	}
 
 	return isSupported;
+}
+
+/**
+ * Checks if user enabled "prefers reduced motion" setting in browser.
+ */
+export function isMotionReduced(): boolean {
+	return window.matchMedia( '(prefers-reduced-motion)' ).matches;
 }

--- a/packages/ckeditor5-utils/tests/env.js
+++ b/packages/ckeditor5-utils/tests/env.js
@@ -63,6 +63,36 @@ describe( 'Env', () => {
 		} );
 	} );
 
+	describe( 'isMotionReduced', () => {
+		let matchMediaStub;
+
+		beforeEach( () => {
+			matchMediaStub = sinon.stub( global.window, 'matchMedia' );
+		} );
+
+		it( 'is a boolean', () => {
+			mockMotionReduced();
+
+			expect( env.isMotionReduced ).to.be.true;
+		} );
+
+		it( 'should watch changes in reduced motion setting', () => {
+			mockMotionReduced();
+
+			expect( env.isMotionReduced ).to.be.true;
+
+			mockMotionReduced( false );
+
+			expect( env.isMotionReduced ).to.be.false;
+		} );
+
+		function mockMotionReduced( enabled = true ) {
+			return matchMediaStub
+				.withArgs( '(prefers-reduced-motion)' )
+				.returns( { matches: enabled } );
+		}
+	} );
+
 	describe( 'features', () => {
 		it( 'is an object', () => {
 			expect( env.features ).to.be.an( 'object' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: UI animations respect user's preferences on reduced motion.

---

### Tickets to close

Closes https://github.com/cksource/ckeditor5-commercial/issues/6030.
Related to https://github.com/cksource/ckeditor5-commercial/pull/6121


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Enhanced accessibility across various components by introducing media queries for reduced motion preferences, ensuring a comfortable viewing experience. Adjustments include disabling animations and transitions in image captions, to-do lists, minimaps, and UI elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->