### PR TITLE
Add remove format support from block elements

### DIFF
--- a/packages/ckeditor5-html-support/src/datafilter.ts
+++ b/packages/ckeditor5-html-support/src/datafilter.ts
@@ -50,6 +50,7 @@ import {
 
 import {
 	getHtmlAttributeName,
+	isGHSAttributeName,
 	type GHSViewAttributes
 } from './utils.js';
 
@@ -554,7 +555,7 @@ export default class DataFilter extends Plugin {
 				}
 
 				for ( const attr of change.attributes.keys() ) {
-					if ( !attr.startsWith( 'html' ) || !attr.endsWith( 'Attributes' ) ) {
+					if ( !isGHSAttributeName( attr ) ) {
 						continue;
 					}
 

--- a/packages/ckeditor5-html-support/src/index.ts
+++ b/packages/ckeditor5-html-support/src/index.ts
@@ -13,6 +13,7 @@ export { default as DataSchema, type DataSchemaBlockElementDefinition } from './
 export { default as HtmlComment } from './htmlcomment.js';
 export { default as FullPage } from './fullpage.js';
 export { default as HtmlPageDataProcessor } from './htmlpagedataprocessor.js';
+export { isGHSAttributeName, type GHSViewAttributes } from './utils.js';
 export type { GeneralHtmlSupportConfig } from './generalhtmlsupportconfig.js';
 export type { default as CodeBlockElementSupport } from './integrations/codeblock.js';
 export type { default as CustomElementSupport } from './integrations/customelement.js';

--- a/packages/ckeditor5-html-support/src/utils.ts
+++ b/packages/ckeditor5-html-support/src/utils.ts
@@ -221,3 +221,18 @@ export function toPascalCase( data: string ): string {
 export function getHtmlAttributeName( viewElementName: string ): string {
 	return `html${ toPascalCase( viewElementName ) }Attributes`;
 }
+
+/**
+ * Checks if the given attribute name is a GHS attribute name.
+ *
+ * @param name Attribute name to check.
+ * @returns `true` if the attribute name is a GHS attribute name, `false` otherwise.
+ * @example
+ * ```js
+ * isGHSAttributeName( 'htmlPAttributes' ); // true
+ * isGHSAttributeName( 'span' ); // false
+ * ```
+ */
+export function isGHSAttributeName<S extends string>( name: S ): boolean {
+	return name.startsWith( 'html' ) && name.endsWith( 'Attributes' );
+}

--- a/packages/ckeditor5-html-support/tests/manual/ghs-all-features.js
+++ b/packages/ckeditor5-html-support/tests/manual/ghs-all-features.js
@@ -56,6 +56,8 @@ ClassicEditor
 		toolbar: [
 			'sourceEditing',
 			'|',
+			'RemoveFormat',
+			'|',
 			'heading',
 			'|',
 			'bold', 'italic', 'strikethrough', 'underline', 'code', 'subscript', 'superscript', 'link',
@@ -72,9 +74,7 @@ ClassicEditor
 			'|',
 			'pageBreak', 'horizontalLine',
 			'|',
-			'undo', 'redo',
-			'|',
-			'RemoveFormat'
+			'undo', 'redo'
 		],
 		htmlSupport: {
 			allow: [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (remove-format): Remove classes and styles added via GHS. Closes https://github.com/ckeditor/ckeditor5/issues/13983

---

### Additional information

⚠️  `Page Break` elements used together with GHS seems to be affected, and it's possible to remove their styling. 
