### PR TITLE
Nested menus should not get their panels focused when the main button is clicked

### DIFF
--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenubehaviors.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenubehaviors.ts
@@ -87,8 +87,24 @@ export const DropdownMenuBehaviors = {
 		menuView.buttonView.on<ButtonExecuteEvent>( 'execute', () => {
 			if ( menuView.isEnabled ) {
 				menuView.isOpen = true;
-				menuView.panelView.focus();
 			}
+		} );
+	},
+
+	/**
+	 * Opens the menu and focuses the panel content upon pressing the Enter key.
+	 */
+	openAndFocusOnEnterKeyPress( menuView: DropdownMenuNestedMenuView ): void {
+		menuView.keystrokes.set( 'enter', ( data, cancel ) => {
+			// Engage only for Enter key press when the button is focused. The panel can contain
+			// other UI components and features that rely on the Enter key press.
+			if ( menuView.focusTracker.focusedElement !== menuView.buttonView.element ) {
+				return;
+			}
+
+			menuView.isOpen = true;
+			menuView.panelView.focus();
+			cancel();
 		} );
 	},
 

--- a/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenunestedmenuview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/menu/dropdownmenunestedmenuview.ts
@@ -245,6 +245,7 @@ export default class DropdownMenuNestedMenuView extends View implements Focusabl
 	 */
 	private _attachBehaviors(): void {
 		DropdownMenuBehaviors.openOnButtonClick( this );
+		DropdownMenuBehaviors.openAndFocusOnEnterKeyPress( this );
 		DropdownMenuBehaviors.openOnArrowRightKey( this );
 		DropdownMenuBehaviors.closeOnEscKey( this );
 		DropdownMenuBehaviors.closeOnArrowLeftKey( this );

--- a/packages/ckeditor5-ui/src/menubar/menubarmenuview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenuview.ts
@@ -173,7 +173,7 @@ export default class MenuBarMenuView extends View implements FocusableView {
 			MenuBarMenuBehaviors.openOnButtonClick( this );
 			MenuBarMenuBehaviors.openOnArrowRightKey( this );
 			MenuBarMenuBehaviors.closeOnArrowLeftKey( this );
-			MenuBarMenuBehaviors.focusOnEnterKeyPress( this );
+			MenuBarMenuBehaviors.openAndFocusOnEnterKeyPress( this );
 			MenuBarMenuBehaviors.closeOnParentClose( this );
 		}
 	}

--- a/packages/ckeditor5-ui/src/menubar/menubarmenuview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenuview.ts
@@ -173,6 +173,7 @@ export default class MenuBarMenuView extends View implements FocusableView {
 			MenuBarMenuBehaviors.openOnButtonClick( this );
 			MenuBarMenuBehaviors.openOnArrowRightKey( this );
 			MenuBarMenuBehaviors.closeOnArrowLeftKey( this );
+			MenuBarMenuBehaviors.focusOnEnterKeyPress( this );
 			MenuBarMenuBehaviors.closeOnParentClose( this );
 		}
 	}

