### PR TITLE
Prevented error thrown when `ckeditor5-utils/src/env.ts` is used in an environment without window global object

### DIFF
--- a/packages/ckeditor5-utils/src/env.ts
+++ b/packages/ckeditor5-utils/src/env.ts
@@ -9,11 +9,13 @@
  * @module utils/env
  */
 
+import globalVar from './dom/global';
+
 /**
  * Safely returns `userAgent` from browser's navigator API in a lower case.
  * If navigator API is not available it will return an empty string.
  */
-export function getUserAgent( ): string {
+export function getUserAgent(): string {
 	// In some environments navigator API might not be available.
 	try {
 		return navigator.userAgent.toLowerCase();
@@ -109,7 +111,9 @@ const env: EnvType = {
 
 	isBlink: isBlink( userAgent ),
 
-	isMediaForcedColors: isMediaForcedColors(),
+	get isMediaForcedColors() {
+		return isMediaForcedColors();
+	},
 
 	get isMotionReduced() {
 		return isMotionReduced();
@@ -218,14 +222,18 @@ export function isRegExpUnicodePropertySupported(): boolean {
 
 /**
  * Checks if the user agent has enabled a forced colors mode (e.g. Windows High Contrast mode).
+ *
+ * Returns `false` in environments where `window` global object is not available.
  */
 export function isMediaForcedColors(): boolean {
-	return window.matchMedia( '(forced-colors: active)' ).matches;
+	return globalVar.window.matchMedia ? globalVar.window.matchMedia( '(forced-colors: active)' ).matches : false;
 }
 
 /**
  * Checks if user enabled "prefers reduced motion" setting in browser.
+ *
+ * Returns `false` in environments where `window` global object is not available.
  */
 export function isMotionReduced(): boolean {
-	return window.matchMedia( '(prefers-reduced-motion)' ).matches;
+	return globalVar.window.matchMedia ? globalVar.window.matchMedia( '(prefers-reduced-motion)' ).matches : false;
 }

--- a/packages/ckeditor5-utils/src/env.ts
+++ b/packages/ckeditor5-utils/src/env.ts
@@ -9,7 +9,7 @@
  * @module utils/env
  */
 
-import globalVar from './dom/global.js';
+import global from './dom/global.js';
 
 /**
  * Safely returns `userAgent` from browser's navigator API in a lower case.
@@ -226,7 +226,7 @@ export function isRegExpUnicodePropertySupported(): boolean {
  * Returns `false` in environments where `window` global object is not available.
  */
 export function isMediaForcedColors(): boolean {
-	return globalVar.window.matchMedia ? globalVar.window.matchMedia( '(forced-colors: active)' ).matches : false;
+	return global.window.matchMedia ? global.window.matchMedia( '(forced-colors: active)' ).matches : false;
 }
 
 /**
@@ -235,5 +235,5 @@ export function isMediaForcedColors(): boolean {
  * Returns `false` in environments where `window` global object is not available.
  */
 export function isMotionReduced(): boolean {
-	return globalVar.window.matchMedia ? globalVar.window.matchMedia( '(prefers-reduced-motion)' ).matches : false;
+	return global.window.matchMedia ? global.window.matchMedia( '(prefers-reduced-motion)' ).matches : false;
 }

--- a/packages/ckeditor5-utils/src/env.ts
+++ b/packages/ckeditor5-utils/src/env.ts
@@ -9,7 +9,7 @@
  * @module utils/env
  */
 
-import globalVar from './dom/global';
+import globalVar from './dom/global.js';
 
 /**
  * Safely returns `userAgent` from browser's navigator API in a lower case.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (utils): Prevented error thrown when `ckeditor5-utils/src/env.ts` is used in an environment without `window` global object. Closes #16368.