### PR TITLE
Avoid creating arrays in getNodeStartOffset

### DIFF
--- a/packages/ckeditor5-engine/src/model/nodelist.ts
+++ b/packages/ckeditor5-engine/src/model/nodelist.ts
@@ -80,7 +80,16 @@ export default class NodeList implements Iterable<Node> {
 	public getNodeStartOffset( node: Node ): number | null {
 		const index = this.getNodeIndex( node );
 
-		return index === null ? null : this._nodes.slice( 0, index ).reduce( ( sum, node ) => sum + node.offsetSize, 0 );
+		if ( index === null ) {
+			return null;
+		}
+
+		let sum = 0;
+		for ( let i = 0; i < index; i++ ) {
+			sum += this._nodes[ i ].offsetSize;
+		}
+
+		return sum;
 	}
 
 	/**


### PR DESCRIPTION
`NodeList.getNodeStartOffset` gets called quite a lot, so it is better not to create a new array slice every time. 