### PR TITLE
Removed the redundant operation for cleaning attributes in nested lists

### DIFF
--- a/packages/ckeditor5-html-support/src/integrations/list.ts
+++ b/packages/ckeditor5-html-support/src/integrations/list.ts
@@ -216,7 +216,7 @@ function viewToModelListAttributeConverter( attributeName: string, dataFilter: D
 
 			// Set list attributes only on same level items, those nested deeper are already handled
 			// by the recursive conversion.
-			if ( item.hasAttribute( attributeName ) ) {
+			if ( item.hasAttribute( 'htmlUlAttributes' ) || item.hasAttribute( 'htmlOlAttributes' ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (html-support): GHS list integration will no longer create a redundant operation to clean attributes in case of nested lists. Closes #16227.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of list attributes in HTML content to ensure that attributes from ancestor lists are not incorrectly applied to descendant lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->