### PR TITLE
Add `/* #__PURE__ */` comments before mixin calls to properly tree-shake unused classes.

### DIFF
--- a/packages/ckeditor5-ui/src/button/filedialogbuttonview.ts
+++ b/packages/ckeditor5-ui/src/button/filedialogbuttonview.ts
@@ -38,7 +38,7 @@ import ListItemButtonView from './listitembuttonview.js';
  * } );
  * ```
  */
-export default class FileDialogButtonView extends FileDialogViewMixin( ButtonView ) {}
+export default class FileDialogButtonView extends /* #__PURE__ */ FileDialogViewMixin( ButtonView ) {}
 
 /**
  * The file dialog button view used in a lists.
@@ -64,7 +64,7 @@ export default class FileDialogButtonView extends FileDialogViewMixin( ButtonVie
  * } );
  * ```
  */
-export class FileDialogListItemButtonView extends FileDialogViewMixin( ListItemButtonView ) {}
+export class FileDialogListItemButtonView extends /* #__PURE__ */ FileDialogViewMixin( ListItemButtonView ) {}
 
 /**
  * Mixin function that enhances a base button view class with file dialog functionality. It is used


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Add `/* #__PURE__ */` comments before mixin calls to properly tree-shake unused classes. Closes #16651.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
