### PR TITLE
Permissions integration in CKBox

### DIFF
--- a/packages/ckeditor5-ckbox/lang/contexts.json
+++ b/packages/ckeditor5-ckbox/lang/contexts.json
@@ -2,6 +2,7 @@
   "Open file manager": "A toolbar button tooltip for opening the file browser that allows inserting an image or a file to the editor.",
   "Cannot determine a category for the uploaded file.": "A message is displayed when CKEditor 5 cannot associate an image with any of the categories defined in CKBox while uploading an asset.",
   "Cannot access default workspace.": "A message is displayed when the user is not authorised to access the CKBox workspace configured as default one.",
+	"No permission to image editing. Try to use file manager or contact you administrator instead.": "The title of the notification displayed when there is no permission to edit assets.",
   "Edit image": "Image toolbar button tooltip for opening a dialog to manipulate the image.",
   "Processing the edited image.": "A message stating that image editing is in progress.",
   "Server failed to process the image.": "A message is displayed when the server fails to process an image or doesn't respond.",

--- a/packages/ckeditor5-ckbox/lang/contexts.json
+++ b/packages/ckeditor5-ckbox/lang/contexts.json
@@ -2,7 +2,7 @@
   "Open file manager": "A toolbar button tooltip for opening the file browser that allows inserting an image or a file to the editor.",
   "Cannot determine a category for the uploaded file.": "A message is displayed when CKEditor 5 cannot associate an image with any of the categories defined in CKBox while uploading an asset.",
   "Cannot access default workspace.": "A message is displayed when the user is not authorised to access the CKBox workspace configured as default one.",
-	"No permission to image editing. Try to use file manager or contact you administrator instead.": "The title of the notification displayed when there is no permission to edit assets.",
+	"No permission for image editing. Try using the file manager or contact your administrator.": "The title of the notification displayed when there is no permission to edit assets.",
   "Edit image": "Image toolbar button tooltip for opening a dialog to manipulate the image.",
   "Processing the edited image.": "A message stating that image editing is in progress.",
   "Server failed to process the image.": "A message is displayed when the server fails to process an image or doesn't respond.",

