### PR TITLE
Feature (engine): Export `_getModelData` and `_setModelData`

### DIFF
--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -197,3 +197,9 @@ export * from './view/styles/border.js';
 export * from './view/styles/margin.js';
 export * from './view/styles/padding.js';
 export * from './view/styles/utils.js';
+
+// Development / testing utils
+export {
+	getData as _getModelData,
+	setData as _setModelData
+} from './dev-utils/model.js';

--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -201,5 +201,14 @@ export * from './view/styles/utils.js';
 // Development / testing utils.
 export {
 	getData as _getModelData,
-	setData as _setModelData
+	setData as _setModelData,
+	parse as _parseModel,
+	stringify as _stringifyModel
 } from './dev-utils/model.js';
+
+export {
+	getData as _getViewData,
+	setData as _setViewData,
+	parse as _parseView,
+	stringify as _stringifyView
+} from './dev-utils/view.js';

--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -198,7 +198,7 @@ export * from './view/styles/margin.js';
 export * from './view/styles/padding.js';
 export * from './view/styles/utils.js';
 
-// Development / testing utils
+// Development / testing utils.
 export {
 	getData as _getModelData,
 	setData as _setModelData


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (engine): Export `_getModelData`, `_setModelData`, `_parseModel`, `_stringifyModel`, `_getViewData`, `_setViewData`, `_parseView`, and `_stringifyView` helpers.

---

### Additional information

In the [Testing helpers](https://ckeditor.com/docs/ckeditor5/latest/framework/develpment-tools/testing-helpers.html) document, we show how to get the stringified version of the model using the `getData` helper. Currently, this helper is not exported from the main package entry point, so it will not be available in the new installation method. This PR adds export of `getData` and `setData` under the aliases `_getModelData` and `_setModelData`. The aliases are prefixed with `_`, because they are only meant to be used in development and testing, not in "production".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced development tools with new utilities for data handling in the editor.
	- Improved parsing and stringifying of model and view data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->