### PR TITLE
Aria live announcements A11y improvements

### DIFF
--- a/packages/ckeditor5-code-block/lang/contexts.json
+++ b/packages/ckeditor5-code-block/lang/contexts.json
@@ -1,5 +1,9 @@
 {
 	"Insert code block": "A label of the button that allows inserting a new code block into the editor content.",
 	"Plain text": "A language of the code block in the editor content when no specific programming language is associated with it.",
+	"Leaving %0 code snippet": "Assistive technologies label for leaving the code block with a specified programming language. Example: 'Leaving JavaScript code snippet'",
+	"Entering %0 code snippet": "Assistive technologies label for entering the code block with a specified programming language. Example: 'Entering JavaScript code snippet'",
+	"Entering code snippet": "Assistive technologies label for entering the code block with unspecified programming language.",
+	"Leaving code snippet": "Assistive technologies label for leaving the code block with unspecified programming language.",
 	"Code block": "The accessible label of the menu bar button that inserts a code block into editor content."
 }

--- a/packages/ckeditor5-code-block/package.json
+++ b/packages/ckeditor5-code-block/package.json
@@ -13,7 +13,8 @@
   "type": "module",
   "main": "src/index.ts",
   "dependencies": {
-    "ckeditor5": "41.3.1"
+    "ckeditor5": "41.3.1",
+    "lodash-es": "4.17.21"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-alignment": "41.3.1",

--- a/packages/ckeditor5-code-block/src/codeblockediting.ts
+++ b/packages/ckeditor5-code-block/src/codeblockediting.ts
@@ -296,7 +296,6 @@ export default class CodeBlockEditing extends Plugin {
 		const languageDefs = getNormalizedAndLocalizedLanguageDefinitions( this.editor );
 
 		let lastFocusedCodeBlock: Element | null = null;
-		let lastAnnouncement: string | null = null;
 
 		const joinAnnouncements = ( announcements: Array<string> ) => upperFirst(
 			announcements
@@ -322,25 +321,12 @@ export default class CodeBlockEditing extends Plugin {
 			}
 
 			if ( ui && announcements.length ) {
-				let announcement = joinAnnouncements( announcements );
+				const announcement = joinAnnouncements( announcements );
 
-				// Handle edge case when:
-				//
-				// 	1. user enters code block #1 with PHP language.
-				//  2. user enters code block #2 with PHP language.
-				//	3. user leaves code block #2 and comes back to code block #1 with identical language
-				//
-				// In this scenario `announcement` will be identical (`Leaving PHP code block, entering PHP code block`)
-				// Screen reader will not detect this change because `aria-live` is identical with previous one and
-				// will skip reading the label.
-				//
-				// Try to bypass this issue by toggling non readable character at the end of phrase.
-				if ( lastAnnouncement === announcement ) {
-					announcement += '.';
-				}
-
-				ui.ariaLiveAnnouncer.announce( 'codeBlocks', announcement, 'assertive' );
-				lastAnnouncement = announcement;
+				ui.ariaLiveAnnouncer.announce( 'codeBlocks', announcement, {
+					politeness: 'assertive',
+					allowReadAgain: true
+				} );
 			}
 
 			lastFocusedCodeBlock = focusParent;

--- a/packages/ckeditor5-code-block/src/codeblockediting.ts
+++ b/packages/ckeditor5-code-block/src/codeblockediting.ts
@@ -297,36 +297,19 @@ export default class CodeBlockEditing extends Plugin {
 
 		let lastFocusedCodeBlock: Element | null = null;
 
-		const joinAnnouncements = ( announcements: Array<string> ) => upperFirst(
-			announcements
-				.map( lowerFirst )
-				.join( ', ' )
-		);
-
 		model.document.selection.on<SelectionChangeRangeEvent>( 'change:range', () => {
 			const focusParent = model.document.selection.focus!.parent;
 
-			if ( lastFocusedCodeBlock === focusParent || !focusParent.is( 'element' ) ) {
+			if ( !ui || lastFocusedCodeBlock === focusParent || !focusParent.is( 'element' ) ) {
 				return;
 			}
 
-			const announcements: Array<string> = [];
-
 			if ( lastFocusedCodeBlock && lastFocusedCodeBlock.is( 'element', 'codeBlock' ) ) {
-				announcements.push( getCodeBlockAriaAnnouncement( t, languageDefs, lastFocusedCodeBlock, 'leave' ) );
+				ui.ariaLiveAnnouncer.announce( getCodeBlockAriaAnnouncement( t, languageDefs, lastFocusedCodeBlock, 'leave' ) );
 			}
 
 			if ( focusParent.is( 'element', 'codeBlock' ) ) {
-				announcements.push( getCodeBlockAriaAnnouncement( t, languageDefs, focusParent, 'enter' ) );
-			}
-
-			if ( ui && announcements.length ) {
-				const announcement = joinAnnouncements( announcements );
-
-				ui.ariaLiveAnnouncer.announce( 'codeBlocks', announcement, {
-					politeness: 'assertive',
-					allowReadAgain: true
-				} );
+				ui.ariaLiveAnnouncer.announce( getCodeBlockAriaAnnouncement( t, languageDefs, focusParent, 'enter' ) );
 			}
 
 			lastFocusedCodeBlock = focusParent;

--- a/packages/ckeditor5-code-block/src/utils.ts
+++ b/packages/ckeditor5-code-block/src/utils.ts
@@ -9,7 +9,6 @@
 
 import type { Editor } from 'ckeditor5/src/core.js';
 import type { CodeBlockLanguageDefinition } from './codeblockconfig.js';
-import { first } from 'ckeditor5/src/utils.js';
 import type {
 	DocumentSelection,
 	Element,
@@ -21,6 +20,8 @@ import type {
 	ViewDocumentFragment,
 	ViewElement
 } from 'ckeditor5/src/engine.js';
+
+import { first, type LocaleTranslate } from 'ckeditor5/src/utils.js';
 
 /**
  * Returns code block languages as defined in `config.codeBlock.languages` but processed:
@@ -257,4 +258,33 @@ export function canBeCodeBlock( schema: Schema, element: Element ): boolean {
 	}
 
 	return schema.checkChild( element.parent as Element, 'codeBlock' );
+}
+
+/**
+ * Get the translated message read by the screen reader when you enter or exit an element with your cursor.
+ */
+export function getCodeBlockAriaAnnouncement(
+	t: LocaleTranslate,
+	languageDefs: Array<CodeBlockLanguageDefinition>,
+	element: Element,
+	direction: 'enter' | 'leave'
+): string {
+	const languagesToLabels = getPropertyAssociation( languageDefs, 'language', 'label' );
+	const codeBlockLanguage = element.getAttribute( 'language' ) as string;
+
+	if ( codeBlockLanguage in languagesToLabels ) {
+		const language = languagesToLabels[ codeBlockLanguage ];
+
+		if ( direction === 'enter' ) {
+			return t( 'Entering %0 code snippet', language );
+		}
+
+		return t( 'Leaving %0 code snippet', language );
+	}
+
+	if ( direction === 'enter' ) {
+		return t( 'Entering code snippet' );
+	}
+
+	return t( 'Leaving code snippet' );
 }

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -1837,12 +1837,14 @@ describe( 'CodeBlockEditing', () => {
 			} );
 
 			expectAnnounce( 'Entering PHP code snippet' );
+			announcerSpy.resetHistory();
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 1, 0 ], root, [ 1, 1 ] ) );
 			} );
 
 			expectAnnounce( 'Leaving PHP code snippet' );
+			announcerSpy.resetHistory();
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 2, 0 ], root, [ 2, 1 ] ) );
@@ -1866,12 +1868,15 @@ describe( 'CodeBlockEditing', () => {
 			} );
 
 			expectAnnounce( 'Entering CSS code snippet' );
+			announcerSpy.resetHistory();
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 1, 0 ], root, [ 1, 1 ] ) );
 			} );
 
-			expectAnnounce( 'Leaving CSS code snippet, entering PHP code snippet' );
+			expectAnnounce( 'Leaving CSS code snippet' );
+			expectAnnounce( 'Entering PHP code snippet' );
+			announcerSpy.resetHistory();
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 2, 0 ], root, [ 2, 1 ] ) );
@@ -1897,35 +1902,34 @@ describe( 'CodeBlockEditing', () => {
 			} );
 
 			expectAnnounce( 'Entering Ruby code snippet' );
+			announcerSpy.resetHistory();
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 0, 0 ], root, [ 0, 1 ] ) );
 			} );
 
-			expectAnnounce( 'Leaving Ruby code snippet, entering CSS code snippet' );
+			expectAnnounce( 'Leaving Ruby code snippet' );
+			expectAnnounce( 'Entering CSS code snippet' );
+			announcerSpy.resetHistory();
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 3, 0 ], root, [ 3, 1 ] ) );
 			} );
 
-			expectAnnounce( 'Leaving CSS code snippet, entering XML code snippet' );
+			expectAnnounce( 'Leaving CSS code snippet' );
+			expectAnnounce( 'Entering XML code snippet' );
+			announcerSpy.resetHistory();
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 4, 0 ], root, [ 4, 1 ] ) );
 			} );
 
-			expectAnnounce( 'Leaving XML code snippet, entering code snippet' );
+			expectAnnounce( 'Leaving XML code snippet' );
+			expectAnnounce( 'Entering code snippet' );
 		} );
 
 		function expectAnnounce( message ) {
-			expect( announcerSpy ).to.be.calledWithExactly(
-				'codeBlocks',
-				message,
-				{
-					politeness: 'assertive',
-					allowReadAgain: true
-				}
-			);
+			expect( announcerSpy ).to.be.calledWithExactly( message );
 		}
 	} );
 

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -1804,13 +1804,13 @@ describe( 'CodeBlockEditing', () => {
 				writer.setSelection( createRange( root, [ 0, 0 ], root, [ 0, 1 ] ) );
 			} );
 
-			expect( announcerSpy ).to.be.calledWithExactly( 'codeBlocks', 'Entering CSS code snippet', 'assertive' );
+			expectAnnounce( 'Entering CSS code snippet' );
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 1, 0 ], root, [ 1, 1 ] ) );
 			} );
 
