### PR TITLE
Hide block toolbar when disable parent button

### DIFF
--- a/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
+++ b/packages/ckeditor5-ui/src/toolbar/block/blocktoolbar.ts
@@ -289,6 +289,15 @@ export default class BlockToolbar extends Plugin {
 			}
 		} );
 
+		// Hide the panelView when the buttonView is disabled. `isEnabled` flag might be changed when
+		// user scrolls the viewport and the button is no longer visible. In such case, the panel should be hidden
+		// otherwise it will be displayed in the wrong place.
+		this.listenTo<ObservableChangeEvent<boolean>>( buttonView, 'change:isEnabled', ( evt, name, isEnabled ) => {
+			if ( !isEnabled && this.panelView.isVisible ) {
+				this._hidePanel( false );
+			}
+		} );
+
 		editor.ui.view.body.add( buttonView );
 
 		return buttonView;

--- a/packages/ckeditor5-ui/tests/toolbar/block/blocktoolbar.js
+++ b/packages/ckeditor5-ui/tests/toolbar/block/blocktoolbar.js
@@ -393,6 +393,16 @@ describe( 'BlockToolbar', () => {
 				sinon.assert.calledOnce( focusSpy );
 			} );
 
+			it( 'should hide the #panelView and do not focus the editable when isEnabled became false', () => {
+				blockToolbar.panelView.isVisible = true;
+				const spy = testUtils.sinon.spy( editor.editing.view, 'focus' );
+
+				blockToolbar.buttonView.isEnabled = false;
+
+				expect( blockToolbar.panelView.isVisible ).to.be.false;
+				sinon.assert.notCalled( spy );
+			} );
+
 			it( 'should hide the #panelView and focus the editable on #execute event when panel was visible', () => {
 				blockToolbar.panelView.isVisible = true;
 				const spy = testUtils.sinon.spy( editor.editing.view, 'focus' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Balloon Editor toolbar no longer sticks out of the limiter element while scrolling. Closes https://github.com/ckeditor/ckeditor5/issues/17002

---

### Additional information

#### Before

https://github.com/user-attachments/assets/6c495658-f549-4d24-9707-277886b28d4a

#### After

https://github.com/user-attachments/assets/aeb17168-d7eb-4622-80fc-384dec3145bd



