### PR TITLE
ToC and restricted editing improvments

### DIFF
--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
@@ -14,11 +14,16 @@ import {
 	addListToDropdown,
 	MenuBarMenuListItemButtonView,
 	type ButtonExecuteEvent,
-	type ListDropdownItemDefinition
+	type ListDropdownItemDefinition, MenuBarMenuView, MenuBarMenuListView, MenuBarMenuListItemView
 } from 'ckeditor5/src/ui.js';
 import { Collection } from 'ckeditor5/src/utils.js';
 
 import lockIcon from '../theme/icons/contentlock.svg';
+
+const BUTTON_TEMPLATES = [
+	{ commandName: 'goToPreviousRestrictedEditingException', label: 'Previous editable region', keystroke: 'Shift+Tab' },
+	{ commandName: 'goToNextRestrictedEditingException', label: 'Next editable region', keystroke: 'Tab' }
+];
 
 /**
  * The restricted editing mode UI feature.
@@ -45,16 +50,9 @@ export default class RestrictedEditingModeUI extends Plugin {
 			const dropdownView = createDropdown( locale );
 			const listItems = new Collection<ListDropdownItemDefinition>();
 
-			listItems.add( this._getButtonDefinition(
-				'goToPreviousRestrictedEditingException',
-				t( 'Previous editable region' ),
-				'Shift+Tab'
-			) );
-			listItems.add( this._getButtonDefinition(
-				'goToNextRestrictedEditingException',
-				t( 'Next editable region' ),
-				'Tab'
-			) );
+			BUTTON_TEMPLATES.forEach( ( { commandName, label, keystroke } ) => {
+				listItems.add( this._getButtonDefinition( commandName, t( label ), keystroke ) );
+			} );
 
 			addListToDropdown( dropdownView, listItems );
 
@@ -73,6 +71,36 @@ export default class RestrictedEditingModeUI extends Plugin {
 			} );
 
 			return dropdownView;
+		} );
+
+		editor.ui.componentFactory.add( 'menuBar:restrictedEditing', locale => {
+			const menuView = new MenuBarMenuView( locale );
+			const listView = new MenuBarMenuListView( locale );
+
+			menuView.set( {
+				class: 'ck-heading-dropdown'
+			} );
+
+			listView.set( {
+				ariaLabel: t( 'Restricted editing' ),
+				role: 'menu'
+			} );
+
+			menuView.buttonView.set( {
+				label: t( 'Restricted editing' )
+			} );
+
+			menuView.panelView.children.add( listView );
+
+			BUTTON_TEMPLATES.forEach( ( { commandName, label, keystroke } ) => {
+				const buttonView = this._createMenuBarButton( t( label ), commandName, keystroke );
+				const listItemView = new MenuBarMenuListItemView( locale, menuView );
+
+				listItemView.children.add( buttonView );
+				listView.items.add( listItemView );
+			} );
+
+			return menuView;
 		} );
 
 		editor.ui.componentFactory.add(

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
@@ -89,8 +89,8 @@ export default class RestrictedEditingModeUI extends Plugin {
 			menuView.panelView.children.add( listView );
 
 			BUTTON_TEMPLATES.forEach( ( { commandName, label, keystroke } ) => {
-				const buttonView = this._createMenuBarButton( t( label ), commandName, keystroke );
 				const listItemView = new MenuBarMenuListItemView( locale, menuView );
+				const buttonView = this._createMenuBarButton( t( label ), commandName, keystroke );
 
 				listItemView.children.add( buttonView );
 				listView.items.add( listItemView );

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
@@ -77,17 +77,13 @@ export default class RestrictedEditingModeUI extends Plugin {
 			const menuView = new MenuBarMenuView( locale );
 			const listView = new MenuBarMenuListView( locale );
 
-			menuView.set( {
-				class: 'ck-heading-dropdown'
-			} );
-
 			listView.set( {
-				ariaLabel: t( 'Restricted editing' ),
+				ariaLabel: t( 'Navigate editable regions' ),
 				role: 'menu'
 			} );
 
 			menuView.buttonView.set( {
-				label: t( 'Restricted editing' )
+				label: t( 'Navigate editable regions' )
 			} );
 
 			menuView.panelView.children.add( listView );

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
@@ -92,6 +92,8 @@ export default class RestrictedEditingModeUI extends Plugin {
 				const listItemView = new MenuBarMenuListItemView( locale, menuView );
 				const buttonView = this._createMenuBarButton( t( label ), commandName, keystroke );
 
+				buttonView.delegate( 'execute' ).to( menuView );
+
 				listItemView.children.add( buttonView );
 				listView.items.add( listItemView );
 			} );
@@ -121,7 +123,6 @@ export default class RestrictedEditingModeUI extends Plugin {
 		view.set( {
 			label,
 			keystroke,
-			tooltip: true,
 			isEnabled: true,
 			isOn: false
 		} );

--- a/packages/ckeditor5-restricted-editing/tests/manual/restrictedediting.js
+++ b/packages/ckeditor5-restricted-editing/tests/manual/restrictedediting.js
@@ -51,6 +51,9 @@ async function startStandardEditingMode() {
 				'mergeTableCells'
 			]
 		},
+		menuBar: {
+			isVisible: true
+		},
 		updateSourceElementOnDestroy: true
 	} );
 }
@@ -80,7 +83,10 @@ async function startRestrictedEditingMode() {
 			contentToolbar: [ 'tableColumn', 'tableRow', 'mergeTableCells' ],
 			tableToolbar: [ 'bold', 'italic' ]
 		},
-		updateSourceElementOnDestroy: true
+		updateSourceElementOnDestroy: true,
+		menuBar: {
+			isVisible: true
+		}
 	} );
 }
 

--- a/packages/ckeditor5-ui/src/menubar/utils.ts
+++ b/packages/ckeditor5-ui/src/menubar/utils.ts
@@ -477,25 +477,8 @@ export const DefaultMenuBarItems: DeepReadonly<MenuBarConfigObject[ 'items' ]> =
 			{
 				groupId: 'standardEditingMode',
 				items: [
-					'menuBar:restrictedEditingException'
-				]
-			},
-			{
-				groupId: 'restrictedEditing',
-				items: [
-					{
-						menuId: 'restrictedEditing',
-						label: 'Restricted editing',
-						groups: [
-							{
-								groupId: 'restrictedEditingMode',
-								items: [
-									'menuBar:restrictedEditingPrevious',
-									'menuBar:restrictedEditingNext'
-								]
-							}
-						]
-					}
+					'menuBar:restrictedEditingException',
+					'menuBar:restrictedEditing'
 				]
 			}
 		]
@@ -517,7 +500,8 @@ export const DefaultMenuBarItems: DeepReadonly<MenuBarConfigObject[ 'items' ]> =
 					'menuBar:htmlEmbed',
 					'menuBar:pageBreak',
 					'menuBar:horizontalLine',
-					'menuBar:codeBlock'
+					'menuBar:codeBlock',
+					'menuBar:tableOfContents'
 				]
 			}
 		]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (document-outline): Added Table of contents button in default menu bar structure. 
Internal (restricted-editing): Refactored the restricted editing buttons in the menu bar.

