### PR TITLE
The factory view includes a component name as a data attribute

### DIFF
--- a/packages/ckeditor5-ui/src/componentfactory.ts
+++ b/packages/ckeditor5-ui/src/componentfactory.ts
@@ -108,6 +108,11 @@ export default class ComponentFactory {
 		const factory = this._components.get( getNormalized( name ) )!;
 		const instance = factory.callback( this.editor.locale );
 
+		// See: https://github.com/ckeditor/ckeditor5/pull/16388#issuecomment-2121026178.
+		if ( !instance ) {
+			return null as any;
+		}
+
 		if ( instance.template ) {
 			instance.extendTemplate( {
 				attributes: {

--- a/packages/ckeditor5-ui/src/componentfactory.ts
+++ b/packages/ckeditor5-ui/src/componentfactory.ts
@@ -105,7 +105,18 @@ export default class ComponentFactory {
 			);
 		}
 
-		return this._components.get( getNormalized( name ) )!.callback( this.editor.locale );
+		const factory = this._components.get( getNormalized( name ) )!;
+		const instance = factory.callback( this.editor.locale );
+
+		if ( instance.template ) {
+			instance.extendTemplate( {
+				attributes: {
+					'data-cke-component-name': name
+				}
+			} );
+		}
+
+		return instance;
 	}
 
 	/**

--- a/packages/ckeditor5-ui/tests/componentfactory.js
+++ b/packages/ckeditor5-ui/tests/componentfactory.js
@@ -121,6 +121,15 @@ describe( 'ComponentFactory', () => {
 
 			expect( instance.element.outerHTML ).to.contains( 'data-cke-component-name="foo"' );
 		} );
+
+		// See: https://github.com/ckeditor/ckeditor5/pull/16388#issuecomment-2121026178.
+		it( 'returns null if a factory callback does not return an instance of View', () => {
+			factory.add( 'foo', () => null );
+
+			const instance = factory.create( 'foo' );
+
+			expect( instance ).to.equal( null );
+		} );
 	} );
 
 	describe( 'has()', () => {

--- a/packages/ckeditor5-ui/tests/componentfactory.js
+++ b/packages/ckeditor5-ui/tests/componentfactory.js
@@ -7,6 +7,18 @@ import Editor from '@ckeditor/ckeditor5-core/src/editor/editor.js';
 import ComponentFactory from '../src/componentfactory.js';
 
 import { expectToThrowCKEditorError } from '@ckeditor/ckeditor5-utils/tests/_utils/utils.js';
+import { View } from '../src/index.js';
+
+class SpanView extends View {
+	constructor( locale, text ) {
+		super( locale );
+
+		this.setTemplate( {
+			tag: 'span',
+			children: [ text ]
+		} );
+	}
+}
 
 describe( 'ComponentFactory', () => {
 	let editor, factory;
@@ -99,6 +111,15 @@ describe( 'ComponentFactory', () => {
 
 			expect( instance ).to.be.instanceof( View );
 			expect( instance.locale ).to.equal( locale );
+		} );
+
+		it( 'attaches the UI component name as a data attribute ([data-cke-component-name])', () => {
+			factory.add( 'foo', locale => new SpanView( locale, 'foo' ) );
+
+			const instance = factory.create( 'foo' );
+			instance.render();
+
+			expect( instance.element.outerHTML ).to.contains( 'data-cke-component-name="foo"' );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (ui): The `ComponentFactory#create()` method returns a view instance with the `[data-cke-component-name]` attribute, which allows programmatic selection of a UI component. Closes #16387.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
