### PR TITLE
Hovering over the menu bar element using the tooltip, the menu closes unexpectedly

### DIFF
--- a/packages/ckeditor5-ui/src/menubar/utils.ts
+++ b/packages/ckeditor5-ui/src/menubar/utils.ts
@@ -8,6 +8,7 @@
  */
 
 import clickOutsideHandler from '../bindings/clickoutsidehandler.js';
+import MenuBarMenuListItemView from './menubarmenulistitemview.js';
 import type MenuBarMenuView from './menubarmenuview.js';
 import type {
 	default as MenuBarView,
@@ -61,9 +62,11 @@ export const MenuBarBehaviors = {
 
 			for ( const menuView of menuBarView.menus ) {
 				// @if CK_DEBUG_MENU_BAR // const wasOpen = menuView.isOpen;
-				menuView.isOpen = (
-					evt.path.includes( menuView ) || ( evt.source as any ).element.contains( menuView.element )
-				) && menuView.isEnabled;
+
+				const pathLeaf = evt.path[ 0 ];
+				const isListItemContainingMenu = pathLeaf instanceof MenuBarMenuListItemView && pathLeaf.children.first === menuView;
+
+				menuView.isOpen = ( evt.path.includes( menuView ) || isListItemContainingMenu ) && menuView.isEnabled;
 
 				// @if CK_DEBUG_MENU_BAR // if ( wasOpen !== menuView.isOpen ) {
 				// @if CK_DEBUG_MENU_BAR // console.log( '[BEHAVIOR] toggleMenusAndFocusItemsOnHover(): Toggle',

--- a/packages/ckeditor5-ui/src/menubar/utils.ts
+++ b/packages/ckeditor5-ui/src/menubar/utils.ts
@@ -61,8 +61,9 @@ export const MenuBarBehaviors = {
 
 			for ( const menuView of menuBarView.menus ) {
 				// @if CK_DEBUG_MENU_BAR // const wasOpen = menuView.isOpen;
-
-				menuView.isOpen = evt.path.includes( menuView ) && menuView.isEnabled;
+				menuView.isOpen = (
+					evt.path.includes( menuView ) || ( evt.source as any ).element.contains( menuView.element )
+				) && menuView.isEnabled;
 
 				// @if CK_DEBUG_MENU_BAR // if ( wasOpen !== menuView.isOpen ) {
 				// @if CK_DEBUG_MENU_BAR // console.log( '[BEHAVIOR] toggleMenusAndFocusItemsOnHover(): Toggle',

--- a/packages/ckeditor5-ui/tests/menubar/utils.js
+++ b/packages/ckeditor5-ui/tests/menubar/utils.js
@@ -331,16 +331,15 @@ describe( 'MenuBarView utils', () => {
 					);
 				} );
 
-				it( 'should toggle menus and move focus while moving the mouse (item -> list-item)', () => {
+				it( 'should keep the menu open while moving the mouse to list item (parent element)', () => {
 					const menuA = getMenuByLabel( menuBarView, 'A' );
 
 					menuA.isOpen = true;
 
+					const parentMenuAAListItem = menuA.panelView.children.first.items.get( 1 );
 					const menuAA = getMenuByLabel( menuBarView, 'AA' );
 
 					menuAA.isOpen = true;
-
-					const menuAAListItem = menuA.panelView.children.first.items.get( 1 );
 
 					menuAA.buttonView.fire( 'execute' );
 
@@ -368,7 +367,7 @@ describe( 'MenuBarView utils', () => {
 						]
 					);
 
-					menuAAListItem.fire( 'mouseenter' );
+					parentMenuAAListItem.fire( 'mouseenter' );
 
 					expect( barDump( menuBarView ) ).to.deep.equal(
 						[

--- a/packages/ckeditor5-ui/tests/menubar/utils.js
+++ b/packages/ckeditor5-ui/tests/menubar/utils.js
@@ -331,6 +331,70 @@ describe( 'MenuBarView utils', () => {
 					);
 				} );
 
+				it( 'should toggle menus and move focus while moving the mouse (item -> list-item)', () => {
+					const menuA = getMenuByLabel( menuBarView, 'A' );
+
+					menuA.isOpen = true;
+
+					const menuAA = getMenuByLabel( menuBarView, 'AA' );
+
+					menuAA.isOpen = true;
+
+					const menuAAListItem = menuA.panelView.children.first.items.get( 1 );
+
+					menuAA.buttonView.fire( 'execute' );
+
+					expect( barDump( menuBarView ) ).to.deep.equal(
+						[
+							{
+								label: 'A', isOpen: true, isFocused: false,
+								items: [
+									{ label: 'A#1', isFocused: false },
+									{ label: 'AA', isOpen: true, isFocused: false, items: [
+										{ label: 'AA#1', isFocused: true },
+										{ label: 'AAA (from-factory)', isOpen: false, isFocused: false, items: [] }
+									] },
+									{ label: 'AB', isOpen: false, isFocused: false, items: [] }
+								]
+							},
+							{
+								label: 'B', isOpen: false, isFocused: false,
+								items: []
+							},
+							{
+								label: 'C', isOpen: false, isFocused: false,
+								items: []
+							}
+						]
+					);
+
+					menuAAListItem.fire( 'mouseenter' );
+
+					expect( barDump( menuBarView ) ).to.deep.equal(
+						[
+							{
+								label: 'A', isOpen: true, isFocused: false,
+								items: [
+									{ label: 'A#1', isFocused: false },
+									{ label: 'AA', isOpen: true, isFocused: true, items: [
+										{ label: 'AA#1', isFocused: false },
+										{ label: 'AAA (from-factory)', isOpen: false, isFocused: false, items: [] }
+									] },
+									{ label: 'AB', isOpen: false, isFocused: false, items: [] }
+								]
+							},
+							{
+								label: 'B', isOpen: false, isFocused: false,
+								items: []
+							},
+							{
+								label: 'C', isOpen: false, isFocused: false,
+								items: []
+							}
+						]
+					);
+				} );
+
 				it( 'should never toggle disabled menus open', () => {
 					const menuA = getMenuByLabel( menuBarView, 'A' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui):  Hovering a tooltip in a menu bar item no longer closes that item. Closes #16157.

---

### Additional information

![obraz](https://github.com/ckeditor/ckeditor5/assets/3949262/8c2f7f63-1a1e-49b0-a7b1-3dbf2203e501)

After leaving the cursor from tooltip, the `evt.source.element` is pointed to `Numbered List` menu item instead of grid. It needs probably more investigation _why_ it happens, but I'd do that in case of any additional bugs with this functionality.  One possible reason might be that `Numbered List` contains submenu. Current solution on the other hand works for now.
