### PR TITLE
Ensured CKEditor 5 UI lists are not affected by Umberto's `.formatted` margins

### DIFF
--- a/docs/assets/snippet-styles.css
+++ b/docs/assets/snippet-styles.css
@@ -74,11 +74,6 @@ It breaks CKEditor 5 (see how <p><code>[]</code></p> looks). */
 	font-size: smaller;
 }
 
-.ck.ck-list {
-	/* See https://github.com/ckeditor/ckeditor5/issues/494 */
-	margin-left: 0;
-}
-
 .demo-row {
 	width: 100%;
 	display: -ms-flexbox;
@@ -142,6 +137,12 @@ It breaks CKEditor 5 (see how <p><code>[]</code></p> looks). */
 	font-weight: bold;
 	font-size: 16px;
 	padding: 0;
+	margin: 0;
+}
+
+/* See https://github.com/ckeditor/ckeditor5/issues/494 */
+/* See https://github.com/ckeditor/ckeditor5/issues/16935 */
+.formatted .ck.ck-list {
 	margin: 0;
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Ensured CKEditor 5 UI lists are not affected by Umberto's `.formatted` margins. Closes #16935.
