### PR TITLE
Make `border=none` setting work in tables

### DIFF
--- a/packages/ckeditor5-paste-from-office/tests/_data/table/tablecellproperties/model.html
+++ b/packages/ckeditor5-paste-from-office/tests/_data/table/tablecellproperties/model.html
@@ -1,6 +1,6 @@
-<table tableBorderColor="{}" tableBorderWidth="{}">
+<table tableBorderColor="{}" tableBorderStyle="none" tableBorderWidth="{}">
 	<tableRow>
-		<tableCell tableCellBackgroundColor="#CCCCCC" tableCellBorderColor="windowtext" tableCellBorderStyle="solid" tableCellBorderWidth="1.0pt" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
+		<tableCell tableCellBackgroundColor="#CCCCCC" tableCellBorderColor="windowtext" tableCellBorderWidth="1.0pt" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="59.0%">
 			<paragraph><$text bold="true">Project Phase</$text></paragraph>
 		</tableCell>
 		<tableCell tableCellBackgroundColor="#CCCCCC" tableCellBorderColor="windowtext" tableCellBorderStyle="{"top":"solid","bottom":"solid","right":"solid","left":"none"}" tableCellBorderWidth="1.0pt" tableCellPadding="{"top":"0cm","bottom":"0cm","right":"5.4pt","left":"5.4pt"}" tableCellWidth="24.0%">

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
@@ -28,7 +28,7 @@ import TableCellHorizontalAlignmentCommand from './commands/tablecellhorizontala
 import TableCellBorderStyleCommand from './commands/tablecellborderstylecommand.js';
 import TableCellBorderColorCommand from './commands/tablecellbordercolorcommand.js';
 import TableCellBorderWidthCommand from './commands/tablecellborderwidthcommand.js';
-import { getNormalizedDefaultProperties } from '../utils/table-properties.js';
+import { getNormalizedDefaultCellProperties } from '../utils/table-properties.js';
 import { enableProperty } from '../utils/common.js';
 
 const VALIGN_VALUES_REG_EXP = /^(top|middle|bottom)$/;
