### PR TITLE
Fix focusing block widgets inside multi root editor

### DIFF
--- a/packages/ckeditor5-clipboard/src/clipboardobserver.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardobserver.ts
@@ -7,7 +7,7 @@
  * @module clipboard/clipboardobserver
  */
 
-import { EventInfo } from '@ckeditor/ckeditor5-utils';
+import { EventInfo, getRangeFromMouseEvent } from '@ckeditor/ckeditor5-utils';
 
 import {
 	DataTransfer,
@@ -92,7 +92,9 @@ export default class ClipboardObserver extends DomEventObserver<
 		};
 
 		if ( domEvent.type == 'drop' || domEvent.type == 'dragover' ) {
-			evtData.dropRange = getDropViewRange( this.view, domEvent as DragEvent );
+			const domRange = getRangeFromMouseEvent( domEvent as DragEvent );
+
+			evtData.dropRange = domRange && this.view.domConverter.domRangeToView( domRange );
 		}
 
 		this.fire( domEvent.type, domEvent, evtData );
@@ -113,30 +115,6 @@ export interface ClipboardEventData {
 	 * The position into which the content is dropped.
 	 */
 	dropRange?: ViewRange | null;
-}
-
-function getDropViewRange( view: EditingView, domEvent: DragEvent & { rangeParent?: Node; rangeOffset?: number } ) {
-	const domDoc = ( domEvent.target as Node ).ownerDocument!;
-	const x = domEvent.clientX;
-	const y = domEvent.clientY;
-	let domRange;
-
-	// Webkit & Blink.
-	if ( domDoc.caretRangeFromPoint && domDoc.caretRangeFromPoint( x, y ) ) {
-		domRange = domDoc.caretRangeFromPoint( x, y );
-	}
-	// FF.
-	else if ( domEvent.rangeParent ) {
-		domRange = domDoc.createRange();
-		domRange.setStart( domEvent.rangeParent, domEvent.rangeOffset! );
-		domRange.collapse( true );
-	}
-
-	if ( domRange ) {
-		return view.domConverter.domRangeToView( domRange );
-	}
-
-	return null;
 }
 
 /**

--- a/packages/ckeditor5-clipboard/tests/dragdrop.js
+++ b/packages/ckeditor5-clipboard/tests/dragdrop.js
@@ -2436,7 +2436,8 @@ describe( 'Drag and Drop', () => {
 		const eventData = prepareEventData( model.document.selection.getLastPosition(), domTarget );
 
 		viewDocument.fire( 'mousedown', {
-			...eventData
+			...eventData,
+			preventDefault
 		} );
 
 		viewDocument.fire( 'dragstart', {

--- a/packages/ckeditor5-editor-multi-root/package.json
+++ b/packages/ckeditor5-editor-multi-root/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@ckeditor/ckeditor5-basic-styles": "43.0.0",
     "@ckeditor/ckeditor5-dev-utils": "^42.0.0",
-    "@ckeditor/ckeditor5-essentials": "43.0.0",
     "@ckeditor/ckeditor5-enter": "43.0.0",
     "@ckeditor/ckeditor5-heading": "43.0.0",
     "@ckeditor/ckeditor5-paragraph": "43.0.0",
@@ -32,6 +31,10 @@
     "@ckeditor/ckeditor5-undo": "43.0.0",
     "@ckeditor/ckeditor5-clipboard": "43.0.0",
     "@ckeditor/ckeditor5-watchdog": "43.0.0",
+    "@ckeditor/ckeditor5-image": "43.0.0",
+    "@ckeditor/ckeditor5-link": "43.0.0",
+    "@ckeditor/ckeditor5-adapter-ckfinder": "43.0.0",
+    "@ckeditor/ckeditor5-ckfinder": "43.0.0",
     "typescript": "5.0.4",
     "webpack": "^5.58.1",
     "webpack-cli": "^4.9.0"

--- a/packages/ckeditor5-editor-multi-root/tests/manual/multirooteditor.html
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/multirooteditor.html
@@ -1,3 +1,9 @@
+<head>
+	<meta http-equiv="Content-Security-Policy" content="script-src 'self' https://ckeditor.com 'unsafe-inline' 'unsafe-eval'">
+</head>
+
+<script src="https://ckeditor.com/apps/ckfinder/3.5.0/ckfinder.js"></script>
+
 <p>
 	<button id="destroyEditor">Destroy editor</button>
 	<button id="initEditor">Init editor</button>
@@ -12,7 +18,19 @@
 <h2>The editable</h2>
 <div class="editable-container">
 	<div id="editor-intro"><p><strong>Exciting</strong> intro text to an article.</p></div>
-	<div id="editor-content"><h2>Exciting news!</h2><p>Lorem ipsum dolor sit amet.</p></div>
+	<div id="editor-content">
+		<table>
+			<tr>
+				<td>First cell</td>
+				<td>Second cell</td>
+			</tr>
+		</table>
+
+		<br />
+		<br />
+
+		<p>Hello World</p>
+	</div>
 	<div id="editor-outro"><p>Closing text.</p></div>
 </div>
 

--- a/packages/ckeditor5-editor-multi-root/tests/manual/multirooteditor.js
+++ b/packages/ckeditor5-editor-multi-root/tests/manual/multirooteditor.js
@@ -10,7 +10,13 @@ import Heading from '@ckeditor/ckeditor5-heading/src/heading.js';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold.js';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic.js';
-import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials.js';
+import Image from '@ckeditor/ckeditor5-image/src/image.js';
+import AutoImage from '@ckeditor/ckeditor5-image/src/autoimage.js';
+import ImageInsert from '@ckeditor/ckeditor5-image/src/imageinsert.js';
+import LinkImage from '@ckeditor/ckeditor5-link/src/linkimage.js';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset.js';
+import CKFinderUploadAdapter from '@ckeditor/ckeditor5-adapter-ckfinder/src/uploadadapter.js';
+import CKFinder from '@ckeditor/ckeditor5-ckfinder/src/ckfinder.js';
 
 const editorData = {
 	intro: document.querySelector( '#editor-intro' ),
@@ -23,8 +29,26 @@ let editor;
 function initEditor() {
 	MultiRootEditor
 		.create( editorData, {
-			plugins: [ Essentials, Paragraph, Heading, Bold, Italic ],
-			toolbar: [ 'heading', '|', 'bold', 'italic', 'undo', 'redo' ]
+			plugins: [
+				Paragraph, Heading, Bold, Italic,
+				Image, ImageInsert, AutoImage, LinkImage,
+				ArticlePluginSet, CKFinderUploadAdapter, CKFinder
+			],
+			toolbar: [
+				'heading', '|', 'bold', 'italic', 'undo', 'redo', '|',
+				'insertImage', 'insertTable', 'blockQuote'
+			],
+			image: {
+				toolbar: [
+					'imageStyle:inline', 'imageStyle:block',
+					'imageStyle:wrapText', '|', 'toggleImageCaption',
+					'imageTextAlternative'
+				]
+			},
+			ckfinder: {
+				// eslint-disable-next-line max-len
+				uploadUrl: 'https://ckeditor.com/apps/ckfinder/3.5.0/core/connector/php/connector.php?command=QuickUpload&type=Files&responseType=json'
+			}
 		} )
 		.then( newEditor => {
 			console.log( 'Editor was initialized', newEditor );
@@ -55,3 +79,5 @@ function destroyEditor() {
 
 document.getElementById( 'initEditor' ).addEventListener( 'click', initEditor );
 document.getElementById( 'destroyEditor' ).addEventListener( 'click', destroyEditor );
+
+initEditor();

--- a/packages/ckeditor5-utils/src/dom/getrangefrommouseevent.ts
+++ b/packages/ckeditor5-utils/src/dom/getrangefrommouseevent.ts
@@ -1,0 +1,44 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/**
+ * @module utils/dom/getrangefrommouseevent
+ */
+
+/**
+ * Returns a DOM range from a given point specified by a mouse event.
+ *
+ * @param domEvent The mouse event.
+ * @returns The DOM range.
+ */
+export default function getRangeFromMouseEvent(
+	domEvent: MouseEvent & {
+		rangeParent?: HTMLElement;
+		rangeOffset?: number;
+	}
+): Range | null {
+	if ( !domEvent.target ) {
+		return null;
+	}
+
+	const domDoc = ( domEvent.target as HTMLElement ).ownerDocument;
+	const x = domEvent.clientX;
+	const y = domEvent.clientY;
+	let domRange = null;
+
+	// Webkit & Blink.
+	if ( domDoc.caretRangeFromPoint && domDoc.caretRangeFromPoint( x, y ) ) {
+		domRange = domDoc.caretRangeFromPoint( x, y );
+	}
+
+	// FF.
+	else if ( domEvent.rangeParent ) {
+		domRange = domDoc.createRange();
+		domRange.setStart( domEvent.rangeParent, domEvent.rangeOffset! );
+		domRange.collapse( true );
+	}
+
+	return domRange;
+}

