### PR TITLE
A11y best practice: Landmarks should be unique

### DIFF
--- a/packages/ckeditor5-ui/src/arialiveannouncer.ts
+++ b/packages/ckeditor5-ui/src/arialiveannouncer.ts
@@ -169,7 +169,6 @@ export class AriaLiveAnnouncerRegionView extends View {
 		this.setTemplate( {
 			tag: 'div',
 			attributes: {
-				role: 'region',
 				'aria-live': politeness,
 				'aria-relevant': 'additions'
 			},

--- a/packages/ckeditor5-ui/tests/editorui/arialiveannouncer.js
+++ b/packages/ckeditor5-ui/tests/editorui/arialiveannouncer.js
@@ -56,7 +56,7 @@ describe( 'AriaLiveAnnouncer', () => {
 			expect( firstRegion.politeness ).to.equal( 'polite' );
 			expect( firstRegion.element.parentNode ).to.equal( announcer.view.element );
 
-			expect( firstRegion.element.getAttribute( 'role' ) ).to.equal( 'region' );
+			expect( firstRegion.element.getAttribute( 'role' ) ).to.be.null;
 			expect( firstRegion.element.getAttribute( 'aria-live' ) ).to.equal( 'polite' );
 			expect( firstRegion.element.querySelector( 'li' ).innerHTML ).to.equal( 'bar' );
 		} );
@@ -73,7 +73,7 @@ describe( 'AriaLiveAnnouncer', () => {
 			expect( firstRegion.politeness ).to.equal( 'polite' );
 			expect( firstRegion.element.parentNode ).to.equal( announcer.view.element );
 
-			expect( firstRegion.element.getAttribute( 'role' ) ).to.equal( 'region' );
+			expect( firstRegion.element.getAttribute( 'role' ) ).to.be.null;
 			expect( firstRegion.element.getAttribute( 'aria-live' ) ).to.equal( 'polite' );
 			expect( firstRegion.element.querySelector( 'li:last-child' ).innerHTML ).to.equal( 'baz' );
 		} );
@@ -188,6 +188,6 @@ describe( 'AriaLiveAnnouncerRegionView', () => {
 	} );
 
 	function queryAllMessages() {
-		return [ ...announcerRegionView.element.querySelectorAll( 'div[role="region"] ul li' ) ].map( element => element.innerHTML );
+		return [ ...announcerRegionView.element.querySelectorAll( 'div[aria-live] ul li' ) ].map( element => element.innerHTML );
 	}
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Remove unnecessary `role=region` from aria live views due to failing `landmarks should be unique` a11y axe rule.  Closes https://github.com/ckeditor/ckeditor5/issues/16544. 

### Further information

1. There is no need to set `role=region` on `aria-live` regions because it's ignored by readers if associated HTML element has no label attributes.
2. `role=region` is an alternative to `aria-live` and should not be used together. 
3. Checked using `NVDA` and it sounds fine. 