### PR TITLE
Update ui on close image ckbox dialog.

### DIFF
--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
@@ -69,7 +69,7 @@ export default class CKBoxImageEditCommand extends Command {
 	*
 	* See: https://github.com/ckeditor/ckeditor5/issues/16153.
 	*/
-	private _updateUiDelayed: DelayedFunc<() => void> = delay( () => this.editor.ui.update(), 0 );
+	private _updateUiDelayed = delay( () => this.editor.ui.update(), 0 );
 
 	/**
 	 * @inheritDoc

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
@@ -234,6 +234,13 @@ export default class CKBoxImageEditCommand extends Command {
 
 		this.editor.editing.view.focus();
 
+		/**
+		 * See https://github.com/ckeditor/ckeditor5/issues/16153#top
+		 */
+		setTimeout( () => {
+			this.editor.ui.update();
+		} );
+
 		this.refresh();
 	}
 

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
@@ -16,8 +16,7 @@ import {
 	createElement,
 	retry,
 	delay,
-	type AbortableFunc,
-	type DelayedFunc
+	type AbortableFunc
 } from 'ckeditor5/src/utils.js';
 import type { Element as ModelElement } from 'ckeditor5/src/engine.js';
 import { Notification } from 'ckeditor5/src/ui.js';

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
@@ -10,7 +10,14 @@
  */
 
 import { Command, PendingActions, type Editor } from 'ckeditor5/src/core.js';
-import { CKEditorError, abortableDebounce, createElement, retry, type AbortableFunc } from 'ckeditor5/src/utils.js';
+import {
+	CKEditorError,
+	abortableDebounce, createElement,
+	retry,
+	delay,
+	type AbortableFunc,
+	type DelayedFunc
+} from 'ckeditor5/src/utils.js';
 import type { Element as ModelElement } from 'ckeditor5/src/engine.js';
 import { Notification } from 'ckeditor5/src/ui.js';
 import { isEqual } from 'lodash-es';
