### PR TITLE
Fix issues with loading CSS and translations in older bundlers

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -206,10 +206,12 @@ jobs:
           name: Check if packages are ready to be released
           command:
             yarn run release:prepare-packages --compile-only --verbose
-      - run:
-          name: Lint generated packages
-          command:
-            yarn run release:lint-packages
+      
+      # Commented out due to a limitation of publint: https://github.com/bluwy/publint/issues/105
+      # - run:
+      #     name: Lint generated packages
+      #     command:
+      #       yarn run release:lint-packages
 
   notify_ci_failure:
     machine: true

--- a/scripts/release/utils/getckeditor5packagejson.js
+++ b/scripts/release/utils/getckeditor5packagejson.js
@@ -34,11 +34,8 @@ module.exports = function getCKEditor5PackageJson() {
 				'types': './dist/types/index.d.ts',
 				'import': './dist/ckeditor5.js'
 			},
-			'./translations/*.js': {
-				'types': './dist/translations/*.d.ts',
-				'import': './dist/translations/*.js'
-			},
-			'./*.css': './dist/*.css',
+			'./*': './dist/*',
+			'./browser/*': null,
 			'./build/*': './build/*',
 			'./src/*': './src/*',
 			'./package.json': './package.json'


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ckeditor5): Update the `exports` field in `package.json` to fix issues with loading CSS and translations in older bundlers. See #16638.

Internal: Remove the "Lint generated packages" step from CI due to a limitation of the validation library.

---

### Additional information

:warning: This PR targets the `release` branch! :warning: 
