### PR TITLE
Other (ckeditor5): Rename `index.js` to `ckeditor5.js` in NIM builds

### DIFF
--- a/scripts/build-ckeditor5.mjs
+++ b/scripts/build-ckeditor5.mjs
@@ -30,7 +30,7 @@ function dist( path ) {
 	console.log( chalk.cyan( '1/3: Generating NPM build...' ) );
 
 	await build( {
-		output: dist( 'index.js' ),
+		output: dist( 'ckeditor5.js' ),
 		tsconfig,
 		banner,
 		sourceMap: true,
@@ -46,16 +46,16 @@ function dist( path ) {
 		translations: 'packages/**/*.po'
 	} );
 
-	await rm( dist( 'index.js' ) );
-	await rm( dist( 'index.js.map' ) );
+	await rm( dist( 'ckeditor5.js' ) );
+	await rm( dist( 'ckeditor5.js.map' ) );
 
 	/**
 	 * Step 2
 	 */
-	console.log( chalk.cyan( '2/3: Generating `index.js` for the NPM build...' ) );
+	console.log( chalk.cyan( '2/3: Generating `ckeditor5.js` for the NPM build...' ) );
 
 	await build( {
-		output: dist( 'tmp/index.js' ),
+		output: dist( 'tmp/ckeditor5.js' ),
 		tsconfig,
 		banner,
 		sourceMap: true,
@@ -64,8 +64,8 @@ function dist( path ) {
 		]
 	} );
 
-	await copyFile( dist( 'tmp/index.js' ), dist( 'index.js' ) );
-	await copyFile( dist( 'tmp/index.js.map' ), dist( 'index.js.map' ) );
+	await copyFile( dist( 'tmp/ckeditor5.js' ), dist( 'ckeditor5.js' ) );
+	await copyFile( dist( 'tmp/ckeditor5.js.map' ), dist( 'ckeditor5.js.map' ) );
 	await rm( dist( 'tmp' ), { recursive: true } );
 
 	/**
@@ -74,7 +74,7 @@ function dist( path ) {
 	console.log( chalk.cyan( '3/3: Generating browser build...' ) );
 
 	await build( {
-		output: dist( 'browser/index.js' ),
+		output: dist( 'browser/ckeditor5.js' ),
 		tsconfig,
 		banner,
 		sourceMap: true,

--- a/scripts/release/utils/getckeditor5packagejson.js
+++ b/scripts/release/utils/getckeditor5packagejson.js
@@ -26,13 +26,13 @@ module.exports = function getCKEditor5PackageJson() {
 		description: 'A set of ready-to-use rich text editors created with a powerful framework.' +
 			' Made with real-time collaborative editing in mind.',
 		type: 'module',
-		main: 'dist/index.js',
-		module: 'dist/index.js',
+		main: 'dist/ckeditor5.js',
+		module: 'dist/ckeditor5.js',
 		types: 'dist/types/index.d.ts',
 		exports: {
 			'.': {
 				'types': './dist/types/index.d.ts',
-				'import': './dist/index.js'
+				'import': './dist/ckeditor5.js'
 			},
 			'./translations/*.js': {
 				'types': './dist/translations/*.d.ts',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (ckeditor5): Rename `index.js` to `ckeditor5.js` in new installation method builds.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
