### PR TITLE
Block toolbar's handle tooltip misaligned

### DIFF
--- a/packages/ckeditor5-ui/src/tooltipmanager.ts
+++ b/packages/ckeditor5-ui/src/tooltipmanager.ts
@@ -415,6 +415,13 @@ export default class TooltipManager extends /* #__PURE__ */ DomEmitterMixin() {
 
 		this.tooltipTextView.text = text;
 
+		this.balloonPanelView.class = [ BALLOON_CLASS, cssClass ]
+			.filter( className => className )
+			.join( ' ' );
+
+		// Ensure that all changes to the tooltip are set before pinning it.
+		// Setting class or text after pinning can cause the tooltip to be pinned in the wrong position.
+		// See https://github.com/ckeditor/ckeditor5/issues/16365
 		this.balloonPanelView.pin( {
 			target: targetDomElement,
 			positions: TooltipManager.getPositioningFunctions( position )
@@ -429,10 +436,6 @@ export default class TooltipManager extends /* #__PURE__ */ DomEmitterMixin() {
 		} );
 
 		this._mutationObserver!.attach( targetDomElement );
-
-		this.balloonPanelView.class = [ BALLOON_CLASS, cssClass ]
-			.filter( className => className )
-			.join( ' ' );
 
 		// Start responding to changes in editor UI or content layout. For instance, when collaborators change content
 		// and a contextual toolbar attached to a content starts to move (and so should move the tooltip).


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Block toolbar's handle tooltip misaligned.

---

### Additional information

Setting balloon panel view class before pinning caused misalignment of tooltip. It looks like `BALLOON_CLASS` and `cssClass` were affecting width of tooltip _after_ pinning it (probably due to word break rules). 
