### PR TITLE
CKBox Permission change tooltip name

### DIFF
--- a/packages/ckeditor5-ckbox/lang/contexts.json
+++ b/packages/ckeditor5-ckbox/lang/contexts.json
@@ -2,7 +2,7 @@
   "Open file manager": "A toolbar button tooltip for opening the file browser that allows inserting an image or a file to the editor.",
   "Cannot determine a category for the uploaded file.": "A message is displayed when CKEditor 5 cannot associate an image with any of the categories defined in CKBox while uploading an asset.",
   "Cannot access default workspace.": "A message is displayed when the user is not authorised to access the CKBox workspace configured as default one.",
-	"You have no image editing permissions.": "The title of the notification displayed when there is no permission to edit assets.",
+  "You have no image editing permissions.": "The title of the notification displayed when there is no permission to edit assets.",
   "Edit image": "Image toolbar button tooltip for opening a dialog to manipulate the image.",
   "Processing the edited image.": "A message stating that image editing is in progress.",
   "Server failed to process the image.": "A message is displayed when the server fails to process an image or doesn't respond.",

--- a/packages/ckeditor5-ckbox/lang/contexts.json
+++ b/packages/ckeditor5-ckbox/lang/contexts.json
@@ -2,7 +2,7 @@
   "Open file manager": "A toolbar button tooltip for opening the file browser that allows inserting an image or a file to the editor.",
   "Cannot determine a category for the uploaded file.": "A message is displayed when CKEditor 5 cannot associate an image with any of the categories defined in CKBox while uploading an asset.",
   "Cannot access default workspace.": "A message is displayed when the user is not authorised to access the CKBox workspace configured as default one.",
-	"No permission for image editing. Try using the file manager or contact your administrator.": "The title of the notification displayed when there is no permission to edit assets.",
+	"You have no image editing permissions.": "The title of the notification displayed when there is no permission to edit assets.",
   "Edit image": "Image toolbar button tooltip for opening a dialog to manipulate the image.",
   "Processing the edited image.": "A message stating that image editing is in progress.",
   "Server failed to process the image.": "A message is displayed when the server fails to process an image or doesn't respond.",

--- a/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditui.ts
+++ b/packages/ckeditor5-ckbox/src/ckboximageedit/ckboximageeditui.ts
@@ -45,7 +45,7 @@ export default class CKBoxImageEditUI extends Plugin {
 
 			view.bind( 'label' ).to( uploadImageCommand, 'isAccessAllowed', isAccessAllowed => isAccessAllowed ?
 				t( 'Edit image' ) :
-				t( 'No permission for image editing. Try using the file manager or contact your administrator.' )
+				t( 'You have no image editing permissions.' )
 			);
 			view.bind( 'isOn' ).to( command, 'value', command, 'isEnabled', ( value, isEnabled ) => value && isEnabled );
 			view.bind( 'isEnabled' ).to( command );

--- a/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditui.js
+++ b/packages/ckeditor5-ckbox/tests/ckboximageedit/ckboximageeditui.js
@@ -97,8 +97,7 @@ describe( 'CKBoxImageEditUI', () => {
 			const uploadImageCommand = editor.commands.get( 'uploadImage' );
 			uploadImageCommand.set( 'isAccessAllowed', false );
 
-			expect( button.label ).to.equal( 'No permission for image editing. Try ' +
-				'using the file manager or contact your administrator.' );
+			expect( button.label ).to.equal( 'You have no image editing permissions.' );
 		} );
 
 		it( 'should have an icon', () => {

--- a/packages/ckeditor5-image/lang/contexts.json
+++ b/packages/ckeditor5-image/lang/contexts.json
@@ -20,7 +20,7 @@
 	"From computer": "The label for the upload image from computer menu bar button (inside 'Image' menu).",
   	"Replace image from computer": "The label for the replace image by upload from computer toolbar button.",
 	"Upload failed": "The title of the notification displayed when upload fails.",
-	"No permission to upload from computer. Try using the file manager or contact your administrator.": "The title of the notification displayed when there is no permission to upload assets.",
+	"You have no image upload permissions.": "The title of the notification displayed when there is no permission to upload assets.",
 	"Image toolbar": "The label used by assistive technologies describing an image toolbar attached to an image widget.",
 	"Resize image": "The label used for the dropdown in the image toolbar containing defined resize options.",
 	"Resize image to %0": "The label used for the standalone resize options buttons in the image toolbar.",

--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
@@ -143,7 +143,7 @@ export default class ImageUploadEditing extends Plugin {
 				const t = editor.locale.t;
 
 				// eslint-disable-next-line max-len
-				notification.showWarning( t( 'No permission to upload from computer. Try using the file manager or contact your administrator.' ), {
+				notification.showWarning( t( 'You have no image upload permissions.' ), {
 					namespace: 'image'
 				} );
 			}

--- a/packages/ckeditor5-image/src/imageupload/imageuploadui.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadui.ts
@@ -114,7 +114,7 @@ export default class ImageUploadUI extends Plugin {
 			'isAccessAllowed',
 			( isImageSelected, isAccessAllowed ) => {
 				if ( !isAccessAllowed ) {
-					return t( 'No permission to upload from computer. Try using the file manager or contact your administrator.' );
+					return t( 'You have no image upload permissions.' );
 				}
 
 				return isImageSelected ? t( 'Replace image from computer' ) : t( 'Upload image from computer' );

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
@@ -252,8 +252,7 @@ describe( 'ImageUploadEditing', () => {
 
 		notification.on( 'show:warning', ( evt, data ) => {
 			tryExpect( done, () => {
-				expect( data.message ).to.equal( 'No permission to upload from computer. Try using the file manager ' +
-				'or contact your administrator.' );
+				expect( data.message ).to.equal( 'You have no image upload permissions.' );
 				evt.stop();
 			} );
 		}, { priority: 'high' } );

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadui.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadui.js
@@ -153,14 +153,12 @@ describe( 'ImageUploadUI', () => {
 			expect( buttonView.label ).to.equal( 'Replace from computer' );
 
 			uploadImageCommand.isAccessAllowed = false;
-			expect( dropdownButton.label ).to.equal( 'No permission to upload from computer. ' +
-				'Try using the file manager or contact your administrator.' );
+			expect( dropdownButton.label ).to.equal( 'You have no image upload permissions.' );
 			expect( buttonView.label ).to.equal( 'Replace from computer' );
 
 			insertImageUI.isImageSelected = false;
 			uploadImageCommand.isAccessAllowed = false;
-			expect( dropdownButton.label ).to.equal( 'No permission to upload from computer. ' +
-				'Try using the file manager or contact your administrator.' );
+			expect( dropdownButton.label ).to.equal( 'You have no image upload permissions.' );
 			expect( buttonView.label ).to.equal( 'Upload from computer' );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ckbox): Rename notification message when no permission to upload image. Closes #16830.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