-			expect( announcerSpy ).to.be.calledWithExactly( 'codeBlocks', 'Leaving CSS code snippet', 'assertive' );
+			expectAnnounce( 'Leaving CSS code snippet' );
 		} );
 
 		it( 'should announce enter and leave code block without language label', () => {
@@ -1820,13 +1820,13 @@ describe( 'CodeBlockEditing', () => {
 				writer.setSelection( createRange( root, [ 0, 0 ], root, [ 0, 1 ] ) );
 			} );
 
-			expect( announcerSpy ).to.be.calledWithExactly( 'codeBlocks', 'Entering code snippet', 'assertive' );
+			expectAnnounce( 'Entering code snippet' );
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 1, 0 ], root, [ 1, 1 ] ) );
 			} );
 
-			expect( announcerSpy ).to.be.calledWithExactly( 'codeBlocks', 'Leaving code snippet', 'assertive' );
+			expectAnnounce( 'Leaving code snippet' );
 		} );
 
 		it( 'should announce sequential entry and exit of a code block with paragraph between', () => {
@@ -1836,19 +1836,19 @@ describe( 'CodeBlockEditing', () => {
 				writer.setSelection( createRange( root, [ 0, 0 ], root, [ 0, 1 ] ) );
 			} );
 
-			expect( announcerSpy ).to.be.calledWithExactly( 'codeBlocks', 'Entering PHP code snippet', 'assertive' );
+			expectAnnounce( 'Entering PHP code snippet' );
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 1, 0 ], root, [ 1, 1 ] ) );
 			} );
 
-			expect( announcerSpy ).to.be.calledWithExactly( 'codeBlocks', 'Leaving PHP code snippet', 'assertive' );
+			expectAnnounce( 'Leaving PHP code snippet' );
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 2, 0 ], root, [ 2, 1 ] ) );
 			} );
 
-			expect( announcerSpy ).to.be.calledWithExactly( 'codeBlocks', 'Entering CSS code snippet', 'assertive' );
+			expectAnnounce( 'Entering CSS code snippet' );
 		} );
 
 		it( 'should announce sequential entry and exit of a code block that starts immediately after another code block', () => {
@@ -1865,27 +1865,19 @@ describe( 'CodeBlockEditing', () => {
 				writer.setSelection( createRange( root, [ 0, 0 ], root, [ 0, 1 ] ) );
 			} );
 
-			expect( announcerSpy ).to.be.calledWithExactly( 'codeBlocks', 'Entering CSS code snippet', 'assertive' );
+			expectAnnounce( 'Entering CSS code snippet' );
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 1, 0 ], root, [ 1, 1 ] ) );
 			} );
 
-			expect( announcerSpy ).to.be.calledWithExactly(
-				'codeBlocks',
-				'Leaving CSS code snippet, entering PHP code snippet',
-				'assertive'
-			);
+			expectAnnounce( 'Leaving CSS code snippet, entering PHP code snippet' );
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 2, 0 ], root, [ 2, 1 ] ) );
 			} );
 
-			expect( announcerSpy ).to.be.calledWithExactly(
-				'codeBlocks',
-				'Leaving PHP code snippet',
-				'assertive'
-			);
+			expectAnnounce( 'Leaving PHP code snippet' );
 		} );
 
 		it( 'should announce random enter and exit of a code block that starts immediately after another code block', () => {
@@ -1904,78 +1896,37 @@ describe( 'CodeBlockEditing', () => {
 				writer.setSelection( createRange( root, [ 2, 0 ], root, [ 2, 1 ] ) );
 			} );
 
-			expect( announcerSpy ).to.be.calledWithExactly( 'codeBlocks', 'Entering Ruby code snippet', 'assertive' );
+			expectAnnounce( 'Entering Ruby code snippet' );
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 0, 0 ], root, [ 0, 1 ] ) );
 			} );
 
-			expect( announcerSpy ).to.be.calledWithExactly(
-				'codeBlocks',
-				'Leaving Ruby code snippet, entering CSS code snippet',
-				'assertive'
-			);
+			expectAnnounce( 'Leaving Ruby code snippet, entering CSS code snippet' );
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 3, 0 ], root, [ 3, 1 ] ) );
 			} );
 
-			expect( announcerSpy ).to.be.calledWithExactly(
-				'codeBlocks',
-				'Leaving CSS code snippet, entering XML code snippet',
-				'assertive'
-			);
+			expectAnnounce( 'Leaving CSS code snippet, entering XML code snippet' );
 
 			model.change( writer => {
 				writer.setSelection( createRange( root, [ 4, 0 ], root, [ 4, 1 ] ) );
 			} );
 
-			expect( announcerSpy ).to.be.calledWithExactly(
-				'codeBlocks',
-				'Leaving XML code snippet, entering code snippet',
-				'assertive'
-			);
+			expectAnnounce( 'Leaving XML code snippet, entering code snippet' );
 		} );
 
-		it( 'should force trigger announce if leaving and entering again code block with the same language', () => {
-			setModelData( model, join( codeblock( 'css' ), codeblock( 'css' ) ) );
-
-			model.change( writer => {
-				writer.setSelection( createRange( root, [ 0, 0 ], root, [ 0, 1 ] ) );
-			} );
-
-			expect( announcerSpy ).to.be.calledWithExactly( 'codeBlocks', 'Entering CSS code snippet', 'assertive' );
-
-			model.change( writer => {
-				writer.setSelection( createRange( root, [ 1, 0 ], root, [ 1, 1 ] ) );
-			} );
-
+		function expectAnnounce( message ) {
 			expect( announcerSpy ).to.be.calledWithExactly(
 				'codeBlocks',
-				'Leaving CSS code snippet, entering CSS code snippet',
-				'assertive'
+				message,
+				{
+					politeness: 'assertive',
+					allowReadAgain: true
+				}
 			);
-
-			model.change( writer => {
-				writer.setSelection( createRange( root, [ 0, 0 ], root, [ 0, 1 ] ) );
-			} );
-
-			expect( announcerSpy ).to.be.calledWithExactly(
-				'codeBlocks',
-				'Leaving CSS code snippet, entering CSS code snippet.',
-				'assertive'
-			);
-
-			model.change( writer => {
-				writer.setSelection( createRange( root, [ 1, 0 ], root, [ 1, 1 ] ) );
-			} );
-
-			expect( announcerSpy ).to.be.calledWithExactly(
-				'codeBlocks',
-				'Leaving CSS code snippet, entering CSS code snippet',
-				'assertive'
-			);
-		} );
+		}
 	} );
 
 	function join( ...lines ) {

--- a/packages/ckeditor5-image/lang/contexts.json
+++ b/packages/ckeditor5-image/lang/contexts.json
@@ -35,5 +35,8 @@
 	"Caption for the image": "Text used by screen readers do describe an image when the image has no text alternative.",
 	"Caption for image: %0": "Text used by screen readers do describe an image when there is a text alternative available, e.g. 'Caption for image: this is a description of the image.'",
 	"The value must not be empty.": "Text used as error label when user submitted custom image resize form with blank value.",
-	"The value should be a plain number.": "Text used as error label when user submitted custom image resize form with incorrect value."
+	"The value should be a plain number.": "Text used as error label when user submitted custom image resize form with incorrect value.",
+	"Uploading image": "Aria status message indicating that the image is being uploaded. Example: 'Uploading image'.",
+	"Image upload complete": "Aria status message indicating that the image has been uploaded successfully. Example: 'Image upload complete'.",
+	"Error during image upload": "Aria status message indicating that an error has occurred during image upload. Example: 'Error during image upload'."
 }

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
@@ -280,16 +280,6 @@ export default class ImageUploadEditing extends Plugin {
 		const imageUtils: ImageUtils = editor.plugins.get( 'ImageUtils' );
 		const imageUploadElements = this._uploadImageElements;
 
-		if ( editor.ui ) {
-			editor.ui.ariaLiveAnnouncer.registerRegion( 'imageUpload' );
-		}
-
-		const ariaAnnounce = ( message: string ) => {
-			if ( editor.ui ) {
-				editor.ui.ariaLiveAnnouncer.announce( 'imageUpload', message );
-			}
-		};
-
 		model.enqueueChange( { isUndoable: false }, writer => {
 			writer.setAttribute( 'uploadStatus', 'reading', imageUploadElements.get( loader.id )! );
 		} );
@@ -330,7 +320,10 @@ export default class ImageUploadEditing extends Plugin {
 					} );
 				}
 
-				ariaAnnounce( t( 'Uploading image' ) );
+				if ( editor.ui ) {
+					editor.ui.ariaLiveAnnouncer.announce( t( 'Uploading image' ) );
+				}
+
 				model.enqueueChange( { isUndoable: false }, writer => {
 					writer.setAttribute( 'uploadStatus', 'uploading', imageElement );
 				} );
@@ -342,7 +335,10 @@ export default class ImageUploadEditing extends Plugin {
 					const imageElement = imageUploadElements.get( loader.id )!;
 
 					writer.setAttribute( 'uploadStatus', 'complete', imageElement );
-					ariaAnnounce( t( 'Image upload complete' ) );
+
+					if ( editor.ui ) {
+						editor.ui.ariaLiveAnnouncer.announce( t( 'Image upload complete' ) );
+					}
 
 					this.fire<ImageUploadCompleteEvent>( 'uploadComplete', { data, imageElement } );
 				} );
