### PR TITLE
Find and replace always replaces the first match when track changes is enabled

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/findandreplacestate.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplacestate.ts
@@ -166,4 +166,21 @@ export default class FindAndReplaceState extends /* #__PURE__ */ ObservableMixin
 /**
  * The callback function used to find matches in the document.
  */
-export type FindCallback = ( ( { item, text }: { item: Item; text: string } ) => Array<ResultType> );
+export type FindCallback = ( { item, text }: { item: Item; text: string } ) => FindCallbackResult;
+
+/**
+ * Represents the result of a find callback.
+ *
+ * Try to avoid returning array of results. Return the `searchText` attribute in the result object instead.
+ * At this moment we have to keep this for backward compatibility.
+ *
+ * The `searchText` attribute in the result object is used to determine if the search text has been changed.
+ * If returned `searchText` is different than the last search text, the search results will be invalidated
+ * while searching for next item and the search will start from beginning instead of pointing second found item.
+ */
+type FindCallbackResult =
+	| Array<ResultType>
+	| {
+		results: Array<ResultType>;
+		searchText: string;
+	};

--- a/packages/ckeditor5-find-and-replace/src/findandreplacestate.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplacestate.ts
@@ -166,21 +166,23 @@ export default class FindAndReplaceState extends /* #__PURE__ */ ObservableMixin
 /**
  * The callback function used to find matches in the document.
  */
-export type FindCallback = ( { item, text }: { item: Item; text: string } ) => FindCallbackResult;
+export type FindCallback = ( { item, text }: { item: Item; text: string } ) => FindCallbackResultObject | FindCallbackResult;
 
 /**
  * Represents the result of a find callback.
  *
- * Try to avoid returning array of results. Return the `searchText` attribute in the result object instead.
- * At this moment we have to keep this for backward compatibility.
- *
- * The `searchText` attribute in the result object is used to determine if the search text has been changed.
+ * The `searchText` attribute in the result object is used to determine if the search text has changed.
  * If returned `searchText` is different than the last search text, the search results will be invalidated
- * while searching for next item and the search will start from beginning instead of pointing second found item.
+ * while searching for next item and the search will start from the beginning of the document.
  */
