### PR TITLE
Unify focus and list items rendering in dropdown menus

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenu.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenu.css
@@ -3,6 +3,37 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+@import "../../../../mixins/_focus.css";
+@import "../../../../mixins/_shadow.css";
+
+.ck.ck-dropdown-menu {
+	& .ck-list-item-button {
+		&:focus,
+		&:active {
+			border-color: transparent;
+			box-shadow: none;
+		}
+
+		&.ck-on:not(.ck-disabled) {
+			&, &:hover {
+				color: var(--ck-color-button-on-color);
+			}
+		}
+	}
+
+	&.ck-dropdown-menu_focus-border-enabled .ck-list-item-button {
+		&:focus,
+		&:active {
+			/* Fix truncated shadows due to rendering order. */
+			position: relative;
+			z-index: 2;
+
+			@mixin ck-focus-ring;
+			@mixin ck-box-shadow var(--ck-focus-outer-shadow);
+		}
+	}
+}
+
 .ck.ck-dropdown-menu__menu {
 	/* Enable font size inheritance, which allows fluid UI scaling. */
 	font-size: inherit;

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenubutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenubutton.css
@@ -15,15 +15,6 @@
 	padding: var(--ck-list-button-padding);
 	border-radius: 0;
 
-	&:focus {
-		border-color: transparent;
-		box-shadow: none;
-
-		&:not(.ck-on) {
-			background: var(--ck-color-button-default-hover-background);
-		}
-	}
-
 	& > .ck-button__label {
 		flex-grow: 1;
 		overflow: hidden;
@@ -32,11 +23,6 @@
 
 	&.ck-disabled > .ck-button__label {
 		@mixin ck-disabled;
-	}
-
-	/* Spacing in buttons that miss the icon. */
-	&.ck-icon-spacing:not(:has(.ck-button__icon)) > .ck-button__label {
-		margin-left: calc(var(--ck-icon-size) - var(--ck-spacing-small));
 	}
 
 	& > .ck-dropdown-menu__menu__button__arrow {

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenulistitembutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenulistitembutton.css
@@ -20,17 +20,4 @@
 		margin-left: calc(-1 * var(--ck-spacing-small));
 		margin-right: var(--ck-spacing-small);
 	}
-
-	/*
-		* Hovered items automatically get focused. Default focus styles look odd
-		* while moving across a huge list of items so let's get rid of them
-		*/
-	&:focus {
-		border-color: transparent;
-		box-shadow: none;
-
-		&:not(.ck-on) {
-			background: var(--ck-color-button-default-hover-background);
-		}
-	}
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenupanel.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenupanel.css
@@ -51,3 +51,4 @@
 		outline: none;
 	}
 }
+

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenubuttonview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenubuttonview.ts
@@ -8,7 +8,7 @@
  */
 
 import IconView from '../../icon/iconview.js';
-import ButtonView from '../../button/buttonview.js';
+import ListItemButtonView from '../../button/listitembuttonview.js';
 import type { Locale } from '@ckeditor/ckeditor5-utils';
 
 import dropdownArrowIcon from '../../../theme/icons/dropdown-arrow.svg';
@@ -18,7 +18,7 @@ import '../../../theme/components/dropdown/menu/dropdownmenubutton.css';
 /**
  * Represents a view for a dropdown menu button.
  */
