### PR TITLE
Added exports for the `blockAutoformatEditing` and the `inlineAutoformatEditing`.

### DIFF
--- a/packages/ckeditor5-autoformat/src/index.ts
+++ b/packages/ckeditor5-autoformat/src/index.ts
@@ -8,5 +8,7 @@
  */
 
 export { default as Autoformat } from './autoformat.js';
+export { default as blockAutoformatEditing } from './blockautoformatediting.js';
+export { default as inlineAutoformatEditing } from './inlineautoformatediting.js';
 
 import './augmentation.js';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (autoformat): The `blockAutoformatEditing` and the `inlineAutoformatEditing` are now exported from the package index. Closes #16815.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