@@ -350,7 +346,9 @@ export default class ImageUploadEditing extends Plugin {
 				clean();
 			} )
 			.catch( error => {
-				ariaAnnounce( t( 'Error during image upload' ) );
+				if ( editor.ui ) {
+					editor.ui.ariaLiveAnnouncer.announce( t( 'Error during image upload' ) );
+				}
 
 				// If status is not 'error' nor 'aborted' - throw error because it means that something else went wrong,
 				// it might be generic error and it would be real pain to find what is going on.

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
@@ -280,6 +280,16 @@ export default class ImageUploadEditing extends Plugin {
 		const imageUtils: ImageUtils = editor.plugins.get( 'ImageUtils' );
 		const imageUploadElements = this._uploadImageElements;
 
+		if ( editor.ui ) {
+			editor.ui.ariaLiveAnnouncer.registerRegion( 'imageUpload' );
+		}
+
+		const ariaAnnounce = ( message: string ) => {
+			if ( editor.ui ) {
+				editor.ui.ariaLiveAnnouncer.announce( 'imageUpload', message );
+			}
+		};
+
 		model.enqueueChange( { isUndoable: false }, writer => {
 			writer.setAttribute( 'uploadStatus', 'reading', imageUploadElements.get( loader.id )! );
 		} );
@@ -320,6 +330,7 @@ export default class ImageUploadEditing extends Plugin {
 					} );
 				}
 
+				ariaAnnounce( t( 'Uploading image' ) );
 				model.enqueueChange( { isUndoable: false }, writer => {
 					writer.setAttribute( 'uploadStatus', 'uploading', imageElement );
 				} );
@@ -331,6 +342,7 @@ export default class ImageUploadEditing extends Plugin {
 					const imageElement = imageUploadElements.get( loader.id )!;
 
 					writer.setAttribute( 'uploadStatus', 'complete', imageElement );
+					ariaAnnounce( t( 'Image upload complete' ) );
 
 					this.fire<ImageUploadCompleteEvent>( 'uploadComplete', { data, imageElement } );
 				} );
