### PR TITLE
Fix inconsistent behave of `getRangeFromMouseEvent` on Safari

### DIFF
--- a/packages/ckeditor5-widget/src/widget.ts
+++ b/packages/ckeditor5-widget/src/widget.ts
@@ -24,7 +24,9 @@ import {
 	type Position,
 	type EditingView,
 	type ViewDocumentTabEvent,
-	type ViewDocumentKeyDownEvent
+	type ViewDocumentKeyDownEvent,
+	type ViewNode,
+	type ViewRange
 } from '@ckeditor/ckeditor5-engine';
 
 import { Delete, type ViewDocumentDeleteEvent } from '@ckeditor/ckeditor5-typing';
@@ -649,12 +651,15 @@ function findClosestEditableOrWidgetAncestor( element: ViewElement ): ViewElemen
  */
 function getElementFromMouseEvent( view: EditingView, domEventData: DomEventData<MouseEvent> ): ViewElement | null {
 	const domRange = getRangeFromMouseEvent( domEventData.domEvent );
+	let viewRange: ViewRange | null = null;
 
-	if ( !domRange ) {
-		return null;
+	if ( domRange ) {
+		viewRange = view.domConverter.domRangeToView( domRange );
+	} else {
+		// Fallback to create range on target element. It happens frequently on Safari browser.
+		// See more: https://github.com/ckeditor/ckeditor5/issues/16978
+		viewRange = view.createRangeIn( domEventData.target );
 	}
-
-	const viewRange = view.domConverter.domRangeToView( domRange );
 
 	if ( !viewRange ) {
 		return null;
@@ -672,12 +677,12 @@ function getElementFromMouseEvent( view: EditingView, domEventData: DomEventData
 		if ( viewPosition.isAtEnd && viewPosition.nodeBefore ) {
 			// Click after a widget tend to return position at the end of the editable element
 			// so use the node before it if range is at the end of a parent.
-			viewNode = viewPosition.nodeBefore as ViewElement;
+			viewNode = viewPosition.nodeBefore as ViewNode;
 		} else if ( viewPosition.isAtStart && viewPosition.nodeAfter ) {
 			// Click before a widget tend to return position at the start of the editable element
 			// so use the node after it if range is at the start of a parent.
 			// See more: https://github.com/ckeditor/ckeditor5/issues/16992
-			viewNode = viewPosition.nodeAfter as ViewElement;
+			viewNode = viewPosition.nodeAfter as ViewNode;
 		}
 	}
 

--- a/packages/ckeditor5-widget/src/widget.ts
+++ b/packages/ckeditor5-widget/src/widget.ts
@@ -655,7 +655,7 @@ function getElementFromMouseEvent( view: EditingView, domEventData: DomEventData
 
 	if ( domRange ) {
 		viewRange = view.domConverter.domRangeToView( domRange );
-	} else {
+	} else if ( domEventData.target ) {
 		// Fallback to create range in target element. It happens frequently on Safari browser.
 		// See more: https://github.com/ckeditor/ckeditor5/issues/16978
 		viewRange = view.createRange( view.createPositionAt( domEventData.target, 0 ) );

--- a/packages/ckeditor5-widget/src/widget.ts
+++ b/packages/ckeditor5-widget/src/widget.ts
@@ -282,6 +282,11 @@ export default class Widget extends Plugin {
 		const viewDocument = view.document;
 		let element: ViewElement | null = domEventData.target;
 
+		// If target is null abort.
+		if ( !element ) {
+			return;
+		}
+
 		// If triple click should select entire paragraph.
 		if ( domEventData.domEvent.detail >= 3 ) {
 			if ( this._selectBlockContent( element ) ) {
@@ -655,7 +660,7 @@ function getElementFromMouseEvent( view: EditingView, domEventData: DomEventData
 
 	if ( domRange ) {
 		viewRange = view.domConverter.domRangeToView( domRange );
-	} else if ( domEventData.target ) {
+	} else {
 		// Fallback to create range in target element. It happens frequently on Safari browser.
 		// See more: https://github.com/ckeditor/ckeditor5/issues/16978
 		viewRange = view.createRange( view.createPositionAt( domEventData.target, 0 ) );

--- a/packages/ckeditor5-widget/src/widget.ts
+++ b/packages/ckeditor5-widget/src/widget.ts
@@ -282,8 +282,7 @@ export default class Widget extends Plugin {
 		const viewDocument = view.document;
 		let element: ViewElement | null = domEventData.target;
 
-		// Some plugins might listen to the same event and override the target by setting it to null.
-		// Drag and drop might be one of such plugins that could set the target to null.
+		// Some of DOM elements have no view element representation so it may be null.
 		if ( !element ) {
 			return;
 		}

--- a/packages/ckeditor5-widget/src/widget.ts
+++ b/packages/ckeditor5-widget/src/widget.ts
@@ -282,7 +282,8 @@ export default class Widget extends Plugin {
 		const viewDocument = view.document;
 		let element: ViewElement | null = domEventData.target;
 
-		// If target is null abort.
+		// Some plugins might listen to the same event and override the target by setting it to null.
+		// Drag and drop might be one of such plugins that could set the target to null.
 		if ( !element ) {
 			return;
 		}

--- a/packages/ckeditor5-widget/src/widget.ts
+++ b/packages/ckeditor5-widget/src/widget.ts
@@ -656,7 +656,7 @@ function getElementFromMouseEvent( view: EditingView, domEventData: DomEventData
 	if ( domRange ) {
 		viewRange = view.domConverter.domRangeToView( domRange );
 	} else {
-		// Fallback to create range on target element. It happens frequently on Safari browser.
+		// Fallback to create range in target element. It happens frequently on Safari browser.
 		// See more: https://github.com/ckeditor/ckeditor5/issues/16978
 		viewRange = view.createRange( view.createPositionAt( domEventData.target, 0 ) );
 	}

--- a/packages/ckeditor5-widget/src/widget.ts
+++ b/packages/ckeditor5-widget/src/widget.ts
@@ -658,7 +658,7 @@ function getElementFromMouseEvent( view: EditingView, domEventData: DomEventData
 	} else {
 		// Fallback to create range on target element. It happens frequently on Safari browser.
 		// See more: https://github.com/ckeditor/ckeditor5/issues/16978
-		viewRange = view.createRangeIn( domEventData.target );
+		viewRange = view.createRange( view.createPositionAt( domEventData.target, 0 ) );
 	}
 
 	if ( !viewRange ) {

--- a/packages/ckeditor5-widget/tests/widget.js
+++ b/packages/ckeditor5-widget/tests/widget.js
@@ -268,7 +268,7 @@ describe( 'Widget', () => {
 		expect( focusSpy ).not.to.be.called;
 	} );
 
-	it( 'should use `createRangeIn` fallback if extracting range from mouse event is not possible', () => {
+	it( 'should use `createRange` fallback if extracting range from mouse event is not possible', () => {
 		setModelData( model, '<editable><widget></widget></editable>' );
 
 		const editableView = viewDocument.getRoot().getChild( 0 );
@@ -283,15 +283,15 @@ describe( 'Widget', () => {
 
 		// Expect to execute `createRangeIn` in hope to find the range.
 		// Let's assume it won't find it and return null.
-		const createRangeSpy = sinon
-			.spy( editor.editing.view, 'createRangeIn' )
-			.withArgs( editableView );
+		const createPositionAtSpy = sinon
+			.spy( editor.editing.view, 'createPositionAt' )
+			.withArgs( editableView, 0 );
 
 		const focusSpy = sinon.spy( View.prototype, 'focus' );
 
 		viewDocument.fire( 'mousedown', domEventDataMock );
 
-		expect( createRangeSpy ).to.be.calledOnce;
+		expect( createPositionAtSpy ).to.be.calledOnce;
 		expect( focusSpy ).to.be.calledOnce;
 	} );
 
@@ -299,8 +299,10 @@ describe( 'Widget', () => {
 		setModelData( model, '<widget><nested></nested></widget>' );
 
 		const widgetView = viewDocument.getRoot().getChild( 0 ).getChild( 0 );
+		const target = view.domConverter.mapViewToDom( widgetView );
+
 		const domEventDataMock = new DomEventData( view, {
-			target: view.domConverter.mapViewToDom( widgetView ),
+			target,
 			preventDefault: sinon.spy()
 		} );
 
@@ -310,9 +312,14 @@ describe( 'Widget', () => {
 
 		// Expect to execute `createRangeIn` in hope to find the range.
 		// Let's assume it won't find it and return null.
+		const position = editor.editing.view.createPositionAt( target, 0 );
 		const createRangeStub = sinon
-			.stub( editor.editing.view, 'createRangeIn' )
-			.withArgs( widgetView )
+			.stub( editor.editing.view, 'createPositionAt' )
+			.returns( position );
+
+		sinon
+			.stub( editor.editing.view, 'createRange' )
+			.withArgs( position )
 			.returns( null );
 
 		sinon

--- a/packages/ckeditor5-widget/tests/widget.js
+++ b/packages/ckeditor5-widget/tests/widget.js
@@ -295,6 +295,31 @@ describe( 'Widget', () => {
 		expect( focusSpy ).to.be.calledOnce;
 	} );
 
+	it( 'should not crash and not focus anything if event target is null', () => {
+		setModelData( model, '<editable><widget></widget></editable>' );
+
+		const editableView = viewDocument.getRoot().getChild( 0 );
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( editableView ),
+			preventDefault: sinon.spy()
+		} );
+
+		// Lets simulate that the other plugin overrides the target to null.
+		editor.plugins.get( Widget ).listenTo(
+			viewDocument, 'mousedown',
+			( eventInfo, domEventData ) => {
+				sinon.stub( domEventData, 'target' ).get( () => null );
+			},
+			{
+				priority: 'high'
+			}
+		);
+
+		const focusSpy = sinon.spy( View.prototype, 'focus' );
+		viewDocument.fire( 'mousedown', domEventDataMock );
+		expect( focusSpy ).not.to.be.called;
+	} );
+
 	it( 'should not focus anything when it\'s not possible to extract range from mouse event', () => {
 		setModelData( model, '<widget><nested></nested></widget>' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (widget): It's now possible to focus root containing only table of contents or embed elements on Safari. Closes https://github.com/ckeditor/ckeditor5/issues/16978

---

### Additional information

It looks like `caretRangeFromPoint` behaves differently on Chrome and Safari when `click` event target occurs in an element that contains `contenteditable=false`.

On Chrome, `contenteditable=false` is being focused.
On Safari it is not, and it used to focus near `contenteditable=true` in the other root element.

#### Before

https://github.com/user-attachments/assets/36482ca7-f863-47c3-902c-1b52dea29a9a

#### After

https://github.com/user-attachments/assets/8d95c398-cec6-4a0f-8871-f5bda95be549



