### PR TITLE
Fix incorrect height of buttons placed in list

### DIFF
--- a/packages/ckeditor5-heading/theme/heading.css
+++ b/packages/ckeditor5-heading/theme/heading.css
@@ -18,7 +18,3 @@
 .ck[class*="ck-heading_heading"] {
 	font-weight: bold;
 }
-
-.ck.ck-list__item > .ck-button[class*="ck-heading_heading"] .ck-button__label {
-	line-height: var(--ck-font-size-large);
-}

--- a/packages/ckeditor5-heading/theme/heading.css
+++ b/packages/ckeditor5-heading/theme/heading.css
@@ -18,3 +18,7 @@
 .ck[class*="ck-heading_heading"] {
 	font-weight: bold;
 }
+
+.ck.ck-list__item > .ck-button[class*="ck-heading_heading"] .ck-button__label {
+	line-height: var(--ck-font-size-large);
+}

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css
@@ -43,6 +43,11 @@
 		   https://github.com/ckeditor/ckeditor5-heading/issues/63 */
 		padding: var(--ck-list-button-padding);
 
+		& .ck-button__label {
+			/* https://github.com/ckeditor/ckeditor5-heading/issues/63 */
+			line-height: calc(1.2 * var(--ck-line-height-base) * var(--ck-font-size-base));
+		}
+
 		&:active {
 			box-shadow: none;
 		}

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css
@@ -45,7 +45,7 @@
 
 		& .ck-button__label {
 			/* https://github.com/ckeditor/ckeditor5-heading/issues/63 */
-			line-height: calc(1.2 * var(--ck-line-height-base) * var(--ck-font-size-base));
+			line-height: calc(1 * var(--ck-line-height-base) * var(--ck-font-size-base));
 		}
 
 		&:active {

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css
@@ -43,7 +43,7 @@
 		   https://github.com/ckeditor/ckeditor5-heading/issues/63 */
 		padding: var(--ck-list-button-padding);
 
-		&:not([class*="ck-heading_heading"]) .ck-button__label {
+		& .ck-button__label {
 			/* https://github.com/ckeditor/ckeditor5-heading/issues/63 */
 			line-height: calc(var(--ck-line-height-base) * var(--ck-font-size-base));
 		}

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css
@@ -43,9 +43,9 @@
 		   https://github.com/ckeditor/ckeditor5-heading/issues/63 */
 		padding: var(--ck-list-button-padding);
 
-		& .ck-button__label {
+		&:not([class*="ck-heading_heading"]) .ck-button__label {
 			/* https://github.com/ckeditor/ckeditor5-heading/issues/63 */
-			line-height: calc(1 * var(--ck-line-height-base) * var(--ck-font-size-base));
+			line-height: calc(var(--ck-line-height-base) * var(--ck-font-size-base));
 		}
 
 		&:active {


### PR DESCRIPTION
Fix (theme-lark): Fixed incorrect (too short) height of buttons placed inside lists (e.g. buttons in annotations menus). This was an accidental regression introduced in one of the recent releases. Closed by #16409.

---

Closes cksource/ckeditor5-commercial#6248.

### Additional information

1. Regression introduced in this [commit](https://github.com/ckeditor/ckeditor5/commit/f072048026c5407467e343c116c71ff5a9d236b4#diff-89c661e74afa6f00cb58fc5bcd651f40c1750417127eae21b1d44d0f94ebf722L46-L50). It looks like accidental removal, menubar is not affected.
2. It fixes an issue causing incorrect height of heading dropdown items in our demos. See more in [comment](https://github.com/ckeditor/ckeditor5/pull/16409#issuecomment-2148971633). 
3. Further explanation https://cksource.slack.com/archives/C05R4RM7HRC/p1717416949627779

#### Before  
 

![image](https://github.com/ckeditor/ckeditor5/assets/3949262/e210a380-5bba-44e9-bf71-a11c5fec0622)
![obraz](https://github.com/ckeditor/ckeditor5/assets/3949262/8efe18d1-95b4-44ce-bfa2-1f308351bc35)

#### After 
 
![obraz](https://github.com/ckeditor/ckeditor5/assets/3949262/89ab33b6-8446-4501-8ae1-08fcb1363719)
![obraz](https://github.com/ckeditor/ckeditor5/assets/3949262/980321f1-4b56-4b03-8410-3d2fc9784d0d)
