### PR TITLE
 DropdownMenuButtonView should inherit from ListItemButtonView for color consistency in various states

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenulistitembutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dropdown/menu/dropdownmenulistitembutton.css
@@ -22,9 +22,9 @@
 	}
 
 	/*
-		* Hovered items automatically get focused. Default focus styles look odd
-		* while moving across a huge list of items so let's get rid of them
-		*/
+	 * Hovered items automatically get focused. Default focus styles look odd
+	 * while moving across a huge list of items so let's get rid of them
+	 */
 	&:focus {
 		border-color: transparent;
 		box-shadow: none;

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenubuttonview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenubuttonview.ts
@@ -8,7 +8,7 @@
  */
 
 import IconView from '../../icon/iconview.js';
-import ButtonView from '../../button/buttonview.js';
+import ListItemButtonView from '../../button/listitembuttonview.js';
 import type { Locale } from '@ckeditor/ckeditor5-utils';
 
 import dropdownArrowIcon from '../../../theme/icons/dropdown-arrow.svg';
@@ -18,7 +18,7 @@ import '../../../theme/components/dropdown/menu/dropdownmenubutton.css';
 /**
  * Represents a view for a dropdown menu button.
  */
-export default class DropdownMenuButtonView extends ButtonView {
+export default class DropdownMenuButtonView extends ListItemButtonView {
 	/**
 	 * An icon that displays an arrow to indicate a direction of the menu.
 	 */

--- a/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenubuttonview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenubuttonview.js
@@ -7,7 +7,7 @@
 
 import { createMockLocale } from './_utils/dropdowntreemock.js';
 
-import { ButtonView, IconView } from '../../../src/index.js';
+import { IconView, ListItemButtonView } from '../../../src/index.js';
 import DropdownMenuButtonView from '../../../src/dropdown/menu/dropdownmenubuttonview.js';
 import dropdownArrowIcon from '../../../theme/icons/dropdown-arrow.svg';
 
@@ -25,7 +25,7 @@ describe( 'DropdownMenuButtonView', () => {
 
 	describe( 'constructor()', () => {
 		it( 'should inherit from ButtonView', () => {
-			expect( buttonView ).to.be.instanceOf( ButtonView );
+			expect( buttonView ).to.be.instanceOf( ListItemButtonView );
 		} );
 
 		it( 'should set #withText', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui):  `DropdownMenuButtonView` should inherit from `ListItemButtonView` for color consistency in various states. Closes #16973.

---

**Before**

<img width="967" alt="Screenshot 2024-08-26 at 16 23 16" src="https://github.com/user-attachments/assets/53ef4531-d88e-485c-ae1c-981ca37d2377">

**After**

<img width="974" alt="Screenshot 2024-08-26 at 16 19 50" src="https://github.com/user-attachments/assets/969adccc-3cc6-4ad4-8095-9752213246c9">
