### PR TITLE
Preserve repeated spaces when text is wrapped with a CSS `white-space` rule

### DIFF
--- a/packages/ckeditor5-engine/src/view/domconverter.ts
+++ b/packages/ckeditor5-engine/src/view/domconverter.ts
@@ -1604,8 +1604,7 @@ export default class DomConverter {
 	private _processDataFromViewText( node: ViewText | ViewTextProxy ): string {
 		let data = node.data;
 
-		// If any of node ancestors has a name which is in `preElements` array, then currently processed
-		// view text node is (will be) in preformatted element. We should not change whitespaces then.
+		// If the currently processed view text node is preformatted, we should not change whitespaces.
 		if ( this._isPreFormatted( node ) ) {
 			return data;
 		}
@@ -1661,7 +1660,7 @@ export default class DomConverter {
 
 	/**
 	 * Checks whether given text contains preformatted white space. This is the case if
-	 * * the text is contained within a `<pre>` element, or
+	 * * any of node ancestors has a name which is in `preElements` array, or
 	 * * the closest ancestor that has the `white-space` CSS property sets it to a value that preserves spaces
 	 *
 	 * @param node Node to check

--- a/packages/ckeditor5-engine/src/view/domconverter.ts
+++ b/packages/ckeditor5-engine/src/view/domconverter.ts
@@ -1508,7 +1508,7 @@ export default class DomConverter {
 			let data: string;
 			let nodeEndsWithSpace: boolean = false;
 
-			if ( _hasViewParentOfType( node, this.preElements ) ) {
+			if ( this._isPreFormatted( node ) ) {
 				data = getDataWithoutFiller( node.data );
 			} else {
 				// Change all consecutive whitespace characters (from the [ \n\t\r] set –
@@ -1606,7 +1606,7 @@ export default class DomConverter {
 
 		// If any of node ancestors has a name which is in `preElements` array, then currently processed
 		// view text node is (will be) in preformatted element. We should not change whitespaces then.
-		if ( node.getAncestors().some( parent => this.preElements.includes( ( parent as ViewElement ).name ) ) ) {
+		if ( this._isPreFormatted( node ) ) {
 			return data;
 		}
 
@@ -1650,13 +1650,40 @@ export default class DomConverter {
 	 * @returns `true` if given `node` ends with space, `false` otherwise.
 	 */
 	private _nodeEndsWithSpace( node: ViewTextProxy ): boolean {
-		if ( node.getAncestors().some( parent => this.preElements.includes( ( parent as ViewElement ).name ) ) ) {
+		if ( this._isPreFormatted( node ) ) {
 			return false;
 		}
 
 		const data = this._processDataFromViewText( node );
 
 		return data.charAt( data.length - 1 ) == ' ';
+	}
+
+	/**
+	 * Checks whether given text contains preformatted white space. This is the case if
+	 * * the text is contained within a `<pre>` element, or
+	 * * the closest ancestor that has the `white-space` CSS property sets it to a value that preserves spaces
+	 *
+	 * @param node Node to check
+	 * @returns `true` if given node contains preformatted white space, `false` otherwise.
+	 */
+	private _isPreFormatted( node: ViewText | ViewTextProxy ): boolean {
+		if ( _hasViewParentOfType( node, this.preElements ) ) {
+			return true;
+		}
+
+		for ( const ancestor of node.getAncestors( { parentFirst: true } ) ) {
+			if ( !ancestor.is( 'element' ) || !ancestor.hasStyle( 'white-space' ) || ancestor.getStyle( 'white-space' ) === 'inherit' ) {
+				continue;
+			}
+
+			// If the node contains the `white-space` property with a value that does not preserve spaces, it will take
+			// precedence over any white-space settings its ancestors contain, so no further parent checking needs to
+			// be done.
+			return [ 'pre', 'pre-wrap', 'break-spaces' ].includes( ancestor.getStyle( 'white-space' )! );
+		}
+
+		return false;
 	}
 
 	/**
@@ -1793,7 +1820,7 @@ export default class DomConverter {
  *
  * @returns`true` if such parent exists or `false` if it does not.
  */
-function _hasViewParentOfType( node: ViewNode, types: ReadonlyArray<string> ) {
+function _hasViewParentOfType( node: ViewNode | ViewTextProxy, types: ReadonlyArray<string> ) {
 	return node.getAncestors().some( parent => parent.is( 'element' ) && types.includes( parent.name ) );
 }
 

--- a/packages/ckeditor5-engine/tests/view/documentfragment.js
+++ b/packages/ckeditor5-engine/tests/view/documentfragment.js
@@ -371,4 +371,10 @@ describe( 'DocumentFragment', () => {
 			expect( properties[ 2 ][ 1 ] ).to.equal( 3 );
 		} );
 	} );
+
+	it( 'name should return undefined', () => {
+		const fragment = new DocumentFragment( document );
+
+		expect( fragment.name ).to.be.undefined;
+	} );
 } );

--- a/packages/ckeditor5-engine/tests/view/domconverter/whitespace-handling-integration.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/whitespace-handling-integration.js
@@ -732,6 +732,24 @@ describe( 'DomConverter – whitespace handling – integration', () => {
 						.to.equal( '<p>&nbsp; &nbsp; foo &nbsp; &nbsp;bar &nbsp; &nbsp;</p>' );
 				}
 			} );
