### PR TITLE
Language recognition for code blocks

### DIFF
--- a/packages/ckeditor5-autoformat/src/autoformat.ts
+++ b/packages/ckeditor5-autoformat/src/autoformat.ts
@@ -192,7 +192,16 @@ export default class Autoformat extends Plugin {
 		const selection = editor.model.document.selection;
 
 		if ( editor.commands.get( 'codeBlock' ) ) {
-			blockAutoformatEditing( editor, this, /^```$/, () => {
+			blockAutoformatEditing( editor, this, /^```(\S+)\s$/, match => {
+				const blockLanguage = match.match[ 1 ];
+				if ( selection.getFirstPosition()!.parent.is( 'element', 'listItem' ) ) {
+					return false;
+				}
+				this.editor.execute( 'codeBlock', {
+					language: blockLanguage, forceValue: true }
+				);
+			} );
+			blockAutoformatEditing( editor, this, /^```\s$/, () => {
 				if ( selection.getFirstPosition()!.parent.is( 'element', 'listItem' ) ) {
 					return false;
 				}

--- a/packages/ckeditor5-autoformat/tests/autoformat.js
+++ b/packages/ckeditor5-autoformat/tests/autoformat.js
@@ -509,57 +509,57 @@ describe( 'Autoformat', () => {
 
 	describe( 'Code block', () => {
 		it( 'should replace triple grave accents with a code block', () => {
-			setData( model, '<paragraph>``[]</paragraph>' );
+			setData( model, '<paragraph>```[]</paragraph>' );
 			model.change( writer => {
-				writer.insertText( '`', doc.selection.getFirstPosition() );
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
 			} );
 
 			expect( getData( model ) ).to.equal( '<codeBlock language="plaintext">[]</codeBlock>' );
 		} );
 
 		it( 'should replace triple grave accents in a heading', () => {
-			setData( model, '<heading1>``[]</heading1>' );
+			setData( model, '<heading1>```[]</heading1>' );
 			model.change( writer => {
-				writer.insertText( '`', doc.selection.getFirstPosition() );
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
 			} );
 
 			expect( getData( model ) ).to.equal( '<codeBlock language="plaintext">[]</codeBlock>' );
 		} );
 
 		it( 'should replace triple grave accents in a non-empty paragraph', () => {
-			setData( model, '<paragraph>``[]let foo = 1;</paragraph>' );
+			setData( model, '<paragraph>```[]let foo = 1;</paragraph>' );
 			model.change( writer => {
-				writer.insertText( '`', doc.selection.getFirstPosition() );
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
 			} );
 
 			expect( getData( model ) ).to.equal( '<codeBlock language="plaintext">[]let foo = 1;</codeBlock>' );
 		} );
 
 		it( 'should not replace triple grave accents in a numbered list', () => {
-			setData( model, '<listItem listIndent="0" listType="numbered">``[]let foo = 1;</listItem>' );
+			setData( model, '<listItem listIndent="0" listType="numbered">```[]let foo = 1;</listItem>' );
 			model.change( writer => {
-				writer.insertText( '`', doc.selection.getFirstPosition() );
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
 			} );
 
-			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="numbered">```[]let foo = 1;</listItem>' );
+			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="numbered">``` []let foo = 1;</listItem>' );
 		} );
 
 		it( 'should not replace triple grave accents in a bulleted list', () => {
-			setData( model, '<listItem listIndent="0" listType="bulleted">``[]let foo = 1;</listItem>' );
+			setData( model, '<listItem listIndent="0" listType="bulleted">```[]let foo = 1;</listItem>' );
 			model.change( writer => {
-				writer.insertText( '`', doc.selection.getFirstPosition() );
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
 			} );
 
-			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="bulleted">```[]let foo = 1;</listItem>' );
+			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="bulleted">``` []let foo = 1;</listItem>' );
 		} );
 
 		it( 'should not replace triple grave accents when already in a code block', () => {
-			setData( model, '<codeBlock language="plaintext">``[]</codeBlock>' );
+			setData( model, '<codeBlock language="plaintext">```[]</codeBlock>' );
 			model.change( writer => {
-				writer.insertText( '`', doc.selection.getFirstPosition() );
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
 			} );
 
-			expect( getData( model ) ).to.equal( '<codeBlock language="plaintext">```[]</codeBlock>' );
+			expect( getData( model ) ).to.equal( '<codeBlock language="plaintext">``` []</codeBlock>' );
 		} );
 
 		it( 'should remember the last used language', () => {
@@ -571,19 +571,55 @@ describe( 'Autoformat', () => {
 
 			// Typing '```' in a single change does not trigger the autoformat feature.
 			model.change( writer => {
-				writer.insertText( '``', doc.selection.getFirstPosition() );
+				writer.insertText( '```', doc.selection.getFirstPosition() );
 			} );
 
 			model.change( writer => {
-				writer.insertText( '`', doc.selection.getFirstPosition() );
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
 			} );
 
 			expect( getData( model ) ).to.equal( '<codeBlock language="cpp">[]</codeBlock>' );
 		} );
+
+		it( 'should replace triple grave accents followed by a language with a code block of that language', () => {
+			setData( model, '<paragraph>```python[]</paragraph>' );
+			model.change( writer => {
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
+			} );
+
+			expect( getData( model ) ).to.equal( '<codeBlock language="python">[]</codeBlock>' );
+		} );
+
+		it( 'should not replace triple grave accents with language in a numbered list', () => {
+			setData( model, '<listItem listIndent="0" listType="numbered">```python[]let foo = 1;</listItem>' );
+			model.change( writer => {
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
+			} );
+
+			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="numbered">```python []let foo = 1;</listItem>' );
+		} );
+
+		it( 'should not replace triple grave accents with language in a bulleted list', () => {
+			setData( model, '<listItem listIndent="0" listType="bulleted">```python[]let foo = 1;</listItem>' );
+			model.change( writer => {
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
+			} );
+
+			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="bulleted">```python []let foo = 1;</listItem>' );
+		} );
+
+		it( 'should not replace triple grave accents with language when already in a code block', () => {
+			setData( model, '<codeBlock language="plaintext">```python[]</codeBlock>' );
+			model.change( writer => {
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
+			} );
+
+			expect( getData( model ) ).to.equal( '<codeBlock language="plaintext">```python []</codeBlock>' );
+		} );
 	} );
 
 	describe( 'Horizontal line', () => {
-		it( 'should replace three dashes with a horizontal line', () => {
+		it( 'should replace three dashes with with language a horizontal line', () => {
 			setData( model, '<paragraph>--[]</paragraph>' );
 			model.change( writer => {
 				writer.insertText( '-', doc.selection.getFirstPosition() );
@@ -613,21 +649,21 @@ describe( 'Autoformat', () => {
 		} );
 
 		it( 'should not replace triple grave accents when inside todo list', () => {
-			setData( model, '<listItem listIndent="0" listType="todo">``[]</listItem>' );
+			setData( model, '<listItem listIndent="0" listType="todo">```[]</listItem>' );
 			model.change( writer => {
-				writer.insertText( '`', doc.selection.getFirstPosition() );
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
 			} );
 
-			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="todo">```[]</listItem>' );
+			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="todo">``` []</listItem>' );
 		} );
 
 		it( 'should not replace triple grave accents when inside checked todo list', () => {
-			setData( model, '<listItem listIndent="0" listType="todo" todoListChecked="true">``[]</listItem>' );
+			setData( model, '<listItem listIndent="0" listType="todo" todoListChecked="true">```[]</listItem>' );
 			model.change( writer => {
-				writer.insertText( '`', doc.selection.getFirstPosition() );
+				writer.insertText( ' ', doc.selection.getFirstPosition() );
 			} );
 
-			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="todo" todoListChecked="true">```[]</listItem>' );
+			expect( getData( model ) ).to.equal( '<listItem listIndent="0" listType="todo" todoListChecked="true">``` []</listItem>' );
 		} );
 	} );
 

--- a/packages/ckeditor5-autoformat/tests/manual/autoformat.md
+++ b/packages/ckeditor5-autoformat/tests/manual/autoformat.md
@@ -18,7 +18,9 @@ Note: autoformat should not work in a code blocks.
 
 1. Type `~~foobar~~` to strikethrough `foobar`. `~~` should be removed.
 
-1. Type `` ``` `` in a new line to create an empty code block. `` ``` `` should be removed.
+1. Type `` ``` `` followed by a language to create an empty code block with that language. `` ```[language] `` should be removed.
+
+1. Type `` ``` `` (``` followed by any whitespace) in a new line to create an empty code block. `` ``` `` should be removed.
 
 1. Type `---` in a new line to create a horizontal line. `---` should be removed.
 


### PR DESCRIPTION
Type autoformat: Adds new autoformatting for language selection. Closes #12212 .

Type codeblock: Closes #12212 .

**Functionality Changes**
Codeblocks can no longer be created by "```" and must contain a space after the triple graves (i.e. "``` "). 

Instead of the default or the last language always being used by the shortcut, codeblocks can now be created with specific languages by adding them after the ```, such as ```python. After the name, the space will then create the block. 

If the language used is not a valid language, it will create an undefined codeblock. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the autoformatting of code blocks in the editor to support language specification directly through markdown-like syntax.
	- Improved handling of code blocks without specified languages to ensure correct formatting.
	- Updated the creation of empty code blocks to automatically remove placeholder text when initiating a new code block with language or whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->