### PR TITLE
Fix missing border in selected focused table cells

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableediting.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableediting.css
@@ -10,15 +10,16 @@
 .ck-widget.table {
 	& td,
 	& th {
+		/**
+		 * While setting outline is fine, the border should not be modified here
+		 * because it overrides the default table cell border color which is not expected.
+		 * So do not use `@mixin ck-focus-ring;` here, or any other border styles.
+		 * See more: https://github.com/ckeditor/ckeditor5/issues/16979
+		 */
 		&.ck-editor__nested-editable.ck-editor__nested-editable_focused,
 		&.ck-editor__nested-editable:focus {
 			/* A very slight background to highlight the focused cell */
 			background: var(--ck-color-selector-focused-cell-background);
-
-			/* Fixes the problem where surrounding cells cover the focused cell's border.
-			It does not fix the problem in all places but the UX is improved.
-			See https://github.com/ckeditor/ckeditor5-table/issues/29. */
-			border-style: none;
 			outline: 1px solid var(--ck-color-focus-border);
 			outline-offset: -1px; /* progressive enhancement - no IE support */
 		}

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widget.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widget.css
@@ -46,10 +46,18 @@
 	These styles show a different border for a blink of an eye, so `:focus` need to have same styles applied. */
 	&.ck-editor__nested-editable_focused,
 	&:focus {
-		@mixin ck-focus-ring;
 		@mixin ck-box-shadow var(--ck-inner-shadow);
 		@mixin ck-media-default-colors {
 			background-color: var(--ck-color-widget-editable-focus-background);
+		}
+
+		/**
+		 * Focus border should not be applied to table cells because it overrides the default table cell border color.
+		 * In other words - in some scenarios, the part of the table cell border is blue, which is not expected behavior
+		 * because it should be the same as the table cell border color.
+		 */
+		&:not(td, th) {
+			@mixin ck-focus-ring;
 		}
 	}
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widget.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-widget/widget.css
@@ -53,7 +53,7 @@
 
 		/**
 		 * Focus border should not be applied to table cells because it overrides the default table cell border color.
-		 * In other words - in some scenarios, the part of the table cell border is blue, which is not expected behavior
+		 * In other words - in some scenarios, the part of the table cell border has focus color style, which is not expected behavior
 		 * because it should be the same as the table cell border color.
 		 */
 		&:not(td, th) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (theme-lark): Fix missing border in focused table cells within selection. Closes https://github.com/ckeditor/ckeditor5/issues/16979

---

### Additional information

Caused by: https://github.com/ckeditor/ckeditor5/pull/16880

#### Before

![obraz](https://github.com/user-attachments/assets/313fbcea-d97c-45da-bdb6-93ee908dbe98)

#### After

![obraz](https://github.com/user-attachments/assets/7e6398fb-99b5-4c27-91ba-c2d4b97c9c53)
