### PR TITLE
[Testing] Tracking the composed range so content can be replaced while composing.

### DIFF
--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -11,6 +11,7 @@
 
 import Observer from './observer.js';
 import MutationObserver from './mutationobserver.js';
+import FocusObserver from './focusobserver.js';
 import { env } from '@ckeditor/ckeditor5-utils';
 import { debounce, type DebouncedFunc } from 'lodash-es';
 
@@ -18,7 +19,7 @@ import type View from '../view.js';
 import type DocumentSelection from '../documentselection.js';
 import type DomConverter from '../domconverter.js';
 import type Selection from '../selection.js';
-import FocusObserver from './focusobserver.js';
+import type { ViewDocumentCompositionStartEvent } from './compositionobserver.js';
 
 type DomSelection = globalThis.Selection;
 
@@ -187,6 +188,11 @@ export default class SelectionObserver extends Observer {
 			// using their mouse).
 			this._documentIsSelectingInactivityTimeoutDebounced();
 		} );
+
+		// On composition start upcast the selection, so it includes composed text to be replaced on composition end.
+		this.listenTo<ViewDocumentCompositionStartEvent>( this.view.document, 'compositionstart', () => {
+			this._handleSelectionChange( null, domDocument );
+		}, { priority: 'lowest' } );
 
 		this._documents.add( domDocument );
 	}

--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -129,7 +129,7 @@ export default class SelectionObserver extends Observer {
 
 			// Make sure that model selection is up-to-date at the end of selecting process.
 			// Sometimes `selectionchange` events could arrive after the `mouseup` event and that selection could be already outdated.
-			this._handleSelectionChange( null, domDocument );
+			this._handleSelectionChange( domDocument );
 
 			this.document.isSelecting = false;
 
@@ -178,7 +178,7 @@ export default class SelectionObserver extends Observer {
 				return;
 			}
 
-			this._handleSelectionChange( domEvent, domDocument );
+			this._handleSelectionChange( domDocument );
 
 			// @if CK_DEBUG_TYPING // if ( ( window as any ).logCKETyping ) {
 			// @if CK_DEBUG_TYPING // 	console.groupEnd();
@@ -191,7 +191,7 @@ export default class SelectionObserver extends Observer {
 
 		// On composition start upcast the selection, so it includes composed text to be replaced on composition end.
 		this.listenTo<ViewDocumentCompositionStartEvent>( this.view.document, 'compositionstart', () => {
-			this._handleSelectionChange( null, domDocument );
+			this._handleSelectionChange( domDocument );
 		}, { priority: 'lowest' } );
 
 		this._documents.add( domDocument );
@@ -228,10 +228,9 @@ export default class SelectionObserver extends Observer {
 	 * a selection changes and fires {@link module:engine/view/document~Document#event:selectionChange} event on every change
 	 * and {@link module:engine/view/document~Document#event:selectionChangeDone} when a selection stop changing.
 	 *
-	 * @param domEvent DOM event.
 	 * @param domDocument DOM document.
 	 */
-	private _handleSelectionChange( domEvent: unknown, domDocument: Document ) {
+	private _handleSelectionChange( domDocument: Document ) {
 		if ( !this.isEnabled ) {
 			return;
 		}

--- a/packages/ckeditor5-typing/src/inserttextobserver.ts
+++ b/packages/ckeditor5-typing/src/inserttextobserver.ts
@@ -128,8 +128,7 @@ export default class InsertTextObserver extends Observer {
 			//     `beforeinput` would come with just the range it's changing and we'd need to calculate that.
 			// We decided to go with the 2nd option for its simplicity and stability.
 			viewDocument.fire( 'insertText', new DomEventData( view, domEvent, {
-				text: data,
-				selection: viewDocument.selection
+				text: data
 			} ) );
 		}, { priority: 'lowest' } );
 	}

--- a/packages/ckeditor5-typing/tests/inserttextobserver.js
+++ b/packages/ckeditor5-typing/tests/inserttextobserver.js
@@ -186,7 +186,7 @@ describe( 'InsertTextObserver', () => {
 		const firstCallArgs = insertTextEventSpy.firstCall.args[ 1 ];
 
 		expect( firstCallArgs.text ).to.equal( 'bar' );
-		expect( firstCallArgs.selection.isEqual( view.document.selection ) ).to.be.true;
+		expect( firstCallArgs.selection ).to.be.undefined;
 	} );
 
 	it( 'should ignore the empty compositionend event (without any data)', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (typing, engine): Tracking the composed range so content can be replaced while composing. Closes #16106.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced text input handling in the editor to support composition start events, improving typing responsiveness and accuracy for various languages.
- **Refactor**
	- Updated event handling in the typing module to utilize specific types, enhancing performance and reliability.
- **Bug Fixes**
	- Ensured synchronous firing of the `selectionChange` event on composition start events at the lowest priority level.
	- Synchronized model and DOM selections during composition events for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->