-export default class DropdownMenuButtonView extends ButtonView {
+export default class DropdownMenuButtonView extends ListItemButtonView {
 	/**
 	 * An icon that displays an arrow to indicate a direction of the menu.
 	 */

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenulistitembuttonview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenulistitembuttonview.ts
@@ -9,38 +9,29 @@
 
 import type { Locale } from '@ckeditor/ckeditor5-utils';
 
-import ButtonView from '../../button/buttonview.js';
+import ListItemButtonView from '../../button/listitembuttonview.js';
 
 import '../../../theme/components/dropdown/menu/dropdownmenulistitembutton.css';
 
 /**
  * Represents a view for a button in a dropdown menu list item.
  */
-export default class DropdownMenuListItemButtonView extends ButtonView {
-	/**
-	 * Determines whether space should be allocated for an icon if it is missing.
-	 */
-	declare public addIconSpace: boolean;
-
+export default class DropdownMenuListItemButtonView extends ListItemButtonView {
 	constructor( locale: Locale, label?: string ) {
 		super( locale );
-
-		const bind = this.bindTemplate;
 
 		this.set( {
 			withText: true,
 			withKeystroke: true,
 			tooltip: false,
 			role: 'menuitem',
-			addIconSpace: false,
 			label
 		} );
 
 		this.extendTemplate( {
 			attributes: {
 				class: [
-					'ck-dropdown-menu__menu__item__button',
-					bind.if( 'addIconSpace', 'ck-icon-spacing' )
+					'ck-dropdown-menu__menu__item__button'
 				]
 			}
 		} );

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenulistview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenulistview.ts
@@ -53,6 +53,7 @@ export default class DropdownMenuListView extends ListView {
 
 		this.role = 'menu';
 		this.set( {
+			_isScrollable: false,
 			isVisible: true,
 			isFocusBorderEnabled: false
 		} );

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenurootlistview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenurootlistview.ts
@@ -128,6 +128,7 @@ export default class DropdownMenuRootListView extends DropdownMenuListView {
 		DropdownRootMenuBehaviors.closeMenuWhenAnotherOnTheSameLevelOpens( this );
 		DropdownRootMenuBehaviors.closeOnClickOutside( this );
 		DropdownRootMenuBehaviors.closeWhenOutsideElementFocused( this );
+		DropdownRootMenuBehaviors.enableFocusHighlightOnInteraction( this );
 	}
 
 	/**
@@ -204,9 +205,14 @@ export default class DropdownMenuRootListView extends DropdownMenuListView {
 		this.items.on<CollectionAddEvent<DropdownMenuListItemView>>( 'add', ( evt, item ) => {
 			const { childView } = item;
 
-			// Add additional CSS class to the panel view if it's a dropdown menu.
+			// Forward the root menu class and focus border state to the child views.
 			if ( childView instanceof DropdownMenuView ) {
+				// It's static property so it's safe to set it directly without bind.
 				childView.panelView.class = this._menuPanelClass;
+
+				// `isFocusBorderEnabled` is controllable by the root menu depending on interaction so
+				// it must be propagated.
+				childView.listView.bind( 'isFocusBorderEnabled' ).to( this, 'isFocusBorderEnabled' );
 			}
 
 			childView.delegate( ...DropdownMenuView.DELEGATED_EVENTS ).to( this, name => `menu:${ name }` );

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuview.ts
@@ -252,9 +252,14 @@ export default class DropdownMenuView extends View implements FocusableView {
 		this.panelView.delegate( ...DropdownMenuView.DELEGATED_EVENTS ).to( this );
 		this.on<ObservableChangeEvent<DropdownMenuView | null>>( 'change:parentMenuView', ( evt, name, parentMenuView ) => {
 			if ( parentMenuView ) {
+				// Ensure that modification of the parent menu class and focus border state is propagated to the child views.
 				this.panelView.unbind( 'class' );
 				this.panelView.bind( 'class' ).to( parentMenuView.panelView, 'class' );
 
+				this.listView.unbind( 'isFocusBorderEnabled' );
+				this.listView.bind( 'isFocusBorderEnabled' ).to( parentMenuView.listView, 'isFocusBorderEnabled' );
+
+				// Delegate events to the parent menu.
 				this.delegate( ...DropdownMenuView.DELEGATED_EVENTS ).to( parentMenuView );
 				DropdownMenuBehaviors.closeOnParentClose( this, parentMenuView );
 			}

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenuview.ts
@@ -294,11 +294,16 @@ export default class DropdownMenuView extends View implements FocusableView {
 	 * Adds the panel view to the editor's body and sets up event listeners.
 	 */
 	private _addToEditorBody() {
-		const { panelView, buttonView, keystrokes, editor } = this;
+		const {
+			panelView, listView, buttonView,
+			keystrokes, editor
+		} = this;
+
 		const { ui } = editor;
 		const { body } = ui.view;
 
 		if ( !body.has( panelView ) ) {
+			listView.checkIfScrollable();
 			body.add( panelView );
 			ui.focusTracker.add( panelView.element! );
 			keystrokes.listenTo( panelView.element! );

--- a/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenulistview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenulistview.js
@@ -8,7 +8,7 @@
 import { global } from '@ckeditor/ckeditor5-utils';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
 import { DropdownMenuFactory } from '../../../src/dropdown/menu/dropdownmenufactory.js';
-import { ListView, DropdownMenuListView, DropdownMenuView, ListItemView } from '../../../src/index.js';
+import { ListView, DropdownMenuListView, DropdownMenuView, ListItemView, DropdownMenuListItemButtonView } from '../../../src/index.js';
 
 import { createMockLocale, createMockMenuDefinition } from './_utils/dropdowntreemock.js';
 import {
@@ -60,6 +60,28 @@ describe( 'DropdownMenuListView', () => {
 
 			listView.isFocusBorderEnabled = false;
 			expect( listView.element.classList.contains( 'ck-dropdown-menu_focus-border-enabled' ) ).to.be.false;
+		} );
+	} );
+
+	describe( 'hasCheckSpace', () => {
+		it( 'should assign icon space if appended toggleable item', () => {
+			factory.appendChildren( [
+				new DropdownMenuListItemButtonView( locale, 'Foo' ),
+				new DropdownMenuListItemButtonView( locale, 'Bar' )
+			] );
+
+			expect( listView.items ).to.have.length( 2 );
+			expect( [ ...listView.items ].some( item => item.childView.hasCheckSpace ) ).to.be.false;
+
+			const toggleableButton = new DropdownMenuListItemButtonView( locale, 'Buz' );
+
+			toggleableButton.isToggleable = true;
+			factory.appendChildren( [
+				toggleableButton
+			] );
+
+			expect( listView.items ).to.have.length( 3 );
+			expect( [ ...listView.items ].every( item => item.childView.hasCheckSpace ) ).to.be.true;
 		} );
 	} );
 

--- a/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenurootlistview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenurootlistview.js
@@ -189,6 +189,14 @@ describe( 'DropdownMenuRootListView', () => {
 
 			sinon.assert.calledOnceWithExactly( spy, rootListView );
 		} );
+
+		it( 'should add a behavior that tracks if user performed keyboard focus interaction', () => {
+			const spy = sinon.spy( DropdownRootMenuBehaviors, 'enableFocusHighlightOnInteraction' );
+
+			rootListView.render();
+
+			sinon.assert.calledOnceWithExactly( spy, rootListView );
+		} );
 	} );
 
 	describe( 'events', () => {
@@ -268,6 +276,59 @@ describe( 'DropdownMenuRootListView', () => {
 		} );
 	} );
 
+	describe( 'isFocusBorderEnabled', () => {
+		it( 'should bind changes in `isFocusBorderEnabled` to every submenu menu', () => {
+			const rootListView = createRootListWithDefinition(
+				createMockMenuDefinition()
+			);
+
+			expect( rootListView.menus.some( menu => menu.listView.isFocusBorderEnabled ) ).to.be.false;
+
+			rootListView.isFocusBorderEnabled = true;
+
+			expect( rootListView.menus.every( menu => menu.listView.isFocusBorderEnabled ) ).to.be.true;
+		} );
+
+		it( 'should set `isFocusBorderEnabled` to every submenu added via appendChildren()', () => {
+			const rootListView = createRootListWithDefinition( [] );
+
+			rootListView.isFocusBorderEnabled = true;
+			rootListView.factory.appendChildren( [
+				createMockMenuDefinition( 'Menu 1' ),
+				createMockMenuDefinition( 'Menu 2' )
+			] );
+
+			expect( rootListView.menus.every( menu => menu.listView.isFocusBorderEnabled ) ).to.be.true;
+		} );
+
+		it( 'should set `isFocusBorderEnabled` to reused menu instance', () => {
+			const rootListView = createRootListWithDefinition(
+				[
+					{
+						menu: 'Tralala',
+						children: [ new DropdownMenuView( editor, 'Hello World 1' ) ]
+					},
+					{
+						menu: 'Tralala',
+						children: [ new DropdownMenuView( editor, 'Hello World 2' ) ]
+					}
+				]
+			);
+
+			rootListView.isFocusBorderEnabled = true;
+			rootListView.factory.appendChild(
+				{
+					menu: 'Menu Root',
+					children: [ new DropdownMenuView( editor, 'Hello World 3' ) ]
+				}
+			);
+
+			const menus = rootListView.menus.filter( menu => menu.listView.isFocusBorderEnabled ).length;
+
+			expect( menus ).to.be.equal( 6 );
+		} );
+	} );
+
 	describe( 'menuPanelClass', () => {
 		it( 'should append `menuPanelClass` to every added submenu via constructor definition', () => {
 			const rootListView = createRootListWithDefinition(
@@ -300,7 +361,7 @@ describe( 'DropdownMenuRootListView', () => {
 			expect( menus ).to.be.equal( 2 );
 		} );
 
-		it( 'should append `menuPanelClass` to reusing menu instance', () => {
+		it( 'should append `menuPanelClass` to reused menu instance', () => {
 			const rootListView = createRootListWithDefinition(
 				[
 					{

--- a/packages/ckeditor5-ui/tests/dropdown/menu/utils/dropdownmenubehaviors.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/utils/dropdownmenubehaviors.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* global document, Event */
+/* global document, Event, KeyboardEvent */
 
 import { keyCodes } from '@ckeditor/ckeditor5-utils';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
@@ -93,6 +93,14 @@ describe( 'Menu Behaviors', () => {
 			beforeEach( () => {
 				menuView = treeNodeByLabel( 'Menu 1' ).menu;
 				otherMenu = treeNodeByLabel( 'Menu 2' ).menu;
+			} );
+
+			it( 'should focus hovered menu', () => {
+				const spyFocus = sinon.spy( menuView.buttonView.element, 'focus' );
+
+				menuView.buttonView.fire( 'mouseenter' );
+
+				expect( spyFocus ).to.be.calledOnce;
 			} );
 
 			it( 'should close other menu on hover menu button item', () => {
@@ -197,6 +205,94 @@ describe( 'Menu Behaviors', () => {
 				menuView.element.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
 				clock.tick( 10 );
 				expect( menuView.isOpen ).to.be.true;
+			} );
+		} );
+
+		describe( 'enableFocusHighlightOnInteraction', () => {
+			it( 'should set proper isFocusBorderEnabled when #isOpen changes', () => {
+				const menuA = treeNodeByLabel( 'Menu 1' ).menu;
+
+				menuA.isOpen = true;
+				rootListView.isFocusBorderEnabled = true;
+
+				// should set isFocusBorderEnabled to false
+				rootListView.isOpen = false;
+
+				expect( rootListView.isFocusBorderEnabled ).to.be.false;
+			} );
+
+			it( 'should set proper isFocusBorderEnabled when a key is pressed', () => {
+				const menuA = treeNodeByLabel( 'Menu 1' ).menu;
+
+				menuA.isOpen = true;
+				menuA.buttonView.focus();
+
+				expect( rootListView.isFocusBorderEnabled ).to.be.false;
+
+				menuA.element.dispatchEvent( new KeyboardEvent( 'keydown', { keyCode: keyCodes.arrowdown } ) );
+				menuA.element.dispatchEvent( new Event( 'focus', { keyCode: keyCodes.arrowdown } ) );
+
+				expect( rootListView.isFocusBorderEnabled ).to.be.true;
+
+				menuA.element.dispatchEvent( new KeyboardEvent( 'keyup', { keyCode: keyCodes.arrowdown } ) );
+
+				expect( rootListView.isFocusBorderEnabled ).to.be.true;
+			} );
+
+			it( 'should set proper isFocusBorderEnabled when a keyup fires before focus', () => {
+				const menuA = treeNodeByLabel( 'Menu 1' ).menu;
+
+				menuA.isOpen = true;
+				menuA.buttonView.focus();
+
+				expect( rootListView.isFocusBorderEnabled ).to.be.false;
+
+				menuA.element.dispatchEvent( new KeyboardEvent( 'keydown', { keyCode: keyCodes.arrowdown } ) );
+				menuA.element.dispatchEvent( new KeyboardEvent( 'keyup', { keyCode: keyCodes.arrowdown } ) );
+				menuA.element.dispatchEvent( new Event( 'focus', { keyCode: keyCodes.arrowdown } ) );
+
+				expect( rootListView.isFocusBorderEnabled ).to.be.false;
+			} );
+
+			it( 'should set proper isFocusBorderEnabled when a keydown fires before focus', () => {
+				const menuA = treeNodeByLabel( 'Menu 1' ).menu;
+
+				menuA.isOpen = true;
+				menuA.buttonView.focus();
+
+				expect( rootListView.isFocusBorderEnabled ).to.be.false;
+
+				menuA.element.dispatchEvent( new Event( 'focus', { keyCode: keyCodes.arrowdown } ) );
+				menuA.element.dispatchEvent( new KeyboardEvent( 'keydown', { keyCode: keyCodes.arrowdown } ) );
+				menuA.element.dispatchEvent( new KeyboardEvent( 'keyup', { keyCode: keyCodes.arrowdown } ) );
+
+				expect( rootListView.isFocusBorderEnabled ).to.be.false;
+			} );
+
+			it( 'should set proper isFocusBorderEnabled when a clicked and focused item on opened menu', () => {
+				const clock = sinon.useFakeTimers();
+
+				sinon.stub( rootListView.element, 'matches' ).withArgs( ':focus-within' ).returns( true	);
+
+				const menuA = treeNodeByLabel( 'Menu 1' ).menu;
+
+				menuA.isOpen = true;
+				menuA.buttonView.focus();
+
+				expect( rootListView.isFocusBorderEnabled ).to.be.false;
+
+				menuA.buttonView.element.dispatchEvent( new Event( 'click' ) );
+
+				expect( rootListView.isFocusBorderEnabled ).to.be.true;
+
+				menuA.isOpen = false;
+				clock.tick( 1000 );
+
+				expect( rootListView.isFocusBorderEnabled ).to.be.false;
+
+				menuA.buttonView.element.dispatchEvent( new Event( 'click' ) );
+
+				expect( rootListView.isFocusBorderEnabled ).to.be.false;
 			} );
 		} );
 

--- a/packages/ckeditor5-ui/tests/dropdown/menu/utils/dropdownmenubehaviors.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/utils/dropdownmenubehaviors.js
@@ -293,6 +293,7 @@ describe( 'Menu Behaviors', () => {
 				menuA.buttonView.element.dispatchEvent( new Event( 'click' ) );
 
 				expect( rootListView.isFocusBorderEnabled ).to.be.false;
+				clock.restore();
 			} );
 		} );
 

--- a/packages/ckeditor5-ui/tests/menubar/utils.js
+++ b/packages/ckeditor5-ui/tests/menubar/utils.js
@@ -991,6 +991,7 @@ describe( 'MenuBarView utils', () => {
 				menuA.buttonView.element.dispatchEvent( new Event( 'click' ) );
 
 				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
+				clock.restore();
 			} );
 		} );
 	} );

--- a/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenulistview.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenulistview.css
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+.ck-dropdown-menu {
+	/*
+	 * This style is set in additional class because `overflow-y: auto` truncates focus border
+	 * when the panel is scrollable. Most of the dropdowns are relatively small and don't need
+	 * scrolling, so we don't want to apply this style to all dropdowns but only to those that
+	 * are large enough to require scrolling.
+	 */
+	&.ck-dropdown-menu_scrollable {
+		max-height: 60vh;
+		overflow-y: auto;
+	}
+}

--- a/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenupanel.css
+++ b/packages/ckeditor5-ui/theme/components/dropdown/menu/dropdownmenupanel.css
@@ -5,7 +5,5 @@
 
 .ck.ck-dropdown-menu__menu__panel {
 	position: absolute;
-	max-height: 60vh;
-	overflow-y: auto;
 	z-index: calc(var(--ck-z-panel) + 1);
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Unify dropdown menus focus behavior with menu bar and other menus.
Internal (ui): Use `ListItemButtonView` instead of `ButtonView` class as base for dropdown menu buttons.
Internal (ui): Add support for `hasIconSpace` attribute of `ListItemButtonView` and allocate space for check marks if there is at least one toggleable menu item in menu.

---

### Additional information

1. I marked this commit as internal because dropdown menu is not released yet. 
2. Focus behavior has been changed in order to make it unified with menu bar. After this change, hovering menu items moves focus from search input to menu items, and any keyboard interaction with the menu makes it show the focus border. 
3. Why is it based on [ck/16311](https://github.com/ckeditor/ckeditor5/pull/16631) branch?
3.1. We don't have manual tests for dropdown menu, and the only way to test that is AI.
3.2. The presence of search input is important to show how "hover focus" behaves with that kind of dropdown. 

#### Part of PRs:

1. https://github.com/ckeditor/ckeditor5/pull/16314
2. https://github.com/ckeditor/ckeditor5/pull/16631

#### Screens

⚠️  Look at the focus placement.

**Before:**

![obraz](https://github.com/ckeditor/ckeditor5/assets/3949262/c9dc8ed4-f9da-4751-8b95-95d3c097635f)

**After:**

![obraz](https://github.com/ckeditor/ckeditor5/assets/3949262/878313e5-4d39-407d-ac3d-78806bb74ddb)

https://github.com/ckeditor/ckeditor5/assets/3949262/4570632f-56ed-474e-a861-dc20d9e7e170

