### PR TITLE
Support Instagram reels and twitter new domain

### DIFF
--- a/packages/ckeditor5-media-embed/src/mediaembedediting.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedediting.ts
@@ -134,11 +134,17 @@ export default class MediaEmbedEditing extends Plugin {
 
 				{
 					name: 'instagram',
-					url: /^instagram\.com\/p\/(\w+)/
+					url: [
+						/^instagram\.com\/p\/(\w+)/,
+						/^instagram\.com\/reel\/(\w+)/
+					]
 				},
 				{
 					name: 'twitter',
-					url: /^twitter\.com/
+					url: [
+						/^twitter\.com/,
+						/^x\.com/
+					]
 				},
 				{
 					name: 'googleMaps',

--- a/packages/ckeditor5-media-embed/tests/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedediting.js
@@ -301,7 +301,11 @@ describe( 'MediaEmbedEditing', () => {
 							testMediaUpcast( [
 								'https://www.instagram.com/p/foo',
 								'www.instagram.com/p/foo',
-								'instagram.com/p/foo'
+								'instagram.com/p/foo',
+
+								'https://www.instagram.com/reel/Foo/',
+								'www.instagram.com/reel/Foo/',
+								'instagram.com/reel/Foo/'
 							] );
 						} );
 
@@ -309,7 +313,11 @@ describe( 'MediaEmbedEditing', () => {
 							testMediaUpcast( [
 								'https://www.twitter.com/foo/bar',
 								'www.twitter.com/foo/bar',
-								'twitter.com/foo/bar'
+								'twitter.com/foo/bar',
+
+								'https://www.x.com/foo/bar',
+								'www.x.com/foo/bar',
+								'x.com/foo/bar'
 							] );
 						} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (media-embed): Support new Twitter domain (x.com) and Instagram Reels. Closes https://github.com/ckeditor/ckeditor5/issues/16435

---

### Additional information

Based on this PR: https://github.com/ckeditor/ckeditor5/pull/16461
I added unit tests.
