### PR TITLE
Reset insert table view in menu bar

### DIFF
--- a/packages/ckeditor5-table/src/tableui.ts
+++ b/packages/ckeditor5-table/src/tableui.ts
@@ -18,7 +18,7 @@ import {
 	type ListDropdownItemDefinition,
 	MenuBarMenuView
 } from 'ckeditor5/src/ui.js';
-import { Collection, type Locale } from 'ckeditor5/src/utils.js';
+import { Collection, type ObservableChangeEvent, type Locale } from 'ckeditor5/src/utils.js';
 
 import InsertTableView from './ui/inserttableview.js';
 
@@ -97,6 +97,12 @@ export default class TableUI extends Plugin {
 			const insertTableView = new InsertTableView( locale );
 
 			insertTableView.delegate( 'execute' ).to( menuView );
+
+			menuView.on<ObservableChangeEvent<boolean>>( 'change:isOpen', ( e, name, isOpen ) => {
+				if ( isOpen ) {
+					insertTableView.reset();
+				}
+			} );
 
 			insertTableView.on( 'execute', () => {
 				editor.execute( 'insertTable', { rows: insertTableView.rows, columns: insertTableView.columns } );

--- a/packages/ckeditor5-table/src/tableui.ts
+++ b/packages/ckeditor5-table/src/tableui.ts
@@ -98,8 +98,8 @@ export default class TableUI extends Plugin {
 
 			insertTableView.delegate( 'execute' ).to( menuView );
 
-			menuView.on<ObservableChangeEvent<boolean>>( 'change:isOpen', ( e, name, isOpen ) => {
-				if ( isOpen ) {
+			menuView.on<ObservableChangeEvent<boolean>>( 'change:isOpen', ( event, name, isOpen ) => {
+				if ( !isOpen ) {
 					insertTableView.reset();
 				}
 			} );

--- a/packages/ckeditor5-table/src/ui/inserttableview.ts
+++ b/packages/ckeditor5-table/src/ui/inserttableview.ts
@@ -160,6 +160,16 @@ export default class InsertTableView extends View {
 	}
 
 	/**
+	 * Resets the rows and columns selection.
+	 */
+	public reset(): void {
+		this.set( {
+			rows: 1,
+			columns: 1
+		} );
+	}
+
+	/**
 	 * @inheritDoc
 	 */
 	public focus(): void {

--- a/packages/ckeditor5-table/tests/tableui.js
+++ b/packages/ckeditor5-table/tests/tableui.js
@@ -196,6 +196,22 @@ describe( 'TableUI', () => {
 			sinon.assert.calledOnce( focusSpy );
 			sinon.assert.callOrder( commandSpy, focusSpy );
 		} );
+
+		it( 'should reset column and rows selection on reopen', () => {
+			const insertView = menuView.panelView.children.first;
+
+			expect( insertView.rows ).to.equal( 1 );
+			expect( insertView.columns ).to.equal( 1 );
+
+			insertView.rows = 3;
+			insertView.columns = 5;
+
+			menuView.isOpen = false;
+			menuView.isOpen = true;
+
+			expect( insertView.rows ).to.equal( 1 );
+			expect( insertView.columns ).to.equal( 1 );
+		} );
 	} );
 
 	describe( 'tableRow dropdown', () => {

--- a/packages/ckeditor5-table/tests/tableui.js
+++ b/packages/ckeditor5-table/tests/tableui.js
@@ -207,6 +207,10 @@ describe( 'TableUI', () => {
 			insertView.columns = 5;
 
 			menuView.isOpen = false;
+
+			expect( insertView.rows ).to.equal( 1 );
+			expect( insertView.columns ).to.equal( 1 );
+
 			menuView.isOpen = true;
 
 			expect( insertView.rows ).to.equal( 1 );

--- a/packages/ckeditor5-table/tests/ui/inserttableview.js
+++ b/packages/ckeditor5-table/tests/ui/inserttableview.js
@@ -222,6 +222,20 @@ describe( 'InsertTableView', () => {
 			} );
 		} );
 	} );
+
+	describe( 'reset()', () => {
+		it( 'should set rows and columns properties to 1', () => {
+			view.focusTracker.focusedElement = view.items.get( 24 ).element;
+
+			expect( view.columns ).to.equal( 5 );
+			expect( view.rows ).to.equal( 3 );
+
+			view.reset();
+
+			expect( view.columns ).to.equal( 1 );
+			expect( view.rows ).to.equal( 1 );
+		} );
+	} );
 } );
 
 function dispatchEvent( el, domEvtName ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (table) Table insert in menu bar always start at 1x1 on menu open. Closes #16156.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
