### PR TITLE
 Miscellaneous accessibility improvements

### DIFF
--- a/packages/ckeditor5-link/src/ui/linkformview.ts
+++ b/packages/ckeditor5-link/src/ui/linkformview.ts
@@ -250,6 +250,7 @@ export default class LinkFormView extends View {
 		const t = this.locale!.t;
 		const labeledInput = new LabeledFieldView( this.locale, createLabeledInputText );
 
+		labeledInput.fieldView.inputMode = 'url';
 		labeledInput.label = t( 'Link URL' );
 
 		return labeledInput;

--- a/packages/ckeditor5-link/tests/ui/linkformview.js
+++ b/packages/ckeditor5-link/tests/ui/linkformview.js
@@ -84,6 +84,10 @@ describe( 'LinkFormView', () => {
 			expect( spy.calledOnce ).to.true;
 		} );
 
+		it( 'should create url input with inputmode=url', () => {
+			expect( view.urlInputView.fieldView.inputMode ).to.be.equal( 'url' );
+		} );
+
 		describe( 'template', () => {
 			it( 'has url input view', () => {
 				expect( view.template.children[ 0 ].get( 0 ) ).to.equal( view.urlInputView );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (link): Set `inputmode=url` to link balloon form input. Closes #16389.