### PR TITLE
Support Instagram reels and twitter new domain

### DIFF
--- a/packages/ckeditor5-media-embed/src/mediaembedediting.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedediting.ts
@@ -134,11 +134,17 @@ export default class MediaEmbedEditing extends Plugin {
 
 				{
 					name: 'instagram',
-					url: /^instagram\.com\/p\/(\w+)/
+					url: [
+						/^instagram\.com\/p\/(\w+)/,
+						/^instagram\.com\/reel\/(\w+)/
+					]
 				},
 				{
 					name: 'twitter',
-					url: /^twitter\.com/
+					url: [
+						/^twitter\.com/,
+						/^x\.com/
+					]
 				},
 				{
 					name: 'googleMaps',


### PR DESCRIPTION
Feature (media-embed): Support new Twitter domain (x.com). Closes #16435
Feature (media-embed): Support Instagram Reels.

