### PR TITLE
Dropdown menus should be rendered using unified paddings for categories and items

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenubutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenubutton.css
@@ -8,11 +8,11 @@
 @import "@ckeditor/ckeditor5-ui/theme/mixins/_dir.css";
 
 /*
-* All menu buttons.
-*/
-.ck.ck-dropdown-menu-list__nested-menu__button {
+ * All menu buttons.
+ */
+.ck.ck-button.ck-dropdown-menu-list__nested-menu__button {
 	width: 100%;
-	padding: var(--ck-list-button-padding);
+	padding: var(--ck-spacing-tiny) calc(2 * var(--ck-spacing-standard));
 	border-radius: 0;
 
 	&:focus {
@@ -44,10 +44,16 @@
 
 		@mixin ck-dir ltr {
 			transform: rotate(-90deg);
+
+			/* Nudge the arrow gently to the right because its center of gravity is to the left */
+			margin-right: calc(-1 * var(--ck-spacing-small));
 		}
 
 		@mixin ck-dir rtl {
 			transform: rotate(90deg);
+
+			/* Nudge the arrow gently to the left because its center of gravity is to the right (after rotation). */
+			margin-left: calc(-1 * var(--ck-spacing-small));
 		}
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (theme-lark): Dropdown menus should be rendered using unified paddings for categories and items. Closes #16971.

---

**Before**

<img width="965" alt="Screenshot 2024-08-26 at 14 54 19" src="https://github.com/user-attachments/assets/55d13ed5-1d04-4d63-9a8b-fd3410ad1766">

**After** 

<img width="968" alt="Screenshot 2024-08-26 at 14 51 56" src="https://github.com/user-attachments/assets/3861743f-b176-48c1-8a98-e8a1b9fd9c86">