-type FindCallbackResult =
-	| Array<ResultType>
-	| {
-		results: Array<ResultType>;
-		searchText: string;
-	};
+export type FindCallbackResultObject = {
+	results: Array<ResultType>;
+	searchText: string;
+};
+
+/**
+ * Represents the result of a find callback.
+ *
+ * @deprecated Use `FindCallbackResultObject` instead.
+ */
+export type FindCallbackResult = Array<ResultType>;

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceutils.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceutils.ts
@@ -47,7 +47,7 @@ export default class FindAndReplaceUtils extends Plugin {
 	public updateFindResultFromRange(
 		range: Range,
 		model: Model,
-		findCallback: ( { item, text }: { item: Item; text: string } ) => Array<ResultType>,
+		findCallback: ( { item, text }: { item: Item; text: string } ) => Array<ResultType> | { results: Array<ResultType> },
 		startResults: Collection<ResultType> | null
 	): Collection<ResultType> {
 		const results = startResults || new Collection();
@@ -67,13 +67,17 @@ export default class FindAndReplaceUtils extends Plugin {
 			[ ...range ].forEach( ( { type, item } ) => {
 				if ( type === 'elementStart' ) {
 					if ( model.schema.checkChild( item, '$text' ) ) {
-						const foundItems = findCallback( {
+						let foundItems = findCallback( {
 							item,
 							text: this.rangeToText( model.createRangeIn( item as Element ) )
 						} );
 
 						if ( !foundItems ) {
 							return;
+						}
+
+						if ( 'results' in foundItems ) {
+							foundItems = foundItems.results;
 						}
 
 						foundItems.forEach( foundItem => {

--- a/packages/ckeditor5-find-and-replace/src/findcommand.ts
+++ b/packages/ckeditor5-find-and-replace/src/findcommand.ts
@@ -60,15 +60,30 @@ export default class FindCommand extends Command {
 		const findAndReplaceUtils: FindAndReplaceUtils = editor.plugins.get( 'FindAndReplaceUtils' );
 
 		let findCallback: FindCallback | undefined;
+		let callbackSearchText: string = '';
 
 		// Allow to execute `find()` on a plugin with a keyword only.
 		if ( typeof callbackOrText === 'string' ) {
-			findCallback = findAndReplaceUtils.findByTextCallback( callbackOrText, { matchCase, wholeWords } );
-
-			this._state.searchText = callbackOrText;
+			findCallback = ( ...args ) => ( {
+				results: findAndReplaceUtils.findByTextCallback( callbackOrText, { matchCase, wholeWords } )( ...args ),
+				searchText: callbackOrText
+			} );
 		} else {
 			findCallback = callbackOrText;
 		}
+
+		// Wrap the callback to get the search text that will be assigned to the state.
+		const oldCallback = findCallback;
+
+		findCallback = ( ...args ) => {
+			const result = oldCallback( ...args );
+
+			if ( result && !Array.isArray( result ) ) {
+				callbackSearchText = result.searchText;
+			}
+
+			return result;
+		};
 
 		// Initial search is done on all nodes in all roots inside the content.
 		const results = model.document.getRootNames()
@@ -82,10 +97,7 @@ export default class FindCommand extends Command {
 		this._state.clear( model );
 		this._state.results.addMany( results );
 		this._state.highlightedResult = results.get( 0 );
-
-		if ( typeof callbackOrText === 'string' ) {
-			this._state.searchText = callbackOrText;
-		}
+		this._state.searchText = callbackSearchText;
 
 		if ( findCallback ) {
 			this._state.lastSearchCallback = findCallback;

--- a/packages/ckeditor5-find-and-replace/src/findcommand.ts
+++ b/packages/ckeditor5-find-and-replace/src/findcommand.ts
@@ -78,7 +78,7 @@ export default class FindCommand extends Command {
 		findCallback = ( ...args ) => {
 			const result = oldCallback( ...args );
 
-			if ( result && !Array.isArray( result ) ) {
+			if ( result && 'searchText' in result ) {
 				callbackSearchText = result.searchText;
 			}
 

--- a/packages/ckeditor5-find-and-replace/tests/findcommand.js
+++ b/packages/ckeditor5-find-and-replace/tests/findcommand.js
@@ -176,6 +176,15 @@ describe( 'FindCommand', () => {
 				);
 			} );
 
+			it( 'sets proper searchText state value', () => {
+				editor.setData( '<p>foo 🐛 bar</p>' );
+
+				const { results } = command.execute( '🐛' );
+
+				expect( results.length ).to.equal( 1 );
+				expect( command._state.searchText ).to.equal( '🐛' );
+			} );
+
 			describe( 'options.matchCase', () => {
 				it( 'set to true doesn\'t match differently cased string', () => {
 					editor.setData( '<p>foo bAr</p>' );
@@ -365,6 +374,35 @@ describe( 'FindCommand', () => {
 
 					expect( results ).to.be.lengthOf( 1 );
 				} );
+			} );
+		} );
+
+		describe( 'with callback passed', () => {
+			it( 'sets returned searchText attribute to the object result', () => {
+				const findAndReplaceUtils = editor.plugins.get( 'FindAndReplaceUtils' );
+
+				setData( model, '<paragraph>[]Foo bar baz. Bam bar bom.</paragraph>' );
+
+				const searchText = 'bar';
+				const { results } = command.execute( ( ...args ) => ( {
+					results: findAndReplaceUtils.findByTextCallback( searchText, {} )( ...args ),
+					searchText
+				} ) );
+
+				expect( results.length ).to.equal( 2 );
+				expect( command._state.searchText ).to.equal( searchText );
+			} );
+
+			it( 'sets empty searchText if array is returned', () => {
+				const findAndReplaceUtils = editor.plugins.get( 'FindAndReplaceUtils' );
+
+				setData( model, '<paragraph>[]Foo bar baz. Bam bar bom.</paragraph>' );
+
+				const searchText = 'bar';
+				const { results } = command.execute( findAndReplaceUtils.findByTextCallback( searchText, {} ) );
+
+				expect( results.length ).to.equal( 2 );
+				expect( command._state.searchText ).to.equal( '' );
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (find-and-replace): Do not replace only the first found word when using it with `Track Changes` plugin.

MINOR BREAKING CHANGE (find-and-replace): The `FindCommand#execute` now accepts a `findCallback` that can return an array of results or an object containing an array of results together with the `searchText` used to invalidate search results in commands like `find previous`, `find next`, and `replace search`.

---

### Additional information

Closes: https://github.com/cksource/ckeditor5-commercial/issues/6193
Commercial PR: https://github.com/cksource/ckeditor5-commercial/pull/6275

#### Debug notes

1. When search is performed, `FindCommand#execute` is called. 
2. It can be called with `callback` or `string` as a search [parameter](https://github.com/ckeditor/ckeditor5/blob/5ed6fb17ea3cb07571468213361035f4846ad483/packages/ckeditor5-find-and-replace/src/findcommand.ts#L55-L56). 
3. This bug is reproducible if `callback` is passed as search parameter.
4. `Track Changes` [intercepts](https://github.com/ckeditor/ckeditor5/blob/5ed6fb17ea3cb07571468213361035f4846ad483/packages/ckeditor5-find-and-replace/src/findcommand.ts#L85-L91) `find and replace` `find` command `execute` and forces using `callback` parameter (it was originally called with `string` search parameter).
5.  `FindCommand#execute` clears `FindAndReplaceState#searchText`.
6. If `string` search parameter is passed, `FindAndReplaceState#searchText` is being reverted after search (in `FindCommand#execute`). If `callback` search parameter is passed, nothing happens and  `FindAndReplaceState#searchText` stays empty.
7. It means that passing `callback` search parameter resets highlight index [here](https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-find-and-replace/src/findandreplace.ts#L57-L94) and [here](https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-find-and-replace/src/findandreplace.ts#L79), and it's causing an issue. `state.searchText` is empty (it was cleared in previous steps while using callback search), on the other hand, `data.searchText` is filled with current input value. 

#### Possible solutions

1. Return `searchText` along with `results` in `FindCallback`. 
1.1. It's more flexible if the command is executed with callback which defines the search phrase inside itself [1].
1.2. It's safer according to tests (none failed).
1.3. It introduces a breaking change in integrations that depends on arguments passed to `FindCommand#execute`.
1.4. Search UI seems not to be bound to `searchText` command value. It needs to be refactored, probably.
1.5. It's not super clear for the users why `searchText` has to be forwarded (despite adding comment). 
2. Get rid of `state.searchText`
2.1. Refactoring whole solution, it's kinda complex and many of the tests will be broken. 
2.2. Rename `searchText` to `queryID` or something like that. It'll be more obvious for the users. Less dangerous, but under the hood it'll work exactly like `1` solution.
3. Get rid of support `callback` find. It's an old feature, there are probably a lot of integrations that might depend on this behavior. 

[1]
```tsx
findCommand.execute( () => {
     const callback = typeof callbackOrText === 'string' ? plugin.findByTextCallback( 'Bunny' ) : 'Bunny';
     ...
     return {
        results: ...,
        searchText: 'Bunny'
     };
} );
```

#### Reproduction video

https://github.com/ckeditor/ckeditor5/assets/3949262/944f3f63-a1a9-4ecf-adb8-336f93f44b2c


