### PR TITLE
CI: restore "medium" resource class for the notifier job

### DIFF
--- a/.circleci/template.yml
+++ b/.circleci/template.yml
@@ -234,7 +234,7 @@ jobs:
 
   notify_ci_failure:
     machine: true
-    resource_class: xlarge
+    resource_class: medium
     parameters:
       hideAuthor:
         type: string


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Restore the `medium` resource class for the notifier job. See #17011.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
