### PR TITLE
Fixed the spacing in buttons without icons

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenulistitembutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenulistitembutton.css
@@ -6,6 +6,11 @@
 .ck.ck-menu-bar__menu .ck-button.ck-menu-bar__menu__item__button {
 	border-radius: 0;
 
+	/* Spacing in buttons that miss the icon. */
+	&:not(:has(.ck-button__icon)) > .ck-button__label {
+		margin-left: calc(var(--ck-icon-size) - var(--ck-spacing-small));
+	}
+
 	& > .ck-spinner-container,
 	& > .ck-spinner-container .ck-spinner {
 		/* These styles correspond to .ck-icon so that the spinner seamlessly replaces the icon. */

--- a/packages/ckeditor5-ui/tests/manual/menubar/menubar.js
+++ b/packages/ckeditor5-ui/tests/manual/menubar/menubar.js
@@ -150,7 +150,8 @@ function createEditor( selector, uiLanguageCode, extraConfig ) {
 			},
 
 			menuBar: {
-				...extraConfig
+				...extraConfig,
+				isVisible: true
 			}
 		} )
 		.then( editor => {

--- a/tests/manual/all-features.js
+++ b/tests/manual/all-features.js
@@ -139,6 +139,9 @@ ClassicEditor
 				}
 			]
 		},
+		menuBar: {
+			isVisible: true
+		},
 		link: {
 			decorators: {
 				isExternal: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (theme-lark): Fixed the spacing in buttons without icons.
