### PR TITLE
Stop creating unnecessary arrays in Renderer._updateAttrs

### DIFF
--- a/packages/ckeditor5-engine/src/view/renderer.ts
+++ b/packages/ckeditor5-engine/src/view/renderer.ts
@@ -585,20 +585,18 @@ export default class Renderer extends /* #__PURE__ */ ObservableMixin() {
 			return;
 		}
 
-		const domAttrKeys = Array.from( ( domElement as DomElement ).attributes ).map( attr => attr.name );
-		const viewAttrKeys = viewElement.getAttributeKeys();
-
-		// Add or overwrite attributes.
-		for ( const key of viewAttrKeys ) {
-			this.domConverter.setDomElementAttribute( domElement as DomElement, key, viewElement.getAttribute( key )!, viewElement );
-		}
-
 		// Remove from DOM attributes which do not exists in the view.
-		for ( const key of domAttrKeys ) {
+		for ( const attr of ( domElement as DomElement ).attributes ) {
+			const key = attr.name;
 			// All other attributes not present in the DOM should be removed.
 			if ( !viewElement.hasAttribute( key ) ) {
 				this.domConverter.removeDomElementAttribute( domElement as DomElement, key );
 			}
+		}
+
+		// Add or overwrite attributes.
+		for ( const key of viewElement.getAttributeKeys() ) {
+			this.domConverter.setDomElementAttribute( domElement as DomElement, key, viewElement.getAttribute( key )!, viewElement );
 		}
 	}
 


### PR DESCRIPTION
This PR optimizes the [Renderer._updateAttrs](https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-engine/src/view/renderer.ts#L577) by removing a unnecessary `Array.from` call. 

This change is a bit more controversial than my previous changes as it changes the order of iterations. I believe the semantics to be identical, but it should be reviewed with a bit of extra care.
