### PR TITLE
Name, role, value accessibility fixes

### DIFF
--- a/packages/ckeditor5-minimap/src/minimapiframeview.ts
+++ b/packages/ckeditor5-minimap/src/minimapiframeview.ts
@@ -55,6 +55,7 @@ export default class MinimapIframeView extends IframeView {
 		this.extendTemplate( {
 			attributes: {
 				tabindex: -1,
+				'aria-hidden': 'true',
 				class: [
 					'ck-minimap__iframe'
 				],

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
@@ -52,6 +52,7 @@ export default class RestrictedEditingModeUI extends Plugin {
 			addListToDropdown( dropdownView, listItems );
 
 			dropdownView.buttonView.set( {
+				role: 'menu',
 				label: t( 'Navigate editable regions' ),
 				icon: lockIcon,
 				tooltip: true,

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
@@ -143,6 +143,7 @@ export default class RestrictedEditingModeUI extends Plugin {
 				withText: true,
 				keystroke,
 				withKeystroke: true,
+				role: 'menuitem',
 				_commandName: commandName
 			} )
 		};

--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmodeui.ts
@@ -49,10 +49,11 @@ export default class RestrictedEditingModeUI extends Plugin {
 				listItems.add( this._getButtonDefinition( commandName, label, keystroke ) );
 			} );
 
-			addListToDropdown( dropdownView, listItems );
+			addListToDropdown( dropdownView, listItems, {
+				role: 'menu'
+			} );
 
 			dropdownView.buttonView.set( {
-				role: 'menu',
 				label: t( 'Navigate editable regions' ),
 				icon: lockIcon,
 				tooltip: true,

--- a/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeui.js
+++ b/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeui.js
@@ -90,6 +90,7 @@ describe( 'RestrictedEditingModeUI', () => {
 				expect( button.withKeystroke ).to.be.true;
 				expect( button.label ).to.equal( 'Previous editable region' );
 				expect( button.keystroke ).to.equal( 'Shift+Tab' );
+				expect( button.role ).to.equal( 'menuitem' );
 			} );
 
 			it( 'should have one that goes forward', () => {
@@ -101,6 +102,7 @@ describe( 'RestrictedEditingModeUI', () => {
 				expect( button.withKeystroke ).to.be.true;
 				expect( button.label ).to.equal( 'Next editable region' );
 				expect( button.keystroke ).to.equal( 'Tab' );
+				expect( button.role ).to.equal( 'menuitem' );
 			} );
 
 			it( 'should focus the view after executing the command', () => {

--- a/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeui.js
+++ b/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeui.js
@@ -63,6 +63,12 @@ describe( 'RestrictedEditingModeUI', () => {
 			expect( button ).to.have.property( 'isOn', false );
 		} );
 
+		it( 'has role="menu" attribute set in items list', () => {
+			dropdown.isOpen = true;
+
+			expect( dropdown.panelView.children.first.role ).to.be.equal( 'menu' );
+		} );
+
 		describe( 'exceptions navigation buttons', () => {
 			beforeEach( () => {
 				dropdown.render();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (restricted-editing): Improved the accessibility of the restricted editing dropdown by setting the correct ARIA role on the list of menu items.

Fix (minimap): Addressed the issue of the minimap iframe being unnecessarily exposed to assistive technologies.   

---

### Additional information

Fixes https://github.com/cksource/ckeditor5-commercial/issues/6038
Commercial repo: https://github.com/cksource/ckeditor5-commercial/pull/6195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced accessibility in the editor by adding `aria-hidden` attribute to the minimap iframe.
	- Improved semantic structure in restricted editing mode by setting the dropdown button's role to 'menu'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->