--- a/packages/ckeditor5-ui/src/menubar/menubarview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarview.ts
@@ -34,7 +34,6 @@ import {
 const EVENT_NAME_DELEGATES = [ 'mouseenter', 'arrowleft', 'arrowright', 'change:isOpen' ] as const;
 
 import '../../theme/components/menubar/menubar.css';
-import type EditorUI from '../editorui/editorui.js';
 
 /**
  * The application menu bar component. It brings a set of top-level menus (and sub-menus) that can be used

--- a/packages/ckeditor5-ui/src/menubar/utils.ts
+++ b/packages/ckeditor5-ui/src/menubar/utils.ts
@@ -265,7 +265,7 @@ export const MenuBarMenuBehaviors = {
 	/**
 	 * Opens the menu and focuses the panel content upon pressing the Enter key.
 	 */
-	focusOnEnterKeyPress( menuView: MenuBarMenuView ): void {
+	openAndFocusOnEnterKeyPress( menuView: MenuBarMenuView ): void {
 		menuView.keystrokes.set( 'enter', ( data, cancel ) => {
 			// Engage only for Enter key press when the button is focused. The panel can contain
 			// other UI components and features that rely on the Enter key press.

--- a/packages/ckeditor5-ui/src/menubar/utils.ts
+++ b/packages/ckeditor5-ui/src/menubar/utils.ts
@@ -8,7 +8,6 @@
  */
 
 import MenuBarMenuListItemView from './menubarmenulistitemview.js';
-import type { Editor } from '@ckeditor/ckeditor5-core';
 import type MenuBarMenuView from './menubarmenuview.js';
 import type {
 	default as MenuBarView,
@@ -185,15 +184,6 @@ export const MenuBarBehaviors = {
 			}
 		} );
 
-		// After clicking menu bar list item the focus is moved to the newly opened submenu.
-		// We need to enable focus border for the submenu items because after pressing arrow down it will
-		// focus second item instead of first which is not super intuitive.
-		menuBarView.listenTo( menuBarView.element!, 'click', () => {
-			if ( menuBarView.isOpen && menuBarView.element!.matches( ':focus-within' ) ) {
-				menuBarView.isFocusBorderEnabled = true;
-			}
-		}, { useCapture: true } );
-
 		menuBarView.listenTo( menuBarView.element!, 'keydown', () => {
 			isKeyPressed = true;
 		}, { useCapture: true } );
@@ -260,10 +250,6 @@ export const MenuBarMenuBehaviors = {
 	openOnButtonClick( menuView: MenuBarMenuView ): void {
 		menuView.buttonView.on<ButtonExecuteEvent>( 'execute', () => {
 			menuView.isOpen = true;
-
-			if ( menuView.parentMenuView ) {
-				menuView.panelView.focus();
-			}
 		} );
 	},
 
@@ -273,6 +259,23 @@ export const MenuBarMenuBehaviors = {
 	toggleOnButtonClick( menuView: MenuBarMenuView ): void {
 		menuView.buttonView.on<ButtonExecuteEvent>( 'execute', () => {
 			menuView.isOpen = !menuView.isOpen;
+		} );
+	},
+
+	/**
+	 * Opens the menu and focuses the panel content upon pressing the Enter key.
+	 */
+	focusOnEnterKeyPress( menuView: MenuBarMenuView ): void {
+		menuView.keystrokes.set( 'enter', ( data, cancel ) => {
+			// Engage only for Enter key press when the button is focused. The panel can contain
+			// other UI components and features that rely on the Enter key press.
+			if ( menuView.focusTracker.focusedElement !== menuView.buttonView.element ) {
+				return;
+			}
+
+			menuView.isOpen = true;
+			menuView.panelView.focus();
+			cancel();
 		} );
 	},
 

--- a/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenubehaviors.js
+++ b/packages/ckeditor5-ui/tests/dropdown/menu/dropdownmenubehaviors.js
@@ -227,6 +227,51 @@ describe( 'Menu Behaviors', () => {
 				expect( menuView.isOpen ).to.be.true;
 			} );
 		} );
+
+		describe( 'openAndFocusOnEnterKeyPress()', () => {
+			beforeEach( () => {
+				rootListView = createRootListView();
+			} );
+
+			it( 'should open the menu and focus its panel upon enter key press', () => {
+				const menuView = menuViewById( 'menu_1' );
+				const keyEvtData = {
+					keyCode: keyCodes.enter,
+					preventDefault: sinon.spy(),
+					stopPropagation: sinon.spy()
+				};
+
+				const focusSpy = sinon.spy( menuView.panelView, 'focus' );
+
+				menuView.buttonView.focus();
+				menuView.keystrokes.press( keyEvtData );
+
+				expect( menuView.isOpen ).to.be.true;
+
+				sinon.assert.calledOnce( focusSpy );
+				sinon.assert.calledOnce( keyEvtData.preventDefault );
+				sinon.assert.calledOnce( keyEvtData.stopPropagation );
+			} );
+
+			it( 'should not intercept enter key press from anywhere but the button view', () => {
+				const menuView = menuViewById( 'menu_1' );
+				const keyEvtData = {
+					keyCode: keyCodes.enter,
+					preventDefault: sinon.spy(),
+					stopPropagation: sinon.spy()
+				};
+
+				const focusSpy = sinon.spy( menuView.panelView, 'focus' );
+
+				menuView.keystrokes.press( keyEvtData );
+
+				expect( menuView.isOpen ).to.be.false;
+
+				sinon.assert.notCalled( focusSpy );
+				sinon.assert.notCalled( keyEvtData.preventDefault );
+				sinon.assert.notCalled( keyEvtData.stopPropagation );
+			} );
+		} );
 	} );
 
 	function createRootListView() {

--- a/packages/ckeditor5-ui/tests/menubar/utils.js
+++ b/packages/ckeditor5-ui/tests/menubar/utils.js
@@ -1472,7 +1472,7 @@ describe( 'MenuBarView utils', () => {
 				} );
 			} );
 
-			describe( 'focusOnEnterKeyPress()', () => {
+			describe( 'openAndFocusOnEnterKeyPress()', () => {
 				it( 'should open the menu and focus its panel upon enter key press', () => {
 					const menuA = getMenuByLabel( menuBarView, 'A' );
 					const keyEvtData = {

--- a/packages/ckeditor5-ui/tests/menubar/utils.js
+++ b/packages/ckeditor5-ui/tests/menubar/utils.js
@@ -392,7 +392,7 @@ describe( 'MenuBarView utils', () => {
 								items: [
 									{ label: 'A#1', isFocused: false },
 									{ label: 'AA', isOpen: true, isFocused: false, items: [
-										{ label: 'AA#1', isFocused: true },
+										{ label: 'AA#1', isFocused: false },
 										{ label: 'AAA (from-factory)', isOpen: false, isFocused: false, items: [] }
 									] },
 									{ label: 'AB', isOpen: false, isFocused: false, items: [] }
@@ -967,31 +967,6 @@ describe( 'MenuBarView utils', () => {
 				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
 			} );
 
-			it( 'should set proper isFocusBorderEnabled when a clicked and focused item on opened menu', () => {
-				const clock = sinon.useFakeTimers();
-
-				sinon.stub( menuBarView.element, 'matches' ).withArgs( ':focus-within' ).returns( true );
-
-				const menuA = getMenuByLabel( menuBarView, 'A' );
-
-				menuA.isOpen = true;
-
-				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
-
-				menuA.buttonView.element.dispatchEvent( new Event( 'click' ) );
-
-				expect( menuBarView.isFocusBorderEnabled ).to.be.true;
-
-				menuA.isOpen = false;
-				clock.tick( 1000 );
-
-				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
-
-				menuA.buttonView.element.dispatchEvent( new Event( 'click' ) );
-
-				expect( menuBarView.isFocusBorderEnabled ).to.be.false;
-			} );
-
 			it( 'should not clean #isFocusBorderEnabled if the menu bar was closed by an Esc key press', async () => {
 				const menuA = getMenuByLabel( menuBarView, 'A' );
 
@@ -1184,7 +1159,7 @@ describe( 'MenuBarView utils', () => {
 								items: [
 									{ label: 'A#1', isFocused: false },
 									{ label: 'AA', isFocused: false, isOpen: true, items: [
-										{ label: 'AA#1', isFocused: true }
+										{ label: 'AA#1', isFocused: false }
 									] }
 								]
 							}
@@ -1201,7 +1176,7 @@ describe( 'MenuBarView utils', () => {
 								items: [
 									{ label: 'A#1', isFocused: false },
 									{ label: 'AA', isFocused: false, isOpen: true, items: [
-										{ label: 'AA#1', isFocused: true }
+										{ label: 'AA#1', isFocused: false }
 									] }
 								]
 							}
@@ -1494,6 +1469,71 @@ describe( 'MenuBarView utils', () => {
 							}
 						]
 					);
+				} );
+			} );
+
+			describe( 'focusOnEnterKeyPress()', () => {
+				it( 'should open the menu and focus its panel upon enter key press', () => {
+					const menuA = getMenuByLabel( menuBarView, 'A' );
+					const keyEvtData = {
+						keyCode: keyCodes.enter,
+						preventDefault: sinon.spy(),
+						stopPropagation: sinon.spy()
+					};
+
+					menuA.isOpen = true;
+
+					const menuAA = getMenuByLabel( menuBarView, 'AA' );
+
+					menuAA.buttonView.focus();
+					menuAA.keystrokes.press( keyEvtData );
+
+					expect( barDump( menuBarView ) ).to.deep.equal(
+						[
+							{
+								label: 'A', isOpen: true, isFocused: false,
+								items: [
+									{ label: 'A#1', isFocused: false },
+									{ label: 'AA', isFocused: false, isOpen: true, items: [
+										{ label: 'AA#1', isFocused: true }
+									] }
+								]
+							}
+						]
+					);
+
+					sinon.assert.calledOnce( keyEvtData.preventDefault );
+					sinon.assert.calledOnce( keyEvtData.stopPropagation );
+				} );
+
+				it( 'should not intercept enter key press from anywhere but the button view', () => {
+					const menuA = getMenuByLabel( menuBarView, 'A' );
+					const keyEvtData = {
+						keyCode: keyCodes.enter,
+						preventDefault: sinon.spy(),
+						stopPropagation: sinon.spy()
+					};
+
+					menuA.isOpen = true;
+
+					const menuAA = getMenuByLabel( menuBarView, 'AA' );
+
+					menuAA.keystrokes.press( keyEvtData );
+
+					expect( barDump( menuBarView ) ).to.deep.equal(
+						[
+							{
+								label: 'A', isOpen: true, isFocused: false,
+								items: [
+									{ label: 'A#1', isFocused: false },
+									{ label: 'AA', isFocused: false, isOpen: false, items: [] }
+								]
+							}
+						]
+					);
+
+					sinon.assert.notCalled( keyEvtData.preventDefault );
+					sinon.assert.notCalled( keyEvtData.stopPropagation );
 				} );
 			} );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Nested menus should not get their panels focused when the main button is clicked. Closes #16857.