--- a/packages/ckeditor5-ckbox/src/ckboxediting.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxediting.ts
@@ -469,7 +469,7 @@ function isLibraryLoaded(): boolean {
 }
 
 /**
- * Checks is access allowed to upload assets, if not it disables `imageUpload` and `ckboxImageEdit` commands.
+ * Checks is access allowed to upload assets.
  */
 async function isUploadPermissionGranted( editor: Editor ): Promise<boolean> {
 	const ckboxUtils = editor.plugins.get( CKBoxUtils );

--- a/packages/ckeditor5-ckbox/src/ckboxediting.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxediting.ts
@@ -470,18 +470,20 @@ async function verifyUploadAssetsPermission( editor: Editor ) {
 
 	const isCreateAssetAlowed = categories.some( category => category[ 'asset:create' ] );
 
-	if ( !isCreateAssetAlowed ) {
-		const uploadImageCommand = editor.commands.get( 'uploadImage' );
-		const imageEditingCommand = editor.commands.get( 'ckboxImageEdit' );
+	if ( isCreateAssetAlowed ) {
+		return;
+	}
 
-		if ( uploadImageCommand ) {
-			uploadImageCommand.isAccessAllowed = false;
-			uploadImageCommand.forceDisabled( COMMAND_FORCE_DISABLE_ID );
-		}
+	const uploadImageCommand = editor.commands.get( 'uploadImage' );
+	const imageEditingCommand = editor.commands.get( 'ckboxImageEdit' );
 
-		if ( imageEditingCommand ) {
-			imageEditingCommand.forceDisabled( COMMAND_FORCE_DISABLE_ID );
-		}
+	if ( uploadImageCommand ) {
+		uploadImageCommand.isAccessAllowed = false;
+		uploadImageCommand.forceDisabled( COMMAND_FORCE_DISABLE_ID );
+	}
+
+	if ( imageEditingCommand ) {
+		imageEditingCommand.forceDisabled( COMMAND_FORCE_DISABLE_ID );
 	}
 }
 

--- a/packages/ckeditor5-ckbox/src/ckboxediting.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxediting.ts
@@ -71,6 +71,7 @@ export default class CKBoxEditing extends Plugin {
 			editor.commands.add( 'ckbox', new CKBoxCommand( editor ) );
 		}
 
+		// Promise is not handled intentionally. Errors should be displayed in console if there are so.
 		isUploadPermissionGranted( editor ).then( ( isCreateAssetAllowed: boolean ) => {
 			if ( !isCreateAssetAllowed ) {
 				this._blockImageCommands();

--- a/packages/ckeditor5-ckbox/src/ckboxediting.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxediting.ts
@@ -72,7 +72,7 @@ export default class CKBoxEditing extends Plugin {
 		}
 
 		// Promise is not handled intentionally. Errors should be displayed in console if there are so.
-		isUploadPermissionGranted( editor ).then( ( isCreateAssetAllowed: boolean ) => {
+		isUploadPermissionGranted( editor ).then( isCreateAssetAllowed => {
 			if ( !isCreateAssetAllowed ) {
 				this._blockImageCommands();
 			}
@@ -479,21 +479,13 @@ async function isUploadPermissionGranted( editor: Editor ): Promise<boolean> {
 	const url = new URL( 'permissions', origin );
 	const { value } = await ckboxUtils.getToken();
 
-	const response = await sendHttpRequest( {
+	const response = ( await sendHttpRequest( {
 		url,
 		authorization: value,
 		signal: ( new AbortController() ).signal // Aborting is unnecessary.
-	} );
+	} ) ) as Record<string, CategoryPermission>;
 
-	const categories: Array<CategoryPermission> = [];
-
-	for ( const key in response ) {
-		categories.push( response[ key ] );
-	}
-
-	const isCreateAssetAllowed = Object.values( categories ).some( category => category[ 'asset:create' ] );
-
-	return isCreateAssetAllowed;
+	return Object.values( response ).some( category => category[ 'asset:create' ] );
 }
 
 type CategoryPermission = {

--- a/packages/ckeditor5-ckbox/src/ckboxediting.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxediting.ts
@@ -9,7 +9,6 @@
  * @module ckbox/ckboxediting
  */
 
-import type { InitializedToken } from '@ckeditor/ckeditor5-cloud-services';
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 import {
 	Range,
@@ -32,6 +31,9 @@ import CKBoxUploadAdapter from './ckboxuploadadapter.js';
 import CKBoxUtils from './ckboxutils.js';
 
 import type { ReplaceImageSourceCommand } from '@ckeditor/ckeditor5-image';
+import { sendHttpRequest } from './utils.js';
+
+const COMMAND_FORCE_DISABLE_ID = 'NoPermission';
 
 /**
  * The CKBox editing feature. It introduces the {@link module:ckbox/ckboxcommand~CKBoxCommand CKBox command} and
@@ -68,6 +70,8 @@ export default class CKBoxEditing extends Plugin {
 		if ( isLibraryLoaded() ) {
 			editor.commands.add( 'ckbox', new CKBoxCommand( editor ) );
 		}
+
+		verifyUploadAssetsPermission( editor );
 	}
 
 	/**
@@ -441,3 +445,40 @@ function shouldUpcastAttributeForNode( node: Node ) {
 function isLibraryLoaded(): boolean {
 	return !!window.CKBox;
 }
+
+/**
+ * Checks is access alowed to upload assets, if not it disables `imageUpload` and `ckboxImageEdit` commands.
+ */
+async function verifyUploadAssetsPermission( editor: Editor ) {
+	const ckboxUtils = editor.plugins.get( CKBoxUtils );
+	const origin = editor.config.get( 'ckbox.serviceOrigin' );
+
+	const url = new URL( origin + '/permissions' );
+	const { value } = await ckboxUtils.getToken();
+
+	const response = await sendHttpRequest( {
+		url,
+		authorization: value
+	} );
+
+	const categories: Array<CategoryPermission> = [];
+
+	for ( const key in response ) {
+		categories.push( response[ key ] );
+	}
+
+	const isCreateAssetAlowed = categories.map( category => category[ 'asset:create' ] ).some( ( item: boolean ) => item );
+
+	if ( !isCreateAssetAlowed ) {
+		const uploadImageCommand = editor.commands.get( 'uploadImage' )!;
+		const imageEditingCommand = editor.commands.get( 'ckboxImageEdit' )!;
+
+		uploadImageCommand.set( 'isAccessAlowed', false );
+		uploadImageCommand.forceDisabled( COMMAND_FORCE_DISABLE_ID );
+		imageEditingCommand.forceDisabled( COMMAND_FORCE_DISABLE_ID );
+	}
+}
+
+type CategoryPermission = {
+	[ key: string ]: boolean;
+};

--- a/packages/ckeditor5-ckbox/src/ckboxediting.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxediting.ts
@@ -447,7 +447,7 @@ function isLibraryLoaded(): boolean {
 }
 
 /**
- * Checks is access alowed to upload assets, if not it disables `imageUpload` and `ckboxImageEdit` commands.
+ * Checks is access allowed to upload assets, if not it disables `imageUpload` and `ckboxImageEdit` commands.
  */
 async function verifyUploadAssetsPermission( editor: Editor ) {
 	const ckboxUtils = editor.plugins.get( CKBoxUtils );
@@ -468,9 +468,9 @@ async function verifyUploadAssetsPermission( editor: Editor ) {
 		categories.push( response[ key ] );
 	}
 
-	const isCreateAssetAlowed = categories.some( category => category[ 'asset:create' ] );
+	const isCreateAssetAllowed = Object.values( categories ).some( category => category[ 'asset:create' ] );
 
-	if ( isCreateAssetAlowed ) {
+	if ( isCreateAssetAllowed ) {
 		return;
 	}
 

--- a/packages/ckeditor5-ckbox/src/ckboxediting.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxediting.ts
@@ -108,6 +108,9 @@ export default class CKBoxEditing extends Plugin {
 		return hasConfiguration || isLibraryLoaded();
 	}
 
+	/**
+	 * Blocks `uploadImage` and `ckboxImageEdit` commands.
+	 */
 	private _blockImageCommands(): void {
 		const editor = this.editor;
 		const uploadImageCommand = editor.commands.get( 'uploadImage' );

--- a/packages/ckeditor5-ckbox/src/ckboxediting.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxediting.ts
@@ -468,7 +468,7 @@ async function verifyUploadAssetsPermission( editor: Editor ) {
 		categories.push( response[ key ] );
 	}
 
-	const isCreateAssetAlowed = categories.map( category => category[ 'asset:create' ] ).some( ( item: boolean ) => item );
+	const isCreateAssetAlowed = categories.some( category => category[ 'asset:create' ] );
 
 	if ( !isCreateAssetAlowed ) {
 		const uploadImageCommand = editor.commands.get( 'uploadImage' );

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditui.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditui.ts
@@ -43,7 +43,7 @@ export default class CKBoxImageEditUI extends Plugin {
 				tooltip: true
 			} );
 
-			view.bind( 'label' ).to( uploadImageCommand, 'isAccessAlowed', isAccessAlowed => isAccessAlowed ?
+			view.bind( 'label' ).to( uploadImageCommand, 'isAccessAllowed', isAccessAllowed => isAccessAllowed ?
 				t( 'Edit image' ) :
 				t( 'No permission to image editing. Try to use file manager or contact you administrator instead.' )
 			);

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditui.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditui.ts
@@ -34,15 +34,19 @@ export default class CKBoxImageEditUI extends Plugin {
 
 		editor.ui.componentFactory.add( 'ckboxImageEdit', locale => {
 			const command = editor.commands.get( 'ckboxImageEdit' )!;
+			const uploadImageCommand = editor.commands.get( 'uploadImage' )!;
 			const view = new ButtonView( locale );
 			const t = locale.t;
 
 			view.set( {
-				label: t( 'Edit image' ),
 				icon: ckboxImageEditIcon,
 				tooltip: true
 			} );
 
+			view.bind( 'label' ).to( uploadImageCommand, 'isAccessAlowed', isAccessAlowed => isAccessAlowed ?
+				t( 'Edit image' ) :
+				t( 'No permission to image editing. Try to use file manager or contact you administrator instead.' )
+			);
 			view.bind( 'isOn' ).to( command, 'value', command, 'isEnabled', ( value, isEnabled ) => value && isEnabled );
 			view.bind( 'isEnabled' ).to( command );
 

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditui.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditui.ts
@@ -45,7 +45,7 @@ export default class CKBoxImageEditUI extends Plugin {
 
 			view.bind( 'label' ).to( uploadImageCommand, 'isAccessAllowed', isAccessAllowed => isAccessAllowed ?
 				t( 'Edit image' ) :
-				t( 'No permission to image editing. Try to use file manager or contact you administrator instead.' )
+				t( 'No permission for image editing. Try using the file manager or contact your administrator.' )
 			);
 			view.bind( 'isOn' ).to( command, 'value', command, 'isEnabled', ( value, isEnabled ) => value && isEnabled );
 			view.bind( 'isEnabled' ).to( command );

--- a/packages/ckeditor5-ckbox/src/utils.ts
+++ b/packages/ckeditor5-ckbox/src/utils.ts
@@ -135,7 +135,7 @@ export function sendHttpRequest( {
 	authorization
 }: {
 	url: URL;
-	signal: AbortSignal;
+	signal?: AbortSignal;
 	authorization: string;
 	method?: 'GET' | 'POST';
 	data?: FormData | null;
@@ -154,16 +154,18 @@ export function sendHttpRequest( {
 	};
 
 	return new Promise<any>( ( resolve, reject ) => {
-		signal.throwIfAborted();
-		signal.addEventListener( 'abort', abortCallback );
-
-		xhr.addEventListener( 'loadstart', () => {
+		if ( signal ) {
+			signal.throwIfAborted();
 			signal.addEventListener( 'abort', abortCallback );
-		} );
 
-		xhr.addEventListener( 'loadend', () => {
-			signal.removeEventListener( 'abort', abortCallback );
-		} );
+			xhr.addEventListener( 'loadstart', () => {
+				signal.addEventListener( 'abort', abortCallback );
+			} );
+
+			xhr.addEventListener( 'loadend', () => {
+				signal.removeEventListener( 'abort', abortCallback );
+			} );
+		}
 
 		xhr.addEventListener( 'error', () => {
 			reject();

--- a/packages/ckeditor5-ckbox/src/utils.ts
+++ b/packages/ckeditor5-ckbox/src/utils.ts
@@ -135,7 +135,7 @@ export function sendHttpRequest( {
 	authorization
 }: {
 	url: URL;
-	signal?: AbortSignal;
+	signal: AbortSignal;
 	authorization: string;
 	method?: 'GET' | 'POST';
 	data?: FormData | null;
@@ -154,18 +154,16 @@ export function sendHttpRequest( {
 	};
 
 	return new Promise<any>( ( resolve, reject ) => {
-		if ( signal ) {
-			signal.throwIfAborted();
+		signal.throwIfAborted();
+		signal.addEventListener( 'abort', abortCallback );
+
+		xhr.addEventListener( 'loadstart', () => {
 			signal.addEventListener( 'abort', abortCallback );
+		} );
 
-			xhr.addEventListener( 'loadstart', () => {
-				signal.addEventListener( 'abort', abortCallback );
-			} );
-
-			xhr.addEventListener( 'loadend', () => {
-				signal.removeEventListener( 'abort', abortCallback );
-			} );
-		}
+		xhr.addEventListener( 'loadend', () => {
+			signal.removeEventListener( 'abort', abortCallback );
+		} );
 
 		xhr.addEventListener( 'error', () => {
 			reject();

--- a/packages/ckeditor5-ckbox/tests/ckboxediting.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxediting.js
@@ -1848,7 +1848,7 @@ describe( 'CKBoxEditing', () => {
 			sinonXHR.restore();
 		} );
 
-		it( 'should not disable image upload command if access alowed', async () => {
+		it( 'should not disable image upload command if access allowed', async () => {
 			sinonXHR.respondWith( 'GET', CKBOX_API_URL + '/permissions', [
 				200,
 				{ 'Content-Type': 'application/json' },
@@ -1872,7 +1872,7 @@ describe( 'CKBoxEditing', () => {
 			expect( uploadImageCommand.isAccessAllowed ).to.be.true;
 		} );
 
-		it( 'should disable image upload command if access not alowed', async () => {
+		it( 'should disable image upload command if access not allowed', async () => {
 			sinonXHR.respondWith( 'GET', CKBOX_API_URL + '/permissions', [
 				200,
 				{ 'Content-Type': 'application/json' },
@@ -1896,7 +1896,7 @@ describe( 'CKBoxEditing', () => {
 			expect( uploadImageCommand.isAccessAllowed ).to.be.false;
 		} );
 
-		it( 'should not disable image upload command if access alowed ( CKBox loaded first )', async () => {
+		it( 'should not disable image upload command if access allowed ( CKBox loaded first )', async () => {
 			sinonXHR.respondWith( 'GET', CKBOX_API_URL + '/permissions', [
 				200,
 				{ 'Content-Type': 'application/json' },
@@ -1920,7 +1920,7 @@ describe( 'CKBoxEditing', () => {
 			expect( uploadImageCommand.isAccessAllowed ).to.be.true;
 		} );
 
-		it( 'should disable image upload command if access not alowed ( CKBox loaded first )', async () => {
+		it( 'should disable image upload command if access not allowed ( CKBox loaded first )', async () => {
 			sinonXHR.respondWith( 'GET', CKBOX_API_URL + '/permissions', [
 				200,
 				{ 'Content-Type': 'application/json' },

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditui.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditui.js
@@ -93,9 +93,9 @@ describe( 'CKBoxImageEditUI', () => {
 			expect( button.label ).to.equal( 'Edit image' );
 		} );
 
-		it( 'should have a label binded to #isAccessAlowed', () => {
+		it( 'should have a label binded to #isAccessAllowed', () => {
 			const uploadImageCommand = editor.commands.get( 'uploadImage' );
-			uploadImageCommand.set( 'isAccessAlowed', false );
+			uploadImageCommand.set( 'isAccessAllowed', false );
 
 			expect( button.label ).to.equal( 'No permission to image editing. Try to ' +
 				'use file manager or contact you administrator instead.' );

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditui.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditui.js
@@ -97,8 +97,8 @@ describe( 'CKBoxImageEditUI', () => {
 			const uploadImageCommand = editor.commands.get( 'uploadImage' );
 			uploadImageCommand.set( 'isAccessAllowed', false );
 
-			expect( button.label ).to.equal( 'No permission to image editing. Try to ' +
-				'use file manager or contact you administrator instead.' );
+			expect( button.label ).to.equal( 'No permission for image editing. Try ' +
+				'using the file manager or contact your administrator.' );
 		} );
 
 		it( 'should have an icon', () => {

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditui.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditui.js
@@ -93,6 +93,14 @@ describe( 'CKBoxImageEditUI', () => {
 			expect( button.label ).to.equal( 'Edit image' );
 		} );
 
+		it( 'should have a label binded to #isAccessAlowed', () => {
+			const uploadImageCommand = editor.commands.get( 'uploadImage' );
+			uploadImageCommand.set( 'isAccessAlowed', false );
+
+			expect( button.label ).to.equal( 'No permission to image editing. Try to ' +
+				'use file manager or contact you administrator instead.' );
+		} );
+
 		it( 'should have an icon', () => {
 			expect( button.icon ).to.match( /^<svg/ );
 		} );

--- a/packages/ckeditor5-image/lang/contexts.json
+++ b/packages/ckeditor5-image/lang/contexts.json
@@ -20,7 +20,7 @@
 	"From computer": "The label for the upload image from computer menu bar button (inside 'Image' menu).",
   	"Replace image from computer": "The label for the replace image by upload from computer toolbar button.",
 	"Upload failed": "The title of the notification displayed when upload fails.",
-	"No permission to upload from computer. Try to use file manager or contact you administrator instead.": "The title of the notification displayed when there is no permission to upload assets.",
+	"No permission to upload from computer. Try using the file manager or contact your administrator.": "The title of the notification displayed when there is no permission to upload assets.",
 	"Image toolbar": "The label used by assistive technologies describing an image toolbar attached to an image widget.",
 	"Resize image": "The label used for the dropdown in the image toolbar containing defined resize options.",
 	"Resize image to %0": "The label used for the standalone resize options buttons in the image toolbar.",

--- a/packages/ckeditor5-image/lang/contexts.json
+++ b/packages/ckeditor5-image/lang/contexts.json
@@ -20,6 +20,7 @@
 	"From computer": "The label for the upload image from computer menu bar button (inside 'Image' menu).",
   	"Replace image from computer": "The label for the replace image by upload from computer toolbar button.",
 	"Upload failed": "The title of the notification displayed when upload fails.",
+	"No permission to upload from computer. Try to use file manager or contact you administrator instead.": "The title of the notification displayed when there is no permission to upload assets.",
 	"Image toolbar": "The label used by assistive technologies describing an image toolbar attached to an image widget.",
 	"Resize image": "The label used for the dropdown in the image toolbar containing defined resize options.",
 	"Resize image to %0": "The label used for the standalone resize options buttons in the image toolbar.",

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
@@ -139,11 +139,16 @@ export default class ImageUploadEditing extends Plugin {
 			} );
 
 			const uploadImageCommand = editor.commands.get( 'uploadImage' )!;
-			const t = this.editor.locale.t;
 
-			if ( !uploadImageCommand.isAccessAlowed ) {
-				window.alert( t( 'No permission to upload from computer. Try to use file ' + // eslint-disable-line no-alert
-					'manager or contact you administrator instead.' ) );
+			if ( !uploadImageCommand.isAccessAllowed ) {
+				const notification: Notification = editor.plugins.get( 'Notification' );
+				const t = editor.locale.t;
+
+				// eslint-disable-next-line max-len
+				notification.showWarning( t( 'No permission to upload from computer. Try using the file manager or contact your administrator.' ), {
+					title: t( 'No permission' ),
+					namespace: 'image'
+				} );
 			}
 		} );
 

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
@@ -7,8 +7,6 @@
  * @module image/imageupload/imageuploadediting
  */
 
-/* globals window */
-
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 
 import {

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
@@ -7,6 +7,8 @@
  * @module image/imageupload/imageuploadediting
  */
 
+/* globals window */
+
 import { Plugin, type Editor } from 'ckeditor5/src/core.js';
 
 import {
@@ -135,6 +137,14 @@ export default class ImageUploadEditing extends Plugin {
 
 				editor.execute( 'uploadImage', { file: images } );
 			} );
+
+			const uploadImageCommand = editor.commands.get( 'uploadImage' )!;
+			const t = this.editor.locale.t;
+
+			if ( !uploadImageCommand.isAccessAlowed ) {
+				window.alert( t( 'No permission to upload from computer. Try to use file ' + // eslint-disable-line no-alert
+					'manager or contact you administrator instead.' ) );
+			}
 		} );
 
 		// Handle HTML pasted with images with base64 or blob sources.

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
@@ -146,7 +146,6 @@ export default class ImageUploadEditing extends Plugin {
 
 				// eslint-disable-next-line max-len
 				notification.showWarning( t( 'No permission to upload from computer. Try using the file manager or contact your administrator.' ), {
-					title: t( 'No permission' ),
 					namespace: 'image'
 				} );
 			}

--- a/packages/ckeditor5-image/src/imageupload/imageuploadui.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadui.ts
@@ -111,10 +111,10 @@ export default class ImageUploadUI extends Plugin {
 			imageInsertUI,
 			'isImageSelected',
 			uploadImageCommand,
-			'isAccessAlowed',
-			( isImageSelected, isAccessAlowed ) => {
-				if ( !isAccessAlowed ) {
-					return t( 'No permission to upload from computer. Try to use file manager or contact you administrator instead.' );
+			'isAccessAllowed',
+			( isImageSelected, isAccessAllowed ) => {
+				if ( !isAccessAllowed ) {
+					return t( 'No permission for image editing. Try using the file manager or contact your administrator.' );
 				}
 
 				return isImageSelected ? t( 'Replace image from computer' ) : t( 'Upload image from computer' );

--- a/packages/ckeditor5-image/src/imageupload/imageuploadui.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadui.ts
@@ -102,6 +102,7 @@ export default class ImageUploadUI extends Plugin {
 	private _createToolbarButton(): ButtonView {
 		const t = this.editor.locale.t;
 		const imageInsertUI: ImageInsertUI = this.editor.plugins.get( 'ImageInsertUI' );
+		const uploadImageCommand = this.editor.commands.get( 'uploadImage' )!;
 
 		const button = this._createButton( FileDialogButtonView );
 
@@ -109,7 +110,15 @@ export default class ImageUploadUI extends Plugin {
 		button.bind( 'label' ).to(
 			imageInsertUI,
 			'isImageSelected',
-			isImageSelected => isImageSelected ? t( 'Replace image from computer' ) : t( 'Upload image from computer' )
+			uploadImageCommand,
+			'isAccessAlowed',
+			( isImageSelected, isAccessAlowed ) => {
+				if ( !isAccessAlowed ) {
+					return t( 'No permission to upload from computer. Try to use file manager or contact you administrator instead.' );
+				}
+
+				return isImageSelected ? t( 'Replace image from computer' ) : t( 'Upload image from computer' );
+			}
 		);
 
 		return button;

--- a/packages/ckeditor5-image/src/imageupload/imageuploadui.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadui.ts
@@ -114,7 +114,7 @@ export default class ImageUploadUI extends Plugin {
 			'isAccessAllowed',
 			( isImageSelected, isAccessAllowed ) => {
 				if ( !isAccessAllowed ) {
-					return t( 'No permission for image editing. Try using the file manager or contact your administrator.' );
+					return t( 'No permission to upload from computer. Try using the file manager or contact your administrator.' );
 				}
 
 				return isImageSelected ? t( 'Replace image from computer' ) : t( 'Upload image from computer' );

--- a/packages/ckeditor5-image/src/imageupload/uploadimagecommand.ts
+++ b/packages/ckeditor5-image/src/imageupload/uploadimagecommand.ts
@@ -51,7 +51,7 @@ export default class UploadImageCommand extends Command {
 	 *
 	 * @observable
 	 */
-	declare public isAccessAlowed: boolean;
+	declare public isAccessAllowed: boolean;
 
 	/**
 	 * Creates an instance of the `imageUlpoad` command. When executed, the command upload one of
@@ -62,7 +62,7 @@ export default class UploadImageCommand extends Command {
 	constructor( editor: Editor ) {
 		super( editor );
 
-		this.set( 'isAccessAlowed', true );
+		this.set( 'isAccessAllowed', true );
 	}
 
 	/**

--- a/packages/ckeditor5-image/src/imageupload/uploadimagecommand.ts
+++ b/packages/ckeditor5-image/src/imageupload/uploadimagecommand.ts
@@ -49,6 +49,7 @@ export default class UploadImageCommand extends Command {
 	/**
 	 * The command property: `false` if there is no permission on image upload, otherwise `true`.
 	 *
+	 * @observable
 	 * @internal
 	 */
 	declare public isAccessAllowed: boolean;

--- a/packages/ckeditor5-image/src/imageupload/uploadimagecommand.ts
+++ b/packages/ckeditor5-image/src/imageupload/uploadimagecommand.ts
@@ -4,7 +4,7 @@
  */
 
 import { FileRepository } from 'ckeditor5/src/upload.js';
-import { Command } from 'ckeditor5/src/core.js';
+import { Command, type Editor } from 'ckeditor5/src/core.js';
 import { toArray, type ArrayOrItem } from 'ckeditor5/src/utils.js';
 import type { Position } from 'ckeditor5/src/engine.js';
 
@@ -46,6 +46,20 @@ import type ImageUtils from '../imageutils.js';
  * ```
  */
 export default class UploadImageCommand extends Command {
+	declare public isAccessAlowed: boolean;
+
+	/**
+	 * Creates an instance of the image ulpoad command. When executed, the command upload one of
+	 * the currently selected image from computer.
+	 *
+	 * @param editor The editor instance.
+	 */
+	constructor( editor: Editor ) {
+		super( editor );
+
+		this.set( 'isAccessAlowed', true );
+	}
+
 	/**
 	 * @inheritDoc
 	 */

--- a/packages/ckeditor5-image/src/imageupload/uploadimagecommand.ts
+++ b/packages/ckeditor5-image/src/imageupload/uploadimagecommand.ts
@@ -49,7 +49,7 @@ export default class UploadImageCommand extends Command {
 	declare public isAccessAlowed: boolean;
 
 	/**
-	 * Creates an instance of the image ulpoad command. When executed, the command upload one of
+	 * Creates an instance of the `imageUlpoad` command. When executed, the command upload one of
 	 * the currently selected image from computer.
 	 *
 	 * @param editor The editor instance.

--- a/packages/ckeditor5-image/src/imageupload/uploadimagecommand.ts
+++ b/packages/ckeditor5-image/src/imageupload/uploadimagecommand.ts
@@ -46,6 +46,11 @@ import type ImageUtils from '../imageutils.js';
  * ```
  */
 export default class UploadImageCommand extends Command {
+	/**
+	 * The command property: `false` if there is no permission on image upload, otherwise `true`.
+	 *
+	 * @observable
+	 */
 	declare public isAccessAlowed: boolean;
 
 	/**

--- a/packages/ckeditor5-image/src/imageupload/uploadimagecommand.ts
+++ b/packages/ckeditor5-image/src/imageupload/uploadimagecommand.ts
@@ -49,7 +49,7 @@ export default class UploadImageCommand extends Command {
 	/**
 	 * The command property: `false` if there is no permission on image upload, otherwise `true`.
 	 *
-	 * @observable
+	 * @internal
 	 */
 	declare public isAccessAllowed: boolean;
 

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
@@ -244,12 +244,20 @@ describe( 'ImageUploadEditing', () => {
 		);
 	} );
 
-	it( 'should display alert when no permission to upload from compouter.', () => {
+	it( 'should display notification when no permission to upload from computer.', done => {
 		const files = [ createNativeFileMock(), createNativeFileMock() ];
 		const dataTransfer = new DataTransfer( { files, types: [ 'Files' ] } );
 		const uploadImageCommand = editor.commands.get( 'uploadImage' );
+		const notification = editor.plugins.get( Notification );
 
-		sinon.stub( window, 'alert' );
+		notification.on( 'show:warning', ( evt, data ) => {
+			tryExpect( done, () => {
+				expect( data.message ).to.equal( 'No permission to upload from computer. Try using the file manager ' +
+				'or contact your administrator.' );
+				evt.stop();
+			} );
+		}, { priority: 'high' } );
+
 		uploadImageCommand.set( 'isAccessAllowed', false );
 
 		setModelData( model, '[]' );
@@ -258,12 +266,6 @@ describe( 'ImageUploadEditing', () => {
 		const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
 
 		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
-
-		sinon.assert.calledOnce( window.alert );
-		expect( window.alert.firstCall.args[ 0 ] ).to.equal(
-			'No permission to upload from computer. Try using the file manager ' +
-			'or contact your administrator.'
-		);
 	} );
 
 	it( 'should insert image when is pasted on allowed position when UploadImageCommand is enabled', () => {

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
@@ -250,7 +250,7 @@ describe( 'ImageUploadEditing', () => {
 		const uploadImageCommand = editor.commands.get( 'uploadImage' );
 
 		sinon.stub( window, 'alert' );
-		uploadImageCommand.set( 'isAccessAlowed', false );
+		uploadImageCommand.set( 'isAccessAllowed', false );
 
 		setModelData( model, '[]' );
 
@@ -261,8 +261,8 @@ describe( 'ImageUploadEditing', () => {
 
 		sinon.assert.calledOnce( window.alert );
 		expect( window.alert.firstCall.args[ 0 ] ).to.equal(
-			'No permission to upload from computer. Try to use file manager ' +
-			'or contact you administrator instead.'
+			'No permission to upload from computer. Try using the file manager ' +
+			'or contact your administrator.'
 		);
 	} );
 

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
@@ -244,6 +244,28 @@ describe( 'ImageUploadEditing', () => {
 		);
 	} );
 
+	it( 'should display alert when no permission to upload from compouter.', () => {
+		const files = [ createNativeFileMock(), createNativeFileMock() ];
+		const dataTransfer = new DataTransfer( { files, types: [ 'Files' ] } );
+		const uploadImageCommand = editor.commands.get( 'uploadImage' );
+
+		sinon.stub( window, 'alert' );
+		uploadImageCommand.set( 'isAccessAlowed', false );
+
+		setModelData( model, '[]' );
+
+		const targetRange = model.createRange( model.createPositionAt( doc.getRoot(), 1 ), model.createPositionAt( doc.getRoot(), 1 ) );
+		const targetViewRange = editor.editing.mapper.toViewRange( targetRange );
+
+		viewDocument.fire( 'clipboardInput', { dataTransfer, targetRanges: [ targetViewRange ] } );
+
+		sinon.assert.calledOnce( window.alert );
+		expect( window.alert.firstCall.args[ 0 ] ).to.equal(
+			'No permission to upload from computer. Try to use file manager ' +
+			'or contact you administrator instead.'
+		);
+	} );
+
 	it( 'should insert image when is pasted on allowed position when UploadImageCommand is enabled', () => {
 		setModelData( model, '<paragraph>foo</paragraph>[<imageBlock></imageBlock>]' );
 

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadui.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadui.js
@@ -130,8 +130,9 @@ describe( 'ImageUploadUI', () => {
 			expect( buttonView.icon ).to.equal( icons.imageUpload );
 		} );
 
-		it( 'should bind to #isImageSelected', () => {
+		it( 'should bind to #isImageSelected and #isAccessAlowed', () => {
 			const insertImageUI = editor.plugins.get( 'ImageInsertUI' );
+			const uploadImageCommand = editor.commands.get( 'uploadImage' );
 
 			mockAnotherIntegration();
 
@@ -150,6 +151,17 @@ describe( 'ImageUploadUI', () => {
 			insertImageUI.isImageSelected = true;
 			expect( dropdownButton.label ).to.equal( 'Replace image from computer' );
 			expect( buttonView.label ).to.equal( 'Replace from computer' );
+
+			uploadImageCommand.isAccessAlowed = false;
+			expect( dropdownButton.label ).to.equal( 'No permission to upload from computer. ' +
+				'Try to use file manager or contact you administrator instead.' );
+			expect( buttonView.label ).to.equal( 'Replace from computer' );
+
+			insertImageUI.isImageSelected = false;
+			uploadImageCommand.isAccessAlowed = false;
+			expect( dropdownButton.label ).to.equal( 'No permission to upload from computer. ' +
+				'Try to use file manager or contact you administrator instead.' );
+			expect( buttonView.label ).to.equal( 'Upload from computer' );
 		} );
 
 		it( 'should close dropdown on execute', () => {

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadui.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadui.js
@@ -130,7 +130,7 @@ describe( 'ImageUploadUI', () => {
 			expect( buttonView.icon ).to.equal( icons.imageUpload );
 		} );
 
-		it( 'should bind to #isImageSelected and #isAccessAlowed', () => {
+		it( 'should bind to #isImageSelected and #isAccessAllowed', () => {
 			const insertImageUI = editor.plugins.get( 'ImageInsertUI' );
 			const uploadImageCommand = editor.commands.get( 'uploadImage' );
 
@@ -152,15 +152,15 @@ describe( 'ImageUploadUI', () => {
 			expect( dropdownButton.label ).to.equal( 'Replace image from computer' );
 			expect( buttonView.label ).to.equal( 'Replace from computer' );
 
-			uploadImageCommand.isAccessAlowed = false;
+			uploadImageCommand.isAccessAllowed = false;
 			expect( dropdownButton.label ).to.equal( 'No permission to upload from computer. ' +
-				'Try to use file manager or contact you administrator instead.' );
+				'Try using the file manager or contact your administrator.' );
 			expect( buttonView.label ).to.equal( 'Replace from computer' );
 
 			insertImageUI.isImageSelected = false;
-			uploadImageCommand.isAccessAlowed = false;
+			uploadImageCommand.isAccessAllowed = false;
 			expect( dropdownButton.label ).to.equal( 'No permission to upload from computer. ' +
-				'Try to use file manager or contact you administrator instead.' );
+				'Try using the file manager or contact your administrator.' );
 			expect( buttonView.label ).to.equal( 'Upload from computer' );
 		} );
 

--- a/packages/ckeditor5-image/tests/imageupload/uploadimagecommand.js
+++ b/packages/ckeditor5-image/tests/imageupload/uploadimagecommand.js
@@ -55,8 +55,8 @@ describe( 'UploadImageCommand', () => {
 	} );
 
 	describe( 'constructor()', () => {
-		it( 'should set `isAccessAlowed` on `true` when initialized', () => {
-			expect( command.isAccessAlowed ).to.be.true;
+		it( 'should set `isAccessAllowed` on `true` when initialized', () => {
+			expect( command.isAccessAllowed ).to.be.true;
 		} );
 	} );
 

--- a/packages/ckeditor5-image/tests/imageupload/uploadimagecommand.js
+++ b/packages/ckeditor5-image/tests/imageupload/uploadimagecommand.js
@@ -54,6 +54,12 @@ describe( 'UploadImageCommand', () => {
 		return editor.destroy();
 	} );
 
+	describe( 'constructor()', () => {
+		it( 'should set `isAccessAlowed` on `true` when initialized', () => {
+			expect( command.isAccessAlowed ).to.be.true;
+		} );
+	} );
+
 	describe( 'isEnabled', () => {
 		it( 'should be true when the selection directly in the root', () => {
 			model.enqueueChange( { isUndoable: false }, () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (ckbox, image): The image upload and edit buttons are disabled if the user has no permission to upload any asset.  

Closes https://github.com/cksource/ckeditor5-commercial/issues/6428.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
