### PR TITLE
Remove Math.random from uid.

### DIFF
--- a/packages/ckeditor5-utils/src/uid.ts
+++ b/packages/ckeditor5-utils/src/uid.ts
@@ -26,19 +26,7 @@ const HEX_NUMBERS = new Array( 256 ).fill( '' )
  */
 export default function uid(): string {
 	// Let's create some positive random 32bit integers first.
-	//
-	// 1. Math.random() is a float between 0 and 1.
-	// 2. 0x100000000 is 2^32 = 4294967296.
-	// 3. >>> 0 enforces integer (in JS all numbers are floating point).
-	//
-	// For instance:
-	//		Math.random() * 0x100000000 = 3366450031.853859
-	// but
-	//		Math.random() * 0x100000000 >>> 0 = 3366450031.
-	const r1 = Math.random() * 0x100000000 >>> 0;
-	const r2 = Math.random() * 0x100000000 >>> 0;
-	const r3 = Math.random() * 0x100000000 >>> 0;
-	const r4 = Math.random() * 0x100000000 >>> 0;
+	const [ r1, r2, r3, r4 ] = crypto.getRandomValues( new Uint32Array( 4 ) );
 
 	// Make sure that id does not start with number.
 	return 'e' +

--- a/packages/ckeditor5-utils/tests/uid.js
+++ b/packages/ckeditor5-utils/tests/uid.js
@@ -7,6 +7,10 @@ import uid from '../src/uid.js';
 
 describe( 'utils', () => {
 	describe( 'uid', () => {
+		afterEach( () => {
+			sinon.restore();
+		} );
+
 		it( 'should return different ids', () => {
 			const id1 = uid();
 			const id2 = uid();
@@ -21,6 +25,14 @@ describe( 'utils', () => {
 			expect( id1 ).to.match( uuidRegex );
 			expect( id2 ).to.match( uuidRegex );
 			expect( id3 ).to.match( uuidRegex );
+		} );
+
+		it( 'should not use Math.random()', () => {
+			const spy = sinon.spy( Math, 'random' );
+
+			uid();
+
+			expect( spy.notCalled ).to.be.true;
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (utils): Remove `Math.random()` from `uid` implementation.
See https://github.com/cksource/ckeditor5-internal/issues/3742.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
