### PR TITLE
Add search support to dropdown menus

### DIFF
--- a/packages/ckeditor5-ui/src/button/buttonlabelwithhighlightview.ts
+++ b/packages/ckeditor5-ui/src/button/buttonlabelwithhighlightview.ts
@@ -1,0 +1,56 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module ui/button/buttonlabelwithhighlightview
+ */
+
+import type ButtonLabel from './buttonlabel.js';
+import HighlightedTextView from '../highlightedtext/highlightedtextview.js';
+
+/**
+ * A button label view that can highlight a text fragment.
+ */
+export default class ButtonLabelWithHighlightView extends HighlightedTextView implements ButtonLabel {
+	/**
+	 * @inheritDoc
+	 */
+	declare public style: string | undefined;
+
+	/**
+	 * @inheritDoc
+	 */
+	declare public text: string | undefined;
+
+	/**
+	 * @inheritDoc
+	 */
+	declare public id: string | undefined;
+
+	/**
+	 * @inheritDoc
+	 */
+	constructor() {
+		super();
+
+		this.set( {
+			style: undefined,
+			text: undefined,
+			id: undefined
+		} );
+
+		const bind = this.bindTemplate;
+
+		this.extendTemplate( {
+			attributes: {
+				class: [
+					'ck-button__label'
+				],
+				style: bind.to( 'style' ),
+				id: bind.to( 'id' )
+			}
+		} );
+	}
+}

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenulistview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenulistview.ts
@@ -12,6 +12,7 @@ import type { DropdownMenuViewsRootTree } from './tree/dropdownmenutreetypings.j
 
 import ListView from '../../list/listview.js';
 import { createTreeFromDropdownMenuView } from './tree/dropdownmenutreecreateutils.js';
+import { walkOverDropdownMenuTreeItems, type DropdownMenuViewsTreeWalkers } from './tree/dropdownmenutreewalker.js';
 
 /**
  * Represents a dropdown menu list view.
@@ -54,5 +55,14 @@ export default class DropdownMenuListView extends ListView {
 		return createTreeFromDropdownMenuView( {
 			menuItems: [ ...this.items ]
 		} );
+	}
+
+	/**
+	 * Walks over the dropdown menu views using the specified walkers.
+	 *
+	 * @param walkers The walkers to use.
+	 */
+	public walk( walkers: DropdownMenuViewsTreeWalkers ): void {
+		walkOverDropdownMenuTreeItems( walkers, this.tree );
 	}
 }

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenurootlistview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenurootlistview.ts
@@ -23,7 +23,7 @@ import { DropdownRootMenuBehaviors } from './utils/dropdownmenubehaviors.js';
 import DropdownMenuView from './dropdownmenuview.js';
 import DropdownMenuListView from './dropdownmenulistview.js';
 
-import { walkOverDropdownMenuTreeItems } from './tree/dropdownmenutreewalker.js';
+import { flattenDropdownMenuTree } from './tree/dropdownmenutreeflattenutils.js';
 
 /**
  * Represents the root list view of a dropdown menu.
@@ -154,13 +154,15 @@ export default class DropdownMenuRootListView extends DropdownMenuListView {
 		const { tree, _cachedMenus } = this;
 
 		if ( !_cachedMenus ) {
-			this._cachedMenus = [];
-
-			walkOverDropdownMenuTreeItems( node => {
+			const result = flattenDropdownMenuTree( tree ).flatMap( ( { node } ) => {
 				if ( node.type === 'Menu' ) {
-					this._cachedMenus!.push( node.menu );
+					return [ node.menu ];
 				}
-			}, tree );
+
+				return [];
+			} );
+
+			this._cachedMenus = result;
 		}
 
 		return this._cachedMenus!;
@@ -172,6 +174,17 @@ export default class DropdownMenuRootListView extends DropdownMenuListView {
 	public close(): void {
 		this.menus.forEach( menuView => {
 			menuView.isOpen = false;
+		} );
+	}
+
+	/**
+	 * Ensures that all menus are preloaded.
+	 *
+	 * 	* It's helpful used together with some search functions where menu must be preloaded before searching.
+	 */
+	public preloadAllMenus(): void {
+		this.menus.forEach( menuView => {
+			menuView.isPendingLazyInitialization = false;
 		} );
 	}
 

--- a/packages/ckeditor5-ui/src/dropdown/menu/filterview/dropdownmenulistfilteredview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/filterview/dropdownmenulistfilteredview.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Editor } from '@ckeditor/ckeditor5-core';
-import type { DropdownMenuDefinition } from '../definition/dropdownmenudefinitiontypings.js';
+import type { DropdownMenuDefinition } from '../dropdownmenufactory.js';
 import type FilteredView from '../../../search/filteredview.js';
 
 import { filterDropdownMenuTreeByRegExp, type DropdownMenuSearchResult } from '../tree/dropdownmenutreefilterutils.js';

--- a/packages/ckeditor5-ui/src/dropdown/menu/filterview/dropdownmenulistfilteredview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/filterview/dropdownmenulistfilteredview.ts
@@ -1,0 +1,136 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module ui/dropdown/menu/filterview/dropdownmenulistfilteredview
+ */
+
+import type { Editor } from '@ckeditor/ckeditor5-core';
+import type { DropdownMenuDefinition } from '../definition/dropdownmenudefinitiontypings.js';
+import type FilteredView from '../../../search/filteredview.js';
+
+import { filterDropdownMenuTreeByRegExp, type DropdownMenuSearchResult } from '../tree/dropdownmenutreefilterutils.js';
+
+import View from '../../../view.js';
+import DropdownMenuListFoundItemsView from './dropdownmenulistfounditemsview.js';
+import DropdownMenuRootListView, { type DropdownMenuRootListViewAttributes } from '../dropdownmenurootlistview.js';
+
+/**
+ * Represents a filtered view for a dropdown menu list.
+ * This class extends the `View` class and implements the `FilteredView` interface.
+ */
+export default class DropdownMenuListFilteredView extends View implements FilteredView {
+	/**
+	 * The root list view of the dropdown menu.
+	 */
+	protected _menuView: DropdownMenuRootListView;
+
+	/**
+	 * The found list view of the dropdown menu.
+	 */
+	protected _foundListView: DropdownMenuListFoundItemsView | null = null;
+
+	/**
+	 * Represents a filtered view for the dropdown menu list.
+	 */
+	constructor(
+		editor: Editor,
+		definitions: Array<DropdownMenuDefinition>,
+		menuAttributes?: DropdownMenuRootListViewAttributes
+	) {
+		super( editor.locale );
+
+		this._menuView = new DropdownMenuRootListView( editor, definitions, menuAttributes );
+		this.setTemplate( {
+			tag: 'div',
+
+			attributes: {
+				class: [
+					'ck',
+					'ck-dropdown-menu-filter'
+				],
+				tabindex: -1
+			},
+
+			children: [
+				this._menuView
+			]
+		} );
+	}
+
+	/**
+	 * The root list view of the dropdown menu.
+	 */
+	public get menuView(): DropdownMenuRootListView {
+		return this._menuView;
+	}
+
+	/**
+	 * Gets the found list view of the dropdown menu.
+	 */
+	public get foundListView(): DropdownMenuListFoundItemsView | null {
+		return this._foundListView;
+	}
+
+	/**
+	 * Filters the dropdown menu list based on the provided regular expression.
+	 *
+	 * @param regExp The regular expression to filter the list.
+	 * @returns An object containing the number of filtered results and the total number of items in the list.
+	 */
+	public filter( regExp: RegExp | null ): DropdownMenuSearchResult {
+		const { element } = this;
+
+		if ( regExp ) {
+			// Preload all menus to ensure that all items are available for filtering.
+			this._menuView.preloadAllMenus();
+		}
+
+		const { filteredTree, resultsCount, totalItemsCount } = filterDropdownMenuTreeByRegExp(
+			regExp,
+			this._menuView.tree
+		);
+
+		element!.innerHTML = '';
+
+		if ( this._foundListView ) {
+			this._foundListView.destroy();
+			this._foundListView = null;
+		}
+
+		if ( resultsCount !== totalItemsCount ) {
+			this._foundListView = new DropdownMenuListFoundItemsView( this.locale!, filteredTree, {
+				highlightRegex: regExp,
+				limitFoundItemsCount: 25
+			} );
+
+			this._menuView.close();
+			this._foundListView.render();
+
+			element!.appendChild( this._foundListView.element! );
+		} else {
+			element!.appendChild( this._menuView.element! );
+		}
+
+		return {
+			filteredTree,
+			resultsCount,
+			totalItemsCount
+		};
+	}
+
+	/**
+	 * Sets the focus on the dropdown menu list.
+	 */
+	public focus(): void {
+		const { _menuView, _foundListView } = this;
+
+		if ( _foundListView ) {
+			_foundListView.focus();
+		} else {
+			_menuView.focus();
+		}
+	}
+}

--- a/packages/ckeditor5-ui/src/dropdown/menu/filterview/dropdownmenulistfounditemsview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/filterview/dropdownmenulistfounditemsview.ts
@@ -1,0 +1,139 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module ui/dropdown/menu/filterview/dropdownmenulistfounditemsview
+ */
+
+import type { Locale } from '@ckeditor/ckeditor5-utils';
+import {
+	groupDropdownTreeByFirstFoundParent,
+	type DropdownMenusViewsFilteredFlatItem,
+	type DropdownMenusViewsFilteredTreeNode
+} from '../tree/dropdownmenutreefilterutils.js';
+
+import ButtonLabelWithHighlightView from '../../../button/buttonlabelwithhighlightview.js';
+import ButtonView from '../../../button/buttonview.js';
+import LabelWithHighlightView from '../../../label/labelwithhighlightview.js';
+import ListItemGroupView from '../../../list/listitemgroupview.js';
+import ListItemView from '../../../list/listitemview.js';
+import ListView from '../../../list/listview.js';
+
+/**
+ * Represents a view for the found list in the dropdown menu list.
+ */
+export default class DropdownMenuListFoundItemsView extends ListView {
+	/**
+	 * The maximum number of found items to display. It prevents slow rendering when there are too many items.
+	 */
+	private readonly config: FoundItemsViewRenderConfig;
+
+	/**
+	 * Creates a new instance of the DropdownMenuListFoundItemsView class.
+	 *
+	 * @param locale The locale object.
+	 * @param tree The filtered tree node.
+	 * @param config The configuration object.
+	 */
+	constructor(
+		locale: Locale,
+		tree: DropdownMenusViewsFilteredTreeNode,
+		config: FoundItemsViewRenderConfig
+	) {
+		super( locale );
+
+		this.config = config;
+		this.role = 'listbox';
+
+		const items = this._createFilteredTreeListBox( tree );
+
+		if ( items.length ) {
+			this.items.addMany( items );
+		}
+	}
+
+	/**
+	 * Creates a filtered tree list box based on the provided highlight regex and tree data.
+	 *
+	 * @param highlightRegex The regular expression used for highlighting the filtered items.
+	 * @param tree The tree data used to create the filtered tree list box.
+	 * @returns An array of ListItemGroupView or ListItemView objects representing the filtered tree list box.
+	 */
+	private _createFilteredTreeListBox(
+		tree: DropdownMenusViewsFilteredTreeNode
+	): Array<ListItemGroupView | ListItemView> {
+		const { locale, config } = this;
+		const { highlightRegex, limitFoundItemsCount } = config;
+
+		const groupedFlatEntries = groupDropdownTreeByFirstFoundParent( tree );
+
+		// Map each flat child node to a ListItemView
+		const mapFlatChildNodeToView = ( entry: DropdownMenusViewsFilteredFlatItem ): ListItemView => {
+			const listItemView = new ListItemView( locale );
+			const labelView = new ButtonLabelWithHighlightView();
+			const button = new ButtonView( locale, labelView );
+
+			button.set( {
+				label: entry.search.raw,
+				withText: true,
+				role: 'option'
+			} );
+
+			listItemView.children.add( button );
+			labelView.highlightText( highlightRegex );
+
+			button.delegate( 'execute' ).to( entry.item );
+			button.bind( 'isEnabled' ).to( entry.item, 'isEnabled' );
+
+			return listItemView;
+		};
+
+		// The total number of items rendered in the dropdown menu list.
+		let totalRenderedItems = 0;
+
+		// Create the filtered tree list box
+		return groupedFlatEntries.flatMap<ListItemGroupView | ListItemView>( ( { parent, children } ) => {
+			const listItems = children
+				.slice( 0, limitFoundItemsCount - totalRenderedItems )
+				.map( mapFlatChildNodeToView );
+
+			if ( !listItems.length ) {
+				return [];
+			}
+
+			totalRenderedItems += listItems.length;
+
+			if ( parent.type === 'Root' ) {
+				return listItems;
+			}
+
+			const labelView = new LabelWithHighlightView();
+			const groupView = new ListItemGroupView( locale, labelView );
+
+			groupView.label = parent.search.raw;
+			groupView.items.addMany( listItems );
+
+			labelView.highlightText( highlightRegex );
+
+			return [ groupView ];
+		} );
+	}
+}
+
+/**
+ * Configuration options for rendering the FoundItemsView in the DropdownMenuList.
+ */
+type FoundItemsViewRenderConfig = {
+
+	/**
+	 * A regular expression used to highlight matching items in the view. If set to `null`, highlighting will be disabled.
+	 */
+	highlightRegex: RegExp | null;
+
+	/**
+	 * The maximum number of found items to display in the view.
+	 */
+	limitFoundItemsCount: number;
+};

