### PR TITLE
In restricted-editing should be possible to escape from table with pressing tab

### DIFF
--- a/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting.js
+++ b/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting.js
@@ -1709,7 +1709,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 
 			model.change( writer => {
 				writer.addMarker( 'restrictedEditingException:1', {
-					range: writer.createRange( writer.createPositionAt( paragraph, 0 ), writer.createPositionAt( paragraph, 3 ) ),
+					range: writer.createRangeIn( paragraph ),
 					usingOperation: true,
 					affectsData: true
 				} );
@@ -1717,7 +1717,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 
 			model.change( writer => {
 				writer.addMarker( 'restrictedEditingException:2', {
-					range: writer.createRange( writer.createPositionAt( paragraph2, 0 ), writer.createPositionAt( paragraph2, 3 ) ),
+					range: writer.createRangeIn( paragraph2 ),
 					usingOperation: true,
 					affectsData: true
 				} );
@@ -1730,7 +1730,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 			sinon.assert.calledOnce( domEvtDataStub.preventDefault );
 			sinon.assert.calledOnce( domEvtDataStub.stopPropagation );
 
-			const position = editor.model.document.selection.getFirstRange().start;
+			const position = model.document.selection.getFirstRange().start;
 
 			expect( position.parent ).to.deep.equal( paragraph2 );
 		} );
@@ -1746,7 +1746,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 
 			model.change( writer => {
 				writer.addMarker( 'restrictedEditingException:1', {
-					range: writer.createRange( writer.createPositionAt( paragraph, 0 ), writer.createPositionAt( paragraph, 3 ) ),
+					range: writer.createRangeIn( paragraph ),
 					usingOperation: true,
 					affectsData: true
 				} );
@@ -1754,7 +1754,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 
 			model.change( writer => {
 				writer.addMarker( 'restrictedEditingException:2', {
-					range: writer.createRange( writer.createPositionAt( paragraph2, 0 ), writer.createPositionAt( paragraph2, 3 ) ),
+					range: writer.createRangeIn( paragraph2 ),
 					usingOperation: true,
 					affectsData: true
 				} );
@@ -1767,7 +1767,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 			sinon.assert.calledOnce( domEvtDataStub.preventDefault );
 			sinon.assert.calledOnce( domEvtDataStub.stopPropagation );
 
-			const position = editor.model.document.selection.getFirstRange().start;
+			const position = model.document.selection.getFirstRange().start;
 
 			expect( position.parent ).to.deep.equal( paragraph2 );
 		} );

--- a/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting.js
+++ b/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting.js
@@ -1732,7 +1732,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 
 			const position = editor.model.document.selection.getFirstRange().start;
 
-			expect( position.parent ).to.equal( paragraph2 );
+			expect( position.parent ).to.deep.equal( paragraph2 );
 		} );
 
 		it( 'should escape from the table', () => {
@@ -1769,7 +1769,7 @@ describe( 'RestrictedEditingModeEditing', () => {
 
 			const position = editor.model.document.selection.getFirstRange().start;
 
-			expect( position.parent ).to.equal( paragraph2 );
+			expect( position.parent ).to.deep.equal( paragraph2 );
 		} );
 
 		it( 'should let the focus go outside the editor on shift+tab when in the first exception', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (restricted-editing): In restricted-editing should be possible to escape from table with pressing tab. Closes #15506.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced handling of tab key events in restricted editing mode to improve navigation and usability.

- **Bug Fixes**
  - Improved test setups for more robust validation of tab navigation within tables in restricted editing mode.

- **Refactor**
  - Removed unused function to streamline codebase.

- **Tests**
  - Expanded testing to cover new scenarios involving tab key interactions in restricted editing contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->