### PR TITLE
The TooltipManager should verify if the tooltip is not already unpinned while trying to update its position.

### DIFF
--- a/packages/ckeditor5-ui/src/tooltipmanager.ts
+++ b/packages/ckeditor5-ui/src/tooltipmanager.ts
@@ -473,7 +473,7 @@ export default class TooltipManager extends DomEmitterMixin() {
 			return;
 		}
 
-		const tooltipData = getTooltipData( this._currentElementWithTooltip! );
+		const tooltipData = getTooltipData( this._currentElementWithTooltip );
 
 		// This could happen if the tooltip was attached somewhere in a contextual content toolbar and the toolbar
 		// disappeared (e.g. removed an image), or the tooltip text was removed.
@@ -484,7 +484,7 @@ export default class TooltipManager extends DomEmitterMixin() {
 		}
 
 		this.balloonPanelView.pin( {
-			target: this._currentElementWithTooltip!,
+			target: this._currentElementWithTooltip,
 			positions: TooltipManager.getPositioningFunctions( tooltipData.position )
 		} );
 	}

--- a/packages/ckeditor5-ui/src/tooltipmanager.ts
+++ b/packages/ckeditor5-ui/src/tooltipmanager.ts
@@ -467,6 +467,12 @@ export default class TooltipManager extends DomEmitterMixin() {
 	 * Hides the tooltip when the element is no longer visible in DOM or the tooltip text was removed.
 	 */
 	private _updateTooltipPosition() {
+		// The tooltip might get removed by focus listener triggered by the same UI `update` event.
+		// See https://github.com/cksource/ckeditor5-commercial/issues/6219.
+		if ( !this._currentElementWithTooltip ) {
+			return;
+		}
+
 		const tooltipData = getTooltipData( this._currentElementWithTooltip! );
 
 		// This could happen if the tooltip was attached somewhere in a contextual content toolbar and the toolbar

--- a/packages/ckeditor5-ui/src/tooltipmanager.ts
+++ b/packages/ckeditor5-ui/src/tooltipmanager.ts
@@ -468,7 +468,7 @@ export default class TooltipManager extends DomEmitterMixin() {
 	 */
 	private _updateTooltipPosition() {
 		// The tooltip might get removed by focus listener triggered by the same UI `update` event.
-		// See https://github.com/cksource/ckeditor5-commercial/issues/6219.
+		// See https://github.com/ckeditor/ckeditor5/pull/16363.
 		if ( !this._currentElementWithTooltip ) {
 			return;
 		}

--- a/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
+++ b/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
@@ -1009,6 +1009,33 @@ describe( 'TooltipManager', () => {
 			sinon.assert.calledOnce( pinSpy );
 			sinon.assert.calledOnce( unpinSpy );
 		} );
+
+		it( 'should not crash when the tooltip gets removed on the same UI `update` event', () => {
+			utils.dispatchMouseEnter( elements.a );
+			utils.waitForTheTooltipToShow( clock );
+
+			sinon.assert.calledOnce( pinSpy );
+
+			editor.ui.update();
+			sinon.assert.calledTwice( pinSpy );
+
+			expect( editor.editing.view.document.isFocused ).to.be.false;
+
+			// Minimal case of unlinking with the button in the link balloon toolbar.
+			// See https://github.com/cksource/ckeditor5-commercial/issues/6219.
+			editor.ui.once( 'update', () => {
+				editor.editing.view.focus();
+			} );
+
+			// After removing a link from content, model changed so view and DOM got updated.
+			editor.ui.update();
+
+			utils.waitForTheTooltipToHide( clock );
+
+			editor.ui.update();
+
+			sinon.assert.calledTwice( pinSpy );
+		} );
 	} );
 
 	describe( '#defaultPositions', () => {

--- a/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
+++ b/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
@@ -1022,7 +1022,7 @@ describe( 'TooltipManager', () => {
 			expect( editor.editing.view.document.isFocused ).to.be.false;
 
 			// Minimal case of unlinking with the button in the link balloon toolbar.
-			// See https://github.com/cksource/ckeditor5-commercial/issues/6219.
+			// See https://github.com/ckeditor/ckeditor5/pull/16363.
 			editor.ui.once( 'update', () => {
 				editor.editing.view.focus();
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): The `TooltipManager` should verify if the tooltip is not already unpinned while trying to update its position. 

Closes https://github.com/cksource/ckeditor5-commercial/issues/6219.

---

### Additional information

This is fixing the following flow:
- Unlink command executed => Model change => View change => View render
- View on render event => fire `layoutChanged` event
- EditorUI on `layoutChanged` event => fire UI `update` event:
1.
    - `LinkUI` on UI `update` event => no link => `_hideUI()` => call `EditingView` `focus()`
    - `TooltipManager` on `focus` (editable) event => no `getDescendantWithTooltip()` => call `_unpinTooltip()`
    - Note that it calls `stopListening( editor.ui, 'update' )`
2.
    - This is the same `update` event as above, the stop listening is affecting only future events, not the current one.
    - `TooltipManager` on UI `update` event => call `_updateTooltipPosition()` for null element

It is safe to check if the tooltip was not already unpinned (`_currentElementWithTooltip` is cleared).

This is fixing a bug introduced in v41.2.0.