### PR TITLE
Docs: Cleanup, highlighted key links and misc improvements.

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -18,22 +18,27 @@ CKEditor&nbsp;5 is a flexible editing framework that provides every type of WYSI
 
 ## Are you new to CKEditor&nbsp;5?
 
-If your dive into using our WYSIWYG editor is only starting, find out how to kick off this adventure easily with the {@link getting-started/quick-start Quick&nbsp;Start} guide. You will learn how to run CKEditor&nbsp;5 from npm or CDN.
+If your dive into using our WYSIWYG editor is only starting, find out how to kick off this adventure easily with the **{@link getting-started/quick-start Quick&nbsp;start guide}**. You will learn how to run CKEditor&nbsp;5 from npm or CDN.
 
 ## Migrating from CKEditor&nbsp;4?
 
-If you are familiar with our previous, discontinued product and would like to switch, check the {@link updating/migration-from-ckeditor-4 migration} section. You will find a useful upgrade guide there to help you switch with the least effort.
+If you are familiar with our previous, discontinued product and would like to switch, check the **{@link updating/migration-from-ckeditor-4 Migration section}**. You will find a useful upgrade guide there to help you switch with the least effort.
 
 ## CKEditor&nbsp;5 framework integrations
 
-Do you prefer to use ready-made frameworks? Native integrations with the most popular libraries will save you time and effort. There are four official integrations so far:
+Do you prefer to use ready-made frameworks? Native integrations with the most popular libraries will save you time and effort. There are five official integrations so far:
 
-* {@link getting-started/integrations/angular CKEditor&nbsp;5 rich-text editor for Angular}
-* {@link getting-started/integrations/react CKEditor&nbsp;5 rich-text editor for React}
-* {@link getting-started/integrations/vuejs-v2 CKEditor&nbsp;5 rich-text editor for Vue.js 2.x}
-* {@link getting-started/integrations/vuejs-v3 CKEditor&nbsp;5 rich-text editor for Vue.js 3.x}
+* {@link getting-started/integrations/angular Integrate CKEditor&nbsp;5 with Angular}
+* {@link getting-started/integrations/react Integrate CKEditor&nbsp;5 with React}
+* {@link getting-started/integrations/next-js Integrate CKEditor&nbsp;5 with Next.js}
+* {@link getting-started/integrations/vuejs-v3 Integrate CKEditor&nbsp;5 with Vue.js 3.x}
+* {@link getting-started/integrations/vuejs-v2 Integrate CKEditor&nbsp;5 with Vue.js 2.x}
 
-However, some more frameworks are also supported. Refer to their documentation on the left to learn how to use them. CKEditor&nbsp;5 is a native JavaScript rich-text editing component written in TypeScript. As such, it is framework-agnostic and can be integrated with any JavaScript framework. It does not require any uncommon techniques or technologies to be used. Therefore, unless the framework you use has atypical limitations, CKEditor&nbsp;5 is compatible with it.
+However, integration steps for some more frameworks are also documented. Refer to their documentation on the left to learn how to use them.
+
+### Support for other frameworks
+
+CKEditor&nbsp;5 is a native JavaScript rich-text editing component written in TypeScript. As such, it is framework-agnostic and **can be integrated with any JavaScript framework and application**. It does not require any uncommon techniques or technologies to be used. Therefore, unless the framework you use has atypical limitations, CKEditor&nbsp;5 is compatible with it.
 
 CKEditor&nbsp;5 is also compatible with popular CSS frameworks such as Bootstrap or Foundation. Such integrations, however, often require additional changes and adjustments that we have gathered {@link getting-started/integrations/css in this guide}.
 
@@ -44,10 +49,6 @@ We plan to provide more integrations with time. We would like to [hear your idea
 Once you install your copy of CKEditor&nbsp;5, take some time to {@link getting-started/setup/configuration configure it} before first use. Set up data-saving methods, editor toolbars, and UI.
 
 You may also take the {@link tutorials/crash-course/editor step-by-step tutorial} that will guide you through the installation and configuration of the editor.
-
-## Want to remove the "Powered by CKEditor" logo?
-
-If you came here looking for a guide on how to suppress the branding logo, check the dedicated {@link getting-started/setup/managing-ckeditor-logo branding} guide.
 
 ## Legacy installation methods
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -26,7 +26,7 @@ If you are familiar with our previous, discontinued product and would like to sw
 
 ## CKEditor&nbsp;5 framework integrations
 
-Do you prefer to use ready-made frameworks? Native integrations with the most popular libraries will save you time and effort. There are five official integrations so far:
+Do you to use a framework? Native integrations with the most popular libraries will save you time and effort. There are five official integrations so far:
 
 * {@link getting-started/integrations/angular Integrate CKEditor&nbsp;5 with Angular}
 * {@link getting-started/integrations/react Integrate CKEditor&nbsp;5 with React}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Cleanup, highlighted key links and misc improvements.

---

### Additional information

*   Quick Start -> Quick start.
*   Mentioned Next.js in the list of frameworks (because it's super important).
*   Removed the note about Powered by -> I think it was added there when we introduced this logo, so it's less of an issue now.
*   Highlighted key links -> To me, they were lost in the surrounding text. In fact, I think that at least  2-3 of those section should clearly separate the CTA link by moving it e.g. to the end of the paragraph or a new paragraph.