### PR TITLE
Support for nightly alpha releases

### DIFF
--- a/scripts/release/preparepackages.js
+++ b/scripts/release/preparepackages.js
@@ -59,7 +59,7 @@ const tasks = new Listr( [
 		},
 		skip: () => {
 			// Nightly releases are not described in the changelog.
-			if ( cliArguments.nightly ) {
+			if ( cliArguments.nightly || cliArguments.nightlyAlpha ) {
 				return true;
 			}
 
@@ -234,7 +234,7 @@ const tasks = new Listr( [
 		},
 		skip: () => {
 			// Nightly releases are not stored in the repository.
-			if ( cliArguments.nightly ) {
+			if ( cliArguments.nightly || cliArguments.nightlyAlpha ) {
 				return true;
 			}
 
@@ -250,11 +250,16 @@ const tasks = new Listr( [
 
 ( async () => {
 	try {
-		latestVersion = cliArguments.nightly ?
-			await releaseTools.getNextNightly() :
-			releaseTools.getLastFromChangelog();
+		if ( cliArguments.nightlyAlpha ) {
+			const CKE5_NEXT_RELEASE_VERSION = process.env.CKE5_NEXT_RELEASE_VERSION.trim();
 
-		versionChangelog = releaseTools.getChangesForVersion( latestVersion );
+			latestVersion = await releaseTools.getNextPreRelease( `${ CKE5_NEXT_RELEASE_VERSION }-alpha` );
+		} else if ( cliArguments.nightly ) {
+			latestVersion = await releaseTools.getNextNightly();
+		} else {
+			latestVersion = releaseTools.getLastFromChangelog();
+			versionChangelog = releaseTools.getChangesForVersion( latestVersion );
+		}
 
 		await tasks.run();
 	} catch ( err ) {

--- a/scripts/release/preparepackages.js
+++ b/scripts/release/preparepackages.js
@@ -261,6 +261,8 @@ const tasks = new Listr( [
 			versionChangelog = releaseTools.getChangesForVersion( latestVersion );
 		}
 
+		console.log( 'Version', latestVersion );
+
 		await tasks.run();
 	} catch ( err ) {
 		process.exitCode = 1;

--- a/scripts/release/publishpackages.js
+++ b/scripts/release/publishpackages.js
@@ -90,7 +90,7 @@ const tasks = new Listr( [
 			} );
 		},
 		// Nightly releases are not stored in the repository.
-		skip: cliArguments.nightly
+		skip: cliArguments.nightly || cliArguments.nightlyAlpha
 	},
 	{
 		title: 'Creating the release page.',
@@ -107,7 +107,7 @@ const tasks = new Listr( [
 			persistentOutput: true
 		},
 		// Nightly releases are not described in the changelog.
-		skip: cliArguments.nightly
+		skip: cliArguments.nightly || cliArguments.nightlyAlpha
 	}
 ], getListrOptions( cliArguments ) );
 
@@ -115,7 +115,7 @@ const tasks = new Listr( [
 	try {
 		if ( process.env.CKE5_RELEASE_TOKEN ) {
 			githubToken = process.env.CKE5_RELEASE_TOKEN;
-		} else if ( !cliArguments.nightly ) {
+		} else if ( !( cliArguments.nightly || cliArguments.nightlyAlpha ) ) {
 			githubToken = await provideToken();
 		}
 

--- a/scripts/release/utils/parsearguments.js
+++ b/scripts/release/utils/parsearguments.js
@@ -17,6 +17,7 @@ module.exports = function parseArguments( cliArguments ) {
 	const config = {
 		boolean: [
 			'nightly',
+			'nightly-alpha',
 			'verbose',
 			'compile-only',
 			'ci',
@@ -36,6 +37,7 @@ module.exports = function parseArguments( cliArguments ) {
 
 		default: {
 			nightly: false,
+			'nightly-alpha': false,
 			concurrency: require( 'os' ).cpus().length / 2,
 			'compile-only': false,
 			packages: null,
@@ -53,14 +55,19 @@ module.exports = function parseArguments( cliArguments ) {
 		options.packages = options.packages.split( ',' );
 	}
 
-	options.npmTag = options[ 'npm-tag' ];
-	delete options[ 'npm-tag' ];
-
-	options.compileOnly = options[ 'compile-only' ];
-	delete options[ 'compile-only' ];
+	replaceKebabCaseWithCamelCase( options, [
+		'npm-tag',
+		'compile-only',
+		'nightly-alpha'
+	] );
 
 	if ( options.nightly ) {
 		options.npmTag = 'nightly';
+	}
+
+	if ( options.nightlyAlpha ) {
+		options.branch = 'release';
+		options.npmTag = 'alpha';
 	}
 
 	if ( process.env.CI ) {
@@ -71,9 +78,27 @@ module.exports = function parseArguments( cliArguments ) {
 };
 
 /**
+ * Replaces all kebab-case keys in the `options` object with camelCase entries.
+ * Kebab-case keys will be removed.
+ *
+ * @param {Object} options
+ * @param {Array.<String>} keys Kebab-case keys in `options` object.
+ */
+function replaceKebabCaseWithCamelCase( options, keys ) {
+	for ( const key of keys ) {
+		const camelCaseKey = key.replace( /-./g, match => match[ 1 ].toUpperCase() );
+
+		options[ camelCaseKey ] = options[ key ];
+		delete options[ key ];
+	}
+}
+
+/**
  * @typedef {Object} ReleaseOptions
  *
  * @property {Boolean} nightly
+ *
+ * @property {Boolean} nightlyAlpha
  *
  * @property {Boolean} external
  *


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Support for publishing the CKEditor 5 alpha releases automatically once a testing phase starts.

---

### Additional information

* [x] Requires published changes from this PR: https://github.com/ckeditor/ckeditor5-dev/pull/959.
	* See: https://github.com/ckeditor/ckeditor5-dev/releases/tag/v40.2.1
