### PR TITLE
Spinner animation keyframe name changed to be unique.

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/spinner/spinner.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/spinner/spinner.css
@@ -10,7 +10,7 @@
 .ck.ck-spinner-container {
 	width: var(--ck-toolbar-spinner-size);
 	height: var(--ck-toolbar-spinner-size);
-	animation: 1.5s infinite rotate linear;
+	animation: 1.5s infinite ck-spinner-rotate linear;
 
 	@media (prefers-reduced-motion: reduce) {
 		animation-duration: 3s;
@@ -25,7 +25,7 @@
 	border-top-color: transparent;
 }
 
-@keyframes rotate {
+@keyframes ck-spinner-rotate {
 	to {
 		transform: rotate(360deg)
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix(theme-lark): Name of spinner animation should be unique now. Closes #16390 .

---

### Additional information

_It was't always broken but only when in editor was used plugin that has spinner (like Export to PDF), that's why it works ok in CKBox Feature demo and didn't in Full Feature example (there was animation name collision - here `CKEditor5` and there `CKBox` animation was called `rotate`)_.
