### PR TITLE
Change configuration handling to make menu bar opt-in in classic editor.

### DIFF
--- a/packages/ckeditor5-core/src/editor/editorconfig.ts
+++ b/packages/ckeditor5-core/src/editor/editorconfig.ts
@@ -384,42 +384,44 @@ export interface EditorConfig {
 	 * ```ts
 	 * ClassicEditor
 	 * 	.create( document.querySelector( '#editor' ), {
-	 * 		menuBar: [
-	 * 			{
-	 * 				menuId: 'formatting',
-	 * 				label: 'Formatting',
-	 * 				groups: [
-	 * 					{
-	 * 						groupId: 'basicStyles',
-	 * 						items: [
-	 * 							'menuBar:bold',
-	 * 							'menuBar:italic',
-	 * 						]
-	 * 					},
-	 * 					{
-	 * 						groupId: 'misc',
-	 * 						items: [
-	 * 							'menuBar:heading',
-	 * 							'menuBar:bulletedList',
-	 * 							'menuBar:numberedList'
-	 * 						]
-	 * 					}
-	 * 				]
-	 * 			},
-	 * 			{
-	 * 				menuId: 'myButtons',
-	 * 				label: 'My actions',
-	 * 				groups: [
-	 * 					{
-	 * 						groupId: 'undo',
-	 * 						items: [
-	 * 							'myButton1',
-	 * 							'myButton2'
-	 * 						]
-	 * 					}
-	 * 				]
-	 * 			}
-	 * 		]
+	 * 		menuBar: {
+	 * 			items: [
+	 * 				{
+	 * 					menuId: 'formatting',
+	 * 					label: 'Formatting',
+	 * 					groups: [
+	 * 						{
+	 * 							groupId: 'basicStyles',
+	 * 							items: [
+	 * 								'menuBar:bold',
+	 * 								'menuBar:italic',
+	 * 							]
+	 * 						},
+	 * 						{
+	 * 							groupId: 'misc',
+	 * 							items: [
+	 * 								'menuBar:heading',
+	 * 								'menuBar:bulletedList',
+	 * 								'menuBar:numberedList'
+	 * 							]
+	 * 						}
+	 * 					]
+	 * 				},
+	 * 				{
+	 * 					menuId: 'myButtons',
+	 * 					label: 'My actions',
+	 * 					groups: [
+	 * 						{
+	 * 							groupId: 'undo',
+	 * 							items: [
+	 * 								'myButton1',
+	 * 								'myButton2'
+	 * 							]
+	 * 						}
+	 * 					]
+	 * 				}
+	 * 			]
+	 * 		}
 	 * 	} )
 	 * 	.then( ... )
 	 * 	.catch( ... );

--- a/packages/ckeditor5-editor-classic/src/classiceditor.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.ts
@@ -74,6 +74,10 @@ export default class ClassicEditor extends ElementApiMixin( Editor ) {
 
 		super( config );
 
+		this.config.define( 'menuBar', {
+			isVisible: false
+		} );
+
 		if ( this.config.get( 'initialData' ) === undefined ) {
 			this.config.set( 'initialData', getInitialData( sourceElementOrData ) );
 		}
@@ -85,7 +89,10 @@ export default class ClassicEditor extends ElementApiMixin( Editor ) {
 		this.model.document.createRoot();
 
 		const shouldToolbarGroupWhenFull = !this.config.get( 'toolbar.shouldNotGroupWhenFull' );
-		const useMenuBar = !!this.config.get( 'menuBar' );
+
+		const menuBarConfig = this.config.get( 'menuBar' )!;
+		const useMenuBar = Array.isArray( menuBarConfig ) || menuBarConfig.isVisible;
+
 		const view = new ClassicEditorUIView( this.locale, this.editing.view, {
 			shouldToolbarGroupWhenFull,
 			useMenuBar

--- a/packages/ckeditor5-editor-classic/src/classiceditor.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.ts
@@ -74,9 +74,7 @@ export default class ClassicEditor extends ElementApiMixin( Editor ) {
 
 		super( config );
 
-		this.config.define( 'menuBar', {
-			isVisible: false
-		} );
+		this.config.define( 'menuBar.isVisible', false );
 
 		if ( this.config.get( 'initialData' ) === undefined ) {
 			this.config.set( 'initialData', getInitialData( sourceElementOrData ) );
@@ -91,11 +89,10 @@ export default class ClassicEditor extends ElementApiMixin( Editor ) {
 		const shouldToolbarGroupWhenFull = !this.config.get( 'toolbar.shouldNotGroupWhenFull' );
 
 		const menuBarConfig = this.config.get( 'menuBar' )!;
-		const useMenuBar = Array.isArray( menuBarConfig ) || menuBarConfig.isVisible;
 
 		const view = new ClassicEditorUIView( this.locale, this.editing.view, {
 			shouldToolbarGroupWhenFull,
-			useMenuBar
+			useMenuBar: menuBarConfig.isVisible
 		} );
 
 		this.ui = new ClassicEditorUI( this, view );

--- a/packages/ckeditor5-editor-classic/src/classiceditor.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.ts
@@ -85,8 +85,10 @@ export default class ClassicEditor extends ElementApiMixin( Editor ) {
 		this.model.document.createRoot();
 
 		const shouldToolbarGroupWhenFull = !this.config.get( 'toolbar.shouldNotGroupWhenFull' );
+		const useMenuBar = !!this.config.get( 'menuBar' );
 		const view = new ClassicEditorUIView( this.locale, this.editing.view, {
-			shouldToolbarGroupWhenFull
+			shouldToolbarGroupWhenFull,
+			useMenuBar
 		} );
 
 		this.ui = new ClassicEditorUI( this, view );

--- a/packages/ckeditor5-editor-classic/src/classiceditorui.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditorui.ts
@@ -157,10 +157,6 @@ export default class ClassicEditorUI extends EditorUI {
 		const editor = this.editor;
 		const config = editor.config.get( 'menuBar' );
 
-		if ( !config ) {
-			return;
-		}
-
 		const menuBarViewElement = this.view.menuBarView.element!;
 		const view = this.view;
 

--- a/packages/ckeditor5-editor-classic/src/classiceditorui.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditorui.ts
@@ -11,6 +11,7 @@ import type { Editor, ElementApi } from 'ckeditor5/src/core.js';
 import {
 	EditorUI,
 	normalizeToolbarConfig,
+	normalizeMenuBarConfig,
 	DialogView,
 	type EditorUIReadyEvent,
 	type DialogViewMoveToEvent,
@@ -38,6 +39,11 @@ export default class ClassicEditorUI extends EditorUI {
 	private readonly _toolbarConfig: ReturnType<typeof normalizeToolbarConfig>;
 
 	/**
+	 * A normalized `config.menuBar` object.
+	 */
+	private readonly _menuBarConfig: ReturnType<typeof normalizeMenuBarConfig>;
+
+	/**
 	 * The element replacer instance used to hide the editor's source element.
 	 */
 	private readonly _elementReplacer: ElementReplacer;
@@ -53,6 +59,10 @@ export default class ClassicEditorUI extends EditorUI {
 
 		this.view = view;
 		this._toolbarConfig = normalizeToolbarConfig( editor.config.get( 'toolbar' ) );
+
+		// We use config.define in ClassicEditor, there will always be some configuration.
+		this._menuBarConfig = normalizeMenuBarConfig( editor.config.get( 'menuBar' )! );
+
 		this._elementReplacer = new ElementReplacer();
 
 		this.listenTo<ViewScrollToTheSelectionEvent>(
@@ -154,15 +164,17 @@ export default class ClassicEditorUI extends EditorUI {
 	 * Initializes the editor menu bar.
 	 */
 	private _initMenuBar(): void {
-		const editor = this.editor;
-		const config = editor.config.get( 'menuBar' );
+		if ( !this._menuBarConfig.isVisible ) {
+			return;
+		}
 
+		const editor = this.editor;
 		const menuBarViewElement = this.view.menuBarView.element!;
 		const view = this.view;
 
 		this.focusTracker.add( menuBarViewElement );
 		editor.keystrokes.listenTo( menuBarViewElement );
-		view.menuBarView.fillFromConfig( config, this.componentFactory );
+		view.menuBarView.fillFromConfig( this._menuBarConfig, this.componentFactory );
 
 		editor.keystrokes.set( 'Esc', ( data, cancel ) => {
 			if ( menuBarViewElement.contains( this.focusTracker.focusedElement ) ) {

--- a/packages/ckeditor5-editor-classic/src/classiceditorui.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditorui.ts
@@ -155,12 +155,18 @@ export default class ClassicEditorUI extends EditorUI {
 	 */
 	private _initMenuBar(): void {
 		const editor = this.editor;
+		const config = editor.config.get( 'menuBar' );
+
+		if ( !config ) {
+			return;
+		}
+
 		const menuBarViewElement = this.view.menuBarView.element!;
 		const view = this.view;
 
 		this.focusTracker.add( menuBarViewElement );
 		editor.keystrokes.listenTo( menuBarViewElement );
-		view.menuBarView.fillFromConfig( editor.config.get( 'menuBar' ), this.componentFactory );
+		view.menuBarView.fillFromConfig( config, this.componentFactory );
 
 		editor.keystrokes.set( 'Esc', ( data, cancel ) => {
 			if ( menuBarViewElement.contains( this.focusTracker.focusedElement ) ) {

--- a/packages/ckeditor5-editor-classic/src/classiceditoruiview.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditoruiview.ts
@@ -40,6 +40,11 @@ export default class ClassicEditorUIView extends BoxedEditorUIView {
 	public readonly editable: InlineEditableUIView;
 
 	/**
+	 * TODO
+	 */
+	private _useMenuBar?: boolean;
+
+	/**
 	 * Creates an instance of the classic editor UI view.
 	 *
 	 * @param locale The {@link module:core/editor/editor~Editor#locale} instance.
@@ -54,6 +59,7 @@ export default class ClassicEditorUIView extends BoxedEditorUIView {
 		editingView: EditingView,
 		options: {
 			shouldToolbarGroupWhenFull?: boolean;
+			useMenuBar?: boolean;
 		} = {}
 	) {
 		super( locale );
@@ -63,6 +69,8 @@ export default class ClassicEditorUIView extends BoxedEditorUIView {
 		this.toolbar = new ToolbarView( locale, {
 			shouldGroupWhenFull: options.shouldToolbarGroupWhenFull
 		} );
+
+		this._useMenuBar = options.useMenuBar;
 
 		this.menuBarView = new MenuBarView( locale );
 
@@ -75,8 +83,12 @@ export default class ClassicEditorUIView extends BoxedEditorUIView {
 	public override render(): void {
 		super.render();
 
-		// Set toolbar as a child of a stickyPanel and makes toolbar sticky.
-		this.stickyPanel.content.addMany( [ this.menuBarView, this.toolbar ] );
+		if ( this._useMenuBar ) {
+			// Set toolbar as a child of a stickyPanel and makes toolbar sticky.
+			this.stickyPanel.content.addMany( [ this.menuBarView, this.toolbar ] );
+		} else {
+			this.stickyPanel.content.add( this.toolbar );
+		}
 
 		this.top.add( this.stickyPanel );
 		this.main.add( this.editable );

--- a/packages/ckeditor5-editor-classic/tests/manual/classiceditor.js
+++ b/packages/ckeditor5-editor-classic/tests/manual/classiceditor.js
@@ -21,7 +21,8 @@ function initEditor() {
 	ClassicEditor
 		.create( document.querySelector( '#editor' ), {
 			plugins: [ Enter, Typing, Paragraph, Undo, Heading, Bold, Italic ],
-			toolbar: [ 'heading', '|', 'bold', 'italic', 'undo', 'redo' ]
+			toolbar: [ 'heading', '|', 'bold', 'italic', 'undo', 'redo' ],
+			menubar: 'default'
 		} )
 		.then( newEditor => {
 			console.log( 'Editor was initialized', newEditor );

--- a/packages/ckeditor5-editor-classic/tests/manual/classiceditor.js
+++ b/packages/ckeditor5-editor-classic/tests/manual/classiceditor.js
@@ -22,7 +22,7 @@ function initEditor() {
 		.create( document.querySelector( '#editor' ), {
 			plugins: [ Enter, Typing, Paragraph, Undo, Heading, Bold, Italic ],
 			toolbar: [ 'heading', '|', 'bold', 'italic', 'undo', 'redo' ],
-			menubar: 'default'
+			menuBar: { isVisible: true }
 		} )
 		.then( newEditor => {
 			console.log( 'Editor was initialized', newEditor );

--- a/packages/ckeditor5-ui/src/menubar/menubarview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarview.ts
@@ -100,13 +100,15 @@ export default class MenuBarView extends View implements FocusableView {
 	 * See the {@link module:core/editor/editorconfig~EditorConfig#menuBar menu bar} in the editor
 	 * configuration reference to learn how to configure the menu bar.
 	 */
-	public fillFromConfig( config: MenuBarConfig, componentFactory: ComponentFactory ): void {
+	public fillFromConfig( config: MenuBarConfig | undefined, componentFactory: ComponentFactory ): void {
 		const locale = this.locale!;
-		const topLevelCategoryMenuViews = normalizeMenuBarConfig( {
+		const normalizedConfig = normalizeMenuBarConfig( {
 			locale,
 			componentFactory,
 			config
-		} )!.items.map( menuDefinition => this._createMenu( {
+		} );
+
+		const topLevelCategoryMenuViews = normalizedConfig.items.map( menuDefinition => this._createMenu( {
 			componentFactory,
 			menuDefinition
 		} ) );
@@ -307,12 +309,13 @@ export default class MenuBarView extends View implements FocusableView {
 	}
 }
 
-export type MenuBarConfig = Array<MenuBarMenuDefinition> | MenuBarConfigObject | 'default';
+export type MenuBarConfig = Array<MenuBarMenuDefinition> | MenuBarConfigObject;
 
 export type MenuBarConfigObject = {
-	items: Array<MenuBarMenuDefinition>;
+	items?: Array<MenuBarMenuDefinition>;
 	removeItems?: Array<string>;
 	addItems?: Array<MenuBarConfigAddedItem | MenuBarConfigAddedGroup | MenuBarConfigAddedMenu>;
+	isVisible?: boolean;
 };
 
 export type MenuBarMenuGroupDefinition = {

--- a/packages/ckeditor5-ui/src/menubar/menubarview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarview.ts
@@ -28,7 +28,7 @@ import MenuBarMenuListItemButtonView from './menubarmenulistitembuttonview.js';
 import MenuBarMenuListItemFileDialogButtonView from './menubarmenulistitemfiledialogbuttonview.js';
 import {
 	MenuBarBehaviors,
-	normalizeMenuBarConfig
+	processMenuBarConfig
 } from './utils.js';
 
 const EVENT_NAME_DELEGATES = [ 'mouseenter', 'arrowleft', 'arrowright', 'change:isOpen' ] as const;
@@ -101,15 +101,15 @@ export default class MenuBarView extends View implements FocusableView {
 	 * See the {@link module:core/editor/editorconfig~EditorConfig#menuBar menu bar} in the editor
 	 * configuration reference to learn how to configure the menu bar.
 	 */
-	public fillFromConfig( config: MenuBarConfig | undefined, componentFactory: ComponentFactory ): void {
+	public fillFromConfig( config: NormalizedMenuBarConfigObject, componentFactory: ComponentFactory ): void {
 		const locale = this.locale!;
-		const normalizedConfig = normalizeMenuBarConfig( {
+		const processedConfig = processMenuBarConfig( {
+			normalizedConfig: config,
 			locale,
-			componentFactory,
-			config
+			componentFactory
 		} );
 
-		const topLevelCategoryMenuViews = normalizedConfig.items.map( menuDefinition => this._createMenu( {
+		const topLevelCategoryMenuViews = processedConfig.items.map( menuDefinition => this._createMenu( {
 			componentFactory,
 			menuDefinition
 		} ) );
@@ -341,13 +341,17 @@ export default class MenuBarView extends View implements FocusableView {
 	}
 }
 
-export type MenuBarConfig = Array<MenuBarMenuDefinition> | MenuBarConfigObject;
+export type MenuBarConfig = MenuBarConfigObject;
 
 export type MenuBarConfigObject = {
 	items?: Array<MenuBarMenuDefinition>;
 	removeItems?: Array<string>;
 	addItems?: Array<MenuBarConfigAddedItem | MenuBarConfigAddedGroup | MenuBarConfigAddedMenu>;
 	isVisible?: boolean;
+};
+
+export type NormalizedMenuBarConfigObject = Required<MenuBarConfigObject> & {
+	isUsingDefaultConfig: boolean;
 };
 
 export type MenuBarMenuGroupDefinition = {

--- a/packages/ckeditor5-ui/src/menubar/menubarview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarview.ts
@@ -100,13 +100,13 @@ export default class MenuBarView extends View implements FocusableView {
 	 * See the {@link module:core/editor/editorconfig~EditorConfig#menuBar menu bar} in the editor
 	 * configuration reference to learn how to configure the menu bar.
 	 */
-	public fillFromConfig( config: MenuBarConfig | undefined, componentFactory: ComponentFactory ): void {
+	public fillFromConfig( config: MenuBarConfig, componentFactory: ComponentFactory ): void {
 		const locale = this.locale!;
 		const topLevelCategoryMenuViews = normalizeMenuBarConfig( {
 			locale,
 			componentFactory,
 			config
-		} ).items.map( menuDefinition => this._createMenu( {
+		} )!.items.map( menuDefinition => this._createMenu( {
 			componentFactory,
 			menuDefinition
 		} ) );
@@ -307,7 +307,7 @@ export default class MenuBarView extends View implements FocusableView {
 	}
 }
 
-export type MenuBarConfig = Array<MenuBarMenuDefinition> | MenuBarConfigObject;
+export type MenuBarConfig = Array<MenuBarMenuDefinition> | MenuBarConfigObject | 'default';
 
 export type MenuBarConfigObject = {
 	items: Array<MenuBarMenuDefinition>;

--- a/packages/ckeditor5-ui/src/menubar/menubarview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarview.ts
@@ -74,8 +74,8 @@ export default class MenuBarView extends View implements FocusableView {
 
 		this.children = this.createCollection();
 
-		// @if CK_DEBUG_MENU_BAR // Logs events in the main event bus of the component.
-		// @if CK_DEBUG_MENU_BAR // this.on( 'submenu', ( evt, data ) => {
+		// @if CK_DEBUG_MENU_BAR // // Logs events in the main event bus of the component.
+		// @if CK_DEBUG_MENU_BAR // this.on( 'menu', ( evt, data ) => {
 		// @if CK_DEBUG_MENU_BAR // 	console.log( `MenuBarView:${ evt.name }`, evt.path.map( view => view.element ) );
 		// @if CK_DEBUG_MENU_BAR // } );
 

--- a/packages/ckeditor5-ui/src/menubar/utils.ts
+++ b/packages/ckeditor5-ui/src/menubar/utils.ts
@@ -636,12 +636,17 @@ export function normalizeMenuBarConfig( {
 	locale: Locale;
 	componentFactory: ComponentFactory;
 	config: Readonly<MenuBarConfig> | undefined;
-} ): MenuBarConfigObject {
+} ): MenuBarConfigObject | null {
+	// The integrator didn't specify any configuration so we don't use menu bar.
+	if ( !config ) {
+		return null;
+	}
+
 	let configObject: DeepReadonly<RequiredMenuBarConfigObject>;
 	let isUsingDefaultConfig = false;
 
-	// The integrator didn't specify any configuration so we use the default one.
-	if ( !config ) {
+	// The integrator chose default configuration.
+	if ( config == 'default' ) {
 		configObject = {
 			items: cloneDeep( DefaultMenuBarItems ) as Array<MenuBarMenuDefinition>,
 			addItems: [],

--- a/packages/ckeditor5-ui/src/menubar/utils.ts
+++ b/packages/ckeditor5-ui/src/menubar/utils.ts
@@ -636,21 +636,17 @@ export function normalizeMenuBarConfig( {
 	locale: Locale;
 	componentFactory: ComponentFactory;
 	config: Readonly<MenuBarConfig> | undefined;
-} ): MenuBarConfigObject | null {
-	// The integrator didn't specify any configuration so we don't use menu bar.
-	if ( !config ) {
-		return null;
-	}
-
+} ): RequiredMenuBarConfigObject {
 	let configObject: DeepReadonly<RequiredMenuBarConfigObject>;
 	let isUsingDefaultConfig = false;
 
-	// The integrator chose default configuration.
-	if ( config == 'default' ) {
+	// The integrator didn't specify any configuration so we use default one.
+	if ( !config ) {
 		configObject = {
 			items: cloneDeep( DefaultMenuBarItems ) as Array<MenuBarMenuDefinition>,
 			addItems: [],
-			removeItems: []
+			removeItems: [],
+			isVisible: true
 		};
 
 		isUsingDefaultConfig = true;
@@ -660,16 +656,18 @@ export function normalizeMenuBarConfig( {
 		configObject = {
 			items: config,
 			addItems: [],
-			removeItems: []
+			removeItems: [],
+			isVisible: true
 		};
 	}
 	// The integrator specified the config as an object but without items. Let's give them defaults but respect their
 	// additions and removals.
-	else if ( !( 'items' in config ) ) {
+	else if ( !( 'items' in config ) || !config.items ) {
 		configObject = {
 			items: cloneDeep( DefaultMenuBarItems ) as Array<MenuBarMenuDefinition>,
 			addItems: [],
 			removeItems: [],
+			isVisible: true,
 			...config
 		};
 
@@ -678,9 +676,11 @@ export function normalizeMenuBarConfig( {
 	// The integrator specified the config as an object and there are items there. Let's take it as it is.
 	else {
 		configObject = {
+			items: config.items,
 			removeItems: [],
 			addItems: [],
-			...config as MenuBarConfigObject
+			isVisible: true,
+			...config
 		};
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui,editor-classic): Streamline menu bar normalization. Made the feature an opt-in in the `ClassicEditor`. Related to https://github.com/ckeditor/ckeditor5/issues/15894.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
