### PR TITLE
Updating the "Data from an external source" tutorial to new installation methods

### DIFF
--- a/docs/tutorials/widgets/data-from-external-source.md
+++ b/docs/tutorials/widgets/data-from-external-source.md
@@ -107,6 +107,7 @@ Finally, you need to load the `ExternalDataWidget` plugin in your `main.js` file
 import { ClassicEditor, Bold, Italic, Essentials, Heading, List, Paragraph } from 'ckeditor5';
 import ExternalDataWidget from './external-data-widget/externaldatawidget';
 import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
+import 'ckeditor5/index.css';
 
 ClassicEditor
     .create( document.querySelector( '#editor' ), {

--- a/docs/tutorials/widgets/data-from-external-source.md
+++ b/docs/tutorials/widgets/data-from-external-source.md
@@ -23,7 +23,19 @@ This guide assumes that you are familiar with the widgets concept introduced in 
 
 The overall project structure will be similar to one described in the {@link tutorials/widgets/implementing-an-inline-widget#bootstrapping-the-project Bootstrapping the project} section of the "Implementing an inline widget" tutorial.
 
-Before building the project you still need to define the `ExternalDataWidget` plugin. The project structure should be as follows:
+The easiest way to set up your project is to grab the starter files from the [GitHub repository for this tutorial](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/data-from-external-source). We gathered all the necessary dependencies there, including some CKEditor&nbsp;5 packages and other files needed to start the editor.
+
+The editor has already been created in the `main.js` file with some basic plugins. All you need to do is clone the repository, navigate to the [starter-files directory](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/data-from-external-source/starter-files), run the `npm install` command, and you can start coding right away.
+
+```bash
+git clone https://github.com/ckeditor/ckeditor5-tutorials-examples
+cd ckeditor5-tutorials-examples/data-from-external-source/starter-files
+
+npm install
+npm run dev
+```
+
+First, lets define the `ExternalDataWidget` plugin. The project structure should be as follows:
 
 ```plain
 ├── main.js
@@ -87,7 +99,34 @@ export default class ExternalDataWidgetEditing extends Plugin {
 }
 ```
 
-At this stage you can build the project and open it in the browser to verify if it is building correctly. After the build is completed, open `index.html` in your browser to check if all is correct at this stage.
+Finally, you need to load the `ExternalDataWidget` plugin in your `main.js` file:
+
+```js
+// main.js
+
+import { ClassicEditor, Bold, Italic, Essentials, Heading, List, Paragraph } from 'ckeditor5';
+import ExternalDataWidget from './external-data-widget/externaldatawidget';
+import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
+
+ClassicEditor
+    .create( document.querySelector( '#editor' ), {
+        plugins: [ Essentials, Paragraph, Heading, List, Bold, Italic, ExternalDataWidget ],
+        toolbar: [ 'heading', 'bold', 'italic', 'numberedList', 'bulletedList', '|', 'undo', 'redo' ]
+    } )
+    .then( editor => {
+        console.log( 'Editor was initialized', editor );
+
+        CKEditorInspector.attach( { editor: 'editor' } );
+
+        // Expose for playing in the console.
+        window.editor = editor;
+    } )
+    .catch( error => {
+        console.error( error.stack );
+    } );
+```
+
+At this stage you can run the project and open it in the browser to verify if it is loading correctly.
 
 ## The model and the view layers
 
@@ -378,7 +417,7 @@ class ExternalDataWidgetUI extends Plugin {
 Add the {@link module:ui/button/buttonview~ButtonView} to the toolbar:
 
 ```js
-// app.js
+// main.js
 
 import {
 	ClassicEditor,
@@ -421,7 +460,6 @@ In this tutorial we will use an external API that provides a current Bitcoin rat
 The data will be fetched every 10 seconds. Each instance of the widget will be updated at the same time. To achieve that, we need to modify the `ExternalDataWidgetEditing` class.
 
 ```js
-
 class ExternalDataWidgetEditing extends Plugin {
 	//
 	constructor( editor ) {
@@ -533,7 +571,7 @@ You can see the external data widget implementation in action in the editor belo
 
 ## Final solution
 
-The following code snippet contains the complete implementation of the `ExternalDataWidget` plugin (and all of its dependencies) and the code needed to run the editor. You can paste it into the `app.js` file and it will run out–of–the–box (excluded the Bitcoin logo):
+The following code snippet contains the complete implementation of the `ExternalDataWidget` plugin (and all of its dependencies) and the code needed to run the editor. You can paste it into the `main.js` file, and it will run out of the box (excluded the Bitcoin logo). There is also a repository with the [final project](https://github.com/ckeditor/ckeditor5-tutorials-examples/tree/main/data-from-external-source/final-project) that you can download and play with.
 
 ```js
 import {
@@ -550,6 +588,8 @@ import {
 	Widget,
 	toWidget
 } from 'ckeditor5';
+import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
+import 'ckeditor5/index.css';
 
 const BitcoinLogoIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" preserveAspectRatio="xMidYMid" viewBox="0 0 1 1"><path d="M63.036 39.741c-4.274 17.143-21.637 27.576-38.782 23.301C7.116 58.768-3.317 41.404.959 24.262 5.23 7.117 22.594-3.317 39.734.957c17.144 4.274 27.576 21.64 23.302 38.784z" style="fill:#f7931a" transform="scale(.01563)"/><path d="M46.1 27.441c.638-4.258-2.604-6.547-7.037-8.074l1.438-5.768-3.511-.875-1.4 5.616c-.923-.23-1.871-.447-2.813-.662l1.41-5.653-3.51-.875-1.438 5.766c-.764-.174-1.514-.346-2.242-.527l.004-.018-4.842-1.209-.934 3.75s2.605.597 2.55.634c1.422.355 1.679 1.296 1.636 2.042l-3.94 15.801c-.174.432-.615 1.08-1.61.834.036.051-2.551-.637-2.551-.637l-1.743 4.019 4.569 1.139c.85.213 1.683.436 2.503.646l-1.453 5.834 3.507.875 1.439-5.772c.958.26 1.888.5 2.798.726l-1.434 5.745 3.51.875 1.454-5.823c5.987 1.133 10.489.676 12.384-4.739 1.527-4.36-.076-6.875-3.226-8.515 2.294-.529 4.022-2.038 4.483-5.155zM38.08 38.69c-1.085 4.36-8.426 2.003-10.806 1.412l1.928-7.729c2.38.594 10.012 1.77 8.878 6.317zm1.086-11.312c-.99 3.966-7.1 1.951-9.082 1.457l1.748-7.01c1.982.494 8.365 1.416 7.334 5.553z" style="fill:#fff" transform="scale(.01563)"/></svg>';
 
@@ -735,11 +775,12 @@ ClassicEditor
 	.then( editor => {
 		console.log( 'Editor was initialized', editor );
 
+		CKEditorInspector.attach( { 'editor': editor } );
+
 		// Expose for playing in the console.
 		window.editor = editor;
 	} )
 	.catch( error => {
 		console.error( error.stack );
 	} );
-
 ```

--- a/docs/tutorials/widgets/implementing-an-inline-widget.md
+++ b/docs/tutorials/widgets/implementing-an-inline-widget.md
@@ -26,7 +26,7 @@ The editor has already been created in the `main.js` file with some basic plugin
 
 ```bash
 git clone https://github.com/ckeditor/ckeditor5-tutorials-examples
-cd ckeditor5-tutorials-examples/abbreviation-plugin/starter-files
+cd ckeditor5-tutorials-examples/inline-widget/starter-files
 
 npm install
 npm run dev
@@ -94,6 +94,34 @@ export default class PlaceholderEditing extends Plugin {
 		console.log( 'PlaceholderEditing#init() got called' );
 	}
 }
+```
+
+Finally, you need to load the `Placeholder` plugin in your `main.js` file:
+
+```js
+// main.js
+
+import { ClassicEditor, Bold, Italic, Essentials, Heading, List, Paragraph } from 'ckeditor5';
+import Placeholder from './placeholder/placeholder';
+import CKEditorInspector from '@ckeditor/ckeditor5-inspector';
+import 'ckeditor5/index.css';
+
+ClassicEditor
+    .create( document.querySelector( '#editor' ), {
+        plugins: [ Essentials, Paragraph, Heading, List, Bold, Italic, Placeholder ],
+        toolbar: [ 'heading', 'bold', 'italic', 'numberedList', 'bulletedList', '|', 'undo', 'redo' ]
+    } )
+    .then( editor => {
+        console.log( 'Editor was initialized', editor );
+
+        CKEditorInspector.attach( { editor: 'editor' } );
+
+        // Expose for playing in the console.
+        window.editor = editor;
+    } )
+    .catch( error => {
+        console.error( error.stack );
+    } );
 ```
 
 At this point, you can run the development server and see in the browser console that the plugins are being initialized.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Updating the "Data from an external source" tutorial to new installation methods.

---

### Additional information

Links to supporting repo won't work because PR is not merged to the master yet.
Here's PR to to the repo with the supporting files: https://github.com/ckeditor/ckeditor5-tutorials-examples/pull/11
