### PR TITLE
Add scrollable dropdown submenus

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenu.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenu.css
@@ -6,8 +6,4 @@
 .ck.ck-dropdown-menu__menu {
 	/* Enable font size inheritance, which allows fluid UI scaling. */
 	font-size: inherit;
-
-	&.ck-dropdown-menu__menu_top-level {
-		max-width: 100%;
-	}
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenubutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenubutton.css
@@ -7,79 +7,77 @@
 @import "../../../mixins/_button.css";
 @import "@ckeditor/ckeditor5-ui/theme/mixins/_dir.css";
 
-.ck.ck-dropdown-menu__menu {
-	/*
-	 * All menu buttons.
-	 */
-	& > .ck-dropdown-menu__menu__button {
-		width: 100%;
-		padding: var(--ck-list-button-padding);
-		border-radius: 0;
+/*
+* All menu buttons.
+*/
+.ck.ck-dropdown-menu__menu__button {
+	width: 100%;
+	padding: var(--ck-list-button-padding);
+	border-radius: 0;
 
-		&:focus {
-			border-color: transparent;
-			box-shadow: none;
+	&:focus {
+		border-color: transparent;
+		box-shadow: none;
 
-			&:not(.ck-on) {
-				background: var(--ck-color-button-default-hover-background);
-			}
+		&:not(.ck-on) {
+			background: var(--ck-color-button-default-hover-background);
 		}
+	}
 
-		& > .ck-button__label {
-			flex-grow: 1;
-			overflow: hidden;
-			text-overflow: ellipsis;
-		}
+	& > .ck-button__label {
+		flex-grow: 1;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
 
-		&.ck-disabled > .ck-button__label {
-			@mixin ck-disabled;
-		}
+	&.ck-disabled > .ck-button__label {
+		@mixin ck-disabled;
+	}
 
-		/* Spacing in buttons that miss the icon. */
-		&.ck-allocate-space-for-icon-if-missing:not(:has(.ck-button__icon)) > .ck-button__label {
-			margin-left: calc(var(--ck-icon-size) - var(--ck-spacing-small));
-		}
+	/* Spacing in buttons that miss the icon. */
+	&.ck-allocate-space-for-icon-if-missing:not(:has(.ck-button__icon)) > .ck-button__label {
+		margin-left: calc(var(--ck-icon-size) - var(--ck-spacing-small));
+	}
 
-		& > .ck-dropdown-menu__menu__button__arrow {
-			width: var(--ck-dropdown-arrow-size);
-
-			@mixin ck-dir ltr {
-				transform: rotate(-90deg);
-			}
-
-			@mixin ck-dir rtl {
-				transform: rotate(90deg);
-			}
-		}
-
-		&.ck-disabled > .ck-dropdown-menu__menu__button__arrow {
-			@mixin ck-disabled;
-		}
+	& > .ck-dropdown-menu__menu__button__arrow {
+		width: var(--ck-dropdown-arrow-size);
 
 		@mixin ck-dir ltr {
-			&:not(.ck-button_with-text) {
-				padding-left: var(--ck-spacing-small);
-			}
-
-			& > .ck-dropdown-menu__menu__button__arrow {
-				right: var(--ck-spacing-standard);
-
-				/* A space to accommodate the triangle. */
-				margin-left: var(--ck-spacing-standard);
-			}
+			transform: rotate(-90deg);
 		}
 
 		@mixin ck-dir rtl {
-			&:not(.ck-button_with-text) {
-				padding-right: var(--ck-spacing-small);
-			}
+			transform: rotate(90deg);
+		}
+	}
 
-			& > .ck-dropdown-menu__menu__button__arrow {
-				left: var(--ck-spacing-standard);
+	&.ck-disabled > .ck-dropdown-menu__menu__button__arrow {
+		@mixin ck-disabled;
+	}
 
-				/* A space to accommodate the triangle. */
-				margin-right: var(--ck-spacing-small);
-			}
+	@mixin ck-dir ltr {
+		&:not(.ck-button_with-text) {
+			padding-left: var(--ck-spacing-small);
+		}
+
+		& > .ck-dropdown-menu__menu__button__arrow {
+			right: var(--ck-spacing-standard);
+
+			/* A space to accommodate the triangle. */
+			margin-left: var(--ck-spacing-standard);
+		}
+	}
+
+	@mixin ck-dir rtl {
+		&:not(.ck-button_with-text) {
+			padding-right: var(--ck-spacing-small);
+		}
+
+		& > .ck-dropdown-menu__menu__button__arrow {
+			left: var(--ck-spacing-standard);
+
+			/* A space to accommodate the triangle. */
+			margin-right: var(--ck-spacing-small);
 		}
 	}
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenulistitem.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenulistitem.css
@@ -7,6 +7,6 @@
 	--ck-dropdown-menu-menu-item-min-width: 18em;
 }
 
-.ck.ck-dropdown-menu__menu .ck.ck-dropdown-menu__menu__item {
+.ck.ck-dropdown-menu__menu__item {
 	min-width: var(--ck-dropdown-menu-menu-item-min-width);
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenulistitembutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenulistitembutton.css
@@ -35,16 +35,6 @@
 			}
 		}
 	}
-
-	/*
-	 * First-level sub-menu item buttons.
-	 */
-	&.ck-dropdown-menu__menu_top-level > .ck-dropdown-menu__menu__panel > ul > .ck-dropdown-menu__menu__item > .ck-dropdown-menu__menu__item__button {
-		/* Spacing in buttons that miss the icon. */
-		&:not(:has(.ck-button__icon)) > .ck-button__label {
-			margin-left: calc(var(--ck-icon-size) - var(--ck-spacing-small));
-		}
-	}
 }
 
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenupanel.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenupanel.css
@@ -10,7 +10,7 @@
 	--ck-dropdown-menu-menu-panel-max-width: 75vw;
 }
 
-.ck.ck-dropdown-menu__menu > .ck.ck-dropdown-menu__menu__panel {
+.ck.ck-dropdown-menu__menu__panel {
 	@mixin ck-rounded-corners;
 	@mixin ck-drop-shadow;
 

--- a/packages/ckeditor5-ui/src/bindings/clickoutsidehandler.ts
+++ b/packages/ckeditor5-ui/src/bindings/clickoutsidehandler.ts
@@ -28,14 +28,14 @@ import type { CallbackOptions, DomEmitter } from '@ckeditor/ckeditor5-utils';
 export default function clickOutsideHandler(
 	{ emitter, activator, callback, contextElements, options }: {
 		emitter: DomEmitter;
-		activator: () => boolean;
+		activator: ( domEvt: MouseEvent ) => boolean;
 		contextElements: Array<HTMLElement> | ( () => Array<HTMLElement> );
 		callback: () => void;
 		options?: CallbackOptions;
 	}
 ): void {
 	emitter.listenTo( document, 'mousedown', ( evt, domEvt ) => {
-		if ( !activator() ) {
+		if ( !activator( domEvt ) ) {
 			return;
 		}
 

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenulistitemview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenulistitemview.ts
@@ -12,6 +12,7 @@ import type { DropdownMenuFocusableFlatItemView } from './typings.js';
 import type DropdownMenuView from './dropdownmenuview.js';
 
 import ListItemView from '../../list/listitemview.js';
+import { isDropdownMenuFocusableFlatItemView } from './guards.js';
 
 import '../../../theme/components/dropdown/menu/dropdownmenulistitem.css';
 
@@ -49,6 +50,10 @@ export default class DropdownMenuListItemView extends ListItemView {
 
 		if ( parentMenuView ) {
 			this.delegate( 'mouseenter' ).to( parentMenuView );
+
+			if ( isDropdownMenuFocusableFlatItemView( flatItemOrNestedMenuView ) ) {
+				flatItemOrNestedMenuView.delegate( 'execute' ).to( parentMenuView, 'item:execute' );
+			}
 		}
 	}
 }

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenupanelview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenupanelview.ts
@@ -7,13 +7,16 @@
  * @module ui/dropdown/menu/dropdownmenupanelview
  */
 
-import type { Locale } from '@ckeditor/ckeditor5-utils';
+import { toUnit, type Locale } from '@ckeditor/ckeditor5-utils';
+
 import type { FocusableView } from '../../focuscycler.js';
 import type ViewCollection from '../../viewcollection.js';
 
 import View from '../../view.js';
 
 import '../../../theme/components/dropdown/menu/dropdownmenupanel.css';
+
+const toPx = /* #__PURE__ */ toUnit( 'px' );
 
 /**
  * Represents the view for the dropdown menu panel.
@@ -43,6 +46,22 @@ export default class DropdownMenuPanelView extends View implements FocusableView
 	declare public position: DropdownMenuPanelPosition;
 
 	/**
+	 * The absolute top position of the menu panel in pixels.
+	 *
+	 * @observable
+	 * @default 0
+	 */
+	declare public top: number;
+
+	/**
+	 * The absolute left position of the menu panel in pixels.
+	 *
+	 * @observable
+	 * @default 0
+	 */
+	declare public left: number;
+
+	/**
 	 * Creates an instance of the menu panel view.
 	 *
 	 * @param locale The localization services instance.
@@ -52,8 +71,12 @@ export default class DropdownMenuPanelView extends View implements FocusableView
 
 		const bind = this.bindTemplate;
 
-		this.set( 'isVisible', false );
-		this.set( 'position', 'se' );
+		this.set( {
+			isVisible: false,
+			position: 'se',
+			top: 0,
+			left: 0
+		} );
 
 		this.children = this.createCollection();
 
@@ -68,7 +91,11 @@ export default class DropdownMenuPanelView extends View implements FocusableView
 					bind.to( 'position', value => `ck-dropdown-menu__menu__panel_position_${ value }` ),
 					bind.if( 'isVisible', 'ck-hidden', value => !value )
 				],
-				tabindex: '-1'
+				tabindex: '-1',
+				style: {
+					top: bind.to( 'top', toPx ),
+					left: bind.to( 'left', toPx )
+				}
 			},
 
 			children: this.children,
@@ -108,4 +135,4 @@ export default class DropdownMenuPanelView extends View implements FocusableView
  *
  * They are reflected as CSS class suffixes on the panel view element.
  */
-export type DropdownMenuPanelPosition = 'se' | 'sw' | 'ne' | 'nw' | 'w' | 'e';
+export type DropdownMenuPanelPosition = 'es' | 'ws' | 'en' | 'wn' | 'w' | 'e';

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuportalview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuportalview.ts
@@ -1,0 +1,96 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module ui/dropdown/menu/dropdownmenupanelportalview
+ */
+
+import { toUnit, type Locale } from '@ckeditor/ckeditor5-utils';
+import View from '../../view.js';
+import type ViewCollection from '../../viewcollection.js';
+
+import '../../../theme/components/dropdown/menu/dropdownmenuportal.css';
+
+const toPx = /* #__PURE__ */ toUnit( 'px' );
+
+export default class DropdownMenuPortalView extends View {
+	/**
+	 * The absolute top position of the portal in pixels.
+	 *
+	 * @observable
+	 * @default 0
+	 */
+	declare public top: number;
+
+	/**
+	 * The absolute left position of the portal in pixels.
+	 *
+	 * @observable
+	 * @default 0
+	 */
+	declare public left: number;
+
+	/**
+	 * The name of the position of the panel, relative to the parent.
+	 *
+	 * This property is reflected in the CSS class suffix set to {@link #element} that controls
+	 * the position of the panel.
+	 *
+	 * @observable
+	 * @default 'se'
+	 */
+	declare public position: DropdownMenuPortalPosition;
+
+	/**
+	 * Indicates whether the dropdown menu portal view is currently visible.
+	 *
+	 * @observable
+	 * @default false
+	 */
+	declare public isVisible: boolean;
+
+	/**
+	 * A collection of child views in the form.
+	 */
+	public readonly children: ViewCollection;
+
+	constructor( locale: Locale ) {
+		super( locale );
+
+		const bind = this.bindTemplate;
+
+		this.children = this.createCollection();
+		this.set( {
+			top: 0,
+			left: 0,
+			position: 'es',
+			isVisible: false
+		} );
+
+		this.setTemplate( {
+			tag: 'div',
+			attributes: {
+				class: [
+					'ck',
+					'ck-dropdown-menu__menu__portal',
+					bind.to( 'position', value => `ck-dropdown-menu__menu__portal_position_${ value }` ),
+					bind.if( 'isVisible', 'ck-hidden', value => !value ),
+					'ck-ai-assistant-ui_theme' // fixme
+				],
+				style: {
+					top: bind.to( 'top', toPx ),
+					left: bind.to( 'left', toPx )
+				},
+				tabindex: '-1'
+			},
+			children: this.children
+		} );
+	}
+}
+
+/**
+ * They are reflected as CSS class suffixes on the panel view element.
+ */
+export type DropdownMenuPortalPosition = 'se' | 'sw' | 'ne' | 'nw' | 'w' | 'e';

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuportalview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuportalview.ts
@@ -7,50 +7,12 @@
  * @module ui/dropdown/menu/dropdownmenupanelportalview
  */
 
-import { toUnit, type Locale } from '@ckeditor/ckeditor5-utils';
-import View from '../../view.js';
+import type { Locale } from '@ckeditor/ckeditor5-utils';
 import type ViewCollection from '../../viewcollection.js';
 
-import '../../../theme/components/dropdown/menu/dropdownmenuportal.css';
-
-const toPx = /* #__PURE__ */ toUnit( 'px' );
+import View from '../../view.js';
 
 export default class DropdownMenuPortalView extends View {
-	/**
-	 * The absolute top position of the portal in pixels.
-	 *
-	 * @observable
-	 * @default 0
-	 */
-	declare public top: number;
-
-	/**
-	 * The absolute left position of the portal in pixels.
-	 *
-	 * @observable
-	 * @default 0
-	 */
-	declare public left: number;
-
-	/**
-	 * The name of the position of the panel, relative to the parent.
-	 *
-	 * This property is reflected in the CSS class suffix set to {@link #element} that controls
-	 * the position of the panel.
-	 *
-	 * @observable
-	 * @default 'se'
-	 */
-	declare public position: DropdownMenuPortalPosition;
-
-	/**
-	 * Indicates whether the dropdown menu portal view is currently visible.
-	 *
-	 * @observable
-	 * @default false
-	 */
-	declare public isVisible: boolean;
-
 	/**
 	 * A collection of child views in the form.
 	 */
@@ -59,15 +21,7 @@ export default class DropdownMenuPortalView extends View {
 	constructor( locale: Locale ) {
 		super( locale );
 
-		const bind = this.bindTemplate;
-
 		this.children = this.createCollection();
-		this.set( {
-			top: 0,
-			left: 0,
-			position: 'es',
-			isVisible: false
-		} );
 
 		this.setTemplate( {
 			tag: 'div',
@@ -75,22 +29,11 @@ export default class DropdownMenuPortalView extends View {
 				class: [
 					'ck',
 					'ck-dropdown-menu__menu__portal',
-					bind.to( 'position', value => `ck-dropdown-menu__menu__portal_position_${ value }` ),
-					bind.if( 'isVisible', 'ck-hidden', value => !value ),
 					'ck-ai-assistant-ui_theme' // fixme
 				],
-				style: {
-					top: bind.to( 'top', toPx ),
-					left: bind.to( 'left', toPx )
-				},
 				tabindex: '-1'
 			},
 			children: this.children
 		} );
 	}
 }
-
-/**
- * They are reflected as CSS class suffixes on the panel view element.
- */
-export type DropdownMenuPortalPosition = 'se' | 'sw' | 'ne' | 'nw' | 'w' | 'e';

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuportalview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuportalview.ts
@@ -22,7 +22,6 @@ export default class DropdownMenuPortalView extends View {
 		super( locale );
 
 		this.children = this.createCollection();
-
 		this.setTemplate( {
 			tag: 'div',
 			attributes: {

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuportalview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuportalview.ts
@@ -28,6 +28,7 @@ export default class DropdownMenuPortalView extends View {
 				class: [
 					'ck',
 					'ck-dropdown-menu__menu__portal',
+					'ck-preserve-dropdown-if-focus-inside',
 					'ck-ai-assistant-ui_theme' // fixme
 				],
 				tabindex: '-1'

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenurootlistview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenurootlistview.ts
@@ -32,7 +32,7 @@ import type {
 
 import type { DropdownMenuViewsRootTree } from './search/tree/dropdownsearchtreetypings.js';
 import type {
-	DropdownMenuCloseAllEvent,
+	DropdownMenuExecuteItemEvent,
 	DropdownMenuChangeIsOpenEvent,
 	DropdownMenuSubmenuChangeEvent,
 	DropdownMenuPreloadAllEvent
@@ -401,7 +401,7 @@ export default class DropdownMenuRootListView extends DropdownMenuListView {
 	 * @internal
 	 */
 	private _watchRootMenuEvents(): void {
-		this.on<DropdownMenuCloseAllEvent>( 'menu:close:all', this.close.bind( this ) );
+		this.on<DropdownMenuExecuteItemEvent>( 'menu:item:execute', this.close.bind( this ) );
 		this.on<DropdownMenuSubmenuChangeEvent>( 'menu:submenu:change', () => {
 			this._cachedMenus = null;
 		} );

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenurootlistview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenurootlistview.ts
@@ -12,8 +12,7 @@ import { once } from 'lodash-es';
 import {
 	CKEditorError,
 	type ObservableChangeEvent,
-	type CollectionAddEvent,
-	type Locale
+	type CollectionAddEvent
 } from '@ckeditor/ckeditor5-utils';
 
 import type {
@@ -25,7 +24,7 @@ import type {
 
 import DropdownMenuListView from './dropdownmenulistview.js';
 
-import type { NonEmptyArray } from '@ckeditor/ckeditor5-core';
+import type { Editor, NonEmptyArray } from '@ckeditor/ckeditor5-core';
 import type {
 	DropdownMenuFocusableView,
 	DropdownNestedMenuListItemView
@@ -63,7 +62,7 @@ import {
  * Represents the root list view of a dropdown menu.
  *
  * ```ts
- * const view = new DropdownMenuRootListView( locale, [
+ * const view = new DropdownMenuRootListView( editor, [
  * 	{
  * 		menu: 'Menu 1',
  * 		children: [
@@ -112,7 +111,14 @@ export default class DropdownMenuRootListView extends DropdownMenuListView {
 	 *
 	 * @internal
 	 */
-	private _lazyInitializeSubMenus: boolean;
+	private readonly _lazyInitializeSubMenus: boolean;
+
+	/**
+	 * The editor instance associated with the dropdown menu root list view.
+	 *
+	 * @internal
+	 */
+	public readonly editor: Editor;
 
 	/**
 	 * Creates an instance of the DropdownMenuRootListView class.
@@ -121,12 +127,14 @@ export default class DropdownMenuRootListView extends DropdownMenuListView {
 	 * @param definition The definition object for the dropdown menu root factory.
 	 * @param lazyInitializeSubMenus Indicates whether the dropdown menu should be lazily initialized when clicked.
 	 */
-	constructor( locale: Locale, definitions?: DropdownMenuDefinitions, lazyInitializeSubMenus = false ) {
-		super( locale );
+	constructor( editor: Editor, definitions?: DropdownMenuDefinitions, lazyInitializeSubMenus = false ) {
+		super( editor.locale );
 
 		this.set( 'isOpen', false );
 
+		this.editor = editor;
 		this._lazyInitializeSubMenus = lazyInitializeSubMenus;
+
 		this._setupIsOpenUpdater();
 		this._watchRootMenuEvents();
 
@@ -322,7 +330,7 @@ export default class DropdownMenuRootListView extends DropdownMenuListView {
 		parentMenuView: DropdownMenuView | null
 	) {
 		const { children, menu } = menuDefinition;
-		const menuView = new DropdownMenuView( this.locale!, menu, parentMenuView );
+		const menuView = new DropdownMenuView( this.editor, menu, parentMenuView );
 
 		if ( this._lazyInitializeSubMenus ) {
 			// Prepend the first item to the menu and append the rest after opening menu.

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuview.ts
@@ -187,8 +187,8 @@ export default class DropdownMenuView extends View implements FocusableView {
 		this.portalView = new DropdownMenuPortalView( editor.locale );
 		this.portalView.children.add( this.panelView );
 
-		this._attachBehaviors();
 		this._attachParentMenuBehaviors();
+		this._attachBehaviors();
 
 		if ( parentMenuView ) {
 			this.parentMenuView = parentMenuView;
@@ -270,6 +270,11 @@ export default class DropdownMenuView extends View implements FocusableView {
 
 		// Let the menu control the position of the panel. The position must be updated every time the menu is open.
 		this.on<ObservableChangeEvent<boolean>>( 'change:isOpen', ( evt, name, isOpen ) => {
+			// Ensure that the event was triggered by this instance.
+			if ( evt.source !== this ) {
+				return;
+			}
+
 			// Removes the portal view from the body when the menu is closed.
 			if ( !isOpen && body.has( portalView ) ) {
 				body.remove( portalView );
@@ -293,7 +298,8 @@ export default class DropdownMenuView extends View implements FocusableView {
 
 		// Let the menu control the position of the panel. The position must be updated every time the menu is open.
 		this.on<ObservableChangeEvent<boolean>>( 'change:isOpen', ( evt, name, isOpen ) => {
-			if ( !isOpen ) {
+			// Ensure that the event was triggered by this instance.
+			if ( !isOpen || evt.source !== this ) {
 				return;
 			}
 

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuview.ts
@@ -29,6 +29,7 @@ import View from '../../view.js';
 import DropdownMenuPanelView, { type DropdownMenuPanelPosition } from './dropdownmenupanelview.js';
 
 import '../../../theme/components/dropdown/menu/dropdownmenu.css';
+import { Editor } from '@ckeditor/ckeditor5-core';
 
 /**
  * Represents a dropdown menu view.
@@ -117,18 +118,18 @@ export default class DropdownMenuView extends View implements FocusableView {
 	declare public pendingLazyInitialization: boolean;
 
 	/**
-	 * Creates an instance of the menu view.
+	 * Creates a new instance of the DropdownMenuView class.
 	 *
-	 * @param locale The localization services instance.
-	 * @param label Label of button
-	 * @param parentMenuView The parent menu view of the menu.
+	 * @param editor The editor instance.
+	 * @param label The label for the dropdown menu button.
+	 * @param parentMenuView The parent dropdown menu view, if any.
 	 */
-	constructor( locale: Locale, label?: string, parentMenuView?: DropdownMenuView | null ) {
-		super( locale );
+	constructor( editor: Editor, label?: string, parentMenuView?: DropdownMenuView | null ) {
+		super( editor.locale );
 
 		const bind = this.bindTemplate;
 
-		this.buttonView = new DropdownMenuButtonView( locale );
+		this.buttonView = new DropdownMenuButtonView( editor.locale );
 		this.buttonView.delegate( 'mouseenter' ).to( this );
 		this.buttonView.bind( 'isOn', 'isEnabled' ).to( this, 'isOpen', 'isEnabled' );
 
@@ -136,10 +137,10 @@ export default class DropdownMenuView extends View implements FocusableView {
 			this.buttonView.label = label;
 		}
 
-		this.panelView = new DropdownMenuPanelView( locale );
+		this.panelView = new DropdownMenuPanelView( editor.locale );
 		this.panelView.bind( 'isVisible' ).to( this, 'isOpen' );
 
-		this.listView = new DropdownMenuListView( locale );
+		this.listView = new DropdownMenuListView( editor.locale );
 		this.listView.bind( 'ariaLabel' ).to( this.buttonView, 'label' );
 
 		this.keystrokes = new KeystrokeHandler();
@@ -167,13 +168,21 @@ export default class DropdownMenuView extends View implements FocusableView {
 			},
 
 			children: [
-				this.buttonView,
-				this.panelView
+				this.buttonView
 			]
 		} );
 
 		this._attachBehaviors();
 		this._attachParentMenuBehaviors();
+
+		this.panelView.render();
+
+		const el = document.createElement( 'div' );
+		el.setAttribute( 'dir', 'ltr' );
+		el.classList.add( 'ck-reset_all' );
+		el.classList.add( 'ck-ai-assistant-ui_theme' );
+		el.appendChild( this.panelView.element! );
+		document.body.appendChild( el );
 
 		if ( parentMenuView ) {
 			this.parentMenuView = parentMenuView;
@@ -249,6 +258,18 @@ export default class DropdownMenuView extends View implements FocusableView {
 				fitInViewport: true,
 				positions: this._panelPositions
 			} );
+
+			const { element } = this.panelView;
+
+			Object.assign(
+				element!.style,
+				{
+					position: 'absolute',
+					left: `${ optimalPanelPosition!.left }px`,
+					top: `${ optimalPanelPosition!.top }px`,
+					zIndex: 1001
+				}
+			);
 
 			this.panelView.position = (
 				optimalPanelPosition ? optimalPanelPosition.name : this._panelPositions[ 0 ].name

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuview.ts
@@ -42,7 +42,7 @@ export default class DropdownMenuView extends View implements FocusableView {
 	 */
 	public static readonly DELEGATED_EVENTS = [
 		'mouseenter', 'arrowleft', 'arrowright',
-		'change:isOpen', 'close:all', 'submenu:change'
+		'change:isOpen', 'item:execute', 'submenu:change'
 	] as const;
 
 	/**
@@ -187,12 +187,12 @@ export default class DropdownMenuView extends View implements FocusableView {
 		this.portalView = new DropdownMenuPortalView( editor.locale );
 		this.portalView.children.add( this.panelView );
 
+		this._attachBehaviors();
+		this._attachParentMenuBehaviors();
+
 		if ( parentMenuView ) {
 			this.parentMenuView = parentMenuView;
 		}
-
-		this._attachBehaviors();
-		this._attachParentMenuBehaviors();
 	}
 
 	/**
@@ -236,7 +236,6 @@ export default class DropdownMenuView extends View implements FocusableView {
 	 * Attaches the parent menu behaviors to the menu.
 	 */
 	private _attachParentMenuBehaviors(): void {
-		this.delegate( 'execute' ).to( this, 'close:all' );
 		this.listView.items.on( 'change', () => {
 			this.fire( 'submenu:change' );
 		} );

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuview.ts
@@ -184,15 +184,15 @@ export default class DropdownMenuView extends View implements FocusableView {
 			]
 		} );
 
-		this._attachBehaviors();
-		this._attachParentMenuBehaviors();
-
 		this.portalView = new DropdownMenuPortalView( editor.locale );
 		this.portalView.children.add( this.panelView );
 
 		if ( parentMenuView ) {
 			this.parentMenuView = parentMenuView;
 		}
+
+		this._attachBehaviors();
+		this._attachParentMenuBehaviors();
 	}
 
 	/**
@@ -242,6 +242,7 @@ export default class DropdownMenuView extends View implements FocusableView {
 			this.fire( 'submenu:change' );
 		} );
 
+		this.portalView.delegate( ...DropdownMenuView.DELEGATED_EVENTS ).to( this );
 		this.on<ObservableChangeEvent<DropdownMenuView | null>>( 'change:parentMenuView', ( evt, name, parentMenuView ) => {
 			if ( parentMenuView ) {
 				this.delegate( ...DropdownMenuView.DELEGATED_EVENTS ).to( parentMenuView );
@@ -266,17 +267,19 @@ export default class DropdownMenuView extends View implements FocusableView {
 	 * so that it optimally uses the available space in the viewport.
 	 */
 	private _repositionPanelOnOpen(): void {
-		const { portalView, panelView, buttonView } = this;
+		const { portalView, panelView, buttonView, keystrokes } = this;
 		const { body } = this.editor.ui.view;
 
 		// Let the menu control the position of the panel. The position must be updated every time the menu is open.
 		this.on<ObservableChangeEvent<boolean>>( 'change:isOpen', ( evt, name, isOpen ) => {
-			if ( isOpen && !body.has( portalView ) ) {
-				body.add( portalView );
-			}
-
 			if ( !isOpen ) {
 				return;
+			}
+
+			// Adds portal view to the body when the menu is open. Binds keystrokes to the portal view.
+			if ( isOpen && !body.has( portalView ) ) {
+				body.add( portalView );
+				keystrokes.listenTo( portalView.element! );
 			}
 
 			const buttonRect = buttonView.element!.getBoundingClientRect();

--- a/packages/ckeditor5-ui/src/dropdown/menu/events.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/events.ts
@@ -48,14 +48,14 @@ export interface DropdownMenuChangeIsOpenEvent extends DropdownMenuEvent {
 }
 
 /**
- * Represents an event that is triggered when all dropdown menus should be closed.
+ * Represents an event that is triggered when a dropdown menu item is executed.
  */
-export interface DropdownMenuCloseAllEvent extends DropdownMenuEvent {
+export interface DropdownMenuExecuteItemEvent extends DropdownMenuEvent {
 
 	/**
 	 * The name of the event.
 	 */
-	name: 'menu:close:all';
+	name: 'menu:item:execute';
 }
 
 /**

--- a/packages/ckeditor5-ui/src/dropdown/menu/filterview/dropdownmenulistfilteredview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/filterview/dropdownmenulistfilteredview.ts
@@ -7,7 +7,7 @@
  * @module ui/dropdown/menu/filterview/dropdownmenulistfilteredview
  */
 
-import type { Locale } from '@ckeditor/ckeditor5-utils';
+import type { Editor } from '@ckeditor/ckeditor5-core';
 import type { DropdownMenuDefinitions } from '../definition/dropdownmenudefinitiontypings.js';
 import type FilteredView from '../../../search/filteredview.js';
 import type { DropdownMenuSearchResult } from '../search/filterdropdownmenutree.js';
@@ -37,13 +37,13 @@ export default class DropdownMenuListFilteredView extends View implements Filter
 	 * Represents a filtered view for the dropdown menu list.
 	 */
 	constructor(
-		locale: Locale,
+		editor: Editor,
 		definitions: DropdownMenuDefinitions,
 		lazyInitializeSubMenus?: boolean
 	) {
-		super( locale );
+		super( editor.locale );
 
-		this._menuView = new DropdownMenuRootListView( locale, definitions, lazyInitializeSubMenus );
+		this._menuView = new DropdownMenuRootListView( editor, definitions, lazyInitializeSubMenus );
 		this.setTemplate( {
 			tag: 'div',
 

--- a/packages/ckeditor5-ui/src/dropdown/menu/utils/dropdownmenubehaviors.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/utils/dropdownmenubehaviors.ts
@@ -178,19 +178,6 @@ export const DropdownMenuBehaviors = {
 	},
 
 	/**
-	 * Closes the menu on the esc key press. This allows for navigating to sub-menus using the keyboard.
-	 */
-	closeOnEscKey( menuView: DropdownMenuView ): void {
-		menuView.keystrokes.set( 'esc', ( data, cancel ) => {
-			if ( menuView.isOpen ) {
-				menuView.isOpen = false;
-				menuView.focus();
-				cancel();
-			}
-		} );
-	},
-
-	/**
 	 * Closes the menu when its parent menu also closed. This prevents from orphaned open menus when the parent menu re-opens.
 	 */
 	closeOnParentClose( menuView: DropdownMenuView, parentMenuView: DropdownMenuView ): void {

--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -427,7 +427,9 @@ function closeDropdownOnClickOutside( dropdownView: DropdownView ) {
 	dropdownView.on<UIViewRenderEvent>( 'render', () => {
 		clickOutsideHandler( {
 			emitter: dropdownView,
-			activator: () => dropdownView.isOpen,
+			activator: ( domEvt: MouseEvent ) => (
+				!hasParentWithPreservedDropdownFocus( domEvt.target as Element | null ) && dropdownView.isOpen
+			),
 			callback: () => {
 				dropdownView.isOpen = false;
 			},
@@ -459,10 +461,21 @@ function closeDropdownOnExecute( dropdownView: DropdownView ) {
  */
 function closeDropdownOnBlur( dropdownView: DropdownView ) {
 	dropdownView.focusTracker.on<ObservableChangeEvent<boolean>>( 'change:isFocused', ( evt, name, isFocused ) => {
-		if ( dropdownView.isOpen && !isFocused ) {
+		if ( !hasParentWithPreservedDropdownFocus( document.activeElement ) && dropdownView.isOpen && !isFocused ) {
 			dropdownView.isOpen = false;
 		}
 	} );
+}
+
+/**
+ * Checks if the given menu element or any of its ancestors has the class 'ck-preserve-dropdown-if-focus-inside',
+ * indicating that the dropdown should not be closed when it's focus is lost.
+ *
+ * @param menu The menu element to check.
+ * @returns `true` if the menu or any of its ancestors has the class 'ck-preserve-dropdown-if-focus-inside', `false` otherwise.
+ */
+function hasParentWithPreservedDropdownFocus( menu: Element | null ): boolean {
+	return !!( menu && menu.closest( '.ck-preserve-dropdown-if-focus-inside' ) );
 }
 
 /**

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -55,6 +55,7 @@ export { default as DropdownButtonView } from './dropdown/button/dropdownbuttonv
 export { default as SplitButtonView } from './dropdown/button/splitbuttonview.js';
 export * from './dropdown/utils.js';
 
+export * from './dropdown/menu/events.js';
 export { default as DropdownMenuView } from './dropdown/menu/dropdownmenuview.js';
 export { default as DropdownMenuListView } from './dropdown/menu/dropdownmenulistview.js';
 export { default as DropdownMenuListItemView } from './dropdown/menu/dropdownmenulistitemview.js';

--- a/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenu.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenu.css
@@ -5,5 +5,4 @@
 
 .ck.ck-dropdown-menu__menu {
 	display: block;
-	position: relative;
 }

--- a/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenubutton.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenubutton.css
@@ -3,9 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-.ck.ck-dropdown-menu__menu  {
-	& > .ck-dropdown-menu__menu__button > .ck-dropdown-menu__menu__button__arrow {
-		pointer-events: none;
-		z-index: var(--ck-z-default);
-	}
+.ck.ck-dropdown-menu__menu__button > .ck-dropdown-menu__menu__button__arrow {
+	pointer-events: none;
+	z-index: var(--ck-z-default);
 }

--- a/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenupanel.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenupanel.css
@@ -4,32 +4,8 @@
  */
 
 .ck.ck-dropdown-menu__menu__panel {
+	position: absolute;
 	max-height: 60vh;
 	overflow-y: auto;
-
-	&.ck-dropdown-menu__menu__panel_position_es,
-	&.ck-dropdown-menu__menu__panel_position_en {
-		left: calc( 100% - var(--ck-dropdown-menu-nested-menu-horizontal-offset) );
-	}
-
-	&.ck-dropdown-menu__menu__panel_position_es {
-		top: 0px;
-	}
-
-	&.ck-dropdown-menu__menu__panel_position_en {
-		bottom: 0px;
-	}
-
-	&.ck-dropdown-menu__menu__panel_position_ws,
-	&.ck-dropdown-menu__menu__panel_position_wn {
-		right: calc( 100% - var(--ck-dropdown-menu-nested-menu-horizontal-offset) );
-	}
-
-	&.ck-dropdown-menu__menu__panel_position_ws {
-		top: 0px;
-	}
-
-	&.ck-dropdown-menu__menu__panel_position_wn {
-		bottom: 0px;
-	}
+	z-index: calc(var(--ck-z-panel) + 1);
 }

--- a/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenupanel.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenupanel.css
@@ -3,34 +3,9 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-:root {
-	--ck-dropdown-menu-nested-menu-horizontal-offset: 5px;
-}
-
-.ck.ck-dropdown-menu__menu > .ck.ck-dropdown-menu__menu__panel {
-	z-index: var(--ck-z-panel);
-	position: absolute;
-
-	&.ck-dropdown-menu__menu__panel_position_ne,
-	&.ck-dropdown-menu__menu__panel_position_nw {
-		bottom: 100%;
-	}
-
-	&.ck-dropdown-menu__menu__panel_position_se,
-	&.ck-dropdown-menu__menu__panel_position_sw {
-		top: 100%;
-		bottom: auto;
-	}
-
-	&.ck-dropdown-menu__menu__panel_position_ne,
-	&.ck-dropdown-menu__menu__panel_position_se {
-		left: 0px;
-	}
-
-	&.ck-dropdown-menu__menu__panel_position_nw,
-	&.ck-dropdown-menu__menu__panel_position_sw {
-		right: 0px;
-	}
+.ck.ck-dropdown-menu__menu__panel {
+	max-height: 60vh;
+	overflow-y: auto;
 
 	&.ck-dropdown-menu__menu__panel_position_es,
 	&.ck-dropdown-menu__menu__panel_position_en {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (ui): Add dropdown menu large menus scrolling support.

---

### Additional information

Current implementation of menu (copied from menubar) does not support scrolling. Submenus are rendered in `MenuPanelView` element, which is kinda problematic in terms of `overflow: scroll`. This PR moves submenu rendering to `ck-body-wrapper`, fixes focus and makes menu keyboard accessible. 

![obraz](https://github.com/ckeditor/ckeditor5/assets/3949262/a704cee2-ac73-48f6-9c23-402a55538c72)