--- a/packages/ckeditor5-ui/src/dropdown/menu/tree/dropdownmenutreefilterutils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/tree/dropdownmenutreefilterutils.ts
@@ -1,0 +1,435 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module ui/dropdown/menu/tree/dropdownmenutreefilterutils
+ */
+
+import { cloneDeepWith } from 'lodash-es';
+
+import type {
+	DropdownMenuViewsRootTree,
+	DropdownMenuViewsTreeChildItem,
+	DropdownMenuViewsTreeFlatItem,
+	DropdownMenusViewsTreeNode,
+	ExcludeDropdownMenuViewTreeNodeByType
+} from './dropdownmenutreetypings.js';
+
+import { walkOverDropdownMenuTreeItems } from './dropdownmenutreewalker.js';
+import {
+	flattenDropdownMenuTree,
+	getTotalDropdownMenuTreeFlatItemsCount
+} from './dropdownmenutreeflattenutils.js';
+
+import View from '../../../view.js';
+
+/**
+ * Filters a dropdown menu tree by a regular expression.
+ *
+ * ```ts
+ * const tree = createTreeFromDropdownMenuView( menuView );
+ *
+ * // For null regExp, the tree should be returned as is.
+ * const { filteredTree } = filterDropdownMenuTreeByRegExp( null, tree );
+ * expect( filteredTree ).to.be.deep.equal( tree );
+ *
+ * // For a regExp matching 'menu 1', only the 'Menu 1' node should be returned.
+ * const { filteredTree: filteredTree2 } = filterDropdownMenuTreeByRegExp( /menu 1/i, tree );
+ *
+ * expect( filteredTree2 ).to.be.deep.equal( {
+ * 	type: 'Root',
+ * 	children: [
+ * 		{
+ *
+ * 			type: 'Menu',
+ * 			search: {
+ * 				raw: 'Menu 1',
+ * 				text: 'menu 1'
+ * 			},
+ * 			menu: new DropdownMenuView( ... ),
+ * 			children: [ ... ]
+ * 		}
+ * 	]
+ * } );
+ * ```
+ *
+ * @param regExp The regular expression used for filtering. If null, returns the tree with all items.
+ * @param tree The dropdown menu tree to filter.
+ * @returns The filtered dropdown menu tree.
+ */
+export const filterDropdownMenuTreeByRegExp = ( regExp: RegExp | null, tree: DropdownMenuViewsRootTree ): DropdownMenuSearchResult =>
+	filterDropdownMenuTree(
+		( { search } ) => {
+			// If no regExp provided treat every item as matching.
+			if ( !regExp ) {
+				return true;
+			}
+
+			return !!search.text.match( regExp );
+		},
+		tree
+	);
+
+/**
+ * Filters the dropdown menu tree based on the provided filter function.
+ * Returns a copy of the filtered tree and does not modify the original tree.
+ *
+ * ```ts
+ * const tree = {
+ * 	type: 'Root',
+ * 	children: [
+ * 		{
+ * 			type: 'Menu',
+ * 			search: {
+ * 				raw: 'Menu 1',
+ * 				text: 'menu 1'
+ * 			},
+ * 			menu: new DropdownMenuView( ... ),
+ * 			children: [
+ * 				{
+ * 					type: 'Item',
+ * 					search: {
+ * 						raw: 'Bread',
+ * 						text: 'bread'
+ * 					},
+ * 					item: new DropdownMenuListItemButtonView( ... )
+ * 				},
+ * 				{
+ * 					type: 'Item',
+ * 					search: {
+ * 						raw: 'Garlic',
+ * 						text: 'garlic'
+ * 					},
+ * 					item: new DropdownMenuListItemButtonView( ... )
+ * 				}
+ * 			]
+ * 		},
+ * 		{
+ * 			type: 'Menu 2',
+ * 			search: {
+ * 				raw: 'Menu 2',
+ * 				text: 'menu 2',
+ * 			},
+ * 			children: [
+ * 				// 10 entries
+ * 			]
+ * 		},
+ * 		{
+ * 			type: 'Menu 3',
+ * 			// ...
+ * 		}
+ * 	]
+ * };
+ *
+ * const filterResult = filterDropdownMenuTree(
+ * 	treeEntry => [ 'garlic', 'menu 2' ].includes( treeEntry.search.text ),
+ * 	tree
+ * );
+ *
+ * expect( filterResult ).to.deep.equal( {
+ * 	totalItemsCount: 12,
+ * 	resultsCount: 11,
+ * 	filteredTree: {
+ * 		type: 'Root',
+ * 		children: [
+ * 			{
+ * 				type: 'Menu',
+ * 				search: {
+ * 					raw: 'Menu 1',
+ * 					text: 'menu 1'
+ * 				},
+ * 				menu: new DropdownMenuView( ... ),
+ * 				children: [
+ * 					{
+ * 						type: 'Item',
+ * 						found: true,
+ * 						search: {
+ * 							raw: 'Bread',
+ * 							text: 'bread'
+ * 						},
+ * 						item: new DropdownMenuListItemButtonView( ... )
+ * 					}
+ * 				]
+ * 			},
+ * 			{
+ * 				type: 'Menu 2',
+ * 				found: true,
+ * 				search: {
+ * 					raw: 'Menu 2',
+ * 					text: 'menu 2',
+ * 				},
+ * 				children: [
+ * 					// 10 identical entries without `found` property
+ * 				]
+ * 			}
+ * 		]
+ * }
+ * } );
+ * ```
+ *
+ * @param filterFn The filter function to apply to each node in the tree.
+ * @param tree The dropdown menu tree to filter.
+ * @returns The filtered tree and the total number of searchable items in the tree.
+ */
+export function filterDropdownMenuTree(
+	filterFn: ( node: ExcludeDropdownMenuViewTreeNodeByType<'Root'> ) => boolean,
+	tree: DropdownMenuViewsRootTree
+): DropdownMenuSearchResult {
+	const clonedTree: DropdownMenusViewsFilteredTreeNode = shallowCloneDropdownMenuTree( tree );
+	const totalItemsCount = getTotalDropdownMenuTreeFlatItemsCount( clonedTree );
+
+	walkOverDropdownMenuTreeItems(
+		{
+			Menu: {
+				enter: ( { node } ) => {
+					if ( filterFn( node ) ) {
+						node.found = true;
+						return false;
+					}
+				},
+
+				leave: ( { parent, node } ) => {
+					// If there is no children left erase current menu from parent entry.
+					if ( !node.children.length ) {
+						tryRemoveDropdownMenuTreeChild( parent, node );
+					}
+				}
+			},
+			Item: ( { parent, node } ) => {
+				// Reject element from tree if not matches.
+				if ( !filterFn( node ) ) {
+					tryRemoveDropdownMenuTreeChild( parent, node );
+				} else {
+					node.found = true;
+				}
+			}
+		},
+		clonedTree
+	);
+
+	return {
+		resultsCount: getTotalDropdownMenuTreeFlatItemsCount( clonedTree ),
+		filteredTree: clonedTree,
+		totalItemsCount
+	};
+}
+
+/**
+ * Represents a type used to mark which tree items have been found.
+ */
+type WithFoundAttribute = {
+	found?: boolean;
+};
+
+/**
+ * Represents a filtered flat item in the dropdown menu views.
+ * It is a type that extends `DropdownMenuViewsTreeFlatItem` and adds the `WithFoundAttribute` attribute.
+ */
+export type DropdownMenusViewsFilteredFlatItem = DropdownMenuViewsTreeFlatItem<WithFoundAttribute>;
+
+/**
+ * Represents a filtered tree node in a dropdown menu view.
+ */
+export type DropdownMenusViewsFilteredTreeNode = DropdownMenusViewsTreeNode<WithFoundAttribute>;
+
+/**
+ * Represents the result of a dropdown menu search.
+ */
+export type DropdownMenuSearchResult = {
+
+	/**
+	 * The filtered tree containing the search results.
+	 */
+	filteredTree: DropdownMenusViewsFilteredTreeNode;
+
+	/**
+	 * The number of search results.
+	 */
+	resultsCount: number;
+
+	/**
+	 * The total number of items in the dropdown menu.
+	 */
+	totalItemsCount: number;
+};
+
+/**
+ * Creates a shallow clone of the dropdown menu tree, excluding instances of the View class.
+ *
+ * ```ts
+ * const tree = createTreeFromDropdownMenuView( menuView );
+ * const clonedTree = shallowCloneDropdownMenuTree( tree );
+ *
+ * // It clones whole tree structure but not the View instances.
+ * expect( tree ).not.to.be.deep.equal( clonedTree );
+ *
+ * // `View` reference is the same.
+ * expect( tree.children[ 0 ].menu ).to.be.instanceOf( View );
+ * expect( clonedTree.children[ 0 ].menu ).to.be.equal( tree.children[ 0 ].menu );)
+ * ```
+ *
+ * @param tree The dropdown menu tree to clone.
+ * @returns The shallow clone of the dropdown menu tree.
+ */
+export function shallowCloneDropdownMenuTree( tree: DropdownMenusViewsTreeNode ): DropdownMenusViewsTreeNode {
+	return cloneDeepWith( tree, ( element ): any => {
+		if ( typeof element === 'object' && element instanceof View ) {
+			return element;
+		}
+	} );
+}
+
+/**
+ * Tries to remove a child from a dropdown menu tree node.
+ *
+ * ```ts
+ * const tree = createTreeFromDropdownMenuView( menuView );
+ * const child = tree.children[ 0 ].children[ 0 ];
+ * const updatedTree = tryRemoveDropdownMenuTreeChild( tree.children[ 0 ], child );
+ *
+ * expect( updatedTree ).to.deep.equal( {
+ * 	type: 'Root',
+ * 	children: [
+ * 		{
+ * 			type: 'Menu',
+ * 			search: {
+ * 				raw: 'Menu 1',
+ * 				text: 'menu 1'
+ * 			},
+ * 			menu: new DropdownMenuView( ... ),
+ * 			children: [
+ * 				// First child has been removed.
+ * 			]
+ * 		}
+ * 	]
+ * } );
+ * ```
+ *
+ * @param parent The parent node. This argument will be modified.
+ * @param child The child node to be removed.
+ * @returns The updated parent node.
+ */
+export function tryRemoveDropdownMenuTreeChild<P extends DropdownMenusViewsTreeNode>(
+	parent: P,
+	child: DropdownMenuViewsTreeChildItem
+): P {
+	switch ( parent.type ) {
+		case 'Item':
+			/* NOP */
+			break;
+
+		case 'Menu':
+		case 'Root': {
+			const index = parent.children.indexOf( child );
+
+			if ( index !== -1 ) {
+				parent.children.splice( index, 1 );
+			}
+		} break;
+
+		default: {
+			const unknownNode: never = parent;
+			throw new Error( `Unknown node type! ${ unknownNode }` );
+		}
+	}
+
+	return parent;
+}
+
+/**
+ * Groups the found items and returns them as a flat list.
+ * If the parent name matches the search phrase, it groups the items under that parent.
+ * Otherwise, it takes the first parent from the edge.
+ *
+ * ```ts
+ * const tree = createTreeFromDropdownMenuView( menuView );
+ * const filteredTree = filterDropdownMenuTreeByRegExp( /menu 1/i, tree );
+ * const groupedTree = groupDropdownTreeByFirstFoundParent( filteredTree );
+ *
+ * expect( groupedTree ).to.deep.equal( [
+ * 	{
+ * 		parent: {
+ * 			type: 'Menu',
+ * 			search: {
+ * 				raw: 'Menu 1',
+ * 				text: 'menu 1'
+ * 			},
+ * 			menu: new DropdownMenuView( ... ),
+ * 			children: [ ... ]
+ * 		},
+ * 		children: [
+ * 			{
+ * 				type: 'Item',
+ * 				search: {
+ * 					raw: 'Buttom',
+ * 					text: 'button'
+ * 				},
+ * 				item: new DropdownMenuListItemButtonView( ... )
+ * 			}
+ * 		]
+ * 	},
+ * ] );
+ * ```
+ *
+ * @param tree The filtered tree of dropdown menu items.
+ * @returns An array of grouped dropdown tree entries.
+ */
+export function groupDropdownTreeByFirstFoundParent( tree: DropdownMenusViewsFilteredTreeNode ): Array<GroupedDropdownTreeFlatEntry> {
+	// Find the grouping parent based on the search results
+	const findGroupingParent = ( parents: Array<DropdownMenusViewsFilteredTreeNode> ): DropdownMenusViewsFilteredTreeNode => {
+		// Reverse the parents array and find the first parent that is marked as found
+		const maybeFirstFoundParent = [ ...parents ].reverse().find( item => item.type !== 'Root' && item.found );
+
+		// If a parent is found, return it
+		if ( maybeFirstFoundParent ) {
+			return maybeFirstFoundParent;
+		}
+
+		// If no parent is found, return the last parent from the edge
+		return parents[ parents.length - 1 ];
+	};
+
+	// Group the parents and their children based on the grouping parent
+	const groupedParents = flattenDropdownMenuTree( tree ).reduce<FoundDropdownTreeParentsItemsMap>(
+		( acc, { parents, node } ) => {
+			if ( node.type !== 'Item' ) {
+				return acc;
+			}
+
+			const groupingParent = findGroupingParent( parents );
+
+			if ( !acc.has( groupingParent ) ) {
+				acc.set( groupingParent, [ node ] );
+			} else {
+				acc.get( groupingParent )!.push( node );
+			}
+
+			return acc;
+		},
+		new Map()
+	);
+
+	// Convert the grouped parents and children into an array of GroupedDropdownTreeFlatEntry objects
+	return Array
+		.from( groupedParents )
+		.map( ( [ parent, children ] ) => ( {
+			parent,
+			children
+		} ) );
+}
+
+/**
+ * Represents a map that stores the found dropdown tree parents and their corresponding items.
+ */
+type FoundDropdownTreeParentsItemsMap = Map<DropdownMenusViewsFilteredTreeNode, Array<DropdownMenusViewsFilteredFlatItem>>;
+
+/**
+ * Represents an entry in the grouped dropdown tree.
+ * It consists of a parent node and an array of its children.
+ */
+type GroupedDropdownTreeFlatEntry = {
+	parent: DropdownMenusViewsFilteredTreeNode;
+	children: Array<DropdownMenusViewsFilteredFlatItem>;
+};

