### PR TITLE
Redesign `on` state in menu and dropdowns

### DIFF
--- a/packages/ckeditor5-alignment/src/alignmentui.ts
+++ b/packages/ckeditor5-alignment/src/alignmentui.ts
@@ -219,16 +219,12 @@ export default class AlignmentUI extends Plugin {
 				const listItemView = new MenuBarMenuListItemView( locale, menuView );
 				const buttonView = new MenuBarMenuListItemButtonView( locale );
 
-				buttonView.extendTemplate( {
-					attributes: {
-						'aria-checked': buttonView.bindTemplate.to( 'isOn' )
-					}
-				} );
-
 				buttonView.delegate( 'execute' ).to( menuView );
 				buttonView.set( {
 					label: this.localizedOptionTitles[ option.name ],
-					icon: iconsMap.get( option.name )
+					icon: iconsMap.get( option.name ),
+					role: 'menuitemcheckbox',
+					isToggleable: true
 				} );
 
 				buttonView.on( 'execute', () => {

--- a/packages/ckeditor5-basic-styles/src/bold/boldui.ts
+++ b/packages/ckeditor5-basic-styles/src/bold/boldui.ts
@@ -40,16 +40,7 @@ export default class BoldUI extends Plugin {
 		} );
 
 		// Add bold button to feature components.
-		editor.ui.componentFactory.add( BOLD, () => {
-			const buttonView = createButton( ButtonView );
-
-			buttonView.set( {
-				tooltip: true
-			} );
-
-			return buttonView;
-		} );
-
+		editor.ui.componentFactory.add( BOLD, () => createButton( ButtonView ) );
 		editor.ui.componentFactory.add( 'menuBar:' + BOLD, () => createButton( MenuBarMenuListItemButtonView ) );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/bold/boldui.ts
+++ b/packages/ckeditor5-basic-styles/src/bold/boldui.ts
@@ -54,7 +54,15 @@ export default class BoldUI extends Plugin {
 		} );
 
 		editor.ui.componentFactory.add( 'menuBar:' + BOLD, () => {
-			return createButton( MenuBarMenuListItemButtonView );
+			const buttonView = createButton( MenuBarMenuListItemButtonView );
+
+			buttonView.set( {
+				role: 'menuitemcheckbox'
+			} );
+
+			buttonView.bind( 'isOn' ).to( command, 'value' );
+
+			return buttonView;
 		} );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/bold/boldui.ts
+++ b/packages/ckeditor5-basic-styles/src/bold/boldui.ts
@@ -30,7 +30,6 @@ export default class BoldUI extends Plugin {
 	public init(): void {
 		const editor = this.editor;
 		const t = editor.locale.t;
-		const command = editor.commands.get( BOLD )!;
 		const createButton = getButtonCreator( {
 			editor,
 			commandName: BOLD,
@@ -48,21 +47,9 @@ export default class BoldUI extends Plugin {
 				tooltip: true
 			} );
 
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
 			return buttonView;
 		} );
 
-		editor.ui.componentFactory.add( 'menuBar:' + BOLD, () => {
-			const buttonView = createButton( MenuBarMenuListItemButtonView );
-
-			buttonView.set( {
-				role: 'menuitemcheckbox'
-			} );
-
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
-			return buttonView;
-		} );
+		editor.ui.componentFactory.add( 'menuBar:' + BOLD, () => createButton( MenuBarMenuListItemButtonView ) );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/code/codeui.ts
+++ b/packages/ckeditor5-basic-styles/src/code/codeui.ts
@@ -33,6 +33,8 @@ export default class CodeUI extends Plugin {
 	 */
 	public init(): void {
 		const editor = this.editor;
+		const command = editor.commands.get( CODE )!;
+
 		const t = editor.locale.t;
 		const createButton = getButtonCreator( {
 			editor,
@@ -45,7 +47,6 @@ export default class CodeUI extends Plugin {
 		// Add code button to feature components.
 		editor.ui.componentFactory.add( CODE, () => {
 			const buttonView = createButton( ButtonView );
-			const command = editor.commands.get( CODE )!;
 
 			buttonView.set( {
 				tooltip: true
@@ -58,7 +59,15 @@ export default class CodeUI extends Plugin {
 		} );
 
 		editor.ui.componentFactory.add( 'menuBar:' + CODE, () => {
-			return createButton( MenuBarMenuListItemButtonView );
+			const buttonView = createButton( MenuBarMenuListItemButtonView );
+
+			buttonView.set( {
+				role: 'menuitemcheckbox'
+			} );
+
+			buttonView.bind( 'isOn' ).to( command, 'value' );
+
+			return buttonView;
 		} );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/code/codeui.ts
+++ b/packages/ckeditor5-basic-styles/src/code/codeui.ts
@@ -33,8 +33,6 @@ export default class CodeUI extends Plugin {
 	 */
 	public init(): void {
 		const editor = this.editor;
-		const command = editor.commands.get( CODE )!;
-
 		const t = editor.locale.t;
 		const createButton = getButtonCreator( {
 			editor,
@@ -52,22 +50,9 @@ export default class CodeUI extends Plugin {
 				tooltip: true
 			} );
 
-			// Bind button model to command.
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
 			return buttonView;
 		} );
 
-		editor.ui.componentFactory.add( 'menuBar:' + CODE, () => {
-			const buttonView = createButton( MenuBarMenuListItemButtonView );
-
-			buttonView.set( {
-				role: 'menuitemcheckbox'
-			} );
-
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
-			return buttonView;
-		} );
+		editor.ui.componentFactory.add( 'menuBar:' + CODE, () => createButton( MenuBarMenuListItemButtonView ) );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/code/codeui.ts
+++ b/packages/ckeditor5-basic-styles/src/code/codeui.ts
@@ -43,16 +43,7 @@ export default class CodeUI extends Plugin {
 		} );
 
 		// Add code button to feature components.
-		editor.ui.componentFactory.add( CODE, () => {
-			const buttonView = createButton( ButtonView );
-
-			buttonView.set( {
-				tooltip: true
-			} );
-
-			return buttonView;
-		} );
-
+		editor.ui.componentFactory.add( CODE, () => createButton( ButtonView ) );
 		editor.ui.componentFactory.add( 'menuBar:' + CODE, () => createButton( MenuBarMenuListItemButtonView ) );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/italic/italicui.ts
+++ b/packages/ckeditor5-basic-styles/src/italic/italicui.ts
@@ -31,7 +31,6 @@ export default class ItalicUI extends Plugin {
 	 */
 	public init(): void {
 		const editor = this.editor;
-		const command = editor.commands.get( ITALIC )!;
 		const t = editor.locale.t;
 		const createButton = getButtonCreator( {
 			editor,
@@ -50,21 +49,9 @@ export default class ItalicUI extends Plugin {
 				tooltip: true
 			} );
 
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
 			return buttonView;
 		} );
 
-		editor.ui.componentFactory.add( 'menuBar:' + ITALIC, () => {
-			const buttonView = createButton( MenuBarMenuListItemButtonView );
-
-			buttonView.set( {
-				role: 'menuitemcheckbox'
-			} );
-
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
-			return buttonView;
-		} );
+		editor.ui.componentFactory.add( 'menuBar:' + ITALIC, () => createButton( MenuBarMenuListItemButtonView ) );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/italic/italicui.ts
+++ b/packages/ckeditor5-basic-styles/src/italic/italicui.ts
@@ -42,16 +42,7 @@ export default class ItalicUI extends Plugin {
 		} );
 
 		// Add bold button to feature components.
-		editor.ui.componentFactory.add( ITALIC, () => {
-			const buttonView = createButton( ButtonView );
-
-			buttonView.set( {
-				tooltip: true
-			} );
-
-			return buttonView;
-		} );
-
+		editor.ui.componentFactory.add( ITALIC, () => createButton( ButtonView ) );
 		editor.ui.componentFactory.add( 'menuBar:' + ITALIC, () => createButton( MenuBarMenuListItemButtonView ) );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/italic/italicui.ts
+++ b/packages/ckeditor5-basic-styles/src/italic/italicui.ts
@@ -56,7 +56,15 @@ export default class ItalicUI extends Plugin {
 		} );
 
 		editor.ui.componentFactory.add( 'menuBar:' + ITALIC, () => {
-			return createButton( MenuBarMenuListItemButtonView );
+			const buttonView = createButton( MenuBarMenuListItemButtonView );
+
+			buttonView.set( {
+				role: 'menuitemcheckbox'
+			} );
+
+			buttonView.bind( 'isOn' ).to( command, 'value' );
+
+			return buttonView;
 		} );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/strikethrough/strikethroughui.ts
+++ b/packages/ckeditor5-basic-styles/src/strikethrough/strikethroughui.ts
@@ -31,7 +31,6 @@ export default class StrikethroughUI extends Plugin {
 	 */
 	public init(): void {
 		const editor = this.editor;
-		const command = editor.commands.get( STRIKETHROUGH )!;
 		const t = editor.locale.t;
 		const createButton = getButtonCreator( {
 			editor,
@@ -50,22 +49,9 @@ export default class StrikethroughUI extends Plugin {
 				tooltip: true
 			} );
 
-			// Bind button model to command.
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
 			return buttonView;
 		} );
 
-		editor.ui.componentFactory.add( 'menuBar:' + STRIKETHROUGH, () => {
-			const buttonView = createButton( MenuBarMenuListItemButtonView );
-
-			buttonView.set( {
-				role: 'menuitemcheckbox'
-			} );
-
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
-			return buttonView;
-		} );
+		editor.ui.componentFactory.add( 'menuBar:' + STRIKETHROUGH, () => createButton( MenuBarMenuListItemButtonView ) );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/strikethrough/strikethroughui.ts
+++ b/packages/ckeditor5-basic-styles/src/strikethrough/strikethroughui.ts
@@ -42,16 +42,7 @@ export default class StrikethroughUI extends Plugin {
 		} );
 
 		// Add strikethrough button to feature components.
-		editor.ui.componentFactory.add( STRIKETHROUGH, () => {
-			const buttonView = createButton( ButtonView );
-
-			buttonView.set( {
-				tooltip: true
-			} );
-
-			return buttonView;
-		} );
-
+		editor.ui.componentFactory.add( STRIKETHROUGH, () => createButton( ButtonView ) );
 		editor.ui.componentFactory.add( 'menuBar:' + STRIKETHROUGH, () => createButton( MenuBarMenuListItemButtonView ) );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/strikethrough/strikethroughui.ts
+++ b/packages/ckeditor5-basic-styles/src/strikethrough/strikethroughui.ts
@@ -31,6 +31,7 @@ export default class StrikethroughUI extends Plugin {
 	 */
 	public init(): void {
 		const editor = this.editor;
+		const command = editor.commands.get( STRIKETHROUGH )!;
 		const t = editor.locale.t;
 		const createButton = getButtonCreator( {
 			editor,
@@ -44,7 +45,6 @@ export default class StrikethroughUI extends Plugin {
 		// Add strikethrough button to feature components.
 		editor.ui.componentFactory.add( STRIKETHROUGH, () => {
 			const buttonView = createButton( ButtonView );
-			const command = editor.commands.get( STRIKETHROUGH )!;
 
 			buttonView.set( {
 				tooltip: true
@@ -57,7 +57,15 @@ export default class StrikethroughUI extends Plugin {
 		} );
 
 		editor.ui.componentFactory.add( 'menuBar:' + STRIKETHROUGH, () => {
-			return createButton( MenuBarMenuListItemButtonView );
+			const buttonView = createButton( MenuBarMenuListItemButtonView );
+
+			buttonView.set( {
+				role: 'menuitemcheckbox'
+			} );
+
+			buttonView.bind( 'isOn' ).to( command, 'value' );
+
+			return buttonView;
 		} );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/subscript/subscriptui.ts
+++ b/packages/ckeditor5-basic-styles/src/subscript/subscriptui.ts
@@ -32,7 +32,6 @@ export default class SubscriptUI extends Plugin {
 	public init(): void {
 		const editor = this.editor;
 		const t = editor.locale.t;
-		const command = editor.commands.get( SUBSCRIPT )!;
 
 		const createButton = getButtonCreator( {
 			editor,
@@ -50,22 +49,9 @@ export default class SubscriptUI extends Plugin {
 				tooltip: true
 			} );
 
-			// Bind button model to command.
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
 			return buttonView;
 		} );
 
-		editor.ui.componentFactory.add( 'menuBar:' + SUBSCRIPT, () => {
-			const buttonView = createButton( MenuBarMenuListItemButtonView );
-
-			buttonView.set( {
-				role: 'menuitemcheckbox'
-			} );
-
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
-			return buttonView;
-		} );
+		editor.ui.componentFactory.add( 'menuBar:' + SUBSCRIPT, () => createButton( MenuBarMenuListItemButtonView ) );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/subscript/subscriptui.ts
+++ b/packages/ckeditor5-basic-styles/src/subscript/subscriptui.ts
@@ -32,6 +32,8 @@ export default class SubscriptUI extends Plugin {
 	public init(): void {
 		const editor = this.editor;
 		const t = editor.locale.t;
+		const command = editor.commands.get( SUBSCRIPT )!;
+
 		const createButton = getButtonCreator( {
 			editor,
 			commandName: SUBSCRIPT,
@@ -43,7 +45,6 @@ export default class SubscriptUI extends Plugin {
 		// Add subscript button to feature components.
 		editor.ui.componentFactory.add( SUBSCRIPT, () => {
 			const buttonView = createButton( ButtonView );
-			const command = editor.commands.get( SUBSCRIPT )!;
 
 			buttonView.set( {
 				tooltip: true
@@ -56,7 +57,15 @@ export default class SubscriptUI extends Plugin {
 		} );
 
 		editor.ui.componentFactory.add( 'menuBar:' + SUBSCRIPT, () => {
-			return createButton( MenuBarMenuListItemButtonView );
+			const buttonView = createButton( MenuBarMenuListItemButtonView );
+
+			buttonView.set( {
+				role: 'menuitemcheckbox'
+			} );
+
+			buttonView.bind( 'isOn' ).to( command, 'value' );
+
+			return buttonView;
 		} );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/subscript/subscriptui.ts
+++ b/packages/ckeditor5-basic-styles/src/subscript/subscriptui.ts
@@ -42,16 +42,7 @@ export default class SubscriptUI extends Plugin {
 		} );
 
 		// Add subscript button to feature components.
-		editor.ui.componentFactory.add( SUBSCRIPT, () => {
-			const buttonView = createButton( ButtonView );
-
-			buttonView.set( {
-				tooltip: true
-			} );
-
-			return buttonView;
-		} );
-
+		editor.ui.componentFactory.add( SUBSCRIPT, () => createButton( ButtonView ) );
 		editor.ui.componentFactory.add( 'menuBar:' + SUBSCRIPT, () => createButton( MenuBarMenuListItemButtonView ) );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/superscript/superscriptui.ts
+++ b/packages/ckeditor5-basic-styles/src/superscript/superscriptui.ts
@@ -32,7 +32,6 @@ export default class SuperscriptUI extends Plugin {
 	public init(): void {
 		const editor = this.editor;
 		const t = editor.locale.t;
-		const command = editor.commands.get( SUPERSCRIPT )!;
 		const createButton = getButtonCreator( {
 			editor,
 			commandName: SUPERSCRIPT,
@@ -49,22 +48,9 @@ export default class SuperscriptUI extends Plugin {
 				tooltip: true
 			} );
 
-			// Bind button model to command.
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
 			return buttonView;
 		} );
 
-		editor.ui.componentFactory.add( 'menuBar:' + SUPERSCRIPT, () => {
-			const buttonView = createButton( MenuBarMenuListItemButtonView );
-
-			buttonView.set( {
-				role: 'menuitemcheckbox'
-			} );
-
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
-			return buttonView;
-		} );
+		editor.ui.componentFactory.add( 'menuBar:' + SUPERSCRIPT, () => createButton( MenuBarMenuListItemButtonView ) );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/superscript/superscriptui.ts
+++ b/packages/ckeditor5-basic-styles/src/superscript/superscriptui.ts
@@ -32,6 +32,7 @@ export default class SuperscriptUI extends Plugin {
 	public init(): void {
 		const editor = this.editor;
 		const t = editor.locale.t;
+		const command = editor.commands.get( SUPERSCRIPT )!;
 		const createButton = getButtonCreator( {
 			editor,
 			commandName: SUPERSCRIPT,
@@ -43,7 +44,6 @@ export default class SuperscriptUI extends Plugin {
 		// Add superscript button to feature components.
 		editor.ui.componentFactory.add( SUPERSCRIPT, () => {
 			const buttonView = createButton( ButtonView );
-			const command = editor.commands.get( SUPERSCRIPT )!;
 
 			buttonView.set( {
 				tooltip: true
@@ -56,7 +56,15 @@ export default class SuperscriptUI extends Plugin {
 		} );
 
 		editor.ui.componentFactory.add( 'menuBar:' + SUPERSCRIPT, () => {
-			return createButton( MenuBarMenuListItemButtonView );
+			const buttonView = createButton( MenuBarMenuListItemButtonView );
+
+			buttonView.set( {
+				role: 'menuitemcheckbox'
+			} );
+
+			buttonView.bind( 'isOn' ).to( command, 'value' );
+
+			return buttonView;
 		} );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/superscript/superscriptui.ts
+++ b/packages/ckeditor5-basic-styles/src/superscript/superscriptui.ts
@@ -41,16 +41,7 @@ export default class SuperscriptUI extends Plugin {
 		} );
 
 		// Add superscript button to feature components.
-		editor.ui.componentFactory.add( SUPERSCRIPT, () => {
-			const buttonView = createButton( ButtonView );
-
-			buttonView.set( {
-				tooltip: true
-			} );
-
-			return buttonView;
-		} );
-
+		editor.ui.componentFactory.add( SUPERSCRIPT, () => createButton( ButtonView ) );
 		editor.ui.componentFactory.add( 'menuBar:' + SUPERSCRIPT, () => createButton( MenuBarMenuListItemButtonView ) );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/underline/underlineui.ts
+++ b/packages/ckeditor5-basic-styles/src/underline/underlineui.ts
@@ -42,16 +42,7 @@ export default class UnderlineUI extends Plugin {
 		} );
 
 		// Add bold button to feature components.
-		editor.ui.componentFactory.add( UNDERLINE, () => {
-			const buttonView = createButton( ButtonView );
-
-			buttonView.set( {
-				tooltip: true
-			} );
-
-			return buttonView;
-		} );
-
+		editor.ui.componentFactory.add( UNDERLINE, () => createButton( ButtonView ) );
 		editor.ui.componentFactory.add( 'menuBar:' + UNDERLINE, () => createButton( MenuBarMenuListItemButtonView ) );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/underline/underlineui.ts
+++ b/packages/ckeditor5-basic-styles/src/underline/underlineui.ts
@@ -56,7 +56,15 @@ export default class UnderlineUI extends Plugin {
 		} );
 
 		editor.ui.componentFactory.add( 'menuBar:' + UNDERLINE, () => {
-			return createButton( MenuBarMenuListItemButtonView );
+			const buttonView = createButton( MenuBarMenuListItemButtonView );
+
+			buttonView.set( {
+				role: 'menuitemcheckbox'
+			} );
+
+			buttonView.bind( 'isOn' ).to( command, 'value' );
+
+			return buttonView;
 		} );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/underline/underlineui.ts
+++ b/packages/ckeditor5-basic-styles/src/underline/underlineui.ts
@@ -31,7 +31,6 @@ export default class UnderlineUI extends Plugin {
 	 */
 	public init(): void {
 		const editor = this.editor;
-		const command = editor.commands.get( UNDERLINE )!;
 		const t = editor.locale.t;
 		const createButton = getButtonCreator( {
 			editor,
@@ -50,21 +49,9 @@ export default class UnderlineUI extends Plugin {
 				tooltip: true
 			} );
 
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
 			return buttonView;
 		} );
 
-		editor.ui.componentFactory.add( 'menuBar:' + UNDERLINE, () => {
-			const buttonView = createButton( MenuBarMenuListItemButtonView );
-
-			buttonView.set( {
-				role: 'menuitemcheckbox'
-			} );
-
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
-			return buttonView;
-		} );
+		editor.ui.componentFactory.add( 'menuBar:' + UNDERLINE, () => createButton( MenuBarMenuListItemButtonView ) );
 	}
 }

--- a/packages/ckeditor5-basic-styles/src/utils.ts
+++ b/packages/ckeditor5-basic-styles/src/utils.ts
@@ -9,7 +9,7 @@
 
 import type { Editor, Plugin } from 'ckeditor5/src/core.js';
 import type AttributeCommand from './attributecommand.js';
-import type { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
+import { ListItemButtonView, type ButtonView, type MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 
 /**
  * Returns a function that creates a (toolbar or menu bar) button for a basic style feature.
@@ -36,6 +36,13 @@ export function getButtonCreator( {
 		} );
 
 		view.bind( 'isEnabled' ).to( command, 'isEnabled' );
+		view.bind( 'isOn' ).to( command, 'value' );
+
+		if ( view instanceof ListItemButtonView ) {
+			view.set( {
+				role: 'menuitemcheckbox'
+			} );
+		}
 
 		// Execute the command.
 		plugin.listenTo( view, 'execute', () => {

--- a/packages/ckeditor5-basic-styles/src/utils.ts
+++ b/packages/ckeditor5-basic-styles/src/utils.ts
@@ -9,7 +9,7 @@
 
 import type { Editor, Plugin } from 'ckeditor5/src/core.js';
 import type AttributeCommand from './attributecommand.js';
-import { ListItemButtonView, type ButtonView, type MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
+import { MenuBarMenuListItemButtonView, type ButtonView } from 'ckeditor5/src/ui.js';
 
 /**
  * Returns a function that creates a (toolbar or menu bar) button for a basic style feature.
@@ -38,9 +38,13 @@ export function getButtonCreator( {
 		view.bind( 'isEnabled' ).to( command, 'isEnabled' );
 		view.bind( 'isOn' ).to( command, 'value' );
 
-		if ( view instanceof ListItemButtonView ) {
+		if ( view instanceof MenuBarMenuListItemButtonView ) {
 			view.set( {
 				role: 'menuitemcheckbox'
+			} );
+		} else {
+			view.set( {
+				tooltip: true
 			} );
 		}
 

--- a/packages/ckeditor5-basic-styles/tests/bold/boldui.js
+++ b/packages/ckeditor5-basic-styles/tests/bold/boldui.js
@@ -43,15 +43,6 @@ describe( 'BoldUI', () => {
 		} );
 
 		testButton();
-
-		it( 'should bind `isOn` to bold command', () => {
-			const command = editor.commands.get( 'bold' );
-
-			expect( boldView.isOn ).to.be.false;
-
-			command.value = true;
-			expect( boldView.isOn ).to.be.true;
-		} );
 	} );
 
 	describe( 'menu bar button', () => {
@@ -60,6 +51,20 @@ describe( 'BoldUI', () => {
 		} );
 
 		testButton();
+
+		it( 'should create button with `menuitemcheckbox` role', () => {
+			expect( boldView.role ).to.equal( 'menuitemcheckbox' );
+		} );
+
+		it( 'should bind `isOn` to `aria-checked` attribute', () => {
+			boldView.render();
+
+			boldView.isOn = true;
+			expect( boldView.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'true' );
+
+			boldView.isOn = false;
+			expect( boldView.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'false' );
+		} );
 	} );
 
 	function testButton() {
@@ -92,6 +97,18 @@ describe( 'BoldUI', () => {
 
 		it( 'should set keystroke in the model', () => {
 			expect( boldView.keystroke ).to.equal( 'CTRL+B' );
+		} );
+
+		it( 'should bind `isOn` to `command`.`value`', () => {
+			const command = editor.commands.get( 'bold' );
+
+			command.value = true;
+
+			expect( boldView.isOn ).to.be.true;
+
+			command.value = false;
+
+			expect( boldView.isOn ).to.be.false;
 		} );
 	}
 } );

--- a/packages/ckeditor5-basic-styles/tests/code/codeui.js
+++ b/packages/ckeditor5-basic-styles/tests/code/codeui.js
@@ -43,15 +43,6 @@ describe( 'CodeUI', () => {
 		} );
 
 		testButton();
-
-		it( 'should bind `isOn` to code command', () => {
-			const command = editor.commands.get( 'code' );
-
-			expect( codeView.isOn ).to.be.false;
-
-			command.value = true;
-			expect( codeView.isOn ).to.be.true;
-		} );
 	} );
 
 	describe( 'menu bar button', () => {
@@ -60,6 +51,20 @@ describe( 'CodeUI', () => {
 		} );
 
 		testButton();
+
+		it( 'should create button with `menuitemcheckbox` role', () => {
+			expect( codeView.role ).to.equal( 'menuitemcheckbox' );
+		} );
+
+		it( 'should bind `isOn` to `aria-checked` attribute', () => {
+			codeView.render();
+
+			codeView.isOn = true;
+			expect( codeView.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'true' );
+
+			codeView.isOn = false;
+			expect( codeView.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'false' );
+		} );
 	} );
 
 	function testButton() {
@@ -86,6 +91,18 @@ describe( 'CodeUI', () => {
 
 			command.isEnabled = false;
 			expect( codeView.isEnabled ).to.be.false;
+		} );
+
+		it( 'should bind `isOn` to `command`.`value`', () => {
+			const command = editor.commands.get( 'code' );
+
+			command.value = true;
+
+			expect( codeView.isOn ).to.be.true;
+
+			command.value = false;
+
+			expect( codeView.isOn ).to.be.false;
 		} );
 	}
 } );

--- a/packages/ckeditor5-basic-styles/tests/italic/italicui.js
+++ b/packages/ckeditor5-basic-styles/tests/italic/italicui.js
@@ -45,15 +45,6 @@ describe( 'ItalicUI', () => {
 		} );
 
 		testButton();
-
-		it( 'should bind `isOn` to italic command', () => {
-			const command = editor.commands.get( 'italic' );
-
-			expect( italicView.isOn ).to.be.false;
-
-			command.value = true;
-			expect( italicView.isOn ).to.be.true;
-		} );
 	} );
 
 	describe( 'menu bar button', () => {
@@ -62,6 +53,20 @@ describe( 'ItalicUI', () => {
 		} );
 
 		testButton();
+
+		it( 'should create button with `menuitemcheckbox` role', () => {
+			expect( italicView.role ).to.equal( 'menuitemcheckbox' );
+		} );
+
+		it( 'should bind `isOn` to `aria-checked` attribute', () => {
+			italicView.render();
+
+			italicView.isOn = true;
+			expect( italicView.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'true' );
+
+			italicView.isOn = false;
+			expect( italicView.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'false' );
+		} );
 	} );
 
 	function testButton() {
@@ -109,6 +114,18 @@ describe( 'ItalicUI', () => {
 
 			expect( wasHandled ).to.be.true;
 			expect( spy.calledOnce ).to.be.true;
+		} );
+
+		it( 'should bind `isOn` to `command`.`value`', () => {
+			const command = editor.commands.get( 'italic' );
+
+			command.value = true;
+
+			expect( italicView.isOn ).to.be.true;
+
+			command.value = false;
+
+			expect( italicView.isOn ).to.be.false;
 		} );
 	}
 } );

--- a/packages/ckeditor5-basic-styles/tests/strikethrough/strikethroughui.js
+++ b/packages/ckeditor5-basic-styles/tests/strikethrough/strikethroughui.js
@@ -45,15 +45,6 @@ describe( 'StrikethroughUI', () => {
 		} );
 
 		testButton();
-
-		it( 'should bind `isOn` to strikethrough command', () => {
-			const command = editor.commands.get( 'strikethrough' );
-
-			expect( strikeView.isOn ).to.be.false;
-
-			command.value = true;
-			expect( strikeView.isOn ).to.be.true;
-		} );
 	} );
 
 	describe( 'menu bar button', () => {
@@ -62,6 +53,20 @@ describe( 'StrikethroughUI', () => {
 		} );
 
 		testButton();
+
+		it( 'should create button with `menuitemcheckbox` role', () => {
+			expect( strikeView.role ).to.equal( 'menuitemcheckbox' );
+		} );
+
+		it( 'should bind `isOn` to `aria-checked` attribute', () => {
+			strikeView.render();
+
+			strikeView.isOn = true;
+			expect( strikeView.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'true' );
+
+			strikeView.isOn = false;
+			expect( strikeView.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'false' );
+		} );
 	} );
 
 	function testButton() {
@@ -112,6 +117,18 @@ describe( 'StrikethroughUI', () => {
 			expect( wasHandled ).to.be.true;
 			expect( spy.calledOnce ).to.be.true;
 			expect( keyEventData.preventDefault.calledOnce ).to.be.true;
+		} );
+
+		it( 'should bind `isOn` to `command`.`value`', () => {
+			const command = editor.commands.get( 'strikethrough' );
+
+			command.value = true;
+
+			expect( strikeView.isOn ).to.be.true;
+
+			command.value = false;
+
+			expect( strikeView.isOn ).to.be.false;
 		} );
 	}
 } );

--- a/packages/ckeditor5-basic-styles/tests/subscript/subscriptui.js
+++ b/packages/ckeditor5-basic-styles/tests/subscript/subscriptui.js
@@ -43,15 +43,6 @@ describe( 'SubscriptUI', () => {
 		} );
 
 		testButton();
-
-		it( 'should bind `isOn` to subscript command', () => {
-			const command = editor.commands.get( 'subscript' );
-
-			expect( subView.isOn ).to.be.false;
-
-			command.value = true;
-			expect( subView.isOn ).to.be.true;
-		} );
 	} );
 
 	describe( 'menu bar button', () => {
@@ -60,6 +51,20 @@ describe( 'SubscriptUI', () => {
 		} );
 
 		testButton();
+
+		it( 'should create button with `menuitemcheckbox` role', () => {
+			expect( subView.role ).to.equal( 'menuitemcheckbox' );
+		} );
+
+		it( 'should bind `isOn` to `aria-checked` attribute', () => {
+			subView.render();
+
+			subView.isOn = true;
+			expect( subView.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'true' );
+
+			subView.isOn = false;
+			expect( subView.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'false' );
+		} );
 	} );
 
 	function testButton() {
@@ -87,6 +92,18 @@ describe( 'SubscriptUI', () => {
 
 			command.isEnabled = false;
 			expect( subView.isEnabled ).to.be.false;
+		} );
+
+		it( 'should bind `isOn` to `command`.`value`', () => {
+			const command = editor.commands.get( 'subscript' );
+
+			command.value = true;
+
+			expect( subView.isOn ).to.be.true;
+
+			command.value = false;
+
+			expect( subView.isOn ).to.be.false;
 		} );
 	}
 } );

--- a/packages/ckeditor5-basic-styles/tests/superscript/superscriptui.js
+++ b/packages/ckeditor5-basic-styles/tests/superscript/superscriptui.js
@@ -43,15 +43,6 @@ describe( 'SuperscriptUI', () => {
 		} );
 
 		testButton();
-
-		it( 'should bind `isOn` to superscript command', () => {
-			const command = editor.commands.get( 'superscript' );
-
-			expect( superView.isOn ).to.be.false;
-
-			command.value = true;
-			expect( superView.isOn ).to.be.true;
-		} );
 	} );
 
 	describe( 'menu bar button', () => {
@@ -60,6 +51,20 @@ describe( 'SuperscriptUI', () => {
 		} );
 
 		testButton();
+
+		it( 'should create button with `menuitemcheckbox` role', () => {
+			expect( superView.role ).to.equal( 'menuitemcheckbox' );
+		} );
+
+		it( 'should bind `isOn` to `aria-checked` attribute', () => {
+			superView.render();
+
+			superView.isOn = true;
+			expect( superView.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'true' );
+
+			superView.isOn = false;
+			expect( superView.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'false' );
+		} );
 	} );
 
 	function testButton() {
@@ -87,6 +92,18 @@ describe( 'SuperscriptUI', () => {
 
 			command.isEnabled = false;
 			expect( superView.isEnabled ).to.be.false;
+		} );
+
+		it( 'should bind `isOn` to `command`.`value`', () => {
+			const command = editor.commands.get( 'superscript' );
+
+			command.value = true;
+
+			expect( superView.isOn ).to.be.true;
+
+			command.value = false;
+
+			expect( superView.isOn ).to.be.false;
 		} );
 	}
 } );

--- a/packages/ckeditor5-basic-styles/tests/underline/underlineui.js
+++ b/packages/ckeditor5-basic-styles/tests/underline/underlineui.js
@@ -45,15 +45,6 @@ describe( 'Underline', () => {
 		} );
 
 		testButton();
-
-		it( 'should bind `isOn` to underline command', () => {
-			const command = editor.commands.get( 'underline' );
-
-			expect( underlineView.isOn ).to.be.false;
-
-			command.value = true;
-			expect( underlineView.isOn ).to.be.true;
-		} );
 	} );
 
 	describe( 'menu bar button', () => {
@@ -109,6 +100,18 @@ describe( 'Underline', () => {
 
 			expect( wasHandled ).to.be.true;
 			expect( spy.calledOnce ).to.be.true;
+		} );
+
+		it( 'should bind `isOn` to `command`.`value`', () => {
+			const command = editor.commands.get( 'underline' );
+
+			command.value = true;
+
+			expect( underlineView.isOn ).to.be.true;
+
+			command.value = false;
+
+			expect( underlineView.isOn ).to.be.false;
 		} );
 	}
 } );

--- a/packages/ckeditor5-block-quote/src/blockquoteui.ts
+++ b/packages/ckeditor5-block-quote/src/blockquoteui.ts
@@ -9,7 +9,6 @@
 
 import { Plugin, icons } from 'ckeditor5/src/core.js';
 import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
-import type BlockQuoteCommand from './blockquotecommand.js';
 
 import '../theme/blockquote.css';
 

--- a/packages/ckeditor5-block-quote/src/blockquoteui.ts
+++ b/packages/ckeditor5-block-quote/src/blockquoteui.ts
@@ -33,7 +33,6 @@ export default class BlockQuoteUI extends Plugin {
 	 */
 	public init(): void {
 		const editor = this.editor;
-		const command: BlockQuoteCommand = editor.commands.get( 'blockQuote' )!;
 
 		editor.ui.componentFactory.add( 'blockQuote', () => {
 			const buttonView = this._createButton( ButtonView );
@@ -42,13 +41,18 @@ export default class BlockQuoteUI extends Plugin {
 				tooltip: true
 			} );
 
-			// Bind button model to command.
-			buttonView.bind( 'isOn' ).to( command, 'value' );
-
 			return buttonView;
 		} );
 
-		editor.ui.componentFactory.add( 'menuBar:blockQuote', () => this._createButton( MenuBarMenuListItemButtonView ) );
+		editor.ui.componentFactory.add( 'menuBar:blockQuote', () => {
+			const buttonView = this._createButton( MenuBarMenuListItemButtonView );
+
+			buttonView.set( {
+				role: 'menuitemcheckbox'
+			} );
+
+			return buttonView;
+		} );
 	}
 
 	/**
@@ -68,6 +72,7 @@ export default class BlockQuoteUI extends Plugin {
 		} );
 
 		view.bind( 'isEnabled' ).to( command, 'isEnabled' );
+		view.bind( 'isOn' ).to( command, 'value' );
 
 		// Execute the command.
 		this.listenTo( view, 'execute', () => {

--- a/packages/ckeditor5-code-block/src/codeblockui.ts
+++ b/packages/ckeditor5-code-block/src/codeblockui.ts
@@ -98,6 +98,7 @@ export default class CodeBlockUI extends Plugin {
 			const menuView = new MenuBarMenuView( locale );
 
 			menuView.buttonView.set( {
+				role: 'menuitem',
 				label: t( 'Code block' ),
 				icon: icons.codeBlock
 			} );
@@ -115,7 +116,11 @@ export default class CodeBlockUI extends Plugin {
 				const buttonView = new MenuBarMenuListItemButtonView( locale );
 
 				buttonView.bind( ...Object.keys( definition.model ) as Array<keyof MenuBarMenuListItemButtonView> ).to( definition.model );
-				buttonView.bind( 'ariaChecked' ).to( buttonView, 'isOn' );
+				buttonView.set( {
+					isToggleable: true,
+					role: 'menuitemcheckbox'
+				} );
+
 				buttonView.delegate( 'execute' ).to( menuView );
 
 				buttonView.on( 'execute', () => {

--- a/packages/ckeditor5-code-block/tests/codeblockui.js
+++ b/packages/ckeditor5-code-block/tests/codeblockui.js
@@ -127,6 +127,20 @@ describe( 'CodeBlockUI', () => {
 			languagesListView = subMenu.panelView.children.first;
 		} );
 
+		it( 'has proper menu item role on button', () => {
+			expect( subMenu.buttonView.role ).to.be.equal( 'menuitem' );
+		} );
+
+		it( 'sets item\'s aria-checked attribute depending on the value of the CodeBlockCommand', () => {
+			const { element } = languagesListView.items.get( 2 ).children.first;
+
+			expect( element.getAttribute( 'aria-checked' ) ).to.be.equal( 'false' );
+
+			command.value = 'cs';
+
+			expect( element.getAttribute( 'aria-checked' ) ).to.be.equal( 'true' );
+		} );
+
 		it( 'has isEnabled bound to command\'s isEnabled', () => {
 			command.isEnabled = true;
 			expect( subMenu ).to.have.property( 'isEnabled', true );

--- a/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceui.ts
@@ -214,6 +214,15 @@ export default class FindAndReplaceUI extends Plugin {
 	private _createDialogButtonForMenuBar(): MenuBarMenuListItemButtonView {
 		const buttonView = this._createButton( MenuBarMenuListItemButtonView );
 		const dialogPlugin = this.editor.plugins.get( 'Dialog' );
+		const dialog = this.editor.plugins.get( 'Dialog' );
+
+		buttonView.set( {
+			role: 'menuitemcheckbox',
+			isToggleable: true
+		} );
+
+		// Button should be on when the find and replace dialog is opened.
+		buttonView.bind( 'isOn' ).to( dialog, 'id', id => id === 'findAndReplace' );
 
 		buttonView.on( 'execute', () => {
 			if ( dialogPlugin.id === 'findAndReplace' ) {

--- a/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
+++ b/packages/ckeditor5-find-and-replace/tests/findandreplaceui.js
@@ -122,6 +122,10 @@ describe( 'FindAndReplaceUI', () => {
 					} );
 
 					testButton();
+
+					it( 'should have proper role set', () => {
+						expect( button.role ).to.be.equal( 'menuitemcheckbox' );
+					} );
 				} );
 
 				function testButton() {
@@ -137,6 +141,16 @@ describe( 'FindAndReplaceUI', () => {
 							button.fire( 'execute' );
 
 							sinon.assert.callOrder( disableCssTransitionsSpy, selectSpy, enableCssTransitionsSpy );
+						} );
+
+						it( 'should be bound to dialog id', () => {
+							dialogPlugin.id = 'findAndReplace';
+
+							expect( button.isOn ).to.be.true;
+
+							dialogPlugin.id = null;
+
+							expect( button.isOn ).to.be.false;
 						} );
 
 						it( 'the form should be reset', () => {

--- a/packages/ckeditor5-font/src/fontfamily/fontfamilyui.ts
+++ b/packages/ckeditor5-font/src/fontfamily/fontfamilyui.ts
@@ -100,8 +100,12 @@ export default class FontFamilyUI extends Plugin {
 				const listItemView = new MenuBarMenuListItemView( locale, menuView );
 				const buttonView = new MenuBarMenuListItemButtonView( locale );
 
+				buttonView.set( {
+					role: 'menuitemradio',
+					isToggleable: true
+				} );
+
 				buttonView.bind( ...Object.keys( definition.model ) as Array<keyof MenuBarMenuListItemButtonView> ).to( definition.model );
-				buttonView.bind( 'ariaChecked' ).to( buttonView, 'isOn' );
 				buttonView.delegate( 'execute' ).to( menuView );
 
 				buttonView.on( 'execute', () => {

--- a/packages/ckeditor5-font/src/fontsize/fontsizeui.ts
+++ b/packages/ckeditor5-font/src/fontsize/fontsizeui.ts
@@ -105,8 +105,12 @@ export default class FontSizeUI extends Plugin {
 				const listItemView = new MenuBarMenuListItemView( locale, menuView );
 				const buttonView = new MenuBarMenuListItemButtonView( locale );
 
+				buttonView.set( {
+					role: 'menuitemradio',
+					isToggleable: true
+				} );
+
 				buttonView.bind( ...Object.keys( definition.model ) as Array<keyof MenuBarMenuListItemButtonView> ).to( definition.model );
-				buttonView.bind( 'ariaChecked' ).to( buttonView, 'isOn' );
 				buttonView.delegate( 'execute' ).to( menuView );
 
 				buttonView.on( 'execute', () => {

--- a/packages/ckeditor5-font/tests/fontfamily/fontfamilyui.js
+++ b/packages/ckeditor5-font/tests/fontfamily/fontfamilyui.js
@@ -316,7 +316,16 @@ describe( 'FontFamilyUI', () => {
 				expect( buttonArial.isOn ).to.be.false;
 
 				command.value = 'Arial, Helvetica, sans-serif';
+
 				expect( buttonArial.isOn ).to.be.true;
+			} );
+
+			it( 'sets item\'s element aria-checked attribute depending on the value of the CodeBlockCommand', () => {
+				expect( buttonArial.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'false' );
+
+				command.value = 'Arial, Helvetica, sans-serif';
+
+				expect( buttonArial.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'true' );
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-font/tests/fontsize/fontsizeui.js
+++ b/packages/ckeditor5-font/tests/fontsize/fontsizeui.js
@@ -357,6 +357,14 @@ describe( 'FontSizeUI', () => {
 				command.value = 'small';
 				expect( buttonSmall.isOn ).to.be.true;
 			} );
+
+			it( 'button has proper `aria-checked` attribute set when active', () => {
+				expect( buttonSmall.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'false' );
+
+				command.value = 'small';
+
+				expect( buttonSmall.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'true' );
+			} );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-heading/src/headingui.ts
+++ b/packages/ckeditor5-heading/src/headingui.ts
@@ -181,12 +181,12 @@ export default class HeadingUI extends Plugin {
 				listView.items.add( listItemView );
 
 				buttonView.set( {
+					isToggleable: true,
 					label: option.title,
 					role: 'menuitemradio',
 					class: option.class
 				} );
 
-				buttonView.bind( 'ariaChecked' ).to( buttonView, 'isOn' );
 				buttonView.delegate( 'execute' ).to( menuView );
 
 				buttonView.on<ButtonExecuteEvent>( 'execute', () => {

--- a/packages/ckeditor5-heading/tests/headingui.js
+++ b/packages/ckeditor5-heading/tests/headingui.js
@@ -405,25 +405,25 @@ describe( 'HeadingUI', () => {
 				] );
 			} );
 
-			it( 'should bind #ariaChecked to #isOn', () => {
+			it( 'should bind `aria-checked` element attribute to #isOn', () => {
 				command.value = 'heading2';
 				paragraphCommand.value = false;
 
-				expect( dumpItems( 'ariaChecked' ) ).to.have.deep.ordered.members( [
-					[ 'Paragraph', false ],
-					[ 'Heading 1', false ],
-					[ 'Heading 2', true ],
-					[ 'Heading 3', false ]
+				expect( dumpItems( item => item.element.getAttribute( 'aria-checked' ) ) ).to.have.deep.ordered.members( [
+					[ 'Paragraph', 'false' ],
+					[ 'Heading 1', 'false' ],
+					[ 'Heading 2', 'true' ],
+					[ 'Heading 3', 'false' ]
 				] );
 
 				command.value = false;
 				paragraphCommand.value = true;
 
-				expect( dumpItems( 'ariaChecked' ) ).to.have.deep.ordered.members( [
-					[ 'Paragraph', true ],
-					[ 'Heading 1', false ],
-					[ 'Heading 2', false ],
-					[ 'Heading 3', false ]
+				expect( dumpItems( item => item.element.getAttribute( 'aria-checked' ) ) ).to.have.deep.ordered.members( [
+					[ 'Paragraph', 'true' ],
+					[ 'Heading 1', 'false' ],
+					[ 'Heading 2', 'false' ],
+					[ 'Heading 3', 'false' ]
 				] );
 			} );
 

--- a/packages/ckeditor5-heading/theme/heading.css
+++ b/packages/ckeditor5-heading/theme/heading.css
@@ -3,15 +3,15 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-.ck.ck-heading_heading1 {
+.ck.ck-heading_heading1 .ck-button__label {
 	font-size: 20px;
 }
 
-.ck.ck-heading_heading2 {
+.ck.ck-heading_heading2 .ck-button__label {
 	font-size: 17px;
 }
 
-.ck.ck-heading_heading3 {
+.ck.ck-heading_heading3 .ck-button__label {
 	font-size: 14px;
 }
 

--- a/packages/ckeditor5-highlight/src/highlightui.ts
+++ b/packages/ckeditor5-highlight/src/highlightui.ts
@@ -286,12 +286,13 @@ export default class HighlightUI extends Plugin {
 
 				buttonView.set( {
 					label: option.title,
-					icon: getIconForType( option.type )
+					icon: getIconForType( option.type ),
+					role: 'menuitemradio',
+					isToggleable: true
 				} );
 
 				buttonView.delegate( 'execute' ).to( menuView );
 				buttonView.bind( 'isOn' ).to( command, 'value', value => value === option.model );
-				buttonView.bind( 'ariaChecked' ).to( buttonView, 'isOn' );
 				buttonView.iconView.bind( 'fillColor' ).to( buttonView, 'isOn', value => value ? 'transparent' : option.color );
 
 				buttonView.on( 'execute', () => {

--- a/packages/ckeditor5-highlight/src/highlightui.ts
+++ b/packages/ckeditor5-highlight/src/highlightui.ts
@@ -291,9 +291,10 @@ export default class HighlightUI extends Plugin {
 					isToggleable: true
 				} );
 
+				buttonView.iconView.fillColor = option.color;
+
 				buttonView.delegate( 'execute' ).to( menuView );
 				buttonView.bind( 'isOn' ).to( command, 'value', value => value === option.model );
-				buttonView.iconView.bind( 'fillColor' ).to( buttonView, 'isOn', value => value ? 'transparent' : option.color );
 
 				buttonView.on( 'execute', () => {
 					editor.execute( 'highlight', { value: option.model } );

--- a/packages/ckeditor5-highlight/tests/highlightui.js
+++ b/packages/ckeditor5-highlight/tests/highlightui.js
@@ -399,29 +399,29 @@ describe( 'HighlightUI', () => {
 				] );
 			} );
 
-			it( 'should bind #ariaChecked to the command', () => {
+			it( 'should bind `aria-checked` attribute to the command', () => {
 				command.value = 'pinkMarker';
 
-				expect( dumpItems( 'ariaChecked' ) ).to.have.deep.ordered.members( [
-					[ 'Yellow marker', false ],
-					[ 'Green marker', false ],
-					[ 'Pink marker', true ],
-					[ 'Blue marker', false ],
-					[ 'Red pen', false ],
-					[ 'Green pen', false ],
-					[ 'Remove highlight', undefined ]
+				expect( dumpItems( item => item.element.getAttribute( 'aria-checked' ) ) ).to.have.deep.ordered.members( [
+					[ 'Yellow marker', 'false' ],
+					[ 'Green marker', 'false' ],
+					[ 'Pink marker', 'true' ],
+					[ 'Blue marker', 'false' ],
+					[ 'Red pen', 'false' ],
+					[ 'Green pen', 'false' ],
+					[ 'Remove highlight', null ]
 				] );
 
 				command.value = 'redPen';
 
-				expect( dumpItems( 'ariaChecked' ) ).to.have.deep.ordered.members( [
-					[ 'Yellow marker', false ],
-					[ 'Green marker', false ],
-					[ 'Pink marker', false ],
-					[ 'Blue marker', false ],
-					[ 'Red pen', true ],
-					[ 'Green pen', false ],
-					[ 'Remove highlight', undefined ]
+				expect( dumpItems( item => item.element.getAttribute( 'aria-checked' ) ) ).to.have.deep.ordered.members( [
+					[ 'Yellow marker', 'false' ],
+					[ 'Green marker', 'false' ],
+					[ 'Pink marker', 'false' ],
+					[ 'Blue marker', 'false' ],
+					[ 'Red pen', 'true' ],
+					[ 'Green pen', 'false' ],
+					[ 'Remove highlight', null ]
 				] );
 			} );
 

--- a/packages/ckeditor5-highlight/tests/highlightui.js
+++ b/packages/ckeditor5-highlight/tests/highlightui.js
@@ -425,32 +425,6 @@ describe( 'HighlightUI', () => {
 				] );
 			} );
 
-			it( 'should bind #fillColor to #isOn', () => {
-				command.value = 'pinkMarker';
-
-				expect( dumpItems( buttonView => buttonView.iconView.fillColor ) ).to.have.deep.ordered.members( [
-					[ 'Yellow marker', 'var(--ck-highlight-marker-yellow)' ],
-					[ 'Green marker', 'var(--ck-highlight-marker-green)' ],
-					[ 'Pink marker', 'transparent' ],
-					[ 'Blue marker', 'var(--ck-highlight-marker-blue)' ],
-					[ 'Red pen', 'var(--ck-highlight-pen-red)' ],
-					[ 'Green pen', 'var(--ck-highlight-pen-green)' ],
-					[ 'Remove highlight', '' ]
-				] );
-
-				command.value = 'redPen';
-
-				expect( dumpItems( buttonView => buttonView.iconView.fillColor ) ).to.have.deep.ordered.members( [
-					[ 'Yellow marker', 'var(--ck-highlight-marker-yellow)' ],
-					[ 'Green marker', 'var(--ck-highlight-marker-green)' ],
-					[ 'Pink marker', 'var(--ck-highlight-marker-pink)' ],
-					[ 'Blue marker', 'var(--ck-highlight-marker-blue)' ],
-					[ 'Red pen', 'transparent' ],
-					[ 'Green pen', 'var(--ck-highlight-pen-green)' ],
-					[ 'Remove highlight', '' ]
-				] );
-			} );
-
 			it( 'should delegate #execute from an item to the menu', () => {
 				const spy = sinon.spy();
 

--- a/packages/ckeditor5-language/src/textpartlanguageui.ts
+++ b/packages/ckeditor5-language/src/textpartlanguageui.ts
@@ -127,8 +127,12 @@ export default class TextPartLanguageUI extends Plugin {
 				const listItemView = new MenuBarMenuListItemView( locale, menuView );
 				const buttonView = new MenuBarMenuListItemButtonView( locale );
 
+				buttonView.set( {
+					role: 'menuitemradio',
+					isToggleable: true
+				} );
+
 				buttonView.bind( ...Object.keys( definition.model ) as Array<keyof MenuBarMenuListItemButtonView> ).to( definition.model );
-				buttonView.bind( 'ariaChecked' ).to( buttonView, 'isOn' );
 				buttonView.delegate( 'execute' ).to( menuView );
 
 				listItemView.children.add( buttonView );

--- a/packages/ckeditor5-language/tests/textpartlanguageui.js
+++ b/packages/ckeditor5-language/tests/textpartlanguageui.js
@@ -231,6 +231,12 @@ describe( 'TextPartLanguageUI', () => {
 				sinon.assert.calledOnce( focusSpy );
 			} );
 
+			it( 'should have menuitem role set on definition items', () => {
+				const items = getListViewItems( menuView.panelView.children.first );
+
+				expect( items.every( item => item.children.first.role === 'menuitemradio' ) ).to.be.true;
+			} );
+
 			describe( 'listview', () => {
 				it( 'should have properties set', () => {
 					// Trigger lazy init.
@@ -269,6 +275,24 @@ describe( 'TextPartLanguageUI', () => {
 						false,
 						true,
 						false
+					] );
+				} );
+
+				it( 'should have `aria-checked` attribute assigned to items', () => {
+					// Trigger lazy init.
+					menuView.isOpen = true;
+
+					setData( editor.model, '<paragraph>[<$text language="fr:ltr">te]xt</$text></paragraph>' );
+
+					const listView = menuView.panelView.children.first;
+					const attributes = getListViewItems( listView )
+						.map( item => item.children.first.element.getAttribute( 'aria-checked' ) );
+
+					expect( attributes ).to.deep.equal( [
+						'false',
+						'false',
+						'true',
+						'false'
 					] );
 				} );
 			} );

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -241,30 +241,32 @@ export default class LinkUI extends Plugin {
 	 */
 	private _createToolbarLinkButton(): void {
 		const editor = this.editor;
-		const linkCommand: LinkCommand = editor.commands.get( 'link' )!;
 
 		editor.ui.componentFactory.add( 'link', () => {
 			const button = this._createButton( ButtonView );
 
 			button.set( {
-				tooltip: true,
-				isToggleable: true
+				tooltip: true
 			} );
-
-			button.bind( 'isOn' ).to( linkCommand, 'value', value => !!value );
 
 			return button;
 		} );
 
 		editor.ui.componentFactory.add( 'menuBar:link', () => {
-			return this._createButton( MenuBarMenuListItemButtonView );
+			const button = this._createButton( MenuBarMenuListItemButtonView );
+
+			button.set( {
+				role: 'menuitemcheckbox'
+			} );
+
+			return button;
 		} );
 	}
 
 	/**
 	 * Creates a button for link command to use either in toolbar or in menu bar.
 	 */
-	private _createButton<T extends typeof ButtonView | typeof MenuBarMenuListItemButtonView>( ButtonClass: T ): InstanceType<T> {
+	private _createButton<T extends typeof ButtonView>( ButtonClass: T ): InstanceType<T> {
 		const editor = this.editor;
 		const locale = editor.locale;
 		const command = editor.commands.get( 'link' )!;
@@ -274,10 +276,12 @@ export default class LinkUI extends Plugin {
 		view.set( {
 			label: t( 'Link' ),
 			icon: linkIcon,
-			keystroke: LINK_KEYSTROKE
+			keystroke: LINK_KEYSTROKE,
+			isToggleable: true
 		} );
 
 		view.bind( 'isEnabled' ).to( command, 'isEnabled' );
+		view.bind( 'isOn' ).to( command, 'value', value => !!value );
 
 		// Show the panel on button click.
 		this.listenTo( view, 'execute', () => this._showUI( true ) );

--- a/packages/ckeditor5-list/src/list/utils.ts
+++ b/packages/ckeditor5-list/src/list/utils.ts
@@ -36,9 +36,16 @@ export function createUIComponents(
 		return buttonView;
 	} );
 
-	editor.ui.componentFactory.add( `menuBar:${ commandName }`, () =>
-		_createButton( MenuBarMenuListItemButtonView, editor, commandName, label, icon )
-	);
+	editor.ui.componentFactory.add( `menuBar:${ commandName }`, () => {
+		const buttonView = _createButton( MenuBarMenuListItemButtonView, editor, commandName, label, icon );
+
+		buttonView.set( {
+			role: 'menuitemcheckbox',
+			isToggleable: true
+		} );
+
+		return buttonView;
+	} );
 }
 
 /**

--- a/packages/ckeditor5-list/tests/list/listui.js
+++ b/packages/ckeditor5-list/tests/list/listui.js
@@ -108,6 +108,14 @@ describe( 'ListUI', () => {
 			numberedListButton = editor.ui.componentFactory.create( 'menuBar:numberedList' );
 		} );
 
+		it( 'should set proper `role` and `isToggleable` attributes', () => {
+			expect( bulletedListButton.role ).to.be.equal( 'menuitemcheckbox' );
+			expect( numberedListButton.role ).to.be.equal( 'menuitemcheckbox' );
+
+			expect( bulletedListButton.isToggleable ).to.be.true;
+			expect( numberedListButton.isToggleable ).to.be.true;
+		} );
+
 		it( 'should set up buttons for bulleted list and numbered list', () => {
 			expect( bulletedListButton ).to.be.instanceOf( MenuBarMenuListItemButtonView );
 			expect( numberedListButton ).to.be.instanceOf( MenuBarMenuListItemButtonView );

--- a/packages/ckeditor5-restricted-editing/src/standardeditingmodeui.ts
+++ b/packages/ckeditor5-restricted-editing/src/standardeditingmodeui.ts
@@ -50,7 +50,7 @@ export default class StandardEditingModeUI extends Plugin {
 	/**
 	 * Creates a button for restricted editing exception command to use either in toolbar or in menu bar.
 	 */
-	private _createButton<T extends typeof ButtonView | typeof MenuBarMenuListItemButtonView>( ButtonClass: T ): InstanceType<T> {
+	private _createButton<T extends typeof ButtonView>( ButtonClass: T ): InstanceType<T> {
 		const editor = this.editor;
 		const locale = editor.locale;
 		const command = this.editor.commands.get( 'restrictedEditingException' )!;

--- a/packages/ckeditor5-show-blocks/src/showblocksui.ts
+++ b/packages/ckeditor5-show-blocks/src/showblocksui.ts
@@ -52,7 +52,7 @@ export default class ShowBlocksUI extends Plugin {
 	/**
 	 * Creates a button for show blocks command to use either in toolbar or in menu bar.
 	 */
-	private _createButton<T extends typeof ButtonView | typeof MenuBarMenuListItemButtonView>( ButtonClass: T ): InstanceType<T> {
+	private _createButton<T extends typeof ButtonView>( ButtonClass: T ): InstanceType<T> {
 		const editor = this.editor;
 		const locale = editor.locale;
 		const command = editor.commands.get( 'showBlocks' )!;
@@ -60,7 +60,9 @@ export default class ShowBlocksUI extends Plugin {
 		const t = locale.t;
 
 		view.set( {
-			label: t( 'Show blocks' )
+			label: t( 'Show blocks' ),
+			isToggleable: true,
+			role: 'menuitemcheckbox'
 		} );
 
 		view.bind( 'isEnabled' ).to( command );

--- a/packages/ckeditor5-show-blocks/tests/showblocksui.js
+++ b/packages/ckeditor5-show-blocks/tests/showblocksui.js
@@ -64,6 +64,20 @@ describe( 'ShowBlocksUI', () => {
 		} );
 
 		testButton( 'showBlocks', 'Show blocks', MenuBarMenuListItemButtonView );
+
+		it( 'should create button with `menuitemcheckbox` role', () => {
+			expect( button.role ).to.equal( 'menuitemcheckbox' );
+		} );
+
+		it( 'should bind `isOn` to `aria-checked` attribute', () => {
+			button.render();
+
+			button.isOn = true;
+			expect( button.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'true' );
+
+			button.isOn = false;
+			expect( button.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'false' );
+		} );
 	} );
 
 	function testButton( featureName, label, Component ) {
@@ -73,6 +87,7 @@ describe( 'ShowBlocksUI', () => {
 
 		it( 'should create UI component with correct attribute values', () => {
 			expect( button.isOn ).to.be.false;
+			expect( button.isToggleable ).to.be.true;
 			expect( button.label ).to.equal( label );
 		} );
 

--- a/packages/ckeditor5-source-editing/src/sourceediting.ts
+++ b/packages/ckeditor5-source-editing/src/sourceediting.ts
@@ -104,7 +104,8 @@ export default class SourceEditing extends Plugin {
 			const buttonView = this._createButton( MenuBarMenuListItemButtonView );
 
 			buttonView.set( {
-				label: t( 'Show source' )
+				label: t( 'Show source' ),
+				role: 'menuitemcheckbox'
 			} );
 
 			return buttonView;
@@ -392,12 +393,13 @@ export default class SourceEditing extends Plugin {
 		}
 	}
 
-	private _createButton<T extends typeof ButtonView | typeof MenuBarMenuListItemButtonView>( ButtonClass: T ): InstanceType<T> {
+	private _createButton<T extends typeof ButtonView>( ButtonClass: T ): InstanceType<T> {
 		const editor = this.editor;
 		const buttonView = new ButtonClass( editor.locale ) as InstanceType<T>;
 
 		buttonView.set( {
-			withText: true
+			withText: true,
+			isToggleable: true
 		} );
 
 		buttonView.bind( 'isOn' ).to( this, 'isSourceEditingMode' );

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -215,6 +215,7 @@ describe( 'SourceEditing', () => {
 				expect( button ).to.be.instanceOf( Component );
 				expect( button.isEnabled ).to.be.true;
 				expect( button.isOn ).to.be.false;
+				expect( button.isToggleable ).to.be.true;
 				expect( button.label ).to.equal( label );
 			} );
 

--- a/packages/ckeditor5-special-characters/src/specialcharacters.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharacters.ts
@@ -249,7 +249,7 @@ export default class SpecialCharacters extends Plugin {
 	/**
 	 * Creates a button for for menu bar that will show special characetrs dialog.
 	 */
-	private _createDialogButton<T extends typeof ButtonView | typeof MenuBarMenuListItemButtonView>( ButtonClass: T ): InstanceType<T> {
+	private _createDialogButton<T extends typeof ButtonView>( ButtonClass: T ): InstanceType<T> {
 		const editor = this.editor;
 		const locale = editor.locale;
 		const buttonView = new ButtonClass( editor.locale ) as InstanceType<T>;

--- a/packages/ckeditor5-special-characters/src/ui/specialcharacterscategoriesview.ts
+++ b/packages/ckeditor5-special-characters/src/ui/specialcharacterscategoriesview.ts
@@ -85,6 +85,7 @@ export default class SpecialCharactersCategoriesView extends View {
 				model: new ViewModel( {
 					name,
 					label,
+					role: 'menuitemradio',
 					withText: true
 				} )
 			};

--- a/packages/ckeditor5-special-characters/tests/ui/specialcharacterscategoriesview.js
+++ b/packages/ckeditor5-special-characters/tests/ui/specialcharacterscategoriesview.js
@@ -120,13 +120,13 @@ describe( 'SpecialCharactersCategoriesView', () => {
 			it( 'have basic properties', () => {
 				expect( groupDropdownView.listView.items
 					.map( item => {
-						const { name, label, withText } = item.children.first;
+						const { name, label, role, withText } = item.children.first;
 
-						return { name, label, withText };
+						return { name, label, role, withText };
 					} ) )
 					.to.deep.equal( [
-						{ name: 'groupA', label: 'labelA', withText: true },
-						{ name: 'groupB', label: 'labelB', withText: true }
+						{ name: 'groupA', label: 'labelA', role: 'menuitemradio', withText: true },
+						{ name: 'groupB', label: 'labelB', role: 'menuitemradio', withText: true }
 					] );
 			} );
 		} );

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/listitembutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/listitembutton.css
@@ -9,7 +9,7 @@
 	&,
 	&.ck-on {
 		background: var(--ck-color-list-background);
-		color: inherit;
+		color: var(--ck-color-text);
 	}
 
 	/*
@@ -24,7 +24,7 @@
 		background: var(--ck-color-list-button-hover-background);
 
 		&:not(.ck-disabled) {
-			color: var(--ck-color-list-button-hover-text);
+			color: var(--ck-color-text);
 		}
 	}
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/listitembutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/listitembutton.css
@@ -12,7 +12,7 @@
 		color: inherit;
 	}
 
-	/**
+	/*
 	 * `.ck-on` class and background styling is overridden for `ck-button` in many places.
 	 * This is a workaround to make sure that the background is not overridden and uses similar
 	 * selector specificity as the other overrides.

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/listitembutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/button/listitembutton.css
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+@import "@ckeditor/ckeditor5-ui/theme/mixins/_dir.css";
+
+.ck.ck-list-item-button {
+	&,
+	&.ck-on {
+		background: var(--ck-color-list-background);
+		color: inherit;
+	}
+
+	/**
+	 * `.ck-on` class and background styling is overridden for `ck-button` in many places.
+	 * This is a workaround to make sure that the background is not overridden and uses similar
+	 * selector specificity as the other overrides.
+	 */
+	&:hover:not(.ck-disabled),
+	&.ck-button.ck-on:hover,
+	&.ck-on:not(.ck-list-item-button_toggleable),
+	&.ck-on:hover {
+		background: var(--ck-color-list-button-hover-background);
+
+		&:not(.ck-disabled) {
+			color: var(--ck-color-list-button-hover-text);
+		}
+	}
+}

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css
@@ -71,7 +71,7 @@
 
 	/* It's unnecessary to change the background/text of a switch toggle; it has different ways
 	of conveying its state (like the switcher) */
-	& > .ck-switchbutton {
+	& > .ck-button.ck-switchbutton {
 		&.ck-on {
 			background: var(--ck-color-list-background);
 			color: inherit;

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css
@@ -25,7 +25,7 @@
 	cursor: default;
 	min-width: 12em;
 
-	& > .ck-button {
+	& > .ck-button:not(.ck-list-item-button) {
 		min-height: unset;
 		width: 100%;
 		border-radius: 0;
@@ -59,7 +59,7 @@
 				background: var(--ck-color-list-button-on-background-focus);
 			}
 
-			&:focus:not(.ck-switchbutton):not(.ck-disabled) {
+			&:focus:not(.ck-disabled) {
 				border-color: var(--ck-color-base-background);
 			}
 		}

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenubutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenubutton.css
@@ -66,20 +66,6 @@
 	&:not(.ck-menu-bar__menu_top-level) .ck-menu-bar__menu__button {
 		border-radius: 0;
 
-		&:focus {
-			border-color: transparent;
-			box-shadow: none;
-
-			&:not(.ck-on) {
-				background: var(--ck-color-button-default-hover-background);
-			}
-		}
-
-		/* Spacing in buttons that miss the icon. */
-		&:not(:has(.ck-button__icon)) > .ck-button__label {
-			margin-left: calc(var(--ck-icon-size) - var(--ck-spacing-small));
-		}
-
 		& > .ck-menu-bar__menu__button__arrow {
 			width: var(--ck-dropdown-arrow-size);
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenulistitembutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenulistitembutton.css
@@ -21,29 +21,6 @@
 			margin-left: calc(-1 * var(--ck-spacing-small));
 			margin-right: var(--ck-spacing-small);
 		}
-
-		/*
-		 * Hovered items automatically get focused. Default focus styles look odd
-		 * while moving across a huge list of items so let's get rid of them
-		 */
-		&:focus {
-			border-color: transparent;
-			box-shadow: none;
-
-			&:not(.ck-on) {
-				background: var(--ck-color-button-default-hover-background);
-			}
-		}
-	}
-
-	/*
-	 * First-level sub-menu item buttons.
-	 */
-	&.ck-menu-bar__menu_top-level > .ck-menu-bar__menu__panel > ul > .ck-menu-bar__menu__item > .ck-menu-bar__menu__item__button {
-		/* Spacing in buttons that miss the icon. */
-		&:not(:has(.ck-button__icon)) > .ck-button__label {
-			margin-left: calc(var(--ck-icon-size) - var(--ck-spacing-small));
-		}
 	}
 }
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenupanel.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenupanel.css
@@ -56,6 +56,11 @@
 		}
 	}
 
+	/*
+	 * Top level menu buttons are styled differently when focused or active.
+	 * They should be highlighted after clicking, without looking at keyboard focus interaction.
+	 * It's because it should indicate that the menu might be opened after pressing the arrow down keyboard button.
+	 */
 	& .ck-menu-bar__menu_top-level > .ck-list-item-button,
 	&.ck-menu-bar_keyboard-focus-interaction .ck-list-item-button {
 		&:focus,

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenupanel.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenupanel.css
@@ -5,6 +5,7 @@
 
 @import "../../../mixins/_rounded.css";
 @import "../../../mixins/_shadow.css";
+@import "../../../mixins/_focus.css";
 
 :root {
 	--ck-menu-bar-menu-panel-max-width: 75vw;
@@ -43,5 +44,28 @@
 
 	&:focus {
 		outline: none;
+	}
+}
+
+.ck.ck-menu-bar {
+	& .ck-list-item-button {
+		&:focus,
+		&:active {
+			border-color: transparent;
+			box-shadow: none;
+		}
+	}
+
+	& .ck-menu-bar__menu_top-level > .ck-list-item-button,
+	&.ck-menu-bar_keyboard-focus-interaction .ck-list-item-button {
+		&:focus,
+		&:active {
+			/* Fix truncated shadows due to rendering order. */
+			position: relative;
+			z-index: 2;
+
+			@mixin ck-focus-ring;
+			@mixin ck-box-shadow var(--ck-focus-outer-shadow);
+		}
 	}
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenupanel.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenupanel.css
@@ -62,7 +62,7 @@
 	 * It's because it should indicate that the menu might be opened after pressing the arrow down keyboard button.
 	 */
 	& .ck-menu-bar__menu_top-level > .ck-list-item-button,
-	&.ck-menu-bar_keyboard-focus-interaction .ck-list-item-button {
+	&.ck-menu-bar_focus-border-enabled .ck-list-item-button {
 		&:focus,
 		&:active {
 			/* Fix truncated shadows due to rendering order. */

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenupanel.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenupanel.css
@@ -56,12 +56,6 @@
 		}
 	}
 
-	/*
-	 * Top level menu buttons are styled differently when focused or active.
-	 * They should be highlighted after clicking, without looking at keyboard focus interaction.
-	 * It's because it should indicate that the menu might be opened after pressing the arrow down keyboard button.
-	 */
-	& .ck-menu-bar__menu_top-level > .ck-list-item-button,
 	&.ck-menu-bar_focus-border-enabled .ck-list-item-button {
 		&:focus,
 		&:active {

--- a/packages/ckeditor5-theme-lark/theme/index.css
+++ b/packages/ckeditor5-theme-lark/theme/index.css
@@ -10,6 +10,7 @@
 @import "./ckeditor5-ui/components/autocomplete/autocomplete.css";
 @import "./ckeditor5-ui/components/button/button.css";
 @import "./ckeditor5-ui/components/button/switchbutton.css";
+@import "./ckeditor5-ui/components/button/listitembutton.css";
 @import "./ckeditor5-ui/components/collapsible/collapsible.css";
 @import "./ckeditor5-ui/components/colorgrid/colorgrid.css";
 @import "./ckeditor5-ui/components/colorselector/colorselector.css";

--- a/packages/ckeditor5-ui/src/button/button.ts
+++ b/packages/ckeditor5-ui/src/button/button.ts
@@ -156,13 +156,6 @@ export default interface Button {
 	class: string | undefined;
 
 	/**
-	 * (Optional) The ARIA property reflected by the `aria-checked` DOM attribute used by assistive technologies.
-	 *
-	 * @observable
-	 */
-	ariaChecked?: boolean | undefined;
-
-	/**
 	 * (Optional) The ARIA property reflected by the `aria-label` DOM attribute used by assistive technologies.
 	 *
 	 * @observable

--- a/packages/ckeditor5-ui/src/button/buttonview.ts
+++ b/packages/ckeditor5-ui/src/button/buttonview.ts
@@ -155,17 +155,28 @@ export default class ButtonView extends View<HTMLButtonElement> implements Butto
 	/**
 	 * @inheritDoc
 	 */
-	declare public ariaChecked: boolean | undefined;
-
-	/**
-	 * @inheritDoc
-	 */
 	declare public ariaLabel?: string | undefined;
 
 	/**
 	 * @inheritDoc
 	 */
 	declare public ariaLabelledBy: string | undefined;
+
+	/**
+	 * Aria-pressed attribute of element. It is calculated based on {@link #isToggleable isToggleable} and {@link #role}.
+	 *
+	 * @readonly
+	 * @internal
+	 */
+	declare public _ariaPressed: string | false;
+
+	/**
+	 * Aria-checked attribute of element. It is calculated based on {@link #isToggleable isToggleable} and {@link #role}.
+	 *
+	 * @readonly
+	 * @internal
+	 */
+	declare public _ariaChecked: string | false;
 
 	/**
 	 * Tooltip of the button bound to the template.
@@ -196,6 +207,8 @@ export default class ButtonView extends View<HTMLButtonElement> implements Butto
 		const ariaLabelUid = uid();
 
 		// Implement the Button interface.
+		this.set( '_ariaPressed', false );
+		this.set( '_ariaChecked', false );
 		this.set( 'ariaLabel', undefined );
 		this.set( 'ariaLabelledBy', `ck-editor__aria-label_${ ariaLabelUid }` );
 		this.set( 'class', undefined );
@@ -251,11 +264,11 @@ export default class ButtonView extends View<HTMLButtonElement> implements Butto
 				role: bind.to( 'role' ),
 				type: bind.to( 'type', value => value ? value : 'button' ),
 				tabindex: bind.to( 'tabindex' ),
-				'aria-checked': bind.to( 'ariaChecked' ),
+				'aria-checked': bind.to( '_ariaChecked' ),
+				'aria-pressed': bind.to( '_ariaPressed' ),
 				'aria-label': bind.to( 'ariaLabel' ),
 				'aria-labelledby': bind.to( 'ariaLabelledBy' ),
 				'aria-disabled': bind.if( 'isEnabled', true, value => !value ),
-				'aria-pressed': bind.to( 'isOn', value => this.isToggleable ? String( !!value ) : false ),
 				'data-cke-tooltip-text': bind.to( '_tooltipString' ),
 				'data-cke-tooltip-position': bind.to( 'tooltipPosition' )
 			},
@@ -276,6 +289,28 @@ export default class ButtonView extends View<HTMLButtonElement> implements Butto
 				} )
 			}
 		};
+
+		this.bind( '_ariaPressed' ).to(
+			this, 'isOn', this, 'isToggleable', this, 'role',
+			( isOn, isToggleable, role ) => {
+				if ( !isToggleable || isCheckableRole( role ) ) {
+					return false;
+				}
+
+				return String( !!isOn );
+			}
+		);
+
+		this.bind( '_ariaChecked' ).to(
+			this, 'isOn', this, 'isToggleable', this, 'role',
+			( isOn, isToggleable, role ) => {
+				if ( !isToggleable || !isCheckableRole( role ) ) {
+					return false;
+				}
+
+				return String( !!isOn );
+			}
+		);
 
 		// On Safari we have to force the focus on a button on click as it's the only browser
 		// that doesn't do that automatically. See #12115.
@@ -400,5 +435,23 @@ export default class ButtonView extends View<HTMLButtonElement> implements Butto
 		}
 
 		return '';
+	}
+}
+
+/**
+ * Checks if `aria-checkbox` can be used with specified role.
+ */
+function isCheckableRole( role: string | undefined ) {
+	switch ( role ) {
+		case 'radio':
+		case 'checkbox':
+		case 'option':
+		case 'switch':
+		case 'menuitemcheckbox':
+		case 'menuitemradio':
+			return true;
+
+		default:
+			return false;
 	}
 }

--- a/packages/ckeditor5-ui/src/button/buttonview.ts
+++ b/packages/ckeditor5-ui/src/button/buttonview.ts
@@ -164,6 +164,7 @@ export default class ButtonView extends View<HTMLButtonElement> implements Butto
 
 	/**
 	 * Aria-pressed attribute of element. It is calculated based on {@link #isToggleable isToggleable} and {@link #role}.
+	 * It's set to true if the button is on and the role is not checkable.
 	 *
 	 * @readonly
 	 * @internal
@@ -172,6 +173,7 @@ export default class ButtonView extends View<HTMLButtonElement> implements Butto
 
 	/**
 	 * Aria-checked attribute of element. It is calculated based on {@link #isToggleable isToggleable} and {@link #role}.
+	 * It's set to true if the button is on and the role is checkable.
 	 *
 	 * @readonly
 	 * @internal

--- a/packages/ckeditor5-ui/src/button/filedialogbuttonview.ts
+++ b/packages/ckeditor5-ui/src/button/filedialogbuttonview.ts
@@ -41,8 +41,28 @@ import ListItemButtonView from './listitembuttonview.js';
 export default class FileDialogButtonView extends FileDialogViewMixin( ButtonView ) {}
 
 /**
- * Represents a view for a button in the file dialog list item.
- * Extends the `ListItemButtonView` class and includes the `FileDialogViewMixin`.
+ * The file dialog button view used in a lists.
+ *
+ * This component provides a button that opens the native file selection dialog.
+ * It can be used to implement the UI of a file upload feature.
+ *
+* ```ts
+ * const view = new FileDialogListItemButtonView( locale );
+ *
+ * view.set( {
+ * 	acceptedType: 'image/*',
+ * 	allowMultipleFiles: true
+ * 	label: t( 'Insert image' ),
+ * 	icon: imageIcon,
+ * 	tooltip: true
+ * } );
+ *
+ * view.on( 'done', ( evt, files ) => {
+ * 	for ( const file of Array.from( files ) ) {
+ * 		console.log( 'Selected file', file );
+ * 	}
+ * } );
+ * ```
  */
 export class FileDialogListItemButtonView extends FileDialogViewMixin( ListItemButtonView ) {}
 

--- a/packages/ckeditor5-ui/src/button/filedialogbuttonview.ts
+++ b/packages/ckeditor5-ui/src/button/filedialogbuttonview.ts
@@ -67,10 +67,11 @@ export default class FileDialogButtonView extends FileDialogViewMixin( ButtonVie
 export class FileDialogListItemButtonView extends FileDialogViewMixin( ListItemButtonView ) {}
 
 /**
- * Mixin function that enhances a base class with file dialog functionality.
- * This mixin is used to create the `FileDialogView` class, which is a view component
- * that includes a button and a hidden file input. When the button is clicked, the file dialog is opened.
- * The mixin adds properties and methods to the base class to handle file selection and rendering.
+ * Mixin function that enhances a base button view class with file dialog functionality. It is used
+ * to create a button view class that opens the native select file dialog when clicked.
+ *
+ * The enhanced view includes a button and a hidden file input. When the button is clicked, the file dialog is opened.
+ * The mixin adds properties and methods to the base class to handle the file selection.
  *
  * @param view The base class to be enhanced with file dialog functionality.
  * @returns A new class that extends the base class and includes the file dialog functionality.

--- a/packages/ckeditor5-ui/src/button/filedialogbuttonview.ts
+++ b/packages/ckeditor5-ui/src/button/filedialogbuttonview.ts
@@ -11,7 +11,8 @@ import View from '../view.js';
 import ButtonView from './buttonview.js';
 import type { ButtonExecuteEvent } from './button.js';
 
-import type { Locale } from '@ckeditor/ckeditor5-utils';
+import type { Constructor, Locale, Mixed } from '@ckeditor/ckeditor5-utils';
+import ListItemButtonView from './listitembuttonview.js';
 
 /**
  * The file dialog button view.
@@ -37,18 +38,104 @@ import type { Locale } from '@ckeditor/ckeditor5-utils';
  * } );
  * ```
  */
-export default class FileDialogButtonView extends ButtonView {
+export default class FileDialogButtonView extends FileDialogViewMixin( ButtonView ) {}
+
+/**
+ * Represents a view for a button in the file dialog list item.
+ * Extends the `ListItemButtonView` class and includes the `FileDialogViewMixin`.
+ */
+export class FileDialogListItemButtonView extends FileDialogViewMixin( ListItemButtonView ) {}
+
+/**
+ * Mixin function that enhances a base class with file dialog functionality.
+ * This mixin is used to create the `FileDialogView` class, which is a view component
+ * that includes a button and a hidden file input. When the button is clicked, the file dialog is opened.
+ * The mixin adds properties and methods to the base class to handle file selection and rendering.
+ *
+ * @param view The base class to be enhanced with file dialog functionality.
+ * @returns A new class that extends the base class and includes the file dialog functionality.
+ */
+function FileDialogViewMixin<Base extends Constructor<ButtonView>>( view: Base ): Mixed<Base, FileDialogButtonViewBase> {
+	abstract class FileDialogView extends view implements FileDialogButtonViewBase {
+		/**
+		 * The button view of the component.
+		 *
+		 * @deprecated
+		 */
+		public buttonView: ButtonView;
+
+		/**
+		 * A hidden `<input>` view used to execute file dialog.
+		 */
+		private _fileInputView: FileInputView;
+
+		/**
+		 * Accepted file types. Can be provided in form of file extensions, media type or one of:
+		 * * `audio/*`,
+		 * * `video/*`,
+		 * * `image/*`.
+		 *
+		 * @observable
+		 */
+		declare public acceptedType: string;
+
+		/**
+		 * Indicates if multiple files can be selected. Defaults to `true`.
+		 *
+		 * @observable
+		 */
+		declare public allowMultipleFiles: boolean;
+
+		/**
+		 * @inheritDoc
+		 */
+		constructor( ...args: Array<any> ) {
+			super( ...args );
+
+			// For backward compatibility.
+			this.buttonView = this;
+
+			this._fileInputView = new FileInputView( this.locale );
+			this._fileInputView.bind( 'acceptedType' ).to( this );
+			this._fileInputView.bind( 'allowMultipleFiles' ).to( this );
+
+			this._fileInputView.delegate( 'done' ).to( this );
+
+			this.on<ButtonExecuteEvent>( 'execute', () => {
+				this._fileInputView.open();
+			} );
+
+			this.extendTemplate( {
+				attributes: {
+					class: 'ck-file-dialog-button'
+				}
+			} );
+		}
+
+		/**
+		 * @inheritDoc
+		 */
+		public override render(): void {
+			super.render();
+
+			this.children.add( this._fileInputView );
+		}
+	}
+
+	return FileDialogView as any;
+}
+
+/**
+ * Represents the base view for a file dialog button component.
+ */
+type FileDialogButtonViewBase = View & {
+
 	/**
 	 * The button view of the component.
 	 *
 	 * @deprecated
 	 */
-	public buttonView: ButtonView;
-
-	/**
-	 * A hidden `<input>` view used to execute file dialog.
-	 */
-	private _fileInputView: FileInputView;
+	buttonView: ButtonView;
 
 	/**
 	 * Accepted file types. Can be provided in form of file extensions, media type or one of:
@@ -58,50 +145,15 @@ export default class FileDialogButtonView extends ButtonView {
 	 *
 	 * @observable
 	 */
-	declare public acceptedType: string;
+	acceptedType: string;
 
 	/**
 	 * Indicates if multiple files can be selected. Defaults to `true`.
 	 *
 	 * @observable
 	 */
-	declare public allowMultipleFiles: boolean;
-
-	/**
-	 * @inheritDoc
-	 */
-	constructor( locale?: Locale ) {
-		super( locale );
-
-		// For backward compatibility.
-		this.buttonView = this;
-
-		this._fileInputView = new FileInputView( locale );
-		this._fileInputView.bind( 'acceptedType' ).to( this );
-		this._fileInputView.bind( 'allowMultipleFiles' ).to( this );
-
-		this._fileInputView.delegate( 'done' ).to( this );
-
-		this.on<ButtonExecuteEvent>( 'execute', () => {
-			this._fileInputView.open();
-		} );
-
-		this.extendTemplate( {
-			attributes: {
-				class: 'ck-file-dialog-button'
-			}
-		} );
-	}
-
-	/**
-	 * @inheritDoc
-	 */
-	public override render(): void {
-		super.render();
-
-		this.children.add( this._fileInputView );
-	}
-}
+	allowMultipleFiles: boolean;
+};
 
 /**
  * The hidden file input view class.

--- a/packages/ckeditor5-ui/src/button/listitembuttonview.ts
+++ b/packages/ckeditor5-ui/src/button/listitembuttonview.ts
@@ -96,12 +96,12 @@ export default class ListItemButtonView extends ButtonView {
 
 		this.on<ObservableChangeEvent<boolean>>(
 			'change:_hasCheck',
-			( evt, propertyName, shouldRenderCheckHolder ) => {
+			( evt, propertyName, hasCheck ) => {
 				const { children, _checkIconHolderView } = this;
 
-				if ( shouldRenderCheckHolder ) {
+				if ( hasCheck ) {
 					children.add( _checkIconHolderView, 0 );
-				} else if ( !shouldRenderCheckHolder ) {
+				} else {
 					children.remove( _checkIconHolderView );
 				}
 			}

--- a/packages/ckeditor5-ui/src/button/listitembuttonview.ts
+++ b/packages/ckeditor5-ui/src/button/listitembuttonview.ts
@@ -4,7 +4,7 @@
  */
 
 /**
- * @module ui/button/buttonlistitemview
+ * @module ui/button/listitembuttonview
  */
 
 import type { ObservableChangeEvent, Locale } from '@ckeditor/ckeditor5-utils';

--- a/packages/ckeditor5-ui/src/button/listitembuttonview.ts
+++ b/packages/ckeditor5-ui/src/button/listitembuttonview.ts
@@ -1,0 +1,195 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module ui/button/buttonlistitemview
+ */
+
+import type { ObservableChangeEvent, Locale } from '@ckeditor/ckeditor5-utils';
+import type ButtonLabel from './buttonlabel.js';
+import type ViewCollection from '../viewcollection.js';
+
+import { icons } from '@ckeditor/ckeditor5-core';
+import ButtonView from './buttonview.js';
+import ButtonLabelView from './buttonlabelview.js';
+import IconView from '../icon/iconview.js';
+import View from '../view.js';
+
+import '../../theme/components/button/listitembutton.css';
+
+/**
+ * Button that is used as dropdown list item entry.
+ */
+export default class ListItemButtonView extends ButtonView {
+	/**
+	 * Holds the view for the check icon of a button list item.
+	 */
+	private readonly _checkIconHolderView = new CheckIconHolderView();
+
+	/**
+	 * The flag that indicates if the button should render a check holder.
+	 *
+	 * @internal
+	 * @readonly
+	 * @observable
+	 */
+	declare public _shouldRenderCheckHolder: boolean;
+
+	/**
+	 * Indicates whether the button view has reserved space for a check holder.
+	 *
+	 * @observable
+	 */
+	declare public hasReservedCheckHolderSpace: boolean;
+
+	/**
+	 * @inheritDoc
+	 */
+	constructor( locale?: Locale, labelView: ButtonLabel = new ButtonLabelView() ) {
+		super( locale, labelView );
+
+		this.set( {
+			hasReservedCheckHolderSpace: false,
+			_shouldRenderCheckHolder: this.isToggleable
+		} );
+
+		const bind = this.bindTemplate;
+
+		this.extendTemplate( {
+			attributes: {
+				class: [
+					'ck-list-item-button',
+					bind.if( 'isToggleable', 'ck-list-item-button_toggleable' )
+				]
+			}
+		} );
+
+		this.bind( '_shouldRenderCheckHolder' ).to(
+			this, 'hasReservedCheckHolderSpace',
+			this, 'isToggleable',
+			( hasReservedCheckHolderSpace, isToggleable ) => hasReservedCheckHolderSpace || isToggleable
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public override render(): void {
+		super.render();
+
+		if ( this._shouldRenderCheckHolder ) {
+			this.children.add( this._checkIconHolderView, 0 );
+		}
+
+		this._watchCheckIconHolderMount();
+	}
+
+	/**
+	 * Renders the check icon if the button is toggleable.
+	 */
+	private _watchCheckIconHolderMount() {
+		this._checkIconHolderView
+			.bind( 'isOn' )
+			.to( this, 'isOn', value => this.isToggleable && value );
+
+		this.on<ObservableChangeEvent<boolean>>(
+			'change:_shouldRenderCheckHolder',
+			( evt, propertyName, shouldRenderCheckHolder ) => {
+				const { children, _checkIconHolderView } = this;
+
+				if ( shouldRenderCheckHolder && !children.has( _checkIconHolderView ) ) {
+					children.add( _checkIconHolderView, 0 );
+				} else if ( !shouldRenderCheckHolder && children.has( _checkIconHolderView ) ) {
+					children.remove( _checkIconHolderView );
+				}
+			}
+		);
+	}
+}
+
+export class CheckIconHolderView extends View {
+	/**
+	 * The view for the check icon of the button list item.
+	 */
+	private readonly _checkIconView: IconView = this._createCheckIconView();
+
+	/**
+	 * Collection of child views.
+	 */
+	public readonly children: ViewCollection<View>;
+
+	/**
+	 * Indicates whether the button is in the "on" state.
+	 */
+	declare public isOn: boolean;
+
+	/**
+	 * @inheritDoc
+	 */
+	constructor() {
+		super();
+
+		const bind = this.bindTemplate;
+
+		this.children = this.createCollection();
+
+		this.set( 'isOn', false );
+		this.setTemplate( {
+			tag: 'span',
+			children: this.children,
+			attributes: {
+				class: [
+					'ck',
+					'ck-list-item-button__check-holder',
+					bind.to( 'isOn', isOn => isOn ? 'ck-on' : 'ck-off' )
+				]
+			}
+		} );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public override render(): void {
+		super.render();
+
+		if ( this.isOn ) {
+			this.children.add( this._checkIconView, 0 );
+		}
+
+		this._watchCheckIconMount();
+	}
+
+	/**
+	 * Renders the check icon if the button is toggleable.
+	 */
+	private _watchCheckIconMount() {
+		this.on<ObservableChangeEvent<boolean>>( 'change:isOn', ( evt, propertyName, isOn ) => {
+			const { children, _checkIconView } = this;
+
+			if ( isOn && !children.has( _checkIconView ) ) {
+				children.add( _checkIconView );
+			} else if ( !isOn && children.has( _checkIconView ) ) {
+				children.remove( _checkIconView );
+			}
+		} );
+	}
+
+	/**
+	 * Creates a check icon view.
+	 */
+	private _createCheckIconView() {
+		const iconView = new IconView();
+
+		iconView.content = icons.check;
+		iconView.extendTemplate( {
+			attributes: {
+				class: 'ck-list-item-button__check-icon'
+			}
+		} );
+
+		return iconView;
+	}
+}

--- a/packages/ckeditor5-ui/src/button/listitembuttonview.ts
+++ b/packages/ckeditor5-ui/src/button/listitembuttonview.ts
@@ -28,7 +28,7 @@ export default class ListItemButtonView extends ButtonView {
 	 *
 	 * @observable
 	 */
-	declare public hasReservedCheckHolderSpace: boolean;
+	declare public hasCheckSpace: boolean;
 
 	/**
 	 * The flag that indicates if the button should render a check holder.
@@ -37,7 +37,7 @@ export default class ListItemButtonView extends ButtonView {
 	 * @readonly
 	 * @observable
 	 */
-	declare public _shouldRenderCheckHolder: boolean;
+	declare public _hasCheck: boolean;
 
 	/**
 	 * Holds the view for the check icon of a button list item.
@@ -51,8 +51,8 @@ export default class ListItemButtonView extends ButtonView {
 		super( locale, labelView );
 
 		this.set( {
-			hasReservedCheckHolderSpace: false,
-			_shouldRenderCheckHolder: this.isToggleable
+			hasCheckSpace: false,
+			_hasCheck: this.isToggleable
 		} );
 
 		const bind = this.bindTemplate;
@@ -66,10 +66,10 @@ export default class ListItemButtonView extends ButtonView {
 			}
 		} );
 
-		this.bind( '_shouldRenderCheckHolder' ).to(
-			this, 'hasReservedCheckHolderSpace',
+		this.bind( '_hasCheck' ).to(
+			this, 'hasCheckSpace',
 			this, 'isToggleable',
-			( hasReservedCheckHolderSpace, isToggleable ) => hasReservedCheckHolderSpace || isToggleable
+			( hasCheckSpace, isToggleable ) => hasCheckSpace || isToggleable
 		);
 	}
 
@@ -79,7 +79,7 @@ export default class ListItemButtonView extends ButtonView {
 	public override render(): void {
 		super.render();
 
-		if ( this._shouldRenderCheckHolder ) {
+		if ( this._hasCheck ) {
 			this.children.add( this._checkIconHolderView, 0 );
 		}
 
@@ -95,7 +95,7 @@ export default class ListItemButtonView extends ButtonView {
 			.to( this, 'isOn', value => this.isToggleable && value );
 
 		this.on<ObservableChangeEvent<boolean>>(
-			'change:_shouldRenderCheckHolder',
+			'change:_hasCheck',
 			( evt, propertyName, shouldRenderCheckHolder ) => {
 				const { children, _checkIconHolderView } = this;
 

--- a/packages/ckeditor5-ui/src/button/listitembuttonview.ts
+++ b/packages/ckeditor5-ui/src/button/listitembuttonview.ts
@@ -24,9 +24,11 @@ import '../../theme/components/button/listitembutton.css';
  */
 export default class ListItemButtonView extends ButtonView {
 	/**
-	 * Holds the view for the check icon of a button list item.
+	 * Indicates whether the button view has reserved space for a check holder.
+	 *
+	 * @observable
 	 */
-	private readonly _checkIconHolderView = new CheckIconHolderView();
+	declare public hasReservedCheckHolderSpace: boolean;
 
 	/**
 	 * The flag that indicates if the button should render a check holder.
@@ -38,11 +40,9 @@ export default class ListItemButtonView extends ButtonView {
 	declare public _shouldRenderCheckHolder: boolean;
 
 	/**
-	 * Indicates whether the button view has reserved space for a check holder.
-	 *
-	 * @observable
+	 * Holds the view for the check icon of a button list item.
 	 */
-	declare public hasReservedCheckHolderSpace: boolean;
+	private readonly _checkIconHolderView = new CheckIconHolderView();
 
 	/**
 	 * @inheritDoc
@@ -111,11 +111,6 @@ export default class ListItemButtonView extends ButtonView {
 
 export class CheckIconHolderView extends View {
 	/**
-	 * The view for the check icon of the button list item.
-	 */
-	private readonly _checkIconView: IconView = this._createCheckIconView();
-
-	/**
 	 * Collection of child views.
 	 */
 	public readonly children: ViewCollection<View>;
@@ -124,6 +119,11 @@ export class CheckIconHolderView extends View {
 	 * Indicates whether the button is in the "on" state.
 	 */
 	declare public isOn: boolean;
+
+	/**
+	 * The view for the check icon of the button list item.
+	 */
+	private readonly _checkIconView: IconView = this._createCheckIconView();
 
 	/**
 	 * @inheritDoc

--- a/packages/ckeditor5-ui/src/button/listitembuttonview.ts
+++ b/packages/ckeditor5-ui/src/button/listitembuttonview.ts
@@ -99,9 +99,9 @@ export default class ListItemButtonView extends ButtonView {
 			( evt, propertyName, shouldRenderCheckHolder ) => {
 				const { children, _checkIconHolderView } = this;
 
-				if ( shouldRenderCheckHolder && !children.has( _checkIconHolderView ) ) {
+				if ( shouldRenderCheckHolder ) {
 					children.add( _checkIconHolderView, 0 );
-				} else if ( !shouldRenderCheckHolder && children.has( _checkIconHolderView ) ) {
+				} else if ( !shouldRenderCheckHolder ) {
 					children.remove( _checkIconHolderView );
 				}
 			}

--- a/packages/ckeditor5-ui/src/colorselector/colorgridsfragmentview.ts
+++ b/packages/ckeditor5-ui/src/colorselector/colorgridsfragmentview.ts
@@ -259,16 +259,21 @@ export default class ColorGridsFragmentView extends View {
 		if ( this.documentColorsCount ) {
 			// Create a label for document colors.
 			const bind = Template.bind( this.documentColors, this.documentColors );
-			const label = new LabelView( this.locale );
-			label.text = this._documentColorsLabel;
-			label.extendTemplate( {
+			const label = new View( this.locale );
+			label.setTemplate( {
+				tag: 'span',
 				attributes: {
 					class: [
 						'ck',
 						'ck-color-grid__label',
 						bind.if( 'isEmpty', 'ck-hidden' )
 					]
-				}
+				},
+				children: [
+					{
+						text: this._documentColorsLabel
+					}
+				]
 			} );
 			this.items.add( label );
 			this.documentColorsGrid = this._createDocumentColorsGrid();

--- a/packages/ckeditor5-ui/src/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialog.ts
@@ -71,7 +71,10 @@ export default class Dialog extends Plugin {
 		this._initFocusToggler();
 		this._initMultiRootIntegration();
 
-		this.set( 'id', null );
+		this.set( {
+			id: null,
+			isOpen: false
+		} );
 
 		// Add the information about the keystroke to the accessibility database.
 		editor.accessibility.addKeystrokeInfos( {

--- a/packages/ckeditor5-ui/src/dropdown/button/splitbuttonview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/button/splitbuttonview.ts
@@ -156,6 +156,11 @@ export default class SplitButtonView extends View<HTMLDivElement> implements Dro
 	/**
 	 * @inheritDoc
 	 */
+	declare public ariaChecked: boolean | undefined;
+
+	/**
+	 * @inheritDoc
+	 */
 	declare public ariaLabel?: string | undefined;
 
 	/**

--- a/packages/ckeditor5-ui/src/dropdown/button/splitbuttonview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/button/splitbuttonview.ts
@@ -156,11 +156,6 @@ export default class SplitButtonView extends View<HTMLDivElement> implements Dro
 	/**
 	 * @inheritDoc
 	 */
-	declare public ariaChecked: boolean | undefined;
-
-	/**
-	 * @inheritDoc
-	 */
 	declare public ariaLabel?: string | undefined;
 
 	/**

--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -560,7 +560,7 @@ function bindViewCollectionItemsToDefinitions(
 		const hasAnyCheckboxOnList = listItemButtons.some( button => button.isToggleable );
 
 		listItemButtons.forEach( item => {
-			item.hasReservedCheckHolderSpace = hasAnyCheckboxOnList;
+			item.hasCheckSpace = hasAnyCheckboxOnList;
 		} );
 	} );
 

--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -545,6 +545,8 @@ function bindViewCollectionItemsToDefinitions(
 ) {
 	// List item checkboxes have a reserved space for the check icon, so we need to know if there are any checkboxes in the list
 	// to adjust the layout accordingly. It'd look weird if the items on the list were not aligned horizontally.
+	//
+	// Possible theoretical performance problem if many items are added one by one, as this will be called for each item.
 	listItems.on( 'change', () => {
 		// Filter-map. Check all items, leave only these that have buttons and return the buttons.
 		const listItemButtons = [ ...listItems ].reduce<Array<ListItemButtonView>>( ( acc, item ) => {

--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -546,6 +546,7 @@ function bindViewCollectionItemsToDefinitions(
 	// List item checkboxes have a reserved space for the check icon, so we need to know if there are any checkboxes in the list
 	// to adjust the layout accordingly. It'd look weird if the items on the list were not aligned horizontally.
 	listItems.on( 'change', () => {
+		// Filter-map. Check all items, leave only these that have buttons and return the buttons.
 		const listItemButtons = [ ...listItems ].reduce<Array<ListItemButtonView>>( ( acc, item ) => {
 			if ( item instanceof ListItemView && item.children.first instanceof ListItemButtonView ) {
 				acc.push( item.children.first );

--- a/packages/ckeditor5-ui/src/dropdown/utils.ts
+++ b/packages/ckeditor5-ui/src/dropdown/utils.ts
@@ -14,7 +14,6 @@ import ToolbarView from '../toolbar/toolbarview.js';
 import ListView from '../list/listview.js';
 import ListItemView from '../list/listitemview.js';
 import ListSeparatorView from '../list/listseparatorview.js';
-import ButtonView from '../button/buttonview.js';
 import SplitButtonView from './button/splitbuttonview.js';
 import SwitchButtonView from '../button/switchbuttonview.js';
 import ViewCollection from '../viewcollection.js';
@@ -25,6 +24,7 @@ import type { default as View, UIViewRenderEvent } from '../view.js';
 import type { ButtonExecuteEvent } from '../button/button.js';
 import type Model from '../model.js';
 import type DropdownButton from './button/dropdownbutton.js';
+import type ButtonView from '../button/buttonview.js';
 import type { FocusableView } from '../focuscycler.js';
 import type { FalsyValue } from '../template.js';
 
@@ -39,7 +39,9 @@ import {
 
 import '../../theme/components/dropdown/toolbardropdown.css';
 import '../../theme/components/dropdown/listdropdown.css';
+
 import ListItemGroupView from '../list/listitemgroupview.js';
+import ListItemButtonView from '../button/listitembuttonview.js';
 
 /**
  * A helper for creating dropdowns. It creates an instance of a {@link module:ui/dropdown/dropdownview~DropdownView dropdown},
@@ -541,6 +543,24 @@ function bindViewCollectionItemsToDefinitions(
 	definitions: Collection<ListDropdownItemDefinition>,
 	locale: Locale
 ) {
+	// List item checkboxes have a reserved space for the check icon, so we need to know if there are any checkboxes in the list
+	// to adjust the layout accordingly. It'd look weird if the items on the list were not aligned horizontally.
+	listItems.on( 'change', () => {
+		const listItemButtons = [ ...listItems ].reduce<Array<ListItemButtonView>>( ( acc, item ) => {
+			if ( item instanceof ListItemView && item.children.first instanceof ListItemButtonView ) {
+				acc.push( item.children.first );
+			}
+
+			return acc;
+		}, [] );
+
+		const hasAnyCheckboxOnList = listItemButtons.some( button => button.isToggleable );
+
+		listItemButtons.forEach( item => {
+			item.hasReservedCheckHolderSpace = hasAnyCheckboxOnList;
+		} );
+	} );
+
 	listItems.bindTo( definitions ).using( def => {
 		if ( def.type === 'separator' ) {
 			return new ListSeparatorView( locale );
@@ -555,12 +575,16 @@ function bindViewCollectionItemsToDefinitions(
 
 			return groupView;
 		} else if ( def.type === 'button' || def.type === 'switchbutton' ) {
+			const isToggleable = def.model.role === 'menuitemcheckbox' || def.model.role === 'menuitemradio';
 			const listItemView = new ListItemView( locale );
-			let buttonView;
+
+			let buttonView: ButtonView;
 
 			if ( def.type === 'button' ) {
-				buttonView = new ButtonView( locale );
-				buttonView.bind( 'ariaChecked' ).to( buttonView, 'isOn' );
+				buttonView = new ListItemButtonView( locale );
+				buttonView.set( {
+					isToggleable
+				} );
 			} else {
 				buttonView = new SwitchButtonView( locale );
 			}

--- a/packages/ckeditor5-ui/src/editorui/accessibilityhelp/accessibilityhelp.ts
+++ b/packages/ckeditor5-ui/src/editorui/accessibilityhelp/accessibilityhelp.ts
@@ -77,7 +77,7 @@ export default class AccessibilityHelp extends Plugin {
 		} );
 
 		editor.keystrokes.set( 'Alt+0', ( evt, cancel ) => {
-			this._showDialog();
+			this._toggleDialog();
 			cancel();
 		} );
 
@@ -87,17 +87,20 @@ export default class AccessibilityHelp extends Plugin {
 	/**
 	 * Creates a button to show accessibility help dialog, for use either in toolbar or in menu bar.
 	 */
-	private _createButton<T extends typeof ButtonView | typeof MenuBarMenuListItemButtonView>( ButtonClass: T ): InstanceType<T> {
+	private _createButton<T extends typeof ButtonView>( ButtonClass: T ): InstanceType<T> {
 		const editor = this.editor;
+		const dialog = editor.plugins.get( 'Dialog' );
 		const locale = editor.locale;
 		const view = new ButtonClass( locale ) as InstanceType<T>;
 
 		view.set( {
 			keystroke: 'Alt+0',
-			icon: accessibilityIcon
+			icon: accessibilityIcon,
+			isToggleable: true
 		} );
 
-		view.on( 'execute', () => this._showDialog() );
+		view.on( 'execute', () => this._toggleDialog() );
+		view.bind( 'isOn' ).to( dialog, 'isOpen', isOpen => isOpen && dialog.id === 'accessibilityHelp' );
 
 		return view;
 	}
@@ -136,7 +139,7 @@ export default class AccessibilityHelp extends Plugin {
 	/**
 	 * Shows the accessibility help dialog. Also, creates {@link #contentView} on demand.
 	 */
-	private _showDialog(): void {
+	private _toggleDialog(): void {
 		const editor = this.editor;
 		const dialog = editor.plugins.get( 'Dialog' );
 		const t = editor.locale.t;
@@ -145,13 +148,17 @@ export default class AccessibilityHelp extends Plugin {
 			this.contentView = new AccessibilityHelpContentView( editor.locale, editor.accessibility.keystrokeInfos );
 		}
 
-		dialog.show( {
-			id: 'accessibilityHelp',
-			className: 'ck-accessibility-help-dialog',
-			title: t( 'Accessibility help' ),
-			icon: accessibilityIcon,
-			hasCloseButton: true,
-			content: this.contentView
-		} );
+		if ( dialog.id === 'accessibilityHelp' ) {
+			dialog.hide();
+		} else {
+			dialog.show( {
+				id: 'accessibilityHelp',
+				className: 'ck-accessibility-help-dialog',
+				title: t( 'Accessibility help' ),
+				icon: accessibilityIcon,
+				hasCloseButton: true,
+				content: this.contentView
+			} );
+		}
 	}
 }

--- a/packages/ckeditor5-ui/src/editorui/accessibilityhelp/accessibilityhelp.ts
+++ b/packages/ckeditor5-ui/src/editorui/accessibilityhelp/accessibilityhelp.ts
@@ -100,7 +100,7 @@ export default class AccessibilityHelp extends Plugin {
 		} );
 
 		view.on( 'execute', () => this._toggleDialog() );
-		view.bind( 'isOn' ).to( dialog, 'isOpen', isOpen => isOpen && dialog.id === 'accessibilityHelp' );
+		view.bind( 'isOn' ).to( dialog, 'id', id => id === 'accessibilityHelp' );
 
 		return view;
 	}

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -25,6 +25,7 @@ export type { default as ButtonLabel } from './button/buttonlabel.js';
 export { default as ButtonView } from './button/buttonview.js';
 export { default as ButtonLabelView } from './button/buttonlabelview.js';
 export { default as SwitchButtonView } from './button/switchbuttonview.js';
+export { default as ListItemButtonView } from './button/listitembuttonview.js';
 export { default as FileDialogButtonView } from './button/filedialogbuttonview.js';
 
 export { default as CollapsibleView } from './collapsible/collapsibleview.js';

--- a/packages/ckeditor5-ui/src/index.ts
+++ b/packages/ckeditor5-ui/src/index.ts
@@ -26,7 +26,7 @@ export { default as ButtonView } from './button/buttonview.js';
 export { default as ButtonLabelView } from './button/buttonlabelview.js';
 export { default as SwitchButtonView } from './button/switchbuttonview.js';
 export { default as ListItemButtonView } from './button/listitembuttonview.js';
-export { default as FileDialogButtonView } from './button/filedialogbuttonview.js';
+export { default as FileDialogButtonView, FileDialogListItemButtonView } from './button/filedialogbuttonview.js';
 
 export { default as CollapsibleView } from './collapsible/collapsibleview.js';
 

--- a/packages/ckeditor5-ui/src/menubar/menubarmenubuttonview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenubuttonview.ts
@@ -8,7 +8,7 @@
  */
 
 import IconView from '../icon/iconview.js';
-import ButtonView from '../button/buttonview.js';
+import ListItemButtonView from '../button/listitembuttonview.js';
 import type { Locale } from '@ckeditor/ckeditor5-utils';
 
 import dropdownArrowIcon from '../../theme/icons/dropdown-arrow.svg';
@@ -19,7 +19,7 @@ import '../../theme/components/menubar/menubarmenubutton.css';
  * A menu {@link module:ui/menubar/menubarmenuview~MenuBarMenuView#buttonView} class. Buttons like this one
  * open both top-level bar menus as well as sub-menus.
  */
-export default class MenuBarMenuButtonView extends ButtonView {
+export default class MenuBarMenuButtonView extends ListItemButtonView {
 	/**
 	 * An icon that displays an arrow to indicate a direction of the menu.
 	 */

--- a/packages/ckeditor5-ui/src/menubar/menubarmenulistitembuttonview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenulistitembuttonview.ts
@@ -8,14 +8,14 @@
  */
 
 import type { Locale } from '@ckeditor/ckeditor5-utils';
-import ButtonView from '../button/buttonview.js';
+import ListItemButtonView from '../button/listitembuttonview.js';
 
 import '../../theme/components/menubar/menubarmenulistitembutton.css';
 
 /**
  * A menu bar list button view. Buttons like this one execute user actions.
  */
-export default class MenuBarMenuListItemButtonView extends ButtonView {
+export default class MenuBarMenuListItemButtonView extends ListItemButtonView {
 	/**
 	 * Creates an instance of the menu bar list button view.
 	 *

--- a/packages/ckeditor5-ui/src/menubar/menubarmenulistitemfiledialogbuttonview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenulistitemfiledialogbuttonview.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Locale } from '@ckeditor/ckeditor5-utils';
-import FileDialogButtonView from '../button/filedialogbuttonview.js';
+import { FileDialogListItemButtonView } from '../button/filedialogbuttonview.js';
 
 import '../../theme/components/menubar/menubarmenulistitembutton.css';
 
@@ -17,7 +17,7 @@ import '../../theme/components/menubar/menubarmenulistitembutton.css';
  *
  * This component provides a button that opens the native file selection dialog.
  */
-export default class MenuBarMenuListItemFileDialogButtonView extends FileDialogButtonView {
+export default class MenuBarMenuListItemFileDialogButtonView extends FileDialogListItemButtonView {
 	/**
 	 * Creates an instance of the menu bar list button view.
 	 *

--- a/packages/ckeditor5-ui/src/menubar/menubarmenulistview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenulistview.ts
@@ -32,14 +32,14 @@ export default class MenuBarMenuListView extends ListView {
 		super( locale );
 
 		this.role = 'menu';
-		this.items.on( 'change', this._preallocateCheckSpacerInItemsIfNeeded.bind( this ) );
+		this.items.on( 'change', this._setItemsCheckSpace.bind( this ) );
 	}
 
 	/**
 	 * This method adds empty space if there is any toggleable item in the list.
 	 * It makes the list properly aligned.
 	 */
-	private _preallocateCheckSpacerInItemsIfNeeded() {
+	private _setItemsCheckSpace() {
 		const hasAnyToggleableItem = (
 			Array
 				.from( this.items )

--- a/packages/ckeditor5-ui/src/menubar/menubarmenulistview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenulistview.ts
@@ -54,7 +54,7 @@ export default class MenuBarMenuListView extends ListView {
 			const listButtonView = pickListButtonMenuViewIfPresent( item );
 
 			if ( listButtonView ) {
-				listButtonView.hasReservedCheckHolderSpace = hasAnyToggleableItem;
+				listButtonView.hasCheckSpace = hasAnyToggleableItem;
 			}
 		} );
 	}

--- a/packages/ckeditor5-ui/src/menubar/menubarmenulistview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenulistview.ts
@@ -8,7 +8,12 @@
  */
 
 import type { Locale } from '@ckeditor/ckeditor5-utils';
+import type View from '../view.js';
+
+import ListItemView from '../list/listitemview.js';
 import ListView from '../list/listview.js';
+import ListItemButtonView from '../button/listitembuttonview.js';
+import ButtonView from '../button/buttonview.js';
 
 /**
  * A list of menu bar items, a child of {@link module:ui/menubar/menubarmenuview~MenuBarMenuView#panelView}.
@@ -27,5 +32,64 @@ export default class MenuBarMenuListView extends ListView {
 		super( locale );
 
 		this.role = 'menu';
+		this.items.on( 'change', this._preallocateCheckSpacerInItemsIfNeeded.bind( this ) );
 	}
+
+	/**
+	 * This method adds empty space if there is any toggleable item in the list.
+	 * It makes the list properly aligned.
+	 */
+	private _preallocateCheckSpacerInItemsIfNeeded() {
+		const hasAnyToggleableItem = (
+			Array
+				.from( this.items )
+				.some( item => {
+					const maybeListButtonView = pickListButtonMenuViewIfPresent( item );
+
+					return maybeListButtonView && maybeListButtonView.isToggleable;
+				} )
+		);
+
+		this.items.forEach( item => {
+			const maybeListButtonView = pickListButtonMenuViewIfPresent( item );
+
+			if ( maybeListButtonView ) {
+				maybeListButtonView.hasReservedCheckHolderSpace = hasAnyToggleableItem;
+			}
+		} );
+	}
+}
+
+/**
+ * Picks the first button menu view from the given item if present.
+ *
+ * @param item The item to check for a button menu view.
+ * @returns The first button menu view found in the item, or `null` if not found.
+ */
+function pickListButtonMenuViewIfPresent( item: View ) {
+	if ( !( item instanceof ListItemView ) ) {
+		return null;
+	}
+
+	return (
+		item
+			.children
+			.map( child => isNestedMenuLikeView( child ) ? child.buttonView : child )
+			.find( item => item instanceof ListItemButtonView ) as ListItemButtonView | undefined
+	);
+}
+
+/**
+ * Checks if the given item is a nested menu-like view. `MenuBarMenuView` imports this file
+ * so to avoid circular dependencies, this function is defined in more generic way.
+ *
+ * @param item The item to check.
+ * @returns `true` if the item is a nested menu-like view, `false` otherwise.
+ */
+function isNestedMenuLikeView( item: any ): item is { buttonView: ButtonView } {
+	return (
+		typeof item === 'object' &&
+			'buttonView' in item &&
+			item.buttonView instanceof ButtonView
+	);
 }

--- a/packages/ckeditor5-ui/src/menubar/menubarmenulistview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenulistview.ts
@@ -44,17 +44,17 @@ export default class MenuBarMenuListView extends ListView {
 			Array
 				.from( this.items )
 				.some( item => {
-					const maybeListButtonView = pickListButtonMenuViewIfPresent( item );
+					const listButtonView = pickListButtonMenuViewIfPresent( item );
 
-					return maybeListButtonView && maybeListButtonView.isToggleable;
+					return listButtonView && listButtonView.isToggleable;
 				} )
 		);
 
 		this.items.forEach( item => {
-			const maybeListButtonView = pickListButtonMenuViewIfPresent( item );
+			const listButtonView = pickListButtonMenuViewIfPresent( item );
 
-			if ( maybeListButtonView ) {
-				maybeListButtonView.hasReservedCheckHolderSpace = hasAnyToggleableItem;
+			if ( listButtonView ) {
+				listButtonView.hasReservedCheckHolderSpace = hasAnyToggleableItem;
 			}
 		} );
 	}

--- a/packages/ckeditor5-ui/src/menubar/menubarview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarview.ts
@@ -60,7 +60,7 @@ export default class MenuBarView extends View implements FocusableView {
 	 *
 	 * @observable
 	 */
-	declare public hadKeyboardFocusInteraction: boolean;
+	declare public isFocusBorderEnabled: boolean;
 
 	/**
 	 * A list of {@link module:ui/menubar/menubarmenuview~MenuBarMenuView} instances registered in the menu bar.
@@ -82,7 +82,7 @@ export default class MenuBarView extends View implements FocusableView {
 
 		this.set( {
 			isOpen: false,
-			hadKeyboardFocusInteraction: false
+			isFocusBorderEnabled: false
 		} );
 
 		this._setupIsOpenUpdater();
@@ -100,7 +100,7 @@ export default class MenuBarView extends View implements FocusableView {
 				class: [
 					'ck',
 					'ck-menu-bar',
-					bind.if( 'hadKeyboardFocusInteraction', 'ck-menu-bar_keyboard-focus-interaction' )
+					bind.if( 'isFocusBorderEnabled', 'ck-menu-bar_focus-border-enabled' )
 				],
 				'aria-label': t( 'Editor menu bar' ),
 				role: 'menubar'
@@ -143,7 +143,7 @@ export default class MenuBarView extends View implements FocusableView {
 		MenuBarBehaviors.closeMenuWhenAnotherOnTheSameLevelOpens( this );
 		MenuBarBehaviors.focusCycleMenusOnArrows( this );
 		MenuBarBehaviors.closeOnClickOutside( this );
-		MenuBarBehaviors.trackKeyboardFocusInteraction( this );
+		MenuBarBehaviors.enableFocusHighlightOnInteraction( this );
 	}
 
 	/**

--- a/packages/ckeditor5-ui/src/menubar/menubarview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarview.ts
@@ -56,7 +56,8 @@ export default class MenuBarView extends View implements FocusableView {
 	/**
 	 * Indicates whether the menu bar has been interacted with using the keyboard.
 	 *
-	 * It is useful for showing focus outlines only when the keyboard is used.
+	 * It is useful for showing focus outlines while hovering over the menu bar when
+	 * interaction with the keyboard was detected.
 	 *
 	 * @observable
 	 */

--- a/packages/ckeditor5-ui/src/menubar/menubarview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarview.ts
@@ -55,7 +55,8 @@ export default class MenuBarView extends View implements FocusableView {
 
 	/**
 	 * Indicates whether the menu bar has been interacted with using the keyboard.
-	 * It's useful for showing focus outlines only when the keyboard is used.
+	 *
+	 * It is useful for showing focus outlines only when the keyboard is used.
 	 *
 	 * @observable
 	 */

--- a/packages/ckeditor5-ui/src/menubar/menubarview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarview.ts
@@ -54,6 +54,14 @@ export default class MenuBarView extends View implements FocusableView {
 	declare public isOpen: boolean;
 
 	/**
+	 * Indicates whether the menu bar has been interacted with using the keyboard.
+	 * It's useful for showing focus outlines only when the keyboard is used.
+	 *
+	 * @observable
+	 */
+	declare public hadKeyboardFocusInteraction: boolean;
+
+	/**
 	 * A list of {@link module:ui/menubar/menubarmenuview~MenuBarMenuView} instances registered in the menu bar.
 	 *
 	 * @observable
@@ -69,8 +77,13 @@ export default class MenuBarView extends View implements FocusableView {
 		super( locale );
 
 		const t = locale.t;
+		const bind = this.bindTemplate;
 
-		this.set( 'isOpen', false );
+		this.set( {
+			isOpen: false,
+			hadKeyboardFocusInteraction: false
+		} );
+
 		this._setupIsOpenUpdater();
 
 		this.children = this.createCollection();
@@ -85,7 +98,8 @@ export default class MenuBarView extends View implements FocusableView {
 			attributes: {
 				class: [
 					'ck',
-					'ck-menu-bar'
+					'ck-menu-bar',
+					bind.if( 'hadKeyboardFocusInteraction', 'ck-menu-bar_keyboard-focus-interaction' )
 				],
 				'aria-label': t( 'Editor menu bar' ),
 				role: 'menubar'
@@ -128,6 +142,7 @@ export default class MenuBarView extends View implements FocusableView {
 		MenuBarBehaviors.closeMenuWhenAnotherOnTheSameLevelOpens( this );
 		MenuBarBehaviors.focusCycleMenusOnArrows( this );
 		MenuBarBehaviors.closeOnClickOutside( this );
+		MenuBarBehaviors.trackKeyboardFocusInteraction( this );
 	}
 
 	/**

--- a/packages/ckeditor5-ui/src/menubar/utils.ts
+++ b/packages/ckeditor5-ui/src/menubar/utils.ts
@@ -163,6 +163,32 @@ export const MenuBarBehaviors = {
 			callback: () => menuBarView.close(),
 			contextElements: () => menuBarView.children.map( child => child.element! )
 		} );
+	},
+
+	/**
+	 * Tracks the keyboard focus interaction on the menu bar view. It is used to determine if the nested items
+	 * of the menu bar should render focus rings after first interaction with the keyboard.
+	 */
+	trackKeyboardFocusInteraction( menuBarView: MenuBarView ): void {
+		let isKeyPressed: boolean = false;
+
+		menuBarView.on<ObservableChangeEvent<boolean>>( 'change:isOpen', () => {
+			menuBarView.hadKeyboardFocusInteraction = false;
+		} );
+
+		menuBarView.listenTo( menuBarView.element!, 'keydown', () => {
+			isKeyPressed = true;
+		}, { useCapture: true } );
+
+		menuBarView.listenTo( menuBarView.element!, 'keyup', () => {
+			isKeyPressed = false;
+		}, { useCapture: true } );
+
+		menuBarView.listenTo( menuBarView.element!, 'focus', () => {
+			if ( isKeyPressed && !menuBarView.hadKeyboardFocusInteraction ) {
+				menuBarView.hadKeyboardFocusInteraction = true;
+			}
+		}, { useCapture: true } );
 	}
 };
 
@@ -216,7 +242,10 @@ export const MenuBarMenuBehaviors = {
 	openOnButtonClick( menuView: MenuBarMenuView ): void {
 		menuView.buttonView.on<ButtonExecuteEvent>( 'execute', () => {
 			menuView.isOpen = true;
-			menuView.panelView.focus();
+
+			if ( menuView.parentMenuView ) {
+				menuView.panelView.focus();
+			}
 		} );
 	},
 
@@ -226,10 +255,6 @@ export const MenuBarMenuBehaviors = {
 	toggleOnButtonClick( menuView: MenuBarMenuView ): void {
 		menuView.buttonView.on<ButtonExecuteEvent>( 'execute', () => {
 			menuView.isOpen = !menuView.isOpen;
-
-			if ( menuView.isOpen ) {
-				menuView.panelView.focus();
-			}
 		} );
 	},
 

--- a/packages/ckeditor5-ui/src/menubar/utils.ts
+++ b/packages/ckeditor5-ui/src/menubar/utils.ts
@@ -56,24 +56,28 @@ export const MenuBarBehaviors = {
 	 */
 	toggleMenusAndFocusItemsOnHover( menuBarView: MenuBarView ): void {
 		menuBarView.on<MenuBarMenuMouseEnterEvent>( 'menu:mouseenter', evt => {
-			// This works only when the menu bar has already been open and the user hover over the menu bar.
-			if ( !menuBarView.isOpen ) {
+			// This behavior should be activated when one of condition is present:
+			// 1. The user opened any submenu of menubar and hover over items in the menu bar.
+			// 2. The user focused whole menubar using keyboard interaction and enabled focus borders and hover over items in the menu bar.
+			if ( !menuBarView.isFocusBorderEnabled && !menuBarView.isOpen ) {
 				return;
 			}
 
-			for ( const menuView of menuBarView.menus ) {
-				// @if CK_DEBUG_MENU_BAR // const wasOpen = menuView.isOpen;
+			if ( menuBarView.isOpen ) {
+				for ( const menuView of menuBarView.menus ) {
+					// @if CK_DEBUG_MENU_BAR // const wasOpen = menuView.isOpen;
 
-				const pathLeaf = evt.path[ 0 ];
-				const isListItemContainingMenu = pathLeaf instanceof MenuBarMenuListItemView && pathLeaf.children.first === menuView;
+					const pathLeaf = evt.path[ 0 ];
+					const isListItemContainingMenu = pathLeaf instanceof MenuBarMenuListItemView && pathLeaf.children.first === menuView;
 
-				menuView.isOpen = ( evt.path.includes( menuView ) || isListItemContainingMenu ) && menuView.isEnabled;
+					menuView.isOpen = ( evt.path.includes( menuView ) || isListItemContainingMenu ) && menuView.isEnabled;
 
-				// @if CK_DEBUG_MENU_BAR // if ( wasOpen !== menuView.isOpen ) {
-				// @if CK_DEBUG_MENU_BAR // console.log( '[BEHAVIOR] toggleMenusAndFocusItemsOnHover(): Toggle',
-				// @if CK_DEBUG_MENU_BAR // 	logMenu( menuView ), 'isOpen', menuView.isOpen
-				// @if CK_DEBUG_MENU_BAR // );
-				// @if CK_DEBUG_MENU_BAR // }
+					// @if CK_DEBUG_MENU_BAR // if ( wasOpen !== menuView.isOpen ) {
+					// @if CK_DEBUG_MENU_BAR // console.log( '[BEHAVIOR] toggleMenusAndFocusItemsOnHover(): Toggle',
+					// @if CK_DEBUG_MENU_BAR // 	logMenu( menuView ), 'isOpen', menuView.isOpen
+					// @if CK_DEBUG_MENU_BAR // );
+					// @if CK_DEBUG_MENU_BAR // }
+				}
 			}
 
 			( evt.source as FocusableView ).focus();
@@ -182,6 +186,9 @@ export const MenuBarBehaviors = {
 			}
 		} );
 
+		// After clicking menu bar list item the focus is moved to the newly opened submenu.
+		// We need to enable focus border for the submenu items because after pressing arrow down it will
+		// focus second item instead of first which is not super intuitive.
 		menuBarView.listenTo( menuBarView.element!, 'click', () => {
 			if ( menuBarView.isOpen && menuBarView.element!.matches( ':focus-within' ) ) {
 				menuBarView.isFocusBorderEnabled = true;
@@ -197,7 +204,7 @@ export const MenuBarBehaviors = {
 		}, { useCapture: true } );
 
 		menuBarView.listenTo( menuBarView.element!, 'focus', () => {
-			if ( isKeyPressed && !menuBarView.isFocusBorderEnabled ) {
+			if ( isKeyPressed ) {
 				menuBarView.isFocusBorderEnabled = true;
 			}
 		}, { useCapture: true } );

--- a/packages/ckeditor5-ui/tests/button/buttonview.js
+++ b/packages/ckeditor5-ui/tests/button/buttonview.js
@@ -343,19 +343,43 @@ describe( 'ButtonView', () => {
 			it( '-pressed reacts to #isOn', () => {
 				view.isToggleable = true;
 				view.isOn = true;
+
 				expect( view.element.attributes[ 'aria-pressed' ].value ).to.equal( 'true' );
+				expect( view.element.hasAttribute( 'aria-checked' ) ).to.be.false;
 
 				view.isOn = false;
+
 				expect( view.element.attributes[ 'aria-pressed' ].value ).to.equal( 'false' );
+				expect( view.element.hasAttribute( 'aria-checked' ) ).to.be.false;
 			} );
 
 			it( '-pressed is not present for non–toggleable button', () => {
 				view.isOn = true;
+
 				expect( view.element.hasAttribute( 'aria-pressed' ) ).to.be.false;
+				expect( view.element.hasAttribute( 'aria-checked' ) ).to.be.false;
 
 				view.isOn = false;
+
 				expect( view.element.hasAttribute( 'aria-pressed' ) ).to.be.false;
+				expect( view.element.hasAttribute( 'aria-checked' ) ).to.be.false;
 			} );
+
+			for ( const role of [ 'radio', 'checkbox', 'option', 'switch', 'menuitemcheckbox', 'menuitemradio' ] ) {
+				it( `-checked reacts to #isOn and "${ role }" button role`, () => {
+					view.role = role;
+					view.isToggleable = true;
+					view.isOn = true;
+
+					expect( view.element.attributes[ 'aria-checked' ].value ).to.equal( 'true' );
+					expect( view.element.hasAttribute( 'aria-pressed' ) ).to.be.false;
+
+					view.isOn = false;
+
+					expect( view.element.attributes[ 'aria-checked' ].value ).to.equal( 'false' );
+					expect( view.element.hasAttribute( 'aria-pressed' ) ).to.be.false;
+				} );
+			}
 
 			it( '-label reacts on #ariaLabel', () => {
 				view.ariaLabel = undefined;

--- a/packages/ckeditor5-ui/tests/button/listitembuttonview.js
+++ b/packages/ckeditor5-ui/tests/button/listitembuttonview.js
@@ -28,8 +28,8 @@ describe( 'ListItemButtonView', () => {
 			expect( view ).to.be.instanceOf( ButtonView );
 		} );
 
-		it( 'should initialize with hasReservedCheckHolderSpace set to false', () => {
-			expect( view.hasReservedCheckHolderSpace ).to.be.false;
+		it( 'should initialize with hasCheckSpace set to false', () => {
+			expect( view.hasCheckSpace ).to.be.false;
 		} );
 
 		it( 'should initialize with isToggleable set to false', () => {
@@ -64,7 +64,7 @@ describe( 'ListItemButtonView', () => {
 		} );
 	} );
 
-	describe( '_shouldRenderCheckHolder', () => {
+	describe( '_hasCheck', () => {
 		const possibleRenderStates = [
 			{ isToggleable: false, checkHolderSpace: false, rendered: false },
 			{ isToggleable: false, checkHolderSpace: true, rendered: true },
@@ -74,10 +74,10 @@ describe( 'ListItemButtonView', () => {
 
 		for ( const { isToggleable, checkHolderSpace, rendered } of possibleRenderStates ) {
 			it(
-				`should render checkbox holder when isToggleable=${ isToggleable } and hasReservedCheckHolderSpace=${ checkHolderSpace }`,
+				`should render checkbox holder when isToggleable=${ isToggleable } and hasCheckSpace=${ checkHolderSpace }`,
 				() => {
 					view.isToggleable = isToggleable;
-					view.hasReservedCheckHolderSpace = checkHolderSpace;
+					view.hasCheckSpace = checkHolderSpace;
 
 					expect( !!view.element.querySelector( '.ck-list-item-button__check-holder' ) ).to.be.equal( rendered );
 				}

--- a/packages/ckeditor5-ui/tests/button/listitembuttonview.js
+++ b/packages/ckeditor5-ui/tests/button/listitembuttonview.js
@@ -1,0 +1,174 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
+import ListItemButtonView, { CheckIconHolderView } from '../../src/button/listitembuttonview.js';
+import ButtonView from '../../src/button/buttonview.js';
+
+describe( 'ListItemButtonView', () => {
+	let locale, view;
+
+	testUtils.createSinonSandbox();
+
+	beforeEach( () => {
+		locale = { t() {} };
+
+		view = new ListItemButtonView( locale );
+		view.render();
+	} );
+
+	afterEach( () => {
+		view.destroy();
+	} );
+
+	describe( 'constructor()', () => {
+		it( 'should inherit from ButtonView', () => {
+			expect( view ).to.be.instanceOf( ButtonView );
+		} );
+
+		it( 'should initialize with hasReservedCheckHolderSpace set to false', () => {
+			expect( view.hasReservedCheckHolderSpace ).to.be.false;
+		} );
+
+		it( 'should initialize with isToggleable set to false', () => {
+			expect( view.isToggleable ).to.be.false;
+		} );
+
+		it( 'should initialize with proper class names', () => {
+			expect( [ ...view.element.classList ] ).to.be.deep.equal( [
+				'ck',
+				'ck-button',
+				'ck-off',
+				'ck-list-item-button'
+			] );
+		} );
+	} );
+
+	describe( 'render()', () => {
+		it( 'should render check holder if initially visible', () => {
+			view = new ListItemButtonView( locale );
+			view.isToggleable = true;
+			view.render();
+
+			expect( view.element.querySelector( '.ck-list-item-button__check-holder' ) ).not.to.be.null;
+		} );
+	} );
+
+	describe( 'isToggleable', () => {
+		it( 'should bind class names properly when isToggleable is set to true', () => {
+			view.isToggleable = true;
+
+			expect( view.element.classList.contains( 'ck-list-item-button_toggleable' ) ).to.be.true;
+		} );
+	} );
+
+	describe( '_shouldRenderCheckHolder', () => {
+		const possibleRenderStates = [
+			{ isToggleable: false, checkHolderSpace: false, rendered: false },
+			{ isToggleable: false, checkHolderSpace: true, rendered: true },
+			{ isToggleable: true, checkHolderSpace: false, rendered: true },
+			{ isToggleable: true, checkHolderSpace: true, rendered: true }
+		];
+
+		for ( const { isToggleable, checkHolderSpace, rendered } of possibleRenderStates ) {
+			it(
+				`should render checkbox holder when isToggleable=${ isToggleable } and hasReservedCheckHolderSpace=${ checkHolderSpace }`,
+				() => {
+					view.isToggleable = isToggleable;
+					view.hasReservedCheckHolderSpace = checkHolderSpace;
+
+					expect( !!view.element.querySelector( '.ck-list-item-button__check-holder' ) ).to.be.equal( rendered );
+				}
+			);
+		}
+
+		it( 'should remove check holder when isToggleable is set to false', () => {
+			view.isToggleable = true;
+			expect( view.element.querySelector( '.ck-list-item-button__check-holder' ) ).not.to.be.null;
+
+			view.isToggleable = false;
+			expect( view.element.querySelector( '.ck-list-item-button__check-holder' ) ).to.be.null;
+		} );
+	} );
+
+	describe( '_checkIconHolderView', () => {
+		it( 'should be instance of CheckIconHolderView', () => {
+			expect( view._checkIconHolderView ).to.be.instanceOf( CheckIconHolderView );
+		} );
+
+		it( 'should have `isOn` bound to parent view', () => {
+			// When is not toggleable, the check icon should be hidden.
+			view.isToggleable = false;
+			view.isOn = true;
+			expect( view._checkIconHolderView.isOn ).to.be.false;
+
+			view.isOn = false;
+			expect( view._checkIconHolderView.isOn ).to.be.false;
+
+			// When is toggleable, the check icon should be visible.
+			view.isToggleable = true;
+			view.isOn = true;
+			expect( view._checkIconHolderView.isOn ).to.be.true;
+
+			view.isOn = false;
+			expect( view._checkIconHolderView.isOn ).to.be.false;
+		} );
+	} );
+} );
+
+describe( 'CheckIconHolderView', () => {
+	let view;
+
+	beforeEach( () => {
+		view = new CheckIconHolderView();
+		view.render();
+	} );
+
+	afterEach( () => {
+		view.destroy();
+	} );
+
+	describe( 'constructor()', () => {
+		it( 'should initialize with proper class names', () => {
+			expect( [ ...view.element.classList ] ).to.be.deep.equal( [
+				'ck',
+				'ck-list-item-button__check-holder',
+				'ck-off'
+			] );
+		} );
+	} );
+
+	describe( 'render()', () => {
+		it( 'should render icon if initially isOn=true', () => {
+			view = new CheckIconHolderView();
+			view.isOn = true;
+			view.render();
+
+			expect( view.element.querySelector( '.ck-list-item-button__check-icon' ) ).not.to.be.null;
+		} );
+	} );
+
+	describe( 'isOn', () => {
+		it( 'should bind class names properly when isOn is set to true', () => {
+			view.isOn = true;
+			expect( view.element.classList.contains( 'ck-on' ) ).to.be.true;
+			expect( view.element.classList.contains( 'ck-off' ) ).to.be.false;
+
+			view.isOn = false;
+			expect( view.element.classList.contains( 'ck-on' ) ).to.be.false;
+			expect( view.element.classList.contains( 'ck-off' ) ).to.be.true;
+		} );
+
+		it( 'should render icon with proper class depending on isOn flag', () => {
+			expect( view.element.querySelector( '.ck-list-item-button__check-icon' ) ).to.be.null;
+
+			view.isOn = true;
+			expect( view.element.querySelector( '.ck-list-item-button__check-icon' ) ).not.to.be.null;
+
+			view.isOn = false;
+			expect( view.element.querySelector( '.ck-list-item-button__check-icon' ) ).to.be.null;
+		} );
+	} );
+} );

--- a/packages/ckeditor5-ui/tests/dialog/dialog.js
+++ b/packages/ckeditor5-ui/tests/dialog/dialog.js
@@ -41,6 +41,10 @@ describe( 'Dialog', () => {
 		expect( Dialog.pluginName ).to.equal( 'Dialog' );
 	} );
 
+	it( 'should initialize with isOpen=false', () => {
+		expect( dialogPlugin.isOpen ).to.be.false;
+	} );
+
 	it( 'should add keystroke accessibility info', () => {
 		expect( editor.accessibility.keystrokeInfos.get( 'navigation' ).groups.get( 'common' ).keystrokes ).to.deep.include( {
 			label: 'Move focus in and out of an active dialog window',

--- a/packages/ckeditor5-ui/tests/dropdown/utils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/utils.js
@@ -944,7 +944,7 @@ describe( 'utils', () => {
 					] );
 
 					for ( const item of listItems ) {
-						expect( item.children.first.hasReservedCheckHolderSpace ).to.be.true;
+						expect( item.children.first.hasCheckSpace ).to.be.true;
 					}
 				} );
 
@@ -961,7 +961,7 @@ describe( 'utils', () => {
 					] );
 
 					for ( const item of listItems ) {
-						expect( item.children.first.hasReservedCheckHolderSpace ).to.be.false;
+						expect( item.children.first.hasCheckSpace ).to.be.false;
 					}
 				} );
 

--- a/packages/ckeditor5-ui/tests/dropdown/utils.js
+++ b/packages/ckeditor5-ui/tests/dropdown/utils.js
@@ -881,7 +881,7 @@ describe( 'utils', () => {
 				expect( dropdownView.listView.element.role ).to.equal( 'bar' );
 			} );
 
-			describe( 'with ButtonView', () => {
+			describe( 'with ListItemButtonView', () => {
 				it( 'is populated using item definitions', () => {
 					definitions.add( {
 						type: 'button',
@@ -906,6 +906,65 @@ describe( 'utils', () => {
 					expect( listItems.first.children.first.labelStyle ).to.equal( 'b' );
 				} );
 
+				it( 'should set `isToggleable=true` only if role `menuitemcheckbox` or `menuitemradio` is set', () => {
+					definitions.addMany( [
+						{
+							type: 'button',
+							model: new Model( { label: 'a', role: 'menuitemcheckbox' } )
+						},
+						{
+							type: 'button',
+							model: new Model( { label: 'b', role: 'menuitemradio' } )
+						},
+						{
+							type: 'button',
+							model: new Model( { label: 'c', role: 'menuitem' } )
+						}
+					] );
+
+					expect( listItems.get( 0 ).children.first.isToggleable ).to.be.true;
+					expect( listItems.get( 1 ).children.first.isToggleable ).to.be.true;
+					expect( listItems.get( 2 ).children.first.isToggleable ).to.be.false;
+				} );
+
+				it( 'should reserve checkbox holder space if there is at least one toggleable item', () => {
+					definitions.addMany( [
+						{
+							type: 'button',
+							model: new Model( { label: 'a', role: 'menuitemcheckbox' } )
+						},
+						{
+							type: 'button',
+							model: new Model( { label: 'b', role: 'menuitemradio' } )
+						},
+						{
+							type: 'button',
+							model: new Model( { label: 'c', role: 'menuitem' } )
+						}
+					] );
+
+					for ( const item of listItems ) {
+						expect( item.children.first.hasReservedCheckHolderSpace ).to.be.true;
+					}
+				} );
+
+				it( 'should not reserve checkbox holder space if there is at least one toggleable item', () => {
+					definitions.addMany( [
+						{
+							type: 'button',
+							model: new Model( { label: 'a', role: 'menuitem' } )
+						},
+						{
+							type: 'button',
+							model: new Model( { label: 'b', role: 'menuitem' } )
+						}
+					] );
+
+					for ( const item of listItems ) {
+						expect( item.children.first.hasReservedCheckHolderSpace ).to.be.false;
+					}
+				} );
+
 				it( 'binds all button properties', () => {
 					const def = {
 						type: 'button',
@@ -919,11 +978,18 @@ describe( 'utils', () => {
 					expect( button.foo ).to.equal( 'bar' );
 					expect( button.baz ).to.equal( 'qux' );
 
+					button.isToggleable = true;
 					button.isOn = true;
-					expect( button.element.attributes[ 'aria-checked' ].value ).to.equal( 'true' );
+
+					expect( button.element.getAttribute( 'aria-pressed' ) ).to.be.equal( 'true' );
 
 					button.isOn = false;
-					expect( button.element.hasAttribute( 'aria-checked' ) ).to.be.false;
+					expect( button.element.getAttribute( 'aria-pressed' ) ).to.be.equal( 'false' );
+
+					button.isOn = true;
+					button.role = 'checkbox';
+					expect( button.element.getAttribute( 'aria-checked' ) ).to.be.equal( 'true' );
+					expect( button.element.getAttribute( 'aria-pressed' ) ).to.be.null;
 
 					def.model.baz = 'foo?';
 					expect( button.baz ).to.equal( 'foo?' );

--- a/packages/ckeditor5-ui/tests/editorui/accessibilityhelp/accessibilityhelp.js
+++ b/packages/ckeditor5-ui/tests/editorui/accessibilityhelp/accessibilityhelp.js
@@ -112,6 +112,18 @@ describe( 'AccessibilityHelp', () => {
 				it( 'should set keystroke in the model', () => {
 					expect( button.keystroke ).to.equal( featureKeystroke );
 				} );
+
+				it( 'should set isOn=true if dialog is visible', () => {
+					button.fire( 'execute' );
+
+					expect( dialogPlugin.id ).to.be.equal( 'accessibilityHelp' );
+					expect( button.isOn ).to.be.true;
+
+					button.fire( 'execute' );
+
+					expect( dialogPlugin.id ).to.be.null;
+					expect( button.isOn ).to.be.false;
+				} );
 			}
 		} );
 
@@ -202,7 +214,7 @@ describe( 'AccessibilityHelp', () => {
 		it( 'should create #contentView', () => {
 			expect( plugin.contentView ).to.be.null;
 
-			plugin._showDialog();
+			plugin._toggleDialog();
 
 			expect( plugin.contentView ).to.be.instanceof( AccessibilityHelpContentView );
 		} );

--- a/packages/ckeditor5-ui/tests/menubar/menubarmenulistitemfiledialogbuttonview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarmenulistitemfiledialogbuttonview.js
@@ -4,7 +4,8 @@
  */
 
 import { Locale } from '@ckeditor/ckeditor5-utils';
-import { FileDialogButtonView, MenuBarMenuListItemFileDialogButtonView } from '../../src/index.js';
+import { MenuBarMenuListItemFileDialogButtonView } from '../../src/index.js';
+import { FileDialogListItemButtonView } from '../../src/button/filedialogbuttonview.js';
 
 describe( 'MenuBarMenuListItemFileDialogButtonView', () => {
 	let buttonView, locale;
@@ -20,7 +21,7 @@ describe( 'MenuBarMenuListItemFileDialogButtonView', () => {
 
 	describe( 'constructor()', () => {
 		it( 'should inherit from FileDialogButtonView', () => {
-			expect( buttonView ).to.be.instanceOf( FileDialogButtonView );
+			expect( buttonView ).to.be.instanceOf( FileDialogListItemButtonView );
 		} );
 
 		it( 'should set #withText', () => {

--- a/packages/ckeditor5-ui/tests/menubar/menubarview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarview.js
@@ -106,11 +106,11 @@ describe( 'MenuBarView', () => {
 				expect( menuBarView.template.attributes[ 'aria-label' ] ).to.include.members( [ 'Editor menu bar' ] );
 			} );
 
-			it( 'has `hadKeyboardFocusInteraction` bound to proper class name', () => {
-				menuBarView.hadKeyboardFocusInteraction = true;
+			it( 'has `isFocusBorderEnabled` bound to proper class name', () => {
+				menuBarView.isFocusBorderEnabled = true;
 				menuBarView.render();
 
-				expect( menuBarView.element.classList.contains( 'ck-menu-bar_keyboard-focus-interaction' ) ).to.be.true;
+				expect( menuBarView.element.classList.contains( 'ck-menu-bar_focus-border-enabled' ) ).to.be.true;
 			} );
 		} );
 
@@ -2060,7 +2060,7 @@ describe( 'MenuBarView', () => {
 		} );
 
 		it( 'should add a behavior that tracks if user performed keyboard focus interaction', () => {
-			const spy = sinon.spy( MenuBarBehaviors, 'trackKeyboardFocusInteraction' );
+			const spy = sinon.spy( MenuBarBehaviors, 'enableFocusHighlightOnInteraction' );
 
 			menuBarView.render();
 

--- a/packages/ckeditor5-ui/tests/menubar/menubarview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarview.js
@@ -105,6 +105,13 @@ describe( 'MenuBarView', () => {
 			it( 'should have an aria-label attribute', () => {
 				expect( menuBarView.template.attributes[ 'aria-label' ] ).to.include.members( [ 'Editor menu bar' ] );
 			} );
+
+			it( 'has `hadKeyboardFocusInteraction` bound to proper class name', () => {
+				menuBarView.hadKeyboardFocusInteraction = true;
+				menuBarView.render();
+
+				expect( menuBarView.element.classList.contains( 'ck-menu-bar_keyboard-focus-interaction' ) ).to.be.true;
+			} );
 		} );
 
 		describe( '#isOpen', () => {
@@ -2046,6 +2053,14 @@ describe( 'MenuBarView', () => {
 
 		it( 'should add a behavior that closes the bar when the user clicked somewhere outside of it', () => {
 			const spy = sinon.spy( MenuBarBehaviors, 'closeOnClickOutside' );
+
+			menuBarView.render();
+
+			sinon.assert.calledOnceWithExactly( spy, menuBarView );
+		} );
+
+		it( 'should add a behavior that tracks if user performed keyboard focus interaction', () => {
+			const spy = sinon.spy( MenuBarBehaviors, 'trackKeyboardFocusInteraction' );
 
 			menuBarView.render();
 

--- a/packages/ckeditor5-ui/tests/menubar/utils.js
+++ b/packages/ckeditor5-ui/tests/menubar/utils.js
@@ -872,60 +872,85 @@ describe( 'MenuBarView utils', () => {
 			} );
 		} );
 
-		describe( 'trackKeyboardFocusInteraction', () => {
-			it( 'should reset the keyboard focus interaction flag of the menu bar when #isOpen changes', () => {
+		describe( 'enableFocusHighlightOnInteraction', () => {
+			it( 'should set proper isFocusBorderEnabled when #isOpen changes', () => {
 				const menuA = getMenuByLabel( menuBarView, 'A' );
 
 				menuA.isOpen = true;
-				menuBarView.hadKeyboardFocusInteraction = true;
+				menuBarView.isFocusBorderEnabled = true;
 				menuBarView.isOpen = false;
 
-				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.false;
+				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
 			} );
 
-			it( 'should set keyboard focus interaction flag of the menu bar when a key is pressed', () => {
+			it( 'should set proper isFocusBorderEnabled when a key is pressed', () => {
 				const menuA = getMenuByLabel( menuBarView, 'A' );
 
 				menuA.isOpen = true;
 
-				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.false;
+				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
 
 				menuA.element.dispatchEvent( new KeyboardEvent( 'keydown', { keyCode: keyCodes.arrowdown } ) );
 				menuA.element.dispatchEvent( new Event( 'focus', { keyCode: keyCodes.arrowdown } ) );
 
-				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.true;
+				expect( menuBarView.isFocusBorderEnabled ).to.be.true;
 
 				menuA.element.dispatchEvent( new KeyboardEvent( 'keyup', { keyCode: keyCodes.arrowdown } ) );
 
-				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.true;
+				expect( menuBarView.isFocusBorderEnabled ).to.be.true;
 			} );
 
-			it( 'should not set keyboard focus interaction flag of the menu bar when a keyup fires before focus', () => {
+			it( 'should set proper isFocusBorderEnabled when a keyup fires before focus', () => {
 				const menuA = getMenuByLabel( menuBarView, 'A' );
 
 				menuA.isOpen = true;
 
-				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.false;
+				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
 
 				menuA.element.dispatchEvent( new KeyboardEvent( 'keydown', { keyCode: keyCodes.arrowdown } ) );
 				menuA.element.dispatchEvent( new KeyboardEvent( 'keyup', { keyCode: keyCodes.arrowdown } ) );
 				menuA.element.dispatchEvent( new Event( 'focus', { keyCode: keyCodes.arrowdown } ) );
 
-				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.false;
+				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
 			} );
 
-			it( 'should not set keyboard focus interaction flag of the menu bar when a keydown fires before focus', () => {
+			it( 'should set proper isFocusBorderEnabled when a keydown fires before focus', () => {
 				const menuA = getMenuByLabel( menuBarView, 'A' );
 
 				menuA.isOpen = true;
 
-				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.false;
+				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
 
 				menuA.element.dispatchEvent( new Event( 'focus', { keyCode: keyCodes.arrowdown } ) );
 				menuA.element.dispatchEvent( new KeyboardEvent( 'keydown', { keyCode: keyCodes.arrowdown } ) );
 				menuA.element.dispatchEvent( new KeyboardEvent( 'keyup', { keyCode: keyCodes.arrowdown } ) );
 
-				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.false;
+				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
+			} );
+
+			it( 'should set proper isFocusBorderEnabled when a clicked and focused item on opened menu', () => {
+				const clock = sinon.useFakeTimers();
+
+				sinon.stub( menuBarView.element, 'matches' ).withArgs( ':focus-within' ).returns( true	);
+
+				const menuA = getMenuByLabel( menuBarView, 'A' );
+
+				menuA.isOpen = true;
+
+				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
+
+				menuA.buttonView.element.dispatchEvent( new Event( 'click' ) );
+
+				expect( menuBarView.isFocusBorderEnabled ).to.be.true;
+
+				menuA.isOpen = false;
+				clock.tick( 1000 );
+
+				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
+
+				menuA.buttonView.element.dispatchEvent( new Event( 'click' ) );
+
+				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
 			} );
 		} );
 	} );
@@ -1646,6 +1671,12 @@ describe( 'MenuBarView utils', () => {
 			beforeEach( () => {
 				menuBarEditorUI.focusTracker.isFocused = true;
 				menuBarEditorUI.focusTracker.focusedElement = domRoot;
+			} );
+
+			it( 'should enable focus border once focused using keyboard', () => {
+				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
+				pressAltF9( menuBarEditor );
+				expect( menuBarView.isFocusBorderEnabled ).to.be.true;
 			} );
 
 			it( 'should focus the menu bar when the focus is in the editing root', () => {

--- a/packages/ckeditor5-ui/tests/menubar/utils.js
+++ b/packages/ckeditor5-ui/tests/menubar/utils.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* global document, Event */
+/* global document, Event, KeyboardEvent */
 
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
 import {
@@ -871,6 +871,63 @@ describe( 'MenuBarView utils', () => {
 				sinon.assert.calledOnce( closeSpy );
 			} );
 		} );
+
+		describe( 'trackKeyboardFocusInteraction', () => {
+			it( 'should reset the keyboard focus interaction flag of the menu bar when #isOpen changes', () => {
+				const menuA = getMenuByLabel( menuBarView, 'A' );
+
+				menuA.isOpen = true;
+				menuBarView.hadKeyboardFocusInteraction = true;
+				menuBarView.isOpen = false;
+
+				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.false;
+			} );
+
+			it( 'should set keyboard focus interaction flag of the menu bar when a key is pressed', () => {
+				const menuA = getMenuByLabel( menuBarView, 'A' );
+
+				menuA.isOpen = true;
+
+				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.false;
+
+				menuA.element.dispatchEvent( new KeyboardEvent( 'keydown', { keyCode: keyCodes.arrowdown } ) );
+				menuA.element.dispatchEvent( new Event( 'focus', { keyCode: keyCodes.arrowdown } ) );
+
+				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.true;
+
+				menuA.element.dispatchEvent( new KeyboardEvent( 'keyup', { keyCode: keyCodes.arrowdown } ) );
+
+				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.true;
+			} );
+
+			it( 'should not set keyboard focus interaction flag of the menu bar when a keyup fires before focus', () => {
+				const menuA = getMenuByLabel( menuBarView, 'A' );
+
+				menuA.isOpen = true;
+
+				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.false;
+
+				menuA.element.dispatchEvent( new KeyboardEvent( 'keydown', { keyCode: keyCodes.arrowdown } ) );
+				menuA.element.dispatchEvent( new KeyboardEvent( 'keyup', { keyCode: keyCodes.arrowdown } ) );
+				menuA.element.dispatchEvent( new Event( 'focus', { keyCode: keyCodes.arrowdown } ) );
+
+				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.false;
+			} );
+
+			it( 'should not set keyboard focus interaction flag of the menu bar when a keydown fires before focus', () => {
+				const menuA = getMenuByLabel( menuBarView, 'A' );
+
+				menuA.isOpen = true;
+
+				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.false;
+
+				menuA.element.dispatchEvent( new Event( 'focus', { keyCode: keyCodes.arrowdown } ) );
+				menuA.element.dispatchEvent( new KeyboardEvent( 'keydown', { keyCode: keyCodes.arrowdown } ) );
+				menuA.element.dispatchEvent( new KeyboardEvent( 'keyup', { keyCode: keyCodes.arrowdown } ) );
+
+				expect( menuBarView.hadKeyboardFocusInteraction ).to.be.false;
+			} );
+		} );
 	} );
 
 	describe( 'MenuBarMenuBehaviors', () => {
@@ -942,7 +999,7 @@ describe( 'MenuBarView utils', () => {
 							{
 								label: 'A', isOpen: true, isFocused: false,
 								items: [
-									{ label: 'A#1', isFocused: true }
+									{ label: 'A#1', isFocused: false }
 								]
 							}
 

--- a/packages/ckeditor5-ui/tests/menubar/utils.js
+++ b/packages/ckeditor5-ui/tests/menubar/utils.js
@@ -150,6 +150,46 @@ describe( 'MenuBarView utils', () => {
 				);
 			} );
 
+			it( 'should focus hovered menu if `isFocusBorderEnabled`', () => {
+				menuBarView.isFocusBorderEnabled = true;
+
+				getMenuByLabel( menuBarView, 'A' ).buttonView.fire( 'mouseenter' );
+				expect( barDump( menuBarView ) ).to.deep.equal(
+					[
+						{
+							label: 'A', isOpen: false, isFocused: true,
+							items: []
+						},
+						{
+							label: 'B', isOpen: false, isFocused: false,
+							items: []
+						},
+						{
+							label: 'C', isOpen: false, isFocused: false,
+							items: []
+						}
+					]
+				);
+
+				getMenuByLabel( menuBarView, 'B' ).buttonView.fire( 'mouseenter' );
+				expect( barDump( menuBarView ) ).to.deep.equal(
+					[
+						{
+							label: 'A', isOpen: false, isFocused: false,
+							items: []
+						},
+						{
+							label: 'B', isOpen: false, isFocused: true,
+							items: []
+						},
+						{
+							label: 'C', isOpen: false, isFocused: false,
+							items: []
+						}
+					]
+				);
+			} );
+
 			describe( 'if the bar is already open', () => {
 				it( 'should toggle menus and move focus while moving the mouse (top-level menu -> top-level menu)', () => {
 					const menuA = getMenuByLabel( menuBarView, 'A' );

--- a/packages/ckeditor5-ui/theme/components/button/listitembutton.css
+++ b/packages/ckeditor5-ui/theme/components/button/listitembutton.css
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+@import "../../mixins/_dir.css";
+
+.ck.ck-list-item-button {
+	min-height: unset;
+	width: 100%;
+	border-radius: 0;
+
+	@mixin ck-dir ltr {
+		text-align: left;
+	}
+
+	@mixin ck-dir rtl {
+		text-align: right;
+	}
+
+	& .ck-list-item-button__check-holder {
+		display: inline-flex;
+		width: 1em;
+		height: 1em;
+
+		@mixin ck-dir ltr {
+			margin-right: var(--ck-spacing-standard);
+		}
+
+		@mixin ck-dir rtl {
+			margin-left: var(--ck-spacing-standard);
+		}
+	}
+
+	& .ck-list-item-button__check-icon {
+		height: 100%;
+	}
+}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Improve accessibility of menu bar toggle items by marking them as `menucheckbox` aria roles. 
Feature (ui): Redesign of menu items styling.
 
Closes https://github.com/ckeditor/ckeditor5/issues/16572.

## Additional information

Commercial PR: https://github.com/cksource/ckeditor5-commercial/pull/6339

### Before

![obraz](https://github.com/ckeditor/ckeditor5/assets/3949262/c5e02dfb-49bb-467f-b49f-4271f1e74839)
![obraz](https://github.com/ckeditor/ckeditor5/assets/3949262/95de538e-e44d-4a12-a821-c03608afee06)

### After

![obraz](https://github.com/ckeditor/ckeditor5/assets/3949262/8f522208-699c-494f-b0c8-fc4d1a2b8c06)
![obraz](https://github.com/ckeditor/ckeditor5/assets/3949262/630584a3-d5a9-4c62-abd0-72a5a8edc3d6)

