### PR TITLE
Aligned docs for changes in package generator

### DIFF
--- a/docs/framework/development-tools/package-generator/javascript-package.md
+++ b/docs/framework/development-tools/package-generator/javascript-package.md
@@ -45,7 +45,8 @@ An overview of the project's directory structure:
 ├─ ckeditor5-metadata.json # See link below for details.
 ├─ LICENSE.md              # All created packages fall under the MIT license.
 ├─ package.json            # See link below for details.
-└─ README.md               # Description of your project and usage instructions.
+├─ README.md               # Description of your project and usage instructions.
+└─ vitest.config.js        # Vitest configuration file.
 ```
 
 <info-box warning>
@@ -59,6 +60,7 @@ Guides for developing some of the files:
 * [.gitignore](https://git-scm.com/docs/gitignore)
 * {@link framework/contributing/package-metadata ckeditor5-metadata.json}
 * [package.json](https://docs.npmjs.com/cli/v7/configuring-npm/package-json)
+* [vitest.config.js](https://vitest.dev/config/)
 
 ## Npm scripts
 
@@ -91,12 +93,7 @@ npm run start -- --language=de
 
 ### `test`
 
-Allows executing unit tests for the package, specified in the `tests/` directory. The command accepts the following modifiers:
-
-* `--coverage` &ndash; Creates the code coverage report.
-* `--watch` &ndash; Observes the source files (the command does not end after executing tests).
-* `--source-map` &ndash; Generates source maps of the sources.
-* `--verbose` &ndash; Prints additional webpack logs.
+Allows executing unit tests for the package specified in the `tests/` directory using [Vitest](https://vitest.dev/) testing framework. To check the code coverage, add the `--coverage` modifier. See other [CLI flags](https://vitest.dev/guide/cli.html) in Vitest.
 
 Examples:
 
@@ -105,7 +102,18 @@ Examples:
 npm run test
 
 # Generate code coverage report after each change in the sources.
-npm run test -- --coverage --test
+npm run test -- --coverage --watch
+```
+
+### `test:debug`
+
+Allows executing unit tests for the package specified in the `tests/` directory using [Vitest](https://vitest.dev/) testing framework with the possibility of debugging them. Once Vitest starts, it will stop execution and wait for you to open developer tools that can connect to Node.js inspector.
+
+Examples:
+
+```bash
+# Execute tests in the debug mode.
+npm run test:debug
 ```
 
 ### `lint`

--- a/docs/framework/development-tools/package-generator/typescript-package.md
+++ b/docs/framework/development-tools/package-generator/typescript-package.md
@@ -52,7 +52,8 @@ An overview of the project's directory structure:
 ├─ tsconfig.dist.json      # Override for options from `tsconfig.json` file during `npm` and browser builds.
 ├─ tsconfig.test.json      # Override for options from `tsconfig.json` file while executing tests.
 ├─ tsconfig.release.json   # Override for options from `tsconfig.json` file during release process.
-└─ README.md               # Description of your project and usage instructions.
+├─ README.md               # Description of your project and usage instructions.
+└─ vitest.config.ts        # Vitest configuration file.
 
 ```
 
@@ -68,6 +69,7 @@ Guides for developing some of the files:
 * [package.json](https://docs.npmjs.com/cli/v7/configuring-npm/package-json)
 * [tsconfig.json](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html)
 * augmentation.ts - Read more in the [relevant issue](https://github.com/ckeditor/ckeditor5/issues/13433), {@link module:core/plugincollection~PluginsMap} and {@link module:core/commandcollection~CommandsMap}.
+* [vitest.config.js](https://vitest.dev/config/)
 
 ## Npm scripts
 
@@ -100,12 +102,7 @@ npm run start -- --language=de
 
 ### `test`
 
-Allows executing unit tests for the package, specified in the `tests/` directory. The command accepts the following modifiers:
-
-* `--coverage` &ndash; Creates the code coverage report.
-* `--watch` &ndash; Observes the source files (the command does not end after executing tests).
-* `--source-map` &ndash; Generates source maps of the sources.
-* `--verbose` &ndash; Prints additional webpack logs.
+Allows executing unit tests for the package specified in the `tests/` directory using [Vitest](https://vitest.dev/) testing framework. To check the code coverage, add the `--coverage` modifier. See other [CLI flags](https://vitest.dev/guide/cli.html) in Vitest.
 
 Examples:
 
@@ -114,7 +111,18 @@ Examples:
 npm run test
 
 # Generate code coverage report after each change in the sources.
-npm run test -- --coverage --test
+npm run test -- --coverage --watch
+```
+
+### `test:debug`
+
+Allows executing unit tests for the package specified in the `tests/` directory using [Vitest](https://vitest.dev/) testing framework with the possibility of debugging them. Once Vitest starts, it will stop execution and wait for you to open developer tools that can connect to Node.js inspector.
+
+Examples:
+
+```bash
+# Execute tests in the debug mode.
+npm run test:debug
 ```
 
 ### `lint`


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Aligned docs for changes in `ckeditor/ckeditor5-package-generator` that uses now Vitest instead of Karma for running unit tests.

---

### Additional information

Related changes in `ckeditor/ckeditor5-package-generator`: https://github.com/ckeditor/ckeditor5-package-generator/pull/187
