### PR TITLE
Changed the place of restricted editing buttons in menu bar

### DIFF
--- a/packages/ckeditor5-ui/src/menubar/utils.ts
+++ b/packages/ckeditor5-ui/src/menubar/utils.ts
@@ -740,9 +740,9 @@ export const DefaultMenuBarItems: DeepReadonly<MenuBarConfigObject[ 'items' ]> =
 				]
 			},
 			{
-				groupId: 'restrictedEditingException',
+				groupId: 'restrictedEditing',
 				items: [
-					'menuBar:restrictedEditingException'
+					'menuBar:restrictedEditing'
 				]
 			}
 		]
@@ -787,9 +787,9 @@ export const DefaultMenuBarItems: DeepReadonly<MenuBarConfigObject[ 'items' ]> =
 				]
 			},
 			{
-				groupId: 'restrictedEditing',
+				groupId: 'restrictedEditingException',
 				items: [
-					'menuBar:restrictedEditing'
+					'menuBar:restrictedEditingException'
 				]
 			}
 		]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Changed the place of restricted editing buttons in the menu bar. Closes #16609.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
