### PR TITLE
Image metadata and "insertImageViaUrl"

### DIFF
--- a/packages/ckeditor5-image/ckeditor5-metadata.json
+++ b/packages/ckeditor5-image/ckeditor5-metadata.json
@@ -253,7 +253,7 @@
 			]
 		},
 		{
-			"name": "Image Insert via Url",
+			"name": "Image insert via URL",
 			"className": "ImageInsertViaUrl",
 			"description": "The image insert via URL plugin. This plugin does not do anything directly, but it loads a set of specific plugins to enable image inserting via URL.",
 			"uiComponents": [

--- a/packages/ckeditor5-image/ckeditor5-metadata.json
+++ b/packages/ckeditor5-image/ckeditor5-metadata.json
@@ -249,7 +249,14 @@
 					"type": "SplitButton",
 					"name": "insertImage",
 					"iconPath": "@ckeditor/ckeditor5-core/theme/icons/image.svg"
-				},
+				}
+			]
+		},
+		{
+			"name": "Image Insert via Url",
+			"className": "ImageInsertViaUrl",
+			"description": "The image insert via URL plugin. This plugin does not do anything directly, but it loads a set of specific plugins to enable image inserting via URL.",
+			"uiComponents": [
 				{
 					"type": "Button",
 					"name": "insertImageViaUrl",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (image): Moved the `insertImageViaUrl` UI component in metadata to the proper plugin.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
