### PR TITLE
The `EditorWatchdog`, `ContextWatchdog`, and `Context` classes are now exposed as static fields of the `Editor` class.

### DIFF
--- a/packages/ckeditor5-core/package.json
+++ b/packages/ckeditor5-core/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@ckeditor/ckeditor5-engine": "41.4.2",
     "@ckeditor/ckeditor5-utils": "41.4.2",
+    "@ckeditor/ckeditor5-watchdog": "41.4.2",
     "lodash-es": "4.17.21"
   },
   "devDependencies": {

--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -25,6 +25,7 @@ import {
 } from '@ckeditor/ckeditor5-engine';
 
 import type { EditorUI } from '@ckeditor/ckeditor5-ui';
+import { ContextWatchdog, EditorWatchdog } from '@ckeditor/ckeditor5-watchdog';
 
 import Context from '../context.js';
 import PluginCollection from '../plugincollection.js';
@@ -642,6 +643,27 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 	public static create( ...args: Array<unknown> ): void { // eslint-disable-line @typescript-eslint/no-unused-vars
 		throw new Error( 'This is an abstract method.' );
 	}
+
+	/**
+	 * The {@link module:core/context~Context} class.
+	 *
+	 * Exposed as static editor field for easier access in editor builds.
+	 */
+	public static Context = Context;
+
+	/**
+	 * The {@link module:watchdog/editorwatchdog~EditorWatchdog} class.
+	 *
+	 * Exposed as static editor field for easier access in editor builds.
+	 */
+	public static EditorWatchdog = EditorWatchdog;
+
+	/**
+	 * The {@link module:watchdog/contextwatchdog~ContextWatchdog} class.
+	 *
+	 * Exposed as static editor field for easier access in editor builds.
+	 */
+	public static ContextWatchdog = ContextWatchdog;
 }
 
 /**

--- a/packages/ckeditor5-core/tests/editor/editor.js
+++ b/packages/ckeditor5-core/tests/editor/editor.js
@@ -20,6 +20,8 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror.js';
 import testUtils from '../../tests/_utils/utils.js';
 import { getData, setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 import Accessibility from '../../src/accessibility.js';
+import EditorWatchdog from '@ckeditor/ckeditor5-watchdog/src/editorwatchdog.js';
+import ContextWatchdog from '@ckeditor/ckeditor5-watchdog/src/contextwatchdog.js';
 
 class TestEditor extends Editor {
 	static create( config ) {
@@ -1345,6 +1347,20 @@ describe( 'Editor', () => {
 				testUtils.sinon.assert.calledOnce( spy );
 				testUtils.sinon.assert.calledWith( spy, options );
 			} );
+		} );
+	} );
+
+	describe( 'static fields', () => {
+		it( 'Editor.Context', () => {
+			expect( Editor.Context ).to.equal( Context );
+		} );
+
+		it( 'Editor.EditorWatchdog', () => {
+			expect( Editor.EditorWatchdog ).to.equal( EditorWatchdog );
+		} );
+
+		it( 'Editor.ContextWatchdog', () => {
+			expect( Editor.ContextWatchdog ).to.equal( ContextWatchdog );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-editor-balloon/src/ballooneditor.ts
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditor.ts
@@ -9,7 +9,6 @@
 
 import {
 	Editor,
-	Context,
 	ElementApiMixin,
 	attachToForm,
 	secureSourceElement,
@@ -19,8 +18,6 @@ import {
 
 import { BalloonToolbar } from 'ckeditor5/src/ui.js';
 import { CKEditorError, getDataFromElement } from 'ckeditor5/src/utils.js';
-
-import { ContextWatchdog, EditorWatchdog } from 'ckeditor5/src/watchdog.js';
 
 import BalloonEditorUI from './ballooneditorui.js';
 import BalloonEditorUIView from './ballooneditoruiview.js';
@@ -219,27 +216,6 @@ export default class BalloonEditor extends /* #__PURE__ */ ElementApiMixin( Edit
 			);
 		} );
 	}
-
-	/**
-	 * The {@link module:core/context~Context} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static Context = Context;
-
-	/**
-	 * The {@link module:watchdog/editorwatchdog~EditorWatchdog} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static EditorWatchdog = EditorWatchdog;
-
-	/**
-	 * The {@link module:watchdog/contextwatchdog~ContextWatchdog} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static ContextWatchdog = ContextWatchdog;
 }
 
 function getInitialData( sourceElementOrData: HTMLElement | string ): string {

--- a/packages/ckeditor5-editor-classic/src/classiceditor.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.ts
@@ -12,15 +12,12 @@ import ClassicEditorUIView from './classiceditoruiview.js';
 
 import {
 	Editor,
-	Context,
 	ElementApiMixin,
 	attachToForm,
 	type EditorConfig,
 	type EditorReadyEvent
 } from 'ckeditor5/src/core.js';
 import { getDataFromElement, CKEditorError } from 'ckeditor5/src/utils.js';
-
-import { ContextWatchdog, EditorWatchdog } from 'ckeditor5/src/watchdog.js';
 
 import { isElement as _isElement } from 'lodash-es';
 
@@ -203,27 +200,6 @@ export default class ClassicEditor extends /* #__PURE__ */ ElementApiMixin( Edit
 			);
 		} );
 	}
