### PR TITLE
Fix truncate tables in printing mode while using export to pdf

### DIFF
--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -42,6 +42,23 @@
 	}
 }
 
+/**
+ * Expanding the table to the full height of the parent container is necessary due to the fact that
+ * the tables are rendered inside a <figure> elements which are kinda buggy in terms of table height calculation.
+ * While setting `height: 100%` fixes the issue in the editing mode described here:
+ * https://github.com/ckeditor/ckeditor5/issues/6186
+ *
+ * it's causing another issue with the table height in the print preview mode here:
+ * https://github.com/cksource/ckeditor5-commercial/issues/6507
+ *
+ * At this moment reset the height to `initial` in the print mode works as a workaround.
+ */
+@media print {
+	.ck-content .table table {
+		height: initial;
+	}
+}
+
 /* Text alignment of the table header should match the editor settings and override the native browser styling,
 when content is available outside the editor. See https://github.com/ckeditor/ckeditor5/issues/6638 */
 .ck-content[dir="rtl"] .table th {

--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -43,15 +43,15 @@
 }
 
 /**
- * Expanding the table to the full height of the parent container is necessary due to the fact that
- * the tables are rendered inside a <figure> elements which are kinda buggy in terms of table height calculation.
+ * Expanding the table to the full height of the parent container is necessary because tables
+ * are rendered inside <figure> elements, which is kinda buggy in table height calculation.
  * While setting `height: 100%` fixes the issue in the editing mode described here:
  * https://github.com/ckeditor/ckeditor5/issues/6186
  *
  * it's causing another issue with the table height in the print preview mode here:
  * https://github.com/ckeditor/ckeditor5/issues/16856
  *
- * At this moment reset the height to `initial` in the print mode works as a workaround.
+ * For now, resetting the height to `initial` in the print mode works as a workaround.
  */
 @media print {
 	.ck-content .table table {

--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -49,7 +49,7 @@
  * https://github.com/ckeditor/ckeditor5/issues/6186
  *
  * it's causing another issue with the table height in the print preview mode here:
- * https://github.com/cksource/ckeditor5-commercial/issues/6507
+ * https://github.com/ckeditor/ckeditor5/issues/16856
  *
  * At this moment reset the height to `initial` in the print mode works as a workaround.
  */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (table): Larger tables are no longer truncated in print mode.  Closes https://github.com/ckeditor/ckeditor5/issues/16856

---

### Additional information

Caused by https://github.com/ckeditor/ckeditor5/issues/6186
Closes: https://github.com/cksource/ckeditor5-commercial/issues/6507
Before:
![obraz](https://github.com/user-attachments/assets/8ad1d272-d8a9-46c4-9e5a-2ba999c57e48)

After:
![obraz](https://github.com/user-attachments/assets/676131e3-c29e-474c-a774-9dac2a09ad55)
