### PR TITLE
Fixes related to merge fields feature

### DIFF
--- a/packages/ckeditor5-code-block/src/codeblockediting.ts
+++ b/packages/ckeditor5-code-block/src/codeblockediting.ts
@@ -139,9 +139,12 @@ export default class CodeBlockEditing extends Plugin {
 			isBlock: true
 		} );
 
-		// Disallow all attributes on `$text` inside `codeBlock`.
-		schema.addAttributeCheck( context => {
-			if ( context.endsWith( 'codeBlock $text' ) ) {
+		// Disallow formatting attributes on `codeBlock` children.
+		schema.addAttributeCheck( ( context, attributeName ) => {
+			const parent = context.getItem( context.length - 2 );
+			const isFormatting = schema.getAttributeProperties( attributeName ).isFormatting;
+
+			if ( isFormatting && parent && parent.name == 'codeBlock' ) {
 				return false;
 			}
 		} );

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -150,9 +150,40 @@ describe( 'CodeBlockEditing', () => {
 		setModelData( model, '<codeBlock language="css">f[o]o</codeBlock>' );
 
 		editor.execute( 'alignment', { value: 'right' } );
+
+		expect( getModelData( model ) ).to.equal( '<codeBlock language="css">f[o]o</codeBlock>' );
+	} );
+
+	it( 'disallows for formatting attributes on nodes inside codeBlock #1 - text', () => {
+		setModelData( model, '<codeBlock language="css">f[o]o</codeBlock>' );
+
 		editor.execute( 'bold' );
 
 		expect( getModelData( model ) ).to.equal( '<codeBlock language="css">f[o]o</codeBlock>' );
+	} );
+
+	it( 'disallows for formatting attributes on nodes inside codeBlock #2 - object', () => {
+		model.schema.register( 'codeBlockObject', {
+			inheritAllFrom: '$inlineObject',
+			allowIn: 'codeBlock',
+			allowAttributes: [ 'bold' ]
+		} );
+
+		const isAllowed = model.schema.checkAttribute( [ '$root', 'codeBlock', 'bold' ], 'objId' );
+
+		expect( isAllowed ).to.be.false;
+	} );
+
+	it( 'allows for non-formatting attributes on nodes inside codeBlock', () => {
+		model.schema.register( 'codeBlockObject', {
+			inheritAllFrom: '$inlineObject',
+			allowIn: 'codeBlock',
+			allowAttributes: [ 'objId' ]
+		} );
+
+		const isAllowed = model.schema.checkAttribute( [ '$root', 'codeBlock', 'codeBlockObject' ], 'objId' );
+
+		expect( isAllowed ).to.be.true;
 	} );
 
 	describe( 'tab key handling', () => {

--- a/packages/ckeditor5-engine/src/index.ts
+++ b/packages/ckeditor5-engine/src/index.ts
@@ -111,6 +111,9 @@ export type { default as Selection, Selectable } from './model/selection.js';
 export type { default as TypeCheckable } from './model/typecheckable.js';
 export type { default as Writer } from './model/writer.js';
 
+// Model utils.
+export * from './model/utils/autoparagraphing.js';
+
 // Model Events.
 export type { DocumentChangeEvent } from './model/document.js';
 export type { DocumentSelectionChangeEvent } from './model/documentselection.js';

--- a/packages/ckeditor5-mention/src/mentionui.ts
+++ b/packages/ckeditor5-mention/src/mentionui.ts
@@ -706,6 +706,10 @@ export function createRegExp( marker: string, minimumCharacters: number ): RegEx
 	const openAfterCharacters = env.features.isRegExpUnicodePropertySupported ? '\\p{Ps}\\p{Pi}"\'' : '\\(\\[{"\'';
 	const mentionCharacters = '.';
 
+	// I wanted to make an util out of it, but since this regexp uses "u" flag, it became difficult.
+	// When "u" flag is used, the regexp has "strict" escaping rules, i.e. if you try to escape a character that does not need
+	// to be escaped, RegExp() will throw. It made it difficult to write a generic util, because different characters are
+	// allowed in different context. For example, escaping "-" sometimes was correct, but sometimes it threw an error.
 	marker = marker.replace( /[.*+?^${}()\-|[\]\\]/g, '\\$&' );
 
 	// The pattern consists of 3 groups:

--- a/packages/ckeditor5-mention/src/mentionui.ts
+++ b/packages/ckeditor5-mention/src/mentionui.ts
@@ -703,11 +703,13 @@ function getLastValidMarkerInText(
  */
 export function createRegExp( marker: string, minimumCharacters: number ): RegExp {
 	const numberOfCharacters = minimumCharacters == 0 ? '*' : `{${ minimumCharacters },}`;
-
 	const openAfterCharacters = env.features.isRegExpUnicodePropertySupported ? '\\p{Ps}\\p{Pi}"\'' : '\\(\\[{"\'';
 	const mentionCharacters = '.';
 
+	marker = marker.replace( /[.*+?^${}()\-|[\]\\]/g, '\\$&' );
+
 	// The pattern consists of 3 groups:
+	//
 	// - 0 (non-capturing): Opening sequence - start of the line, space or an opening punctuation character like "(" or "\"",
 	// - 1: The marker character,
 	// - 2: Mention input (taking the minimal length into consideration to trigger the UI),
@@ -715,6 +717,7 @@ export function createRegExp( marker: string, minimumCharacters: number ): RegEx
 	// The pattern matches up to the caret (end of string switch - $).
 	//               (0:      opening sequence       )(1:   marker  )(2:                typed mention              )$
 	const pattern = `(?:^|[ ${ openAfterCharacters }])([${ marker }])(${ mentionCharacters }${ numberOfCharacters })$`;
+
 	return new RegExp( pattern, 'u' );
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (mention): Escape mentions markers when building regular expression to prevent crashes when markers like '\\' are used. Closes #16818.

Internal (code-block): Disallow formatting attributes on nodes inside code block (instead of disallowing all attributes on text nodes). This is at the same time broader and more precise rule.