### PR TITLE
Special characters menu item is not correctly marked when enabled

### DIFF
--- a/packages/ckeditor5-special-characters/src/specialcharacters.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharacters.ts
@@ -247,7 +247,7 @@ export default class SpecialCharacters extends Plugin {
 	}
 
 	/**
-	 * Creates a button for for menu bar that will show special characetrs dialog.
+	 * Creates a button for toolbar anda menu bar that will show special characters dialog.
 	 */
 	private _createDialogButton<T extends typeof ButtonView>( ButtonClass: T ): InstanceType<T> {
 		const editor = this.editor;
@@ -259,7 +259,8 @@ export default class SpecialCharacters extends Plugin {
 
 		buttonView.set( {
 			label: t( 'Special characters' ),
-			icon: specialCharactersIcon
+			icon: specialCharactersIcon,
+			isToggleable: true
 		} );
 
 		buttonView.bind( 'isOn' ).to( dialogPlugin, 'id', id => id === 'specialCharacters' );

--- a/packages/ckeditor5-special-characters/src/specialcharacters.ts
+++ b/packages/ckeditor5-special-characters/src/specialcharacters.ts
@@ -247,7 +247,7 @@ export default class SpecialCharacters extends Plugin {
 	}
 
 	/**
-	 * Creates a button for toolbar anda menu bar that will show special characters dialog.
+	 * Creates a button for toolbar and menu bar that will show special characters dialog.
 	 */
 	private _createDialogButton<T extends typeof ButtonView>( ButtonClass: T ): InstanceType<T> {
 		const editor = this.editor;

--- a/packages/ckeditor5-special-characters/tests/specialcharacters.js
+++ b/packages/ckeditor5-special-characters/tests/specialcharacters.js
@@ -80,6 +80,7 @@ describe( 'SpecialCharacters', () => {
 		it( 'should get basic properties', () => {
 			expect( button.label ).to.equal( 'Special characters' );
 			expect( button.icon ).to.equal( specialCharactersIcon );
+			expect( button.isToggleable ).to.be.true;
 		} );
 
 		it( 'should bind #isEnabled to the command', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (special-characters): Toolbar and menu bar button should be marked as toggleable. Closes #16858.

---

### Additional information

I added `isToggleable` for both menu bar and toolbar buttons. I see it is done the same way for AI Assistant and Comments archive so I assume this is the pattern we follow.