### PR TITLE
Updating the "Implementing an inline widget" tutorial to new installation methods

### DIFF
--- a/docs/tutorials/widgets/implementing-an-inline-widget.md
+++ b/docs/tutorials/widgets/implementing-an-inline-widget.md
@@ -16,11 +16,9 @@ You will build a "placeholder" feature that allows the users to insert predefine
 
 ## Before you start
 
-This guide assumes that you are familiar with the widgets concept introduced in the {@link tutorials/widgets/implementing-a-block-widget Implementing a block widget} tutorial. The tutorial will also reference various concepts from the {@link framework/architecture/intro CKEditor&nbsp;5 architecture}.
+This guide assumes that you are familiar with the widgets concept introduced in the {@link tutorials/widgets/implementing-a-block-widget Implementing a block widget} tutorial, especially the {@link tutorials/widgets/implementing-a-block-widget#lets-start Let's start} and {@link tutorials/widgets/implementing-a-block-widget#plugin-structure Plugin structure} sections. The tutorial will also reference various concepts from the {@link framework/architecture/intro CKEditor&nbsp;5 architecture}.
 
 ## Bootstrapping the project
-
-The overall project structure will be similar to one described in {@link tutorials/widgets/implementing-a-block-widget#lets-start Let's start} and {@link tutorials/widgets/implementing-a-block-widget#plugin-structure Plugin structure} sections of the "Implementing a block widget" tutorial.
 
 The easiest way to set up your project is to grab the starter files from the [GitHub repository for this tutorial](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/inline-widget/starter-files). We gathered all the necessary dependencies there, including some CKEditor 5 packages and other files needed to start the editor.
 
@@ -34,7 +32,7 @@ npm install
 npm run dev
 ```
 
-First, let's define the `Placeholder` plugin. The project will have a structure as below:
+First, let's define the `Placeholder` plugin. The project should have a structure shown below:
 
 ```plain
 ├── main.js
@@ -98,11 +96,11 @@ export default class PlaceholderEditing extends Plugin {
 }
 ```
 
-At this point, you can run development server and see in the browser console that the plugins are being initialized.
+At this point, you can run the development server and see in the browser console that the plugins are being initialized.
 
 ## The model and the view layers
 
-The placeholder feature will be {@link module:engine/model/schema~SchemaItemDefinition defined as an inline} (text-like) element so it will be inserted into other editor blocks, like `<paragraph>`, that allow text. The placeholder will have a `name` attribute. This means that the model containing some text and a placeholder will look like this:
+The placeholder feature will be {@link module:engine/model/schema~SchemaItemDefinition defined} as an inline (text-like) element so it will be inserted into other editor blocks, like `<paragraph>`, that allow text. The placeholder will have a `name` attribute. This means that the model containing some text and a placeholder will look like this:
 
 ```html
 <paragraph>
@@ -150,7 +148,7 @@ The schema is defined so now you can define the model-view converters.
 
 ### Defining converters
 
-The HTML structure (data output) of the converter will be a `<span>` with a `placeholder` class. The text inside the `<span>` will be the placeholder's name.
+The HTML structure (data output) of the converter will be a `<span>` with the `placeholder` class. The text inside the `<span>` will be the placeholder's name.
 
 ```html
 <span class="placeholder">{name}</span>
@@ -232,7 +230,7 @@ export default class PlaceholderEditing extends Plugin {
 
 ### Feature styles
 
-As you could notice, the editing part imports the `./theme/placeholder.css` CSS file which describes how the placeholder is displayed in the editing view:
+The editing part imports the `./theme/placeholder.css` CSS file which describes how the placeholder is displayed in the editing view:
 
 ```css
 /* placeholder/theme/placeholder.css */

--- a/docs/tutorials/widgets/implementing-an-inline-widget.md
+++ b/docs/tutorials/widgets/implementing-an-inline-widget.md
@@ -22,13 +22,22 @@ This guide assumes that you are familiar with the widgets concept introduced in 
 
 The overall project structure will be similar to one described in {@link tutorials/widgets/implementing-a-block-widget#lets-start Let's start} and {@link tutorials/widgets/implementing-a-block-widget#plugin-structure Plugin structure} sections of the "Implementing a block widget" tutorial.
 
-Before building the project you still need to define the `Placeholder` plugin. The project will have a structure as below:
+The easiest way to set up your project is to grab the starter files from the [GitHub repository for this tutorial](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/inline-widget/starter-files). We gathered all the necessary dependencies there, including some CKEditor 5 packages and other files needed to start the editor.
+
+The editor has already been created in the `main.js` file with some basic plugins. All you need to do is clone the repository, navigate to the starter-files directory, run the `npm install` command, and you can start coding right away.
+
+```bash
+git clone https://github.com/ckeditor/ckeditor5-tutorials-examples
+cd ckeditor5-tutorials-examples/abbreviation-plugin/starter-files
+
+npm install
+npm run dev
+```
+
+First, let's define the `Placeholder` plugin. The project will have a structure as below:
 
 ```plain
-├── app.js
-├── dist
-│   ├── bundle.js
-│   └── bundle.js.map
+├── main.js
 ├── index.html
 ├── node_modules
 ├── package.json
@@ -39,10 +48,7 @@ Before building the project you still need to define the `Placeholder` plugin. T
 │   ├── placeholderui.js
 │   └── theme
 │       └── placeholder.css
-│
-│   ... the rest of the plugin files go here as well.
-│
-└── webpack.config.js
+└─ ...
 ```
 
 You can see that the placeholder feature has an established plugin structure: the master (glue) plugin (`placeholder/placeholder.js`), the "editing" (`placeholder/placeholderediting.js`) and the "UI" (`placeholder/placeholderui.js`) parts.
@@ -92,7 +98,7 @@ export default class PlaceholderEditing extends Plugin {
 }
 ```
 
-At this stage you can build the project and open it in the browser to verify if it is building correctly.
+At this point, you can run development server and see in the browser console that the plugins are being initialized.
 
 ## The model and the view layers
 
@@ -320,7 +326,7 @@ export default class PlaceholderEditing extends Plugin {
 
 ### Let's see it!
 
-You can rebuild the project now. You should be able to execute the `placeholder` command to insert a new placeholder:
+You should be able to execute the `placeholder` command to insert a new placeholder:
 
 ```js
 editor.execute( 'placeholder', { value: 'time' } );
@@ -359,7 +365,7 @@ Fortunately, CKEditor&nbsp;5 {@link module:engine/conversion/mapper~Mapper#event
 
 import {
 	Plugin,
-// MODIFIED
+	// MODIFIED
 	Widget,
 	toWidget,
 	viewToModelPositionOutsideModelElement
@@ -482,7 +488,7 @@ function getDropdownItemsDefinitions( placeholderNames ) {
 Add the dropdown to the toolbar:
 
 ```js
-// app.js
+// main.js
 
 import {
 	ClassicEdito,
@@ -607,7 +613,7 @@ You can see the placeholder widget implementation in action in the editor below.
 
 ## Final solution
 
-The following code snippet contains a complete implementation of the `Placeholder` plugin (and all its dependencies) and the code to run the editor. You can paste it into the `app.js` file and it will run out–of–the–box:
+The following code snippet contains a complete implementation of the `Placeholder` plugin (and all its dependencies) and the code to run the editor. You can paste it into the `main.js` file and it will run out of the box. There is also a repository with the [final project](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/inline-widget/final-project) that you can download and play with.
 
 ```js
 import {
@@ -628,6 +634,8 @@ import {
 	createDropdown,
 	Collection
 } from 'ckeditor5';
+import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
+import 'ckeditor5/index.css';
 
 class Placeholder extends Plugin {
 	static get requires() {
@@ -813,6 +821,8 @@ ClassicEditor
 	} )
 	.then( editor => {
 		console.log( 'Editor was initialized', editor );
+		
+		CKEditorInspector.attach( { 'editor': editor } );
 
 		// Expose for playing in the console.
 		window.editor = editor;

--- a/docs/tutorials/widgets/implementing-an-inline-widget.md
+++ b/docs/tutorials/widgets/implementing-an-inline-widget.md
@@ -14,7 +14,7 @@ You will build a "placeholder" feature that allows the users to insert predefine
 	If you want to see the final product of this tutorial before you plunge in, check out the [demo](#demo).
 </info-box>
 
-## Before you start ⚠️
+## Before you start
 
 This guide assumes that you are familiar with the widgets concept introduced in the {@link tutorials/widgets/implementing-a-block-widget Implementing a block widget} tutorial. The tutorial will also reference various concepts from the {@link framework/architecture/intro CKEditor&nbsp;5 architecture}.
 
@@ -22,151 +22,9 @@ This guide assumes that you are familiar with the widgets concept introduced in 
 
 The overall project structure will be similar to one described in {@link tutorials/widgets/implementing-a-block-widget#lets-start Let's start} and {@link tutorials/widgets/implementing-a-block-widget#plugin-structure Plugin structure} sections of the "Implementing a block widget" tutorial.
 
-First, install required dependencies:
-
-```bash
-npm install --save \
-	css-loader@5 \
-	postcss-loader@4 \
-	raw-loader@4 \
-	style-loader@2 \
-	webpack@5 \
-	webpack-cli@4 \
-	@ckeditor/ckeditor5-basic-styles \
-	@ckeditor/ckeditor5-core \
-	@ckeditor/ckeditor5-dev-utils \
-	@ckeditor/ckeditor5-editor-classic \
-	@ckeditor/ckeditor5-essentials \
-	@ckeditor/ckeditor5-heading \
-	@ckeditor/ckeditor5-list \
-	@ckeditor/ckeditor5-paragraph \
-	@ckeditor/ckeditor5-theme-lark \
-	@ckeditor/ckeditor5-ui \
-	@ckeditor/ckeditor5-utils \
-	@ckeditor/ckeditor5-widget \
-	@ckeditor/ckeditor5-inspector
-```
-
-Create a minimal webpack configuration:
-
-```js
-// webpack.config.js
-
-'use strict';
-
-const path = require( 'path' );
-const { styles } = require( '@ckeditor/ckeditor5-dev-utils' );
-
-module.exports = {
-	entry: './app.js',
-
-	output: {
-		path: path.resolve( __dirname, 'dist' ),
-		filename: 'bundle.js'
-	},
-
-	module: {
-		rules: [
-			{
-				test: /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
-				use: [ 'raw-loader' ]
-			},
-			{
-				test: /ckeditor5-[^/\\]+[/\\]theme[/\\].+\.css$/,
-				use: [
-					{
-						loader: 'style-loader',
-						options: {
-							injectType: 'singletonStyleTag',
-							attributes: {
-								'data-cke': true
-							}
-						}
-					},
-					'css-loader',
-					{
-						loader: 'postcss-loader',
-						options: {
-							postcssOptions: styles.getPostCssConfig( {
-								themeImporter: {
-									themePath: require.resolve( '@ckeditor/ckeditor5-theme-lark' )
-								},
-								minify: true
-							} )
-						}
-					}
-				]
-			}
-		]
-	},
-
-	// Useful for debugging.
-	devtool: 'source-map',
-
-	// By default webpack logs warnings if the bundle is bigger than 200kb.
-	performance: { hints: false }
-};
-```
-
-Add an `index.html` page:
-
-```html
-<!DOCTYPE html>
-<html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<title>CKEditor 5 Framework – Implementing a simple widget</title>
-	</head>
-	<body>
-		<div id="editor">
-			<p>Editor content goes here.</p>
-		</div>
-
-		<script src="dist/bundle.js"></script>
-	</body>
-</html>
-```
-
-The application entry point (`app.js`):
-
-```js
-// app.js
-
-import {
-	ClassicEditor,
-	Bold,
-	Italic,
-	Essentials,
-	Heading,
-	List,
-	Paragraph
-	} from 'ckeditor5';
-
-import Placeholder from './placeholder/placeholder';
-
-import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
-
-ClassicEditor
-	.create( document.querySelector( '#editor' ), {
-		plugins: [ Essentials, Paragraph, Heading, List, Bold, Italic, Placeholder ],
-		toolbar: [ 'heading', 'bold', 'italic', 'numberedList', 'bulletedList' ]
-	} )
-	.then( editor => {
-		console.log( 'Editor was initialized', editor );
-
-		CKEditorInspector.attach( 'editor', editor );
-
-		// Expose for playing in the console.
-		window.editor = editor;
-	} )
-	.catch( error => {
-		console.error( error.stack );
-	} );
-```
-
 Before building the project you still need to define the `Placeholder` plugin. The project will have a structure as below:
 
-```
+```plain
 ├── app.js
 ├── dist
 │   ├── bundle.js
@@ -476,7 +334,7 @@ This should result in:
 
 If you play more with the widget (for example, try to select it by dragging the mouse from its right to the left edge), you will see the following error logged to the console:
 
-```
+```plain
 Uncaught CKEditorError: model-nodelist-offset-out-of-bounds: Given offset cannot be found in the node list.
 ```
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Updating the "Implementing an inline widget" tutorial to new installation methods.

---

### Additional information

Links to supporting repo won't work because PR is not merged to the master yet.
Here's PR to to the repo with the supporting files: https://github.com/ckeditor/ckeditor5-tutorials-examples/pull/10
