### PR TITLE
No longer crash after selecting color in table cell formatting form

### DIFF
--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -297,6 +297,12 @@ export default class ColorPickerView extends View {
 	public isValid(): boolean {
 		const { t } = this.locale!;
 
+		// If the input is hidden, it's always valid, because there is no way to select
+		// invalid color value using diagram color picker.
+		if ( this._config.hideInput ) {
+			return true;
+		}
+
 		this.resetValidationStatus();
 
 		// One error per field is enough.

--- a/packages/ckeditor5-ui/tests/colorpicker/colorpickerview.js
+++ b/packages/ckeditor5-ui/tests/colorpicker/colorpickerview.js
@@ -397,6 +397,8 @@ describe( 'ColorPickerView', () => {
 			view.render();
 
 			expect( view.isValid() ).to.be.true;
+
+			view.destroy();
 		} );
 	} );
 

--- a/packages/ckeditor5-ui/tests/colorpicker/colorpickerview.js
+++ b/packages/ckeditor5-ui/tests/colorpicker/colorpickerview.js
@@ -372,6 +372,34 @@ describe( 'ColorPickerView', () => {
 		} );
 	} );
 
+	describe( 'isValid()', () => {
+		let hexInputElement;
+
+		beforeEach( () => {
+			hexInputElement = view.hexInputRow.inputView.fieldView.element;
+		} );
+
+		it( 'should return true for a valid color', () => {
+			hexInputElement.value = '#000';
+
+			expect( view.isValid() ).to.be.true;
+		} );
+
+		it( 'should return false for an invalid color', () => {
+			hexInputElement.value = 'Foo Bar';
+
+			expect( view.isValid() ).to.be.false;
+		} );
+
+		it( 'should return true if the hex input is not shown', () => {
+			const view = new ColorPickerView( locale, { format: 'hex', hideInput: true } );
+
+			view.render();
+
+			expect( view.isValid() ).to.be.true;
+		} );
+	} );
+
 	describe( 'color property', () => {
 		it( 'should be initialized with a proper value', () => {
 			expect( view.color ).to.be.equal( '' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): No longer crash while selecting color in table cell formatting form. Closes https://github.com/ckeditor/ckeditor5/issues/16664

---

### Additional information

1. Caused by this [commit](https://github.com/ckeditor/ckeditor5/commit/caea11e431fc56f911f4cf4ad4f73bc74d36a8b9#diff-1594461a97d09ec34385b4bd65b6d02f1426d81063af97cbdd197ae2941f8635R303).
2. I missed edge-case where `isValid` is called on color selector that has `hideInput` config flag set to `true`.
3. It means that `isValid` was called on a non-existing hex input DOM node, and it raised an exception. 
4. I added regression tests.