-
-	/**
-	 * The {@link module:core/context~Context} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static Context = Context;
-
-	/**
-	 * The {@link module:watchdog/editorwatchdog~EditorWatchdog} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static EditorWatchdog = EditorWatchdog;
-
-	/**
-	 * The {@link module:watchdog/contextwatchdog~ContextWatchdog} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static ContextWatchdog = ContextWatchdog;
 }
 
 function getInitialData( sourceElementOrData: HTMLElement | string ): string {

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitor.ts
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitor.ts
@@ -9,7 +9,6 @@
 
 import {
 	Editor,
-	Context,
 	ElementApiMixin,
 	secureSourceElement,
 	type EditorConfig,
@@ -19,8 +18,6 @@ import {
 	CKEditorError,
 	getDataFromElement
 } from 'ckeditor5/src/utils.js';
-
-import { ContextWatchdog, EditorWatchdog } from 'ckeditor5/src/watchdog.js';
 
 import DecoupledEditorUI from './decouplededitorui.js';
 import DecoupledEditorUIView from './decouplededitoruiview.js';
@@ -245,27 +242,6 @@ export default class DecoupledEditor extends /* #__PURE__ */ ElementApiMixin( Ed
 			);
 		} );
 	}
-
-	/**
-	 * The {@link module:core/context~Context} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static Context = Context;
-
-	/**
-	 * The {@link module:watchdog/editorwatchdog~EditorWatchdog} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static EditorWatchdog = EditorWatchdog;
-
-	/**
-	 * The {@link module:watchdog/contextwatchdog~ContextWatchdog} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static ContextWatchdog = ContextWatchdog;
 }
 
 function getInitialData( sourceElementOrData: HTMLElement | string ): string {

--- a/packages/ckeditor5-editor-inline/src/inlineeditor.ts
+++ b/packages/ckeditor5-editor-inline/src/inlineeditor.ts
@@ -9,7 +9,6 @@
 
 import {
 	Editor,
-	Context,
 	ElementApiMixin,
 	attachToForm,
 	secureSourceElement,
@@ -17,8 +16,6 @@ import {
 	type EditorReadyEvent
 } from 'ckeditor5/src/core.js';
 import { getDataFromElement, CKEditorError } from 'ckeditor5/src/utils.js';
-
-import { ContextWatchdog, EditorWatchdog } from 'ckeditor5/src/watchdog.js';
 
 import InlineEditorUI from './inlineeditorui.js';
 import InlineEditorUIView from './inlineeditoruiview.js';
@@ -206,27 +203,6 @@ export default class InlineEditor extends /* #__PURE__ */ ElementApiMixin( Edito
 			);
 		} );
 	}
-
-	/**
-	 * The {@link module:core/context~Context} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static Context = Context;
-
-	/**
-	 * The {@link module:watchdog/editorwatchdog~EditorWatchdog} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static EditorWatchdog = EditorWatchdog;
-
-	/**
-	 * The {@link module:watchdog/contextwatchdog~ContextWatchdog} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static ContextWatchdog = ContextWatchdog;
 }
 
 function getInitialData( sourceElementOrData: HTMLElement | string ): string {

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -9,7 +9,6 @@
 
 import {
 	Editor,
-	Context,
 	secureSourceElement,
 	type EditorConfig,
 	type EditorReadyEvent
@@ -23,8 +22,6 @@ import {
 	type CollectionAddEvent,
 	type DecoratedMethodEvent
 } from 'ckeditor5/src/utils.js';
-
-import { ContextWatchdog, EditorWatchdog } from 'ckeditor5/src/watchdog.js';
 
 import MultiRootEditorUI from './multirooteditorui.js';
 import MultiRootEditorUIView from './multirooteditoruiview.js';
@@ -885,27 +882,6 @@ export default class MultiRootEditor extends Editor {
 			);
 		} );
 	}
-
-	/**
-	 * The {@link module:core/context~Context} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static Context = Context;
-
-	/**
-	 * The {@link module:watchdog/editorwatchdog~EditorWatchdog} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static EditorWatchdog = EditorWatchdog;
-
-	/**
-	 * The {@link module:watchdog/contextwatchdog~ContextWatchdog} class.
-	 *
-	 * Exposed as static editor field for easier access in editor builds.
-	 */
-	public static ContextWatchdog = ContextWatchdog;
 
 	/**
 	 * @internal


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (core): The `EditorWatchdog`, `ContextWatchdog`, and `Context` classes are now exposed as static fields of the `Editor` class. Closes #13852.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
