### PR TITLE
Pagination fails to recalculate and adds empty page to the document when inserting manual page break in some scenarios

### DIFF
--- a/packages/ckeditor5-page-break/theme/pagebreak.css
+++ b/packages/ckeditor5-page-break/theme/pagebreak.css
@@ -50,4 +50,16 @@
 			display: none;
 		}
 	}
+
+	/*
+	 * From time to time placing page-break directly after a block element with margin causes appending a new blank page in pagination mode.
+	 * Removing margin-bottom from the block element fixes that issue and the margin is not being moved to the next blank page.
+	 *
+	 * Keep this in sync with the pagination plugins.
+	 *
+	 * See more: https://github.com/cksource/ckeditor5-commercial/issues/6289#top
+	 */
+	.ck-content *:has(+ .page-break) {
+		margin-bottom: 0;
+	}
 }

--- a/packages/ckeditor5-page-break/theme/pagebreak.css
+++ b/packages/ckeditor5-page-break/theme/pagebreak.css
@@ -57,7 +57,7 @@
 	 *
 	 * Keep this in sync with the pagination plugins.
 	 *
-	 * See more: https://github.com/cksource/ckeditor5-commercial/issues/6289#top
+	 * See more: https://github.com/cksource/ckeditor5-commercial/issues/6289.
 	 */
 	.ck-content *:has(+ .page-break) {
 		margin-bottom: 0;

--- a/packages/ckeditor5-page-break/theme/pagebreak.css
+++ b/packages/ckeditor5-page-break/theme/pagebreak.css
@@ -56,8 +56,6 @@
 	 * Removing margin-bottom from the block element fixes that issue and the margin is not being moved to the next blank page.
 	 *
 	 * Keep this in sync with the pagination plugins.
-	 *
-	 * See more: https://github.com/cksource/ckeditor5-commercial/issues/6289.
 	 */
 	.ck-content *:has(+ .page-break) {
 		margin-bottom: 0;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (page-break): No longer generate extra empty page after placing page-break after element with margin.

---

### Additional information

Closes https://github.com/cksource/ckeditor5-commercial/issues/6289
Commercial PR: https://github.com/cksource/ckeditor5-commercial/pull/6437
Look at this demo: http://localhost:8125/ckeditor5/external/ckeditor5-commercial/packages/ckeditor5-pagination/tests/manual/pagination.html

#### Before

![obraz](https://github.com/user-attachments/assets/bbb24bcc-6b1f-4208-b992-57f672ac404c)

#### After

![obraz](https://github.com/user-attachments/assets/afcbb2c0-49a5-4dbd-8f7f-a2f44406985c)