### PR TITLE
Add widget ESC shortuct accessibility dialog entry

### DIFF
--- a/packages/ckeditor5-widget/lang/contexts.json
+++ b/packages/ckeditor5-widget/lang/contexts.json
@@ -8,5 +8,5 @@
 	"Insert a new paragraph directly before a widget": "Accessibility help dialog entry explaining the meaning of the keystroke that inserts a paragraph before a widget.",
 	"Move the caret to allow typing directly before a widget": "Accessibility help dialog entry explaining the meaning of the keystroke that moves the caret before a widget.",
 	"Move the caret to allow typing directly after a widget": "Accessibility help dialog entry explaining the meaning of the keystroke that moves the caret after a widget.",
-	"Move focus from nested editable back to the widget": "Accessibility help dialog entry explaining the meaning of the keystroke that moves selection from nested editable back to the parent widget."
+	"Move focus from an editable area back to the parent widget": "Accessibility help dialog entry explaining the meaning of the keystroke that moves selection from a nested editable area back to the parent widget."
 }

--- a/packages/ckeditor5-widget/lang/contexts.json
+++ b/packages/ckeditor5-widget/lang/contexts.json
@@ -7,5 +7,6 @@
 	"Insert a new paragraph directly after a widget": "Accessibility help dialog entry explaining the meaning of the keystroke that inserts a paragraph after a widget.",
 	"Insert a new paragraph directly before a widget": "Accessibility help dialog entry explaining the meaning of the keystroke that inserts a paragraph before a widget.",
 	"Move the caret to allow typing directly before a widget": "Accessibility help dialog entry explaining the meaning of the keystroke that moves the caret before a widget.",
-	"Move the caret to allow typing directly after a widget": "Accessibility help dialog entry explaining the meaning of the keystroke that moves the caret after a widget."
+	"Move the caret to allow typing directly after a widget": "Accessibility help dialog entry explaining the meaning of the keystroke that moves the caret after a widget.",
+	"Move focus from nested editable back to the widget": "Accessibility help dialog entry explaining the meaning of the keystroke that moves selection from nested editable back to the parent widget."
 }

--- a/packages/ckeditor5-widget/src/widget.ts
+++ b/packages/ckeditor5-widget/src/widget.ts
@@ -247,7 +247,7 @@ export default class Widget extends Plugin {
 			label: t( 'Keystrokes that can be used when a widget is selected (for example: image, table, etc.)' ),
 			keystrokes: [
 				{
-					label: t( 'Move focus from nested editable back to the widget' ),
+					label: t( 'Move focus from an editable area back to the parent widget' ),
 					keystroke: 'Esc'
 				},
 				{

--- a/packages/ckeditor5-widget/src/widget.ts
+++ b/packages/ckeditor5-widget/src/widget.ts
@@ -247,6 +247,10 @@ export default class Widget extends Plugin {
 			label: t( 'Keystrokes that can be used when a widget is selected (for example: image, table, etc.)' ),
 			keystrokes: [
 				{
+					label: t( 'Move focus from nested editable back to the widget' ),
+					keystroke: 'Esc'
+				},
+				{
 					label: t( 'Insert a new paragraph directly after a widget' ),
 					keystroke: 'Enter'
 				},

--- a/packages/ckeditor5-widget/tests/widget.js
+++ b/packages/ckeditor5-widget/tests/widget.js
@@ -147,7 +147,7 @@ describe( 'Widget', () => {
 		);
 
 		expect( editor.accessibility.keystrokeInfos.get( 'contentEditing' ).groups.get( 'widget' ).keystrokes ).to.deep.include( {
-			label: 'Move focus from nested editable back to the widget',
+			label: 'Move focus from an editable area back to the parent widget',
 			keystroke: 'Esc'
 		} );
 

--- a/packages/ckeditor5-widget/tests/widget.js
+++ b/packages/ckeditor5-widget/tests/widget.js
@@ -147,6 +147,11 @@ describe( 'Widget', () => {
 		);
 
 		expect( editor.accessibility.keystrokeInfos.get( 'contentEditing' ).groups.get( 'widget' ).keystrokes ).to.deep.include( {
+			label: 'Move focus from nested editable back to the widget',
+			keystroke: 'Esc'
+		} );
+
+		expect( editor.accessibility.keystrokeInfos.get( 'contentEditing' ).groups.get( 'widget' ).keystrokes ).to.deep.include( {
 			label: 'Insert a new paragraph directly after a widget',
 			keystroke: 'Enter'
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (widget): Add information in a11y dialog that it is possible to move focus from nested editable back to the widget.

---

### Additional information

Closes https://github.com/cksource/ckeditor5-commercial/issues/6040
