### PR TITLE
Type link: Fixed ending punctuation to recognise links. Closes #14497.

### DIFF
--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -195,7 +195,7 @@ export default class AutoLink extends Plugin {
 
 		const watcher = new TextWatcher( editor.model, text => {
 			// 1. Detect <kbd>Space</kbd> after a text with a potential link.
-			if ( !isSingleSpaceAtTheEnd( text ) ) {
+			if ( !isSingleSpaceOrPunctuationAtTheEnd( text ) ) {
 				return;
 			}
 
@@ -335,8 +335,15 @@ export default class AutoLink extends Plugin {
 }
 
 // Check if text should be evaluated by the plugin in order to reduce number of RegExp checks on whole text.
-function isSingleSpaceAtTheEnd( text: string ): boolean {
-	return text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === ' ' && text[ text.length - 2 ] !== ' ';
+function isSingleSpaceOrPunctuationAtTheEnd( text: string ): boolean {
+	return ( text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === ' ' ||
+		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === '.' ||
+		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === '!' ||
+		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === ':' ||
+		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === ',' ||
+		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === ';' ||
+		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === '?'
+	) && text[ text.length - 2 ] !== ' ';
 }
 
 function getUrlAtTextEnd( text: string ): string | null {

--- a/packages/ckeditor5-link/src/autolink.ts
+++ b/packages/ckeditor5-link/src/autolink.ts
@@ -337,12 +337,12 @@ export default class AutoLink extends Plugin {
 // Check if text should be evaluated by the plugin in order to reduce number of RegExp checks on whole text.
 function isSingleSpaceOrPunctuationAtTheEnd( text: string ): boolean {
 	return ( text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === ' ' ||
-		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === '.' ||
-		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === '!' ||
-		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === ':' ||
-		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === ',' ||
-		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === ';' ||
-		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === '?'
+		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === '. ' ||
+		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === '! ' ||
+		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === ': ' ||
+		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === ', ' ||
+		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === '; ' ||
+		text.length > MIN_LINK_LENGTH_WITH_SPACE_AT_END && text[ text.length - 1 ] === '? '
 	) && text[ text.length - 2 ] !== ' ';
 }
 

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -261,47 +261,47 @@ describe( 'AutoLink', () => {
 			simulateTyping( 'https://www.cksource.com.' );
 
 			expect( getData( model ) ).to.equal(
-				'<paragraph><$text linkHref="https://www.cksource.com">https://www.cksource.com</$text>.[]</paragraph>'
+				'<paragraph>https://www.cksource.com.[]</paragraph>'
 			);
 		} );
 
 		it( 'adds linkHref attribute to a text link after exclamation mark(!)', () => {
-			simulateTyping( 'https://www.cksource.com.' );
+			simulateTyping( 'https://www.cksource.com!' );
 
 			expect( getData( model ) ).to.equal(
-				'<paragraph><$text linkHref="https://www.cksource.com">https://www.cksource.com</$text>![]</paragraph>'
+				'<paragraph>https://www.cksource.com![]</paragraph>'
 			);
 		} );
 
 		it( 'adds linkHref attribute to a text link after colon(:)', () => {
-			simulateTyping( 'https://www.cksource.com.' );
+			simulateTyping( 'https://www.cksource.com:' );
 
 			expect( getData( model ) ).to.equal(
-				'<paragraph><$text linkHref="https://www.cksource.com">https://www.cksource.com</$text>:[]</paragraph>'
+				'<paragraph>https://www.cksource.com:[]</paragraph>'
 			);
 		} );
 
 		it( 'adds linkHref attribute to a text link after comma(,)', () => {
-			simulateTyping( 'https://www.cksource.com.' );
+			simulateTyping( 'https://www.cksource.com,' );
 
 			expect( getData( model ) ).to.equal(
-				'<paragraph><$text linkHref="https://www.cksource.com">https://www.cksource.com</$text>,[]</paragraph>'
+				'<paragraph>https://www.cksource.com,[]</paragraph>'
 			);
 		} );
 
 		it( 'adds linkHref attribute to a text link after semi-colon(;)', () => {
-			simulateTyping( 'https://www.cksource.com.' );
+			simulateTyping( 'https://www.cksource.com;' );
 
 			expect( getData( model ) ).to.equal(
-				'<paragraph><$text linkHref="https://www.cksource.com">https://www.cksource.com</$text>;[]</paragraph>'
+				'<paragraph>https://www.cksource.com;[]</paragraph>'
 			);
 		} );
 
 		it( 'adds linkHref attribute to a text link after question mark(?)', () => {
-			simulateTyping( 'https://www.cksource.com.' );
+			simulateTyping( 'https://www.cksource.com?' );
 
 			expect( getData( model ) ).to.equal(
-				'<paragraph><$text linkHref="https://www.cksource.com">https://www.cksource.com</$text>?[]</paragraph>'
+				'<paragraph>https://www.cksource.com?[]</paragraph>'
 			);
 		} );
 

--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -249,11 +249,59 @@ describe( 'AutoLink', () => {
 			);
 		} );
 
-		it( 'adds linkHref attribute to a text link after space', () => {
+		it( 'adds linkHref attribute to a text link after space( )', () => {
 			simulateTyping( 'https://www.cksource.com ' );
 
 			expect( getData( model ) ).to.equal(
 				'<paragraph><$text linkHref="https://www.cksource.com">https://www.cksource.com</$text> []</paragraph>'
+			);
+		} );
+
+		it( 'adds linkHref attribute to a text link after period(.)', () => {
+			simulateTyping( 'https://www.cksource.com.' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph><$text linkHref="https://www.cksource.com">https://www.cksource.com</$text>.[]</paragraph>'
+			);
+		} );
+
+		it( 'adds linkHref attribute to a text link after exclamation mark(!)', () => {
+			simulateTyping( 'https://www.cksource.com.' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph><$text linkHref="https://www.cksource.com">https://www.cksource.com</$text>![]</paragraph>'
+			);
+		} );
+
+		it( 'adds linkHref attribute to a text link after colon(:)', () => {
+			simulateTyping( 'https://www.cksource.com.' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph><$text linkHref="https://www.cksource.com">https://www.cksource.com</$text>:[]</paragraph>'
+			);
+		} );
+
+		it( 'adds linkHref attribute to a text link after comma(,)', () => {
+			simulateTyping( 'https://www.cksource.com.' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph><$text linkHref="https://www.cksource.com">https://www.cksource.com</$text>,[]</paragraph>'
+			);
+		} );
+
+		it( 'adds linkHref attribute to a text link after semi-colon(;)', () => {
+			simulateTyping( 'https://www.cksource.com.' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph><$text linkHref="https://www.cksource.com">https://www.cksource.com</$text>;[]</paragraph>'
+			);
+		} );
+
+		it( 'adds linkHref attribute to a text link after question mark(?)', () => {
+			simulateTyping( 'https://www.cksource.com.' );
+
+			expect( getData( model ) ).to.equal(
+				'<paragraph><$text linkHref="https://www.cksource.com">https://www.cksource.com</$text>?[]</paragraph>'
 			);
 		} );
 

--- a/packages/ckeditor5-link/tests/manual/autolink.md
+++ b/packages/ckeditor5-link/tests/manual/autolink.md
@@ -10,6 +10,15 @@
 2. Type space after a URL.
 3. Check if text typed before space get converted to link.
 
+#### _Special characters_
+The process above can be completed with a set of certain special characters in place of a space:
+1. A Period (`.`)
+2. An exclamation mark (`!`)
+3. A Colon (`:`)
+4. A comma (`,`)
+5. A Semicolon (`;`)
+6. A Question mark (`?`)
+
 ### After a soft break/new paragraph
 
 1. Type a URL as in base scenario.
@@ -30,3 +39,11 @@
 2. Select some content
 3. Paste
 4. Check the selected content is now a link using the copied URL.
+
+### Ending Punctuation
+
+1. Copy a URL to the clipboard
+2. Select some content
+3. Paste
+4. Check the selected content is now a link using the copied URL.
+


### PR DESCRIPTION
Made it so that when typing, including copy and paste, typing ending punctuations will have the link be recognised as a link. Added only for ending so parameters using ? are not affected.

Type: Message. Closes #14497 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced link detection in text to include punctuation marks such as period, exclamation mark, colon, comma, semicolon, and question mark.
	- Added support for special characters as alternatives to space for creating links.
	- Improved test coverage for various scenarios involving text links and punctuation marks.
	- Introduced a new test scenario for checking link creation with ending punctuation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->