### PR TITLE
Updating the "Implementing a block widget" tutorial to new installation methods

### DIFF
--- a/docs/tutorials/widgets/implementing-a-block-widget.md
+++ b/docs/tutorials/widgets/implementing-a-block-widget.md
@@ -839,7 +839,7 @@ You can see the block widget implementation in action in the editor below. You c
 
 ## Final solution
 
-The following code contains a complete implementation of the `SimpleBox` plugin (and all its dependencies) and the code to run the editor. You can paste it into the [`main.js`](#plugin-structure) file and it will run out–of–the–box. There is also a repository with the [final project](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/block-widget/final-project) that you can download and play with.
+The following code contains a complete implementation of the `SimpleBox` plugin (and all its dependencies) and the code to run the editor. You can paste it into the [`main.js`](#plugin-structure) file, and it will run out of the box. There is also a repository with the [final project](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/block-widget/final-project) that you can download and play with.
 
 ```js
 import {

--- a/docs/tutorials/widgets/implementing-a-block-widget.md
+++ b/docs/tutorials/widgets/implementing-a-block-widget.md
@@ -38,7 +38,7 @@ npm install
 npm run dev
 ```
 
-And now, you should see a CKEditor&nbsp;5 instance in your browser like this:
+You should see a CKEditor&nbsp;5 instance in your browser like this:
 
 {@img assets/img/tutorial-implementing-a-widget-1.png Screenshot of a classic editor initialized from source.}
 
@@ -296,7 +296,7 @@ export default class SimpleBoxEditing extends Plugin {
 }
 ```
 
-Once you have converters, you can try to see the simple box in action. You have not defined a way to insert a new simple box into the document yet, so load it via the editor data. To do that, you need to modify the `index.html` file:
+Once you have the converters, you can try to see the simple box in action. You have not defined a way to insert a new simple box into the document yet, so load it via the editor data. To do that, you need to modify the `index.html` file:
 
 ```html
 <!DOCTYPE html>
@@ -353,7 +353,7 @@ Voilà &ndash; this is your first simple box instance:
 
 {@img assets/img/tutorial-implementing-a-widget-3.png Screenshot of a classic editor with an instance of a simple box inside.}
 
-### What's in the model?
+### What is in the model?
 
 The HTML that you added to the `index.html` file is your editor's data. This is what `editor.getData()` would return. Also, for now, this also the DOM structure which is rendered by the CKEditor&nbsp;5 engine in the editable region:
 
@@ -443,11 +443,7 @@ See what else you can improve.
 ### Making simple box a widget
 
 <info-box>
-	If you are familiar with the {@link @ckeditor4 guide/dev/deep_dive/widgets/README widget system of CKEditor 4}, you will notice significant differences in how widgets are implemented in CKEditor&nbsp;5.
-
-	CKEditor 4 implementation exposes a declarative API that controls the entire behavior of a widget (from its schema and internal model to the styles, clicking behavior, context menu and the dialog).
-
-	In CKEditor&nbsp;5 the widget system was redesigned. Most of its responsibilities were taken over by the engine, some were extracted to a separate package ({@link api/widget `@ckeditor/ckeditor5-widget`}) and some have to be handled by other utilities provided by CKEditor&nbsp;5 Framework.
+	In CKEditor&nbsp;5 the widget system is mostly handled by the engine. Some of it is contained withing the ({@link api/widget `@ckeditor/ckeditor5-widget`}) package and some have to be handled by other utilities provided by CKEditor&nbsp;5 Framework.
 
 	CKEditor&nbsp;5 implementation is, therefore, open for extensions and recomposition. You can choose the behaviors that you want (just like you did so far in this tutorial by defining a schema) and skip others or implement them by yourself.
 </info-box>
@@ -673,17 +669,17 @@ export default class SimpleBoxEditing extends Plugin {
 }
 ```
 
-You can now execute this command to insert a new simple box. Calling:
+You can now execute this command to insert a new simple box. Call:
 
 ```js
 editor.execute( 'insertSimpleBox' );
 ```
 
-Should result in:
+It should result in:
 
 {@img assets/img/tutorial-implementing-a-widget-6.png Screenshot of a simple box instance inserted at the beginning of the editor content.}
 
-You can also try inspecting the `isEnabled` property value (or just checking it in CKEditor&nbsp;5 inspector):
+You can also try inspecting the `isEnabled` property value (or just checking it in the CKEditor&nbsp;5 inspector):
 
 ```js
 console.log( editor.commands.get( 'insertSimpleBox' ).isEnabled );

--- a/docs/tutorials/widgets/implementing-a-block-widget.md
+++ b/docs/tutorials/widgets/implementing-a-block-widget.md
@@ -26,7 +26,19 @@ This tutorial will reference various parts of the {@link framework/architecture/
 
 ## Let's start
 
-And now see if everything worked well by opening the index page in your browser. You should see a CKEditor&nbsp;5 instance like this:
+The easiest way to set up your project is to grab the starter files from the [GitHub repository for this tutorial](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/block-widget). We gathered all the necessary dependencies there, including some CKEditor&nbsp;5 packages and other files needed to start the editor.
+
+The editor has already been created in the `main.js` file with some basic plugins. All you need to do is clone the repository, navigate to the [starter-files directory](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/block-widget/starter-files), run the `npm install` command, and you can start coding right away.
+
+```bash
+git clone https://github.com/ckeditor/ckeditor5-tutorials-examples
+cd ckeditor5-tutorials-examples/block-widget/starter-files
+
+npm install
+npm run dev
+```
+
+And now, you should see a CKEditor&nbsp;5 instance in your browser like this:
 
 {@img assets/img/tutorial-implementing-a-widget-1.png Screenshot of a classic editor initialized from source.}
 
@@ -92,10 +104,10 @@ export default class SimpleBoxEditing extends Plugin {
 }
 ```
 
-Finally, you need to load the `SimpleBox` plugin in your `app.js` file:
+Finally, you need to load the `SimpleBox` plugin in your `main.js` file:
 
 ```js
-// app.js
+// main.js
 
 import {
 	ClassicEditor,
@@ -128,7 +140,7 @@ ClassicEditor
 	} );
 ```
 
-Rebuild your project, refresh the browser and you should see that the `SimpleBoxEditing` and `SmpleBoxUI` plugins were loaded:
+Your page will refresh and you should see that the `SimpleBoxEditing` and `SmpleBoxUI` plugins were loaded:
 
 {@img assets/img/tutorial-implementing-a-widget-2.png Screenshot of a classic editor initialized from source with the "SimpleBoxEditing#init() got called" and "SimpleBoxUI#init() got called" messages on the console.}
 
@@ -337,7 +349,7 @@ Once you have converters, you can try to see the simple box in action. You have 
 </html>
 ```
 
-Rebuild your project and voilà &ndash; this is your first simple box instance:
+Voilà &ndash; this is your first simple box instance:
 
 {@img assets/img/tutorial-implementing-a-widget-3.png Screenshot of a classic editor with an instance of a simple box inside.}
 
@@ -349,10 +361,10 @@ The HTML that you added to the `index.html` file is your editor's data. This is 
 
 However, what's in the model?
 
-To learn that, use the official {@link framework/development-tools/inspector CKEditor&nbsp;5 inspector}. Once {@link framework/development-tools/inspector#importing-the-inspector installed}, you need to load it in the `app.js` file:
+To learn that, use the official {@link framework/development-tools/inspector CKEditor&nbsp;5 inspector}. Once {@link framework/development-tools/inspector#importing-the-inspector installed}, you need to load it in the `main.js` file:
 
 ```js
-// app.js
+// main.js
 
 import {
 	ClassicEditor,
@@ -379,7 +391,7 @@ ClassicEditor
 	.then( editor => {
 		console.log( 'Editor was initialized', editor );
 
-		CKEditorInspector.attach( 'editor', editor );
+		CKEditorInspector.attach( { 'editor': editor } );
 
 		window.editor = editor;
 	} )
@@ -388,7 +400,7 @@ ClassicEditor
 	} );
 ```
 
-After rebuilding your project and refreshing the page you will see the inspector:
+After refreshing the page, you will see the inspector:
 
 {@img assets/img/tutorial-implementing-a-widget-4b.png Screenshot of a the simple box widget structure displayed by CKEditor&nbsp;5 inspector.}
 
@@ -559,7 +571,7 @@ export default class SimpleBoxEditing extends Plugin {
 
 ### Behavior after turning simple box into a widget
 
-You can rebuild your project now and see how your simple box plugin has changed.
+Now, you should see how your simple box plugin has changed.
 
 {@img assets/img/tutorial-implementing-a-widget-5.png Screenshot of the widget focus outline.}
 
@@ -827,7 +839,7 @@ You can see the block widget implementation in action in the editor below. You c
 
 ## Final solution
 
-The following code contains a complete implementation of the `SimpleBox` plugin (and all its dependencies) and the code to run the editor. You can paste it into the [`main.js`](#plugin-structure) file and it will run out–of–the–box:
+The following code contains a complete implementation of the `SimpleBox` plugin (and all its dependencies) and the code to run the editor. You can paste it into the [`main.js`](#plugin-structure) file and it will run out–of–the–box. There is also a repository with the [final project](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/block-widget/final-project) that you can download and play with.
 
 ```js
 import {
@@ -845,6 +857,8 @@ import {
 	toWidget,
 	toWidgetEditable
 } from 'ckeditor5';
+import 'ckeditor5/index.css';
+import CKEditorInspector from '@ckeditor/ckeditor5-inspector';  
 
 class SimpleBox extends Plugin {
 	static get requires() {
@@ -1056,6 +1070,8 @@ ClassicEditor
 	} )
 	.then( editor => {
 		console.log( 'Editor was initialized', editor );
+
+		CKEditorInspector.attach( { 'editor': editor } );
 
 		window.editor = editor;
 	} )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Updating the "Implementing a block widget" tutorial to new installation methods.

---

### Additional information

Links to supporting repo won't work because PR is not merged to the master yet.
Here's PR to to the repo with the supporting files: https://github.com/ckeditor/ckeditor5-tutorials-examples/pull/9
