### PR TITLE
Tooltip flashes while clicking toolbar items

### DIFF
--- a/packages/ckeditor5-ui/src/tooltipmanager.ts
+++ b/packages/ckeditor5-ui/src/tooltipmanager.ts
@@ -308,7 +308,10 @@ export default class TooltipManager extends /* #__PURE__ */ DomEmitterMixin() {
 
 		this._unpinTooltip();
 
-		if ( evt.name === 'focus' ) {
+		// The tooltip should be pinned immediately when the element gets focused using keyboard.
+		// If it is focused using the mouse, the tooltip should be pinned after a delay to prevent flashing.
+		// See https://github.com/ckeditor/ckeditor5/issues/16383
+		if ( evt.name === 'focus' && !elementWithTooltipAttribute.matches( ':hover' ) ) {
 			this._pinTooltip( elementWithTooltipAttribute, getTooltipData( elementWithTooltipAttribute ) );
 		} else {
 			this._pinTooltipDebounced( elementWithTooltipAttribute, getTooltipData( elementWithTooltipAttribute ) );

--- a/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
+++ b/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
@@ -366,6 +366,16 @@ describe( 'TooltipManager', () => {
 		} );
 
 		describe( 'on focus', () => {
+			it( 'should not focus immediately if hovered', () => {
+				sinon.stub( elements.a, 'matches' ).withArgs( ':hover' ).returns( true );
+
+				utils.dispatchFocus( elements.a );
+				sinon.assert.notCalled( pinSpy );
+
+				utils.waitForTheTooltipToShow( clock );
+				sinon.assert.calledOnce( pinSpy );
+			} );
+
 			it( 'should not work for elements that have no descendant with the data-attribute', () => {
 				utils.dispatchFocus( elements.unrelated );
 				utils.waitForTheTooltipToShow( clock );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Ensure tooltips are not pinned when the element is not being hovered over.

---

### Additional information

1. Marked as `internal` - it's not regression. The issue was introduced in [commit](https://github.com/ckeditor/ckeditor5/commit/9a6b96b9c35864433929e13e8ae7ecfb8ee70f2e) that hasn't been released yet.
2. Closes https://github.com/ckeditor/ckeditor5/issues/16383

### Video

#### Before:

https://github.com/ckeditor/ckeditor5/assets/3949262/e57962ac-a5ec-4f47-bcb9-9f0faac91262



#### After:

https://github.com/ckeditor/ckeditor5/assets/3949262/d94223ba-b096-40ca-8858-b6bc5fb4f8a8


