### PR TITLE
Fix `todoListChecked` data lost in to-do list

### DIFF
--- a/packages/ckeditor5-list/src/list/converters.ts
+++ b/packages/ckeditor5-list/src/list/converters.ts
@@ -81,6 +81,7 @@ export function listItemUpcastConverter(): GetCallback<UpcastElementEvent> {
 
 		const listItemId = ListItemUid.next();
 		const listIndent = getIndent( data.viewItem );
+		const todoListChecked = isTodoListChecked( items );
 		let listType = data.viewItem.parent && data.viewItem.parent.is( 'element', 'ol' ) ? 'numbered' : 'bulleted';
 
 		// Preserve list type if was already set (for example by to-do list feature).
@@ -93,7 +94,10 @@ export function listItemUpcastConverter(): GetCallback<UpcastElementEvent> {
 		const attributes = {
 			listItemId,
 			listIndent,
-			listType
+			listType,
+			// In some cases we need to set value of `todoListChecked` attribute in to-do lists.
+			// See: https://github.com/ckeditor/ckeditor5/issues/15602#top.
+			...( ( listType === 'todo' ) && todoListChecked ? { todoListChecked } : null )
 		};
 
 		for ( const item of items ) {
@@ -710,4 +714,15 @@ function shouldUseBogusParagraph(
 	}
 
 	return blocks.length < 2;
+}
+
+// Returns `true` if at least one item have `todoListChecked` attribute set on `true`.
+function isTodoListChecked( items: Array<Element> ) {
+	for ( let i = 0; i < items.length; i++ ) {
+		if ( items[ i ].getAttribute( 'todoListChecked' ) ) {
+			return true;
+		}
+	}
+
+	return false;
 }

--- a/packages/ckeditor5-list/src/list/converters.ts
+++ b/packages/ckeditor5-list/src/list/converters.ts
@@ -81,7 +81,6 @@ export function listItemUpcastConverter(): GetCallback<UpcastElementEvent> {
 
 		const listItemId = ListItemUid.next();
 		const listIndent = getIndent( data.viewItem );
-		const todoListChecked = isTodoListChecked( items );
 		let listType = data.viewItem.parent && data.viewItem.parent.is( 'element', 'ol' ) ? 'numbered' : 'bulleted';
 
 		// Preserve list type if was already set (for example by to-do list feature).
@@ -94,10 +93,7 @@ export function listItemUpcastConverter(): GetCallback<UpcastElementEvent> {
 		const attributes = {
 			listItemId,
 			listIndent,
-			listType,
-			// In some cases we need to set value of `todoListChecked` attribute in to-do lists.
-			// See: https://github.com/ckeditor/ckeditor5/issues/15602#top.
-			...( ( listType === 'todo' ) && todoListChecked ? { todoListChecked } : null )
+			listType
 		};
 
 		for ( const item of items ) {
@@ -714,15 +710,4 @@ function shouldUseBogusParagraph(
 	}
 
 	return blocks.length < 2;
-}
-
-// Returns `true` if at least one item have `todoListChecked` attribute set on `true`.
-function isTodoListChecked( items: Array<Element> ) {
-	for ( let i = 0; i < items.length; i++ ) {
-		if ( items[ i ].getAttribute( 'todoListChecked' ) ) {
-			return true;
-		}
-	}
-
-	return false;
 }

--- a/packages/ckeditor5-list/src/todolist/todolistediting.ts
+++ b/packages/ckeditor5-list/src/todolist/todolistediting.ts
@@ -406,7 +406,7 @@ function todoListItemUpcastConverter(): GetCallback<UpcastElementEvent> {
 			return;
 		}
 
-		// Group to-do list items by their listItemId attribute to ensure that all items of the same list have the same checked state.
+		// Group to-do list items by their listItemId attribute to ensure that all items of the same list item have the same checked state.
 		const groupedItems = Array
 			.from( data.modelRange.getItems( { shallow: true } ) )
 			.filter( ( item ): item is Element =>

--- a/packages/ckeditor5-list/src/todolist/todolistediting.ts
+++ b/packages/ckeditor5-list/src/todolist/todolistediting.ts
@@ -427,7 +427,7 @@ function todoListItemUpcastConverter(): GetCallback<UpcastElementEvent> {
 		// that has checked state set to true. In such cases, we need to ensure that all items of the same list have the same checked state.
 		// See more: https://github.com/ckeditor/ckeditor5/issues/15602
 		for ( const [ , items ] of groupedItems.entries() ) {
-			if ( [ ...items ].some( item => item.getAttribute( 'todoListChecked' ) ) ) {
+			if ( items.some( item => item.getAttribute( 'todoListChecked' ) ) ) {
 				for ( const item of items ) {
 					writer.setAttribute( 'todoListChecked', true, item );
 				}

--- a/packages/ckeditor5-list/src/todolist/todolistediting.ts
+++ b/packages/ckeditor5-list/src/todolist/todolistediting.ts
@@ -32,7 +32,7 @@ import {
 
 import { Plugin } from 'ckeditor5/src/core.js';
 
-import { isFirstBlockOfListItem, isListItemBlock } from '../list/utils/model.js';
+import { getAllListItemBlocks, isFirstBlockOfListItem, isListItemBlock } from '../list/utils/model.js';
 import ListEditing, {
 	type ListEditingCheckElementEvent,
 	type ListEditingPostFixerEvent
@@ -414,10 +414,10 @@ function todoListItemUpcastConverter(): GetCallback<UpcastElementEvent> {
 			)
 			.reduce( ( acc, item ) => {
 				const listItemId = item.getAttribute( 'listItemId' ) as string;
-				const items = acc.get( listItemId ) || [];
 
-				items.push( item );
-				acc.set( listItemId, items );
+				if ( !acc.has( listItemId ) ) {
+					acc.set( listItemId, getAllListItemBlocks( item ) );
+				}
 
 				return acc;
 			}, new Map<string, Array<Element>>() );
@@ -427,7 +427,7 @@ function todoListItemUpcastConverter(): GetCallback<UpcastElementEvent> {
 		// that has checked state set to true. In such cases, we need to ensure that all items of the same list have the same checked state.
 		// See more: https://github.com/ckeditor/ckeditor5/issues/15602
 		for ( const [ , items ] of groupedItems.entries() ) {
-			if ( items.some( item => item.getAttribute( 'todoListChecked' ) ) ) {
+			if ( [ ...items ].some( item => item.getAttribute( 'todoListChecked' ) ) ) {
 				for ( const item of items ) {
 					writer.setAttribute( 'todoListChecked', true, item );
 				}

--- a/packages/ckeditor5-list/tests/todolist/todolistediting.js
+++ b/packages/ckeditor5-list/tests/todolist/todolistediting.js
@@ -203,6 +203,18 @@ describe( 'TodoListEditing', () => {
 			);
 		} );
 
+		it( 'should convert li with a checkbox and a paragraph ( when checked )', () => {
+			testUpcast(
+				'<ul>' +
+					'<li>' +
+						'<input type="checkbox" checked="checked">' +
+						'<p>foo</p>' +
+					'</li>' +
+				'</ul>',
+				'<paragraph listIndent="0" listItemId="a00" listType="todo" todoListChecked="true">foo</paragraph>'
+			);
+		} );
+
 		it( 'should convert li with a checkbox and two paragraphs', () => {
 			testUpcast(
 				'<ul>' +

--- a/packages/ckeditor5-list/tests/todolist/todolistediting.js
+++ b/packages/ckeditor5-list/tests/todolist/todolistediting.js
@@ -215,6 +215,41 @@ describe( 'TodoListEditing', () => {
 			);
 		} );
 
+		it( 'should convert nested li with a checkbox and a paragraph ( when checked )', () => {
+			testUpcast(
+				'<ul>' +
+					'<li>' +
+						'<input type="checkbox">' +
+						'<ul>' +
+							'<li>' +
+								'<input type="checkbox" checked="checked">' +
+								'<p>foo</p>' +
+							'</li>' +
+						'</ul>' +
+					'</li>' +
+				'</ul>',
+				'<paragraph listIndent="0" listItemId="a01" listType="todo"></paragraph>' +
+				'<paragraph listIndent="1" listItemId="a00" listType="todo" todoListChecked="true">foo</paragraph>'
+			);
+		} );
+
+		it( 'should not convert nested li if it was already consumed', () => {
+			editor.data.upcastDispatcher.on( 'element:li', ( evt, data, conversionApi ) => {
+				conversionApi.consumable.consume( data.viewItem, { name: true } );
+			}, { priority: 'highest' } );
+
+			editor.setData(
+				'<ul>' +
+					'<li>' +
+						'<input type="checkbox" checked="checked">' +
+						'<p>foo</p>' +
+					'</li>' +
+				'</ul>'
+			);
+
+			expect( getModelData( model, { withoutSelection: true } ) ).to.equal( '<paragraph></paragraph>' );
+		} );
+
 		it( 'should convert li with a checkbox and two paragraphs', () => {
 			testUpcast(
 				'<ul>' +


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (List): Should not lost data of `todoListChecked` attribute in to-do lists. Closes #15602.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
