### PR TITLE
Fix memory leak in `tooltipmanager.js` test

### DIFF
--- a/packages/ckeditor5-ui/src/tooltipmanager.ts
+++ b/packages/ckeditor5-ui/src/tooltipmanager.ts
@@ -391,7 +391,7 @@ export default class TooltipManager extends DomEmitterMixin() {
 		targetDomElement: HTMLElement,
 		{ text, position, cssClass }: TooltipData
 	): void {
-		this._unpinTooltipDebounced.cancel();
+		this._unpinTooltip();
 
 		// Use the body collection of the first editor.
 		const bodyViewCollection = first( TooltipManager._editors.values() )!.ui.view.body;
@@ -447,6 +447,7 @@ export default class TooltipManager extends DomEmitterMixin() {
 
 		this._currentElementWithTooltip = null;
 		this._currentTooltipPosition = null;
+		this.tooltipTextView.text = '';
 
 		if ( this._resizeObserver ) {
 			this._resizeObserver.destroy();

--- a/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
+++ b/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
@@ -749,7 +749,7 @@ describe( 'TooltipManager', () => {
 				sinon.assert.calledOnce( unpinSpy );
 
 				utils.waitForTheTooltipToHide( clock );
-				sinon.assert.calledTwice( unpinSpy );
+				sinon.assert.calledThrice( unpinSpy );
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Force fully unpin tooltip before pin due to memleak issues in tests. 
