### PR TITLE
Close toolbars on open or close source view

### DIFF
--- a/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
@@ -399,13 +399,22 @@ export default class BalloonPanelView extends View {
 		// Hide the panel if the target element is no longer visible.
 		if ( targetElement && !this._resizeObserver ) {
 			const checkVisibility = () => {
-				if ( !targetElement.checkVisibility( { checkVisibilityCSS: false } ) ) {
-					this.isVisible = false;
+				// If the target element is no longer visible, hide the panel.
+				if ( !targetElement.checkVisibility() ) {
+					this.hide();
 				}
 			};
 
+			// Element is being resize to 0x0 after being hidden, so we need to
+			// check size in order to determine if it's visible or not.
 			this._resizeObserver = new ResizeObserver( targetElement, checkVisibility );
-			checkVisibility();
+
+			// Check the visibility of the target element immediately, as the target element might be
+			// already hidden when the panel is being pinned. It's wrapped in requestAnimationFrame because the
+			// `_startPinning` method is called during `pin()` and the panel is not yet visible, and not every listener
+			// has been attached yet. This way, we wait until rest of the listeners are attached in caller methods
+			// and then check the visibility.
+			window.requestAnimationFrame( checkVisibility );
 		}
 	}
 

--- a/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
@@ -260,7 +260,7 @@ export default class BalloonPanelView extends View {
 	 *
 	 * @param options Positioning options compatible with {@link module:utils/dom/position~getOptimalPosition}.
 	 * Default `positions` array is {@link module:ui/panel/balloon/balloonpanelview~BalloonPanelView.defaultPositions}.
-	 * @returns {Boolean} Whether the balloon was shown and successfully attached or not. Attaching can fail if the target
+	 * @returns Whether the balloon was shown and successfully attached or not. Attaching can fail if the target
 	 * provided in the options is invisible (e.g. element detached from DOM).
 	 */
 	public attachTo( options: Partial<PositionOptions> ): boolean {
@@ -388,7 +388,7 @@ export default class BalloonPanelView extends View {
 	 * Starts managing the pinned state of the panel. See {@link #pin}.
 	 *
 	 * @param options Positioning options compatible with {@link module:utils/dom/position~getOptimalPosition}.
-	 * @returns {Boolean} Whether the balloon was shown and successfully attached or not. Attaching can fail if the target
+	 * @returns Whether the balloon was shown and successfully attached or not. Attaching can fail if the target
 	 * provided in the options is invisible (e.g. element detached from DOM).
 	 */
 	private _startPinning( options: Partial<PositionOptions> ): boolean {

--- a/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
@@ -405,8 +405,8 @@ export default class BalloonPanelView extends View {
 				}
 			};
 
-			// Element is being resize to 0x0 after being hidden, so we need to
-			// check size in order to determine if it's visible or not.
+			// Element is being resized to 0x0 after it's parent became hidden,
+			// so we need to check size in order to determine if it's visible or not.
 			this._resizeObserver = new ResizeObserver( targetElement, checkVisibility );
 
 			// Check the visibility of the target element immediately, as the target element might be

--- a/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
@@ -260,8 +260,16 @@ export default class BalloonPanelView extends View {
 	 *
 	 * @param options Positioning options compatible with {@link module:utils/dom/position~getOptimalPosition}.
 	 * Default `positions` array is {@link module:ui/panel/balloon/balloonpanelview~BalloonPanelView.defaultPositions}.
+	 * @returns {Boolean} Whether the balloon was shown and successfully attached or not. Attaching can fail if the target
+	 * provided in the options is invisible (e.g. element detached from DOM).
 	 */
-	public attachTo( options: Partial<PositionOptions> ): void {
+	public attachTo( options: Partial<PositionOptions> ): boolean {
+		const target = getDomElement( options.target );
+
+		if ( target && !isVisible( target ) ) {
+			return false;
+		}
+
 		this.show();
 
 		const defaultPositions = BalloonPanelView.defaultPositions;
@@ -299,6 +307,8 @@ export default class BalloonPanelView extends View {
 		this.left = left;
 		this.position = position;
 		this.withArrow = withArrow;
+
+		return true;
 	}
 
 	/**
@@ -338,6 +348,10 @@ export default class BalloonPanelView extends View {
 	public pin( options: Partial<PositionOptions> ): void {
 		this.unpin();
 
+		if ( !this._startPinning( options ) ) {
+			return;
+		}
+
 		this._pinWhenIsVisibleCallback = () => {
 			if ( this.isVisible ) {
 				this._startPinning( options );
@@ -345,8 +359,6 @@ export default class BalloonPanelView extends View {
 				this._stopPinning();
 			}
 		};
-
-		this._startPinning( options );
 
 		// Control the state of the listeners depending on whether the panel is visible
 		// or not.
@@ -376,9 +388,13 @@ export default class BalloonPanelView extends View {
 	 * Starts managing the pinned state of the panel. See {@link #pin}.
 	 *
 	 * @param options Positioning options compatible with {@link module:utils/dom/position~getOptimalPosition}.
+	 * @returns {Boolean} Whether the balloon was shown and successfully attached or not. Attaching can fail if the target
+	 * provided in the options is invisible (e.g. element detached from DOM).
 	 */
-	private _startPinning( options: Partial<PositionOptions> ) {
-		this.attachTo( options );
+	private _startPinning( options: Partial<PositionOptions> ): boolean {
+		if ( !this.attachTo( options ) ) {
+			return false;
+		}
 
 		const targetElement = getDomElement( options.target );
 		const limiterElement = options.limiter ? getDomElement( options.limiter ) : global.document.body;
@@ -417,14 +433,9 @@ export default class BalloonPanelView extends View {
 			// Element is being resized to 0x0 after it's parent became hidden,
 			// so we need to check size in order to determine if it's visible or not.
 			this._resizeObserver = new ResizeObserver( targetElement, checkVisibility );
-
-			// Check the visibility of the target element immediately, as the target element might be
-			// already hidden when the panel is being pinned. It's wrapped in `requestAnimationFrame` because the
-			// `_startPinning` method is called during `pin()` and the panel is not yet visible, and not every listener
-			// has been attached yet. This way, we wait until rest of the listeners are attached in caller methods
-			// and then check the visibility.
-			window.requestAnimationFrame( checkVisibility );
 		}
+
+		return true;
 	}
 
 	/**

--- a/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
@@ -156,7 +156,7 @@ export default class BalloonPanelView extends View {
 	private _pinWhenIsVisibleCallback: ( () => void ) | null;
 
 	/**
-	 * A ResizeObserver instance used to watch if target element is still visible.
+	 * An instance of resize observer used to detect if target element is still visible.
 	 */
 	private _resizeObserver: ResizeObserver | null;
 
@@ -410,7 +410,7 @@ export default class BalloonPanelView extends View {
 			this._resizeObserver = new ResizeObserver( targetElement, checkVisibility );
 
 			// Check the visibility of the target element immediately, as the target element might be
-			// already hidden when the panel is being pinned. It's wrapped in requestAnimationFrame because the
+			// already hidden when the panel is being pinned. It's wrapped in `requestAnimationFrame` because the
 			// `_startPinning` method is called during `pin()` and the panel is not yet visible, and not every listener
 			// has been attached yet. This way, we wait until rest of the listeners are attached in caller methods
 			// and then check the visibility.

--- a/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
@@ -15,6 +15,7 @@ import {
 	global,
 	isRange,
 	toUnit,
+	isVisible,
 	ResizeObserver,
 	type Locale,
 	type ObservableChangeEvent,
@@ -200,6 +201,14 @@ export default class BalloonPanelView extends View {
 
 			children: this.content
 		} );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public override destroy(): void {
+		this.hide();
+		super.destroy();
 	}
 
 	/**
@@ -400,8 +409,8 @@ export default class BalloonPanelView extends View {
 		if ( targetElement && !this._resizeObserver ) {
 			const checkVisibility = () => {
 				// If the target element is no longer visible, hide the panel.
-				if ( !targetElement.checkVisibility() ) {
-					this.hide();
+				if ( !isVisible( targetElement ) ) {
+					this.unpin();
 				}
 			};
 

--- a/packages/ckeditor5-ui/src/tooltipmanager.ts
+++ b/packages/ckeditor5-ui/src/tooltipmanager.ts
@@ -13,7 +13,6 @@ import type { EditorUIUpdateEvent } from './editorui/editorui.js';
 
 import {
 	DomEmitterMixin,
-	ResizeObserver,
 	first,
 	global,
 	isVisible,
@@ -113,14 +112,6 @@ export default class TooltipManager extends /* #__PURE__ */ DomEmitterMixin() {
 	 * Stores the current tooltip position. `null` when there's no tooltip in the UI.
 	 */
 	private _currentTooltipPosition: TooltipPosition | null = null;
-
-	/**
-	 * An instance of the resize observer that keeps track on target element visibility,
-	 * when it hides the tooltip should also disappear.
-	 *
-	 * {@link module:core/editor/editorconfig~EditorConfig#balloonToolbar configuration}.
-	 */
-	private _resizeObserver: ResizeObserver | null = null;
 
 	/**
 	 * An instance of the mutation observer that keeps track on target element attributes changes.
@@ -428,14 +419,6 @@ export default class TooltipManager extends /* #__PURE__ */ DomEmitterMixin() {
 			positions: TooltipManager.getPositioningFunctions( position )
 		} );
 
-		this._resizeObserver = new ResizeObserver( targetDomElement, () => {
-			// The ResizeObserver will call its callback when the target element hides and the tooltip
-			// should also disappear (https://github.com/ckeditor/ckeditor5/issues/12492).
-			if ( !isVisible( targetDomElement ) ) {
-				this._unpinTooltip();
-			}
-		} );
-
 		this._mutationObserver!.attach( targetDomElement );
 
 		// Start responding to changes in editor UI or content layout. For instance, when collaborators change content
@@ -465,10 +448,6 @@ export default class TooltipManager extends /* #__PURE__ */ DomEmitterMixin() {
 		this._currentElementWithTooltip = null;
 		this._currentTooltipPosition = null;
 		this.tooltipTextView.text = '';
-
-		if ( this._resizeObserver ) {
-			this._resizeObserver.destroy();
-		}
 
 		this._mutationObserver!.detach();
 	}

--- a/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
+++ b/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
@@ -1027,31 +1027,25 @@ describe( 'BalloonPanelView', () => {
 				} );
 
 				it( 'should hide if the target is not visible (display: none)', () => {
-					const spy = sinon.spy( view, 'hide' );
+					const showSpy = sinon.spy( view, 'show' );
+					const hideSpy = sinon.spy( view, 'hide' );
 
 					target.style.display = 'none';
 					view.pin( { target, limiter } );
 
-					// Expect that hide is being called asynchronously.
-					sinon.assert.notCalled( spy );
-					clock.tick( 100 );
-
-					sinon.assert.calledOnce( spy );
-					expect( view.isVisible ).to.be.false;
+					sinon.assert.notCalled( hideSpy );
+					sinon.assert.notCalled( showSpy );
 				} );
 
 				it( 'should not hide if the target is not visible (visibility: hidden)', () => {
-					const spy = sinon.spy( view, 'hide' );
+					const showSpy = sinon.spy( view, 'show' );
+					const hideSpy = sinon.spy( view, 'hide' );
 
 					target.style.visibility = 'hidden';
 					view.pin( { target, limiter } );
 
-					// Expect that hide is being called asynchronously.
-					sinon.assert.notCalled( spy );
-					clock.tick( 100 );
-
-					sinon.assert.notCalled( spy );
-					expect( view.isVisible ).to.be.true;
+					sinon.assert.notCalled( hideSpy );
+					sinon.assert.calledOnce( showSpy );
 				} );
 
 				it( 'should hide if the target is being hidden (display: none)', () => {

--- a/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
+++ b/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
@@ -9,7 +9,7 @@ import ViewCollection from '../../../src/viewcollection.js';
 import BalloonPanelView from '../../../src/panel/balloon/balloonpanelview.js';
 import ButtonView from '../../../src/button/buttonview.js';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
-import { Rect } from '@ckeditor/ckeditor5-utils';
+import { Rect, ResizeObserver, global } from '@ckeditor/ckeditor5-utils';
 
 describe( 'BalloonPanelView', () => {
 	let view;
@@ -48,6 +48,10 @@ describe( 'BalloonPanelView', () => {
 
 		it( 'creates view#content collection', () => {
 			expect( view.content ).to.be.instanceOf( ViewCollection );
+		} );
+
+		it( 'should initialize _resizeObserver with null value', () => {
+			expect( view._resizeObserver ).to.be.null;
 		} );
 	} );
 
@@ -970,6 +974,118 @@ describe( 'BalloonPanelView', () => {
 
 				notRelatedElement.dispatchEvent( new Event( 'scroll' ) );
 				sinon.assert.calledTwice( attachToSpy );
+			} );
+
+			describe( 'observe element visibility', () => {
+				let clock;
+
+				beforeEach( () => {
+					clock = sinon.useFakeTimers();
+				} );
+
+				afterEach( () => {
+					clock.restore();
+				} );
+
+				it( 'should hide if the target is not visible (display: none)', () => {
+					const spy = sinon.spy( view, 'hide' );
+
+					target.style.display = 'none';
+					view.pin( { target, limiter } );
+
+					// Expect that hide is being called asynchronously.
+					sinon.assert.notCalled( spy );
+					clock.tick( 100 );
+
+					sinon.assert.calledOnce( spy );
+					expect( view.isVisible ).to.be.false;
+				} );
+
+				it( 'should not hide if the target is not visible (visibility: hidden)', () => {
+					const spy = sinon.spy( view, 'hide' );
+
+					target.style.visibility = 'hidden';
+					view.pin( { target, limiter } );
+
+					// Expect that hide is being called asynchronously.
+					sinon.assert.notCalled( spy );
+					clock.tick( 100 );
+
+					sinon.assert.notCalled( spy );
+					expect( view.isVisible ).to.be.true;
+				} );
+
+				it( 'should hide if the target is being hidden (display: none)', () => {
+					const resizeCallbackRef = createResizeObserverCallbackRef();
+
+					view.pin( { target, limiter } );
+					clock.tick( 100 );
+
+					expect( view.isVisible ).to.be.true;
+
+					// It's still visible, nothing changed.
+					resizeCallbackRef.current( [ { target } ] );
+					clock.tick( 100 );
+					expect( view.isVisible ).to.be.true;
+
+					// Hide the target and force call resize callback.
+					target.style.display = 'none';
+					resizeCallbackRef.current( [ { target } ] );
+
+					// It should be hidden now.
+					clock.tick( 100 );
+					expect( view.isVisible ).to.be.false;
+				} );
+
+				it( 'should not hide if the target is being hidden (visibility: hidden)', () => {
+					const resizeCallbackRef = createResizeObserverCallbackRef();
+
+					view.pin( { target, limiter } );
+					clock.tick( 100 );
+
+					expect( view.isVisible ).to.be.true;
+
+					// It's still visible, nothing changed.
+					resizeCallbackRef.current( [ { target } ] );
+					clock.tick( 100 );
+					expect( view.isVisible ).to.be.true;
+
+					// Hide the target and force call resize callback.
+					target.style.visibility = 'hidden';
+					resizeCallbackRef.current( [ { target } ] );
+
+					// It should be still visible.
+					clock.tick( 100 );
+					expect( view.isVisible ).to.be.true;
+				} );
+
+				it( 'should properly cleanup resize observer when stop pinning', () => {
+					view.pin( { target, limiter } );
+					clock.tick( 100 );
+
+					expect( view._resizeObserver ).not.to.be.null;
+
+					view.unpin();
+					clock.tick( 100 );
+
+					expect( view._resizeObserver ).to.be.null;
+				} );
+
+				function createResizeObserverCallbackRef() {
+					const resizeCallbackRef = { current: null };
+
+					ResizeObserver._observerInstance = null;
+					testUtils.sinon.stub( global.window, 'ResizeObserver' ).callsFake( callback => {
+						resizeCallbackRef.current = callback;
+
+						return {
+							observe() {},
+							unobserve() {}
+						};
+					} );
+
+					return resizeCallbackRef;
+				}
 			} );
 		} );
 

--- a/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
+++ b/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
@@ -55,6 +55,45 @@ describe( 'BalloonPanelView', () => {
 		} );
 	} );
 
+	describe( 'destroy()', () => {
+		it( 'should hide the panel if it is pinned', () => {
+			view.isVisible = false;
+
+			view.show();
+
+			expect( view.isVisible ).to.true;
+
+			view.destroy();
+
+			expect( view.isVisible ).to.false;
+		} );
+
+		it( 'should destroy the _resizeObserver if present', () => {
+			const target = document.createElement( 'div' );
+			const limiter = document.createElement( 'div' );
+
+			document.body.appendChild( target );
+			document.body.appendChild( limiter );
+
+			view.show();
+			view.pin( {
+				target,
+				limiter
+			} );
+
+			const spy = sinon.spy( view._resizeObserver, 'destroy' );
+
+			sinon.assert.notCalled( spy );
+
+			view.destroy();
+
+			sinon.assert.calledOnce( spy );
+
+			target.remove();
+			limiter.remove();
+		} );
+	} );
+
 	describe( 'DOM bindings', () => {
 		describe( 'arrow', () => {
 			it( 'should react on view#position', () => {

--- a/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
+++ b/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
@@ -1065,9 +1065,12 @@ describe( 'BalloonPanelView', () => {
 
 					expect( view._resizeObserver ).not.to.be.null;
 
+					const destroyObserverSpy = sinon.spy( view._resizeObserver, 'destroy' );
+
 					view.unpin();
 					clock.tick( 100 );
 
+					expect( destroyObserverSpy ).to.be.calledOnce;
 					expect( view._resizeObserver ).to.be.null;
 				} );
 

--- a/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
+++ b/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
@@ -873,7 +873,7 @@ describe( 'TooltipManager', () => {
 				// ResizeObserver is asynchronous.
 				await wait( 100 );
 
-				sinon.assert.calledOnce( unpinSpy );
+				sinon.assert.called( unpinSpy );
 			} );
 
 			it( 'should unpin if the element that it was attached was hidden in CSS', async () => {
@@ -897,7 +897,7 @@ describe( 'TooltipManager', () => {
 				// ResizeObserver is asynchronous.
 				await wait( 100 );
 
-				sinon.assert.calledOnce( unpinSpy );
+				sinon.assert.called( unpinSpy );
 			} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Hide the pinned balloon panel view when the pin target is no longer visible. Closes https://github.com/ckeditor/ckeditor5/issues/16739. 

### Additional information

#### Before

https://github.com/user-attachments/assets/7c859ea6-8d94-49b8-a4c4-31ad788ae384

#### After

https://github.com/user-attachments/assets/98bc68b0-7be6-4fe4-bc8a-1b499a329228

#### Debug info

1. `SourceEditing` fires `change:isSourceEditingMode` after toggling source editing mode.
2. Some of the commands (e.g. `TableColumnResizeEditing`) tend to trigger `update ui` event while calling `_disableCommands` in `change:isSourceEditingMode` listener placed inside `SourceEditing` plugin.
3. These plugins tend to modify content or classes of editable, causing `update ui` to be fired, which lead to pin every tooltip again, even if pin target is hidden. 
4. I added pin target visibility watcher in balloon panel view and it looks ok. 