### PR TITLE
Mark mixin calls as pure

### DIFF
--- a/packages/ckeditor5-cloud-services/src/token/token.ts
+++ b/packages/ckeditor5-cloud-services/src/token/token.ts
@@ -19,7 +19,7 @@ const DEFAULT_TOKEN_REFRESH_TIMEOUT_TIME = 3600000;
  * Class representing the token used for communication with CKEditor Cloud Services.
  * Value of the token is retrieving from the specified URL and is refreshed every 1 hour by default.
  */
-export default class Token extends ObservableMixin() {
+export default class Token extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * Value of the token.
 	 * The value of the token is undefined if `initValue` is not provided or `init` method was not called.

--- a/packages/ckeditor5-cloud-services/src/uploadgateway/fileuploader.ts
+++ b/packages/ckeditor5-cloud-services/src/uploadgateway/fileuploader.ts
@@ -18,7 +18,7 @@ const BASE64_HEADER_REG_EXP = /^data:(\S*?);base64,/;
 /**
  * FileUploader class used to upload single file.
  */
-export default class FileUploader extends EmitterMixin() {
+export default class FileUploader extends /* #__PURE__ */ EmitterMixin() {
 	/**
 	 * A file that is being uploaded.
 	 */

--- a/packages/ckeditor5-core/src/command.ts
+++ b/packages/ckeditor5-core/src/command.ts
@@ -30,7 +30,7 @@ import type Editor from './editor/editor.js';
  * By default, commands are disabled when the editor is in the {@link module:core/editor/editor~Editor#isReadOnly read-only} mode
  * but commands with the {@link module:core/command~Command#affectsData `affectsData`} flag set to `false` will not be disabled.
  */
-export default class Command extends ObservableMixin() {
+export default class Command extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * The editor on which this command will be used.
 	 */

--- a/packages/ckeditor5-core/src/contextplugin.ts
+++ b/packages/ckeditor5-core/src/contextplugin.ts
@@ -35,7 +35,7 @@ import type PluginCollection from './plugincollection.js';
  * * An {@link module:core/plugin~Plugin editor plugin} can require a context plugin.
  * * A context plugin MUST NOT require an {@link module:core/plugin~Plugin editor plugin}.
  */
-export default class ContextPlugin extends ObservableMixin() implements PluginInterface {
+export default class ContextPlugin extends /* #__PURE__ */ ObservableMixin() implements PluginInterface {
 	/**
 	 * The context or editor instance.
 	 */

--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -53,7 +53,7 @@ import type { EditorConfig } from './editorconfig.js';
  * the specific editor implements also the {@link ~Editor#ui} property
  * (as most editor implementations do).
  */
-export default abstract class Editor extends ObservableMixin() {
+export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * A namespace for the accessibility features of the editor.
 	 */

--- a/packages/ckeditor5-core/src/plugin.ts
+++ b/packages/ckeditor5-core/src/plugin.ts
@@ -16,7 +16,7 @@ import type Editor from './editor/editor.js';
 /**
  * The base class for CKEditor plugin classes.
  */
-export default class Plugin extends ObservableMixin() implements PluginInterface {
+export default class Plugin extends /* #__PURE__ */ ObservableMixin() implements PluginInterface {
 	/**
 	 * The editor instance.
 	 *

--- a/packages/ckeditor5-core/src/plugincollection.ts
+++ b/packages/ckeditor5-core/src/plugincollection.ts
@@ -13,7 +13,9 @@ import type { LoadedPlugins, PluginClassConstructor, PluginConstructor, PluginIn
 /**
  * Manages a list of CKEditor plugins, including loading, resolving dependencies and initialization.
  */
-export default class PluginCollection<TContext extends object> extends EmitterMixin() implements Iterable<PluginEntry<TContext>> {
+export default class PluginCollection<TContext extends object>
+	extends /* #__PURE__ */ EmitterMixin()
+	implements Iterable<PluginEntry<TContext>> {
 	private _context: TContext;
 
 	private _plugins = new Map<PluginConstructor<TContext> | string, PluginInterface>();

--- a/packages/ckeditor5-editor-balloon/src/ballooneditor.ts
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditor.ts
@@ -51,7 +51,7 @@ import { isElement as _isElement } from 'lodash-es';
  * Read more about initializing the editor from source or as a build in
  * {@link module:editor-balloon/ballooneditor~BalloonEditor.create `BalloonEditor.create()`}.
  */
-export default class BalloonEditor extends ElementApiMixin( Editor ) {
+export default class BalloonEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 	/**
 	 * @inheritDoc
 	 */

--- a/packages/ckeditor5-editor-classic/src/classiceditor.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.ts
@@ -47,7 +47,7 @@ import { isElement as _isElement } from 'lodash-es';
  * Read more about initializing the editor from source or as a build in
  * {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`}.
  */
-export default class ClassicEditor extends ElementApiMixin( Editor ) {
+export default class ClassicEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 	/**
 	 * @inheritDoc
 	 */

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitor.ts
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitor.ts
@@ -60,7 +60,7 @@ import { isElement as _isElement } from 'lodash-es';
  * Read more about initializing the editor from source or as a build in
  * {@link module:editor-decoupled/decouplededitor~DecoupledEditor.create `DecoupledEditor.create()`}.
  */
-export default class DecoupledEditor extends ElementApiMixin( Editor ) {
+export default class DecoupledEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 	/**
 	 * @inheritDoc
 	 */

--- a/packages/ckeditor5-editor-inline/src/inlineeditor.ts
+++ b/packages/ckeditor5-editor-inline/src/inlineeditor.ts
@@ -48,7 +48,7 @@ import { isElement as _isElement } from 'lodash-es';
  * Read more about initializing the editor from source or as a build in
  * {@link module:editor-inline/inlineeditor~InlineEditor.create `InlineEditor.create()`}.
  */
-export default class InlineEditor extends ElementApiMixin( Editor ) {
+export default class InlineEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 	/**
 	 * @inheritDoc
 	 */

--- a/packages/ckeditor5-engine/src/controller/datacontroller.ts
+++ b/packages/ckeditor5-engine/src/controller/datacontroller.ts
@@ -63,7 +63,7 @@ import type DataProcessor from '../dataprocessor/dataprocessor.js';
  * editor.data.get( { rootName: 'customRoot' } ); // -> '<p>Hello!</p>'
  * ```
  */
-export default class DataController extends EmitterMixin() {
+export default class DataController extends /* #__PURE__ */ EmitterMixin() {
 	/**
 	 * Data model.
 	 */

--- a/packages/ckeditor5-engine/src/controller/editingcontroller.ts
+++ b/packages/ckeditor5-engine/src/controller/editingcontroller.ts
@@ -54,7 +54,7 @@ import type { ViewDocumentInputEvent } from '../view/observer/inputobserver.js';
  * including selection handling. It also creates the {@link ~EditingController#view view} which builds a
  * browser-independent virtualization over the DOM elements. The editing controller also attaches default converters.
  */
-export default class EditingController extends ObservableMixin() {
+export default class EditingController extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * Editor model.
 	 */

--- a/packages/ckeditor5-engine/src/conversion/downcastdispatcher.ts
+++ b/packages/ckeditor5-engine/src/conversion/downcastdispatcher.ts
@@ -117,7 +117,7 @@ import type ViewElement from '../view/element.js';
  * } );
  * ```
  */
-export default class DowncastDispatcher extends EmitterMixin() {
+export default class DowncastDispatcher extends /* #__PURE__ */ EmitterMixin() {
 	/**
 	 * A template for an interface passed by the dispatcher to the event callbacks.
 	 *

--- a/packages/ckeditor5-engine/src/conversion/mapper.ts
+++ b/packages/ckeditor5-engine/src/conversion/mapper.ts
@@ -41,7 +41,7 @@ import type ViewNode from '../view/node.js';
  * with `'lowest'` priority. To override default `Mapper` mapping, add custom callback with higher priority and
  * stop the event.
  */
-export default class Mapper extends EmitterMixin() {
+export default class Mapper extends /* #__PURE__ */ EmitterMixin() {
 	/**
 	 * Model element to view element mapping.
 	 */

--- a/packages/ckeditor5-engine/src/conversion/upcastdispatcher.ts
+++ b/packages/ckeditor5-engine/src/conversion/upcastdispatcher.ts
@@ -121,7 +121,7 @@ import { CKEditorError, EmitterMixin } from '@ckeditor/ckeditor5-utils';
  * @fires text
  * @fires documentFragment
  */
-export default class UpcastDispatcher extends EmitterMixin() {
+export default class UpcastDispatcher extends /* #__PURE__ */ EmitterMixin() {
 	/**
 	 * An interface passed by the dispatcher to the event callbacks.
 	 */

--- a/packages/ckeditor5-engine/src/model/document.ts
+++ b/packages/ckeditor5-engine/src/model/document.ts
@@ -50,7 +50,7 @@ const graveyardName = '$graveyard';
  * However, the document may contain multiple roots – e.g. when the editor has multiple editable areas
  * (e.g. a title and a body of a message).
  */
-export default class Document extends EmitterMixin() {
+export default class Document extends /* #__PURE__ */ EmitterMixin() {
 	/**
 	 * The {@link module:engine/model/model~Model model} that the document is a part of.
 	 */

--- a/packages/ckeditor5-engine/src/model/documentselection.ts
+++ b/packages/ckeditor5-engine/src/model/documentselection.ts
@@ -60,7 +60,7 @@ const storePrefix = 'selection:';
  * If you need to represent a selection in document fragment,
  * use {@link module:engine/model/selection~Selection Selection class} instead.
  */
-export default class DocumentSelection extends EmitterMixin( TypeCheckable ) {
+export default class DocumentSelection extends /* #__PURE__ */ EmitterMixin( TypeCheckable ) {
 	/**
 	 * Selection used internally by that class (`DocumentSelection` is a proxy to that selection).
 	 */

--- a/packages/ckeditor5-engine/src/model/liveposition.ts
+++ b/packages/ckeditor5-engine/src/model/liveposition.ts
@@ -30,7 +30,7 @@ import { CKEditorError, EmitterMixin } from '@ckeditor/ckeditor5-utils';
  * have to be unbound.
  * Use {@link module:engine/model/liveposition~LivePosition#detach} whenever you don't need `LivePosition` anymore.
  */
-export default class LivePosition extends EmitterMixin( Position ) {
+export default class LivePosition extends /* #__PURE__ */ EmitterMixin( Position ) {
 	/**
 	 * Root of the position path.
 	 */

--- a/packages/ckeditor5-engine/src/model/liverange.ts
+++ b/packages/ckeditor5-engine/src/model/liverange.ts
@@ -28,7 +28,7 @@ import { EmitterMixin } from '@ckeditor/ckeditor5-utils';
  * **Note:** Be very careful when dealing with `LiveRange`. Each `LiveRange` instance bind events that might
  * have to be unbound. Use {@link module:engine/model/liverange~LiveRange#detach detach} whenever you don't need `LiveRange` anymore.
  */
-export default class LiveRange extends EmitterMixin( Range ) {
+export default class LiveRange extends /* #__PURE__ */ EmitterMixin( Range ) {
 	/**
 	 * Creates a live range.
 	 *

--- a/packages/ckeditor5-engine/src/model/markercollection.ts
+++ b/packages/ckeditor5-engine/src/model/markercollection.ts
@@ -33,7 +33,7 @@ import { CKEditorError, EmitterMixin } from '@ckeditor/ckeditor5-utils';
  *
  * @see module:engine/model/markercollection~Marker
  */
-export default class MarkerCollection extends EmitterMixin() implements Iterable<Marker> {
+export default class MarkerCollection extends /* #__PURE__ */ EmitterMixin() implements Iterable<Marker> {
 	/**
 	 * Stores {@link ~Marker markers} added to the collection.
 	 */
@@ -347,7 +347,7 @@ export interface MarkerData {
  *
  * `Marker` instances are created and destroyed only by {@link ~MarkerCollection MarkerCollection}.
  */
-class Marker extends EmitterMixin( TypeCheckable ) {
+class Marker extends /* #__PURE__ */ EmitterMixin( TypeCheckable ) {
 	/**
 	 * Marker's name.
 	 */

--- a/packages/ckeditor5-engine/src/model/model.ts
+++ b/packages/ckeditor5-engine/src/model/model.ts
@@ -45,7 +45,7 @@ import {
  * Editor's data model. Read about the model in the
  * {@glink framework/architecture/editing-engine engine architecture} guide.
  */
-export default class Model extends ObservableMixin() {
+export default class Model extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * Model's marker collection.
 	 */

--- a/packages/ckeditor5-engine/src/model/schema.ts
+++ b/packages/ckeditor5-engine/src/model/schema.ts
@@ -35,7 +35,7 @@ import { CKEditorError, first, ObservableMixin } from '@ckeditor/ckeditor5-utils
  * {@glink framework/architecture/editing-engine Introduction to the Editing engine architecture} guide.
  * * The {@glink framework/deep-dive/schema Schema deep-dive} guide.
  */
-export default class Schema extends ObservableMixin() {
+export default class Schema extends /* #__PURE__ */ ObservableMixin() {
 	private readonly _sourceDefinitions: Record<string, Array<SchemaItemDefinition>> = {};
 
 	/**

--- a/packages/ckeditor5-engine/src/model/selection.ts
+++ b/packages/ckeditor5-engine/src/model/selection.ts
@@ -26,7 +26,7 @@ import { CKEditorError, EmitterMixin, isIterable } from '@ckeditor/ckeditor5-uti
  * Additionally, selection may have its own attributes (think – whether text typed in in this selection
  * should have those attributes – e.g. whether you type a bolded text).
  */
-export default class Selection extends EmitterMixin( TypeCheckable ) {
+export default class Selection extends /* #__PURE__ */ EmitterMixin( TypeCheckable ) {
 	/**
 	 * Specifies whether the last added range was added as a backward or forward range.
 	 */

--- a/packages/ckeditor5-engine/src/view/document.ts
+++ b/packages/ckeditor5-engine/src/view/document.ts
@@ -22,7 +22,7 @@ import type DowncastWriter from './downcastwriter.js';
  * Document class creates an abstract layer over the content editable area, contains a tree of view elements and
  * {@link module:engine/view/documentselection~DocumentSelection view selection} associated with this document.
  */
-export default class Document extends BubblingEmitterMixin( ObservableMixin() ) {
+export default class Document extends /* #__PURE__ */ BubblingEmitterMixin( /* #__PURE__ */ ObservableMixin() ) {
 	/**
 	 * Selection done on this document.
 	 */

--- a/packages/ckeditor5-engine/src/view/documentfragment.ts
+++ b/packages/ckeditor5-engine/src/view/documentfragment.ts
@@ -25,7 +25,7 @@ import type Node from './node.js';
  * {@link module:engine/view/upcastwriter~UpcastWriter#createDocumentFragment `UpcastWriter#createDocumentFragment()`}
  * method.
  */
-export default class DocumentFragment extends EmitterMixin( TypeCheckable ) implements Iterable<Node> {
+export default class DocumentFragment extends /* #__PURE__ */ EmitterMixin( TypeCheckable ) implements Iterable<Node> {
 	/**
 	 * The document to which this document fragment belongs.
 	 */

--- a/packages/ckeditor5-engine/src/view/documentselection.ts
+++ b/packages/ckeditor5-engine/src/view/documentselection.ts
@@ -34,7 +34,7 @@ import type Range from './range.js';
  * the {@link module:engine/view/view~View#change `View#change()`} block
  * (so via {@link module:engine/view/downcastwriter~DowncastWriter#setSelection `DowncastWriter#setSelection()`}).
  */
-export default class DocumentSelection extends EmitterMixin( TypeCheckable ) {
+export default class DocumentSelection extends /* #__PURE__ */ EmitterMixin( TypeCheckable ) {
 	/**
 	 * Selection is used internally (`DocumentSelection` is a proxy to that selection).
 	 */

--- a/packages/ckeditor5-engine/src/view/editableelement.ts
+++ b/packages/ckeditor5-engine/src/view/editableelement.ts
@@ -23,7 +23,7 @@ import type Node from './node.js';
  * The constructor of this class shouldn't be used directly. To create new `EditableElement` use the
  * {@link module:engine/view/downcastwriter~DowncastWriter#createEditableElement `downcastWriter#createEditableElement()`} method.
  */
-export default class EditableElement extends ObservableMixin( ContainerElement ) {
+export default class EditableElement extends /* #__PURE__ */ ObservableMixin( ContainerElement ) {
 	/**
 	 * Whether the editable is in read-write or read-only mode.
 	 *

--- a/packages/ckeditor5-engine/src/view/node.ts
+++ b/packages/ckeditor5-engine/src/view/node.ts
@@ -28,7 +28,7 @@ import type Element from './element.js';
  * Use the {@link module:engine/view/downcastwriter~DowncastWriter} or {@link module:engine/view/upcastwriter~UpcastWriter}
  * to create new instances of view nodes.
  */
-export default abstract class Node extends EmitterMixin( TypeCheckable ) {
+export default abstract class Node extends /* #__PURE__ */ EmitterMixin( TypeCheckable ) {
 	/**
 	 * The document instance to which this node belongs.
 	 */

--- a/packages/ckeditor5-engine/src/view/observer/observer.ts
+++ b/packages/ckeditor5-engine/src/view/observer/observer.ts
@@ -18,7 +18,7 @@ import type View from '../view.js';
  * Observers can also add features to the view, for instance by updating its status or marking elements
  * which need a refresh on DOM events.
  */
-export default abstract class Observer extends DomEmitterMixin() {
+export default abstract class Observer extends /* #__PURE__ */ DomEmitterMixin() {
 	/**
 	 * An instance of the view controller.
 	 */

--- a/packages/ckeditor5-engine/src/view/renderer.ts
+++ b/packages/ckeditor5-engine/src/view/renderer.ts
@@ -54,7 +54,7 @@ type DomSelection = globalThis.Selection;
  * Renderer uses {@link module:engine/view/domconverter~DomConverter} to transform view nodes and positions
  * to and from the DOM.
  */
-export default class Renderer extends ObservableMixin() {
+export default class Renderer extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * Set of DOM Documents instances.
 	 */

--- a/packages/ckeditor5-engine/src/view/selection.ts
+++ b/packages/ckeditor5-engine/src/view/selection.ts
@@ -36,7 +36,7 @@ import type EditableElement from './editableelement.js';
  * A selection can consist of {@link module:engine/view/range~Range ranges} that can be set by using
  * the {@link module:engine/view/selection~Selection#setTo `Selection#setTo()`} method.
  */
-export default class Selection extends EmitterMixin( TypeCheckable ) {
+export default class Selection extends /* #__PURE__ */ EmitterMixin( TypeCheckable ) {
 	/**
 	 * Stores all ranges that are selected.
 	 */

--- a/packages/ckeditor5-engine/src/view/view.ts
+++ b/packages/ckeditor5-engine/src/view/view.ts
@@ -83,7 +83,7 @@ type DomRange = globalThis.Range;
  * If you do not need full a DOM - view management, and only want to transform a tree of view elements to a tree of DOM
  * elements you do not need this controller. You can use the {@link module:engine/view/domconverter~DomConverter DomConverter} instead.
  */
-export default class View extends ObservableMixin() {
+export default class View extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * Instance of the {@link module:engine/view/document~Document} associated with this view controller.
 	 */

--- a/packages/ckeditor5-find-and-replace/src/findandreplacestate.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplacestate.ts
@@ -14,7 +14,7 @@ import type { ResultType } from './findandreplace.js';
 /**
  * The object storing find and replace plugin state for a given editor instance.
  */
-export default class FindAndReplaceState extends ObservableMixin() {
+export default class FindAndReplaceState extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * A collection of find matches.
 	 *

--- a/packages/ckeditor5-link/src/utils/manualdecorator.ts
+++ b/packages/ckeditor5-link/src/utils/manualdecorator.ts
@@ -16,7 +16,7 @@ import type { NormalizedLinkDecoratorManualDefinition } from '../utils.js';
  * to support integration with the UI state. An instance of this class is a model with the state of individual manual decorators.
  * These decorators are kept as collections in {@link module:link/linkcommand~LinkCommand#manualDecorators}.
  */
-export default class ManualDecorator extends ObservableMixin() {
+export default class ManualDecorator extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * An ID of a manual decorator which is the name of the attribute in the model, for example: 'linkManualDecorator0'.
 	 */

--- a/packages/ckeditor5-paragraph/src/paragraphbuttonui.ts
+++ b/packages/ckeditor5-paragraph/src/paragraphbuttonui.ts
@@ -13,8 +13,6 @@ import { ButtonView } from '@ckeditor/ckeditor5-ui';
 import Paragraph from './paragraph.js';
 import type ParagraphCommand from './paragraphcommand.js';
 
-const icon = icons.paragraph;
-
 /**
  * This plugin defines the `'paragraph'` button. It can be used together with
  * {@link module:heading/headingbuttonsui~HeadingButtonsUI} to replace the standard heading dropdown.
@@ -52,7 +50,7 @@ export default class ParagraphButtonUI extends Plugin {
 			const command: ParagraphCommand = editor.commands.get( 'paragraph' )!;
 
 			view.label = t( 'Paragraph' );
-			view.icon = icon;
+			view.icon = icons.paragraph;
 			view.tooltip = true;
 			view.isToggleable = true;
 			view.bind( 'isEnabled' ).to( command );

--- a/packages/ckeditor5-typing/src/textwatcher.ts
+++ b/packages/ckeditor5-typing/src/textwatcher.ts
@@ -25,7 +25,7 @@ import type {
  * {@link module:typing/textwatcher~TextWatcher#event:matched:selection `matched:selection`} and
  * {@link module:typing/textwatcher~TextWatcher#event:unmatched `unmatched`} events on typing or selection changes.
  */
-export default class TextWatcher extends ObservableMixin() {
+export default class TextWatcher extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * The editor's model.
 	 */

--- a/packages/ckeditor5-ui/src/colorselector/documentcolorcollection.ts
+++ b/packages/ckeditor5-ui/src/colorselector/documentcolorcollection.ts
@@ -19,7 +19,7 @@ import {
 /**
  * A collection to store document colors. It enforces colors to be unique.
  */
-export default class DocumentColorCollection extends ObservableMixin( Collection<ColorDefinition> ) {
+export default class DocumentColorCollection extends /* #__PURE__ */ ObservableMixin( Collection<ColorDefinition> ) {
 	/**
 	 * Indicates whether the document color collection is empty.
 	 *

--- a/packages/ckeditor5-ui/src/dialog/dialogview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogview.ts
@@ -68,7 +68,7 @@ const toPx = toUnit( 'px' );
 /**
  * A dialog view class.
  */
-export default class DialogView extends DraggableViewMixin( View ) implements DraggableView {
+export default class DialogView extends /* #__PURE__ */ DraggableViewMixin( View ) implements DraggableView {
 	/**
 	 * A collection of the child views inside of the dialog.
 	 * A dialog can have 3 optional parts: header, content, and actions.

--- a/packages/ckeditor5-ui/src/editorui/accessibilityhelp/accessibilityhelp.ts
+++ b/packages/ckeditor5-ui/src/editorui/accessibilityhelp/accessibilityhelp.ts
@@ -8,9 +8,12 @@
  */
 
 import { Plugin } from '@ckeditor/ckeditor5-core';
-import { ButtonView, MenuBarMenuListItemButtonView, Dialog, type EditorUIReadyEvent } from '../../index.js';
+import ButtonView from '../../button/buttonview.js';
+import Dialog from '../../dialog/dialog.js';
+import MenuBarMenuListItemButtonView from '../../menubar/menubarmenulistitembuttonview.js';
 import AccessibilityHelpContentView from './accessibilityhelpcontentview.js';
 import { getEnvKeystrokeText } from '@ckeditor/ckeditor5-utils';
+import type { EditorUIReadyEvent } from '../../editorui/editorui.js';
 import type { AddRootEvent } from '@ckeditor/ckeditor5-editor-multi-root';
 import type { DowncastWriter, ViewRootEditableElement } from '@ckeditor/ckeditor5-engine';
 

--- a/packages/ckeditor5-ui/src/editorui/editorui.ts
+++ b/packages/ckeditor5-ui/src/editorui/editorui.ts
@@ -31,7 +31,7 @@ import type { ViewDocumentLayoutChangedEvent, ViewScrollToTheSelectionEvent } fr
 /**
  * A class providing the minimal interface that is required to successfully bootstrap any editor UI.
  */
-export default abstract class EditorUI extends ObservableMixin() {
+export default abstract class EditorUI extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * The editor that the UI belongs to.
 	 */

--- a/packages/ckeditor5-ui/src/editorui/poweredby.ts
+++ b/packages/ckeditor5-ui/src/editorui/poweredby.ts
@@ -38,7 +38,7 @@ type PoweredByConfig = Required<UiConfig>[ 'poweredBy' ];
  *
  * @private
  */
-export default class PoweredBy extends DomEmitterMixin() {
+export default class PoweredBy extends /* #__PURE__ */ DomEmitterMixin() {
 	/**
 	 * Editor instance the helper was created for.
 	 */

--- a/packages/ckeditor5-ui/src/focuscycler.ts
+++ b/packages/ckeditor5-ui/src/focuscycler.ts
@@ -70,7 +70,7 @@ import type ViewCollection from './viewcollection.js';
  *
  * Check out the {@glink framework/deep-dive/ui/focus-tracking "Deep dive into focus tracking"} guide to learn more.
  */
-export default class FocusCycler extends EmitterMixin() {
+export default class FocusCycler extends /* #__PURE__ */ EmitterMixin() {
 	/**
 	 * A {@link module:ui/focuscycler~FocusableView focusable views} collection that the cycler operates on.
 	 */

--- a/packages/ckeditor5-ui/src/model.ts
+++ b/packages/ckeditor5-ui/src/model.ts
@@ -13,7 +13,7 @@ import { extend } from 'lodash-es';
 /**
  * The base MVC model class.
  */
-export default class Model extends ObservableMixin() {
+export default class Model extends /* #__PURE__ */ ObservableMixin() {
 	[ x: string ]: unknown;
 
 	/**

--- a/packages/ckeditor5-ui/src/template.ts
+++ b/packages/ckeditor5-ui/src/template.ts
@@ -65,7 +65,7 @@ const xhtmlNs = 'http://www.w3.org/1999/xhtml';
  * See {@link module:ui/template~TemplateDefinition} to know more about templates and complex
  * template definitions.
  */
-export default class Template extends EmitterMixin() {
+export default class Template extends /* #__PURE__ */ EmitterMixin() {
 	public ns?: string;
 
 	/**

--- a/packages/ckeditor5-ui/src/tooltipmanager.ts
+++ b/packages/ckeditor5-ui/src/tooltipmanager.ts
@@ -83,7 +83,7 @@ const BALLOON_CLASS = 'ck-tooltip';
  * **Note**: This class is a singleton. All editor instances re-use the same instance loaded by
  * {@link module:ui/editorui/editorui~EditorUI} of the first editor.
  */
-export default class TooltipManager extends DomEmitterMixin() {
+export default class TooltipManager extends /* #__PURE__ */ DomEmitterMixin() {
 	/**
 	 * The view rendering text of the tooltip.
 	 */

--- a/packages/ckeditor5-ui/src/view.ts
+++ b/packages/ckeditor5-ui/src/view.ts
@@ -91,7 +91,9 @@ import '../theme/globals/globals.css';
  * } );
  * ```
  */
-export default class View<TElement extends HTMLElement = HTMLElement> extends DomEmitterMixin( ObservableMixin() ) {
+export default class View<TElement extends HTMLElement = HTMLElement>
+	extends /* #__PURE__ */ DomEmitterMixin( /* #__PURE__ */ ObservableMixin() )
+{
 	/**
 	 * An HTML element of the view. `null` until {@link #render rendered}
 	 * from the {@link #template}.

--- a/packages/ckeditor5-ui/tests/manual/bindings/draggableviewmixin.ts
+++ b/packages/ckeditor5-ui/tests/manual/bindings/draggableviewmixin.ts
@@ -6,7 +6,7 @@
 import { View } from '../../../src/index.js';
 import DraggableViewMixin, { type DraggableView } from '../../../src/bindings/draggableviewmixin.js';
 
-class DraggableTestView extends DraggableViewMixin( View ) implements DraggableView {
+class DraggableTestView extends /* #__PURE__ */ DraggableViewMixin( View ) implements DraggableView {
 	declare public top: number;
 	declare public left: number;
 

--- a/packages/ckeditor5-upload/src/filereader.ts
+++ b/packages/ckeditor5-upload/src/filereader.ts
@@ -16,7 +16,7 @@ type DomFileReader = globalThis.FileReader;
 /**
  * Wrapper over the native `FileReader`.
  */
-export default class FileReader extends ObservableMixin() {
+export default class FileReader extends /* #__PURE__ */ ObservableMixin() {
 	public total!: number;
 
 	/**

--- a/packages/ckeditor5-upload/src/filerepository.ts
+++ b/packages/ckeditor5-upload/src/filerepository.ts
@@ -257,7 +257,7 @@ export default class FileRepository extends Plugin {
  *
  * It is used to control the process of reading the file and uploading it using the specified upload adapter.
  */
-class FileLoader extends ObservableMixin() {
+class FileLoader extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * Unique id of FileLoader instance.
 	 *

--- a/packages/ckeditor5-utils/src/collection.ts
+++ b/packages/ckeditor5-utils/src/collection.ts
@@ -24,7 +24,7 @@ import isIterable from './isiterable.js';
  *
  * @typeParam T The type of the collection element.
  */
-export default class Collection<T extends Record<string, any>> extends EmitterMixin() implements Iterable<T> {
+export default class Collection<T extends Record<string, any>> extends /* #__PURE__ */ EmitterMixin() implements Iterable<T> {
 	/**
 	 * The internal list of items in the collection.
 	 */

--- a/packages/ckeditor5-utils/src/dom/emittermixin.ts
+++ b/packages/ckeditor5-utils/src/dom/emittermixin.ts
@@ -208,7 +208,7 @@ export default function DomEmitterMixin( base?: Constructor<Emitter> ): unknown 
  *                    +-----------------------------------------+
  *                                fire( click, DOM Event )
  */
-class ProxyEmitter extends EmitterMixin() {
+class ProxyEmitter extends /* #__PURE__ */ EmitterMixin() {
 	private readonly _domNode: Node | Window;
 	private readonly _options: { capture: boolean; passive: boolean };
 

--- a/packages/ckeditor5-utils/src/dom/emittermixin.ts
+++ b/packages/ckeditor5-utils/src/dom/emittermixin.ts
@@ -21,7 +21,7 @@ import isWindow from './iswindow.js';
 import type EventInfo from '../eventinfo.js';
 import type { Constructor, Mixed } from '../mix.js';
 
-const defaultEmitterClass = DomEmitterMixin( EmitterMixin() );
+const defaultEmitterClass = /* #__PURE__ */ DomEmitterMixin( /* #__PURE__ */ EmitterMixin() );
 
 /**
  * Mixin that injects the DOM events API into its host. It provides the API

--- a/packages/ckeditor5-utils/src/focustracker.ts
+++ b/packages/ckeditor5-utils/src/focustracker.ts
@@ -25,7 +25,7 @@ import CKEditorError from './ckeditorerror.js';
  *
  * Check out the {@glink framework/deep-dive/ui/focus-tracking "Deep dive into focus tracking"} guide to learn more.
  */
-export default class FocusTracker extends DomEmitterMixin( ObservableMixin() ) {
+export default class FocusTracker extends /* #__PURE__ */ DomEmitterMixin( /* #__PURE__ */ ObservableMixin() ) {
 	/**
 	 * True when one of the registered elements is focused.
 	 *

--- a/packages/ckeditor5-utils/src/observablemixin.ts
+++ b/packages/ckeditor5-utils/src/observablemixin.ts
@@ -22,7 +22,7 @@ const boundPropertiesSymbol = Symbol( 'boundProperties' );
 const decoratedMethods = Symbol( 'decoratedMethods' );
 const decoratedOriginal = Symbol( 'decoratedOriginal' );
 
-const defaultObservableClass = ObservableMixin( EmitterMixin() );
+const defaultObservableClass = /* #__PURE__ */ ObservableMixin( /* #__PURE__ */ EmitterMixin() );
 
 /**
  * A mixin that injects the "observable properties" and data binding functionality described in the

--- a/packages/ckeditor5-widget/src/highlightstack.ts
+++ b/packages/ckeditor5-widget/src/highlightstack.ts
@@ -22,7 +22,7 @@ import type { DowncastWriter, HighlightDescriptor } from '@ckeditor/ckeditor5-en
  *
  * This way, highlight will be applied with the same rules it is applied on texts.
  */
-export default class HighlightStack extends EmitterMixin() {
+export default class HighlightStack extends /* #__PURE__ */ EmitterMixin() {
 	private readonly _stack: Array<HighlightDescriptor> = [];
 
 	/**

--- a/packages/ckeditor5-widget/src/widgetresize/resizer.ts
+++ b/packages/ckeditor5-widget/src/widgetresize/resizer.ts
@@ -25,7 +25,7 @@ import type { ViewElement } from '@ckeditor/ckeditor5-engine';
 /**
  * Represents a resizer for a single resizable object.
  */
-export default class Resizer extends ObservableMixin() {
+export default class Resizer extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * Flag that indicates whether resizer can be used.
 	 *

--- a/packages/ckeditor5-widget/src/widgetresize/resizerstate.ts
+++ b/packages/ckeditor5-widget/src/widgetresize/resizerstate.ts
@@ -15,7 +15,7 @@ import { calculateResizeHostPercentageWidth } from '../utils.js';
 /**
  * Stores the internal state of a single resizable object.
  */
-export default class ResizeState extends ObservableMixin() {
+export default class ResizeState extends /* #__PURE__ */ ObservableMixin() {
 	/**
 	 * The position of the handle that initiated the resizing. E.g. `"top-left"`, `"bottom-right"` etc. or `null`
 	 * if unknown.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix: Improve tree-shaking by prefixing mixin calls with `/* #__PURE__ */` magic comment. See #16292.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
