### PR TITLE
Fix schema for hgroup and summary elements

### DIFF
--- a/packages/ckeditor5-html-support/src/schemadefinitions.ts
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.ts
@@ -285,6 +285,7 @@ export default {
 					'htmlH3',
 					'htmlH4',
 					'htmlH5',
+					'htmlH6',
 					'$text'
 				],
 				allowIn: 'htmlDetails',

--- a/packages/ckeditor5-html-support/src/schemadefinitions.ts
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.ts
@@ -349,7 +349,7 @@ export default {
 			model: 'htmlHgroup',
 			view: 'hgroup',
 			modelSchema: {
-				allowIn: '$root',
+				allowIn: '$container',
 				allowChildren: [
 					'paragraph',
 					'htmlP',

--- a/packages/ckeditor5-html-support/src/schemadefinitions.ts
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.ts
@@ -288,8 +288,8 @@ export default {
 					'$text'
 				],
 				allowIn: 'htmlDetails',
-				isBlock: false,
-				isLimit: true
+				isLimit: true,
+				isBlock: false
 			}
 		},
 		{
@@ -349,6 +349,7 @@ export default {
 			model: 'htmlHgroup',
 			view: 'hgroup',
 			modelSchema: {
+				allowIn: '$root',
 				allowChildren: [
 					'paragraph',
 					'htmlP',
@@ -359,8 +360,7 @@ export default {
 					'htmlH5',
 					'htmlH6'
 				],
-				isBlock: false,
-				allowIn: "$root"
+				isBlock: false
 			}
 		},
 		{

--- a/packages/ckeditor5-html-support/src/schemadefinitions.ts
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.ts
@@ -279,9 +279,17 @@ export default {
 			model: 'htmlSummary',
 			view: 'summary',
 			modelSchema: {
-				allowChildren: '$text',
+				allowChildren: [
+					'htmlH1',
+					'htmlH2',
+					'htmlH3',
+					'htmlH4',
+					'htmlH5',
+					'$text'
+				],
 				allowIn: 'htmlDetails',
-				isBlock: false
+				isBlock: false,
+				isLimit: true
 			}
 		},
 		{
@@ -342,6 +350,8 @@ export default {
 			view: 'hgroup',
 			modelSchema: {
 				allowChildren: [
+					'paragraph',
+					'htmlP',
 					'htmlH1',
 					'htmlH2',
 					'htmlH3',
@@ -349,7 +359,8 @@ export default {
 					'htmlH5',
 					'htmlH6'
 				],
-				isBlock: false
+				isBlock: false,
+				allowIn: "$root"
 			}
 		},
 		{

--- a/packages/ckeditor5-html-support/tests/integrations/heading.js
+++ b/packages/ckeditor5-html-support/tests/integrations/heading.js
@@ -82,7 +82,10 @@ describe( 'HeadingElementSupport', () => {
 				model: 'htmlHgroup',
 				view: 'hgroup',
 				modelSchema: {
+					allowIn: '$container',
 					allowChildren: [
+						'paragraph',
+						'htmlP',
 						'htmlH1',
 						'htmlH2',
 						'htmlH3',
@@ -487,7 +490,10 @@ describe( 'HeadingElementSupport', () => {
 				model: 'htmlHgroup',
 				view: 'hgroup',
 				modelSchema: {
+					allowIn: '$container',
 					allowChildren: [
+						'paragraph',
+						'htmlP',
 						'htmlH1',
 						'htmlH2',
 						'htmlH3',


### PR DESCRIPTION
Refer to https://github.com/ckeditor/ckeditor5/issues/16947

Fixes schema of summary and hgroup elements so that they work as expected.