### PR TITLE
Fix rendering children of raw elements with `dataPipeline:transparentRendering`

### DIFF
--- a/packages/ckeditor5-engine/src/view/domconverter.ts
+++ b/packages/ckeditor5-engine/src/view/domconverter.ts
@@ -563,7 +563,19 @@ export default class DomConverter {
 				!first( childView.getAttributes() );
 
 			if ( transparentRendering && this.renderingMode == 'data' ) {
-				yield* this.viewChildrenToDom( childView, options );
+				// `RawElement` doesn't have #children defined, so they need to be temporarily rendered
+				// and extracted directly.
+				if ( childView.is( 'rawElement' ) ) {
+					const tempElement = this._domDocument.createElement( childView.name );
+
+					childView.render( tempElement, this );
+
+					yield* [ ...tempElement.childNodes ];
+
+					tempElement.remove();
+				} else {
+					yield* this.viewChildrenToDom( childView, options );
+				}
 			} else {
 				if ( transparentRendering ) {
 					/**

--- a/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
+++ b/packages/ckeditor5-engine/tests/view/domconverter/view-to-dom.js
@@ -1232,6 +1232,24 @@ describe( 'DomConverter', () => {
 				sinon.assert.notCalled( warnStub );
 			} );
 
+			it( 'should yield the `RawElement` children properly', () => {
+				const downcastWriter = new DowncastWriter( viewDocument );
+				const dataConverter = new DomConverter( viewDocument, {
+					renderingMode: 'data'
+				} );
+				const parentElement = downcastWriter.createContainerElement( 'p' );
+				const transparentRawElement = downcastWriter.createRawElement( 'span', {}, function( domElement ) {
+					domElement.innerHTML = 'foo';
+				} );
+
+				downcastWriter.insert( downcastWriter.createPositionAt( parentElement, 'end' ), transparentRawElement );
+				downcastWriter.setCustomProperty( 'dataPipeline:transparentRendering', true, transparentRawElement );
+
+				expect( dataConverter.viewToDom( parentElement ).outerHTML ).to.equal(
+					'<p>foo</p>'
+				);
+			} );
+
 			it( 'should not be transparent in the editing pipeline', () => {
 				converter.renderingMode = 'editing';
 				converter.blockFillerMode = 'br';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (engine): Fix rendering children of `RawElement` with `dataPipeline:transparentRendering` property set.

---

### Additional information


