### PR TITLE
Fix truncated menu bar rendering on Firefox/Linux

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenubutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenubutton.css
@@ -44,6 +44,7 @@
 	&.ck-menu-bar__menu_top-level > .ck-menu-bar__menu__button {
 		padding: var(--ck-spacing-small) var(--ck-spacing-medium);
 		min-height: unset;
+		line-height: normal;
 
 		& .ck-button__label {
 			width: unset;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Fix truncated menu bar rendering on Firefox/Linux. Closes #16151.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