@@ -53,6 +60,15 @@ export default class CKBoxImageEditCommand extends Command {
 	 * A wrapper function to prepare mount options. Ensures that at most one preparation is in-flight.
 	 */
 	private _prepareOptions: AbortableFunc<[ ProcessingState ], Promise<Record<string, unknown>>>;
+
+	/**
+	* CKBox's onClose function runs before the final cleanup, potentially causing
+	* page layout changes after it finishes. To address this, we use a setTimeout hack
+	* to ensure that floating elements on the page maintain their correct position.
+	*
+	* See: https://github.com/ckeditor/ckeditor5/issues/16153
+	*/
+	private _updateUiDelayed: DelayedFunc<() => void> = delay( () => this.editor.ui.update(), 0 );
 
 	/**
 	 * @inheritDoc
@@ -129,6 +145,8 @@ export default class CKBoxImageEditCommand extends Command {
 		this._handleImageEditorClose();
 
 		this._prepareOptions.abort();
+
+		this._updateUiDelayed.cancel();
 
 		for ( const state of this._processInProgress.values() ) {
 			state.controller.abort();
@@ -234,19 +252,7 @@ export default class CKBoxImageEditCommand extends Command {
 
 		this.editor.editing.view.focus();
 
-		/**
-		 * Callaback onClose in the CKBox is called before logic which could
-		 * affect layout on the page, so we updating ui at the end.
-		 *
-		 * See https://github.com/ckeditor/ckeditor5/issues/16153#top
-		 */
-		const timeId = setTimeout( () => {
-			this.editor.ui.update();
-		} );
-
-		this.editor.on( 'destroy', () => {
-			clearTimeout( timeId );
-		} );
+		this._updateUiDelayed();
 
 		this.refresh();
 	}

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
@@ -12,7 +12,8 @@
 import { Command, PendingActions, type Editor } from 'ckeditor5/src/core.js';
 import {
 	CKEditorError,
-	abortableDebounce, createElement,
+	abortableDebounce,
+	createElement,
 	retry,
 	delay,
 	type AbortableFunc,
@@ -66,7 +67,7 @@ export default class CKBoxImageEditCommand extends Command {
 	* page layout changes after it finishes. To address this, we use a setTimeout hack
 	* to ensure that floating elements on the page maintain their correct position.
 	*
-	* See: https://github.com/ckeditor/ckeditor5/issues/16153
+	* See: https://github.com/ckeditor/ckeditor5/issues/16153.
 	*/
 	private _updateUiDelayed: DelayedFunc<() => void> = delay( () => this.editor.ui.update(), 0 );
 

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
@@ -235,10 +235,17 @@ export default class CKBoxImageEditCommand extends Command {
 		this.editor.editing.view.focus();
 
 		/**
+		 * Callaback onClose in the CKBox is called before logic which could
+		 * affect layout on the page, so we updating ui at the end.
+		 *
 		 * See https://github.com/ckeditor/ckeditor5/issues/16153#top
 		 */
-		setTimeout( () => {
+		const timeId = setTimeout( () => {
 			this.editor.ui.update();
+		} );
+
+		this.editor.on( 'destroy', () => {
+			clearTimeout( timeId );
 		} );
 
 		this.refresh();

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* global window, console, btoa, setTimeout, AbortController, globalThis */
+/* global window, console, btoa, setTimeout, AbortController */
 
 import { global } from '@ckeditor/ckeditor5-utils';
 import { Command } from 'ckeditor5/src/core.js';
@@ -441,13 +441,9 @@ describe( 'CKBoxImageEditCommand', () => {
 					controller: new AbortController()
 				} );
 
-				const clearTimeoutSpy = sinon.spy( globalThis, 'clearTimeout' );
+				const clearTimeoutSpy = sinon.spy( command._updateUiDelayed, 'cancel' );
 
 				editor.fire( 'ready' );
-
-				command.on( 'destroy', () => {
-					sinon.assert.calledOnce( clearTimeoutSpy );
-				} );
 
 				expect( command.value ).to.be.false;
 
@@ -455,7 +451,8 @@ describe( 'CKBoxImageEditCommand', () => {
 
 				options.onClose();
 
-				await editor.destroy();
+				command.destroy();
+				sinon.assert.calledTwice( clearTimeoutSpy );
 
 				expect( command.value ).to.be.false;
 			} );

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
@@ -393,6 +393,38 @@ describe( 'CKBoxImageEditCommand', () => {
 				expect( command.value ).to.be.false;
 				sinon.assert.calledOnce( refreshSpy );
 			} );
+
+			it( 'should update ui after closing the CKBox Image Editor dialog', async () => {
+				const ckboxImageId = 'example-id';
+				const clock = sinon.useFakeTimers();
+
+				setModelData( model,
+					`[<imageBlock alt="alt text" ckboxImageId="${ ckboxImageId }" src="/assets/sample.png"></imageBlock>]`
+				);
+
+				const imageElement = editor.model.document.selection.getSelectedElement();
+
+				const options = await command._prepareOptions( {
+					element: imageElement,
+					ckboxImageId,
+					controller: new AbortController()
+				} );
+
+				const refreshSpy = testUtils.sinon.spy( editor.ui, 'update' );
+
+				expect( command.value ).to.be.false;
+
+				command.execute();
+				expect( command.value ).to.be.true;
+
+				options.onClose();
+
+				await clock.tickAsync( 10 );
+
+				expect( command.value ).to.be.false;
+				sinon.assert.calledOnce( refreshSpy );
+				clock.restore();
+			} );
 		} );
 
 		describe( 'saving edited asset', () => {

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditcommand.js
@@ -428,7 +428,6 @@ describe( 'CKBoxImageEditCommand', () => {
 
 			it( 'should clear timer on editor destroy', async () => {
 				const ckboxImageId = 'example-id';
-				const clock = sinon.useFakeTimers();
 
 				setModelData( model,
 					`[<imageBlock alt="alt text" ckboxImageId="${ ckboxImageId }" src="/assets/sample.png"></imageBlock>]`
@@ -446,7 +445,7 @@ describe( 'CKBoxImageEditCommand', () => {
 
 				editor.fire( 'ready' );
 
-				editor.on( 'destroy', () => {
+				command.on( 'destroy', () => {
 					sinon.assert.calledOnce( clearTimeoutSpy );
 				} );
 
@@ -459,7 +458,6 @@ describe( 'CKBoxImageEditCommand', () => {
 				await editor.destroy();
 
 				expect( command.value ).to.be.false;
-				clock.restore();
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ckbox): The image toolbar stays attached to the image after closing CKBox. Closes #16153.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._