### PR TITLE
Fix incorrect color picker doc 

### DIFF
--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -311,7 +311,7 @@ export default class ColorPickerView extends View {
 	}
 
 	/**
-	 * Cleans up the supplementary error and information text of the {@link #urlInputView}
+	 * Cleans up the supplementary error and information text of input inside the {@link #hexInputRow}
 	 * bringing them back to the state when the form has been displayed for the first time.
 	 *
 	 * See {@link #isValid}.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Fix incorrect color picker doc of `resetValidationStatus` method. 
