### PR TITLE
Export `ViewDocumentBlurEvent` and `ViewDocumentFocusEvent` types from the main index

### DIFF
--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -159,7 +159,12 @@ export { default as ClickObserver } from './view/observer/clickobserver.js';
 export { default as DomEventObserver } from './view/observer/domeventobserver.js';
 export { default as MouseObserver } from './view/observer/mouseobserver.js';
 export { default as TabObserver } from './view/observer/tabobserver.js';
-export { default as FocusObserver } from './view/observer/focusobserver.js';
+
+export {
+	default as FocusObserver,
+	type ViewDocumentBlurEvent,
+	type ViewDocumentFocusEvent
+} from './view/observer/focusobserver.js';
 
 export { default as DowncastWriter } from './view/downcastwriter.js';
 export { default as UpcastWriter } from './view/upcastwriter.js';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (engine): Export `ViewDocumentBlurEvent` and `ViewDocumentFocusEvent` types from the main index.

---

### Additional information

These two types are used in our Angular integration and are imported from the `@ckeditor/ckeditor5-engine/src/view/observer/focusobserver` file which is not available in the new installation methods.
