### PR TITLE
[IME] Tracking the composed range so content can be replaced while composing

### DIFF
--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -189,7 +189,9 @@ export default class SelectionObserver extends Observer {
 			this._documentIsSelectingInactivityTimeoutDebounced();
 		} );
 
-		// On composition start upcast the selection, so it includes composed text to be replaced on composition end.
+		// Update the model DocumentSelection just after the Renderer and the SelectionObserver are locked.
+		// We do this synchronously (without waiting for the `selectionchange` DOM event) as browser updates
+		// the DOM selection (but not visually) to span the text that is under composition and could be replaced.
 		this.listenTo<ViewDocumentCompositionStartEvent>( this.view.document, 'compositionstart', () => {
 			this._handleSelectionChange( domDocument );
 		}, { priority: 'lowest' } );

--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -11,6 +11,7 @@
 
 import Observer from './observer.js';
 import MutationObserver from './mutationobserver.js';
+import FocusObserver from './focusobserver.js';
 import { env } from '@ckeditor/ckeditor5-utils';
 import { debounce, type DebouncedFunc } from 'lodash-es';
 
@@ -18,7 +19,7 @@ import type View from '../view.js';
 import type DocumentSelection from '../documentselection.js';
 import type DomConverter from '../domconverter.js';
 import type Selection from '../selection.js';
-import FocusObserver from './focusobserver.js';
+import type { ViewDocumentCompositionStartEvent } from './compositionobserver.js';
 
 type DomSelection = globalThis.Selection;
 
@@ -187,6 +188,11 @@ export default class SelectionObserver extends Observer {
 			// using their mouse).
 			this._documentIsSelectingInactivityTimeoutDebounced();
 		} );
+
+		// On composition start upcast the selection, so it includes composed text to be replaced on composition end.
+		this.listenTo<ViewDocumentCompositionStartEvent>( this.view.document, 'compositionstart', () => {
+			this._handleSelectionChange( null, domDocument );
+		}, { priority: 'lowest' } );
 
 		this._documents.add( domDocument );
 	}

--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -129,7 +129,7 @@ export default class SelectionObserver extends Observer {
 
 			// Make sure that model selection is up-to-date at the end of selecting process.
 			// Sometimes `selectionchange` events could arrive after the `mouseup` event and that selection could be already outdated.
-			this._handleSelectionChange( null, domDocument );
+			this._handleSelectionChange( domDocument );
 
 			this.document.isSelecting = false;
 
@@ -178,7 +178,7 @@ export default class SelectionObserver extends Observer {
 				return;
 			}
 
-			this._handleSelectionChange( domEvent, domDocument );
+			this._handleSelectionChange( domDocument );
 
 			// @if CK_DEBUG_TYPING // if ( ( window as any ).logCKETyping ) {
 			// @if CK_DEBUG_TYPING // 	console.groupEnd();
@@ -191,7 +191,7 @@ export default class SelectionObserver extends Observer {
 
 		// On composition start upcast the selection, so it includes composed text to be replaced on composition end.
 		this.listenTo<ViewDocumentCompositionStartEvent>( this.view.document, 'compositionstart', () => {
-			this._handleSelectionChange( null, domDocument );
+			this._handleSelectionChange( domDocument );
 		}, { priority: 'lowest' } );
 
 		this._documents.add( domDocument );
@@ -228,10 +228,9 @@ export default class SelectionObserver extends Observer {
 	 * a selection changes and fires {@link module:engine/view/document~Document#event:selectionChange} event on every change
 	 * and {@link module:engine/view/document~Document#event:selectionChangeDone} when a selection stop changing.
 	 *
-	 * @param domEvent DOM event.
 	 * @param domDocument DOM document.
 	 */
-	private _handleSelectionChange( domEvent: unknown, domDocument: Document ) {
+	private _handleSelectionChange( domDocument: Document ) {
 		if ( !this.isEnabled ) {
 			return;
 		}

--- a/packages/ckeditor5-typing/src/inserttextobserver.ts
+++ b/packages/ckeditor5-typing/src/inserttextobserver.ts
@@ -112,21 +112,10 @@ export default class InsertTextObserver extends Observer {
 			// @if CK_DEBUG_TYPING // }
 
 			// How do we know where to insert the composed text?
-			// The selection observer is blocked and the view is not updated with the composition changes.
-			// There were three options:
-			//   - Store the selection on `compositionstart` and use it now. This wouldn't work in RTC
-			//     where the view would change and the stored selection might get incorrect.
-			//     We'd need to fallback to the current view selection anyway.
-			//   - Use the current view selection. This is a bit weird and non-intuitive because
-			//     this isn't necessarily the selection on which the user started composing.
-			//     We cannot even know whether it's still collapsed (there might be some weird
-			//     editor feature that changed it in unpredictable ways for us). But it's by far
-			//     the simplest solution and should be stable (the selection is definitely correct)
-			//     and probably mostly predictable (features usually don't modify the selection
-			//     unless called explicitly by the user).
-			//   - Try to follow it from the `beforeinput` events. This would be really complex as each
-			//     `beforeinput` would come with just the range it's changing and we'd need to calculate that.
-			// We decided to go with the 2nd option for its simplicity and stability.
+			// 1. The SelectionObserver is blocked and the view is not updated with the composition changes.
+			// 2. The last moment before it's locked is the `compositionstart` event.
+			// 3. The `SelectionObserver` is listening for `compositionstart` event and immediately converts
+			//    the selection. Handles this at the lowest priority so after the rendering is blocked.
 			viewDocument.fire( 'insertText', new DomEventData( view, domEvent, {
 				text: data
 			} ) );
@@ -173,7 +162,7 @@ export interface InsertTextEventData extends DomEventData {
 	 * The selection into which the text should be inserted.
 	 * If not specified, the insertion should occur at the current view selection.
 	 */
-	selection: ViewSelection | ViewDocumentSelection;
+	selection?: ViewSelection | ViewDocumentSelection;
 
 	/**
 	 * The range that view selection should be set to after insertion.

--- a/packages/ckeditor5-typing/src/inserttextobserver.ts
+++ b/packages/ckeditor5-typing/src/inserttextobserver.ts
@@ -128,8 +128,7 @@ export default class InsertTextObserver extends Observer {
 			//     `beforeinput` would come with just the range it's changing and we'd need to calculate that.
 			// We decided to go with the 2nd option for its simplicity and stability.
 			viewDocument.fire( 'insertText', new DomEventData( view, domEvent, {
-				text: data,
-				selection: viewDocument.selection
+				text: data
 			} ) );
 		}, { priority: 'lowest' } );
 	}

--- a/packages/ckeditor5-typing/tests/inserttextobserver.js
+++ b/packages/ckeditor5-typing/tests/inserttextobserver.js
@@ -186,7 +186,7 @@ describe( 'InsertTextObserver', () => {
 		const firstCallArgs = insertTextEventSpy.firstCall.args[ 1 ];
 
 		expect( firstCallArgs.text ).to.equal( 'bar' );
-		expect( firstCallArgs.selection.isEqual( view.document.selection ) ).to.be.true;
+		expect( firstCallArgs.selection ).to.be.undefined;
 	} );
 
 	it( 'should ignore the empty compositionend event (without any data)', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (typing, engine): Predictive text should not get doubled while typing. Closes #16106.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
