### PR TITLE
Fix pinning the balloons to `#text` nodes

### DIFF
--- a/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
@@ -396,7 +396,7 @@ export default class BalloonPanelView extends View {
 			return false;
 		}
 
-		const targetElement = getDomElement( options.target );
+		let targetElement = getDomElement( options.target );
 		const limiterElement = options.limiter ? getDomElement( options.limiter ) : global.document.body;
 
 		// Then we need to listen on scroll event of eny element in the document.
@@ -422,17 +422,25 @@ export default class BalloonPanelView extends View {
 		} );
 
 		// Hide the panel if the target element is no longer visible.
-		if ( targetElement && !this._resizeObserver ) {
-			const checkVisibility = () => {
-				// If the target element is no longer visible, hide the panel.
-				if ( !isVisible( targetElement ) ) {
-					this.unpin();
-				}
-			};
+		if ( !this._resizeObserver ) {
+			// If the target element is a text node, we need to check the parent element.
+			// It's because `ResizeObserver` accept only elements, not text nodes.
+			if ( targetElement instanceof Text ) {
+				targetElement = targetElement.parentElement;
+			}
 
-			// Element is being resized to 0x0 after it's parent became hidden,
-			// so we need to check size in order to determine if it's visible or not.
-			this._resizeObserver = new ResizeObserver( targetElement, checkVisibility );
+			if ( targetElement ) {
+				const checkVisibility = () => {
+					// If the target element is no longer visible, hide the panel.
+					if ( !isVisible( targetElement ) ) {
+						this.unpin();
+					}
+				};
+
+				// Element is being resized to 0x0 after it's parent became hidden,
+				// so we need to check size in order to determine if it's visible or not.
+				this._resizeObserver = new ResizeObserver( targetElement, checkVisibility );
+			}
 		}
 
 		return true;

--- a/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
@@ -16,6 +16,7 @@ import {
 	isRange,
 	toUnit,
 	isVisible,
+	isText,
 	ResizeObserver,
 	type Locale,
 	type ObservableChangeEvent,
@@ -425,7 +426,7 @@ export default class BalloonPanelView extends View {
 		if ( !this._resizeObserver ) {
 			// If the target element is a text node, we need to check the parent element.
 			// It's because `ResizeObserver` accept only elements, not text nodes.
-			if ( targetElement && targetElement.nodeType === Node.TEXT_NODE ) {
+			if ( targetElement && isText( targetElement ) ) {
 				targetElement = targetElement.parentElement;
 			}
 

--- a/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
+++ b/packages/ckeditor5-ui/src/panel/balloon/balloonpanelview.ts
@@ -425,7 +425,7 @@ export default class BalloonPanelView extends View {
 		if ( !this._resizeObserver ) {
 			// If the target element is a text node, we need to check the parent element.
 			// It's because `ResizeObserver` accept only elements, not text nodes.
-			if ( targetElement instanceof Text ) {
+			if ( targetElement && targetElement.nodeType === Node.TEXT_NODE ) {
 				targetElement = targetElement.parentElement;
 			}
 

--- a/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
+++ b/packages/ckeditor5-ui/tests/panel/balloon/balloonpanelview.js
@@ -1107,6 +1107,35 @@ describe( 'BalloonPanelView', () => {
 					expect( view._resizeObserver ).to.be.null;
 				} );
 
+				it( 'should watch parent element visibility changes if target is text node', () => {
+					const resizeCallbackRef = createResizeObserverCallbackRef();
+					const textNode = target.appendChild(
+						document.createTextNode( 'Hello World' )
+					);
+
+					const range = document.createRange();
+					range.setStart( textNode, 1 );
+					range.setEnd( textNode, 8 );
+
+					view.pin( { target: range, limiter } );
+					clock.tick( 100 );
+
+					expect( view.isVisible ).to.be.true;
+
+					// It's still visible, nothing changed.
+					resizeCallbackRef.current( [ { target } ] );
+					clock.tick( 100 );
+					expect( view.isVisible ).to.be.true;
+
+					// Hide the target and force call resize callback.
+					target.style.display = 'none';
+					resizeCallbackRef.current( [ { target } ] );
+
+					// It should be hidden now.
+					clock.tick( 100 );
+					expect( view.isVisible ).to.be.false;
+				} );
+
 				function createResizeObserverCallbackRef() {
 					const resizeCallbackRef = { current: null };
 

--- a/packages/ckeditor5-utils/src/dom/isvisible.ts
+++ b/packages/ckeditor5-utils/src/dom/isvisible.ts
@@ -17,6 +17,18 @@
  * **Note**: This helper does not check whether the element is hidden by cropping, overflow, etc..
  * To check that, use {@link module:utils/dom/rect~Rect} instead.
  */
-export default function isVisible( element: HTMLElement | null | undefined ): boolean {
-	return !!( element && element.getClientRects && element.getClientRects().length );
+export default function isVisible( element: Text | HTMLElement | null | undefined ): boolean {
+	if ( !element ) {
+		return false;
+	}
+
+	if ( element instanceof Text ) {
+		return isVisible( element.parentElement );
+	}
+
+	if ( element.getClientRects ) {
+		return !!( element.getClientRects().length );
+	}
+
+	return false;
 }

--- a/packages/ckeditor5-utils/src/dom/isvisible.ts
+++ b/packages/ckeditor5-utils/src/dom/isvisible.ts
@@ -3,6 +3,8 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+import isText from './istext.js';
+
 /**
  * @module utils/dom/isvisible
  */
@@ -22,7 +24,7 @@ export default function isVisible( element: Text | HTMLElement | null | undefine
 		return false;
 	}
 
-	if ( element instanceof Text ) {
+	if ( isText( element ) ) {
 		return isVisible( element.parentElement );
 	}
 

--- a/packages/ckeditor5-utils/src/dom/isvisible.ts
+++ b/packages/ckeditor5-utils/src/dom/isvisible.ts
@@ -3,11 +3,11 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-import isText from './istext.js';
-
 /**
  * @module utils/dom/isvisible
  */
+
+import isText from './istext.js';
 
 /**
  * Checks whether the element is visible to the user in DOM:

--- a/packages/ckeditor5-utils/tests/dom/isvisible.js
+++ b/packages/ckeditor5-utils/tests/dom/isvisible.js
@@ -80,4 +80,17 @@ describe( 'isVisible()', () => {
 
 		expect( isVisible( element ) ).to.be.false;
 	} );
+
+	it( 'should return visibility of parent element if text node is passed', () => {
+		document.body.appendChild( element );
+
+		const textNode = document.createTextNode( 'foo' );
+		element.appendChild( textNode );
+
+		expect( isVisible( textNode ) ).to.be.true;
+
+		element.style.display = 'none';
+
+		expect( isVisible( textNode ) ).to.be.false;
+	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Restored the ability to pin balloons to text nodes in the DOM tree. Closes https://github.com/ckeditor/ckeditor5/issues/16958 https://github.com/ckeditor/ckeditor5/issues/16889.

---

### Additional information

1. Introduced in https://github.com/ckeditor/ckeditor5/issues/16739 , we added visibility check before mounting of tooltips to avoid displaying them on hidden elements (which was causing another issue). 
2. Regression was caused by `isVisible` function. It was returning `false` for `$text` nodes, so it was impossible to pin balloons to such nodes.
3. I extracted docs example to standalone manual test. Apply this patch to your git repo to test it on your own [pin-balloons-demo.patch](https://github.com/user-attachments/files/16706397/pin-balloons-demo.txt)

#### Before

https://github.com/user-attachments/assets/b3019683-74ba-4697-a683-6ef9ea719563

#### After

https://github.com/user-attachments/assets/7fb27a4e-b564-4c36-a42a-fc77fb156050

