### PR TITLE
hgroup and summary should work with source editing

### DIFF
--- a/packages/ckeditor5-html-support/src/integrations/heading.ts
+++ b/packages/ckeditor5-html-support/src/integrations/heading.ts
@@ -70,5 +70,12 @@ export default class HeadingElementSupport extends Plugin {
 				allowChildren: headerModels
 			}
 		} );
+
+		dataSchema.extendBlockElement( {
+			model: 'htmlSummary',
+			modelSchema: {
+				allowChildren: headerModels
+			}
+		} );
 	}
 }

--- a/packages/ckeditor5-html-support/src/schemadefinitions.ts
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.ts
@@ -349,7 +349,7 @@ export default {
 			model: 'htmlHgroup',
 			view: 'hgroup',
 			modelSchema: {
-				allowIn: '$container',
+				allowIn: [ '$root', '$container' ],
 				allowChildren: [
 					'paragraph',
 					'htmlP',

--- a/packages/ckeditor5-html-support/src/schemadefinitions.ts
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.ts
@@ -279,8 +279,17 @@ export default {
 			model: 'htmlSummary',
 			view: 'summary',
 			modelSchema: {
-				allowChildren: '$text',
+				allowChildren: [
+					'htmlH1',
+					'htmlH2',
+					'htmlH3',
+					'htmlH4',
+					'htmlH5',
+					'htmlH6',
+					'$text'
+				],
 				allowIn: 'htmlDetails',
+				isLimit: true,
 				isBlock: false
 			}
 		},
@@ -341,7 +350,10 @@ export default {
 			model: 'htmlHgroup',
 			view: 'hgroup',
 			modelSchema: {
+				allowIn: '$root',
 				allowChildren: [
+					'paragraph',
+					'htmlP',
 					'htmlH1',
 					'htmlH2',
 					'htmlH3',

--- a/packages/ckeditor5-html-support/src/schemadefinitions.ts
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.ts
@@ -289,7 +289,6 @@ export default {
 					'$text'
 				],
 				allowIn: 'htmlDetails',
-				isLimit: true,
 				isBlock: false
 			}
 		},

--- a/packages/ckeditor5-html-support/src/schemadefinitions.ts
+++ b/packages/ckeditor5-html-support/src/schemadefinitions.ts
@@ -349,7 +349,7 @@ export default {
 			model: 'htmlHgroup',
 			view: 'hgroup',
 			modelSchema: {
-				allowIn: '$root',
+				allowIn: '$container',
 				allowChildren: [
 					'paragraph',
 					'htmlP',

--- a/packages/ckeditor5-html-support/tests/integrations/heading.js
+++ b/packages/ckeditor5-html-support/tests/integrations/heading.js
@@ -82,7 +82,10 @@ describe( 'HeadingElementSupport', () => {
 				model: 'htmlHgroup',
 				view: 'hgroup',
 				modelSchema: {
+					allowIn: '$root',
 					allowChildren: [
+						'paragraph',
+						'htmlP',
 						'htmlH1',
 						'htmlH2',
 						'htmlH3',
@@ -93,6 +96,28 @@ describe( 'HeadingElementSupport', () => {
 						'heading2',
 						'otherHeading'
 					],
+					isBlock: false
+				},
+				isBlock: true
+			} ] );
+		} );
+
+		it( 'should add heading models as allowed children of htmlSummary', () => {
+			expect( Array.from( dataSchema.getDefinitionsForView( 'summary' ) ) ).to.deep.equal( [ {
+				model: 'htmlSummary',
+				view: 'summary',
+				modelSchema: {
+					allowChildren: [
+						'htmlH1',
+						'htmlH2',
+						'htmlH3',
+						'htmlH4',
+						'htmlH5',
+						'htmlH6',
+						'$text'
+					],
+					allowIn: 'htmlDetails',
+					isLimit: true,
 					isBlock: false
 				},
 				isBlock: true
@@ -487,7 +512,10 @@ describe( 'HeadingElementSupport', () => {
 				model: 'htmlHgroup',
 				view: 'hgroup',
 				modelSchema: {
+					allowIn: '$root',
 					allowChildren: [
+						'paragraph',
+						'htmlP',
 						'htmlH1',
 						'htmlH2',
 						'htmlH3',

--- a/packages/ckeditor5-html-support/tests/integrations/heading.js
+++ b/packages/ckeditor5-html-support/tests/integrations/heading.js
@@ -82,7 +82,7 @@ describe( 'HeadingElementSupport', () => {
 				model: 'htmlHgroup',
 				view: 'hgroup',
 				modelSchema: {
-					allowIn: '$container',
+					allowIn: [ '$root', '$container' ],
 					allowChildren: [
 						'paragraph',
 						'htmlP',
@@ -114,7 +114,10 @@ describe( 'HeadingElementSupport', () => {
 						'htmlH4',
 						'htmlH5',
 						'htmlH6',
-						'$text'
+						'$text',
+						'heading1',
+						'heading2',
+						'otherHeading'
 					],
 					allowIn: 'htmlDetails',
 					isBlock: false
@@ -511,7 +514,7 @@ describe( 'HeadingElementSupport', () => {
 				model: 'htmlHgroup',
 				view: 'hgroup',
 				modelSchema: {
-					allowIn: '$container',
+					allowIn: [ '$root', '$container' ],
 					allowChildren: [
 						'paragraph',
 						'htmlP',

--- a/packages/ckeditor5-html-support/tests/integrations/heading.js
+++ b/packages/ckeditor5-html-support/tests/integrations/heading.js
@@ -82,7 +82,7 @@ describe( 'HeadingElementSupport', () => {
 				model: 'htmlHgroup',
 				view: 'hgroup',
 				modelSchema: {
-					allowIn: '$root',
+					allowIn: '$container',
 					allowChildren: [
 						'paragraph',
 						'htmlP',
@@ -511,7 +511,7 @@ describe( 'HeadingElementSupport', () => {
 				model: 'htmlHgroup',
 				view: 'hgroup',
 				modelSchema: {
-					allowIn: '$root',
+					allowIn: '$container',
 					allowChildren: [
 						'paragraph',
 						'htmlP',

--- a/packages/ckeditor5-html-support/tests/integrations/heading.js
+++ b/packages/ckeditor5-html-support/tests/integrations/heading.js
@@ -117,7 +117,6 @@ describe( 'HeadingElementSupport', () => {
 						'$text'
 					],
 					allowIn: 'htmlDetails',
-					isLimit: true,
 					isBlock: false
 				},
 				isBlock: true


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (html-support): `hgroup` and `summary` elements should work with source editing. Closes #16947 .

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