--- a/packages/ckeditor5-utils/src/index.ts
+++ b/packages/ckeditor5-utils/src/index.ts
@@ -54,6 +54,7 @@ export { default as global } from './dom/global.js';
 export { default as getAncestors } from './dom/getancestors.js';
 export { default as getDataFromElement } from './dom/getdatafromelement.js';
 export { default as getBorderWidths } from './dom/getborderwidths.js';
+export { default as getRangeFromMouseEvent } from './dom/getrangefrommouseevent.js';
 export { default as isText } from './dom/istext.js';
 export { default as Rect, type RectSource } from './dom/rect.js';
 export { default as ResizeObserver } from './dom/resizeobserver.js';

--- a/packages/ckeditor5-utils/tests/dom/getrangefrommouseevent.js
+++ b/packages/ckeditor5-utils/tests/dom/getrangefrommouseevent.js
@@ -1,0 +1,76 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import getRangeFromMouseEvent from '../../src/dom/getrangefrommouseevent.js';
+
+describe( 'getRangeFromMouseEvent()', () => {
+	it( 'should use Document#caretRangeFromPoint method to obtain range on Webkit & Blink', () => {
+		const fakeRange = {
+			startOffset: 0,
+			endOffset: 0
+		};
+
+		const caretRangeFromPointSpy = sinon.stub().returns( fakeRange );
+		const evt = {
+			clientX: 10,
+			clientY: 11,
+			target: {
+				ownerDocument: {
+					caretRangeFromPoint: caretRangeFromPointSpy
+				}
+			}
+		};
+
+		expect( getRangeFromMouseEvent( evt ) ).to.be.equal( fakeRange );
+		expect( caretRangeFromPointSpy ).to.be.calledWith( 10, 11 );
+	} );
+
+	it( 'should use Document#createRange method to obtain range on Firefox', () => {
+		const fakeRange = {
+			startOffset: 0,
+			endOffset: 0,
+			setStart: sinon.stub(),
+			collapse: sinon.stub()
+		};
+
+		const evt = {
+			clientX: 10,
+			clientY: 11,
+			rangeOffset: 13,
+			rangeParent: { parent: true },
+			target: {
+				ownerDocument: {
+					createRange: sinon.stub().returns( fakeRange )
+				}
+			}
+		};
+
+		expect( getRangeFromMouseEvent( evt ) ).to.be.equal( fakeRange );
+
+		expect( fakeRange.collapse ).to.be.calledWith( true );
+		expect( fakeRange.setStart ).to.be.calledWith( evt.rangeParent, evt.rangeOffset );
+	} );
+
+	it( 'should return null if event target is null', () => {
+		const evt = {
+			target: null
+		};
+
+		expect( getRangeFromMouseEvent( evt ) ).to.be.null;
+	} );
+
+	it( 'should return null if event target is not null but it\'s not possible to create range on document', () => {
+		const evt = {
+			target: {
+				ownerDocument: {
+					createRange: null,
+					caretRangeFromPoint: null
+				}
+			}
+		};
+
+		expect( getRangeFromMouseEvent( evt ) ).to.be.null;
+	} );
+} );