+
+			it( 'a surrounding <pre> will take precedence over an element that sets white-space to collapse', () => {
+				for ( const collapseWhiteSpace of collapseWhiteSpaceValues ) {
+					editor.setData(
+						'<pre>' +
+							`<span style="white-space: ${ collapseWhiteSpace };">` +
+								'    foo    bar    ' +
+							'</span>' +
+						'</pre>'
+					);
+
+					expect( getData( editor.model, { withoutSelection: true } ) )
+						.to.equal( '<paragraph>    foo    bar    </paragraph>' );
+
+					expect( editor.getData() )
+						.to.equal( '<p>&nbsp; &nbsp; foo &nbsp; &nbsp;bar &nbsp; &nbsp;</p>' );
+				}
+			} );
 		} );
 
 		it( 'in nested blocks', () => {

--- a/packages/ckeditor5-engine/tests/view/domconverter/whitespace-handling-integration.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/whitespace-handling-integration.js
@@ -639,6 +639,101 @@ describe( 'DomConverter – whitespace handling – integration', () => {
 			expect( editor.getData() ).to.equal( '<pre>    foo\n    bar\n    </pre>' );
 		} );
 
+		describe( 'in elements that contain preformatted whitespace using the white-space CSS property', () => {
+			const preserveWhiteSpaceValues = [ 'pre', 'pre-wrap', 'break-spaces' ];
+			const collapseWhiteSpaceValues = [ 'normal', 'nowrap', 'pre-line', 'unset', 'revert' ];
+
+			it( 'which is the direct ancestor', () => {
+				for ( const preserveWhiteSpace of preserveWhiteSpaceValues ) {
+					editor.setData(
+						`<span style="white-space: ${ preserveWhiteSpace };">` +
+							'    foo    bar    ' +
+						'</span>'
+					);
+
+					expect( getData( editor.model, { withoutSelection: true } ) )
+						.to.equal( '<paragraph>    foo    bar    </paragraph>' );
+
+					expect( editor.getData() )
+						.to.equal( '<p>&nbsp; &nbsp; foo &nbsp; &nbsp;bar &nbsp; &nbsp;</p>' );
+				}
+			} );
+
+			it( 'which is the indirect ancestor', () => {
+				for ( const preserveWhiteSpace of preserveWhiteSpaceValues ) {
+					editor.setData(
+						`<span style="white-space: ${ preserveWhiteSpace };">` +
+							'<span><span>    foo    bar    </span></span>' +
+						'</span>'
+					);
+
+					expect( getData( editor.model, { withoutSelection: true } ) )
+						.to.equal( '<paragraph>    foo    bar    </paragraph>' );
+
+					expect( editor.getData() )
+						.to.equal( '<p>&nbsp; &nbsp; foo &nbsp; &nbsp;bar &nbsp; &nbsp;</p>' );
+				}
+			} );
+
+			it( 'in a block that overwrites the white-space of its parent', () => {
+				for ( const collapseWhiteSpace of collapseWhiteSpaceValues ) {
+					for ( const preserveWhiteSpace of preserveWhiteSpaceValues ) {
+						editor.setData(
+							`<span style="white-space: ${ collapseWhiteSpace };">` +
+								`<span style="white-space: ${ preserveWhiteSpace }">` +
+									'    foo    bar    ' +
+								'</span>' +
+							'</span>'
+						);
+
+						expect( getData( editor.model, { withoutSelection: true } ) )
+							.to.equal( '<paragraph>    foo    bar    </paragraph>' );
+
+						expect( editor.getData() )
+							.to.equal( '<p>&nbsp; &nbsp; foo &nbsp; &nbsp;bar &nbsp; &nbsp;</p>' );
+					}
+				}
+			} );
+
+			it( 'which contains a child that resets it back to not preformatted', () => {
+				for ( const preserveWhiteSpace of preserveWhiteSpaceValues ) {
+					for ( const collapseWhiteSpace of collapseWhiteSpaceValues ) {
+						editor.setData(
+							`<span style="white-space: ${ preserveWhiteSpace };">` +
+								`<span style="white-space: ${ collapseWhiteSpace }">` +
+									'    foo    bar    ' +
+								'</span>' +
+							'</span>'
+						);
+
+						expect( getData( editor.model, { withoutSelection: true } ) )
+							.to.equal( '<paragraph>foo bar</paragraph>' );
+
+						expect( editor.getData() )
+							.to.equal( '<p>foo bar</p>' );
+					}
+				}
+			} );
+
+			it( 'which contains a block containing white-space: inherit', () => {
+				for ( const preserveWhiteSpace of preserveWhiteSpaceValues ) {
+					editor.setData(
+						`<span style="white-space: ${ preserveWhiteSpace };">` +
+							'<span style="white-space: inherit">' +
+								'    foo    bar    ' +
+							'</span>' +
+						'</span>'
+					);
+
+					expect( getData( editor.model, { withoutSelection: true } ) )
+						.to.equal( '<paragraph>    foo    bar    </paragraph>' );
+
+					expect( editor.getData() )
+						.to.equal( '<p>&nbsp; &nbsp; foo &nbsp; &nbsp;bar &nbsp; &nbsp;</p>' );
+				}
+			} );
+		} );
+
 		it( 'in nested blocks', () => {
 			editor.model.schema.register( 'ul', { inheritAllFrom: '$block', allowIn: 'li' } );
 			editor.model.schema.register( 'li', { inheritAllFrom: '$block', allowIn: 'ul' } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (engine): Preserve repeated spaces in text that is contained within an element that renders (repeated) white space. Closes #16124

---

### Additional information

This pull request offers a possible solution for #16124.

It will preserve (repeated) whitespace when the text is contained within a block that preserves whitespace during rendering, which is done through the `white-space` CSS property. This is similar to what the code for the `<pre>` element is already doing.

Existing code within CKEditor is already taking care of swapping out the repeated spaces by `&nbsp;`-patterns, so they are also preserved when the data is extracted again.
