### PR TITLE
PoC: Limit CSP impact of Font plugin and Text alignment

### DIFF
--- a/packages/ckeditor5-engine/src/view/domconverter.ts
+++ b/packages/ckeditor5-engine/src/view/domconverter.ts
@@ -512,9 +512,15 @@ export default class DomConverter {
 			domElement.removeAttribute( UNSAFE_ATTRIBUTE_NAME_PREFIX + key );
 		}
 
-		// If the attribute should not be rendered, rename it (instead of removing) to give developers some idea of what
-		// is going on (https://github.com/ckeditor/ckeditor5/issues/10801).
-		domElement.setAttribute( shouldRenderAttribute ? key : UNSAFE_ATTRIBUTE_NAME_PREFIX + key, value );
+		if ( shouldRenderAttribute && key === 'style' ) {
+			// The `style` attribute is a special case. It should be set as a property of the element, not as an attribute.
+			// This is because setting it as an attribute would not work if CSP is enabled with `style-src: 'self';` set.
+			domElement.style.cssText = value;
+		} else {
+			// If the attribute should not be rendered, rename it (instead of removing) to give developers some idea of what
+			// is going on (https://github.com/ckeditor/ckeditor5/issues/10801).
+			domElement.setAttribute( shouldRenderAttribute ? key : UNSAFE_ATTRIBUTE_NAME_PREFIX + key, value );
+		}
 	}
 
 	/**

--- a/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/domconverter.js
@@ -640,7 +640,7 @@ describe( 'DomConverter', () => {
 							'foo' +
 							'<span ' +
 								'class="foo-class" ' +
-								'style="border:1px solid blue" ' +
+								'style="border: 1px solid blue;" ' +
 								'data-foo="bar" ' +
 								'data-ck-unsafe-attribute-onclick="foobar">bar' +
 							'</span>' +
@@ -657,7 +657,7 @@ describe( 'DomConverter', () => {
 							'foo' +
 							'<span ' +
 								'class="foo-class" ' +
-								'style="border:1px solid blue" ' +
+								'style="border: 1px solid blue;" ' +
 								'data-foo="bar" ' +
 								'data-ck-unsafe-attribute-value="javascript:baz">bar' +
 							'</span>' +
@@ -674,7 +674,7 @@ describe( 'DomConverter', () => {
 							'foo' +
 							'<span ' +
 								'class="foo-class" ' +
-								'style="border:1px solid blue" ' +
+								'style="border: 1px solid blue;" ' +
 								'data-foo="bar" ' +
 								'data-ck-unsafe-attribute-value="data:text/html">bar' +
 							'</span>' +
@@ -691,7 +691,7 @@ describe( 'DomConverter', () => {
 							'foo' +
 							'<iframe ' +
 								'class="foo-class" ' +
-								'style="border:1px solid blue" ' +
+								'style="border: 1px solid blue;" ' +
 								'data-foo="bar" ' +
 								'data-ck-unsafe-attribute-srcdoc="<script>baz</script>">bar' +
 							'</iframe>' +
@@ -700,13 +700,13 @@ describe( 'DomConverter', () => {
 					{
 						html: '<div data-foo="bar">' +
 							'foo' +
-							'<span class="foo-class" style="border:1px solid blue" data-foo="bar" contenteditable="false">' +
+							'<span class="foo-class" style="border: 1px solid blue" data-foo="bar" contenteditable="false">' +
 							'bar' +
 							'</span>' +
 							'</div>',
 						expected: '<div data-foo="bar">' +
 							'foo' +
-							'<span class="foo-class" style="border:1px solid blue" data-foo="bar" contenteditable="false">' +
+							'<span class="foo-class" style="border: 1px solid blue;" data-foo="bar" contenteditable="false">' +
 							'bar' +
 							'</span>' +
 							'</div>'
@@ -745,7 +745,7 @@ describe( 'DomConverter', () => {
 				converter.setContentOf( element, html );
 
 				expect( element.innerHTML ).to.equal(
-					'<div>foo<span data-ck-unsafe-element="script" class="foo-class" style="foo-style" data-foo="bar">bar</span></div>'
+					'<div>foo<span data-ck-unsafe-element="script" class="foo-class" style="" data-foo="bar">bar</span></div>'
 				);
 			} );
 
@@ -1004,42 +1004,42 @@ describe( 'DomConverter', () => {
 			converter.setContentOf( domElement, html );
 
 			expect( domElement.outerHTML ).to.equal(
-				'<p>foo<span data-ck-unsafe-element="script" class="foo-class" style="foo-style" data-foo="bar">bar</span></p>'
+				'<p>foo<span data-ck-unsafe-element="script" class="foo-class" style="" data-foo="bar">bar</span></p>'
 			);
 
 			converter.removeDomElementAttribute( domElement.lastChild, 'data-ck-unsafe-element' );
 
 			expect( domElement.outerHTML ).to.equal(
-				'<p>foo<span data-ck-unsafe-element="script" class="foo-class" style="foo-style" data-foo="bar">bar</span></p>'
+				'<p>foo<span data-ck-unsafe-element="script" class="foo-class" style="" data-foo="bar">bar</span></p>'
 			);
 
 			converter.removeDomElementAttribute( domElement.lastChild, 'class' );
 
 			expect( domElement.outerHTML ).to.equal(
-				'<p>foo<span data-ck-unsafe-element="script" style="foo-style" data-foo="bar">bar</span></p>'
+				'<p>foo<span data-ck-unsafe-element="script" style="" data-foo="bar">bar</span></p>'
 			);
 		} );
 
 		it( 'should skip removing the (replacement) attribute representing the unsafe <style> tag', () => {
 			const domElement = document.createElement( 'p' );
-			const html = 'foo<style class="foo-class" style="foo-style" data-foo="bar">bar</style>';
+			const html = 'foo<style class="foo-class" style="" data-foo="bar">bar</style>';
 
 			converter.setContentOf( domElement, html );
 
 			expect( domElement.outerHTML ).to.equal(
-				'<p>foo<span data-ck-unsafe-element="style" class="foo-class" style="foo-style" data-foo="bar">bar</span></p>'
+				'<p>foo<span data-ck-unsafe-element="style" class="foo-class" style="" data-foo="bar">bar</span></p>'
 			);
 
 			converter.removeDomElementAttribute( domElement.lastChild, 'data-ck-unsafe-element' );
 
 			expect( domElement.outerHTML ).to.equal(
-				'<p>foo<span data-ck-unsafe-element="style" class="foo-class" style="foo-style" data-foo="bar">bar</span></p>'
+				'<p>foo<span data-ck-unsafe-element="style" class="foo-class" style="" data-foo="bar">bar</span></p>'
 			);
 
 			converter.removeDomElementAttribute( domElement.lastChild, 'class' );
 
 			expect( domElement.outerHTML ).to.equal(
-				'<p>foo<span data-ck-unsafe-element="style" style="foo-style" data-foo="bar">bar</span></p>'
+				'<p>foo<span data-ck-unsafe-element="style" style="" data-foo="bar">bar</span></p>'
 			);
 		} );
 	} );

--- a/packages/ckeditor5-engine/tests/view/renderer.js
+++ b/packages/ckeditor5-engine/tests/view/renderer.js
@@ -3420,10 +3420,12 @@ describe( 'Renderer', () => {
 			it( 'should handle styles change in replaced elements', () => {
 				const view = '' +
 					'<container:ol>' +
-						'<container:li style="color:#000;font-weight:bold;">Foo</container:li>' +
+						'<container:li style="color:rgb(0, 0, 0);font-weight:bold;">Foo</container:li>' +
 						'<container:li>Bar ' +
 							'<attribute:i>' +
-								'<attribute:b style="color:#00F;background-color:#000;font-size:12px;">Baz</attribute:b>' +
+								'<attribute:b style="color:rgb(0, 0, 255);background-color:rgb(0, 0, 0);font-size:12px;">' +
+									'Baz' +
+								'</attribute:b>' +
 							' Bax</attribute:i>' +
 						'</container:li>' +
 					'</container:ol>';
@@ -3434,8 +3436,9 @@ describe( 'Renderer', () => {
 				renderer.render();
 
 				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( normalizeHtml(
-					'<ol><li style="color:#000;font-weight:bold;">Foo</li>' +
-					'<li>Bar <i><b style="color:#00F;background-color:#000;font-size:12px;">Baz</b> Bax</i></li></ol>' ) );
+					'<ol><li style="color:rgb(0, 0, 0);font-weight:bold;">Foo</li>' +
+					'<li>Bar <i>' +
+					'<b style="color:rgb(0, 0, 255);background-color:rgb(0, 0, 0);font-size:12px;">Baz</b> Bax</i></li></ol>' ) );
 
 				const viewOL = viewRoot.getChild( 0 );
 				const viewLI1 = viewOL.getChild( 0 );
@@ -3456,8 +3459,8 @@ describe( 'Renderer', () => {
 				renderer.render();
 
 				expect( normalizeHtml( domRoot.innerHTML ) ).to.equal( normalizeHtml(
-					'<ol><li style="color:#FFF;">Foo</li>' +
-					'<li style="font-weight:bold;">Ba1 <i style="color:#000;border-width:1px;">Ba3 ' +
+					'<ol><li style="color:rgb(255, 255, 255);">Foo</li>' +
+					'<li style="font-weight:bold;">Ba1 <i style="color:rgb(0, 0, 0);border-width:1px;">Ba3 ' +
 					'<b style="font-size:15px;">Ba2</b></i></li></ol>' ) );
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (engine): Use `cssText` instead of `setAttribute('style', ..)` approach to set styling due to bypass CSP issues. 

## Additional information

Part of https://github.com/ckeditor/ckeditor5/issues/15509

1. Setting `setAttribute( 'style', 'color: red' )` with `style-src: 'self';` assigned to CSP throws an error `Refused to apply inline style because it violates the following Content Security Policy directive: "style-src 'self' [...]`
2. Setting `element.style.color = 'red';` works fine and nothing is being thrown, although there is an issue with removal of attributes from element. We cannot handle situation where `color` attribute is being removed, we can detect only changes.
3. Setting `element.style.cssText` seems to fix the issue above and does not throw error. 
