### PR TITLE
Use `aria-describedby` instead of `aria-expanded` in docs tooltips

### DIFF
--- a/docs/_snippets/assets.js
+++ b/docs/_snippets/assets.js
@@ -75,7 +75,10 @@ window.attachTourBalloon = function( { target, text, editor, tippyOptions } ) {
 		interactive: true,
 		theme: 'light-border',
 		zIndex: 1,
-		appendTo: () => document.body
+		appendTo: () => document.body,
+		aria: {
+			content: 'describedby'
+		}
 	}, tippyOptions );
 
 	const tooltip = window.umberto.createTooltip( target, content, options );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Improve accessibility of tooltips in docs by using `aria-describedby` instead of `aria-expanded` in tooltips.

---

### Additional information

Closes https://github.com/cksource/ckeditor5-commercial/issues/6037
