### PR TITLE
Export `XmlDataProcessor` from the main index.

### DIFF
--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -58,6 +58,7 @@ export type { Consumables, default as ViewConsumable } from './conversion/viewco
 // DataProcessor.
 export type { default as DataProcessor } from './dataprocessor/dataprocessor.js';
 export { default as HtmlDataProcessor } from './dataprocessor/htmldataprocessor.js';
+export { default as XmlDataProcessor } from './dataprocessor/xmldataprocessor.js';
 
 // Model / Operation.
 export type { default as Operation } from './model/operation/operation.js';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (engine): Export `XmlDataProcessor` from the main index.

---

### Additional information

This class is used in `@wiris/mathtype-ckeditor5` plugin and is imported from the `@ckeditor/ckeditor5-engine/src/dataprocessor/xmldataprocessor` file which is not available in the new installation methods.