@@ -338,6 +350,8 @@ export default class ImageUploadEditing extends Plugin {
 				clean();
 			} )
 			.catch( error => {
+				ariaAnnounce( t( 'Error during image upload' ) );
+
 				// If status is not 'error' nor 'aborted' - throw error because it means that something else went wrong,
 				// it might be generic error and it would be real pain to find what is going on.
 				if ( loader.status !== 'error' && loader.status !== 'aborted' ) {

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
@@ -1415,7 +1415,7 @@ describe( 'ImageUploadEditing', () => {
 		} );
 
 		function expectAnnounce( message ) {
-			expect( announcerSpy ).to.be.calledWithExactly( 'imageUpload', message );
+			expect( announcerSpy ).to.be.calledWithExactly( message );
 		}
 	} );
 

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
@@ -3,9 +3,10 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals window, setTimeout, atob, URL, Blob, HTMLCanvasElement, console */
+/* globals window, setTimeout, atob, URL, Blob, HTMLCanvasElement, console, document */
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor.js';
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor.js';
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin.js';
 import ClipboardPipeline from '@ckeditor/ckeditor5-clipboard/src/clipboardpipeline.js';
@@ -34,7 +35,7 @@ describe( 'ImageUploadEditing', () => {
 	const base64Sample = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';
 
 	let adapterMocks = [];
-	let editor, model, view, doc, fileRepository, viewDocument, nativeReaderMock, loader;
+	let editor, editorElement, model, view, doc, fileRepository, viewDocument, nativeReaderMock, loader;
 
 	testUtils.createSinonSandbox();
 
@@ -53,14 +54,18 @@ describe( 'ImageUploadEditing', () => {
 	}
 
 	beforeEach( () => {
+		editorElement = document.createElement( 'div' );
+
+		document.body.appendChild( editorElement );
+
 		sinon.stub( window, 'FileReader' ).callsFake( () => {
 			nativeReaderMock = new NativeFileReaderMock();
 
 			return nativeReaderMock;
 		} );
 
-		return VirtualTestEditor
-			.create( {
+		return ClassicEditor
+			.create( editorElement, {
 				plugins: [
 					ImageBlockEditing, ImageInlineEditing, ImageUploadEditing,
 					Paragraph, UndoEditing, UploadAdapterPluginMock, ClipboardPipeline
@@ -80,6 +85,7 @@ describe( 'ImageUploadEditing', () => {
 	} );
 
 	afterEach( () => {
+		editorElement.remove();
 		sinon.restore();
 		adapterMocks = [];
 
@@ -1340,6 +1346,77 @@ describe( 'ImageUploadEditing', () => {
 				done();
 			} );
 		} );
+	} );
+
+	describe( 'accessibility', () => {
+		let announcerSpy;
+
+		beforeEach( async () => {
+			announcerSpy = sinon.spy( editor.ui.ariaLiveAnnouncer, 'announce' );
+		} );
+
+		it( 'should announce error in aria live', done => {
+			const notification = editor.plugins.get( Notification );
+			const file = createNativeFileMock();
+
+			notification.on( 'show:warning', evt => {
+				tryExpect( done, () => {
+					expectAnnounce( 'Error during image upload' );
+					evt.stop();
+				} );
+			}, { priority: 'high' } );
+
+			setModelData( model, '<paragraph>{}foo bar</paragraph>' );
+			editor.execute( 'uploadImage', { file } );
+
+			loader.file.then( () => nativeReaderMock.mockError( 'Reading error.' ) );
+		} );
+
+		it( 'should announce uploading image in aria live', done => {
+			const file = createNativeFileMock();
+			setModelData( model, '<paragraph>{}foo bar</paragraph>' );
+			editor.execute( 'uploadImage', { file } );
+
+			model.document.once( 'change', () => {
+				tryExpect( done, () => {
+					expectAnnounce( 'Uploading image' );
+				} );
+			} );
+
+			expect( loader.status ).to.equal( 'reading' );
+
+			loader.file.then( () => nativeReaderMock.mockSuccess( base64Sample ) );
+		} );
+
+		it( 'should allow modifying the image element once the original image is uploaded', async () => {
+			const file = createNativeFileMock();
+			setModelData( model, '<paragraph>[]foo bar</paragraph>' );
+
+			const imageUploadEditing = editor.plugins.get( 'ImageUploadEditing' );
+			const uploadCompleteSpy = sinon.spy();
+
+			imageUploadEditing.on( 'uploadComplete', uploadCompleteSpy );
+
+			editor.execute( 'uploadImage', { file } );
+
+			await new Promise( res => {
+				model.document.once( 'change', res );
+				loader.file.then( () => nativeReaderMock.mockSuccess( base64Sample ) );
+			} );
+
+			sinon.assert.notCalled( uploadCompleteSpy );
+
+			await new Promise( res => {
+				model.document.once( 'change', res, { priority: 'lowest' } );
+				loader.file.then( () => adapterMocks[ 0 ].mockSuccess( { default: 'image.png' } ) );
+			} );
+
+			expectAnnounce( 'Image upload complete' );
+		} );
+
+		function expectAnnounce( message ) {
+			expect( announcerSpy ).to.be.calledWithExactly( 'imageUpload', message );
+		}
 	} );
 
 	describe( 'fallback image conversion on canvas', () => {

--- a/packages/ckeditor5-list/lang/contexts.json
+++ b/packages/ckeditor5-list/lang/contexts.json
@@ -29,5 +29,7 @@
 	"Reversed order": "The label of the switch button that reverses the order of the numbered list.",
 	"Keystrokes that can be used in a list": "Accessibility help dialog header text displayed before the list of keystrokes that can be used in a list.",
 	"Increase list item indent": "Keystroke description for assistive technologies: keystroke for increasing list item indentation.",
-	"Decrease list item indent": "Keystroke description for assistive technologies: keystroke for decreasing list item indentation."
+	"Decrease list item indent": "Keystroke description for assistive technologies: keystroke for decreasing list item indentation.",
+	"Entering todo list": "Assistive technologies label for entering the todo list. Example: 'Entering todo list'.",
+	"Leaving todo list": "Assistive technologies label for leaving the todo list. Example: 'Leaving todo list'."
 }

--- a/packages/ckeditor5-list/lang/contexts.json
+++ b/packages/ckeditor5-list/lang/contexts.json
@@ -30,6 +30,6 @@
 	"Keystrokes that can be used in a list": "Accessibility help dialog header text displayed before the list of keystrokes that can be used in a list.",
 	"Increase list item indent": "Keystroke description for assistive technologies: keystroke for increasing list item indentation.",
 	"Decrease list item indent": "Keystroke description for assistive technologies: keystroke for decreasing list item indentation.",
-	"Entering todo list": "Assistive technologies label for entering the todo list. Example: 'Entering todo list'.",
-	"Leaving todo list": "Assistive technologies label for leaving the todo list. Example: 'Leaving todo list'."
+	"Entering a to-do list": "Assistive technologies label for entering the to-do list.",
+	"Leaving a to-do list": "Assistive technologies label for leaving the to-do list."
 }

--- a/packages/ckeditor5-list/src/legacytodolist/legacytodolistediting.ts
+++ b/packages/ckeditor5-list/src/legacytodolist/legacytodolistediting.ts
@@ -19,7 +19,9 @@ import type {
 	ViewDocumentArrowKeyEvent,
 	ViewDocumentKeyDownEvent,
 	AttributeOperation,
-	RenameOperation
+	RenameOperation,
+	SelectionChangeRangeEvent,
+	DocumentFragment
 } from 'ckeditor5/src/engine.js';
 
 import { Plugin } from 'ckeditor5/src/core.js';
@@ -188,6 +190,8 @@ export default class LegacyTodoListEditing extends Plugin {
 
 			return hasChanged;
 		} );
+
+		this._initAriaAnnouncements();
 	}
 
 	/**
@@ -207,6 +211,41 @@ export default class LegacyTodoListEditing extends Plugin {
 			writer.setSelection( listItem, 'end' );
 			editor.execute( 'checkTodoList' );
 			writer.setSelection( previousSelectionRanges );
+		} );
+	}
+
+	/**
+	 * Observe when user enters or leaves todo list and set proper aria value in global live announcer.
+	 * This allows screen readers to indicate when the user has entered and left the specified todo list.
+	 *
+	 * @internal
+	 */
+	private _initAriaAnnouncements( ) {
+		const { model, ui, t } = this.editor;
+		let lastFocusedCodeBlock: Element | DocumentFragment | null = null;
+
+		if ( !ui ) {
+			return;
+		}
+
+		ui.ariaLiveAnnouncer.registerRegion( 'legacyTodoList' );
+
+		const announce = ( message: string ) => {
+			ui.ariaLiveAnnouncer.announce( 'legacyTodoList', message );
+		};
+
+		model.document.selection.on<SelectionChangeRangeEvent>( 'change:range', () => {
+			const focusParent = model.document.selection.focus!.parent;
+			const lastElementIsTodoList = isLegacyTodoListItemElement( lastFocusedCodeBlock );
+			const currentElementIsTodoList = isLegacyTodoListItemElement( focusParent );
+
+			if ( lastElementIsTodoList && !currentElementIsTodoList ) {
+				announce( t( 'Leaving todo list' ) );
+			} else if ( !lastElementIsTodoList && currentElementIsTodoList ) {
+				announce( t( 'Entering todo list' ) );
+			}
+
+			lastFocusedCodeBlock = focusParent;
 		} );
 	}
 }
@@ -248,4 +287,11 @@ function jumpOverCheckmarkOnSideArrowKeyPress( model: Model, locale: Locale ): G
 			eventInfo.stop();
 		}
 	};
+}
+
+/**
+ * Returns true if the given element is a list item model element of a to-do list.
+ */
+function isLegacyTodoListItemElement( element: Element | DocumentFragment | null ): boolean {
+	return !!element && element.is( 'element', 'listItem' ) && element.getAttribute( 'listType' ) === 'todo';
 }

--- a/packages/ckeditor5-list/src/legacytodolist/legacytodolistediting.ts
+++ b/packages/ckeditor5-list/src/legacytodolist/legacytodolistediting.ts
@@ -228,21 +228,15 @@ export default class LegacyTodoListEditing extends Plugin {
 			return;
 		}
 
-		ui.ariaLiveAnnouncer.registerRegion( 'legacyTodoList' );
-
-		const announce = ( message: string ) => {
-			ui.ariaLiveAnnouncer.announce( 'legacyTodoList', message );
-		};
-
 		model.document.selection.on<SelectionChangeRangeEvent>( 'change:range', () => {
 			const focusParent = model.document.selection.focus!.parent;
 			const lastElementIsTodoList = isLegacyTodoListItemElement( lastFocusedCodeBlock );
 			const currentElementIsTodoList = isLegacyTodoListItemElement( focusParent );
 
 			if ( lastElementIsTodoList && !currentElementIsTodoList ) {
-				announce( t( 'Leaving todo list' ) );
+				ui.ariaLiveAnnouncer.announce( t( 'Leaving todo list' ) );
 			} else if ( !lastElementIsTodoList && currentElementIsTodoList ) {
-				announce( t( 'Entering todo list' ) );
+				ui.ariaLiveAnnouncer.announce( t( 'Entering todo list' ) );
 			}
 
 			lastFocusedCodeBlock = focusParent;

--- a/packages/ckeditor5-list/src/legacytodolist/legacytodolistediting.ts
+++ b/packages/ckeditor5-list/src/legacytodolist/legacytodolistediting.ts
@@ -234,9 +234,9 @@ export default class LegacyTodoListEditing extends Plugin {
 			const currentElementIsTodoList = isLegacyTodoListItemElement( focusParent );
 
 			if ( lastElementIsTodoList && !currentElementIsTodoList ) {
-				ui.ariaLiveAnnouncer.announce( t( 'Leaving todo list' ) );
+				ui.ariaLiveAnnouncer.announce( t( 'Leaving a to-do list' ) );
 			} else if ( !lastElementIsTodoList && currentElementIsTodoList ) {
-				ui.ariaLiveAnnouncer.announce( t( 'Entering todo list' ) );
+				ui.ariaLiveAnnouncer.announce( t( 'Entering a to-do list' ) );
 			}
 
 			lastFocusedCodeBlock = focusParent;

--- a/packages/ckeditor5-list/src/todolist/todolistediting.ts
+++ b/packages/ckeditor5-list/src/todolist/todolistediting.ts
@@ -382,9 +382,9 @@ export default class TodoListEditing extends Plugin {
 			const currentElementIsTodoList = isTodoListItemElement( focusParent );
 
 			if ( lastElementIsTodoList && !currentElementIsTodoList ) {
-				ui.ariaLiveAnnouncer.announce( t( 'Leaving todo list' ) );
+				ui.ariaLiveAnnouncer.announce( t( 'Leaving a to-do list' ) );
 			} else if ( !lastElementIsTodoList && currentElementIsTodoList ) {
-				ui.ariaLiveAnnouncer.announce( t( 'Entering todo list' ) );
+				ui.ariaLiveAnnouncer.announce( t( 'Entering a to-do list' ) );
 			}
 
 			lastFocusedCodeBlock = focusParent;

--- a/packages/ckeditor5-list/src/todolist/todolistediting.ts
+++ b/packages/ckeditor5-list/src/todolist/todolistediting.ts
@@ -555,5 +555,13 @@ function isLabelElement( viewElement: ViewElement | ViewDocumentFragment | null 
  * Returns true if the given element is a list item model element of a to-do list.
  */
 function isTodoListItemElement( element: Element | DocumentFragment | null ): boolean {
-	return !!element && element.is( 'element', 'paragraph' ) && element.getAttribute( 'listType' ) == 'todo';
+	if ( !element ) {
+		return false;
+	}
+
+	if ( !element.is( 'element', 'paragraph' ) && !element.is( 'element', 'listItem' ) ) {
+		return false;
+	}
+
+	return element.getAttribute( 'listType' ) == 'todo';
 }

--- a/packages/ckeditor5-list/src/todolist/todolistediting.ts
+++ b/packages/ckeditor5-list/src/todolist/todolistediting.ts
@@ -376,21 +376,15 @@ export default class TodoListEditing extends Plugin {
 			return;
 		}
 
-		ui.ariaLiveAnnouncer.registerRegion( 'todoList' );
-
-		const announce = ( message: string ) => {
-			ui.ariaLiveAnnouncer.announce( 'todoList', message );
-		};
-
 		model.document.selection.on<SelectionChangeRangeEvent>( 'change:range', () => {
 			const focusParent = model.document.selection.focus!.parent;
 			const lastElementIsTodoList = isTodoListItemElement( lastFocusedCodeBlock );
 			const currentElementIsTodoList = isTodoListItemElement( focusParent );
 
 			if ( lastElementIsTodoList && !currentElementIsTodoList ) {
-				announce( t( 'Leaving todo list' ) );
+				ui.ariaLiveAnnouncer.announce( t( 'Leaving todo list' ) );
 			} else if ( !lastElementIsTodoList && currentElementIsTodoList ) {
-				announce( t( 'Entering todo list' ) );
+				ui.ariaLiveAnnouncer.announce( t( 'Entering todo list' ) );
 			}
 
 			lastFocusedCodeBlock = focusParent;

--- a/packages/ckeditor5-list/src/todolist/todolistediting.ts
+++ b/packages/ckeditor5-list/src/todolist/todolistediting.ts
@@ -17,7 +17,9 @@ import {
 	type ViewDocumentKeyDownEvent,
 	type ViewDocumentArrowKeyEvent,
 	type MapperViewToModelPositionEvent,
-	type ViewDocumentFragment
+	type ViewDocumentFragment,
+	type SelectionChangeRangeEvent,
+	type DocumentFragment
 } from 'ckeditor5/src/engine.js';
 
 import {
@@ -336,6 +338,8 @@ export default class TodoListEditing extends Plugin {
 				data.modelPosition = model.createPositionAt( nodeAfter, 0 );
 			}
 		}, { priority: 'low' } );
+
+		this._initAriaAnnouncements();
 	}
 
 	/**
@@ -355,6 +359,41 @@ export default class TodoListEditing extends Plugin {
 			writer.setSelection( listItem, 'end' );
 			editor.execute( 'checkTodoList' );
 			writer.setSelection( previousSelectionRanges );
+		} );
+	}
+
+	/**
+	 * Observe when user enters or leaves todo list and set proper aria value in global live announcer.
+	 * This allows screen readers to indicate when the user has entered and left the specified todo list.
+	 *
+	 * @internal
+	 */
+	private _initAriaAnnouncements( ) {
+		const { model, ui, t } = this.editor;
+		let lastFocusedCodeBlock: Element | DocumentFragment | null = null;
+
+		if ( !ui ) {
+			return;
+		}
+
+		ui.ariaLiveAnnouncer.registerRegion( 'todoList' );
+
+		const announce = ( message: string ) => {
+			ui.ariaLiveAnnouncer.announce( 'todoList', message );
+		};
+
+		model.document.selection.on<SelectionChangeRangeEvent>( 'change:range', () => {
+			const focusParent = model.document.selection.focus!.parent;
+			const lastElementIsTodoList = isTodoListItemElement( lastFocusedCodeBlock );
+			const currentElementIsTodoList = isTodoListItemElement( focusParent );
+
+			if ( lastElementIsTodoList && !currentElementIsTodoList ) {
+				announce( t( 'Leaving todo list' ) );
+			} else if ( !lastElementIsTodoList && currentElementIsTodoList ) {
+				announce( t( 'Entering todo list' ) );
+			}
+
+			lastFocusedCodeBlock = focusParent;
 		} );
 	}
 }
@@ -516,4 +555,11 @@ function jumpOverCheckmarkOnSideArrowKeyPress( model: Model, locale: Locale ): G
  */
 function isLabelElement( viewElement: ViewElement | ViewDocumentFragment | null ): boolean {
 	return !!viewElement && viewElement.is( 'attributeElement' ) && viewElement.hasClass( 'todo-list__label' );
+}
+
+/**
+ * Returns true if the given element is a list item model element of a to-do list.
+ */
+function isTodoListItemElement( element: Element | DocumentFragment | null ): boolean {
+	return !!element && element.is( 'element', 'paragraph' ) && element.getAttribute( 'listType' ) == 'todo';
 }

--- a/packages/ckeditor5-list/tests/legacytodolist/legacytodolistediting.js
+++ b/packages/ckeditor5-list/tests/legacytodolist/legacytodolistediting.js
@@ -739,11 +739,11 @@ describe( 'LegacyTodoListEditing', () => {
 		} );
 
 		function expectNotToAnnounce( message ) {
-			expect( announcerSpy ).not.to.be.calledWithExactly( 'legacyTodoList', message );
+			expect( announcerSpy ).not.to.be.calledWithExactly( message );
 		}
 
 		function expectAnnounce( message ) {
-			expect( announcerSpy ).to.be.calledWithExactly( 'legacyTodoList', message );
+			expect( announcerSpy ).to.be.calledWithExactly( message );
 		}
 
 		function moveSelection( startPath, endPath ) {

--- a/packages/ckeditor5-list/tests/legacytodolist/legacytodolistediting.js
+++ b/packages/ckeditor5-list/tests/legacytodolist/legacytodolistediting.js
@@ -675,6 +675,91 @@ describe( 'LegacyTodoListEditing', () => {
 		} );
 	} );
 
+	describe( 'accessibility', () => {
+		let announcerSpy, editorElement;
+
+		beforeEach( async () => {
+			editorElement = document.createElement( 'div' );
+			document.body.appendChild( editorElement );
+
+			return ClassicTestEditor
+				.create( editorElement, {
+					plugins: [ Paragraph, LegacyTodoListEditing ]
+				} )
+				.then( newEditor => {
+					editor = newEditor;
+
+					model = editor.model;
+					modelDoc = model.document;
+					modelRoot = modelDoc.getRoot();
+
+					view = editor.editing.view;
+					viewDoc = view.document;
+					announcerSpy = sinon.spy( editor.ui.ariaLiveAnnouncer, 'announce' );
+				} );
+		} );
+
+		afterEach( () => {
+			editorElement.remove();
+			return editor.destroy();
+		} );
+
+		it( 'should announce entering and leaving list', () => {
+			setModelData( model,
+				'<paragraph>[Foo]</paragraph>' +
+				'<listItem listType="todo" listIndent="0">1</listItem>' +
+				'<listItem listType="todo" listIndent="0" todoListChecked="true">2</listItem>' +
+				'<paragraph>Foo</paragraph>'
+			);
+
+			moveSelection( [ 1, 0 ], [ 1, 1 ] );
+			expectAnnounce( 'Entering todo list' );
+
+			moveSelection( [ 3, 0 ], [ 3, 1 ] );
+			expectAnnounce( 'Leaving todo list' );
+		} );
+
+		it( 'should announce entering and leaving list once, even if there is nested list', () => {
+			setModelData( model,
+				'<paragraph>[Foo]</paragraph>' +
+				'<listItem listType="todo" listIndent="0">1</listItem>' +
+				'<listItem listType="todo" listIndent="1">1</listItem>' +
+				'<listItem listType="todo" listIndent="0" todoListChecked="true">2</listItem>' +
+				'<paragraph>Foo</paragraph>'
+			);
+
+			moveSelection( [ 1, 0 ], [ 1, 1 ] );
+			expectAnnounce( 'Entering todo list' );
+
+			moveSelection( [ 2, 0 ], [ 2, 1 ] );
+			expectNotToAnnounce( 'Leaving todo list' );
+
+			moveSelection( [ 4, 0 ], [ 4, 1 ] );
+			expectAnnounce( 'Leaving todo list' );
+		} );
+
+		function expectNotToAnnounce( message ) {
+			expect( announcerSpy ).not.to.be.calledWithExactly( 'legacyTodoList', message );
+		}
+
+		function expectAnnounce( message ) {
+			expect( announcerSpy ).to.be.calledWithExactly( 'legacyTodoList', message );
+		}
+
+		function moveSelection( startPath, endPath ) {
+			model.change( writer => {
+				writer.setSelection( createRange( modelRoot, startPath, modelRoot, endPath ) );
+			} );
+		}
+
+		function createRange( startElement, startPath, endElement, endPath ) {
+			return model.createRange(
+				model.createPositionFromPath( startElement, startPath ),
+				model.createPositionFromPath( endElement, endPath )
+			);
+		}
+	} );
+
 	describe( 'data pipeline m -> v', () => {
 		it( 'should convert to-do list item', () => {
 			setModelData( model,

--- a/packages/ckeditor5-list/tests/legacytodolist/legacytodolistediting.js
+++ b/packages/ckeditor5-list/tests/legacytodolist/legacytodolistediting.js
@@ -713,10 +713,10 @@ describe( 'LegacyTodoListEditing', () => {
 			);
 
 			moveSelection( [ 1, 0 ], [ 1, 1 ] );
-			expectAnnounce( 'Entering todo list' );
+			expectAnnounce( 'Entering a to-do list' );
 
 			moveSelection( [ 3, 0 ], [ 3, 1 ] );
-			expectAnnounce( 'Leaving todo list' );
+			expectAnnounce( 'Leaving a to-do list' );
 		} );
 
 		it( 'should announce entering and leaving list once, even if there is nested list', () => {
@@ -729,13 +729,13 @@ describe( 'LegacyTodoListEditing', () => {
 			);
 
 			moveSelection( [ 1, 0 ], [ 1, 1 ] );
-			expectAnnounce( 'Entering todo list' );
+			expectAnnounce( 'Entering a to-do list' );
 
 			moveSelection( [ 2, 0 ], [ 2, 1 ] );
-			expectNotToAnnounce( 'Leaving todo list' );
+			expectNotToAnnounce( 'Leaving a to-do list' );
 
 			moveSelection( [ 4, 0 ], [ 4, 1 ] );
-			expectAnnounce( 'Leaving todo list' );
+			expectAnnounce( 'Leaving a to-do list' );
 		} );
 
 		function expectNotToAnnounce( message ) {

--- a/packages/ckeditor5-list/tests/todolist/todolistediting.js
+++ b/packages/ckeditor5-list/tests/todolist/todolistediting.js
@@ -39,9 +39,7 @@ describe( 'TodoListEditing', () => {
 		editorElement = document.createElement( 'div' );
 		document.body.appendChild( editorElement );
 
-		editor = await ClassicTestEditor.create( editorElement, {
-			plugins: [ Paragraph, TodoListEditing, BlockQuoteEditing, TableEditing, HeadingEditing, AlignmentEditing ]
-		} );
+		editor = await createEditor();
 
 		model = editor.model;
 		modelRoot = model.document.getRoot();
@@ -961,6 +959,33 @@ describe( 'TodoListEditing', () => {
 			announcerSpy = sinon.spy( editor.ui.ariaLiveAnnouncer, 'announce' );
 		} );
 
+		it( 'should announce entering and leaving list (multiBlock = false)', async () => {
+			await editor.destroy();
+
+			editor = await createEditor( {
+				list: {
+					multiBlock: false
+				}
+			} );
+
+			model = editor.model;
+			modelRoot = model.document.getRoot();
+			announcerSpy = sinon.spy( editor.ui.ariaLiveAnnouncer, 'announce' );
+
+			setModelData( model,
+				'<paragraph>[Foo]</paragraph>' +
+				'<listItem listType="todo" listIndent="0">1</listItem>' +
+				'<listItem listType="todo" listIndent="0" todoListChecked="true">2</listItem>' +
+				'<paragraph>Foo</paragraph>'
+			);
+
+			moveSelection( [ 1, 0 ], [ 1, 1 ] );
+			expectAnnounce( 'Entering a to-do list' );
+
+			moveSelection( [ 3, 0 ], [ 3, 1 ] );
+			expectAnnounce( 'Leaving a to-do list' );
+		} );
+
 		it( 'should announce entering and leaving list', () => {
 			setModelData( model,
 				'<paragraph>[Foo]</paragraph>' +
@@ -1275,6 +1300,13 @@ describe( 'TodoListEditing', () => {
 			} );
 		} );
 	} );
+
+	async function createEditor( config = {} ) {
+		return ClassicTestEditor.create( editorElement, {
+			plugins: [ Paragraph, TodoListEditing, BlockQuoteEditing, TableEditing, HeadingEditing, AlignmentEditing ],
+			...config
+		} );
+	}
 
 	function testUpcast( input, output ) {
 		editor.setData( input );

--- a/packages/ckeditor5-list/tests/todolist/todolistediting.js
+++ b/packages/ckeditor5-list/tests/todolist/todolistediting.js
@@ -996,11 +996,11 @@ describe( 'TodoListEditing', () => {
 		} );
 
 		function expectNotToAnnounce( message ) {
-			expect( announcerSpy ).not.to.be.calledWithExactly( 'todoList', message );
+			expect( announcerSpy ).not.to.be.calledWithExactly( message );
 		}
 
 		function expectAnnounce( message ) {
-			expect( announcerSpy ).to.be.calledWithExactly( 'todoList', message );
+			expect( announcerSpy ).to.be.calledWithExactly( message );
 		}
 
 		function moveSelection( startPath, endPath ) {

--- a/packages/ckeditor5-list/tests/todolist/todolistediting.js
+++ b/packages/ckeditor5-list/tests/todolist/todolistediting.js
@@ -970,10 +970,10 @@ describe( 'TodoListEditing', () => {
 			);
 
 			moveSelection( [ 1, 0 ], [ 1, 1 ] );
-			expectAnnounce( 'Entering todo list' );
+			expectAnnounce( 'Entering a to-do list' );
 
 			moveSelection( [ 3, 0 ], [ 3, 1 ] );
-			expectAnnounce( 'Leaving todo list' );
+			expectAnnounce( 'Leaving a to-do list' );
 		} );
 
 		it( 'should announce entering and leaving list once, even if there is nested list', () => {
@@ -986,13 +986,13 @@ describe( 'TodoListEditing', () => {
 			);
 
 			moveSelection( [ 1, 0 ], [ 1, 1 ] );
-			expectAnnounce( 'Entering todo list' );
+			expectAnnounce( 'Entering a to-do list' );
 
 			moveSelection( [ 2, 0 ], [ 2, 1 ] );
-			expectNotToAnnounce( 'Leaving todo list' );
+			expectNotToAnnounce( 'Leaving a to-do list' );
 
 			moveSelection( [ 4, 0 ], [ 4, 1 ] );
-			expectAnnounce( 'Leaving todo list' );
+			expectAnnounce( 'Leaving a to-do list' );
 		} );
 
 		function expectNotToAnnounce( message ) {

--- a/packages/ckeditor5-ui/src/arialiveannouncer.ts
+++ b/packages/ckeditor5-ui/src/arialiveannouncer.ts
@@ -7,6 +7,7 @@
  * @module ui/arialiveannouncer
  */
 
+import type { DomConverter } from '@ckeditor/ckeditor5-engine';
 import type { Editor } from '@ckeditor/ckeditor5-core';
 import type { Locale, ObservableChangeEvent } from '@ckeditor/ckeditor5-utils';
 import type ViewCollection from './viewcollection.js';
@@ -100,7 +101,7 @@ export default class AriaLiveAnnouncer {
 		let regionView = this.view.regionViews.find( view => view.regionName === regionName );
 
 		if ( !regionView ) {
-			regionView = new AriaLiveAnnouncerRegionView( this.view.locale! );
+			regionView = new AriaLiveAnnouncerRegionView( this.view.locale!, editor.data.htmlProcessor.domConverter );
 			this.view.regionViews.add( regionView );
 		}
 
@@ -184,7 +185,7 @@ export class AriaLiveAnnouncerRegionView extends View {
 	 */
 	declare public regionName: string;
 
-	constructor( locale: Locale ) {
+	constructor( locale: Locale, domConverter: DomConverter ) {
 		super( locale );
 
 		const bind = this.bindTemplate;
@@ -204,7 +205,11 @@ export class AriaLiveAnnouncerRegionView extends View {
 		} );
 
 		this.on<ObservableChangeEvent<string>>( 'change:content', ( evt, name, content ) => {
-			this.element![ this.isUnsafeHTML ? 'innerHTML' : 'innerText' ] = content;
+			if ( this.isUnsafeHTML ) {
+				domConverter.setContentOf( this.element!, content );
+			} else {
+				this.element!.innerText = content;
+			}
 		} );
 	}
 }

--- a/packages/ckeditor5-ui/src/arialiveannouncer.ts
+++ b/packages/ckeditor5-ui/src/arialiveannouncer.ts
@@ -9,7 +9,7 @@
 
 import type { DomConverter } from '@ckeditor/ckeditor5-engine';
 import type { Editor } from '@ckeditor/ckeditor5-core';
-import type { Locale, ObservableChangeEvent } from '@ckeditor/ckeditor5-utils';
+import type { Locale } from '@ckeditor/ckeditor5-utils';
 import type ViewCollection from './viewcollection.js';
 import View from './view.js';
 
@@ -36,9 +36,10 @@ export const AriaLiveAnnouncerPoliteness = {
  * These announcements are consumed and propagated by screen readers and give users a better understanding of the current
  * state of the editor.
  *
- * To announce a state change to an editor feature named `'Some feature'`, use the {@link #announce} method:
+ * To announce a state change to an editor use the {@link #announce} method:
+ *
  * ```ts
- * editor.ui.ariaLiveAnnouncer.announce( 'Some feature', 'Text of an announcement.' );
+ * editor.ui.ariaLiveAnnouncer.announce( 'Text of an announcement.' );
  * ```
  */
 export default class AriaLiveAnnouncer {
@@ -57,79 +58,61 @@ export default class AriaLiveAnnouncer {
 	 */
 	constructor( editor: Editor ) {
 		this.editor = editor;
+
+		/**
+		 * Some screen readers only look at changes in the aria-live region.
+		 * They might not read a region that already has content when it is added.
+		 * To stop this problem, make sure to set up regions for all politeness settings when the editor starts.
+		 */
+		editor.once( 'ready', () => {
+			for ( const politeness of Object.values( AriaLiveAnnouncerPoliteness ) ) {
+				this.announce( '', politeness );
+			}
+		} );
 	}
 
 	/**
-	 * Appends empty `aria-live` announcement region. Some of screen readers tend to not read newly added
-	 * regions with already filled text content. Appending empty region before any action prevents
-	 * that behavior and screen readers are forced to read updated text.
-	 */
-	public registerRegion( regionName: string ): void {
-		this.announce( regionName, '' );
-	}
-
-	/**
-	 * Sets an announcement text to an aria region associated with a specific editor feature. The text is then
-	 * announced by a screen reader to the user.
+	 * Sets an announcement text to an aria region that is then announced by a screen reader to the user.
 	 *
-	 * If the aria region of a given name does not exist, it will be created and can be re-used later. The name of the region
-	 * groups announcements originating from a specific editor feature and does not get announced by a screen reader.
-	 *
-	 * Using multiple regions allows for many announcements to be emitted in a short period of time. Changes to ARIA-live announcements
-	 * are captured by a screen reader and read out in the order they were emitted.
+	 * If the aria region of a specified politeness does not exist, it will be created and can be re-used later.
 	 *
 	 * The default announcement politeness level is `'polite'`.
 	 *
 	 * ```ts
 	 * // Most screen readers will queue announcements from multiple aria-live regions and read them out in the order they were emitted.
- 	 * editor.ui.ariaLiveAnnouncer.announce( 'image', 'Image uploaded.' );
- 	 * editor.ui.ariaLiveAnnouncer.announce( 'network', 'Connection lost. Reconnecting.' );
+ 	 * editor.ui.ariaLiveAnnouncer.announce( 'Image uploaded.' );
+ 	 * editor.ui.ariaLiveAnnouncer.announce( 'Connection lost. Reconnecting.' );
  	 * ```
 	 */
 	public announce(
-		regionName: string,
 		announcement: string,
 		attributes: AriaLiveAnnouncerPolitenessValue | AriaLiveAnnounceConfig = AriaLiveAnnouncerPoliteness.POLITE
 	): void {
 		const editor = this.editor;
+
+		if ( !editor.ui.view ) {
+			return;
+		}
 
 		if ( !this.view ) {
 			this.view = new AriaLiveAnnouncerView( editor.locale );
 			editor.ui.view.body.add( this.view );
 		}
 
-		let regionView = this.view.regionViews.find( view => view.regionName === regionName );
-
-		if ( !regionView ) {
-			regionView = new AriaLiveAnnouncerRegionView( this.view.locale!, editor.data.htmlProcessor.domConverter );
-			this.view.regionViews.add( regionView );
-		}
-
-		const { politeness, allowReadAgain, isUnsafeHTML }: AriaLiveAnnounceConfig = typeof attributes === 'string' ? {
+		const { politeness, isUnsafeHTML }: AriaLiveAnnounceConfig = typeof attributes === 'string' ? {
 			politeness: attributes
 		} : attributes;
 
-		// Handle edge case when:
-		//
-		// 	1. user enters code block #1 with PHP language.
-		//  2. user enters code block #2 with PHP language.
-		//	3. user leaves code block #2 and comes back to code block #1 with identical language
-		//
-		// In this scenario `announcement` will be identical (`Leaving PHP code block, entering PHP code block`)
-		// Screen reader will not detect this change because `aria-live` is identical with previous one and
-		// will skip reading the label.
-		//
-		// Try to bypass this issue by toggling non readable character at the end of phrase.
-		if ( allowReadAgain && regionView.content === announcement ) {
-			// eslint-disable-next-line no-irregular-whitespace
-			announcement = `${ announcement } `;
+		let politenessRegionView = this.view.regionViews.find( view => view.politeness === politeness );
+
+		if ( !politenessRegionView ) {
+			politenessRegionView = new AriaLiveAnnouncerRegionView( editor, politeness );
+			this.view.regionViews.add( politenessRegionView );
 		}
 
-		regionView.set( {
-			regionName,
-			isUnsafeHTML: !!isUnsafeHTML,
-			content: announcement,
-			politeness
+		politenessRegionView.announce( {
+			announcement,
+			isUnsafeHTML
 		} );
 	}
 }
@@ -162,62 +145,98 @@ export class AriaLiveAnnouncerView extends View {
 }
 
 /**
- * The view that represents a single `aria-live` region (e.g. for a specific editor feature) and its text.
+ * The view that represents a single `aria-live`.
  */
 export class AriaLiveAnnouncerRegionView extends View {
 	/**
-	 * Current content of the region.
-	 */
-	declare public content: string;
-
-	/**
-	 * Indication that region has HTML content.
-	 */
-	declare public isUnsafeHTML: boolean;
-
-	/**
 	 * Current politeness level of the region.
 	 */
-	declare public politeness: typeof AriaLiveAnnouncerPoliteness[ keyof typeof AriaLiveAnnouncerPoliteness ];
+	public readonly politeness: AriaLiveAnnouncerPolitenessValue;
 
 	/**
-	 * A unique name of the region, usually associated with a specific editor feature or system.
+	 * DOM converter used to sanitize unsafe HTML passed to {@link #announce} method.
 	 */
-	declare public regionName: string;
+	private _domConverter: DomConverter;
 
-	constructor( locale: Locale, domConverter: DomConverter ) {
-		super( locale );
+	/**
+	 * Interval used to remove additions. It prevents accumulation of added nodes in region.
+	 */
+	private _pruneAnnouncementsInterval: ReturnType<typeof setInterval> | null;
 
-		const bind = this.bindTemplate;
-
-		this.set( 'regionName', '' );
-		this.set( 'content', '' );
-		this.set( 'isUnsafeHTML', false );
-		this.set( 'politeness', AriaLiveAnnouncerPoliteness.POLITE );
+	constructor( editor: Editor, politeness: AriaLiveAnnouncerPolitenessValue ) {
+		super( editor.locale );
 
 		this.setTemplate( {
 			tag: 'div',
 			attributes: {
 				role: 'region',
-				'data-region': bind.to( 'regionName' ),
-				'aria-live': bind.to( 'politeness' )
+				'aria-live': politeness,
+				'aria-relevant': 'additions'
+			},
+			children: [
+				{
+					tag: 'ul',
+					attributes: {
+						class: [
+							'ck',
+							'ck-aria-live-region-list'
+						]
+					}
+				}
+			]
+		} );
+
+		editor.on( 'destroy', () => {
+			if ( this._pruneAnnouncementsInterval !== null ) {
+				clearInterval( this._pruneAnnouncementsInterval! );
+				this._pruneAnnouncementsInterval = null;
 			}
 		} );
 
-		this.on<ObservableChangeEvent<string>>( 'change:content', ( evt, name, content ) => {
-			if ( this.isUnsafeHTML ) {
-				domConverter.setContentOf( this.element!, content );
-			} else {
-				this.element!.innerText = content;
+		this.politeness = politeness;
+		this._domConverter = editor.data.htmlProcessor.domConverter;
+		this._pruneAnnouncementsInterval = setInterval( () => {
+			if ( this.element && this._listElement!.firstChild ) {
+				this._listElement!.firstChild!.remove();
 			}
-		} );
+		}, 5000 );
+	}
+
+	/**
+	 * Appends new announcement to region.
+	 */
+	public announce( { announcement, isUnsafeHTML }: AriaLiveAppendContentAttributes ): void {
+		if ( !announcement.trim().length ) {
+			return;
+		}
+
+		const messageListItem = document.createElement( 'li' );
+
+		if ( isUnsafeHTML ) {
+			this._domConverter.setContentOf( messageListItem, announcement );
+		} else {
+			messageListItem.innerText = announcement;
+		}
+
+		this._listElement!.appendChild( messageListItem );
+	}
+
+	/**
+	 * Return current announcements list HTML element.
+	 */
+	private get _listElement(): HTMLElement | null {
+		return this.element!.querySelector( 'ul' )!;
 	}
 }
 
 type AriaLiveAnnouncerPolitenessValue = typeof AriaLiveAnnouncerPoliteness[ keyof typeof AriaLiveAnnouncerPoliteness ];
 
+type AriaLiveAppendContentAttributes = {
+	announcement: string;
+	isUnsafeHTML?: boolean;
+};
+
 type AriaLiveAnnounceConfig = {
 	politeness: AriaLiveAnnouncerPolitenessValue;
-	allowReadAgain?: boolean;
 	isUnsafeHTML?: boolean;
 };

--- a/packages/ckeditor5-ui/tests/editorui/arialiveannouncer.js
+++ b/packages/ckeditor5-ui/tests/editorui/arialiveannouncer.js
@@ -26,6 +26,21 @@ describe( 'AriaLiveAnnouncer', () => {
 		await editor.destroy();
 	} );
 
+	describe( 'registerRegion()', () => {
+		it( 'should create empty region with specified name', () => {
+			announcer.registerRegion( 'foo' );
+
+			expect( announcer.view.regionViews.length ).to.equal( 1 );
+
+			const region = announcer.view.regionViews.first;
+
+			expect( region.regionName ).to.equal( 'foo' );
+			expect( region.content ).to.equal( '' );
+			expect( region.politeness ).to.equal( 'polite' );
+			expect( region.element.parentNode ).to.equal( announcer.view.element );
+		} );
+	} );
+
 	describe( 'announce()', () => {
 		it( 'should create, then add the view to the body collection', () => {
 			expect( announcer.view ).to.be.undefined;
@@ -54,7 +69,7 @@ describe( 'AriaLiveAnnouncer', () => {
 
 			expect( firstRegion ).to.be.instanceOf( AriaLiveAnnouncerRegionView );
 			expect( firstRegion.regionName ).to.equal( 'foo' );
-			expect( firstRegion.text ).to.equal( 'bar' );
+			expect( firstRegion.content ).to.equal( 'bar' );
 			expect( firstRegion.politeness ).to.equal( 'polite' );
 			expect( firstRegion.element.parentNode ).to.equal( announcer.view.element );
 
@@ -74,7 +89,7 @@ describe( 'AriaLiveAnnouncer', () => {
 
 			expect( firstRegion ).to.be.instanceOf( AriaLiveAnnouncerRegionView );
 			expect( firstRegion.regionName ).to.equal( 'foo' );
-			expect( firstRegion.text ).to.equal( 'baz' );
+			expect( firstRegion.content ).to.equal( 'baz' );
 			expect( firstRegion.politeness ).to.equal( 'polite' );
 			expect( firstRegion.element.parentNode ).to.equal( announcer.view.element );
 
@@ -94,12 +109,12 @@ describe( 'AriaLiveAnnouncer', () => {
 			const lastRegion = announcer.view.regionViews.last;
 
 			expect( firstRegion.regionName ).to.equal( 'foo' );
-			expect( firstRegion.text ).to.equal( 'bar' );
+			expect( firstRegion.content ).to.equal( 'bar' );
 			expect( firstRegion.politeness ).to.equal( 'polite' );
 			expect( firstRegion.element.parentNode ).to.equal( announcer.view.element );
 
 			expect( lastRegion.regionName ).to.equal( 'baz' );
-			expect( lastRegion.text ).to.equal( 'qux' );
+			expect( lastRegion.content ).to.equal( 'qux' );
 			expect( lastRegion.politeness ).to.equal( 'polite' );
 			expect( lastRegion.element.parentNode ).to.equal( announcer.view.element );
 		} );
@@ -111,6 +126,33 @@ describe( 'AriaLiveAnnouncer', () => {
 
 			expect( firstRegion.politeness ).to.equal( 'assertive' );
 			expect( firstRegion.element.getAttribute( 'aria-live' ) ).to.equal( 'assertive' );
+		} );
+
+		it( 'should be possible to read selected text again', () => {
+			announcer.announce( 'foo', 'bar', {
+				politeness: 'polite',
+				allowReadAgain: true
+			} );
+
+			announcer.announce( 'foo', 'bar', {
+				politeness: 'polite',
+				allowReadAgain: true
+			} );
+
+			const firstRegion = announcer.view.regionViews.first;
+
+			expect( firstRegion.content ).to.equal( 'bar ' );
+		} );
+
+		it( 'should be possible to read selected text with HTML tags', () => {
+			announcer.announce( 'foo', '<h1>Foo</h1>', {
+				politeness: 'polite',
+				isUnsafeHTML: true
+			} );
+
+			const firstRegion = announcer.view.regionViews.first;
+
+			expect( firstRegion.content ).to.equal( '<h1>Foo</h1>' );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-ui/tests/editorui/arialiveannouncer.js
+++ b/packages/ckeditor5-ui/tests/editorui/arialiveannouncer.js
@@ -26,34 +26,19 @@ describe( 'AriaLiveAnnouncer', () => {
 		await editor.destroy();
 	} );
 
-	describe( 'registerRegion()', () => {
-		it( 'should create empty region with specified name', () => {
-			announcer.registerRegion( 'foo' );
-
-			expect( announcer.view.regionViews.length ).to.equal( 1 );
-
-			const region = announcer.view.regionViews.first;
-
-			expect( region.regionName ).to.equal( 'foo' );
-			expect( region.content ).to.equal( '' );
-			expect( region.politeness ).to.equal( 'polite' );
-			expect( region.element.parentNode ).to.equal( announcer.view.element );
-		} );
-	} );
-
 	describe( 'announce()', () => {
 		it( 'should create, then add the view to the body collection', () => {
-			expect( announcer.view ).to.be.undefined;
+			expect( announcer.view ).not.to.be.undefined;
 
-			announcer.announce( 'foo', 'bar' );
+			announcer.announce( 'bar' );
 
 			expect( announcer.view ).to.be.instanceOf( AriaLiveAnnouncerView );
-			expect( announcer.view.regionViews.length ).to.equal( 1 );
+			expect( announcer.view.regionViews.length ).to.equal( 2 );
 			expect( editor.ui.view.body.has( announcer.view ) ).to.be.true;
 		} );
 
 		it( 'should create the view from template upon first use', () => {
-			announcer.announce( 'foo', 'bar' );
+			announcer.announce( 'bar' );
 
 			expect( announcer.view.element.tagName ).to.equal( 'DIV' );
 			expect( announcer.view.element.className.includes( 'ck' ) ).to.be.true;
@@ -61,98 +46,148 @@ describe( 'AriaLiveAnnouncer', () => {
 		} );
 
 		it( 'should create a new region (if does not exist) and set its text', () => {
-			announcer.announce( 'foo', 'bar' );
+			announcer.announce( 'bar' );
 
-			expect( announcer.view.regionViews.length ).to.equal( 1 );
+			expect( announcer.view.regionViews.length ).to.equal( 2 );
 
 			const firstRegion = announcer.view.regionViews.first;
 
 			expect( firstRegion ).to.be.instanceOf( AriaLiveAnnouncerRegionView );
-			expect( firstRegion.regionName ).to.equal( 'foo' );
-			expect( firstRegion.content ).to.equal( 'bar' );
 			expect( firstRegion.politeness ).to.equal( 'polite' );
 			expect( firstRegion.element.parentNode ).to.equal( announcer.view.element );
 
 			expect( firstRegion.element.getAttribute( 'role' ) ).to.equal( 'region' );
 			expect( firstRegion.element.getAttribute( 'aria-live' ) ).to.equal( 'polite' );
-			expect( firstRegion.element.innerHTML ).to.equal( 'bar' );
-			expect( firstRegion.element.dataset.region ).to.equal( 'foo' );
+			expect( firstRegion.element.querySelector( 'li' ).innerHTML ).to.equal( 'bar' );
 		} );
 
 		it( 'should set a new text in an existing region', () => {
-			announcer.announce( 'foo', 'bar' );
-			announcer.announce( 'foo', 'baz' );
+			announcer.announce( 'bar' );
+			announcer.announce( 'baz' );
 
-			expect( announcer.view.regionViews.length ).to.equal( 1 );
+			expect( announcer.view.regionViews.length ).to.equal( 2 );
 
 			const firstRegion = announcer.view.regionViews.first;
 
 			expect( firstRegion ).to.be.instanceOf( AriaLiveAnnouncerRegionView );
-			expect( firstRegion.regionName ).to.equal( 'foo' );
-			expect( firstRegion.content ).to.equal( 'baz' );
 			expect( firstRegion.politeness ).to.equal( 'polite' );
 			expect( firstRegion.element.parentNode ).to.equal( announcer.view.element );
 
 			expect( firstRegion.element.getAttribute( 'role' ) ).to.equal( 'region' );
 			expect( firstRegion.element.getAttribute( 'aria-live' ) ).to.equal( 'polite' );
-			expect( firstRegion.element.innerHTML ).to.equal( 'baz' );
-			expect( firstRegion.element.dataset.region ).to.equal( 'foo' );
+			expect( firstRegion.element.querySelector( 'li:last-child' ).innerHTML ).to.equal( 'baz' );
 		} );
 
-		it( 'should be able to create more than a single region', () => {
-			announcer.announce( 'foo', 'bar' );
-			announcer.announce( 'baz', 'qux' );
+		it( 'should be able to create region depending on politeness', () => {
+			announcer.announce( 'foo', 'polite' );
+			announcer.announce( 'bar', 'polite' );
+
+			announcer.announce( 'qux', 'assertive' );
 
 			expect( announcer.view.regionViews.length ).to.equal( 2 );
 
 			const firstRegion = announcer.view.regionViews.first;
 			const lastRegion = announcer.view.regionViews.last;
 
-			expect( firstRegion.regionName ).to.equal( 'foo' );
-			expect( firstRegion.content ).to.equal( 'bar' );
 			expect( firstRegion.politeness ).to.equal( 'polite' );
 			expect( firstRegion.element.parentNode ).to.equal( announcer.view.element );
+			expect( firstRegion.element.querySelector( 'li:first-child' ).innerText ).to.equal( 'foo' );
+			expect( firstRegion.element.querySelector( 'li:last-child' ).innerText ).to.equal( 'bar' );
+			expect( firstRegion.element.querySelectorAll( 'li' ).length ).to.equal( 2 );
 
-			expect( lastRegion.regionName ).to.equal( 'baz' );
-			expect( lastRegion.content ).to.equal( 'qux' );
-			expect( lastRegion.politeness ).to.equal( 'polite' );
+			expect( lastRegion.politeness ).to.equal( 'assertive' );
 			expect( lastRegion.element.parentNode ).to.equal( announcer.view.element );
+			expect( lastRegion.element.querySelector( 'li:first-child' ).innerText ).to.equal( 'qux' );
+			expect( lastRegion.element.querySelectorAll( 'li' ).length ).to.equal( 1 );
 		} );
 
 		it( 'should be able to set the politeness of the announcement', () => {
-			announcer.announce( 'foo', 'bar', 'assertive' );
+			announcer.announce( 'bar', 'assertive' );
 
-			const firstRegion = announcer.view.regionViews.first;
+			const lastRegion = announcer.view.regionViews.last;
 
-			expect( firstRegion.politeness ).to.equal( 'assertive' );
-			expect( firstRegion.element.getAttribute( 'aria-live' ) ).to.equal( 'assertive' );
-		} );
-
-		it( 'should be possible to read selected text again', () => {
-			announcer.announce( 'foo', 'bar', {
-				politeness: 'polite',
-				allowReadAgain: true
-			} );
-
-			announcer.announce( 'foo', 'bar', {
-				politeness: 'polite',
-				allowReadAgain: true
-			} );
-
-			const firstRegion = announcer.view.regionViews.first;
-
-			expect( firstRegion.content ).to.equal( 'bar ' );
+			expect( lastRegion.politeness ).to.equal( 'assertive' );
+			expect( lastRegion.element.getAttribute( 'aria-live' ) ).to.equal( 'assertive' );
 		} );
 
 		it( 'should be possible to read selected text with HTML tags', () => {
-			announcer.announce( 'foo', '<h1>Foo</h1>', {
+			announcer.announce( '<h1>Foo</h1>', {
 				politeness: 'polite',
 				isUnsafeHTML: true
 			} );
 
 			const firstRegion = announcer.view.regionViews.first;
 
-			expect( firstRegion.content ).to.equal( '<h1>Foo</h1>' );
+			expect( firstRegion.element.querySelector( 'li' ).innerHTML ).to.equal( '<h1>Foo</h1>' );
 		} );
 	} );
+} );
+
+describe( 'AriaLiveAnnouncerRegionView', () => {
+	let editor, sourceElement, announcerRegionView;
+
+	testUtils.createSinonSandbox();
+
+	beforeEach( async () => {
+		sinon.useFakeTimers( { now: Date.now() } );
+		sourceElement = document.createElement( 'div' );
+		document.body.appendChild( sourceElement );
+		editor = await ClassicEditor.create( sourceElement );
+
+		announcerRegionView = new AriaLiveAnnouncerRegionView( editor, 'polite' );
+		announcerRegionView.render();
+	} );
+
+	afterEach( async () => {
+		sinon.restore();
+		sourceElement.remove();
+
+		if ( editor ) {
+			await editor.destroy();
+		}
+	} );
+
+	it( 'there should be no announcements after init', () => {
+		expect( queryAllMessages().length ).to.be.equal( 0 );
+	} );
+
+	it( 'should prune old announcements using interval', () => {
+		announcerRegionView.announce( { announcement: 'Foo' } );
+		announcerRegionView.announce( { announcement: 'Bar' } );
+		expect( queryAllMessages().length ).to.be.equal( 2 );
+
+		sinon.clock.tick( 12000 );
+		expect( queryAllMessages().length ).to.be.equal( 0 );
+
+		announcerRegionView.announce( { announcement: 'Foo' } );
+		expect( queryAllMessages().length ).to.be.equal( 1 );
+
+		sinon.clock.tick( 6000 );
+		expect( queryAllMessages().length ).to.be.equal( 0 );
+	} );
+
+	it( 'should properly set and destroy interval', async () => {
+		expect( announcerRegionView._pruneAnnouncementsInterval ).not.to.be.null;
+
+		await editor.destroy();
+		editor = null;
+
+		expect( announcerRegionView._pruneAnnouncementsInterval ).to.be.null;
+	} );
+
+	describe( 'announce()', () => {
+		it( 'should append non-empty announcement', () => {
+			announcerRegionView.announce( { announcement: 'Hello World' } );
+			expect( queryAllMessages() ).to.be.deep.equal( [ 'Hello World' ] );
+		} );
+
+		it( 'should not append empty announcement', () => {
+			announcerRegionView.announce( { announcement: '' } );
+			expect( queryAllMessages().length ).to.be.equal( 0 );
+		} );
+	} );
+
+	function queryAllMessages() {
+		return [ ...announcerRegionView.element.querySelectorAll( 'div[role="region"] ul li' ) ].map( element => element.innerHTML );
+	}
 } );

--- a/packages/ckeditor5-ui/tests/panel/balloon/contextualballoon.js
+++ b/packages/ckeditor5-ui/tests/panel/balloon/contextualballoon.js
@@ -158,7 +158,7 @@ describe( 'ContextualBalloon', () => {
 			const spy = sinon.spy( balloon, '_createPanelView' );
 
 			expect( balloon._view ).to.be.null;
-			expect( editor.ui.view.body.length ).to.equal( 0 );
+			expect( editor.ui.view.body.length ).to.equal( 1 );
 			sinon.assert.notCalled( spy );
 
 			expect( balloon.view ).to.instanceof( BalloonPanelView );
@@ -169,7 +169,7 @@ describe( 'ContextualBalloon', () => {
 			const spy = sinon.spy( balloon, '_createPanelView' );
 
 			expect( balloon._view ).to.be.null;
-			expect( editor.ui.view.body.length ).to.equal( 0 );
+			expect( editor.ui.view.body.length ).to.equal( 1 );
 			sinon.assert.notCalled( spy );
 
 			balloon.add( {

--- a/packages/ckeditor5-ui/tests/panel/balloon/contextualballoon.js
+++ b/packages/ckeditor5-ui/tests/panel/balloon/contextualballoon.js
@@ -158,18 +158,17 @@ describe( 'ContextualBalloon', () => {
 			const spy = sinon.spy( balloon, '_createPanelView' );
 
 			expect( balloon._view ).to.be.null;
-			expect( editor.ui.view.body.length ).to.equal( 1 );
 			sinon.assert.notCalled( spy );
 
 			expect( balloon.view ).to.instanceof( BalloonPanelView );
 			sinon.assert.calledOnce( spy );
+			expect( editor.ui.view.body.has( balloon._view ) ).to.be.true;
 		} );
 
 		it( 'should create BalloonPanelView on first view added', () => {
 			const spy = sinon.spy( balloon, '_createPanelView' );
 
 			expect( balloon._view ).to.be.null;
-			expect( editor.ui.view.body.length ).to.equal( 1 );
 			sinon.assert.notCalled( spy );
 
 			balloon.add( {
@@ -181,6 +180,7 @@ describe( 'ContextualBalloon', () => {
 
 			expect( balloon._view ).to.instanceof( BalloonPanelView );
 			sinon.assert.calledOnce( spy );
+			expect( editor.ui.view.body.has( balloon._view ) ).to.be.true;
 		} );
 	} );
 

--- a/packages/ckeditor5-ui/theme/components/arialiveannouncer/arialiveannouncer.css
+++ b/packages/ckeditor5-ui/theme/components/arialiveannouncer/arialiveannouncer.css
@@ -8,3 +8,7 @@
 	left: -10000px;
 	top: -10000px;
 }
+
+.ck.ck-aria-live-region-list {
+	list-style-type: none;
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (code-block): Introduced screen reader announcements for entering or exiting code block elements in the document editor. Closes #16053.

Other (ui): Refactored the `AriaLiveAnnouncer` to use the `aria-relevant` attribute and make concurrent announcements queued by screen readers.

MINOR BREAKING CHANGE (ui): The region name argument of the `AriaLiveAnnouncer#announce()`  method has been dropped. Please check out the latest API documentation for more information. 

### Tickets to close

https://github.com/cksource/ckeditor5-commercial/issues/6031.
https://github.com/cksource/ckeditor5-commercial/issues/6033

Part of: 
https://github.com/cksource/ckeditor5-commercial/pull/6163

Announcer refactor:
https://github.com/ckeditor/ckeditor5/pull/16199