### PR TITLE
feat(domeventobserver): #16412 add support for usePassive option to the DomEventObserver

### DIFF
--- a/packages/ckeditor5-engine/src/view/observer/domeventobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/domeventobserver.ts
@@ -57,6 +57,12 @@ export default abstract class DomEventObserver<
 	public useCapture: boolean = false;
 
 	/**
+	 * If set to `true`, indicates that the function specified by listener will never call preventDefault()
+	 * Default value is `false`.
+	 */
+	public usePassive: boolean = false;
+
+	/**
 	 * Callback which should be called when the DOM event occurred. Note that the callback will not be called if
 	 * observer {@link #isEnabled is not enabled}.
 	 *
@@ -75,7 +81,7 @@ export default abstract class DomEventObserver<
 				if ( this.isEnabled && !this.checkShouldIgnoreEventFromTarget( domEvent.target as any ) ) {
 					this.onDomEvent( domEvent );
 				}
-			}, { useCapture: this.useCapture } );
+			}, { useCapture: this.useCapture, usePassive: this.usePassive } );
 		} );
 	}
 

--- a/packages/ckeditor5-engine/src/view/observer/domeventobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/domeventobserver.ts
@@ -57,7 +57,7 @@ export default abstract class DomEventObserver<
 	public useCapture: boolean = false;
 
 	/**
-	 * If set to `true`, indicates that the function specified by listener will never call preventDefault()
+	 * If set to `true`, indicates that the function specified by listener will never call `preventDefault()`.
 	 * Default value is `false`.
 	 */
 	public usePassive: boolean = false;


### PR DESCRIPTION
Fixes #16412

This change permits a user to create a `scrollend` event listener which does not block future scroll events.