### PR TITLE
Added './ckeditor5.css': './dist/ckeditor5.css' to the list of exports

### DIFF
--- a/scripts/release/utils/getckeditor5packagejson.js
+++ b/scripts/release/utils/getckeditor5packagejson.js
@@ -38,6 +38,7 @@ module.exports = function getCKEditor5PackageJson() {
 				'types': './dist/translations/*.d.ts',
 				'import': './dist/translations/*.js'
 			},
+			'./ckeditor5.css': './dist/ckeditor5.css',
 			'./*.css': './dist/*.css',
 			'./build/*': './build/*',
 			'./src/*': './src/*',


### PR DESCRIPTION
Including './ckeditor5.css': './dist/ckeditor5.css' to the list of exports for compatibility with some frameworks.

When integrating with Quasar (and other frameworks) there seemingly is a need to manually edit the node_mobuldes/ckeditor5/dist/package.json and add in the line "./ckeditor5.css": "./dist/ckeditor5.css" in order to expose the css for the editor to import into the component directly. Otherwise the editor's appearance is not displayed correctly.