--- a/packages/ckeditor5-ui/src/dropdown/menu/tree/dropdownmenutreeflattenutils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/tree/dropdownmenutreeflattenutils.ts
@@ -1,0 +1,151 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module ui/dropdown/menu/tree/dropdownmenutreeflattenutils
+ */
+
+import type { DropdownMenusViewsTreeNode } from './dropdownmenutreetypings.js';
+
+import { walkOverDropdownMenuTreeItems } from './dropdownmenutreewalker.js';
+
+/**
+ * Flattens a dropdown menu tree into an array of flattened nodes.
+ *
+ * ```ts
+ * const tree = {
+ * 	type: 'Root',
+ * 	children: [
+ * 		{
+ * 			type: 'Menu',
+ * 			search: {
+ * 				raw: 'Menu 1',
+ * 				text: 'menu 1'
+ * 			},
+ * 			menu: new DropdownMenuView( ... ),
+ * 			children: [
+ * 				{
+ * 					type: 'Item',
+ * 					search: {
+ * 						raw: 'Buttom',
+ * 						text: 'button'
+ * 					},
+ * 					item: new DropdownMenuListItemButtonView( ... )
+ * 				}
+ * 			]
+ * 		}
+ * 	]
+ * };
+ *
+ * const flattenEntries = flattenDropdownMenuTree( tree );
+ *
+ * expect( flattenEntries ).to.deep.equal( [
+ * 	{
+ * 		parents: [ tree ]
+ * 		node: tree,
+ * 	},
+ * 	{
+ * 		parents: [ tree ],
+ * 		node: tree.children[ 0 ]
+ * 	},
+ * 	{
+ * 		parents: [ tree, tree.children[ 0 ] ],
+ * 		node: tree.children[ 0 ].children[ 0 ]
+ * 	}
+ * ] );
+ * ```
+ *
+ * @template Extend The type of additional properties that can be attached to each node.
+ * @param tree The dropdown menu tree to flatten.
+ * @returns An array of flattened nodes.
+ */
+export function flattenDropdownMenuTree<Extend>(
+	tree: DropdownMenusViewsTreeNode<Extend>
+): Array<DropdownMenusViewsTreeFlattenNode<Extend>> {
+	const flattenNodes: Array<DropdownMenusViewsTreeFlattenNode<Extend>> = [];
+
+	walkOverDropdownMenuTreeItems(
+		{
+			Default: ( { node, parents } ) => {
+				flattenNodes.push(
+					{
+						parents,
+						node
+					}
+				);
+			}
+		},
+		tree
+	);
+
+	return flattenNodes;
+}
+
+/**
+ * Represents a node in the flattened tree structure of dropdown menus views.
+ */
+type DropdownMenusViewsTreeFlattenNode<Extend = unknown> = {
+	parents: Array<DropdownMenusViewsTreeNode<Extend>>;
+	node: DropdownMenusViewsTreeNode<Extend>;
+};
+
+/**
+ * Calculates the total number of searchable button like items in a dropdown menu tree.
+ *
+ * ```ts
+ * const totalItemsCount = getTotalDropdownMenuTreeFlatItemsCount( {
+ * 	type: 'Root',
+ * 	children: [
+ * 		{
+ * 			type: 'Menu',
+ * 			search: {
+ * 				raw: 'Menu 1',
+ * 				text: 'menu 1'
+ * 			},
+ * 			menu: new DropdownMenuView( ... ),
+ * 			children: [
+ * 				{
+ * 					type: 'Item',
+ * 					search: {
+ * 						raw: 'Buttom',
+ * 						text: 'button'
+ * 					},
+ * 					item: new DropdownMenuListItemButtonView( ... )
+ * 				},
+ * 				{
+ * 					type: 'Item',
+ * 					search: {
+ * 						raw: 'Buttom 2',
+ * 						text: 'button 2'
+ * 					},
+ * 					item: new DropdownMenuListItemButtonView( ... )
+ * 				}
+ * 			]
+ * 		}
+ * 	]
+ * } );
+ *
+ * // Counts "Button 1" and "Button 2" excluding "Menu 1"
+ * expect( totalItemsCount ).to.equal( 2 )
+ * ```
+ *
+ * @template Extend The type of data associated with each tree node.
+ * @param tree The root node of the dropdown menu tree.
+ * @returns The total number of searchable items in the tree.
+ */
+export function getTotalDropdownMenuTreeFlatItemsCount<Extend>( tree: DropdownMenusViewsTreeNode<Extend> ): number {
+	let totalItemsCount = 0;
+
+	walkOverDropdownMenuTreeItems<Extend>(
+		{
+			Item: () => {
+				totalItemsCount++;
+			}
+		},
+		tree
+	);
+
+	return totalItemsCount;
+}

--- a/packages/ckeditor5-ui/src/dropdown/menu/tree/dropdownmenutreewalker.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/tree/dropdownmenutreewalker.ts
@@ -7,50 +7,128 @@
  * @module ui/dropdown/menu/tree/dropdownmenutreewalker
  */
 
-import type { DropdownMenusViewsTreeNode } from './dropdownmenutreetypings.js';
+import type { NonEmptyArray } from '@ckeditor/ckeditor5-core';
+import type {
+	DropdownMenusViewsTreeNode,
+	DropdownMenusViewsTreeNodeType,
+	ExtractDropdownMenuViewTreeNodeByType
+} from './dropdownmenutreetypings.js';
 
 /**
- * Walks over the tree of dropdown menu items and invokes the provided walker for each node.
+ * Walks over the tree of dropdown menu items and invokes the provided walkers for each node.
  *
- * @param walker The walker to be invoked for each node.
+ * ```ts
+ * const tree = createTreeFromDropdownMenuView( menuView );
+ *
+ * // Inline walker function for the `Item` node type.
+ * walkOverDropdownMenuTreeItems( {
+ * 	Item: ( { node, parents, parent } ) => {
+ * 		// Exec something after entering `Item` node.
+ * 	},
+ * }, tree );
+ *
+ * // Abort walking over the tree children.
+ * walkOverDropdownMenuTreeItems( {
+ * 	Menu: ( { node, parents, parent } ) => {
+ * 		// Do not walk through it's children.
+ * 		return false;
+ * 	},
+ * }, tree );
+ *
+ * // `enter` and `leave` functions for the `Menu` node type.
+ * walkOverDropdownMenuTreeItems( {
+ * 	Menu: {
+ * 		enter: ( { node, parents, parent } ) => {
+ * 			// Exec something after entering `Menu` node.
+ * 		},
+ * 		leave: ( { node, parents, parent } ) => {
+ * 			// Exec something after leaving `Menu` node.
+ * 		}
+ * 	}
+ * }, tree );
+ *
+ * // Default walker for all node types.
+ * walkOverDropdownMenuTreeItems( {
+ * 	Default: ( { node, parents, parent } ) => {
+ * 		// Exec something for all node types.
+ * 	}
+ * }, tree );
+ * ```
+ *
+ * @template Extend The type of additional data that can be passed to the walkers.
+ * @param walkers The walkers to be invoked for each node.
  * @param root The root node of the dropdown menu tree.
  */
