### PR TITLE
CKBox plugins should not wait for token fetch.

### DIFF
--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditcommand.ts
@@ -310,7 +310,7 @@ export default class CKBoxImageEditCommand extends Command {
 		const response: CKBoxRawAssetDataDefinition = await sendHttpRequest( {
 			url,
 			signal,
-			authorization: ckboxUtils.getToken().value
+			authorization: ( await ckboxUtils.getToken() ).value
 		} );
 		const status = response.metadata!.metadataProcessingStatus;
 

--- a/packages/ckeditor5-ckbox/src/ckboxuploadadapter.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxuploadadapter.ts
@@ -98,7 +98,7 @@ class Adapter implements UploadAdapter {
 	/**
 	 * CKEditor Cloud Services access token.
 	 */
-	public token: InitializedToken;
+	public token: Promise<InitializedToken>;
 
 	/**
 	 * The editor instance.
@@ -148,7 +148,7 @@ class Adapter implements UploadAdapter {
 		const uploadUrl = new URL( 'assets', this.serviceOrigin );
 		const formData = new FormData();
 
-		uploadUrl.searchParams.set( 'workspaceId', ckboxUtils.getWorkspaceId() );
+		uploadUrl.searchParams.set( 'workspaceId', await ckboxUtils.getWorkspaceId() );
 
 		formData.append( 'categoryId', category );
 		formData.append( 'file', file );
@@ -165,7 +165,7 @@ class Adapter implements UploadAdapter {
 				}
 			},
 			signal: this.controller.signal,
-			authorization: this.token.value
+			authorization: ( await this.token ).value
 		} as const;
 
 		return sendHttpRequest( requestConfig )

--- a/packages/ckeditor5-ckbox/src/ckboxutils.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxutils.ts
@@ -29,7 +29,7 @@ export default class CKBoxUtils extends Plugin {
 	/**
 	 * CKEditor Cloud Services access token.
 	 */
-	private _token!: InitializedToken;
+	private _token!: Promise<InitializedToken>;
 
 	/**
 	 * @inheritDoc
@@ -48,7 +48,7 @@ export default class CKBoxUtils extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
-	public async init(): Promise<void> {
+	public init(): void {
 		const editor = this.editor;
 		const hasConfiguration = !!editor.config.get( 'ckbox' );
 		const isLibraryLoaded = !!window.CKBox;
@@ -94,27 +94,27 @@ export default class CKBoxUtils extends Plugin {
 		}
 
 		if ( ckboxTokenUrl == cloudServicesTokenUrl ) {
-			this._token = cloudServices.token!;
+			this._token = Promise.resolve( cloudServices.token! );
 		} else {
-			this._token = await cloudServices.registerTokenUrl( ckboxTokenUrl );
+			this._token = cloudServices.registerTokenUrl( ckboxTokenUrl );
 		}
 	}
 
 	/**
 	 * Returns a token used by the CKBox plugin for communication with the CKBox service.
 	 */
-	public getToken(): InitializedToken {
+	public getToken(): Promise<InitializedToken> {
 		return this._token;
 	}
 
 	/**
 	 * The ID of workspace to use when uploading an image.
 	 */
-	public getWorkspaceId(): string {
+	public async getWorkspaceId(): Promise<string> {
 		const t = this.editor.t;
 		const cannotAccessDefaultWorkspaceError = t( 'Cannot access default workspace.' );
 		const defaultWorkspaceId = this.editor.config.get( 'ckbox.defaultUploadWorkspaceId' );
-		const workspaceId = getWorkspaceId( this._token, defaultWorkspaceId );
+		const workspaceId = getWorkspaceId( await this._token, defaultWorkspaceId );
 
 		if ( workspaceId == null ) {
 			/**
@@ -222,17 +222,17 @@ export default class CKBoxUtils extends Plugin {
 			return undefined;
 		}
 
-		function fetchCategories( offset: number ): Promise<{ totalCount: number; items: Array<AvailableCategory> }> {
+		async function fetchCategories( offset: number ): Promise<{ totalCount: number; items: Array<AvailableCategory> }> {
 			const categoryUrl = new URL( 'categories', serviceOrigin );
 
 			categoryUrl.searchParams.set( 'limit', String( ITEMS_PER_REQUEST ) );
 			categoryUrl.searchParams.set( 'offset', String( offset ) );
-			categoryUrl.searchParams.set( 'workspaceId', workspaceId );
+			categoryUrl.searchParams.set( 'workspaceId', await workspaceId );
 
 			return sendHttpRequest( {
 				url: categoryUrl,
 				signal,
-				authorization: token.value
+				authorization: ( await token ).value
 			} );
 		}
 	}

--- a/packages/ckeditor5-ckbox/src/ckboxutils.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxutils.ts
@@ -192,7 +192,7 @@ export default class CKBoxUtils extends Plugin {
 		const token = this._token;
 		const { signal } = options;
 		const serviceOrigin = editor.config.get( 'ckbox.serviceOrigin' )!;
-		const workspaceId = this.getWorkspaceId();
+		const workspaceId = await this.getWorkspaceId();
 
 		try {
 			const result: Array<AvailableCategory> = [];
@@ -227,7 +227,7 @@ export default class CKBoxUtils extends Plugin {
 
 			categoryUrl.searchParams.set( 'limit', String( ITEMS_PER_REQUEST ) );
 			categoryUrl.searchParams.set( 'offset', String( offset ) );
-			categoryUrl.searchParams.set( 'workspaceId', await workspaceId );
+			categoryUrl.searchParams.set( 'workspaceId', workspaceId );
 
 			return sendHttpRequest( {
 				url: categoryUrl,

--- a/packages/ckeditor5-ckbox/tests/ckboxuploadadapter.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxuploadadapter.js
@@ -996,7 +996,7 @@ describe( 'CKBoxUploadAdapter', () => {
 				for ( const { testName, workspaceId, tokenClaims } of testData ) {
 					it( testName, async () => {
 						TokenMock.initialToken = createToken( tokenClaims );
-						ckboxUtils._token.refreshToken();
+						( await ckboxUtils._token ).refreshToken();
 
 						sinonXHR.respondWith( 'GET', /\/categories/, [
 							200,
@@ -1035,9 +1035,9 @@ describe( 'CKBoxUploadAdapter', () => {
 			} );
 
 			describe( 'defaultUploadWorkspaceId is defined', () => {
-				it( 'should use the default workspace', () => {
+				it( 'should use the default workspace', async () => {
 					TokenMock.initialToken = createToken( { auth: { ckbox: { workspaces: [ 'workspace1', 'workspace2' ] } } } );
-					ckboxUtils._token.refreshToken();
+					( await ckboxUtils._token ).refreshToken();
 
 					sinonXHR.respondWith( 'GET', /\/categories/, [
 						200,
@@ -1075,9 +1075,9 @@ describe( 'CKBoxUploadAdapter', () => {
 						} );
 				} );
 
-				it( 'should use the default workspace when the user is superadmin', () => {
+				it( 'should use the default workspace when the user is superadmin', async () => {
 					TokenMock.initialToken = createToken( { auth: { ckbox: { role: 'superadmin' } } } );
-					ckboxUtils._token.refreshToken();
+					( await ckboxUtils._token ).refreshToken();
 
 					sinonXHR.respondWith( 'GET', /\/categories/, [
 						200,
@@ -1115,11 +1115,11 @@ describe( 'CKBoxUploadAdapter', () => {
 						} );
 				} );
 
-				it( 'should throw an error when default workspace is not listed in the token', () => {
+				it( 'should throw an error when default workspace is not listed in the token', async () => {
 					sinon.stub( console, 'error' );
 
 					TokenMock.initialToken = createToken( { auth: { ckbox: { workspaces: [ 'workspace1', 'workspace2' ] } } } );
-					ckboxUtils._token.refreshToken();
+					( await ckboxUtils._token ).refreshToken();
 
 					sinonXHR.respondWith( 'GET', /\/categories/, [
 						200,
@@ -1137,9 +1137,9 @@ describe( 'CKBoxUploadAdapter', () => {
 						.then( () => {
 							throw new Error( 'Expected to be rejected.' );
 						}, err => {
-							expect( console.error.callCount ).to.equal( 1 );
+							expect( console.error.callCount ).to.equal( 2 );
 							expect( console.error.firstCall.args[ 0 ] ).to.match( /^ckbox-access-default-workspace-error/ );
-							expect( err ).to.equal( 'Cannot access default workspace.' );
+							expect( err ).to.equal( 'Cannot determine a category for the uploaded file.' );
 						} );
 				} );
 			} );

--- a/packages/ckeditor5-ckbox/tests/ckboxuploadadapter.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxuploadadapter.js
@@ -1137,9 +1137,9 @@ describe( 'CKBoxUploadAdapter', () => {
 						.then( () => {
 							throw new Error( 'Expected to be rejected.' );
 						}, err => {
-							expect( console.error.callCount ).to.equal( 2 );
+							expect( console.error.callCount ).to.equal( 1 );
 							expect( console.error.firstCall.args[ 0 ] ).to.match( /^ckbox-access-default-workspace-error/ );
-							expect( err ).to.equal( 'Cannot determine a category for the uploaded file.' );
+							expect( err ).to.equal( 'Cannot access default workspace.' );
 						} );
 				} );
 			} );

--- a/packages/ckeditor5-ckbox/tests/ckboxutils.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxutils.js
@@ -65,15 +65,17 @@ describe( 'CKBoxUtils', () => {
 	} );
 
 	describe( 'getToken()', () => {
-		it( 'should return an instance of token', () => {
-			expect( ckboxUtils.getToken() ).to.be.instanceOf( Token );
+		it( 'should return an instance of token', async () => {
+			expect( await ckboxUtils.getToken() ).to.be.instanceOf( Token );
 		} );
 	} );
 
 	describe( 'fetching token', () => {
-		it( 'should create an instance of Token class which is ready to use (specified ckbox.tokenUrl)', () => {
-			expect( ckboxUtils.getToken() ).to.be.instanceOf( Token );
-			expect( ckboxUtils.getToken().value ).to.equal( token );
+		it( 'should create an instance of Token class which is ready to use (specified ckbox.tokenUrl)', async () => {
+			const resolvedToken = await ckboxUtils.getToken();
+
+			expect( resolvedToken ).to.be.instanceOf( Token );
+			expect( resolvedToken.value ).to.equal( token );
 			expect( editor.plugins.get( 'CloudServicesCore' ).tokenUrl ).to.equal( 'http://cs.example.com' );
 		} );
 
@@ -105,8 +107,10 @@ describe( 'CKBoxUtils', () => {
 				} );
 
 			const ckboxUtils = editor.plugins.get( CKBoxUtils );
-			expect( ckboxUtils.getToken() ).to.be.instanceOf( Token );
-			expect( ckboxUtils.getToken().value ).to.equal( token );
+			const resolvedToken = await ckboxUtils.getToken();
+
+			expect( resolvedToken ).to.be.instanceOf( Token );
+			expect( resolvedToken.value ).to.equal( token );
 			expect( editor.plugins.get( 'CloudServicesCore' ).tokenUrl ).to.equal( 'http://cs.example.com' );
 
 			editorElement.remove();
@@ -142,8 +146,10 @@ describe( 'CKBoxUtils', () => {
 				} );
 
 			const ckboxUtils = editor.plugins.get( CKBoxUtils );
-			expect( ckboxUtils.getToken() ).to.be.instanceOf( Token );
-			expect( ckboxUtils.getToken().value ).to.equal( token );
+			const resolvedToken = await ckboxUtils.getToken();
+
+			expect( resolvedToken ).to.be.instanceOf( Token );
+			expect( resolvedToken.value ).to.equal( token );
 			expect( editor.plugins.get( 'CloudServicesCore' ).tokenUrl ).to.equal( 'http://ckbox.example.com' );
 
 			editorElement.remove();
@@ -179,8 +185,10 @@ describe( 'CKBoxUtils', () => {
 				} );
 
 			const ckboxUtils = editor.plugins.get( CKBoxUtils );
-			expect( ckboxUtils.getToken() ).to.be.instanceOf( Token );
-			expect( ckboxUtils.getToken().value ).to.equal( token );
+			const resolvedToken = await ckboxUtils.getToken();
+
+			expect( resolvedToken ).to.be.instanceOf( Token );
+			expect( resolvedToken.value ).to.equal( token );
 			expect( editor.plugins.get( 'CloudServicesCore' ).tokenUrl ).to.equal( 'http://example.com' );
 
 			editorElement.remove();


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (ckbox): The plugin no longer slows down the editor startup because it fetches the token in the background instead of during the editor’s initialization. Closes https://github.com/ckeditor/ckeditor5/issues/16760

MINOR BREAKING CHANGE (ckbox): The `CKBoxUtils#getWorkspaceId` and `CKBoxUtils#getToken` methods now return a promise instead of a resolved value.