--- a/packages/ckeditor5-widget/tests/widget.js
+++ b/packages/ckeditor5-widget/tests/widget.js
@@ -396,10 +396,6 @@ describe( 'Widget', () => {
 			.returns( {} );
 
 		sinon
-			.stub( parentView, 'is' )
-			.withArgs( 'editableElement' ).returns( true );
-
-		sinon
 			.stub( view.domConverter, 'domRangeToView' )
 			.returns( {
 				start: {

--- a/packages/ckeditor5-widget/tests/widget.js
+++ b/packages/ckeditor5-widget/tests/widget.js
@@ -21,6 +21,9 @@ import { getCode, keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard.js';
 import toArray from '@ckeditor/ckeditor5-utils/src/toarray.js';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
 import env from '@ckeditor/ckeditor5-utils/src/env.js';
+import View from '@ckeditor/ckeditor5-engine/src/view/view.js';
+import RootEditableElement from '@ckeditor/ckeditor5-engine/src/view/rooteditableelement.js';
+import EditableElement from '@ckeditor/ckeditor5-engine/src/view/editableelement.js';
 
 describe( 'Widget', () => {
 	let element, editor, model, view, viewDocument;
@@ -182,6 +185,235 @@ describe( 'Widget', () => {
 
 	it( 'should require the WidgetTypeAround and Delete plugins', () => {
 		expect( Widget.requires ).to.have.members( [ WidgetTypeAround, Delete ] );
+	} );
+
+	it( 'should not focus anything when there is no editable ancestor on mousedown', () => {
+		setModelData( model, '<paragraph>Hello</paragraph>' );
+
+		const paragraphView = viewDocument.getRoot().getChild( 0 );
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( paragraphView ),
+			preventDefault: sinon.spy()
+		} );
+
+		const isEditableElementStub = sinon
+			.stub( RootEditableElement.prototype, 'is' )
+			.withArgs( 'editableElement' )
+			.returns( false );
+
+		const focusSpy = sinon.spy( View.prototype, 'focus' );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		expect( focusSpy ).not.to.be.called;
+
+		isEditableElementStub.reset();
+		focusSpy.restore();
+	} );
+
+	it( 'should not crash if the click target is not inside nested editable', () => {
+		setModelData( model, '<widget><nested>Hello</nested></widget>' );
+
+		const nestedView = viewDocument.getRoot().getChild( 0 ).getChild( 0 );
+
+		nestedView.parent = null;
+
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( nestedView ),
+			preventDefault: sinon.spy()
+		} );
+
+		const isEditableElementStub = sinon
+			.stub( EditableElement.prototype, 'is' )
+			.withArgs( 'editableElement' )
+			.returns( false );
+
+		const focusSpy = sinon.spy( View.prototype, 'focus' );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		expect( focusSpy ).not.to.be.called;
+
+		isEditableElementStub.reset();
+		focusSpy.restore();
+	} );
+
+	it( 'should not focus anything when the range start element is not present', () => {
+		setModelData( model, '<paragraph>Hello</paragraph>' );
+
+		const paragraphView = viewDocument.getRoot().getChild( 0 );
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( paragraphView ),
+			preventDefault: sinon.spy()
+		} );
+
+		sinon
+			.stub( domEventDataMock.domTarget.ownerDocument, 'caretRangeFromPoint' )
+			.returns( {} );
+
+		sinon
+			.stub( view.domConverter, 'domRangeToView' )
+			.returns( {
+				start: {
+					parent: null
+				}
+			} );
+
+		const focusSpy = sinon.spy( View.prototype, 'focus' );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		expect( focusSpy ).not.to.be.called;
+	} );
+
+	it( 'should not focus anything when it\'s not possible to extract range from mouse event', () => {
+		setModelData( model, '<paragraph>Hello</paragraph>' );
+
+		const paragraphView = viewDocument.getRoot().getChild( 0 );
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( paragraphView ),
+			preventDefault: sinon.spy()
+		} );
+
+		sinon
+			.stub( domEventDataMock.domTarget.ownerDocument, 'caretRangeFromPoint' )
+			.returns( null );
+
+		sinon
+			.stub( view.domConverter, 'domRangeToView' )
+			.returns( {
+				start: {
+					parent: paragraphView
+				}
+			} );
+
+		const focusSpy = sinon.spy( View.prototype, 'focus' );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		expect( focusSpy ).not.to.be.called;
+	} );
+
+	it( 'should not focus anything when the range start element is text node', () => {
+		setModelData( model, '<paragraph>Hello</paragraph>' );
+
+		const paragraphView = viewDocument.getRoot().getChild( 0 );
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( paragraphView ),
+			preventDefault: sinon.spy()
+		} );
+
+		sinon
+			.stub( domEventDataMock.domTarget.ownerDocument, 'caretRangeFromPoint' )
+			.returns( {} );
+
+		sinon
+			.stub( view.domConverter, 'domRangeToView' )
+			.returns( {
+				start: {
+					parent: {
+						is: sinon.stub().withArgs( '$text' ).returns( true )
+					}
+				}
+			} );
+
+		const focusSpy = sinon.spy( View.prototype, 'focus' );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		expect( focusSpy ).not.to.be.called;
+	} );
+
+	it( 'should not focus anything if there is no widget ancestor of element found in click point', () => {
+		setModelData( model, '<paragraph>Hello</paragraph>' );
+
+		const paragraphView = viewDocument.getRoot().getChild( 0 );
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( paragraphView ),
+			preventDefault: sinon.spy()
+		} );
+
+		sinon
+			.stub( domEventDataMock.domTarget.ownerDocument, 'caretRangeFromPoint' )
+			.returns( {} );
+
+		sinon
+			.stub( view.domConverter, 'domRangeToView' )
+			.returns( {
+				start: {
+					parent: paragraphView
+				}
+			} );
+
+		const focusSpy = sinon.spy( View.prototype, 'focus' );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		expect( focusSpy ).not.to.be.called;
+	} );
+
+	it( 'should not lookup for widget ancestor of element found in click point if it\'s widget', () => {
+		setModelData( model, '<paragraph>Hello</paragraph><widget>ABC</widget>' );
+
+		const paragraphView = viewDocument.getRoot().getChild( 0 );
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( paragraphView ),
+			preventDefault: sinon.spy()
+		} );
+
+		sinon
+			.stub( domEventDataMock.domTarget.ownerDocument, 'caretRangeFromPoint' )
+			.returns( {} );
+
+		sinon
+			.stub( view.domConverter, 'domRangeToView' )
+			.returns( {
+				start: {
+					parent: viewDocument.getRoot().getChild( 1 )
+				}
+			} );
+
+		const focusSpy = sinon.stub( View.prototype, 'focus' ).returns( true );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		expect( focusSpy ).to.be.called;
+	} );
+
+	it( 'should focus if clicked node that is at the end', () => {
+		setModelData( model, '<editable><inline-widget></inline-widget></editable>' );
+
+		const parentView = viewDocument.getRoot().getChild( 0 );
+		const widgetView = parentView.getChild( 0 );
+
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( parentView ),
+			preventDefault: sinon.spy()
+		} );
+
+		sinon
+			.stub( domEventDataMock.domTarget.ownerDocument, 'caretRangeFromPoint' )
+			.returns( {} );
+
+		sinon
+			.stub( parentView, 'is' )
+			.withArgs( 'editableElement' ).returns( true );
+
+		sinon
+			.stub( view.domConverter, 'domRangeToView' )
+			.returns( {
+				start: {
+					isAtEnd: true,
+					parent: parentView,
+					nodeBefore: widgetView
+				}
+			} );
+
+		const focusSpy = sinon.stub( View.prototype, 'focus' ).returns( true );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		expect( focusSpy ).to.be.called;
 	} );
 
 	it( 'should create selection over clicked widget', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (editor-multi-root): No longer lose selection on clicking editable containing only one block element. Closes https://github.com/ckeditor/ckeditor5/issues/16806

---

### Additional information

I adjusted multi-root demos with additional plugins to make debugging block items easier.
Debug log: https://github.com/ckeditor/ckeditor5/issues/16806#issuecomment-2275645126

#### Before

https://github.com/user-attachments/assets/b2ccd2c6-7149-4d2c-9e6a-f89f3c5be012

#### After

https://github.com/user-attachments/assets/d9f89d58-3cf0-4048-be5d-385f09314ff8

https://github.com/user-attachments/assets/d52fc851-2323-42e3-afb7-c1d51ee666e3



