### PR TITLE
Disable comments archive ui plugin when disabling commands.

### DIFF
--- a/packages/ckeditor5-source-editing/src/sourceediting.ts
+++ b/packages/ckeditor5-source-editing/src/sourceediting.ts
@@ -329,6 +329,13 @@ export default class SourceEditing extends Plugin {
 		for ( const command of editor.commands.commands() ) {
 			command.forceDisabled( COMMAND_FORCE_DISABLE_ID );
 		}
+
+		// Comments archive UI plugin will be disabled manually too.
+		const commentsArchivePlugin = editor.plugins.get( 'CommentsArchiveUI' ) as Plugin | undefined;
+
+		if ( commentsArchivePlugin ) {
+			commentsArchivePlugin.forceDisabled( COMMAND_FORCE_DISABLE_ID );
+		}
 	}
 
 	/**
@@ -339,6 +346,13 @@ export default class SourceEditing extends Plugin {
 
 		for ( const command of editor.commands.commands() ) {
 			command.clearForceDisabled( COMMAND_FORCE_DISABLE_ID );
+		}
+
+		// Comments archive UI plugin will be enabled manually too.
+		const commentsArchivePlugin = editor.plugins.get( 'CommentsArchiveUI' ) as Plugin | undefined;
+
+		if ( commentsArchivePlugin ) {
+			commentsArchivePlugin.clearForceDisabled( COMMAND_FORCE_DISABLE_ID );
 		}
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (comments): Disable comments archive buttons in source editing mode.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
