### PR TITLE
Prevent tooltips from overlapping the menu bar

### DIFF
--- a/packages/ckeditor5-ui/src/tooltipmanager.ts
+++ b/packages/ckeditor5-ui/src/tooltipmanager.ts
@@ -288,14 +288,14 @@ export default class TooltipManager extends DomEmitterMixin() {
 	private _onEnterOrFocus( evt: EventInfo, { target }: any ) {
 		const elementWithTooltipAttribute = getDescendantWithTooltip( target );
 
-		// Unpin if element is focused, regardless of whether it contains a label or not.
-		// It also prevents tooltips from overlapping the menu bar
-		if ( evt.name === 'focus' ) {
-			this._unpinTooltip();
-		}
-
 		// Abort when there's no descendant needing tooltip.
 		if ( !elementWithTooltipAttribute ) {
+			// Unpin if element is focused, regardless of whether it contains a label or not.
+			// It also prevents tooltips from overlapping the menu bar
+			if ( evt.name === 'focus' ) {
+				this._unpinTooltip();
+			}
+
 			return;
 		}
 
@@ -306,10 +306,7 @@ export default class TooltipManager extends DomEmitterMixin() {
 			return;
 		}
 
-		if ( evt.name === 'mouseenter' ) {
-			this._unpinTooltip();
-		}
-
+		this._unpinTooltip();
 		this._pinTooltipDebounced( elementWithTooltipAttribute, getTooltipData( elementWithTooltipAttribute ) );
 	}
 

--- a/packages/ckeditor5-ui/src/tooltipmanager.ts
+++ b/packages/ckeditor5-ui/src/tooltipmanager.ts
@@ -285,8 +285,14 @@ export default class TooltipManager extends DomEmitterMixin() {
 	 * @param evt An object containing information about the fired event.
 	 * @param domEvent The DOM event.
 	 */
-	private _onEnterOrFocus( evt: unknown, { target }: any ) {
+	private _onEnterOrFocus( evt: EventInfo, { target }: any ) {
 		const elementWithTooltipAttribute = getDescendantWithTooltip( target );
+
+		// Unpin if element is focused, regardless of whether it contains a label or not.
+		// It also prevents tooltips from overlapping the menu bar
+		if ( evt.name === 'focus' ) {
+			this._unpinTooltip();
+		}
 
 		// Abort when there's no descendant needing tooltip.
 		if ( !elementWithTooltipAttribute ) {
@@ -300,7 +306,9 @@ export default class TooltipManager extends DomEmitterMixin() {
 			return;
 		}
 
-		this._unpinTooltip();
+		if ( evt.name === 'mouseenter' ) {
+			this._unpinTooltip();
+		}
 
 		this._pinTooltipDebounced( elementWithTooltipAttribute, getTooltipData( elementWithTooltipAttribute ) );
 	}

--- a/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
+++ b/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
@@ -441,17 +441,13 @@ describe( 'TooltipManager', () => {
 					} );
 				} );
 
-				it( 'should show up for the first element the mouse entered (last element has no tooltip)', () => {
+				it( 'should not show up for the first element the focus (last element has no tooltip)', () => {
 					utils.dispatchFocus( elements.a );
 					utils.dispatchFocus( elements.unrelated );
 
 					utils.waitForTheTooltipToShow( clock );
 
-					sinon.assert.calledOnce( pinSpy );
-					sinon.assert.calledWith( pinSpy, {
-						target: elements.a,
-						positions: sinon.match.array
-					} );
+					sinon.assert.notCalled( pinSpy );
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
+++ b/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
@@ -441,7 +441,7 @@ describe( 'TooltipManager', () => {
 					} );
 				} );
 
-				it( 'should not show up for the first element the focus (last element has no tooltip)', () => {
+				it( 'should not show up anchor after focus unrelated element without tooltip', () => {
 					utils.dispatchFocus( elements.a );
 					utils.dispatchFocus( elements.unrelated );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui):  Prevent tooltips from overlapping the menu bar.

---

### Additional information

![obraz](https://github.com/ckeditor/ckeditor5/assets/3949262/1732bc4c-ba08-4172-aaea-26083e7233ba)

