### PR TITLE
Docs: Add `Potential issues with Jest testing` React docs section

### DIFF
--- a/docs/getting-started/integrations/angular.md
+++ b/docs/getting-started/integrations/angular.md
@@ -707,8 +707,6 @@ The `moduleResolution` option of the TypeScript configuration determines the alg
 
 Jest is the default test runner used by many Angular apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js with the use of JSDOM. JSDOM is not a complete DOM implementation and while it is apparently sufficient for standard apps, it is not able to polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
 
-A better approach to test the component inside a fully-fledged web browser, implementing a complete DOM, is to use [`jest-puppeteer`](https://github.com/smooth-code/jest-puppeteer).
-
 If this is not possible, you can use the following mocks to make the tests pass:
 
 ```javascript

--- a/docs/getting-started/integrations/angular.md
+++ b/docs/getting-started/integrations/angular.md
@@ -712,35 +712,37 @@ A better approach to test the component inside a fully-fledged web browser, impl
 If this is not possible, you can use the following mocks to make the tests pass:
 
 ```ts
-window.scrollTo = jest.fn();
+beforeAll( () => {
+	window.scrollTo = jest.fn();
 
-window.ResizeObserver = class ResizeObserver {
-	observe() {}
-	unobserve() {}
-	disconnect() {}
-};
-
-for (const key of ['InputEvent', 'KeyboardEvent']) {
-	window[key].prototype.getTargetRanges = () => {
-		const range = new StaticRange({
-			startContainer: document.body.querySelector('.ck-editor__editable p')!,
-			startOffset: 0,
-			endContainer: document.body.querySelector('.ck-editor__editable p')!,
-			endOffset: 0,
-		});
-
-		return [range];
+	window.ResizeObserver = class ResizeObserver {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
 	};
-}
 
-Range.prototype.getClientRects = () => ({
-	item: () => null,
-	length: 0,
-	[Symbol.iterator]: function* () {},
-});
+	for (const key of ['InputEvent', 'KeyboardEvent']) {
+		window[key].prototype.getTargetRanges = () => {
+			const range = new StaticRange({
+				startContainer: document.body.querySelector('.ck-editor__editable p'),
+				startOffset: 0,
+				endContainer: document.body.querySelector('.ck-editor__editable p'),
+				endOffset: 0,
+			});
+
+			return [range];
+		};
+	}
+
+	Range.prototype.getClientRects = () => ({
+		item: () => null,
+		length: 0,
+		[Symbol.iterator]: function* () {},
+	});
+} );
 ```
 
-These mocks are not perfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Keep in mind that they are not a replacement for proper browser testing.
+These mocks should be placed before the tests that use CKEditor&nbsp;5. They are not perfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Keep in mind that they are not a replacement for proper browser testing.
 
 ## Contributing and reporting issues
 

--- a/docs/getting-started/integrations/angular.md
+++ b/docs/getting-started/integrations/angular.md
@@ -703,7 +703,7 @@ The `moduleResolution` option of the TypeScript configuration determines the alg
 * You can update Angular to version 18, where the `moduleResolution` option is set to `bundler`  by default.
 * You can import translations directly from our CDN, like: `import ‘https://cdn.ckeditor.com/ckeditor5/{@var ckeditor5-version}/translations/es.umd.js’;`. This way, the editor will load the translations automatically, so you do not need to pass them manually into the config.
 
-### Potential issues with Jest testing
+### Jest testing
 
 You can use Jest as a test runner in Angular apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js that uses JSDOM. JSDOM is not a complete DOM implementation, and while it is sufficient for standard apps, it cannot polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
 

--- a/docs/getting-started/integrations/angular.md
+++ b/docs/getting-started/integrations/angular.md
@@ -696,6 +696,8 @@ There is a known issue related to the localization in Angular 17. Read more in t
 
 ## Known issues
 
+### Module resolution
+
 The `moduleResolution` option of the TypeScript configuration determines the algorithm for finding and resolving modules from `node_modules`. In Angular 17, the option is set to `node` by default. This option prevents type declaration for editor translations from being correctly loaded. To fix it, you have several options:
 
 * You can set the `moduleResolution` option to `bundler`. It is the recommended setting in TypeScript 5.0+ for applications that use a bundler. And it is a recommended way of fixing this problem. You can check other solutions below for lower TypeScript versions.

--- a/docs/getting-started/integrations/angular.md
+++ b/docs/getting-started/integrations/angular.md
@@ -709,7 +709,15 @@ The `moduleResolution` option of the TypeScript configuration determines the alg
 
 You can use Jest as a test runner in Angular apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js that uses JSDOM. JSDOM is not a complete DOM implementation, and while it is sufficient for standard apps, it cannot polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
 
-If this is not possible, you can use the following mocks to make the tests pass:
+For testing CKEditor&nbsp;5, it is recommended to use testing frameworks that utilize a real browser and provide a complete DOM implementation. Some popular options include:
+
+* [Vitest](https://vitest.netlify.app/)
+* [Playwright](https://playwright.dev/)
+* [Cypress](https://www.cypress.io/)
+
+These frameworks offer better support for testing CKEditor&nbsp;5 and provide a more accurate representation of how the editor behaves in a real browser environment.
+
+If this is not possible and you still want to use Jest, you can mock some of the required APIs. Below is an example of how to mock some of the APIs used by CKEditor&nbsp;5:
 
 ```javascript
 beforeAll( () => {

--- a/docs/getting-started/integrations/angular.md
+++ b/docs/getting-started/integrations/angular.md
@@ -740,7 +740,7 @@ Range.prototype.getClientRects = () => ({
 });
 ```
 
-These mocks are not perfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Keep in mind that they are not a replacement for proper browser testing and cover only the initialization and rendering of the editor.
+These mocks are not perfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Keep in mind that they are not a replacement for proper browser testing.
 
 ## Contributing and reporting issues
 

--- a/docs/getting-started/integrations/angular.md
+++ b/docs/getting-started/integrations/angular.md
@@ -711,7 +711,7 @@ You can use Jest as a test runner in Angular apps. Unfortunately, Jest does not 
 
 For testing CKEditor&nbsp;5, it is recommended to use testing frameworks that utilize a real browser and provide a complete DOM implementation. Some popular options include:
 
-* [Vitest](https://vitest.netlify.app/)
+* [Vitest](https://vitest.dev/)
 * [Playwright](https://playwright.dev/)
 * [Cypress](https://www.cypress.io/)
 

--- a/docs/getting-started/integrations/angular.md
+++ b/docs/getting-started/integrations/angular.md
@@ -711,8 +711,8 @@ A better approach to test the component inside a fully-fledged web browser, impl
 
 If this is not possible, you can use the following mocks to make the tests pass:
 
-```ts
-beforeAll( () => {
+```javascript
+beforeAll(() => {
 	window.scrollTo = jest.fn();
 
 	window.ResizeObserver = class ResizeObserver {
@@ -739,7 +739,7 @@ beforeAll( () => {
 		length: 0,
 		[Symbol.iterator]: function* () {},
 	});
-} );
+});
 ```
 
 These mocks should be placed before the tests that use CKEditor&nbsp;5. They are not perfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Keep in mind that they are not a replacement for proper browser testing.

--- a/docs/getting-started/integrations/angular.md
+++ b/docs/getting-started/integrations/angular.md
@@ -705,7 +705,7 @@ The `moduleResolution` option of the TypeScript configuration determines the alg
 
 ### Potential issues with Jest testing
 
-Jest is the default test runner used by many Vue apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js with the use of JSDOM. JSDOM is not a complete DOM implementation and while it is apparently sufficient for standard apps, it is not able to polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
+Jest is the default test runner used by many Angular apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js with the use of JSDOM. JSDOM is not a complete DOM implementation and while it is apparently sufficient for standard apps, it is not able to polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
 
 A better approach to test the component inside a fully-fledged web browser, implementing a complete DOM, is to use [`jest-puppeteer`](https://github.com/smooth-code/jest-puppeteer).
 

--- a/docs/getting-started/integrations/angular.md
+++ b/docs/getting-started/integrations/angular.md
@@ -705,12 +705,12 @@ The `moduleResolution` option of the TypeScript configuration determines the alg
 
 ### Potential issues with Jest testing
 
-Jest is the default test runner used by many Angular apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js with the use of JSDOM. JSDOM is not a complete DOM implementation and while it is apparently sufficient for standard apps, it is not able to polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
+You can use Jest as a test runner in Angular apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js that uses JSDOM. JSDOM is not a complete DOM implementation, and while it is sufficient for standard apps, it cannot polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
 
 If this is not possible, you can use the following mocks to make the tests pass:
 
 ```javascript
-beforeAll(() => {
+beforeAll( () => {
 	window.scrollTo = jest.fn();
 
 	window.ResizeObserver = class ResizeObserver {
@@ -719,28 +719,28 @@ beforeAll(() => {
 		disconnect() {}
 	};
 
-	for (const key of ['InputEvent', 'KeyboardEvent']) {
-		window[key].prototype.getTargetRanges = () => {
-			const range = new StaticRange({
-				startContainer: document.body.querySelector('.ck-editor__editable p'),
+	for ( const key of [ 'InputEvent', 'KeyboardEvent' ] ) {
+		window[ key ].prototype.getTargetRanges = () => {
+			const range = new StaticRange( {
+				startContainer: document.body.querySelector( '.ck-editor__editable p' ),
 				startOffset: 0,
-				endContainer: document.body.querySelector('.ck-editor__editable p'),
-				endOffset: 0,
-			});
+				endContainer: document.body.querySelector( '.ck-editor__editable p' ),
+				endOffset: 0
+			} );
 
-			return [range];
+			return [ range ];
 		};
 	}
 
-	Range.prototype.getClientRects = () => ({
+	Range.prototype.getClientRects = () => ( {
 		item: () => null,
 		length: 0,
-		[Symbol.iterator]: function* () {},
-	});
-});
+		[ Symbol.iterator ]: function* () {}
+	} );
+} );
 ```
 
-These mocks should be placed before the tests that use CKEditor&nbsp;5. They are not perfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Keep in mind that they are not a replacement for proper browser testing.
+These mocks should be placed before the tests that use CKEditor&nbsp;5. They are imperfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Keep in mind that they are not a replacement for proper browser testing.
 
 ## Contributing and reporting issues
 

--- a/docs/getting-started/integrations/react.md
+++ b/docs/getting-started/integrations/react.md
@@ -283,7 +283,7 @@ Jest is the default test runner used by many React apps. Unfortunately, Jest doe
 
 For testing CKEditor&nbsp;5, it is recommended to use testing frameworks that utilize a real browser and provide a complete DOM implementation. Some popular options include:
 
-* [Vitest](https://vitest.netlify.app/)
+* [Vitest](https://vitest.dev/)
 * [Playwright](https://playwright.dev/)
 * [Cypress](https://www.cypress.io/)
 

--- a/docs/getting-started/integrations/react.md
+++ b/docs/getting-started/integrations/react.md
@@ -279,7 +279,7 @@ For more information, please refer to the {@link getting-started/setup/ui-langua
 
 ### Jest testing
 
-Jest is the default test runner used by many React apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js with the use of JSDOM. JSDOM is not a complete DOM implementation and while it is apparently sufficient for standard apps, it is not able to polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
+Jest is the default test runner used by many React apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js that uses JSDOM. JSDOM is not a complete DOM implementation, and while it is sufficient for standard apps, it cannot polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
 
 If this is not possible, you can use the following mock snippet:
 

--- a/docs/getting-started/integrations/react.md
+++ b/docs/getting-started/integrations/react.md
@@ -293,59 +293,61 @@ import { userEvent } from '@testing-library/user-event';
 import { DecoupledEditor, Essentials, Paragraph } from 'ckeditor5';
 import { CKEditor } from '@ckeditor/ckeditor5-react';
 
-window.scrollTo = jest.fn();
+beforeAll( () => {
+	window.scrollTo = jest.fn();
 
-window.ResizeObserver = class ResizeObserver {
-  observe() {}
-  unobserve() {}
-  disconnect() {}
-};
+	window.ResizeObserver = class ResizeObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+	};
 
-for (const key of ['InputEvent', 'KeyboardEvent']) {
-  window[key].prototype.getTargetRanges = () => {
-    const range = new StaticRange({
-      startContainer: document.body.querySelector('.ck-editor__editable p')!,
-      startOffset: 0,
-      endContainer: document.body.querySelector('.ck-editor__editable p')!,
-      endOffset: 0,
-    });
+	for (const key of ['InputEvent', 'KeyboardEvent']) {
+	window[key].prototype.getTargetRanges = () => {
+		const range = new StaticRange({
+		startContainer: document.body.querySelector('.ck-editor__editable p'),
+		startOffset: 0,
+		endContainer: document.body.querySelector('.ck-editor__editable p'),
+		endOffset: 0,
+		});
 
-    return [range];
-  };
-}
+		return [range];
+	};
+	}
 
-Range.prototype.getClientRects = () => ({
-  item: () => null,
-  length: 0,
-  [Symbol.iterator]: function* () {},
-});
+	Range.prototype.getClientRects = () => ({
+	item: () => null,
+	length: 0,
+	[Symbol.iterator]: function* () {},
+	});
 
-const SomeComponent = ({ value, onChange }) => {
-  const editorRef = useRef();
+	const SomeComponent = ({ value, onChange }) => {
+	const editorRef = useRef();
 
-  return (
-    <div
-      style={{
-        border: '1px solid black',
-        padding: 10,
-      }}
-    >
-      <CKEditor
-        editor={DecoupledEditor}
-        config={{
-          plugins: [Essentials, Paragraph],
-        }}
-        onReady={(editor) => {
-          editorRef.current = editor;
-        }}
-        data={value}
-        onChange={() => {
-          onChange(editorRef.current?.getData());
-        }}
-      />
-    </div>
-  );
-};
+	return (
+		<div
+		style={{
+			border: '1px solid black',
+			padding: 10,
+		}}
+		>
+		<CKEditor
+			editor={DecoupledEditor}
+			config={{
+			plugins: [Essentials, Paragraph],
+			}}
+			onReady={(editor) => {
+			editorRef.current = editor;
+			}}
+			data={value}
+			onChange={() => {
+			onChange(editorRef.current?.getData());
+			}}
+		/>
+		</div>
+	);
+	};
+} );
 
 it('renders', async () => {
   render(<SomeComponent value="this is some content" />);

--- a/docs/getting-started/integrations/react.md
+++ b/docs/getting-started/integrations/react.md
@@ -293,16 +293,16 @@ import { userEvent } from '@testing-library/user-event';
 import { DecoupledEditor, Essentials, Paragraph } from 'ckeditor5';
 import { CKEditor } from '@ckeditor/ckeditor5-react';
 
-global.window.scrollTo = jest.fn();
+window.scrollTo = jest.fn();
 
-global.window.ResizeObserver = class ResizeObserver {
+window.ResizeObserver = class ResizeObserver {
   observe() {}
   unobserve() {}
   disconnect() {}
 };
 
 for (const key of ['InputEvent', 'KeyboardEvent']) {
-  global.window[key].prototype.getTargetRanges = () => {
+  window[key].prototype.getTargetRanges = () => {
     const range = new StaticRange({
       startContainer: document.body.querySelector('.ck-editor__editable p')!,
       startOffset: 0,

--- a/docs/getting-started/integrations/react.md
+++ b/docs/getting-started/integrations/react.md
@@ -285,7 +285,7 @@ A better approach to test the component inside a fully-fledged web browser, impl
 
 If this is not possible, you can use the following mock snippet:
 
-```tsx
+```jsx
 import React, { useRef } from 'react';
 import { render, waitFor, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
@@ -293,79 +293,79 @@ import { userEvent } from '@testing-library/user-event';
 import { DecoupledEditor, Essentials, Paragraph } from 'ckeditor5';
 import { CKEditor } from '@ckeditor/ckeditor5-react';
 
-beforeAll( () => {
+beforeAll(() => {
 	window.scrollTo = jest.fn();
 
 	window.ResizeObserver = class ResizeObserver {
-	observe() {}
-	unobserve() {}
-	disconnect() {}
+		observe() {}
+		unobserve() {}
+		disconnect() {}
 	};
 
 	for (const key of ['InputEvent', 'KeyboardEvent']) {
-	window[key].prototype.getTargetRanges = () => {
-		const range = new StaticRange({
-		startContainer: document.body.querySelector('.ck-editor__editable p'),
-		startOffset: 0,
-		endContainer: document.body.querySelector('.ck-editor__editable p'),
-		endOffset: 0,
-		});
+		window[key].prototype.getTargetRanges = () => {
+			const range = new StaticRange({
+				startContainer: document.body.querySelector('.ck-editor__editable p'),
+				startOffset: 0,
+				endContainer: document.body.querySelector('.ck-editor__editable p'),
+				endOffset: 0,
+			});
 
-		return [range];
-	};
+			return [range];
+		};
 	}
 
 	Range.prototype.getClientRects = () => ({
-	item: () => null,
-	length: 0,
-	[Symbol.iterator]: function* () {},
+		item: () => null,
+		length: 0,
+		[Symbol.iterator]: function* () {},
 	});
 
 	const SomeComponent = ({ value, onChange }) => {
-	const editorRef = useRef();
+		const editorRef = useRef();
 
-	return (
-		<div
-		style={{
-			border: '1px solid black',
-			padding: 10,
-		}}
-		>
-		<CKEditor
-			editor={DecoupledEditor}
-			config={{
-			plugins: [Essentials, Paragraph],
-			}}
-			onReady={(editor) => {
-			editorRef.current = editor;
-			}}
-			data={value}
-			onChange={() => {
-			onChange(editorRef.current?.getData());
-			}}
-		/>
-		</div>
-	);
+		return (
+			<div
+				style={{
+					border: '1px solid black',
+					padding: 10,
+				}}
+			>
+				<CKEditor
+					editor={DecoupledEditor}
+					config={{
+						plugins: [Essentials, Paragraph],
+					}}
+					onReady={(editor) => {
+						editorRef.current = editor;
+					}}
+					data={value}
+					onChange={() => {
+						onChange(editorRef.current?.getData());
+					}}
+				/>
+			</div>
+		);
 	};
-} );
+});
 
 it('renders', async () => {
-  render(<SomeComponent value="this is some content" />);
+	render(<SomeComponent value="this is some content" />);
 
-  await waitFor(() => expect(screen.getByText(/some content/)).toBeTruthy());
+	await waitFor(() => expect(screen.getByText(/some content/)).toBeTruthy());
 });
 
 it('updates', async () => {
-  const onChange = jest.fn();
-  render(<SomeComponent value="this is some content" onChange={onChange} />);
+	const onChange = jest.fn();
+	render(<SomeComponent value="this is some content" onChange={onChange} />);
 
-  await waitFor(() => expect(screen.getByText(/some content/)).toBeTruthy());
+	await waitFor(() => expect(screen.getByText(/some content/)).toBeTruthy());
 
-  await userEvent.click(document.querySelector('[contenteditable="true"]'));
+	await userEvent.click(document.querySelector('[contenteditable="true"]'));
 
-  userEvent.keyboard('more stuff');
+	userEvent.keyboard('more stuff');
 
-  await waitFor(() => expect(onChange).toHaveBeenCalled());
+	await waitFor(() => expect(onChange).toHaveBeenCalled());
 });
 ```
 

--- a/docs/getting-started/integrations/react.md
+++ b/docs/getting-started/integrations/react.md
@@ -279,7 +279,7 @@ For more information, please refer to the {@link getting-started/setup/ui-langua
 
 ### Potential issues with Jest testing
 
-Jest is the default test runner used by many React apps. Unfortunately, Jest does not use a real browser – instead, it runs tests in Node.js with the use of JSDOM. JSDOM is not a complete DOM implementation and while it's apparently sufficient for standard apps, it's not able to polyfill all the DOM APIs that CKEditor 5 requires.
+Jest is the default test runner used by many React apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js with the use of JSDOM. JSDOM is not a complete DOM implementation and while it is apparently sufficient for standard apps, it is not able to polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
 
 A better approach to test the component inside a fully-fledged web browser, implementing a complete DOM, is to use [`jest-puppeteer`](https://github.com/smooth-code/jest-puppeteer).
 
@@ -367,7 +367,7 @@ it('updates', async () => {
 });
 ```
 
-The mocks above test only two basic scenarios, and it is likely that more will need to be added, which may change with each version of the editor.
+The mocks presented above only test two basic scenarios, and it is likely that more will need to be added, which may change with each version of the editor.
 
 ## Contributing and reporting issues
 

--- a/docs/getting-started/integrations/react.md
+++ b/docs/getting-started/integrations/react.md
@@ -281,8 +281,6 @@ For more information, please refer to the {@link getting-started/setup/ui-langua
 
 Jest is the default test runner used by many React apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js with the use of JSDOM. JSDOM is not a complete DOM implementation and while it is apparently sufficient for standard apps, it is not able to polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
 
-A better approach to test the component inside a fully-fledged web browser, implementing a complete DOM, is to use [`jest-puppeteer`](https://github.com/smooth-code/jest-puppeteer).
-
 If this is not possible, you can use the following mock snippet:
 
 ```jsx

--- a/docs/getting-started/integrations/react.md
+++ b/docs/getting-started/integrations/react.md
@@ -277,7 +277,7 @@ export default App;
 
 For more information, please refer to the {@link getting-started/setup/ui-language Setting the UI language} guide.
 
-### Potential issues with Jest testing
+### Jest testing
 
 Jest is the default test runner used by many React apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js with the use of JSDOM. JSDOM is not a complete DOM implementation and while it is apparently sufficient for standard apps, it is not able to polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
 

--- a/docs/getting-started/integrations/react.md
+++ b/docs/getting-started/integrations/react.md
@@ -281,7 +281,15 @@ For more information, please refer to the {@link getting-started/setup/ui-langua
 
 Jest is the default test runner used by many React apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js that uses JSDOM. JSDOM is not a complete DOM implementation, and while it is sufficient for standard apps, it cannot polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
 
-If this is not possible, you can use the following mock snippet:
+For testing CKEditor&nbsp;5, it is recommended to use testing frameworks that utilize a real browser and provide a complete DOM implementation. Some popular options include:
+
+* [Vitest](https://vitest.netlify.app/)
+* [Playwright](https://playwright.dev/)
+* [Cypress](https://www.cypress.io/)
+
+These frameworks offer better support for testing CKEditor&nbsp;5 and provide a more accurate representation of how the editor behaves in a real browser environment.
+
+If this is not possible and you still want to use Jest, you can mock some of the required APIs. Below is an example of how to mock some of the APIs used by CKEditor&nbsp;5:
 
 ```jsx
 import React, { useRef } from 'react';

--- a/docs/getting-started/integrations/react.md
+++ b/docs/getting-started/integrations/react.md
@@ -291,7 +291,7 @@ import { userEvent } from '@testing-library/user-event';
 import { DecoupledEditor, Essentials, Paragraph } from 'ckeditor5';
 import { CKEditor } from '@ckeditor/ckeditor5-react';
 
-beforeAll(() => {
+beforeAll( () => {
 	window.scrollTo = jest.fn();
 
 	window.ResizeObserver = class ResizeObserver {
@@ -300,74 +300,74 @@ beforeAll(() => {
 		disconnect() {}
 	};
 
-	for (const key of ['InputEvent', 'KeyboardEvent']) {
-		window[key].prototype.getTargetRanges = () => {
-			const range = new StaticRange({
-				startContainer: document.body.querySelector('.ck-editor__editable p'),
+	for ( const key of [ 'InputEvent', 'KeyboardEvent' ] ) {
+		window[ key ].prototype.getTargetRanges = () => {
+			const range = new StaticRange( {
+				startContainer: document.body.querySelector( '.ck-editor__editable p' ),
 				startOffset: 0,
-				endContainer: document.body.querySelector('.ck-editor__editable p'),
-				endOffset: 0,
-			});
+				endContainer: document.body.querySelector( '.ck-editor__editable p' ),
+				endOffset: 0
+			} );
 
-			return [range];
+			return [ range ];
 		};
 	}
 
-	Range.prototype.getClientRects = () => ({
+	Range.prototype.getClientRects = () => ( {
 		item: () => null,
 		length: 0,
-		[Symbol.iterator]: function* () {},
-	});
+		[ Symbol.iterator ]: function* () {}
+	} );
+} );
 
-	const SomeComponent = ({ value, onChange }) => {
-		const editorRef = useRef();
+const SomeComponent = ( { value, onChange } ) => {
+	const editorRef = useRef();
 
-		return (
-			<div
-				style={{
-					border: '1px solid black',
-					padding: 10,
+	return (
+		<div
+			style={{
+				border: '1px solid black',
+				padding: 10,
+			}}
+		>
+			<CKEditor
+				editor={ DecoupledEditor }
+				config={{
+					plugins: [ Essentials, Paragraph ],
 				}}
-			>
-				<CKEditor
-					editor={DecoupledEditor}
-					config={{
-						plugins: [Essentials, Paragraph],
-					}}
-					onReady={(editor) => {
-						editorRef.current = editor;
-					}}
-					data={value}
-					onChange={() => {
-						onChange(editorRef.current?.getData());
-					}}
-				/>
-			</div>
-		);
-	};
-});
+				onReady={ (editor) => {
+					editorRef.current = editor;
+				} }
+				data={ value }
+				onChange={ () => {
+					onChange( editorRef.current?.getData() );
+				} }
+			/>
+		</div>
+	);
+};
 
-it('renders', async () => {
-	render(<SomeComponent value="this is some content" />);
+it( 'renders', async () => {
+	render( <SomeComponent value="this is some content" /> );
 
-	await waitFor(() => expect(screen.getByText(/some content/)).toBeTruthy());
-});
+	await waitFor( () => expect( screen.getByText( /some content/ ) ).toBeTruthy());
+} );
 
-it('updates', async () => {
+it( 'updates', async () => {
 	const onChange = jest.fn();
-	render(<SomeComponent value="this is some content" onChange={onChange} />);
+	render( <SomeComponent value="this is some content" onChange={onChange} /> );
 
-	await waitFor(() => expect(screen.getByText(/some content/)).toBeTruthy());
+	await waitFor( () => expect( screen.getByText( /some content/ ) ).toBeTruthy() );
 
-	await userEvent.click(document.querySelector('[contenteditable="true"]'));
+	await userEvent.click( document.querySelector( '[contenteditable="true"]' ) );
 
-	userEvent.keyboard('more stuff');
+	userEvent.keyboard( 'more stuff' );
 
-	await waitFor(() => expect(onChange).toHaveBeenCalled());
-});
+	await waitFor( () => expect( onChange ).toHaveBeenCalled() );
+} );
 ```
 
-The mocks presented above only test two basic scenarios, and it is likely that more will need to be added, which may change with each version of the editor.
+The mocks presented above only test two basic scenarios, and more will likely need to be added, which may change with each version of the editor.
 
 ## Contributing and reporting issues
 

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -480,7 +480,15 @@ For more information, refer to the {@link getting-started/setup/ui-language Sett
 
 You can use Jest as a test runner in Vue apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js that uses JSDOM. JSDOM is not a complete DOM implementation, and while it is sufficient for standard apps, it cannot polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
 
-If this is not possible, you can use the following mocks to make the tests pass:
+For testing CKEditor&nbsp;5, it is recommended to use testing frameworks that utilize a real browser and provide a complete DOM implementation. Some popular options include:
+
+* [Vitest](https://vitest.netlify.app/)
+* [Playwright](https://playwright.dev/)
+* [Cypress](https://www.cypress.io/)
+
+These frameworks offer better support for testing CKEditor&nbsp;5 and provide a more accurate representation of how the editor behaves in a real browser environment.
+
+If this is not possible and you still want to use Jest, you can mock some of the required APIs. Below is an example of how to mock some of the APIs used by CKEditor&nbsp;5:
 
 ```javascript
 beforeAll( () => {

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -513,7 +513,7 @@ Range.prototype.getClientRects = () => ({
 });
 ```
 
-These mocks are not perfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Keep in mind that they are not a replacement for proper browser testing and cover only the initialization and rendering of the editor.
+These mocks are not perfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Keep in mind that they are not a replacement for proper browser testing.
 
 ## Contributing and reporting issues
 

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -484,7 +484,7 @@ A better approach to test the component inside a fully-fledged web browser, impl
 
 If this is not possible, you can use the following mocks to make the tests pass:
 
-```ts
+```javascript
 beforeAll( () => {
 	window.scrollTo = jest.fn();
 
@@ -512,7 +512,7 @@ beforeAll( () => {
 		length: 0,
 		[Symbol.iterator]: function* () {},
 	});
-	} );
+} );
 ```
 
 These mocks should be placed before the tests that use CKEditor&nbsp;5. They are not perfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Keep in mind that they are not a replacement for proper browser testing.

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -400,7 +400,7 @@ Since accessing the editor toolbar is not possible until after the editor instan
 <script>
 	import { DecoupledEditor, Bold, Essentials, Italic, Paragraph, Undo } from 'ckeditor5';
 	import CKEditor from '@ckeditor/ckeditor5-vue';
-	
+
 	import 'ckeditor5/ckeditor5.css';
 
 	export default {
@@ -475,6 +475,45 @@ export default {
 ```
 
 For more information, refer to the {@link getting-started/setup/ui-language Setting the UI language} guide.
+
+### Potential issues with Jest testing
+
+Jest is the default test runner used by many Vue apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js with the use of JSDOM. JSDOM is not a complete DOM implementation and while it is apparently sufficient for standard apps, it is not able to polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
+
+A better approach to test the component inside a fully-fledged web browser, implementing a complete DOM, is to use [`jest-puppeteer`](https://github.com/smooth-code/jest-puppeteer).
+
+If this is not possible, you can use the following mocks to make the tests pass:
+
+```ts
+window.scrollTo = jest.fn();
+
+window.ResizeObserver = class ResizeObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+};
+
+for (const key of ['InputEvent', 'KeyboardEvent']) {
+	window[key].prototype.getTargetRanges = () => {
+		const range = new StaticRange({
+			startContainer: document.body.querySelector('.ck-editor__editable p')!,
+			startOffset: 0,
+			endContainer: document.body.querySelector('.ck-editor__editable p')!,
+			endOffset: 0,
+		});
+
+		return [range];
+	};
+}
+
+Range.prototype.getClientRects = () => ({
+	item: () => null,
+	length: 0,
+	[Symbol.iterator]: function* () {},
+});
+```
+
+These mocks are not perfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Keep in mind that they are not a replacement for proper browser testing and cover only the initialization and rendering of the editor.
 
 ## Contributing and reporting issues
 

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -485,35 +485,37 @@ A better approach to test the component inside a fully-fledged web browser, impl
 If this is not possible, you can use the following mocks to make the tests pass:
 
 ```ts
-window.scrollTo = jest.fn();
+beforeAll( () => {
+	window.scrollTo = jest.fn();
 
-window.ResizeObserver = class ResizeObserver {
-	observe() {}
-	unobserve() {}
-	disconnect() {}
-};
-
-for (const key of ['InputEvent', 'KeyboardEvent']) {
-	window[key].prototype.getTargetRanges = () => {
-		const range = new StaticRange({
-			startContainer: document.body.querySelector('.ck-editor__editable p')!,
-			startOffset: 0,
-			endContainer: document.body.querySelector('.ck-editor__editable p')!,
-			endOffset: 0,
-		});
-
-		return [range];
+	window.ResizeObserver = class ResizeObserver {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
 	};
-}
 
-Range.prototype.getClientRects = () => ({
-	item: () => null,
-	length: 0,
-	[Symbol.iterator]: function* () {},
-});
+	for (const key of ['InputEvent', 'KeyboardEvent']) {
+		window[key].prototype.getTargetRanges = () => {
+			const range = new StaticRange({
+				startContainer: document.body.querySelector('.ck-editor__editable p')!,
+				startOffset: 0,
+				endContainer: document.body.querySelector('.ck-editor__editable p')!,
+				endOffset: 0,
+			});
+
+			return [range];
+		};
+	}
+
+	Range.prototype.getClientRects = () => ({
+		item: () => null,
+		length: 0,
+		[Symbol.iterator]: function* () {},
+	});
+	} );
 ```
 
-These mocks are not perfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Keep in mind that they are not a replacement for proper browser testing.
+These mocks should be placed before the tests that use CKEditor&nbsp;5. They are not perfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Keep in mind that they are not a replacement for proper browser testing.
 
 ## Contributing and reporting issues
 

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -480,8 +480,6 @@ For more information, refer to the {@link getting-started/setup/ui-language Sett
 
 Jest is the default test runner used by many Vue apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js with the use of JSDOM. JSDOM is not a complete DOM implementation and while it is apparently sufficient for standard apps, it is not able to polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
 
-A better approach to test the component inside a fully-fledged web browser, implementing a complete DOM, is to use [`jest-puppeteer`](https://github.com/smooth-code/jest-puppeteer).
-
 If this is not possible, you can use the following mocks to make the tests pass:
 
 ```javascript

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -482,7 +482,7 @@ You can use Jest as a test runner in Vue apps. Unfortunately, Jest does not use 
 
 For testing CKEditor&nbsp;5, it is recommended to use testing frameworks that utilize a real browser and provide a complete DOM implementation. Some popular options include:
 
-* [Vitest](https://vitest.netlify.app/)
+* [Vitest](https://vitest.dev/)
 * [Playwright](https://playwright.dev/)
 * [Cypress](https://www.cypress.io/)
 

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -476,7 +476,7 @@ export default {
 
 For more information, refer to the {@link getting-started/setup/ui-language Setting the UI language} guide.
 
-### Potential issues with Jest testing
+### Jest testing
 
 Jest is the default test runner used by many Vue apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js with the use of JSDOM. JSDOM is not a complete DOM implementation and while it is apparently sufficient for standard apps, it is not able to polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
 
@@ -513,7 +513,7 @@ beforeAll( () => {
 } );
 ```
 
-These mocks should be placed before the tests that use CKEditor&nbsp;5. They are not perfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Keep in mind that they are not a replacement for proper browser testing.
+These mocks should be placed before the tests that use CKEditor&nbsp;5. They are imperfect and may not cover all the cases, but they should be sufficient for basic initialization and rendering editor. Remember that they are not a replacement for proper browser testing.
 
 ## Contributing and reporting issues
 

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -478,7 +478,7 @@ For more information, refer to the {@link getting-started/setup/ui-language Sett
 
 ### Jest testing
 
-Jest is the default test runner used by many Vue apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js with the use of JSDOM. JSDOM is not a complete DOM implementation and while it is apparently sufficient for standard apps, it is not able to polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
+You can use Jest as a test runner in Vue apps. Unfortunately, Jest does not use a real browser. Instead, it runs tests in Node.js that uses JSDOM. JSDOM is not a complete DOM implementation, and while it is sufficient for standard apps, it cannot polyfill all the DOM APIs that CKEditor&nbsp;5 requires.
 
 If this is not possible, you can use the following mocks to make the tests pass:
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Add `Potential issues with Jest testing` section to React integration docs.

---

### Additional information

Related to https://github.com/ckeditor/ckeditor5-react/issues/225

I added this section to address the increasing number of reports regarding issues with Jest testing in React applications. This explanation clarifies the limitations of Jest when used with CKEditor 5 and provides a solution for more accurate testing by using jest-puppeteer or a mock snippet.