### PR TITLE
Fix schema definitions of hgroup and summary

### DIFF
--- a/packages/ckeditor5-html-support/src/schemadefinitions.ts
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.ts
@@ -279,9 +279,17 @@ export default {
 			model: 'htmlSummary',
 			view: 'summary',
 			modelSchema: {
-				allowChildren: '$text',
+				allowChildren: [
+					'htmlH1',
+					'htmlH2',
+					'htmlH3',
+					'htmlH4',
+					'htmlH5',
+					'$text'
+				],
 				allowIn: 'htmlDetails',
-				isBlock: false
+				isBlock: false,
+				isLimit: true
 			}
 		},
 		{
@@ -342,6 +350,8 @@ export default {
 			view: 'hgroup',
 			modelSchema: {
 				allowChildren: [
+					'paragraph',
+					'htmlP',
 					'htmlH1',
 					'htmlH2',
 					'htmlH3',
@@ -349,7 +359,8 @@ export default {
 					'htmlH5',
 					'htmlH6'
 				],
-				isBlock: false
+				isBlock: false,
+				allowIn: "$root"
 			}
 		},
 		{


### PR DESCRIPTION
Refer to: https://github.com/ckeditor/ckeditor5/issues/16947

This PR fixes the hgroup and summary schema definitions so that they function as expected.