### PR TITLE
Add Golang language to code-block

### DIFF
--- a/packages/ckeditor5-code-block/docs/features/code-blocks.md
+++ b/packages/ckeditor5-code-block/docs/features/code-blocks.md
@@ -179,6 +179,7 @@ The {@link module:code-block/codeblock~CodeBlock} plugin registers:
 		{ language: 'cpp', label: 'C++' },
 		{ language: 'css', label: 'CSS' },
 		{ language: 'diff', label: 'Diff' },
+		{ language: 'go', label: 'Go' },
 		{ language: 'html', label: 'HTML' },
 		{ language: 'java', label: 'Java' },
 		{ language: 'javascript', label: 'JavaScript' },

--- a/packages/ckeditor5-code-block/src/codeblockconfig.ts
+++ b/packages/ckeditor5-code-block/src/codeblockconfig.ts
@@ -90,6 +90,7 @@ export interface CodeBlockConfig {
 	 * 	{ language: 'cpp', label: 'C++' },
 	 * 	{ language: 'css', label: 'CSS' },
 	 * 	{ language: 'diff', label: 'Diff' },
+	 * 	{ language: 'go', label: 'Go' },
 	 * 	{ language: 'html', label: 'HTML' },
 	 * 	{ language: 'java', label: 'Java' },
 	 * 	{ language: 'javascript', label: 'JavaScript' },

--- a/packages/ckeditor5-code-block/src/codeblockediting.ts
+++ b/packages/ckeditor5-code-block/src/codeblockediting.ts
@@ -80,6 +80,7 @@ export default class CodeBlockEditing extends Plugin {
 				{ language: 'cpp', label: 'C++' },
 				{ language: 'css', label: 'CSS' },
 				{ language: 'diff', label: 'Diff' },
+				{ language: 'go', label: 'Go' },
 				{ language: 'html', label: 'HTML' },
 				{ language: 'java', label: 'Java' },
 				{ language: 'javascript', label: 'JavaScript' },

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -87,6 +87,7 @@ describe( 'CodeBlockEditing', () => {
 						{ language: 'cpp', label: 'C++' },
 						{ language: 'css', label: 'CSS' },
 						{ language: 'diff', label: 'Diff' },
+						{ language: 'go', label: 'Go' },
 						{ language: 'html', label: 'HTML' },
 						{ language: 'java', label: 'Java' },
 						{ language: 'javascript', label: 'JavaScript' },

--- a/packages/ckeditor5-code-block/tests/codeblockui.js
+++ b/packages/ckeditor5-code-block/tests/codeblockui.js
@@ -243,6 +243,10 @@ describe( 'CodeBlockUI', () => {
 						withText: true
 					},
 					{
+						label: 'Go',
+						withText: true
+					},
+					{
 						label: 'HTML',
 						withText: true
 					},


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (ckeditor5-code-block): In this small PR, I added the Go/Golang programming language to the code block.

Docs (ckeditor5-code-block): Go/Golang programming language was added to the document.