### PR TITLE
Docs: Fix table styling example having wrong structure

### DIFF
--- a/packages/ckeditor5-table/docs/features/tables-styling.md
+++ b/packages/ckeditor5-table/docs/features/tables-styling.md
@@ -190,14 +190,14 @@ const tableConfig = {
 				width: '550px',
 				height: '450px'
 			},
-			// The default styles for table cells in the editor.
-			// They should be synchronized with the content styles.
+		},
+		// The default styles for table cells in the editor.
+		// They should be synchronized with the content styles.
 		tableCellProperties: {
 			defaultProperties: {
 				horizontalAlignment: 'center',
 				verticalAlignment: 'bottom',
 				padding: '10px'
-			}
 			}
 		}
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs table: Fix table styling example having wrong structure

---

### Additional information

If you use the current example in the documentation you'll get this error when building:

```
ERROR in /srv/http/iTop/js/ckeditor/src/ckeditor.ts
219:16-225:17
[tsl] ERROR in /srv/http/iTop/js/ckeditor/src/ckeditor.ts(219,17)
      TS2322: Type '{ defaultProperties: { borderStyle: string; borderColor: string; borderWidth: string; alignment: string; width: string; height: string; }; tableCellProperties: { defaultProperties: { horizontalAlignment: string; verticalAlignment: string; padding: string; }; }; }' is not assignable to type 'TablePropertiesConfig'.
  Object literal may only specify known properties, and 'tableCellProperties' does not exist in type 'TablePropertiesConfig'.
ts-loader-default_e3b0c44298fc1c14
``` 

Fixing the example structure allows to build and to set the default table style to CKEditor build
