### PR TITLE
Exclude TypeScript declaration files when collecting translation source files

### DIFF
--- a/scripts/translations/utils.js
+++ b/scripts/translations/utils.js
@@ -74,7 +74,7 @@ function parseArguments( args ) {
 }
 
 /**
- * Returns absolute paths to CKEditor 5 sources. Files located in the `src/lib/` directory are excluded.
+ * Returns absolute paths to CKEditor 5 sources. Files located in the `src/lib/` directory and TypeScript declaration files are excluded.
  *
  * @param {TranslationOptions} options
  * @returns {Array.<String>}
@@ -92,7 +92,8 @@ function getCKEditor5SourceFiles( { cwd, includeExternalDirectory } ) {
 
 	return patterns.map( item => glob.sync( item, globOptions ) )
 		.flat()
-		.filter( srcPath => !srcPath.match( /packages\/[^/]+\/src\/lib\// ) );
+		.filter( srcPath => !srcPath.match( /packages\/[^/]+\/src\/lib\// ) )
+		.filter( srcPath => !srcPath.endsWith( '.d.ts' ) );
 }
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Exclude TypeScript declaration files when collecting translation source files.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