-export function walkOverDropdownMenuTreeItems(
-	walker: ( node: DropdownMenusViewsTreeNode ) => void,
-	root: DropdownMenusViewsTreeNode
+export function walkOverDropdownMenuTreeItems<Extend>(
+	walkers: DropdownMenuViewsTreeWalkers<Extend>,
+	root: DropdownMenusViewsTreeNode<Extend>
 ): void {
 	// Initialize an array to keep track of parent nodes
-	const parents: Array<DropdownMenusViewsTreeNode> = [];
+	const parents: Array<DropdownMenusViewsTreeNode<Extend>> = [];
 
 	// Define a visitor function that will be called for each node
 	const visitor: DropdownMenuViewsTreeVisitor = node => {
+		// Get the walker functions for the current node type
+		const {
+			enter = () => {},
+			leave = () => {}
+		} = ( () => {
+			const walkerOrCallback = walkers[ node.type ] || walkers.Default || {};
+
+			if ( typeof walkerOrCallback === 'function' ) {
+				return {
+					enter: walkerOrCallback
+				};
+			}
+
+			return walkerOrCallback;
+		} )() as DropdownMenuViewsTreeWalker;
+
+		// Create metadata object for the current node
+		const walkerMetadata: DropdownMenuViewsTreeWalkerMetadata = {
+			parents: [ ...parents ] as any,
+			parent: ( parents[ parents.length - 1 ] || null ) as any,
+			node,
+			visitor
+		};
+
 		// Add the current node to the parents array.
 		parents.push( node );
 
 		// Call the enter function for the current node
-		walker( node );
+		const result = enter( walkerMetadata );
 
 		// Process the children of the current node based on its type
-		switch ( node.type ) {
-			case 'Item':
-				// Do not do anything. Items have no children.
-				break;
+		if ( result !== false ) {
+			switch ( node.type ) {
+				case 'Item':
+					// Do not do anything. Items have no children.
+					break;
 
-			case 'Menu':
-			case 'Root':
-				for ( let i = 0; i < node.children.length; ) {
-					const child = node.children[ i ];
+				case 'Menu':
+				case 'Root':
+					for ( let i = 0; i < node.children.length; ) {
+						const child = node.children[ i ];
 
-					// Call the visitor function for each child node
-					visitor( child );
+						// Call the visitor function for each child node
+						visitor( child );
 
-					// If the child node was not removed, increment the index
-					if ( child === node.children[ i ] ) {
-						++i;
+						// If the child node was not removed, increment the index
+						if ( child === node.children[ i ] ) {
+							++i;
+						}
 					}
+					break;
+
+				default: {
+					const unknownNode: never = node;
+					throw new Error( `Unknown node type: ${ unknownNode }` );
 				}
-				break;
+			}
 		}
+
+		// Call the leave function for the current node
+		leave( walkerMetadata );
 
 		// Remove the current node from the parents array if it's not the root node
 		parents.pop();
@@ -61,8 +139,80 @@ export function walkOverDropdownMenuTreeItems(
 }
 
 /**
+ * Metadata object for the walker function.
+ *
+ * @template K The type of dropdown menu node type.
+ * @template Extend The type of additional data that can be passed to the walkers.
+ */
+export type DropdownMenuViewsTreeWalkerMetadata<
+	T extends DropdownMenusViewsTreeNodeType = DropdownMenusViewsTreeNodeType,
+	Extend = unknown
+> =
+	& {
+		visitor: DropdownMenuViewsTreeVisitor;
+		node: ExtractDropdownMenuViewTreeNodeByType<T, Extend>;
+	}
+	& (
+		T extends 'Root' ? {
+			// The root node has no parent.
+			parents: [];
+			parent: null;
+		} : {
+			// The parent nodes and the parent node for the current node.
+			parents: NonEmptyArray<DropdownMenusViewsTreeNode<Extend>>;
+			parent: DropdownMenusViewsTreeNode<Extend>;
+		}
+	);
+
+/**
+ * Represents a tree walker for navigating through the views of a dropdown menu.
+ *
+ * @template K The type of dropdown menu views tree node type.
+ * @template Extend Additional data type for extending the tree walker.
+ */
+export type DropdownMenuViewsTreeWalker<
+	T extends DropdownMenusViewsTreeNodeType = DropdownMenusViewsTreeNodeType,
+	Extend = unknown
+> = {
+
+	/**
+	 * Function called when entering a node.
+	 *
+	 * @param entry - The metadata object for the current node.
+	 * @returns A boolean value indicating whether to continue traversing the tree.
+	 *          Returning `true` will continue to the next node, while returning `false` will stop the traversal.
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+	enter?: ( entry: DropdownMenuViewsTreeWalkerMetadata<T, Extend> ) => boolean | void;
+
+	/**
+	 * Function called when leaving a node.
+	 *
+	 * @param entry - The metadata object for the current node.
+	 */
+	leave?: ( entry: DropdownMenuViewsTreeWalkerMetadata<T, Extend> ) => void;
+};
+
+/**
  * Visitor function for the dropdown menu tree.
  *
  * @param node The current dropdown menu node.
  */
 type DropdownMenuViewsTreeVisitor = ( node: DropdownMenusViewsTreeNode ) => void;
+
+/**
+ * Object containing all the walkers for different dropdown menu node types.
+ *
+ * @template Extend The type of additional data that can be passed to the walkers.
+ */
+export type DropdownMenuViewsTreeWalkers<Extend = unknown> =
+	& {
+		[T in DropdownMenusViewsTreeNodeType]?:
+			| DropdownMenuViewsTreeWalker<T, Extend>
+			| DropdownMenuViewsTreeWalker<T, Extend>['enter'];
+	}
+	& {
+		Default?:
+			| DropdownMenuViewsTreeWalker<DropdownMenusViewsTreeNodeType, Extend>
+			| DropdownMenuViewsTreeWalker<DropdownMenusViewsTreeNodeType, Extend>['enter'];
+	};

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -24,6 +24,7 @@ export type { default as Button, ButtonExecuteEvent } from './button/button.js';
 export type { default as ButtonLabel } from './button/buttonlabel.js';
 export { default as ButtonView } from './button/buttonview.js';
 export { default as ButtonLabelView } from './button/buttonlabelview.js';
+export { default as ButtonLabelWithHighlightView } from './button/buttonlabelwithhighlightview.js';
 export { default as SwitchButtonView } from './button/switchbuttonview.js';
 export { default as ListItemButtonView } from './button/listitembuttonview.js';
 export { default as FileDialogButtonView, FileDialogListItemButtonView } from './button/filedialogbuttonview.js';
@@ -59,6 +60,7 @@ export * from './dropdown/menu/events.js';
 export { default as DropdownMenuView } from './dropdown/menu/dropdownmenuview.js';
 export { default as DropdownMenuListView } from './dropdown/menu/dropdownmenulistview.js';
 export { default as DropdownMenuListItemView } from './dropdown/menu/dropdownmenulistitemview.js';
+export { default as DropdownMenuListFilteredView } from './dropdown/menu/filterview/dropdownmenulistfilteredview.js';
 export { default as DropdownMenuListItemButtonView } from './dropdown/menu/dropdownmenulistitembuttonview.js';
 export type { DropdownMenuDefinition, DropdownMenuItemDefinition } from './dropdown/menu/dropdownmenufactory.js';
 
@@ -88,6 +90,7 @@ export { default as TextareaView, type TextareaViewUpdateEvent } from './textare
 export { default as IframeView } from './iframe/iframeview.js';
 
 export { default as LabelView } from './label/labelview.js';
+export { default as LabelWithHighlightView } from './label/labelwithhighlightview.js';
 
 export { type LabeledFieldViewCreator, default as LabeledFieldView } from './labeledfield/labeledfieldview.js';
 export * from './labeledfield/utils.js';

--- a/packages/ckeditor5-ui/src/label/labelwithhighlightview.ts
+++ b/packages/ckeditor5-ui/src/label/labelwithhighlightview.ts
@@ -1,0 +1,52 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module ui/label/labelwithhighlightview
+ */
+
+import type LabelView from './labelview.js';
+
+import { uid } from '@ckeditor/ckeditor5-utils';
+import HighlightedTextView from '../highlightedtext/highlightedtextview.js';
+
+/**
+ * A label view that can highlight a text fragment.
+ */
+export default class LabelWithHighlightView extends HighlightedTextView implements LabelView {
+	/**
+	 * @inheritDoc
+	 */
+	public readonly id: string;
+
+	/**
+	 * @inheritDoc
+	 */
+	declare public for: string | undefined;
+
+	/**
+	 * @inheritDoc
+	 */
+	constructor() {
+		super();
+
+		this.set( 'for', undefined );
+
+		const bind = this.bindTemplate;
+
+		this.id = `ck-editor__label_${ uid() }`;
+
+		this.extendTemplate( {
+			attributes: {
+				class: [
+					'ck',
+					'ck-label'
+				],
+				id: this.id,
+				for: bind.to( 'for' )
+			}
+		} );
+	}
+}

--- a/packages/ckeditor5-ui/tests/button/buttonlabelwithhighlightview.js
+++ b/packages/ckeditor5-ui/tests/button/buttonlabelwithhighlightview.js
@@ -1,0 +1,94 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import { global } from '@ckeditor/ckeditor5-utils';
+import HighlightedTextView from '../../src/highlightedtext/highlightedtextview.js';
+import ButtonLabelWithHighlightView from '../../src/button/buttonlabelwithhighlightview.js';
+
+describe( 'ButtonLabelWithHighlightView', () => {
+	let view;
+
+	beforeEach( () => {
+		view = new ButtonLabelWithHighlightView( );
+		view.render();
+
+		global.document.body.appendChild( view.element );
+	} );
+
+	afterEach( () => {
+		view.element.remove();
+		view.destroy();
+	} );
+
+	describe( 'constructor()', () => {
+		it( 'should be HighlightedTextView instance', () => {
+			expect( view ).to.be.instanceof( HighlightedTextView );
+		} );
+
+		it( 'should set initial properties as undefined', () => {
+			expect( view.style ).to.equal( undefined );
+			expect( view.text ).to.equal( undefined );
+			expect( view.id ).to.equal( undefined );
+		} );
+	} );
+
+	describe( 'default template', () => {
+		it( 'should bind view#style to template style', () => {
+			view.style = 'color: red';
+
+			expect( view.element.getAttribute( 'style' ) ).to.equal( 'color: red' );
+
+			view.style = 'color: blue';
+
+			expect( view.element.getAttribute( 'style' ) ).to.equal( 'color: blue' );
+		} );
+
+		it( 'should bind view#text to template text', () => {
+			view.text = 'Test';
+
+			expect( view.element.textContent ).to.equal( 'Test' );
+
+			view.text = undefined;
+
+			expect( view.element.textContent ).to.equal( '' );
+		} );
+
+		it( 'should bind view#id to template id', () => {
+			view.id = 'test-id';
+
+			expect( view.element.getAttribute( 'id' ) ).to.equal( 'test-id' );
+
+			view.id = 'new-id';
+
+			expect( view.element.getAttribute( 'id' ) ).to.equal( 'new-id' );
+		} );
+	} );
+
+	describe( 'Highlighting template text', () => {
+		beforeEach( () => {
+			view.text = 'Example text';
+		} );
+
+		it( 'should not highlight anything when no query is specified', () => {
+			view.highlightText( null );
+
+			expect( view.element.innerHTML ).to.equal( 'Example text' );
+		} );
+
+		it( 'should highlight the query', () => {
+			view.highlightText( new RegExp( /text/, 'ig' ) );
+
+			expect( view.element.innerHTML ).to.equal( 'Example <mark>text</mark>' );
+		} );
+
+		it( 'should highlight multiple occurences of the query', () => {
+			view.highlightText( new RegExp( /e/, 'ig' ) );
+
+			expect( view.element.innerHTML ).to.equal(
+				'<mark>E</mark>xampl<mark>e</mark> t<mark>e</mark>xt'
+			);
+		} );
+	} );
+} );

--- a/packages/ckeditor5-ui/tests/dropdown/menu/_utils/dropdowntreemenudump.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/_utils/dropdowntreemenudump.js
@@ -1,0 +1,139 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import { createTextSearchMetadata } from '../../../../src/dropdown/menu/tree/dropdownmenutreecreateutils.js';
+import { walkOverDropdownMenuTreeItems } from '../../../../src/dropdown/menu/tree/dropdownmenutreewalker.js';
+
+/**
+ * Dumps the dropdown menu tree into a string.
+ *
+ * ```ts
+ * const tree = {
+ * 	type: 'Root',
+ * 	children: [
+ * 		{
+ * 			type: 'Menu',
+ * 			search: {
+ * 				raw: 'Menu 1',
+ * 				text: 'menu 1'
+ * 			},
+ * 			menu: new DropdownMenuView( ... ),
+ * 			children: [
+ * 				{
+ * 					type: 'Item',
+ * 					search: {
+ * 						raw: 'Buttom',
+ * 						text: 'button'
+ * 					},
+ * 					item: new DropdownMenuListItemButtonView( ... )
+ * 				}
+ * 			]
+ * 		}
+ * 	]
+ * };
+ *
+ * const dump = dumpDropdownMenuTree( tree );
+ *
+ * expect( dump ).to.equal( `<Root>
+ *   <Menu 1>
+ *     <Item raw="Button" text="button" />
+ *   </Menu 1>
+ * </Root>` );
+ * ```
+ *
+ * @param tree The dropdown menu tree to dump.
+ * @returns The string representation of the dropdown menu tree.
+ */
+export function dumpDropdownMenuTree( tree ) {
+	const lines = [];
+	let lastEnteredNode = null;
+
+	const formatAttributes = attributes =>
+		Object
+			.entries( attributes )
+			.map( ( [ key, value ] ) => ` ${ key }="${ value }"` )
+			.join( '' );
+
+	walkOverDropdownMenuTreeItems( {
+		Default: {
+			enter: ( { node, parents } ) => {
+				const nesting = '  '.repeat( parents.length );
+				const attributes = node.type === 'Root' ? '' : formatAttributes( node.search );
+
+				lastEnteredNode = node;
+				lines.push( `${ nesting }<${ node.type }${ attributes }>` );
+
+				// Skip walking into not initialized menus.
+				if ( node.type === 'Menu' && node.menu.isPendingLazyInitialization ) {
+					return false;
+				}
+			},
+			leave: ( { node, parents } ) => {
+				if ( lastEnteredNode === node ) {
+					// It's self enclosing tag. Like this one: <Item />
+					lines[ lines.length - 1 ] = lines[ lines.length - 1 ].replace( />$/, ' />' );
+				} else {
+					// It's tag with children. Like this one: <Menu>...</Menu>
+					const nesting = '  '.repeat( parents.length );
+
+					lines.push( `${ nesting }</${ node.type }>` );
+				}
+			}
+		}
+	}, tree );
+
+	return lines.join( '\n' );
+}
+
+/**
+ * A collection of utility functions for creating tree dump tags.
+ */
+export const Dump = {
+	/**
+	 * Creates a root tree dump tag.
+	 */
+	root: ( children = [] ) => treeDumpTag( 'Root', {}, children ).join( '\n' ),
+
+	/**
+	 * Creates a menu tree dump tag.
+	 */
+	menu: ( text, children = [] ) => treeDumpTag(
+		'Menu',
+		createTextSearchMetadata( text ),
+		children
+	),
+
+	/**
+	 * Creates an item tree dump tag.
+	 */
+	item: text => treeDumpTag( 'Item', createTextSearchMetadata( text ) )
+};
+
+/**
+ * Generates a string representation of an HTML tag with optional attributes and children.
+ *
+ * @param name The name of the HTML tag.
+ * @param attributes Optional attributes for the HTML tag.
+ * @param children Optional children elements of the HTML tag.
+ * @returns The string representation of the HTML tag.
+ */
+function treeDumpTag( name, attributes = {}, children = [] ) {
+	const formattedAttributes = (
+		Object
+			.entries( attributes )
+			.map( ( [ key, value ] ) => ` ${ key }="${ value }"` )
+			.join( '' )
+	);
+
+	if ( !children.length ) {
+		return [ `<${ name }${ formattedAttributes } />` ];
+	}
+
+	return [
+		`<${ name }${ formattedAttributes }>`,
+		...children.flat().map( child => `  ${ child }` ),
+		`</${ name }>`
+	];
+}

--- a/packages/ckeditor5-ui/tests/dropdown/menu/_utils/dropdowntreeutils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/_utils/dropdowntreeutils.js
@@ -125,13 +125,19 @@ export function findMenuTreeItemByLabel( label, tree ) {
 export function findAllMenusTreeItemsByLabel( label, tree ) {
 	const foundMenus = [];
 
-	const lookup = node => {
-		if ( node.search && node.search.raw === label ) {
+	const lookup = ( { node } ) => {
+		if ( node.search.raw === label ) {
 			foundMenus.push( node );
 		}
 	};
 
-	walkOverDropdownMenuTreeItems( lookup, tree );
+	walkOverDropdownMenuTreeItems(
+		{
+			Item: lookup,
+			Menu: lookup
+		},
+		tree
+	);
 
 	return foundMenus;
 }

--- a/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenuview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenuview.js
@@ -13,13 +13,15 @@ import {
 	Locale
 } from '@ckeditor/ckeditor5-utils';
 
+import { createMockMenuDefinition } from './_utils/dropdowntreemock.js';
+import { Dump, dumpDropdownMenuTree } from './_utils/dropdowntreemenudump.js';
+
 import DropdownMenuButtonView from '../../../src/dropdown/menu/dropdownmenubuttonview.js';
 import DropdownMenuPanelView from '../../../src/dropdown/menu/dropdownmenupanelview.js';
 import { DropdownMenuView } from '../../../src/index.js';
 import { DropdownMenuBehaviors } from '../../../src/dropdown/menu/utils/dropdownmenubehaviors.js';
 import { DropdownMenuViewPanelPositioningFunctions } from '../../../src/dropdown/menu/utils/dropdownmenupositioningfunctions.js';
 import { DropdownMenuFactory } from '../../../src/dropdown/menu/dropdownmenufactory.js';
-import { createMockMenuDefinition } from './_utils/dropdowntreemock.js';
 
 describe( 'DropdownMenuView', () => {
 	let menuView, element, editor, parentMenuView;
@@ -273,7 +275,15 @@ describe( 'DropdownMenuView', () => {
 
 		it( 'should be possible to append menu items using factory', () => {
 			menuView.factory.appendChildren( [ createMockMenuDefinition() ] );
-			expect( menuView.listView.items.length ).to.be.equal( 1 );
+			expect( dumpDropdownMenuTree( menuView.listView.tree ) ).to.be.equal(
+				Dump.root( [
+					Dump.menu( 'Menu 1', [
+						Dump.item( 'Foo' ),
+						Dump.item( 'Bar' ),
+						Dump.item( 'Buz' )
+					] )
+				] )
+			);
 		} );
 	} );
 

--- a/packages/ckeditor5-ui/tests/dropdown/menu/filterview/dropdownmenulistfilteredview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/filterview/dropdownmenulistfilteredview.js
@@ -1,0 +1,191 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global document */
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
+import DropdownMenuRootListView from '../../../../src/dropdown/menu/dropdownmenurootlistview.js';
+import {
+	DropdownMenuListFilteredView,
+	DropdownMenuListItemButtonView } from '../../../../src/index.js';
+
+import { Dump, dumpDropdownMenuTree } from '../_utils/dropdowntreemenudump.js';
+import { createMockMenuDefinition } from '../_utils/dropdowntreemock.js';
+import { createRootTree } from '../_utils/dropdowntreeutils.js';
+
+describe( 'DropdownMenuListFilteredView', () => {
+	let locale, listView, editor, element;
+
+	beforeEach( async () => {
+		element = document.body.appendChild(
+			document.createElement( 'div' )
+		);
+
+		editor = await ClassicTestEditor.create( element );
+		locale = editor.locale;
+
+		listView = createBlankMenuListFoundItemsView();
+		listView.render();
+	} );
+
+	afterEach( async () => {
+		await editor.destroy();
+		element.remove();
+	} );
+
+	describe( 'constructor()', () => {
+		it( 'should create instance of DropdownMenuListFilteredView', () => {
+			expect( listView ).to.be.instanceOf( DropdownMenuListFilteredView );
+		} );
+
+		it( 'should assign proper CSS classes', () => {
+			expect( listView.template.attributes.class ).to.include.members( [ 'ck', 'ck-dropdown-menu-filter' ] );
+		} );
+
+		it( 'should create menu view instance', () => {
+			expect( listView._menuView ).to.be.instanceOf( DropdownMenuRootListView );
+		} );
+
+		it( 'should not create found list view instance', () => {
+			expect( listView._foundListView ).to.be.null;
+		} );
+	} );
+
+	describe( 'focus()', () => {
+		it( 'should call focus on menuView if there are no found items', () => {
+			const menuViewFocusSpy = sinon.spy( listView._menuView, 'focus' );
+
+			listView.focus();
+
+			expect( menuViewFocusSpy ).to.be.calledOnce;
+		} );
+
+		it( 'should call focus on list view if there are found items', () => {
+			appendMockedMenu();
+			listView.filter( /Garlic/gi );
+
+			const listViewFocusSpy = sinon.spy( listView._foundListView, 'focus' );
+
+			listView.focus();
+
+			expect( listViewFocusSpy ).to.be.calledOnce;
+		} );
+	} );
+
+	describe( 'foundListView getter', () => {
+		it( 'should be null initially', () => {
+			expect( listView.foundListView ).to.be.null;
+		} );
+
+		it( 'should return found list view instance', () => {
+			appendMockedMenu();
+			listView.filter( /Garlic/gi );
+
+			expect( listView.foundListView ).to.be.equal( listView._foundListView );
+			expect( listView.foundListView ).not.to.be.null;
+		} );
+	} );
+
+	describe( 'menuView getter', () => {
+		it( 'should return menu view instance', () => {
+			expect( listView.menuView ).to.be.equal( listView._menuView );
+		} );
+
+		it( 'should be possible to dump menu view using getter', () => {
+			expect( dumpDropdownMenuTree( listView.menuView.tree ) ).to.be.equal( Dump.root() );
+		} );
+
+		it( 'should be possible to append new menu items to filter view', () => {
+			appendMockedMenu();
+
+			expect( dumpDropdownMenuTree( listView.menuView.tree ) ).to.be.equal(
+				Dump.root( [
+					Dump.menu( 'Menu 1', [
+						Dump.item( 'Foo' ),
+						Dump.item( 'Bar' ),
+						Dump.item( 'Buz' )
+					] ),
+					Dump.item( 'Garlic' ),
+					Dump.item( 'Bread' )
+				] )
+			);
+		} );
+	} );
+
+	describe( 'filter()', () => {
+		it( 'should filter items in menu view', () => {
+			appendMockedMenu();
+
+			assertSearchResult( {
+				result: listView.filter( /Garlic/gi ),
+				found: 1,
+				total: 5,
+				dump: Dump.root( [
+					Dump.item( 'Garlic' )
+				] )
+			} );
+		} );
+
+		it( 'should filter items in menu view multiple times', () => {
+			appendMockedMenu();
+
+			assertSearchResult( {
+				result: listView.filter( /Garlic/gi ),
+				found: 1,
+				total: 5,
+				dump: Dump.root( [
+					Dump.item( 'Garlic' )
+				] )
+			} );
+
+			assertSearchResult( {
+				result: listView.filter( /Menu 1/gi ),
+				found: 3,
+				total: 5,
+				dump: Dump.root( [
+					Dump.menu( 'Menu 1', [
+						Dump.item( 'Foo' ),
+						Dump.item( 'Bar' ),
+						Dump.item( 'Buz' )
+					] )
+				] )
+			} );
+		} );
+
+		it( 'should reset view if all matched', () => {
+			appendMockedMenu();
+
+			listView.filter( /Garlic/gi );
+
+			expect( listView._menuView.element.parentNode ).to.be.null;
+			expect( listView._foundListView.element ).not.to.be.null;
+
+			listView.filter( /.+/gi );
+
+			expect( listView._foundListView ).to.be.null;
+			expect( listView._menuView.element.parentNode ).not.to.be.null;
+		} );
+
+		function assertSearchResult( { result, found, total, dump } ) {
+			expect( result.resultsCount ).to.be.equal( found );
+			expect( result.totalItemsCount ).to.be.equal( total );
+			expect( dumpDropdownMenuTree( result.filteredTree ) ).to.be.equal( dump );
+		}
+	} );
+
+	function createBlankMenuListFoundItemsView() {
+		return new DropdownMenuListFilteredView( editor, createRootTree() );
+	}
+
+	function appendMockedMenu() {
+		listView.menuView.factory.appendChildren(
+			[
+				createMockMenuDefinition(),
+				new DropdownMenuListItemButtonView( locale, 'Garlic' ),
+				new DropdownMenuListItemButtonView( locale, 'Bread' )
+			]
+		);
+	}
+} );

--- a/packages/ckeditor5-ui/tests/dropdown/menu/filterview/dropdownmenulistfounditemsview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/filterview/dropdownmenulistfounditemsview.js
@@ -1,0 +1,354 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global document */
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
+import DropdownMenuListFoundItemsView from '../../../../src/dropdown/menu/filterview/dropdownmenulistfounditemsview.js';
+import DropdownMenuListItemButtonView from '../../../../src/dropdown/menu/dropdownmenulistitembuttonview.js';
+import { filterDropdownMenuTreeByRegExp } from '../../../../src/dropdown/menu/tree/dropdownmenutreefilterutils.js';
+
+import { createBlankRootListView, createMockDropdownMenuDefinition } from '../_utils/dropdowntreemock.js';
+import { createRootTree } from '../_utils/dropdowntreeutils.js';
+import { dumpFoundFilteredDropdownMenuEntries } from '../_utils/dropdownmenufilterviewutils.js';
+
+describe( 'DropdownMenuListFoundItemsView', () => {
+	let locale, editor, element;
+
+	beforeEach( async () => {
+		element = document.body.appendChild(
+			document.createElement( 'div' )
+		);
+
+		editor = await ClassicTestEditor.create( element );
+		locale = editor.locale;
+	} );
+
+	afterEach( async () => {
+		await editor.destroy();
+		element.remove();
+	} );
+
+	describe( 'constructor()', () => {
+		it( 'should create instance of DropdownMenuListFoundItemsView', () => {
+			const listView = createBlankMenuListFoundItemsView();
+
+			expect( listView ).to.be.instanceOf( DropdownMenuListFoundItemsView );
+		} );
+
+		it( 'should set proper listbox role', () => {
+			const listView = createBlankMenuListFoundItemsView();
+
+			expect( listView.role ).to.be.equal( 'listbox' );
+		} );
+
+		function createBlankMenuListFoundItemsView() {
+			return new DropdownMenuListFoundItemsView( locale, createRootTree(), {
+				highlightRegex: null,
+				limitFoundItemsCount: 50
+			} );
+		}
+	} );
+
+	describe( 'list', () => {
+		it( 'should list of filtered flatten items', () => {
+			const searchRegexp = /Garlic/gi;
+			const menuRootList = createBlankRootListView( editor );
+
+			menuRootList.factory.appendChildren( [
+				new DropdownMenuListItemButtonView( locale, 'Bread' ),
+				new DropdownMenuListItemButtonView( locale, 'Garlic' )
+			] );
+
+			const { filteredTree } = filterDropdownMenuTreeByRegExp( searchRegexp, menuRootList.tree );
+			const foundItemsView = new DropdownMenuListFoundItemsView( locale, filteredTree, {
+				highlightRegex: searchRegexp,
+				limitFoundItemsCount: 50
+			} );
+
+			const renderedItems = dumpFoundFilteredDropdownMenuEntries( foundItemsView );
+
+			expect( renderedItems ).to.be.deep.equal( [
+				{
+					type: 'Item',
+					label: 'Garlic'
+				}
+			] );
+
+			menuRootList.destroy();
+		} );
+
+		it( 'should list of filtered group items', () => {
+			const searchRegexp = /buz|foo|bread/g;
+
+			const { menuRootList: { tree } } = createMockDropdownMenuDefinition( editor, [
+				new DropdownMenuListItemButtonView( locale, 'Bread' )
+			] );
+
+			const { filteredTree } = filterDropdownMenuTreeByRegExp( searchRegexp, tree );
+			const foundItemsView = new DropdownMenuListFoundItemsView( locale, filteredTree, {
+				highlightRegex: searchRegexp,
+				limitFoundItemsCount: 50
+			} );
+
+			const renderedItems = dumpFoundFilteredDropdownMenuEntries( foundItemsView );
+
+			expect( renderedItems ).to.be.deep.equal( [
+				{
+					type: 'Group',
+					label: 'Menu 1',
+					children: [
+						{
+							type: 'Item',
+							label: 'Foo'
+						},
+						{
+							type: 'Item',
+							label: 'Buz'
+						}
+					]
+				},
+				{
+					type: 'Item',
+					label: 'Bread'
+				}
+			] );
+
+			foundItemsView.destroy();
+		} );
+
+		describe( 'limits', () => {
+			it( 'should limit total amount of found items rendered in group', () => {
+				const searchRegexp = /buz|foo|bread/g;
+
+				const { menuRootList: { tree } } = createMockDropdownMenuDefinition( editor, [
+					new DropdownMenuListItemButtonView( locale, 'Bread' )
+				] );
+
+				const { filteredTree } = filterDropdownMenuTreeByRegExp( searchRegexp, tree );
+				const foundItemsView = new DropdownMenuListFoundItemsView( locale, filteredTree, {
+					limitFoundItemsCount: 1,
+					highlightRegex: searchRegexp
+				} );
+
+				const renderedItems = dumpFoundFilteredDropdownMenuEntries( foundItemsView );
+
+				expect( renderedItems ).to.be.deep.equal( [
+					{
+						type: 'Group',
+						label: 'Menu 1',
+						children: [
+							{
+								type: 'Item',
+								label: 'Foo'
+							}
+						]
+					}
+				] );
+
+				foundItemsView.destroy();
+			} );
+
+			it( 'should limit total amount of found items in flat list', () => {
+				const searchRegexp = /buz|foo|bread/g;
+
+				const { tree } = createBlankRootListView( editor, [
+					new DropdownMenuListItemButtonView( locale, 'Bread 1' ),
+					new DropdownMenuListItemButtonView( locale, 'Bread 2' ),
+					new DropdownMenuListItemButtonView( locale, 'Bread 3' ),
+					new DropdownMenuListItemButtonView( locale, 'Bread 4' )
+				] );
+
+				const { filteredTree } = filterDropdownMenuTreeByRegExp( searchRegexp, tree );
+				const foundItemsView = new DropdownMenuListFoundItemsView( locale, filteredTree, {
+					limitFoundItemsCount: 2,
+					highlightRegex: searchRegexp
+				} );
+
+				const renderedItems = dumpFoundFilteredDropdownMenuEntries( foundItemsView );
+
+				expect( renderedItems ).to.be.deep.equal( [
+					{
+						type: 'Item',
+						label: 'Bread 1'
+					},
+					{
+						type: 'Item',
+						label: 'Bread 2'
+					}
+				] );
+
+				foundItemsView.destroy();
+			} );
+		} );
+
+		describe( 'highlight', () => {
+			it( 'should highlight found flat items in root element', () => {
+				const searchRegexp = /Garlic/gi;
+				const menuRootList = createBlankRootListView( editor );
+
+				menuRootList.factory.appendChildren( [
+					new DropdownMenuListItemButtonView( locale, 'Bread' ),
+					new DropdownMenuListItemButtonView( locale, 'Garlic' ),
+					new DropdownMenuListItemButtonView( locale, 'Bear Garlic' )
+				] );
+
+				const { filteredTree } = filterDropdownMenuTreeByRegExp( searchRegexp, menuRootList.tree );
+				const foundItemsView = new DropdownMenuListFoundItemsView( locale, filteredTree, {
+					highlightRegex: searchRegexp,
+					limitFoundItemsCount: 50
+				} );
+
+				const renderedItems = dumpFoundFilteredDropdownMenuEntries( foundItemsView, { htmlLabel: true } );
+
+				expect( renderedItems ).to.be.deep.equal( [
+					{
+						type: 'Item',
+						label: '<mark>Garlic</mark>'
+					},
+					{
+						type: 'Item',
+						label: 'Bear <mark>Garlic</mark>'
+					}
+				] );
+
+				menuRootList.destroy();
+			} );
+
+			it( 'should highlight found group items in multiple groups at the same time', () => {
+				const searchRegexp = /Garlic/gi;
+				const menuRootList = createBlankRootListView( editor, [
+					{
+						menu: 'Breakfast',
+						children: [
+							new DropdownMenuListItemButtonView( locale, 'Bread' ),
+							new DropdownMenuListItemButtonView( locale, 'Garlic Onion' )
+						]
+					},
+					{
+						menu: 'Dinner',
+						children: [
+							new DropdownMenuListItemButtonView( locale, 'Hamburger' ),
+							new DropdownMenuListItemButtonView( locale, 'Garlic Tomatoes' ),
+							new DropdownMenuListItemButtonView( locale, 'Garlic Potatoes' )
+						]
+					}
+				] );
+
+				const { filteredTree } = filterDropdownMenuTreeByRegExp( searchRegexp, menuRootList.tree );
+				const foundItemsView = new DropdownMenuListFoundItemsView( locale, filteredTree, {
+					highlightRegex: searchRegexp,
+					limitFoundItemsCount: 50
+				} );
+
+				const renderedItems = dumpFoundFilteredDropdownMenuEntries( foundItemsView, { htmlLabel: true } );
+
+				expect( renderedItems ).to.be.deep.equal( [
+					{
+						type: 'Group',
+						label: 'Breakfast',
+						children: [
+							{
+								type: 'Item',
+								label: '<mark>Garlic</mark> Onion'
+							}
+						]
+					},
+					{
+						type: 'Group',
+						label: 'Dinner',
+						children: [
+							{
+								type: 'Item',
+								label: '<mark>Garlic</mark> Tomatoes'
+							},
+							{
+								type: 'Item',
+								label: '<mark>Garlic</mark> Potatoes'
+							}
+						]
+					}
+				] );
+
+				menuRootList.destroy();
+			} );
+
+			it( 'should highlight whole groups', () => {
+				const searchRegexp = /Breakfast/gi;
+				const menuRootList = createBlankRootListView( editor, [
+					{
+						menu: 'Breakfast',
+						children: [
+							new DropdownMenuListItemButtonView( locale, 'Garlic Onion' )
+						]
+					}
+				] );
+
+				const { filteredTree } = filterDropdownMenuTreeByRegExp( searchRegexp, menuRootList.tree );
+				const foundItemsView = new DropdownMenuListFoundItemsView( locale, filteredTree, {
+					highlightRegex: searchRegexp,
+					limitFoundItemsCount: 50
+				} );
+
+				const renderedItems = dumpFoundFilteredDropdownMenuEntries( foundItemsView, { htmlLabel: true } );
+
+				expect( renderedItems ).to.be.deep.equal( [
+					{
+						type: 'Group',
+						label: '<mark>Breakfast</mark>',
+						children: [
+							{
+								type: 'Item',
+								label: 'Garlic Onion'
+							}
+						]
+					}
+				] );
+
+				menuRootList.destroy();
+			} );
+
+			it( 'should highlight whole groups and their children', () => {
+				const searchRegexp = /Breakfast/gi;
+				const menuRootList = createBlankRootListView( editor, [
+					{
+						menu: 'Breakfast',
+						children: [
+							new DropdownMenuListItemButtonView( locale, 'Turbo-Breakfast' ),
+							new DropdownMenuListItemButtonView( locale, 'Garlic Onion' )
+						]
+					}
+				] );
+
+				const { filteredTree } = filterDropdownMenuTreeByRegExp( searchRegexp, menuRootList.tree );
+				const foundItemsView = new DropdownMenuListFoundItemsView( locale, filteredTree, {
+					highlightRegex: searchRegexp,
+					limitFoundItemsCount: 50
+				} );
+
+				const renderedItems = dumpFoundFilteredDropdownMenuEntries( foundItemsView, { htmlLabel: true } );
+
+				expect( renderedItems ).to.be.deep.equal( [
+					{
+						type: 'Group',
+						label: '<mark>Breakfast</mark>',
+						children: [
+							{
+								type: 'Item',
+								label: 'Turbo-<mark>Breakfast</mark>'
+							},
+							{
+								type: 'Item',
+								label: 'Garlic Onion'
+							}
+						]
+					}
+				] );
+
+				menuRootList.destroy();
+			} );
+		} );
+	} );
+} );

--- a/packages/ckeditor5-ui/tests/dropdown/menu/tree/dropdownmenutreefilterutils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/tree/dropdownmenutreefilterutils.js
@@ -1,0 +1,382 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global document */
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
+import { getTotalDropdownMenuTreeFlatItemsCount } from '../../../../src/dropdown/menu/tree/dropdownmenutreeflattenutils.js';
+import {
+	filterDropdownMenuTree,
+	filterDropdownMenuTreeByRegExp,
+	shallowCloneDropdownMenuTree,
+	tryRemoveDropdownMenuTreeChild,
+	groupDropdownTreeByFirstFoundParent
+} from '../../../../src/dropdown/menu/tree/dropdownmenutreefilterutils.js';
+
+import { createMockDropdownMenuDefinition } from '../_utils/dropdowntreemock.js';
+import {
+	createRootTree,
+	findMenuTreeItemByLabel,
+	mapButtonViewToFlatMenuTreeItem,
+	mapMenuViewToMenuTreeItemByLabel,
+	markAsFound
+} from '../_utils/dropdowntreeutils.js';
+
+describe( 'filterDropdownMenuTree', () => {
+	let editor, element;
+
+	beforeEach( async () => {
+		element = document.body.appendChild(
+			document.createElement( 'div' )
+		);
+
+		editor = await ClassicTestEditor.create( element );
+	} );
+
+	afterEach( async () => {
+		await editor.destroy();
+		element.remove();
+	} );
+
+	it( 'should return 0 found items on empty tree', () => {
+		const result = filterDropdownMenuTree( () => true, createRootTree() );
+
+		expect( result ).to.deep.equal( {
+			resultsCount: 0,
+			totalItemsCount: 0,
+			filteredTree: createRootTree()
+		} );
+	} );
+
+	it( 'should return all menu children if menu label matches', () => {
+		const { menuRootList, menusDefinitions } = createMockDropdownMenuDefinition( editor );
+		const { tree } = menuRootList;
+
+		const { resultsCount, filteredTree, totalItemsCount } = filterDropdownMenuTree(
+			node => node.search.raw === 'Menu 1',
+			tree
+		);
+
+		expect( resultsCount ).to.be.equal( 3 );
+		expect( totalItemsCount ).to.be.equal( 5 );
+		expect( filteredTree ).to.deep.equal(
+			createRootTree( [
+				markAsFound(
+					mapMenuViewToMenuTreeItemByLabel(
+						'Menu 1',
+						tree,
+						menusDefinitions[ 0 ].children.map( mapButtonViewToFlatMenuTreeItem )
+					)
+				)
+			] )
+		);
+	} );
+
+	it( 'should return child if label matches', () => {
+		const { menuRootList, menusDefinitions } = createMockDropdownMenuDefinition( editor );
+		const { tree } = menuRootList;
+
+		const { resultsCount, filteredTree, totalItemsCount } = filterDropdownMenuTree(
+			node => node.search.raw === 'Foo',
+			tree
+		);
+
+		expect( resultsCount ).to.be.equal( 1 );
+		expect( totalItemsCount ).to.be.equal( 5 );
+		expect( filteredTree ).to.deep.equal(
+			createRootTree( [
+				mapMenuViewToMenuTreeItemByLabel(
+					'Menu 1',
+					tree,
+					[
+						mapButtonViewToFlatMenuTreeItem( menusDefinitions[ 0 ].children[ 0 ] )
+					].map( markAsFound )
+				)
+			] )
+		);
+	} );
+
+	it( 'should not modify passed tree object', () => {
+		const { menuRootList } = createMockDropdownMenuDefinition( editor );
+
+		const tree = Object.freeze( menuRootList.tree );
+		const { filteredTree } = filterDropdownMenuTree(
+			node => node.search.raw === 'Foo',
+			tree
+		);
+
+		expect( filteredTree ).not.to.be.equal( tree );
+		expect( getTotalDropdownMenuTreeFlatItemsCount( filteredTree ) ).not.to.be.equal(
+			getTotalDropdownMenuTreeFlatItemsCount( tree )
+		);
+	} );
+} );
+
+describe( 'filterDropdownMenuTreeByRegExp', () => {
+	let editor, element;
+
+	beforeEach( async () => {
+		element = document.body.appendChild(
+			document.createElement( 'div' )
+		);
+
+		editor = await ClassicTestEditor.create( element );
+	} );
+
+	afterEach( async () => {
+		await editor.destroy();
+		element.remove();
+	} );
+
+	it( 'should return 0 found items on empty tree', () => {
+		const result = filterDropdownMenuTreeByRegExp( /[.*]/g, createRootTree() );
+
+		expect( result ).to.deep.equal( {
+			resultsCount: 0,
+			totalItemsCount: 0,
+			filteredTree: createRootTree()
+		} );
+	} );
+
+	it( 'should return all menu children if menu label matches', () => {
+		const { menuRootList, menusDefinitions } = createMockDropdownMenuDefinition( editor );
+		const { tree } = menuRootList;
+		const { resultsCount, filteredTree, totalItemsCount } = filterDropdownMenuTreeByRegExp(
+			/Menu 1/ig,
+			tree
+		);
+
+		expect( resultsCount ).to.be.equal( 3 );
+		expect( totalItemsCount ).to.be.equal( 5 );
+		expect( filteredTree ).to.deep.equal(
+			createRootTree( [
+				markAsFound(
+					mapMenuViewToMenuTreeItemByLabel(
+						'Menu 1',
+						tree,
+						menusDefinitions[ 0 ].children.map( mapButtonViewToFlatMenuTreeItem )
+					)
+				)
+			] )
+		);
+	} );
+
+	it( 'should return all child items if regexp is null', () => {
+		const { menuRootList, menusDefinitions } = createMockDropdownMenuDefinition( editor );
+		const { tree } = menuRootList;
+		const { resultsCount, filteredTree, totalItemsCount } = filterDropdownMenuTreeByRegExp( null, tree );
+
+		expect( resultsCount ).to.be.equal( 5 );
+		expect( totalItemsCount ).to.be.equal( 5 );
+		expect( filteredTree ).to.deep.equal(
+			createRootTree( [
+				markAsFound(
+					mapMenuViewToMenuTreeItemByLabel(
+						'Menu 1',
+						tree,
+						menusDefinitions[ 0 ].children.map( mapButtonViewToFlatMenuTreeItem )
+					)
+				),
+
+				markAsFound(
+					mapMenuViewToMenuTreeItemByLabel(
+						'Menu 2',
+						tree,
+						menusDefinitions[ 1 ].children.map( mapButtonViewToFlatMenuTreeItem )
+					)
+				)
+			] )
+		);
+	} );
+
+	it( 'should return child if label matches', () => {
+		const { menuRootList, menusDefinitions } = createMockDropdownMenuDefinition( editor );
+		const { tree } = menuRootList;
+
+		const { resultsCount, filteredTree, totalItemsCount } = filterDropdownMenuTreeByRegExp(
+			/Foo/ig,
+			tree
+		);
+
+		expect( resultsCount ).to.be.equal( 1 );
+		expect( totalItemsCount ).to.be.equal( 5 );
+		expect( filteredTree ).to.deep.equal(
+			createRootTree( [
+				mapMenuViewToMenuTreeItemByLabel(
+					'Menu 1',
+					tree,
+					[
+						mapButtonViewToFlatMenuTreeItem( menusDefinitions[ 0 ].children[ 0 ] )
+					].map( markAsFound )
+				)
+			] )
+		);
+	} );
+
+	it( 'should not modify passed tree object', () => {
+		const { menuRootList } = createMockDropdownMenuDefinition( editor );
+
+		const tree = Object.freeze( menuRootList.tree );
+		const { filteredTree } = filterDropdownMenuTreeByRegExp(
+			/Foo/gi,
+			tree
+		);
+
+		expect( filteredTree ).not.to.be.equal( tree );
+		expect( getTotalDropdownMenuTreeFlatItemsCount( filteredTree ) ).not.to.be.equal(
+			getTotalDropdownMenuTreeFlatItemsCount( tree )
+		);
+	} );
+} );
+
+describe( 'shallowCloneDropdownMenuTree', () => {
+	let editor, element;
+
+	beforeEach( async () => {
+		element = document.body.appendChild(
+			document.createElement( 'div' )
+		);
+
+		editor = await ClassicTestEditor.create( element );
+	} );
+
+	afterEach( async () => {
+		await editor.destroy();
+		element.remove();
+	} );
+
+	it( 'should clone tree with nested children (except views)', () => {
+		const { menuRootList } = createMockDropdownMenuDefinition( editor );
+
+		const tree = Object.freeze( menuRootList.tree );
+		const clonedTree = shallowCloneDropdownMenuTree( tree );
+
+		clonedTree.children.push( 2 );
+		clonedTree.children[ 0 ].children.push( 3 );
+
+		expect( clonedTree ).not.to.be.equal( tree );
+		expect( clonedTree.children[ 0 ].menu ).to.be.equal( tree.children[ 0 ].menu );
+	} );
+} );
+
+describe( 'tryRemoveDropdownMenuTreeChild', () => {
+	let editor, element;
+
+	beforeEach( async () => {
+		element = document.body.appendChild(
+			document.createElement( 'div' )
+		);
+
+		editor = await ClassicTestEditor.create( element );
+	} );
+
+	afterEach( async () => {
+		await editor.destroy();
+		element.remove();
+	} );
+
+	it( 'should remove menu child from root node', () => {
+		const { menuRootList } = createMockDropdownMenuDefinition( editor );
+		const { tree } = menuRootList;
+		const [ child ] = tree.children;
+
+		const resultTree = tryRemoveDropdownMenuTreeChild( tree, child );
+
+		expect( tree ).to.be.equal( resultTree );
+		expect( tree.children ).not.to.contain( child );
+	} );
+
+	it( 'should remove menu child from menu node', () => {
+		const { menuRootList } = createMockDropdownMenuDefinition( editor );
+		const { tree } = menuRootList;
+
+		const [ parent ] = tree.children;
+		const [ child ] = parent.children;
+
+		tryRemoveDropdownMenuTreeChild( parent, child );
+		expect( parent.children ).not.to.contain( child );
+	} );
+
+	it( 'should do do nothing on item entry', () => {
+		const { menuRootList } = createMockDropdownMenuDefinition( editor );
+		const { tree } = menuRootList;
+
+		const [ parent ] = tree.children;
+		const [ child ] = parent.children;
+
+		expect( () => {
+			tryRemoveDropdownMenuTreeChild( child, null );
+		} ).not.to.throw();
+	} );
+
+	it( 'should throw on unknown entry', () => {
+		expect( () => {
+			tryRemoveDropdownMenuTreeChild( {}, null );
+		} ).to.throw();
+	} );
+} );
+
+describe( 'groupDropdownTreeByFirstFoundParent', () => {
+	let editor, element;
+
+	beforeEach( async () => {
+		element = document.body.appendChild(
+			document.createElement( 'div' )
+		);
+
+		editor = await ClassicTestEditor.create( element );
+	} );
+
+	afterEach( async () => {
+		await editor.destroy();
+		element.remove();
+	} );
+
+	it( 'should return 0 results if passed empty tree', () => {
+		const result = groupDropdownTreeByFirstFoundParent( createRootTree() );
+
+		expect( result ).to.be.deep.equal( [] );
+	} );
+
+	it( 'should all children of menu entry if it\'s marked as found', () => {
+		const { groupedList, byLabel } = filterByRegExpMock( /Menu 1/gi );
+
+		expect( groupedList ).to.deep.equal(
+			[
+				{
+					parent: byLabel( 'Menu 1' ),
+					children: [ byLabel( 'Foo' ), byLabel( 'Bar' ), byLabel( 'Buz' ) ]
+				}
+			]
+		);
+	} );
+
+	it( 'should return matching flat item child', () => {
+		const { groupedList, byLabel } = filterByRegExpMock( /Buz/gi );
+
+		expect( groupedList ).to.deep.equal(
+			[
+				{
+					parent: byLabel( 'Menu 1' ),
+					children: [ byLabel( 'Buz' ) ]
+				}
+			]
+		);
+	} );
+
+	function filterByRegExpMock( regexp ) {
+		const { menuRootList: { tree } } = createMockDropdownMenuDefinition( editor );
+		const { filteredTree } = filterDropdownMenuTreeByRegExp( regexp, tree );
+
+		const byLabel = label => findMenuTreeItemByLabel( label, filteredTree );
+		const groupedList = groupDropdownTreeByFirstFoundParent( filteredTree );
+
+		return {
+			filteredTree,
+			groupedList,
+			byLabel
+		};
+	}
+} );

--- a/packages/ckeditor5-ui/tests/dropdown/menu/tree/dropdownmenutreeflattenutils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/tree/dropdownmenutreeflattenutils.js
@@ -1,0 +1,121 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global document */
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
+import {
+	flattenDropdownMenuTree,
+	getTotalDropdownMenuTreeFlatItemsCount
+} from '../../../../src/dropdown/menu/tree/dropdownmenutreeflattenutils.js';
+
+import { createRootTree, findMenuTreeItemByLabel } from '../_utils/dropdowntreeutils.js';
+import {
+	createBlankRootListView,
+	createMockDropdownMenuDefinition
+} from '../_utils/dropdowntreemock.js';
+
+describe( 'flattenDropdownMenuTree', () => {
+	let editor, element;
+
+	beforeEach( async () => {
+		element = document.body.appendChild(
+			document.createElement( 'div' )
+		);
+
+		editor = await ClassicTestEditor.create( element );
+	} );
+
+	afterEach( async () => {
+		await editor.destroy();
+		element.remove();
+	} );
+
+	it( 'should return only root tree if passed empty tree', () => {
+		const { tree } = createBlankRootListView( editor );
+		const flatten = flattenDropdownMenuTree( tree );
+
+		expect( flatten ).to.deep.equal( [
+			{
+				parents: [],
+				node: tree
+			}
+		] );
+	} );
+
+	it( 'should return flatten list of nodes with parents', () => {
+		const { menuRootList: { tree } } = createMockDropdownMenuDefinition( editor );
+		const flatten = flattenDropdownMenuTree( tree );
+
+		const byLabel = label => findMenuTreeItemByLabel( label, tree );
+
+		expect( flatten ).to.deep.equal(
+			[
+				{
+					parents: [],
+					node: tree
+				},
+				{
+					parents: [ tree ],
+					node: byLabel( 'Menu 1' )
+				},
+				{
+					parents: [ tree, byLabel( 'Menu 1' ) ],
+					node: byLabel( 'Foo' )
+				},
+				{
+					parents: [ tree, byLabel( 'Menu 1' ) ],
+					node: byLabel( 'Bar' )
+				},
+				{
+					parents: [ tree, byLabel( 'Menu 1' ) ],
+					node: byLabel( 'Buz' )
+				},
+				{
+					parents: [ tree ],
+					node: byLabel( 'Menu 2' )
+				},
+				{
+					parents: [ tree, byLabel( 'Menu 2' ) ],
+					node: byLabel( 'A' )
+				},
+				{
+					parents: [ tree, byLabel( 'Menu 2' ) ],
+					node: byLabel( 'B' )
+				}
+			]
+		);
+	} );
+} );
+
+describe( 'getTotalDropdownMenuTreeFlatItemsCount', () => {
+	let editor, element;
+
+	beforeEach( async () => {
+		element = document.body.appendChild(
+			document.createElement( 'div' )
+		);
+
+		editor = await ClassicTestEditor.create( element );
+	} );
+
+	afterEach( async () => {
+		await editor.destroy();
+		element.remove();
+	} );
+
+	it( 'should return 0 results if passed empty tree', () => {
+		const result = getTotalDropdownMenuTreeFlatItemsCount( createRootTree() );
+
+		expect( result ).to.be.equal( 0 );
+	} );
+
+	it( 'should return proper flat items count', () => {
+		const { menuRootList: { tree } } = createMockDropdownMenuDefinition( editor );
+		const result = getTotalDropdownMenuTreeFlatItemsCount( tree );
+
+		expect( result ).to.be.equal( 5 );
+	} );
+} );

--- a/packages/ckeditor5-ui/tests/dropdown/menu/tree/dropdownmenutreewalker.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/tree/dropdownmenutreewalker.js
@@ -1,0 +1,179 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* global document */
+
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
+import { walkOverDropdownMenuTreeItems } from '../../../../src/dropdown/menu/tree/dropdownmenutreewalker.js';
+
+import { createMockDropdownMenuDefinition } from '../_utils/dropdowntreemock.js';
+import { createRootTree } from '../_utils/dropdowntreeutils.js';
+
+describe( 'walkOverDropdownMenuTreeItems', () => {
+	let element, editor;
+
+	beforeEach( async () => {
+		element = document.createElement( 'div' );
+		document.body.appendChild( element );
+		editor = await ClassicTestEditor.create( element );
+	} );
+
+	afterEach( async () => {
+		await editor.destroy();
+		element.remove();
+	} );
+
+	it( 'should not crash if passed blank tree', () => {
+		const tree = createRootTree();
+
+		expect( () => {
+			walkOverDropdownMenuTreeItems( {}, tree );
+		} ).not.to.throw();
+	} );
+
+	it( 'should walk through tree in correct order', () => {
+		const { menuRootList } = createMockDropdownMenuDefinition( editor );
+		const { tree } = menuRootList;
+
+		const tracking = {
+			entered: [],
+			left: []
+		};
+
+		const trackedWalkers = {
+			enter: ( { node } ) => {
+				tracking.entered.push( node.search.raw );
+			},
+			leave: ( { node } ) => {
+				tracking.left.unshift( node.search.raw );
+			}
+		};
+
+		walkOverDropdownMenuTreeItems(
+			{
+				Item: trackedWalkers,
+				Menu: trackedWalkers
+			},
+			tree
+		);
+
+		expect( tracking.entered ).to.be.deep.equal( [
+			'Menu 1', 'Foo', 'Bar', 'Buz', 'Menu 2', 'A', 'B'
+		] );
+
+		expect( tracking.left ).to.be.deep.equal( [
+			'Menu 2', 'B', 'A', 'Menu 1', 'Buz', 'Bar', 'Foo'
+		] );
+	} );
+
+	it( 'should be possible to pass walker inline enter function', () => {
+		const { menuRootList } = createMockDropdownMenuDefinition( editor );
+		const { tree } = menuRootList;
+
+		const entered = [];
+		const trackedWalkers = ( { node } ) => {
+			entered.push( node.search.raw );
+		};
+
+		walkOverDropdownMenuTreeItems(
+			{
+				Item: trackedWalkers,
+				Menu: trackedWalkers
+			},
+			tree
+		);
+
+		expect( entered ).to.be.deep.equal( [
+			'Menu 1', 'Foo', 'Bar', 'Buz', 'Menu 2', 'A', 'B'
+		] );
+	} );
+
+	it( 'default walker should walk through tree in correct order', () => {
+		const { menuRootList } = createMockDropdownMenuDefinition( editor );
+		const { tree } = menuRootList;
+
+		const tracking = {
+			entered: [],
+			left: []
+		};
+
+		const trackedWalkers = {
+			enter: ( { node } ) => {
+				tracking.entered.push(
+					node.type === 'Root' ? 'Root' : node.search.raw
+				);
+			},
+			leave: ( { node } ) => {
+				tracking.left.unshift(
+					node.type === 'Root' ? 'Root' : node.search.raw
+				);
+			}
+		};
+
+		walkOverDropdownMenuTreeItems(
+			{
+				Item: trackedWalkers,
+				Default: trackedWalkers
+			},
+			tree
+		);
+
+		expect( tracking.entered ).to.be.deep.equal( [
+			'Root', 'Menu 1', 'Foo', 'Bar', 'Buz', 'Menu 2', 'A', 'B'
+		] );
+
+		expect( tracking.left ).to.be.deep.equal( [
+			'Root', 'Menu 2', 'B', 'A', 'Menu 1', 'Buz', 'Bar', 'Foo'
+		] );
+	} );
+
+	it( 'should abort walking to children in node if enter returns false', () => {
+		const { menuRootList } = createMockDropdownMenuDefinition( editor );
+		const { tree } = menuRootList;
+
+		const tracking = {
+			entered: [],
+			left: []
+		};
+
+		const trackedWalkers = {
+			enter: ( { node } ) => {
+				tracking.entered.push( node.search.raw );
+
+				if ( node.search.raw === 'Menu 2' ) {
+					return false;
+				}
+			},
+			leave: ( { node } ) => {
+				tracking.left.unshift( node.search.raw );
+			}
+		};
+
+		walkOverDropdownMenuTreeItems(
+			{
+				Item: trackedWalkers,
+				Menu: trackedWalkers
+			},
+			tree
+		);
+
+		expect( tracking.entered ).to.be.deep.equal( [
+			'Menu 1', 'Foo', 'Bar', 'Buz', 'Menu 2'
+		] );
+
+		expect( tracking.left ).to.be.deep.equal( [
+			'Menu 2', 'Menu 1', 'Buz', 'Bar', 'Foo'
+		] );
+	} );
+
+	it( 'should raise exception on unknown node', () => {
+		expect( () => {
+			walkOverDropdownMenuTreeItems(
+				{},
+				createRootTree( [ {} ] )
+			);
+		} ).to.throw();
+	} );
+} );

--- a/packages/ckeditor5-ui/tests/label/labelwithhighlightview.js
+++ b/packages/ckeditor5-ui/tests/label/labelwithhighlightview.js
@@ -1,0 +1,97 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import { global } from '@ckeditor/ckeditor5-utils';
+import HighlightedTextView from '../../src/highlightedtext/highlightedtextview.js';
+import LabelWithHighlightView from '../../src/label/labelwithhighlightview.js';
+
+describe( 'LabelWithHighlightView', () => {
+	let view;
+
+	beforeEach( () => {
+		view = new LabelWithHighlightView( );
+		view.render();
+
+		global.document.body.appendChild( view.element );
+	} );
+
+	afterEach( () => {
+		view.element.remove();
+		view.destroy();
+	} );
+
+	describe( 'constructor()', () => {
+		it( 'should be HighlightedTextView instance', () => {
+			expect( view ).to.be.instanceof( HighlightedTextView );
+		} );
+
+		it( 'should set initial properties', () => {
+			expect( view.text ).to.equal( undefined );
+			expect( view.for ).to.equal( undefined );
+			expect( view.id ).to.match( /^ck-editor__label_.+/g );
+		} );
+	} );
+
+	describe( 'default template', () => {
+		it( 'should define element name and CSS classes', () => {
+			expect( view.element.tagName ).to.equal( 'SPAN' );
+			expect( view.element.classList.contains( 'ck' ) ).to.be.true;
+			expect( view.element.classList.contains( 'ck-label' ) ).to.be.true;
+		} );
+
+		it( 'should bind view#text to template text', () => {
+			view.text = 'Test';
+
+			expect( view.element.textContent ).to.equal( 'Test' );
+
+			view.text = undefined;
+
+			expect( view.element.textContent ).to.equal( '' );
+		} );
+
+		describe( 'for attribute', () => {
+			it( 'should react on view#for', () => {
+				view.for = 'bar';
+
+				expect( view.element.getAttribute( 'for' ) ).to.equal( 'bar' );
+
+				view.for = 'baz';
+
+				expect( view.element.getAttribute( 'for' ) ).to.equal( 'baz' );
+			} );
+		} );
+
+		it( 'should set view#id to template id', () => {
+			expect( view.element.id ).to.equal( view.id );
+			expect( view.element.id ).to.match( /^ck-editor__label_.+/ );
+		} );
+	} );
+
+	describe( 'Highlighting template text', () => {
+		beforeEach( () => {
+			view.text = 'Example text';
+		} );
+
+		it( 'should not highlight anything when no query is specified', () => {
+			view.highlightText( null );
+
+			expect( view.element.innerHTML ).to.equal( 'Example text' );
+		} );
+
+		it( 'should highlight the query', () => {
+			view.highlightText( new RegExp( /text/, 'ig' ) );
+
+			expect( view.element.innerHTML ).to.equal( 'Example <mark>text</mark>' );
+		} );
+
+		it( 'should highlight multiple occurences of the query', () => {
+			view.highlightText( new RegExp( /e/, 'ig' ) );
+
+			expect( view.element.innerHTML ).to.equal(
+				'<mark>E</mark>xampl<mark>e</mark> t<mark>e</mark>xt'
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
Feature (ui): Add search support to dropdown menus.

Part of https://github.com/ckeditor/ckeditor5/issues/16311.

---

### Related PRs

Focus change PR: https://github.com/ckeditor/ckeditor5/pull/16642
Base dropdown component PR: https://github.com/ckeditor/ckeditor5/pull/16631
AI integration PR: https://github.com/cksource/ckeditor5-commercial/pull/6213

### Screens

![Menu](https://github.com/ckeditor/ckeditor5/assets/3949262/cd9f319b-d00b-41c2-896c-0de58c5c52ac)
![Search](https://github.com/ckeditor/ckeditor5/assets/3949262/d67b6f19-210a-4380-bc11-724cb19ca640)

### Further context

This PR adds search input to whole dropdown menus implementation. It reduced the size of main PR.