### PR TITLE
Use safer way for stringifying number in CKBox categories fetcher

### DIFF
--- a/packages/ckeditor5-ckbox/src/ckboxutils.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxutils.ts
@@ -225,8 +225,8 @@ export default class CKBoxUtils extends Plugin {
 		function fetchCategories( offset: number ): Promise<{ totalCount: number; items: Array<AvailableCategory> }> {
 			const categoryUrl = new URL( 'categories', serviceOrigin );
 
-			categoryUrl.searchParams.set( 'limit', ITEMS_PER_REQUEST.toString() );
-			categoryUrl.searchParams.set( 'offset', offset.toString() );
+			categoryUrl.searchParams.set( 'limit', String( ITEMS_PER_REQUEST ) );
+			categoryUrl.searchParams.set( 'offset', String( offset ) );
 			categoryUrl.searchParams.set( 'workspaceId', workspaceId );
 
 			return sendHttpRequest( {

--- a/packages/ckeditor5-ckbox/tests/ckboxutils.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxutils.js
@@ -562,6 +562,24 @@ describe( 'CKBoxUtils', () => {
 			sinonXHR.restore();
 		} );
 
+		// See: https://github.com/ckeditor/ckeditor5/issues/16040
+		it( 'should not use `Number#toString()` method due to minification issues on some bundlers', async () => {
+			const categories = createCategories( 10 );
+			const toStringSpy = sinon.spy( Number.prototype, 'toString' );
+
+			sinonXHR.respondWith( 'GET', CKBOX_API_URL + '/categories?limit=50&offset=0&workspaceId=workspace1', [
+				200,
+				{ 'Content-Type': 'application/json' },
+				JSON.stringify( {
+					items: categories, offset: 0, limit: 50, totalCount: 10
+				} )
+			] );
+
+			await ckboxUtils._getAvailableCategories( options );
+
+			expect( toStringSpy ).not.to.be.called;
+		} );
+
 		it( 'should return categories in one call', async () => {
 			const categories = createCategories( 10 );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ckbox): Use a safer way to convert numbers to strings to avoid issues with some bundlers. Closes https://github.com/ckeditor/ckeditor5/issues/16040

---

### Additional information

1. PR based on: https://github.com/ckeditor/ckeditor5/pull/16041
2. I added unit test to prevent regressions.
