### PR TITLE
Export `ViewDocumentPasteEvent` from `Clipboard` plugin.

### DIFF
--- a/packages/ckeditor5-clipboard/src/index.ts
+++ b/packages/ckeditor5-clipboard/src/index.ts
@@ -39,6 +39,7 @@ export { default as DragDropBlockToolbar } from './dragdropblocktoolbar.js';
 export type {
 	ViewDocumentClipboardInputEvent,
 	ViewDocumentCopyEvent,
+	ViewDocumentPasteEvent,
 	ViewDocumentCutEvent
 } from './clipboardobserver.js';
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (clipboard): Export `ViewDocumentPasteEvent` from clipboard. 

---

### Additional information

It's needed in `paste` event firing in `AI` plugin.
Commercial PR: https://github.com/cksource/ckeditor5-commercial/pull/6319
