### PR TITLE
Fix multi-root editor focus root which has side image.

### DIFF
--- a/packages/ckeditor5-widget/src/widget.ts
+++ b/packages/ckeditor5-widget/src/widget.ts
@@ -666,9 +666,20 @@ function getElementFromMouseEvent( view: EditingView, domEventData: DomEventData
 		return null;
 	}
 
-	// Click after a widget tend to return position at the end of the editable element
-	// so use the node before it if range is at the end of a parent.
-	const viewNode = viewPosition.parent.is( 'editableElement' ) && viewPosition.isAtEnd && viewPosition.nodeBefore || viewPosition.parent;
+	let viewNode = viewPosition.parent;
+
+	if ( viewPosition.parent.is( 'editableElement' ) ) {
+		if ( viewPosition.isAtEnd && viewPosition.nodeBefore ) {
+			// Click after a widget tend to return position at the end of the editable element
+			// so use the node before it if range is at the end of a parent.
+			viewNode = viewPosition.nodeBefore as ViewElement;
+		} else if ( viewPosition.isAtStart && viewPosition.nodeAfter ) {
+			// Click before a widget tend to return position at the start of the editable element
+			// so use the node after it if range is at the start of a parent.
+			// See more: https://github.com/ckeditor/ckeditor5/issues/16992
+			viewNode = viewPosition.nodeAfter as ViewElement;
+		}
+	}
 
 	if ( viewNode.is( '$text' ) ) {
 		return viewNode.parent as ViewElement;

--- a/packages/ckeditor5-widget/tests/widget.js
+++ b/packages/ckeditor5-widget/tests/widget.js
@@ -380,7 +380,7 @@ describe( 'Widget', () => {
 		expect( focusSpy ).to.be.called;
 	} );
 
-	it( 'should focus if clicked node that is at the end', () => {
+	it( 'should focus widget if clicked node that is at the end and parent contenteditable is selected', () => {
 		setModelData( model, '<editable><inline-widget></inline-widget></editable>' );
 
 		const parentView = viewDocument.getRoot().getChild( 0 );
@@ -402,6 +402,38 @@ describe( 'Widget', () => {
 					isAtEnd: true,
 					parent: parentView,
 					nodeBefore: widgetView
+				}
+			} );
+
+		const focusSpy = sinon.stub( View.prototype, 'focus' ).returns( true );
+
+		viewDocument.fire( 'mousedown', domEventDataMock );
+
+		expect( focusSpy ).to.be.called;
+	} );
+
+	it( 'should focus widget if clicked node that is at the start and parent contenteditable is selected', () => {
+		setModelData( model, '<editable><inline-widget></inline-widget></editable>' );
+
+		const parentView = viewDocument.getRoot().getChild( 0 );
+		const widgetView = parentView.getChild( 0 );
+
+		const domEventDataMock = new DomEventData( view, {
+			target: view.domConverter.mapViewToDom( parentView ),
+			preventDefault: sinon.spy()
+		} );
+
+		sinon
+			.stub( domEventDataMock.domTarget.ownerDocument, 'caretRangeFromPoint' )
+			.returns( {} );
+
+		sinon
+			.stub( view.domConverter, 'domRangeToView' )
+			.returns( {
+				start: {
+					isAtStart: true,
+					parent: parentView,
+					nodeAfter: widgetView
 				}
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (widget): It's now possible to focus a root that has only side image. Closes https://github.com/ckeditor/ckeditor5/issues/16992

---

### Additional information

#### Before

https://github.com/user-attachments/assets/072b6831-c9c0-4cbe-a139-c78ed178b004

#### After

https://github.com/user-attachments/assets/d5d6f768-06a9-470f-9959-20559d17fe94