@@ -76,13 +76,9 @@ export default class TableCellPropertiesEditing extends Plugin {
 		const schema = editor.model.schema;
 		const conversion = editor.conversion;
 
-		editor.config.define( 'table.tableCellProperties.defaultProperties', {
-			borderStyle: 'solid',
-			borderColor: 'hsl(0, 0%, 75%)',
-			borderWidth: '1px'
-		} );
+		editor.config.define( 'table.tableCellProperties.defaultProperties', { } );
 
-		const defaultTableCellProperties = getNormalizedDefaultProperties(
+		const defaultTableCellProperties = getNormalizedDefaultCellProperties(
 			editor.config.get( 'table.tableCellProperties.defaultProperties' )!,
 			{
 				includeVerticalAlignmentProperty: true,

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesediting.ts
@@ -76,7 +76,11 @@ export default class TableCellPropertiesEditing extends Plugin {
 		const schema = editor.model.schema;
 		const conversion = editor.conversion;
 
-		editor.config.define( 'table.tableCellProperties.defaultProperties', {} );
+		editor.config.define( 'table.tableCellProperties.defaultProperties', {
+			borderStyle: 'solid',
+			borderColor: 'hsl(0, 0%, 75%)',
+			borderWidth: '1px'
+		} );
 
 		const defaultTableCellProperties = getNormalizedDefaultProperties(
 			editor.config.get( 'table.tableCellProperties.defaultProperties' )!,

--- a/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.ts
+++ b/packages/ckeditor5-table/src/tablecellproperties/tablecellpropertiesui.ts
@@ -32,7 +32,7 @@ import { getTableWidgetAncestor } from '../utils/ui/widget.js';
 import { getBalloonCellPositionData, repositionContextualBalloon } from '../utils/ui/contextualballoon.js';
 
 import tableCellProperties from './../../theme/icons/table-cell-properties.svg';
-import { getNormalizedDefaultProperties, type NormalizedDefaultProperties } from '../utils/table-properties.js';
+import { getNormalizedDefaultCellProperties, type NormalizedDefaultProperties } from '../utils/table-properties.js';
 import type { GetCallback, ObservableChangeEvent } from 'ckeditor5/src/utils.js';
 
 import type TableCellBorderStyleCommand from './commands/tablecellborderstylecommand.js';
@@ -119,7 +119,7 @@ export default class TableCellPropertiesUI extends Plugin {
 		const editor = this.editor;
 		const t = editor.t;
 
-		this._defaultTableCellProperties = getNormalizedDefaultProperties(
+		this._defaultTableCellProperties = getNormalizedDefaultCellProperties(
 			editor.config.get( 'table.tableCellProperties.defaultProperties' )!,
 			{
 				includeVerticalAlignmentProperty: true,

--- a/packages/ckeditor5-table/src/tablecellwidth/tablecellwidthediting.ts
+++ b/packages/ckeditor5-table/src/tablecellwidth/tablecellwidthediting.ts
@@ -11,7 +11,7 @@ import { Plugin } from 'ckeditor5/src/core.js';
 
 import TableEditing from './../tableediting.js';
 import TableCellWidthCommand from './commands/tablecellwidthcommand.js';
-import { getNormalizedDefaultProperties } from '../utils/table-properties.js';
+import { getNormalizedDefaultCellProperties } from '../utils/table-properties.js';
 import { enableProperty } from '../utils/common.js';
 
 /**
@@ -41,7 +41,7 @@ export default class TableCellWidthEditing extends Plugin {
 	public init(): void {
 		const editor = this.editor;
 
-		const defaultTableCellProperties = getNormalizedDefaultProperties(
+		const defaultTableCellProperties = getNormalizedDefaultCellProperties(
 			editor.config.get( 'table.tableCellProperties.defaultProperties' )!
 		);
 

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
@@ -24,7 +24,7 @@ import TableBorderWidthCommand from './commands/tableborderwidthcommand.js';
 import TableWidthCommand from './commands/tablewidthcommand.js';
 import TableHeightCommand from './commands/tableheightcommand.js';
 import TableAlignmentCommand from './commands/tablealignmentcommand.js';
-import { getNormalizedDefaultProperties } from '../utils/table-properties.js';
+import { getNormalizedDefaultTableProperties } from '../utils/table-properties.js';
 
 const ALIGN_VALUES_REG_EXP = /^(left|center|right)$/;
 const FLOAT_VALUES_REG_EXP = /^(left|none|right)$/;
@@ -69,17 +69,14 @@ export default class TablePropertiesEditing extends Plugin {
 		const schema = editor.model.schema;
 		const conversion = editor.conversion;
 
-		editor.config.define( 'table.tableProperties.defaultProperties', {
-			borderStyle: 'double',
-			borderColor: 'hsl(0, 0%, 70%)',
-			borderWidth: '1px',
-			width: '100%',
-			height: '100%'
-		} );
+		editor.config.define( 'table.tableProperties.defaultProperties', {} );
 
-		const defaultTableProperties = getNormalizedDefaultProperties( editor.config.get( 'table.tableProperties.defaultProperties' )!, {
-			includeAlignmentProperty: true
-		} );
+		const defaultTableProperties = getNormalizedDefaultTableProperties(
+			editor.config.get( 'table.tableProperties.defaultProperties' )!,
+			{
+				includeAlignmentProperty: true
+			}
+		);
 
 		editor.data.addStyleProcessorRules( addBorderRules );
 		enableBorderProperties( schema, conversion, {

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesediting.ts
@@ -69,7 +69,13 @@ export default class TablePropertiesEditing extends Plugin {
 		const schema = editor.model.schema;
 		const conversion = editor.conversion;
 
-		editor.config.define( 'table.tableProperties.defaultProperties', {} );
+		editor.config.define( 'table.tableProperties.defaultProperties', {
+			borderStyle: 'double',
+			borderColor: 'hsl(0, 0%, 70%)',
+			borderWidth: '1px',
+			width: '100%',
+			height: '100%'
+		} );
 
 		const defaultTableProperties = getNormalizedDefaultProperties( editor.config.get( 'table.tableProperties.defaultProperties' )!, {
 			includeAlignmentProperty: true

--- a/packages/ckeditor5-table/src/tableproperties/tablepropertiesui.ts
+++ b/packages/ckeditor5-table/src/tableproperties/tablepropertiesui.ts
@@ -31,7 +31,7 @@ import {
 } from '../utils/ui/table-properties.js';
 import { getSelectionAffectedTableWidget } from '../utils/ui/widget.js';
 import { getBalloonTablePositionData, repositionContextualBalloon } from '../utils/ui/contextualballoon.js';
-import { getNormalizedDefaultProperties, type NormalizedDefaultProperties } from '../utils/table-properties.js';
+import { getNormalizedDefaultTableProperties, type NormalizedDefaultProperties } from '../utils/table-properties.js';
 import type { Batch } from 'ckeditor5/src/engine.js';
 import type { EventInfo, ObservableChangeEvent } from 'ckeditor5/src/utils.js';
 
@@ -117,9 +117,13 @@ export default class TablePropertiesUI extends Plugin {
 		const editor = this.editor;
 		const t = editor.t;
 
-		this._defaultTableProperties = getNormalizedDefaultProperties( editor.config.get( 'table.tableProperties.defaultProperties' )!, {
-			includeAlignmentProperty: true
-		} );
+		this._defaultTableProperties = getNormalizedDefaultTableProperties(
+			editor.config.get( 'table.tableProperties.defaultProperties' )!,
+			{
+				includeAlignmentProperty: true
+			}
+		);
+
 		this._balloon = editor.plugins.get( ContextualBalloon );
 
 		editor.ui.componentFactory.add( 'tableProperties', locale => {

--- a/packages/ckeditor5-table/src/utils/table-properties.ts
+++ b/packages/ckeditor5-table/src/utils/table-properties.ts
@@ -79,24 +79,41 @@ export interface NormalizedDefaultProperties {
 }
 
 /**
- * Options for the `getNormalizedDefaultProperties` function.
+ * Options used to determine which properties should be added to the normalized configuration.
  */
-type NormalizeTableDefaultPropertiesOptions = {
+export type NormalizeTableDefaultPropertiesOptions = {
+
+	/**
+	 * Whether the "alignment" property should be added.
+	 */
 	includeAlignmentProperty?: boolean;
+
+	/**
+	 * Whether the "padding" property should be added.
+	 */
 	includePaddingProperty?: boolean;
+
+	/**
+	 * Whether the "verticalAlignment" property should be added.
+	 */
 	includeVerticalAlignmentProperty?: boolean;
+
+	/**
+	 * Whether the "horizontalAlignment" property should be added.
+	 */
 	includeHorizontalAlignmentProperty?: boolean;
+
+	/**
+	 * Whether the content is right-to-left.
+	 */
 	isRightToLeftContent?: boolean;
 };
 
 /**
  * Returns the normalized configuration.
  *
- * @param options.includeAlignmentProperty Whether the "alignment" property should be added.
- * @param options.includePaddingProperty Whether the "padding" property should be added.
- * @param options.includeVerticalAlignmentProperty Whether the "verticalAlignment" property should be added.
- * @param options.includeHorizontalAlignmentProperty Whether the "horizontalAlignment" property should be added.
- * @param options.isRightToLeftContent Whether the content is right-to-left.
+ * @param config The configuration to normalize.
+ * @param options Options used to determine which properties should be added.
  */
 export function getNormalizedDefaultProperties(
 	config: Partial<NormalizedDefaultProperties> | undefined,
@@ -133,6 +150,9 @@ export function getNormalizedDefaultProperties(
 
 /**
  * Returns the normalized default table properties.
+ *
+ * @param config The configuration to normalize.
+ * @param options Options used to determine which properties should be added.
  */
 export function getNormalizedDefaultTableProperties(
 	config: Partial<NormalizedDefaultProperties> | undefined,
@@ -150,6 +170,9 @@ export function getNormalizedDefaultTableProperties(
 
 /**
  * Returns the normalized default cell properties.
+ *
+ * @param config The configuration to normalize.
+ * @param options Options used to determine which properties should be added.
  */
 export function getNormalizedDefaultCellProperties(
 	config: Partial<NormalizedDefaultProperties> | undefined,

--- a/packages/ckeditor5-table/src/utils/table-properties.ts
+++ b/packages/ckeditor5-table/src/utils/table-properties.ts
@@ -79,6 +79,17 @@ export interface NormalizedDefaultProperties {
 }
 
 /**
+ * Options for the `getNormalizedDefaultProperties` function.
+ */
+type NormalizeTableDefaultPropertiesOptions = {
+	includeAlignmentProperty?: boolean;
+	includePaddingProperty?: boolean;
+	includeVerticalAlignmentProperty?: boolean;
+	includeHorizontalAlignmentProperty?: boolean;
+	isRightToLeftContent?: boolean;
+};
+
+/**
  * Returns the normalized configuration.
  *
  * @param options.includeAlignmentProperty Whether the "alignment" property should be added.
@@ -89,13 +100,7 @@ export interface NormalizedDefaultProperties {
  */
 export function getNormalizedDefaultProperties(
 	config: Partial<NormalizedDefaultProperties> | undefined,
-	options: {
-		includeAlignmentProperty?: boolean;
-		includePaddingProperty?: boolean;
-		includeVerticalAlignmentProperty?: boolean;
-		includeHorizontalAlignmentProperty?: boolean;
-		isRightToLeftContent?: boolean;
-	} = {}
+	options: NormalizeTableDefaultPropertiesOptions = {}
 ): NormalizedDefaultProperties {
 	const normalizedConfig: NormalizedDefaultProperties = {
 		borderStyle: 'none',
@@ -124,4 +129,36 @@ export function getNormalizedDefaultProperties(
 	}
 
 	return normalizedConfig;
+}
+
+/**
+ * Returns the normalized default table properties.
+ */
+export function getNormalizedDefaultTableProperties(
+	config: Partial<NormalizedDefaultProperties> | undefined,
+	options?: NormalizeTableDefaultPropertiesOptions
+): NormalizedDefaultProperties {
+	return getNormalizedDefaultProperties( {
+		borderStyle: 'double',
+		borderColor: 'hsl(0, 0%, 70%)',
+		borderWidth: '1px',
+		width: '100%',
+		height: '100%',
+		...config
+	}, options );
+}
+
+/**
+ * Returns the normalized default cell properties.
+ */
+export function getNormalizedDefaultCellProperties(
+	config: Partial<NormalizedDefaultProperties> | undefined,
+	options?: NormalizeTableDefaultPropertiesOptions
+): NormalizedDefaultProperties {
+	return getNormalizedDefaultProperties( {
+		borderStyle: 'solid',
+		borderColor: 'hsl(0, 0%, 75%)',
+		borderWidth: '1px',
+		...config
+	}, options );
 }

--- a/packages/ckeditor5-table/src/utils/table-properties.ts
+++ b/packages/ckeditor5-table/src/utils/table-properties.ts
@@ -144,8 +144,6 @@ export function getNormalizedDefaultTableProperties(
 		borderStyle: 'double',
 		borderColor: 'hsl(0, 0%, 70%)',
 		borderWidth: '1px',
-		width: '100%',
-		height: '100%',
 		...config
 	}, options );
 }

--- a/packages/ckeditor5-table/src/utils/table-properties.ts
+++ b/packages/ckeditor5-table/src/utils/table-properties.ts
@@ -139,7 +139,7 @@ export function getNormalizedDefaultTableProperties(
 	options?: NormalizeTableDefaultPropertiesOptions
 ): NormalizedDefaultProperties {
 	return getNormalizedDefaultProperties( {
-		// It's workaround for the issue with missing support for border none in the table element.
+		// It adds support for border none in the table element, keep it in sync with the content styles
 		// See more: https://github.com/ckeditor/ckeditor5/issues/6841#issuecomment-1959195608
 		borderStyle: 'double',
 		borderColor: 'hsl(0, 0%, 70%)',
@@ -158,7 +158,7 @@ export function getNormalizedDefaultCellProperties(
 	options?: NormalizeTableDefaultPropertiesOptions
 ): NormalizedDefaultProperties {
 	return getNormalizedDefaultProperties( {
-		// It's workaround for the issue with missing support for border none in the table element.
+		// It adds support for border none in the table element, keep it in sync with the content styles
 		// See more: https://github.com/ckeditor/ckeditor5/issues/6841#issuecomment-1959195608
 		borderStyle: 'solid',
 		borderColor: 'hsl(0, 0%, 75%)',

--- a/packages/ckeditor5-table/src/utils/table-properties.ts
+++ b/packages/ckeditor5-table/src/utils/table-properties.ts
@@ -139,6 +139,8 @@ export function getNormalizedDefaultTableProperties(
 	options?: NormalizeTableDefaultPropertiesOptions
 ): NormalizedDefaultProperties {
 	return getNormalizedDefaultProperties( {
+		// It's workaround for the issue with missing support for border none in the table element.
+		// See more: https://github.com/ckeditor/ckeditor5/issues/6841#issuecomment-1959195608
 		borderStyle: 'double',
 		borderColor: 'hsl(0, 0%, 70%)',
 		borderWidth: '1px',
@@ -156,6 +158,8 @@ export function getNormalizedDefaultCellProperties(
 	options?: NormalizeTableDefaultPropertiesOptions
 ): NormalizedDefaultProperties {
 	return getNormalizedDefaultProperties( {
+		// It's workaround for the issue with missing support for border none in the table element.
+		// See more: https://github.com/ckeditor/ckeditor5/issues/6841#issuecomment-1959195608
 		borderStyle: 'solid',
 		borderColor: 'hsl(0, 0%, 75%)',
 		borderWidth: '1px',

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -46,11 +46,7 @@ describe( 'table cell properties', () => {
 
 			expect( config ).to.be.an( 'object' );
 			expect( config ).to.have.property( 'defaultProperties' );
-			expect( config.defaultProperties ).to.include( {
-				borderStyle: 'solid',
-				borderColor: 'hsl(0, 0%, 75%)',
-				borderWidth: '1px'
-			} );
+			expect( config.defaultProperties ).to.include( {} );
 		} );
 
 		it( 'adds tableCellBorderColor command', () => {

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -46,7 +46,11 @@ describe( 'table cell properties', () => {
 
 			expect( config ).to.be.an( 'object' );
 			expect( config ).to.have.property( 'defaultProperties' );
-			expect( config.defaultProperties ).to.deep.equal( {} );
+			expect( config.defaultProperties ).to.include( {
+				borderStyle: 'solid',
+				borderColor: 'hsl(0, 0%, 75%)',
+				borderWidth: '1px'
+			} );
 		} );
 
 		it( 'adds tableCellBorderColor command', () => {
@@ -89,14 +93,24 @@ describe( 'table cell properties', () => {
 			} );
 
 			describe( 'upcast conversion', () => {
-				it( 'should upcast border shorthand', () => {
+				it( 'should not upcast border values which are same as default', () => {
 					editor.setData( '<table><tr><td style="border:1px solid #f00">foo</td></tr></table>' );
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
 					expect( tableCell.getAttribute( 'tableCellBorderColor' ) ).to.equal( '#f00' );
-					expect( tableCell.getAttribute( 'tableCellBorderStyle' ) ).to.equal( 'solid' );
-					expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.equal( '1px' );
+					expect( tableCell.getAttribute( 'tableCellBorderStyle' ) ).to.be.undefined;
+					expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.be.undefined;
+				} );
+
+				it( 'should upcast border shorthand', () => {
+					editor.setData( '<table><tr><td style="border:2px dashed #f00">foo</td></tr></table>' );
+
+					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
+
+					expect( tableCell.getAttribute( 'tableCellBorderColor' ) ).to.equal( '#f00' );
+					expect( tableCell.getAttribute( 'tableCellBorderStyle' ) ).to.equal( 'dashed' );
+					expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.equal( '2px' );
 				} );
 
 				it( 'should upcast border-color shorthand', () => {
@@ -116,21 +130,21 @@ describe( 'table cell properties', () => {
 				} );
 
 				it( 'should upcast border-width shorthand', () => {
-					editor.setData( '<table><tr><td style="border-width:1px">foo</td></tr></table>' );
+					editor.setData( '<table><tr><td style="border-width:3px">foo</td></tr></table>' );
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
-					expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.equal( '1px' );
+					expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.equal( '3px' );
 				} );
 
 				it( 'should upcast border-top shorthand', () => {
-					editor.setData( '<table><tr><td style="border-top:1px solid #f00">foo</td></tr></table>' );
+					editor.setData( '<table><tr><td style="border-top:2px double #f00">foo</td></tr></table>' );
 
 					const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
 					assertTRBLAttribute( tableCell, 'tableCellBorderColor', '#f00', null, null, null );
-					assertTRBLAttribute( tableCell, 'tableCellBorderStyle', 'solid', null, null, null );
-					assertTRBLAttribute( tableCell, 'tableCellBorderWidth', '1px', null, null, null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderStyle', 'double', null, null, null );
+					assertTRBLAttribute( tableCell, 'tableCellBorderWidth', '2px', null, null, null );
 				} );
 
 				it( 'should upcast border-right shorthand', () => {

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -46,7 +46,7 @@ describe( 'table cell properties', () => {
 
 			expect( config ).to.be.an( 'object' );
 			expect( config ).to.have.property( 'defaultProperties' );
-			expect( config.defaultProperties ).to.include( {} );
+			expect( config.defaultProperties ).to.deep.equal( {} );
 		} );
 
 		it( 'adds tableCellBorderColor command', () => {

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesui.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesui.js
@@ -693,9 +693,9 @@ describe( 'table cell properties', () => {
 
 					expect( contextualBalloon.visibleView ).to.equal( tableCellPropertiesView );
 					expect( tableCellPropertiesView ).to.include( {
-						borderStyle: 'none',
-						borderColor: '',
-						borderWidth: '',
+						borderStyle: 'solid',
+						borderColor: 'hsl(0, 0%, 75%)',
+						borderWidth: '1px',
 						height: '',
 						padding: '',
 						backgroundColor: '',

--- a/packages/ckeditor5-table/tests/tableclipboard-paste.js
+++ b/packages/ckeditor5-table/tests/tableclipboard-paste.js
@@ -3935,15 +3935,15 @@ describe( 'table clipboard', () => {
 			);
 
 			pasteTable( [
-				[ { contents: 'aa', style: 'border:1px solid #f00;background:#ba7' }, 'ab' ],
+				[ { contents: 'aa', style: 'border:3px dashed #f00;background:#ba7' }, 'ab' ],
 				[ 'ba', 'bb' ]
 			] );
 
 			const tableCell = model.document.getRoot().getNodeByPath( [ 0, 0, 0 ] );
 
 			expect( tableCell.getAttribute( 'tableCellBorderColor' ) ).to.equal( '#f00' );
-			expect( tableCell.getAttribute( 'tableCellBorderStyle' ) ).to.equal( 'solid' );
-			expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.equal( '1px' );
+			expect( tableCell.getAttribute( 'tableCellBorderStyle' ) ).to.equal( 'dashed' );
+			expect( tableCell.getAttribute( 'tableCellBorderWidth' ) ).to.equal( '3px' );
 			expect( tableCell.getAttribute( 'tableCellBackgroundColor' ) ).to.equal( '#ba7' );
 		} );
 
@@ -4032,7 +4032,7 @@ describe( 'table clipboard', () => {
 			await createEditor( [ TableCellPropertiesEditing ] );
 
 			const color = 'rgb(242, 242, 242)';
-			const style = 'solid';
+			const style = 'double';
 			const width = '2px';
 
 			pasteHtml( editor,

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -50,7 +50,13 @@ describe( 'table properties', () => {
 
 				expect( config ).to.be.an( 'object' );
 				expect( config ).to.have.property( 'defaultProperties' );
-				expect( config.defaultProperties ).to.deep.equal( {} );
+				expect( config.defaultProperties ).to.include( {
+					borderStyle: 'double',
+					borderColor: 'hsl(0, 0%, 70%)',
+					borderWidth: '1px',
+					width: '100%',
+					height: '100%'
+				} );
 			} );
 
 			it( 'adds tableBorderColor command', () => {
@@ -101,13 +107,13 @@ describe( 'table properties', () => {
 				} );
 
 				it( 'should upcast border shorthand', () => {
-					editor.setData( '<table style="border:1px solid #f00"><tr><td>foo</td></tr></table>' );
+					editor.setData( '<table style="border:2px solid #f00"><tr><td>foo</td></tr></table>' );
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
 					expect( table.getAttribute( 'tableBorderColor' ) ).to.equal( '#f00' );
 					expect( table.getAttribute( 'tableBorderStyle' ) ).to.equal( 'solid' );
-					expect( table.getAttribute( 'tableBorderWidth' ) ).to.equal( '1px' );
+					expect( table.getAttribute( 'tableBorderWidth' ) ).to.equal( '2px' );
 				} );
 
 				it( 'should upcast border-color shorthand', () => {
@@ -127,11 +133,11 @@ describe( 'table properties', () => {
 				} );
 
 				it( 'should upcast border-width shorthand', () => {
-					editor.setData( '<table style="border-width:1px"><tr><td>foo</td></tr></table>' );
+					editor.setData( '<table style="border-width:3px"><tr><td>foo</td></tr></table>' );
 
 					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
 
-					expect( table.getAttribute( 'tableBorderWidth' ) ).to.equal( '1px' );
+					expect( table.getAttribute( 'tableBorderWidth' ) ).to.equal( '3px' );
 				} );
 
 				it( 'should upcast border-top shorthand', () => {
@@ -234,11 +240,11 @@ describe( 'table properties', () => {
 					// https://github.com/ckeditor/ckeditor5/issues/6177.
 					it( 'should upcast tables with nested tables in their cells', () => {
 						editor.setData(
-							'<table style="border:1px solid red">' +
+							'<table style="border:2px solid red">' +
 								'<tr>' +
 									'<td>parent:00</td>' +
 									'<td>' +
-										'<table style="border:1px solid green"><tr><td>child:00</td></tr></table>' +
+										'<table style="border:2px solid green"><tr><td>child:00</td></tr></table>' +
 									'</td>' +
 								'</tr>' +
 							'</table>'
@@ -248,12 +254,12 @@ describe( 'table properties', () => {
 
 						expect( table.getAttribute( 'tableBorderColor' ) ).to.equal( 'red' );
 						expect( table.getAttribute( 'tableBorderStyle' ) ).to.equal( 'solid' );
-						expect( table.getAttribute( 'tableBorderWidth' ) ).to.equal( '1px' );
+						expect( table.getAttribute( 'tableBorderWidth' ) ).to.equal( '2px' );
 
 						// Also check the entire structure of the model.
 						// Previously the test was too loose in that regard.
 						expect( getModelData( editor.model ) ).to.equal(
-							'[<table tableBorderColor="red" tableBorderStyle="solid" tableBorderWidth="1px">' +
+							'[<table tableBorderColor="red" tableBorderStyle="solid" tableBorderWidth="2px">' +
 								'<tableRow>' +
 									'<tableCell>' +
 										'<paragraph>' +
@@ -261,7 +267,7 @@ describe( 'table properties', () => {
 										'</paragraph>' +
 									'</tableCell>' +
 									'<tableCell>' +
-										'<table tableBorderColor="green" tableBorderStyle="solid" tableBorderWidth="1px">' +
+										'<table tableBorderColor="green" tableBorderStyle="solid" tableBorderWidth="2px">' +
 											'<tableRow>' +
 												'<tableCell>' +
 													'<paragraph>' +
@@ -386,7 +392,7 @@ describe( 'table properties', () => {
 										'<paragraph>parent:00</paragraph>' +
 									'</tableCell>' +
 									'<tableCell>' +
-										'<table tableBorderColor="green" tableBorderStyle="solid" tableBorderWidth="1px">' +
+										'<table tableBorderColor="green" tableBorderStyle="solid">' +
 											'<tableRow>' +
 												'<tableCell>' +
 													'<paragraph>child:00</paragraph>' +

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -50,13 +50,7 @@ describe( 'table properties', () => {
 
 				expect( config ).to.be.an( 'object' );
 				expect( config ).to.have.property( 'defaultProperties' );
-				expect( config.defaultProperties ).to.include( {
-					borderStyle: 'double',
-					borderColor: 'hsl(0, 0%, 70%)',
-					borderWidth: '1px',
-					width: '100%',
-					height: '100%'
-				} );
+				expect( config.defaultProperties ).to.include( {} );
 			} );
 
 			it( 'adds tableBorderColor command', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -90,6 +90,16 @@ describe( 'table properties', () => {
 			} );
 
 			describe( 'upcast conversion', () => {
+				it( 'should not upcast border shorthand when values are the same as default values', () => {
+					editor.setData( '<table style="border:1px double hsl(0, 0%, 70%)"><tr><td>foo</td></tr></table>' );
+
+					const table = model.document.getRoot().getNodeByPath( [ 0 ] );
+
+					expect( table.getAttribute( 'tableBorderColor' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableBorderStyle' ) ).to.be.undefined;
+					expect( table.getAttribute( 'tableBorderWidth' ) ).to.be.undefined;
+				} );
+
 				it( 'should upcast border shorthand', () => {
 					editor.setData( '<table style="border:1px solid #f00"><tr><td>foo</td></tr></table>' );
 
@@ -402,11 +412,11 @@ describe( 'table properties', () => {
 
 						it( 'should upcast tables with nested tables in their cells', () => {
 							editor.setData(
-								'<table style="border:1px solid red">' +
+								'<table style="border:2px solid red">' +
 									'<tr>' +
 										'<td>parent:00</td>' +
 										'<td>' +
-											'<table style="border:1px solid green"><tr><td>child:00</td></tr></table>' +
+											'<table style="border:2px solid green"><tr><td>child:00</td></tr></table>' +
 										'</td>' +
 									'</tr>' +
 								'</table>'
@@ -416,10 +426,10 @@ describe( 'table properties', () => {
 
 							expect( table.getAttribute( 'tableBorderColor' ) ).to.equal( 'red' );
 							expect( table.getAttribute( 'tableBorderStyle' ) ).to.equal( 'solid' );
-							expect( table.getAttribute( 'tableBorderWidth' ) ).to.equal( '1px' );
+							expect( table.getAttribute( 'tableBorderWidth' ) ).to.equal( '2px' );
 
 							expect( getModelData( editor.model ) ).to.equal(
-								'[<table tableBorderColor="red" tableBorderStyle="solid" tableBorderWidth="1px">' +
+								'[<table tableBorderColor="red" tableBorderStyle="solid" tableBorderWidth="2px">' +
 									'<tableRow>' +
 										'<tableCell>' +
 											'<paragraph>' +

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -50,7 +50,7 @@ describe( 'table properties', () => {
 
 				expect( config ).to.be.an( 'object' );
 				expect( config ).to.have.property( 'defaultProperties' );
-				expect( config.defaultProperties ).to.include( {} );
+				expect( config.defaultProperties ).to.deep.equal( {} );
 			} );
 
 			it( 'adds tableBorderColor command', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
@@ -669,12 +669,12 @@ describe( 'table properties', () => {
 
 					expect( contextualBalloon.visibleView ).to.equal( tablePropertiesView );
 					expect( tablePropertiesView ).to.include( {
-						borderStyle: 'none',
-						borderColor: '',
-						borderWidth: '',
+						borderStyle: 'double',
+						borderColor: 'hsl(0, 0%, 70%)',
+						borderWidth: '1px',
 						backgroundColor: '',
-						width: '',
-						height: '',
+						width: '100%',
+						height: '100%',
 						alignment: 'center'
 					} );
 				} );

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesui.js
@@ -673,8 +673,8 @@ describe( 'table properties', () => {
 						borderColor: 'hsl(0, 0%, 70%)',
 						borderWidth: '1px',
 						backgroundColor: '',
-						width: '100%',
-						height: '100%',
+						width: '',
+						height: '',
 						alignment: 'center'
 					} );
 				} );

--- a/packages/ckeditor5-table/tests/utils/table-properties.js
+++ b/packages/ckeditor5-table/tests/utils/table-properties.js
@@ -185,8 +185,8 @@ describe( 'table utils', () => {
 					borderStyle: 'double',
 					borderColor: 'hsl(0, 0%, 70%)',
 					borderWidth: '1px',
-					width: '100%',
-					height: '100%'
+					width: '',
+					height: ''
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-table/tests/utils/table-properties.js
+++ b/packages/ckeditor5-table/tests/utils/table-properties.js
@@ -3,7 +3,11 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import { getNormalizedDefaultProperties } from '../../src/utils/table-properties.js';
+import {
+	getNormalizedDefaultCellProperties,
+	getNormalizedDefaultProperties,
+	getNormalizedDefaultTableProperties
+} from '../../src/utils/table-properties.js';
 
 describe( 'table utils', () => {
 	describe( 'table-properties', () => {
@@ -168,6 +172,32 @@ describe( 'table utils', () => {
 					borderWidth: '',
 					borderColor: '',
 					backgroundColor: '',
+					width: '',
+					height: ''
+				} );
+			} );
+		} );
+
+		describe( 'getNormalizedDefaultTableProperties()', () => {
+			it( 'should return proper default properties for table', () => {
+				expect( getNormalizedDefaultTableProperties() ).to.deep.equal( {
+					backgroundColor: '',
+					borderStyle: 'double',
+					borderColor: 'hsl(0, 0%, 70%)',
+					borderWidth: '1px',
+					width: '100%',
+					height: '100%'
+				} );
+			} );
+		} );
+
+		describe( 'getNormalizedDefaultCellProperties', () => {
+			it( 'should return proper default properties for cell', () => {
+				expect( getNormalizedDefaultCellProperties() ).to.deep.equal( {
+					backgroundColor: '',
+					borderStyle: 'solid',
+					borderColor: 'hsl(0, 0%, 75%)',
+					borderWidth: '1px',
 					width: '',
 					height: ''
 				} );

--- a/packages/ckeditor5-table/tests/utils/table-properties.js
+++ b/packages/ckeditor5-table/tests/utils/table-properties.js
@@ -191,7 +191,7 @@ describe( 'table utils', () => {
 			} );
 		} );
 
-		describe( 'getNormalizedDefaultCellProperties', () => {
+		describe( 'getNormalizedDefaultCellProperties()', () => {
 			it( 'should return proper default properties for cell', () => {
 				expect( getNormalizedDefaultCellProperties() ).to.deep.equal( {
 					backgroundColor: '',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (table): Changed default table and table cell properties to match the content styles. Fixes problem with setting `border = none` on the table. Closes #6841. 

---

### Additional information
More context: #16810.
It's follow-up of this PR: #16002  
Fixes that have to be applied:

1.  https://github.com/ckeditor/ckeditor5/issues/16810#issuecomment-2258181045
2.  https://github.com/ckeditor/ckeditor5/pull/16002#issuecomment-2270562447

I decided to keep this in new PR due to change of ownership of this issue and keeping history of previous PR untouched.

#### Paste from Office test changes explanation

Aligned with actual data

```
<table class=MsoTableGrid border=1 cellspacing=0 cellpadding=0 width=597 style='border-collapse:collapse;mso-table-layout-alt:fixed;
border:none;
^^^^^^^^^
mso-border-alt:solid windowtext .5pt;mso-yfti-tbllook:1184;mso-padding-alt:
0cm 5.4pt 0cm 5.4pt'>
```

The first cell has a full border:

```
<td width="59%" style='width:59.0%;border:solid windowtext 1.0pt;mso-border-alt:
                                   ^^^^^^^^^^
solid windowtext .5pt;background:#CCCCCC;padding:0cm 5.4pt 0cm 5.4pt'>
```

While other cells have specific borders:

```
<td width="24%" style='width:24.0%;border:solid windowtext 1.0pt;
border-left:none;mso-border-left-alt:solid windowtext .5pt;mso-border-alt:solid windowtext .5pt;
^^^^^^^^^^^^^
background:#CCCCCC;padding:0cm 5.4pt 0cm 5.4pt'>
```