### PR TITLE
Fix (ckeditor5): Change the path to the types in the `package.json`.

### DIFF
--- a/scripts/release/utils/getckeditor5packagejson.js
+++ b/scripts/release/utils/getckeditor5packagejson.js
@@ -28,10 +28,10 @@ module.exports = function getCKEditor5PackageJson() {
 		type: 'module',
 		main: 'dist/ckeditor5.js',
 		module: 'dist/ckeditor5.js',
-		types: 'dist/types/index.d.ts',
+		types: 'dist/index.d.ts',
 		exports: {
 			'.': {
-				'types': './dist/types/index.d.ts',
+				'types': './dist/index.d.ts',
 				'import': './dist/ckeditor5.js'
 			},
 			'./translations/*.js': {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ckeditor5): Change the path to the types in the `package.json`. See #16684.

---

### Additional information

:warning: This PR targets the `release` branch! :warning: Blocked by the release of the new major version of `build-tools`.
