### PR TITLE
Added handling for the inline view container elements in the `text/plain` data transfer

### DIFF
--- a/packages/ckeditor5-clipboard/src/pasteplaintext.ts
+++ b/packages/ckeditor5-clipboard/src/pasteplaintext.ts
@@ -81,7 +81,7 @@ export default class PastePlainText extends Plugin {
 }
 
 /**
- * Returns true if specified `documentFragment` represents the unformatted inline content.
+ * Returns true if specified `documentFragment` represents an unformatted inline content.
  */
 function isUnformattedInlineContent( documentFragment: DocumentFragment, model: Model ): boolean {
 	const range = model.createRangeIn( documentFragment );
@@ -93,7 +93,7 @@ function isUnformattedInlineContent( documentFragment: DocumentFragment, model: 
 
 		const attributeKeys = Array.from( child.getAttributeKeys() );
 
-		if ( attributeKeys.length !== 0 && attributeKeys.find( key => model.schema.getAttributeProperties( key ).isFormatting ) ) {
+		if ( attributeKeys.find( key => model.schema.getAttributeProperties( key ).isFormatting ) ) {
 			return false;
 		}
 	}

--- a/packages/ckeditor5-clipboard/src/pasteplaintext.ts
+++ b/packages/ckeditor5-clipboard/src/pasteplaintext.ts
@@ -9,7 +9,7 @@
 
 import { Plugin } from '@ckeditor/ckeditor5-core';
 
-import type { DocumentFragment, Schema, ViewDocumentKeyDownEvent } from '@ckeditor/ckeditor5-engine';
+import type { DocumentFragment, Model } from '@ckeditor/ckeditor5-engine';
 
 import ClipboardObserver from './clipboardobserver.js';
 import ClipboardPipeline, { type ClipboardContentInsertionEvent } from './clipboardpipeline.js';
@@ -41,21 +41,14 @@ export default class PastePlainText extends Plugin {
 		const editor = this.editor;
 		const model = editor.model;
 		const view = editor.editing.view;
-		const viewDocument = view.document;
 		const selection = model.document.selection;
 
-		let shiftPressed = false;
-
 		view.addObserver( ClipboardObserver );
-
-		this.listenTo<ViewDocumentKeyDownEvent>( viewDocument, 'keydown', ( evt, data ) => {
-			shiftPressed = data.shiftKey;
-		} );
 
 		editor.plugins.get( ClipboardPipeline ).on<ClipboardContentInsertionEvent>( 'contentInsertion', ( evt, data ) => {
 			// Plain text can be determined based on the event flag (#7799) or auto-detection (#1006). If detected,
 			// preserve selection attributes on pasted items.
-			if ( !shiftPressed && !isPlainTextFragment( data.content, model.schema ) ) {
+			if ( !isUnformattedInlineContent( data.content, model ) ) {
 				return;
 			}
 
@@ -76,8 +69,10 @@ export default class PastePlainText extends Plugin {
 				const range = writer.createRangeIn( data.content );
 
 				for ( const item of range.getItems() ) {
-					if ( item.is( '$textProxy' ) ) {
-						writer.setAttributes( textAttributes, item );
+					for ( const attribute of textAttributes ) {
+						if ( model.schema.checkAttribute( item, attribute[ 0 ] ) ) {
+							writer.setAttribute( attribute[ 0 ], attribute[ 1 ], item );
+						}
 					}
 				}
 			} );
@@ -86,18 +81,22 @@ export default class PastePlainText extends Plugin {
 }
 
 /**
- * Returns true if specified `documentFragment` represents a plain text.
+ * Returns true if specified `documentFragment` represents the unformatted inline content.
  */
-function isPlainTextFragment( documentFragment: DocumentFragment, schema: Schema ): boolean {
-	if ( documentFragment.childCount > 1 ) {
-		return false;
+function isUnformattedInlineContent( documentFragment: DocumentFragment, model: Model ): boolean {
+	const range = model.createRangeIn( documentFragment );
+
+	for ( const child of range.getItems() ) {
+		if ( !model.schema.isInline( child ) ) {
+			return false;
+		}
+
+		const attributeKeys = Array.from( child.getAttributeKeys() );
+
+		if ( attributeKeys.length !== 0 && attributeKeys.find( key => model.schema.getAttributeProperties( key ).isFormatting ) ) {
+			return false;
+		}
 	}
 
-	const child = documentFragment.getChild( 0 )!;
-
-	if ( schema.isObject( child ) ) {
-		return false;
-	}
-
-	return Array.from( child.getAttributeKeys() ).length == 0;
+	return true;
 }

--- a/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
+++ b/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
@@ -86,9 +86,9 @@ function newLinePadding(
 		return '\n';
 	}
 
-	// Do not add padding between inline container elements.
-	if ( ( element.is( 'containerElement' ) && element.getCustomProperty( '$inlineContainer' ) ) ||
-		( previous.is( 'containerElement' ) && previous.getCustomProperty( '$inlineContainer' ) ) ) {
+	// Do not add padding around the elements that won't be rendered.
+	if ( ( element.is( 'element' ) && element.getCustomProperty( 'dataPipeline:transparentRendering' ) ) ||
+		( previous.is( 'element' ) && previous.getCustomProperty( 'dataPipeline:transparentRendering' ) ) ) {
 		return '';
 	}
 

--- a/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
+++ b/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
@@ -87,7 +87,7 @@ function newLinePadding(
 	}
 
 	// Do not add padding around the elements that won't be rendered.
-	if ( 
+	if (
 		element.is( 'element' ) && element.getCustomProperty( 'dataPipeline:transparentRendering' ) ||
 		previous.is( 'element' ) && previous.getCustomProperty( 'dataPipeline:transparentRendering' )
 	) {

--- a/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
+++ b/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
@@ -87,8 +87,10 @@ function newLinePadding(
 	}
 
 	// Do not add padding around the elements that won't be rendered.
-	if ( ( element.is( 'element' ) && element.getCustomProperty( 'dataPipeline:transparentRendering' ) ) ||
-		( previous.is( 'element' ) && previous.getCustomProperty( 'dataPipeline:transparentRendering' ) ) ) {
+	if ( 
+		element.is( 'element' ) && element.getCustomProperty( 'dataPipeline:transparentRendering' ) ||
+		previous.is( 'element' ) && previous.getCustomProperty( 'dataPipeline:transparentRendering' )
+	) {
 		return '';
 	}
 

--- a/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
+++ b/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
@@ -86,6 +86,12 @@ function newLinePadding(
 		return '\n';
 	}
 
+	// Do not add padding between inline container elements.
+	if ( ( element.is( 'containerElement' ) && element.getCustomProperty( '$inlineContainer' ) ) ||
+		( previous.is( 'containerElement' ) && previous.getCustomProperty( '$inlineContainer' ) ) ) {
+		return '';
+	}
+
 	// Add empty lines between container elements.
 	return '\n\n';
 }

--- a/packages/ckeditor5-clipboard/tests/pasteplaintext.js
+++ b/packages/ckeditor5-clipboard/tests/pasteplaintext.js
@@ -178,28 +178,6 @@ describe( 'PastePlainText', () => {
 		);
 	} );
 
-	it( 'should discard selection attributes if shift key was not pressed while pasting', () => {
-		setModelData( model, '<paragraph><$text bold="true">Bolded []text.</$text></paragraph>' );
-
-		const dataTransferMock = createDataTransfer( {
-			'text/html': 'foo<br>bar',
-			'text/plain': 'foo\nbar'
-		} );
-
-		viewDocument.fire( 'clipboardInput', {
-			dataTransfer: dataTransferMock,
-			stopPropagation() {},
-			preventDefault() {}
-		} );
-
-		expect( getModelData( model ) ).to.equal(
-			'<paragraph>' +
-				'<$text bold="true">Bolded </$text>' +
-				'foo<softBreak></softBreak>bar[]' +
-				'<$text bold="true">text.</$text>' +
-			'</paragraph>' );
-	} );
-
 	it( 'should work if the insertContent event is cancelled', () => {
 		// (#7887).
 		setModelData( model, '<paragraph><$text bold="true">Bolded []text.</$text></paragraph>' );
@@ -276,38 +254,6 @@ describe( 'PastePlainText', () => {
 			'<paragraph><$text bold="true">Bolded </$text></paragraph>' +
 			'[<obj></obj>]' +
 			'<paragraph><$text bold="true">.</$text></paragraph>'
-		);
-	} );
-
-	it( 'ignores clipboard input as plain text when shift was released', () => {
-		setModelData( model, '<paragraph><$text bold="true">Bolded []text.</$text></paragraph>' );
-
-		const dataTransferMock = createDataTransfer( {
-			'text/html': 'foo<br>bar',
-			'text/plain': 'foo\nbar'
-		} );
-
-		fireKeyEvent( 'a', {
-			shiftKey: true
-		} );
-
-		fireKeyEvent( 'v', {
-			shiftKey: false,
-			ctrlKey: true
-		} );
-
-		viewDocument.fire( 'clipboardInput', {
-			dataTransfer: dataTransferMock,
-			stopPropagation() {},
-			preventDefault() {}
-		} );
-
-		expect( getModelData( model ) ).to.equal(
-			'<paragraph>' +
-			'<$text bold="true">Bolded </$text>' +
-			'foo<softBreak></softBreak>bar[]' +
-			'<$text bold="true">text.</$text>' +
-			'</paragraph>'
 		);
 	} );
 

--- a/packages/ckeditor5-clipboard/tests/utils/viewtoplaintext.js
+++ b/packages/ckeditor5-clipboard/tests/utils/viewtoplaintext.js
@@ -34,6 +34,18 @@ describe( 'viewToPlainText()', () => {
 		);
 	} );
 
+	it( 'should not put empty line before or after the inline container element', () => {
+		const viewString = 'Abc <container:h1>Header</container:h1> xyz';
+		const expectedText = 'Abc Header xyz';
+
+		const view = parseView( viewString );
+		view.getChild( 1 )._setCustomProperty( '$inlineContainer', true );
+
+		const text = viewToPlainText( view );
+
+		expect( text ).to.equal( expectedText );
+	} );
+
 	it( 'should turn a soft break into a single empty line', () => {
 		testViewToPlainText(
 			'<container:p>Foo<empty:br />Bar</container:p>',

--- a/packages/ckeditor5-clipboard/tests/utils/viewtoplaintext.js
+++ b/packages/ckeditor5-clipboard/tests/utils/viewtoplaintext.js
@@ -34,12 +34,12 @@ describe( 'viewToPlainText()', () => {
 		);
 	} );
 
-	it( 'should not put empty line before or after the inline container element', () => {
+	it( 'should not put empty line before or after the element with `dataPipeline:transparentRendering` property', () => {
 		const viewString = 'Abc <container:h1>Header</container:h1> xyz';
 		const expectedText = 'Abc Header xyz';
 
 		const view = parseView( viewString );
-		view.getChild( 1 )._setCustomProperty( '$inlineContainer', true );
+		view.getChild( 1 )._setCustomProperty( 'dataPipeline:transparentRendering', true );
 
 		const text = viewToPlainText( view );
 

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -1692,6 +1692,37 @@ describe( 'CodeBlockEditing', () => {
 			sinon.assert.calledOnce( contentInsertionSpy );
 		} );
 
+		it( 'should filter out the disallowed element from pasted content', () => {
+			setModelData( model, '<codeBlock language="css">f[o]o</codeBlock>' );
+
+			const clipboardPlugin = editor.plugins.get( ClipboardPipeline );
+			const contentInsertionSpy = sinon.spy();
+
+			clipboardPlugin.on( 'contentInsertion', contentInsertionSpy );
+			clipboardPlugin.on( 'contentInsertion', ( evt, data ) => {
+				model.change( writer => {
+					const fragment = writer.createDocumentFragment();
+					const element = writer.createElement( 'paragraph' );
+					writer.append( element, fragment );
+					data.content = fragment;
+				} );
+			}, { priority: 'high' } );
+
+			const dataTransferMock = {
+				getData: sinon.stub().withArgs( 'text/plain' ).returns( 'bar\nbaz\n' )
+			};
+
+			viewDoc.fire( 'clipboardInput', {
+				dataTransfer: dataTransferMock,
+				stop: sinon.spy()
+			} );
+
+			expect( getModelData( model ) ).to.equal( '<codeBlock language="css">f[]o</codeBlock>' );
+
+			// Make sure that ClipboardPipeline was not interrupted.
+			sinon.assert.calledOnce( contentInsertionSpy );
+		} );
+
 		describe( 'getSelectedContent()', () => {
 			it( 'should not engage when there is nothing selected', () => {
 				setModelData( model, '<codeBlock language="css">fo[]o<softBreak></softBreak>bar</codeBlock>' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (clipboard): Added handling for the elements with `dataPipeline:transparentRendering` property in the `text/plain` data transfer. Closes https://github.com/ckeditor/ckeditor5/issues/16583.

---

### Additional information

Theoretically, we could also solve it without adding a custom element property, but it's more complex: we need to convert the element to model one and then check in schema if it is an inline object or something similar.