### PR TITLE
Update Vue docs for use with npm and CDN

### DIFF
--- a/docs/getting-started/integrations-cdn/react-default-cdn.md
+++ b/docs/getting-started/integrations-cdn/react-default-cdn.md
@@ -16,37 +16,21 @@ order: 10
 	</a>
 </p>
 
-React lets you build user interfaces out of individual pieces called components. CKEditor&nbsp;5 can be used as one of such components. This guide explains how to integrate CKEditor&nbsp;5 into your React application using CDN.
+CKEditor&nbsp;5 has an official React integration that you can use to add a rich text editor to your application. This guide will help you install it and configure to use the CDN distribution of the CKEditor&nbsp;5.
 
-<info-box hint>
-	Starting from version 6.0.0 of this package, you can use native type definitions provided by CKEditor&nbsp;5. Check the details about {@link getting-started/setup/typescript-support TypeScript support}.
-</info-box>
-
-## Quick start
+This guide assumes that you already have a React project. If you do not have one, see the [React documentation](https://react.dev/learn/start-a-new-react-project) to learn how to create it.
 
 {@snippet getting-started/use-builder}
 
-### Setting up the project
+## Quick start
 
-This guide assumes you have a React project. You can create a basic React project using [Vite](https://vitejs.dev/). Refer to the [React documentation](https://react.dev/learn/start-a-new-react-project) to learn how to set up a project in the framework.
-
-### Installing the React component from npm
-
-Install the `@ckeditor/ckeditor5-react` package:
+Start by installing the React integration for CKEditor&nbsp;5 from npm:
 
 ```bash
 npm install @ckeditor/ckeditor5-react
 ```
 
-The `useCKEditorCloud` hook is responsible for returning information that:
-
-* The editor is still downloading from the CDN with the `status = 'loading'`.
-* An error occurred during the download when `status = 'error'`. Further information is in the error field.
-* About the editor in the data field and its dependencies when `status = 'success'`.
-
-### Using the component
-
-Use the `<CKEditor>` component inside your project. The below example shows how to use it with the open-source plugins.
+Once the integration is installed, create a new React component called `Editor.jsx`. It will use the `useCKEditorCloud` helper to load the editor code from the CDN and the `<CKEditor>` component to run it, both of which come from the above package. The following example shows a component with open source and premium CKEditor&nbsp;5 plugins.
 
 ```js
 import React from 'react';
@@ -55,6 +39,7 @@ import { CKEditor, useCKEditorCloud } from '@ckeditor/ckeditor5-react';
 const CKEditorDemo = () => {
 	const cloud = useCKEditorCloud( {
 		version: '{@var ckeditor5-version}',
+		premium: true
 	} );
 
 	if ( cloud.status === 'error' ) {
@@ -67,59 +52,11 @@ const CKEditorDemo = () => {
 
 	const {
 		ClassicEditor,
-		Bold,
-		Essentials,
-		Italic,
 		Paragraph,
-		Undo,
-	} = cloud.CKEditor;
-
-	return (
-		<CKEditor
-			editor={ ClassicEditor }
-			data={ '<p>Hello world!</p>' }
-			config={ {
-				licenseKey: 'GPL',
-				toolbar: {
-					items: [ 'undo', 'redo', '|', 'bold', 'italic' ],
-				},
-				plugins: [ Bold, Essentials, Italic, Paragraph, Undo ],
-			} }
-		/>
-	);
-};
-```
-
-### Using the component with premium plugins
-
-To use premium plugins, set the `premium` property to `true` in the `useCKEditorCloud` configuration and provide your license key in the `CKEditor` configuration.
-
-```js
-import React from 'react';
-import { CKEditor, useCKEditorCloud } from '@ckeditor/ckeditor5-react';
-
-const CKEditorDemo = () => {
-	const cloud = useCKEditorCloud( {
-		version: '{@var ckeditor5-version}',
-		premium: true,
-	} );
-
-	if ( cloud.status === 'error' ) {
-		return <div>Error!</div>;
-	}
-
-	if ( cloud.status === 'loading' ) {
-		return <div>Loading...</div>;
-	}
-
-	const {
-		ClassicEditor,
-		Bold,
 		Essentials,
+		Bold,
 		Italic,
-		Mention,
-		Paragraph,
-		Undo,
+		Mention
 	} = cloud.CKEditor;
 
 	const { SlashCommand } = cloud.CKEditorPremiumFeatures;
@@ -129,142 +66,20 @@ const CKEditorDemo = () => {
 			editor={ ClassicEditor }
 			data={ '<p>Hello world!</p>' }
 			config={ {
-				licenseKey: '<YOUR_LICENSE_KEY>',
+				licenseKey: '<YOUR_LICENSE_KEY>', // Or "GPL"
 				toolbar: {
 					items: [ 'undo', 'redo', '|', 'bold', 'italic' ],
 				},
-				plugins: [
-					Bold,
-					Essentials,
-					Italic,
-					Mention,
-					Paragraph,
-					Undo,
-					SlashCommand,
-				],
+				plugins: [ Essentials, Paragraph, Bold, Italic, Mention, SlashCommand ],
 			} }
 		/>
 	);
 };
 ```
 
-With the configuration in place, you can use the above elements as any other React component.
+In the above example, the `useCKEditorCloud` helper is used to load the editor code and plugins from CDN. The `premium` option is set to also load premium plugins. For more information about the `useCKEditorCloud` helper, see the {@link getting-started/setup/loading-cdn-resources Loading CDN resources} page.
 
-```html
-<App>
-	<CKEditorDemo />
-</App>
-```
-
-### Using the component with CKBox
-
-To use `CKBox`, specify the version and theme (optionally) in the `useCKEditorCloud` configuration. Also, remember about the actual plugin configuration inside `<CKEditor/>` component.
-
-```js
-import React from 'react';
-import { CKEditor, useCKEditorCloud } from '@ckeditor/ckeditor5-react';
-
-const CKEditorDemo = () => {
-	const cloud = useCKEditorCloud( {
-		version: '{@var ckeditor5-version}',
-		ckbox: {
-			version: '2.5.1',
-			// Optional - it's already 'lark' by default.
-			theme: 'lark',
-		},
-	} );
-
-	if ( cloud.status === 'error' ) {
-		return <div>Error!</div>;
-	}
-
-	if ( cloud.status === 'loading' ) {
-		return <div>Loading...</div>;
-	}
-
-	const {
-		ClassicEditor,
-		Bold,
-		Essentials,
-		Italic,
-		Mention,
-		Paragraph,
-		Undo,
-		CKBox,
-		CKBoxImageEdit,
-	} = cloud.CKEditor;
-
-	return (
-		<CKEditor
-			editor={ ClassicEditor }
-			data={ '<p>Hello world!</p>' }
-			config={ {
-				toolbar: {
-					items: [ 'undo', 'redo', '|', 'bold', 'italic' ],
-				},
-				plugins: [
-					Bold,
-					Essentials,
-					Italic,
-					Mention,
-					Paragraph,
-					Undo,
-					CKBox,
-					CKBoxImageEdit,
-				],
-				ckbox: {
-					tokenUrl: 'https://api.ckbox.io/token/demo',
-					forceDemoLabel: true,
-					allowExternalImagesEditing: [ /^data:/, /^i.imgur.com\//, 'origin' ],
-				},
-			} }
-		/>
-	);
-};
-```
-
-### Using the component with external plugins
-
-There are various ways to use external plugins. Here is a list of them:
-
-* **Local UMD Plugins:** Dynamically import local UMD modules using the `import()` syntax.
-* **Local External Imports:** Load external plugins locally using additional bundler configurations (such as Vite).
-* **CDN Third-Party Plugins:** Load JavaScript and CSS files from a CDN by specifying the URLs.
-* **Verbose Configuration:** Advanced plugin loading with options to specify both script and style sheet URLs, along with an optional `checkPluginLoaded` function to verify the plugin has been correctly loaded into the global scope.
-
-Here is an example:
-
-```js
-import React from 'react';
-import { CKEditor, useCKEditorCloud } from '@ckeditor/ckeditor5-react';
-
-const CKEditorDemo = () => {
-	const cloud = useCKEditorCloud( {
-		version: '{@var ckeditor5-version}',
-		plugins: {
-			PluginUMD: async () => await import( './your-local-import.umd.js' ),
-			PluginLocalImport: async () => await import( './your-local-import' ),
-			PluginThirdParty: [
-				'https://cdn.example.com/plugin3.js',
-				'https://cdn.example.com/plugin3.css'
-			]
-		}
-	} );
-
-	if ( cloud.status === 'error' ) {
-		return <div>Error!</div>;
-	}
-
-	if ( cloud.status === 'loading' ) {
-		return <div>Loading...</div>;
-	}
-
-	const { PluginUMD, PluginLocalImport, PluginThirdParty } = cloud.loadedPlugins;
-	// ...
-};
-```
-
-### Component properties
+## Component properties
 
 The `<CKEditor>` component supports the following properties:
 

--- a/docs/getting-started/integrations-cdn/vuejs-v3.md
+++ b/docs/getting-started/integrations-cdn/vuejs-v3.md
@@ -44,57 +44,49 @@ Once the integration is installed, create a new Vue component called `Editor.vue
 	/>
 </template>
 
-<script>
+<script setup>
+import { ref, markRaw, computed } from 'vue';
 import { Ckeditor, useCKEditorCloud } from '@ckeditor/ckeditor5-vue';
 
-export default {
-	name: 'Editor',
-	components: {
-		Ckeditor
-	},
-	data() {
-		return {
-			cloud: useCKEditorCloud( {
-				version: '{@var ckeditor5-version}',
-				premium: true
-			} ),
-			data: '<p>Hello world!</p>',
-			config: {
-				licenseKey: '<YOUR_LICENSE_KEY>', // Or "GPL"
-				toolbar: [ 'undo', 'redo', '|', 'bold', 'italic' ]
-			}
-		}
-	},
-	computed: {
-		editor() {
-			if ( !this.cloud.data ) {
-				return null;
-			}
+const cloud = useCKEditorCloud( {
+	version: '{@var ckeditor5-version}',
+	premium: true
+} );
 
-			const {
-				ClassicEditor,
-				Paragraph,
-				Essentials,
-				Bold,
-				Italic,
-				Mention
-			} = this.cloud.data.CKEditor;
+const data = ref( '<p>Hello world!</p>' );
 
-			const { SlashCommand } = this.cloud.data.CKEditorPremiumFeatures;
+const config = markRaw( {
+	licenseKey: '<YOUR_LICENSE_KEY>', // Or "GPL"
+	toolbar: [ 'undo', 'redo', '|', 'bold', 'italic' ]
+} );
 
-			return class Editor extends ClassicEditor {
-				static builtinPlugins = [
-					Essentials,
-					Paragraph,
-					Bold,
-					Italic,
-					Mention,
-					SlashCommand
-				];
-			};
-		}
+const editor = computed( () => {
+	if ( !cloud.data.value ) {
+		return null;
 	}
-}
+
+	const {
+		ClassicEditor,
+		Paragraph,
+		Essentials,
+		Bold,
+		Italic,
+		Mention
+	} = cloud.data.value.CKEditor;
+
+	const { SlashCommand } = cloud.data.value.CKEditorPremiumFeatures;
+
+	return class Editor extends ClassicEditor {
+		static builtinPlugins = [
+			Essentials,
+			Paragraph,
+			Bold,
+			Italic,
+			Mention,
+			SlashCommand
+		];
+	};
+} );
 </script>
 ```
 
@@ -126,25 +118,8 @@ This directive specifies the editor to be used by the component. It must directl
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor :editor="editor" />
-	</div>
+	<ckeditor :editor="editor" />
 </template>
-
-<script>
-	import { ClassicEditor } from 'ckeditor5';
-
-	export default {
-		name: 'app',
-		data() {
-			return {
-				editor: ClassicEditor,
-
-				// ...
-			};
-		}
-	};
-</script>
 ```
 
 ### `tag-name`
@@ -165,36 +140,28 @@ A [standard directive](https://v3.vuejs.org/guide/component-basics.html#using-v-
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor :editor="editor" v-model="editorData" />
-		<button @click="emptyEditor">Empty the editor</button>
+	<ckeditor :editor="editor" v-model="data" />
+	<button @click="emptyEditor">Empty the editor</button>
 
-		<h2>Editor data</h2>
-		<code>{{ editorData }}</code>
-	</div>
+	<h2>Editor data</h2>
+	<code>{{ data }}</code>
 </template>
 
-<script>
-	import { ClassicEditor } from 'ckeditor5';
+<script setup>
+import { ref } from 'vue';
+import { Ckeditor } from '@ckeditor/ckeditor5-vue';
 
-	export default {
-		name: 'app',
-		data() {
-			return {
-				editor: ClassicEditor,
-				editorData: '<p>Content of the editor.</p>'
-			};
-		},
-		methods: {
-			emptyEditor() {
-				this.editorData = '';
-			}
-		}
-	};
+// Editor loading and configuration is skipped for brevity.
+
+const data = ref( '<p>Hello world!</p>' );
+
+function emptyEditor() {
+	data.value = '';
+}
 </script>
 ```
 
-In the above example, the `editorData` property will be updated automatically as the user types and the content changes. It can also be used to change (as in `emptyEditor()`) or set the initial content of the editor.
+In the above example, the `data` property will be updated automatically as the user types and the content changes. It can also be used to change (as in `emptyEditor()`) or set the initial content of the editor.
 
 If you only want to execute an action when the editor data changes, use the [`input`](#input) event.
 
@@ -204,23 +171,16 @@ Allows a one–way data binding that sets the content of the editor. Unlike [`v-
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor :editor="editor" :model-value="editorData" />
-	</div>
+	<ckeditor :editor="editor" :model-value="data" />
 </template>
 
-<script>
-	import { ClassicEditor } from 'ckeditor5';
+<script setup>
+import { ref } from 'vue';
+import { Ckeditor } from '@ckeditor/ckeditor5-vue';
 
-	export default {
-		name: 'app',
-		data() {
-			return {
-				editor: ClassicEditor,
-				editorData: '<p>Content of the editor.</p>'
-			};
-		}
-	};
+// Editor loading and configuration is skipped for brevity.
+
+const data = ref( '<p>Hello world!</p>' );
 </script>
 ```
 
@@ -228,29 +188,23 @@ To execute an action when the editor data changes, use the [`input`](#input) eve
 
 ### `config`
 
-Specifies the {@link module:core/editor/editorconfig~EditorConfig configuration} of the editor.
+Specifies the {@link module:core/editor/config~config configuration} of the editor.
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor :editor="editor" :config="editorConfig" />
-	</div>
+	<ckeditor :editor="editor" :config="config" />
 </template>
 
-<script>
-	import { ClassicEditor } from 'ckeditor5';
+<script setup>
+import { markRaw } from 'vue';
+import { Ckeditor } from '@ckeditor/ckeditor5-vue';
 
-	export default {
-		name: 'app',
-		data() {
-			return {
-				editor: ClassicEditor,
-				editorConfig: {
-					toolbar: [ 'bold', 'italic', '|', 'link' ]
-				}
-			};
-		}
-	};
+// Editor loading and configuration is skipped for brevity.
+
+const config = markRaw( {
+	licenseKey: '<YOUR_LICENSE_KEY>', // Or "GPL"
+	toolbar: [ 'undo', 'redo', '|', 'bold', 'italic' ]
+} );
 </script>
 ```
 
@@ -262,24 +216,16 @@ It sets the initial read–only state of the editor and changes it during its li
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor :editor="editor" :disabled="editorDisabled" />
-	</div>
+	<ckeditor :editor="editor" :disabled="disabled" />
 </template>
 
-<script>
-	import { ClassicEditor } from 'ckeditor5';
+<script setup>
+import { ref } from 'vue';
+import { Ckeditor } from '@ckeditor/ckeditor5-vue';
 
-	export default {
-		name: 'app',
-		data() {
-			return {
-				editor: ClassicEditor,
-				// This editor will be read–only when created.
-				editorDisabled: true
-			};
-		}
-	};
+// Editor loading and configuration is skipped for brevity.
+
+const disabled = ref( true );
 </script>
 ```
 
@@ -292,7 +238,18 @@ The reason for introducing this option is performance issues in large documents.
 This option allows the integrator to disable the default behavior and only call the {@link module:core/editor/editor~Editor#getData `editor.getData()`} method on demand, which prevents the slowdowns. You can read more in the [relevant issue](https://github.com/ckeditor/ckeditor5-vue/issues/246).
 
 ```html
-<ckeditor :editor="editor" :disableTwoWayDataBinding="true" />
+<template>
+	<ckeditor :editor="editor" :disableTwoWayDataBinding="disableTwoWayDataBinding" />
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { Ckeditor } from '@ckeditor/ckeditor5-vue';
+
+// Editor loading and configuration is skipped for brevity.
+
+const disableTwoWayDataBinding = ref( true );
+</script>
 ```
 
 ## Component events
@@ -349,35 +306,50 @@ Since accessing the editor toolbar is not possible until after the editor instan
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor :editor="editor" @ready="onReady" />
-	</div>
+    <ckeditor
+			v-if="editor"
+			v-model="data"
+			:editor="editor"
+			@ready="onReady"
+		/>
 </template>
 
-<script>
-	import { DecoupledEditor, Bold, Essentials, Italic, Paragraph, Undo } from 'ckeditor5';
-	import CKEditor from '@ckeditor/ckeditor5-vue';
-	
-	import 'ckeditor5/ckeditor5.css';
+<script setup>
+import { ref, computed } from 'vue';
+import { Ckeditor, useCKEditorCloud } from '@ckeditor/ckeditor5-vue';
 
-	export default {
-		name: 'app',
-		data() {
-			return {
-				editor: DecoupledEditor,
-				// ...
-			};
-		},
-		methods: {
-			onReady( editor )  {
-				// Insert the toolbar before the editable area.
-				editor.ui.getEditableElement().parentElement.insertBefore(
-					editor.ui.view.toolbar.element,
-					editor.ui.getEditableElement()
-				);
-			}
-		}
-	};
+const cloud = useCKEditorCloud( {
+    version: '{@var ckeditor5-version}'
+} );
+
+const data = ref( '<p>Hello world!</p>' );
+
+const editor = computed( () => {
+    if ( !cloud.data.value ) {
+        return null;
+    }
+
+    const {
+        DecoupledEditor,
+        Paragraph,
+        Essentials
+    } = cloud.data.value.CKEditor;
+
+    return class Editor extends DecoupledEditor {
+        static builtinPlugins = [
+            Essentials,
+            Paragraph
+        ];
+    };
+} );
+
+function onReady( editor ) {
+    // Insert the toolbar before the editable area.
+    editor.ui.getEditableElement().parentElement.insertBefore(
+        editor.ui.view.toolbar.element,
+        editor.ui.getEditableElement()
+    );
+}
 </script>
 ```
 
@@ -388,50 +360,6 @@ We provide a **ready-to-use integration** featuring collaborative editing in a V
 * [CKEditor&nbsp;5 with real-time collaboration features](https://github.com/ckeditor/ckeditor5-collaboration-samples/tree/master/real-time-collaboration-for-vue)
 
 It is not mandatory to build applications on top of the above sample, however, it should help you get started.
-
-### Localization
-
-CKEditor&nbsp;5 supports {@link getting-started/setup/ui-language multiple UI languages}, and so does the official Vue component. Follow the instructions below to translate CKEditor&nbsp;5 in your Vue application.
-
-Similarly to CSS style sheets, both packages have separate translations. Import them as shown in the example below. Then, pass them to the `translations` array inside the `editorConfig` prop in the component:
-
-```html
-<template>
-	<div id="app">
-		<ckeditor :editor="editor" v-model="editorData" :config="editorConfig" />
-	</div>
-</template>
-
-<script>
-import { ClassicEditor, Bold, Essentials, Italic, Paragraph } from 'ckeditor5';
-// More imports...
-
-import coreTranslations from 'ckeditor5/translations/es.js';
-import premiumFeaturesTranslations from 'ckeditor5-premium-features/translations/es.js';
-
-// Style sheets imports...
-
-export default {
-	name: 'app',
-	data() {
-		return {
-			editor: ClassicEditor,
-			editorData: '<p>Hola desde CKEditor 5 en Vue!</p>',
-			editorConfig: {
-				licenseKey: '<YOUR_LICENSE_KEY>', // Or 'GPL'.
-				toolbar: {
-					items: [ 'undo', 'redo', '|', 'bold', 'italic' ],
-				},
-				plugins: [ Bold, Essentials, Italic, Paragraph ],
-				translations: [ coreTranslations, premiumFeaturesTranslations ]
-			}
-		};
-	}
-};
-</script>
-```
-
-For more information, refer to the {@link getting-started/setup/ui-language Setting the UI language} guide.
 
 ## Contributing and reporting issues
 

--- a/docs/getting-started/integrations-cdn/vuejs-v3.md
+++ b/docs/getting-started/integrations-cdn/vuejs-v3.md
@@ -8,7 +8,7 @@ order: 50
 
 {@snippet installation/integrations/framework-integration}
 
-# Vue.js 3+ rich text editor component
+# Vue.js 3+ rich text editor component (CDN)
 
 <p>
 	<a href="https://www.npmjs.com/package/@ckeditor/ckeditor5-vue" target="_blank" rel="noopener">
@@ -16,142 +16,106 @@ order: 50
 	</a>
 </p>
 
-Vue.js is a versatile framework for building web user interfaces. CKEditor&nbsp;5 provides the official Vue component you can use in your application.
+CKEditor&nbsp;5 has an official Vue integration that you can use to add a rich text editor to your application. This guide will help you install it and configure to use the CDN distribution of the CKEditor&nbsp;5.
 
-<info-box hint>
-	Starting from version 5.0.0 of this package, you can use native type definitions provided by CKEditor&nbsp;5. Check the details about {@link getting-started/setup/typescript-support TypeScript support}.
-</info-box>
+This guide assumes that you already have a Vue project. If you do not have one, see the [Vue documentation](https://vuejs.org/guide/quick-start) to learn how to create it.
 
 ## Quick start
 
 {@snippet getting-started/use-builder}
 
-### Setting up the project
+### Installing and configuring the Vue integration
 
-This guide assumes that you already have a Vue project. If you do not have one, see the [Vue documentation](https://vuejs.org/guide/quick-start) to learn how to create it.
+Start by installing the Vue integration for CKEditor&nbsp;5 from npm:
 
-### Installation
-
-Start by installing the following packages:
-
-* `ckeditor5` &ndash; contains all open-source plugins and features for CKEditor&nbsp;5.
-
-	```bash
-	npm install ckeditor5
-	```
-
-* `ckeditor5-premium-features` &ndash; contains premium plugins and features for CKEditor&nbsp;5. Depending on your configuration and chosen plugins, you might not need it.
-
-	```bash
-	npm install ckeditor5-premium-features
-	```
-
-* `@ckeditor/ckeditor5-vue` &ndash; the [CKEditor&nbsp;5 WYSIWYG editor component for Vue](https://www.npmjs.com/package/@ckeditor/ckeditor5-vue).
-
-	```bash
-	npm install @ckeditor/ckeditor5-vue
-	```
-
-With these packages installed, you now need to choose whether to install the `<ckeditor>` component globally or locally and follow the appropriate instructions below.
-
-#### Installing the `<ckeditor>` component globally
-
-To register the `<ckeditor>` component globally, you must install the CKEditor&nbsp;5 plugin for Vue.
-
-If you are using a plain Vue project, you should find the file where the `createApp` function is called and register the `CkeditorPlugin` plugin with the [`use()` method](https://vuejs.org/api/application.html#app-use).
-
-```js
-import { createApp } from 'vue';
-import { CkeditorPlugin } from '@ckeditor/ckeditor5-vue';
-import App from './App.vue';
-
-createApp( App )
-	.use( CkeditorPlugin )
-	.mount( '#app' );
+```bash
+npm install @ckeditor/ckeditor5-vue
 ```
 
-If you are using Nuxt.js, you can follow the [Nuxt.js documentation](https://nuxt.com/docs/guide/directory-structure/plugins#vue-plugins) to get access to the `use()` method and register this plugin.
-
-Now you can use the `<ckeditor>` component in any of your Vue components. The following example shows a single file component with open source and premium plugins.
+Once the integration is installed, create a new Vue component called `Editor.vue`. It will use the `useCKEditorCloud` helper to load the editor code from CDN and the `<ckeditor>` component to run it. The following example shows a single file component with open source and premium CKEditor&nbsp;5 plugins.
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor
-			v-model="editorData"
-			:editor="editor"
-			:config="editorConfig"
-		/>
-	</div>
+	<ckeditor
+		v-if="editor"
+		v-model="data"
+		:editor="editor"
+		:config="config"
+	/>
 </template>
 
 <script>
-import { ClassicEditor, Bold, Essentials, Italic, Mention, Paragraph, Undo } from 'ckeditor5';
-import { SlashCommand } from 'ckeditor5-premium-features';
-
-import 'ckeditor5/ckeditor5.css';
-import 'ckeditor5-premium-features/ckeditor5-premium-features.css';
+import { Ckeditor, useCKEditorCloud } from '@ckeditor/ckeditor5-vue';
 
 export default {
-	name: 'app',
-	data() {
-		return {
-			editor: ClassicEditor,
-			editorData: '<p>Hello from CKEditor 5 in Vue!</p>',
-			editorConfig: {
-				licenseKey: '<YOUR_LICENSE_KEY>', // Or 'GPL'.
-				plugins: [ Bold, Essentials, Italic, Mention, Paragraph, SlashCommand, Undo ],
-				toolbar: [ 'undo', 'redo', '|', 'bold', 'italic' ],
-				// Other configuration options...
-			}
-		};
-	}
-};
-</script>
-```
-
-#### Using the `<ckeditor>` component locally
-
-If you do not want to enable the CKEditor&nbsp;5 component globally, you can import the `Ckeditor` component from the `@ckeditor/ckeditor5-vue` package directly into the Vue component where you want to use it, and add it to the `components` object.
-
-```html
-<template>
-	<div id="app">
-		<ckeditor
-			v-model="editorData"
-			:editor="editor"
-			:config="editorConfig"
-		/>
-	</div>
-</template>
-
-<script>
-import { ClassicEditor, Bold, Essentials, Italic, Mention, Paragraph, Undo } from 'ckeditor5';
-import { SlashCommand } from 'ckeditor5-premium-features';
-import { Ckeditor } from '@ckeditor/ckeditor5-vue';
-
-import 'ckeditor5/ckeditor5.css';
-import 'ckeditor5-premium-features/ckeditor5-premium-features.css';
-
-export default {
-	name: 'app',
+	name: 'Editor',
 	components: {
 		Ckeditor
 	},
 	data() {
 		return {
-			editor: ClassicEditor,
-			editorData: '<p>Hello from CKEditor 5 in Vue!</p>',
-			editorConfig: {
-				licenseKey: '<YOUR_LICENSE_KEY>', // Or 'GPL'.
-				plugins: [ Bold, Essentials, Italic, Mention, Paragraph, SlashCommand, Undo ],
-				toolbar: [ 'undo', 'redo', '|', 'bold', 'italic' ],
-				// Other configuration options...
+			cloud: useCKEditorCloud( {
+				version: '43.0.0',
+				premium: true
+			} ),
+			data: '<p>Hello world!</p>',
+			config: {
+				licenseKey: '<YOUR_LICENSE_KEY>', // Or "GPL"
+				toolbar: [ 'heading', '|', 'bold', 'italic' ]
 			}
-		};
+		}
+	},
+	computed: {
+		editor() {
+			if ( !this.cloud.data ) {
+				return null;
+			}
+
+			const {
+				ClassicEditor,
+				Paragraph,
+				Essentials,
+				Heading,
+				Bold,
+				Italic,
+				Mention
+			} = this.cloud.data.CKEditor;
+
+			const { SlashCommand } = this.cloud.data.CKEditorPremiumFeatures;
+
+			return class Editor extends ClassicEditor {
+				static builtinPlugins = [
+					Essentials,
+					Paragraph,
+					Heading,
+					Bold,
+					Italic,
+					Mention,
+					SlashCommand
+				];
+			};
+		}
 	}
-};
+}
 </script>
+```
+
+Now you can import and use the `Editor.vue` component anywhere in your application.
+
+```html
+<template>
+	<Editor />
+</template>
+```
+
+If you use Nuxt.js with server-side rendering enabled, remember to wrap the `<Editor>` component in the `<ClientOnly>` component to avoid issues with the editor calling browser-specific APIs on the server.
+
+```html
+<template>
+	<ClientOnly>
+		<Editor />
+	</ClientOnly>
+</template>
 ```
 
 ## Component directives

--- a/docs/getting-started/integrations-cdn/vuejs-v3.md
+++ b/docs/getting-started/integrations-cdn/vuejs-v3.md
@@ -20,11 +20,10 @@ CKEditor&nbsp;5 has an official Vue integration that you can use to add a rich t
 
 This guide assumes that you already have a Vue project. If you do not have one, see the [Vue documentation](https://vuejs.org/guide/quick-start) to learn how to create it.
 
-## Quick start
 
 {@snippet getting-started/use-builder}
 
-### Installing and configuring the Vue integration
+## Quick start
 
 Start by installing the Vue integration for CKEditor&nbsp;5 from npm:
 
@@ -32,7 +31,7 @@ Start by installing the Vue integration for CKEditor&nbsp;5 from npm:
 npm install @ckeditor/ckeditor5-vue
 ```
 
-Once the integration is installed, create a new Vue component called `Editor.vue`. It will use the `useCKEditorCloud` helper to load the editor code from CDN and the `<ckeditor>` component to run it. The following example shows a single file component with open source and premium CKEditor&nbsp;5 plugins.
+Once the integration is installed, create a new Vue component called `Editor.vue`. It will use the `useCKEditorCloud` helper to load the editor code from the CDN and the `<ckeditor>` component to run it, both of which come from the above package. The following example shows a single file component with open source and premium CKEditor&nbsp;5 plugins.
 
 ```html
 <template>

--- a/docs/getting-started/integrations-cdn/vuejs-v3.md
+++ b/docs/getting-started/integrations-cdn/vuejs-v3.md
@@ -61,7 +61,7 @@ export default {
 			data: '<p>Hello world!</p>',
 			config: {
 				licenseKey: '<YOUR_LICENSE_KEY>', // Or "GPL"
-				toolbar: [ 'heading', '|', 'bold', 'italic' ]
+				toolbar: [ 'undo', 'redo', '|', 'bold', 'italic' ]
 			}
 		}
 	},
@@ -75,7 +75,6 @@ export default {
 				ClassicEditor,
 				Paragraph,
 				Essentials,
-				Heading,
 				Bold,
 				Italic,
 				Mention
@@ -87,7 +86,6 @@ export default {
 				static builtinPlugins = [
 					Essentials,
 					Paragraph,
-					Heading,
 					Bold,
 					Italic,
 					Mention,
@@ -102,7 +100,7 @@ export default {
 
 In the above example, the `useCKEditorCloud` helper is used to load the editor code and plugins from CDN. The `premium` option is set to also load premium plugins. For more information about the `useCKEditorCloud` helper, see the {@link getting-started/setup/loading-cdn-resources Loading CDN resources} page.
 
-Now you can import and use the `Editor.vue` component anywhere in your application.
+Now, you can import and use the `Editor.vue` component anywhere in your application.
 
 ```html
 <template>

--- a/docs/getting-started/integrations-cdn/vuejs-v3.md
+++ b/docs/getting-started/integrations-cdn/vuejs-v3.md
@@ -20,7 +20,6 @@ CKEditor&nbsp;5 has an official Vue integration that you can use to add a rich t
 
 This guide assumes that you already have a Vue project. If you do not have one, see the [Vue documentation](https://vuejs.org/guide/quick-start) to learn how to create it.
 
-
 {@snippet getting-started/use-builder}
 
 ## Quick start

--- a/docs/getting-started/integrations-cdn/vuejs-v3.md
+++ b/docs/getting-started/integrations-cdn/vuejs-v3.md
@@ -55,7 +55,7 @@ export default {
 	data() {
 		return {
 			cloud: useCKEditorCloud( {
-				version: '43.0.0',
+				version: '{@var ckeditor5-version}',
 				premium: true
 			} ),
 			data: '<p>Hello world!</p>',
@@ -99,6 +99,8 @@ export default {
 }
 </script>
 ```
+
+In the above example, the `useCKEditorCloud` helper is used to load the editor code and plugins from CDN. The `premium` option is set to also load premium plugins. For more information about the `useCKEditorCloud` helper, see the {@link getting-started/setup/loading-cdn-resources Loading CDN resources} page.
 
 Now you can import and use the `Editor.vue` component anywhere in your application.
 

--- a/docs/getting-started/integrations/react-default-npm.md
+++ b/docs/getting-started/integrations/react-default-npm.md
@@ -16,21 +16,13 @@ order: 10
 	</a>
 </p>
 
-React lets you build user interfaces out of individual pieces called components. CKEditor&nbsp;5 can be used as one of such components. This guide explains how to integrate CKEditor&nbsp;5 into your React application using npm.
+CKEditor&nbsp;5 has an official React integration that you can use to add a rich text editor to your application. This guide will help you install it and configure to use the npm distribution of the CKEditor&nbsp;5.
 
-<info-box hint>
-	Starting from version 6.0.0 of this package, you can use native type definitions provided by CKEditor&nbsp;5. Check the details about {@link getting-started/setup/typescript-support TypeScript support}.
-</info-box>
+This guide assumes that you already have a React project. If you do not have one, see the [React documentation](https://react.dev/learn/start-a-new-react-project) to learn how to create it.
 
 {@snippet getting-started/use-builder}
 
 ## Quick start
-
-### Setting up the project
-
-This guide assumes you have a React project. You can create a basic React project using [Vite](https://vitejs.dev/). Refer to the [React documentation](https://react.dev/learn/start-a-new-react-project) to learn how to set up a project in the framework.
-
-### Installing from npm
 
 First, install the CKEditor&nbsp;5 packages:
 

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -16,7 +16,7 @@ order: 50
 	</a>
 </p>
 
-CKEditor&nbsp;5 has an official Vue integration that you can use to add a rich text editor to your application. This guide will help you install it and configure to use the CDN distribution of the CKEditor&nbsp;5.
+CKEditor&nbsp;5 has an official Vue integration that you can use to add a rich text editor to your application. This guide will help you install it and configure to use the npm distribution of the CKEditor&nbsp;5.
 
 This guide assumes that you already have a Vue project. If you do not have one, see the [Vue documentation](https://vuejs.org/guide/quick-start) to learn how to create it.
 

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -52,36 +52,27 @@ With these packages installed, create a new Vue component called `Editor.vue`. I
 <template>
 	<ckeditor
 		v-model="data"
-		:editor="editor"
+		:editor="ClassicEditor"
 		:config="config"
 	/>
 </template>
 
-<script>
-import { ClassicEditor, Bold, Essentials, Italic, Mention, Paragraph, Undo } from 'ckeditor5';
+<script setup>
+import { ref, markRaw } from 'vue';
+import { ClassicEditor, Paragraph, Essentials, Bold, Italic, Mention } from 'ckeditor5';
 import { SlashCommand } from 'ckeditor5-premium-features';
 import { Ckeditor } from '@ckeditor/ckeditor5-vue';
 
 import 'ckeditor5/ckeditor5.css';
 import 'ckeditor5-premium-features/ckeditor5-premium-features.css';
 
-export default {
-	name: 'Editor',
-	components: {
-		Ckeditor
-	},
-	data() {
-		return {
-			editor: ClassicEditor,
-			data: '<p>Hello from CKEditor 5 in Vue!</p>',
-			config: {
-				licenseKey: '<YOUR_LICENSE_KEY>', // Or 'GPL'.
-				plugins: [ Bold, Essentials, Italic, Mention, Paragraph, SlashCommand, Undo ],
-				toolbar: [ 'undo', 'redo', '|', 'bold', 'italic' ]
-			}
-		};
-	}
-};
+const data = ref( '<p>Hello world!</p>' );
+
+const config = markRaw( {
+	licenseKey: '<YOUR_LICENSE_KEY>', // Or "GPL"
+	plugins: [ Essentials, Paragraph, Bold, Italic, Mention, SlashCommand ],
+	toolbar: [ 'undo', 'redo', '|', 'bold', 'italic' ]
+} );
 </script>
 ```
 
@@ -111,24 +102,12 @@ This directive specifies the editor to be used by the component. It must directl
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor :editor="editor" />
-	</div>
+	<ckeditor :editor="ClassicEditor" />
 </template>
 
-<script>
-	import { ClassicEditor } from 'ckeditor5';
-
-	export default {
-		name: 'app',
-		data() {
-			return {
-				editor: ClassicEditor,
-
-				// ...
-			};
-		}
-	};
+<script setup>
+import { ClassicEditor } from 'ckeditor5';
+import { Ckeditor } from '@ckeditor/ckeditor5-vue';
 </script>
 ```
 
@@ -150,36 +129,27 @@ A [standard directive](https://v3.vuejs.org/guide/component-basics.html#using-v-
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor :editor="editor" v-model="editorData" />
-		<button @click="emptyEditor">Empty the editor</button>
+	<ckeditor :editor="ClassicEditor" v-model="data" />
+	<button @click="emptyEditor">Empty the editor</button>
 
-		<h2>Editor data</h2>
-		<code>{{ editorData }}</code>
-	</div>
+	<h2>Editor data</h2>
+	<code>{{ data }}</code>
 </template>
 
-<script>
-	import { ClassicEditor } from 'ckeditor5';
+<script setup>
+import { ref } from 'vue';
+import { ClassicEditor } from 'ckeditor5';
+import { Ckeditor } from '@ckeditor/ckeditor5-vue';
 
-	export default {
-		name: 'app',
-		data() {
-			return {
-				editor: ClassicEditor,
-				editorData: '<p>Content of the editor.</p>'
-			};
-		},
-		methods: {
-			emptyEditor() {
-				this.editorData = '';
-			}
-		}
-	};
+const data = ref( '<p>Hello world!</p>' );
+
+function emptyEditor() {
+	data.value = '';
+}
 </script>
 ```
 
-In the above example, the `editorData` property will be updated automatically as the user types and the content changes. It can also be used to change (as in `emptyEditor()`) or set the initial content of the editor.
+In the above example, the `data` property will be updated automatically as the user types and the content changes. It can also be used to change (as in `emptyEditor()`) or set the initial content of the editor.
 
 If you only want to execute an action when the editor data changes, use the [`input`](#input) event.
 
@@ -189,23 +159,15 @@ Allows a one–way data binding that sets the content of the editor. Unlike [`v-
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor :editor="editor" :model-value="editorData" />
-	</div>
+	<ckeditor :editor="ClassicEditor" :model-value="data" />
 </template>
 
-<script>
-	import { ClassicEditor } from 'ckeditor5';
+<script setup>
+import { ref } from 'vue';
+import { ClassicEditor } from 'ckeditor5';
+import { Ckeditor } from '@ckeditor/ckeditor5-vue';
 
-	export default {
-		name: 'app',
-		data() {
-			return {
-				editor: ClassicEditor,
-				editorData: '<p>Content of the editor.</p>'
-			};
-		}
-	};
+const data = ref( '<p>Hello world!</p>' );
 </script>
 ```
 
@@ -213,29 +175,23 @@ To execute an action when the editor data changes, use the [`input`](#input) eve
 
 ### `config`
 
-Specifies the {@link module:core/editor/editorconfig~EditorConfig configuration} of the editor.
+Specifies the {@link module:core/editor/config~config configuration} of the editor.
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor :editor="editor" :config="editorConfig" />
-	</div>
+    <ckeditor :editor="ClassicEditor" :config="config" />
 </template>
 
-<script>
-	import { ClassicEditor } from 'ckeditor5';
+<script setup>
+import { markRaw } from 'vue';
+import { ClassicEditor, Essentials, Paragraph } from 'ckeditor5';
+import { Ckeditor } from '@ckeditor/ckeditor5-vue';
 
-	export default {
-		name: 'app',
-		data() {
-			return {
-				editor: ClassicEditor,
-				editorConfig: {
-					toolbar: [ 'bold', 'italic', '|', 'link' ]
-				}
-			};
-		}
-	};
+const config = markRaw( {
+    licenseKey: '<YOUR_LICENSE_KEY>', // Or "GPL"
+		plugins: [ Essentials, Paragraph ],
+    toolbar: [ 'undo', 'redo' ]
+} );
 </script>
 ```
 
@@ -247,24 +203,15 @@ It sets the initial read–only state of the editor and changes it during its li
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor :editor="editor" :disabled="editorDisabled" />
-	</div>
+	<ckeditor :editor="ClassicEditor" :disabled="disabled" />
 </template>
 
-<script>
-	import { ClassicEditor } from 'ckeditor5';
+<script setup>
+import { ref } from 'vue';
+import { ClassicEditor } from 'ckeditor5';
+import { Ckeditor } from '@ckeditor/ckeditor5-vue';
 
-	export default {
-		name: 'app',
-		data() {
-			return {
-				editor: ClassicEditor,
-				// This editor will be read–only when created.
-				editorDisabled: true
-			};
-		}
-	};
+const disabled = ref( true );
 </script>
 ```
 
@@ -334,35 +281,22 @@ Since accessing the editor toolbar is not possible until after the editor instan
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor :editor="editor" @ready="onReady" />
-	</div>
+	<ckeditor :editor="DecoupledEditor" @ready="onReady" />
 </template>
 
-<script>
-	import { DecoupledEditor, Bold, Essentials, Italic, Paragraph, Undo } from 'ckeditor5';
-	import CKEditor from '@ckeditor/ckeditor5-vue';
+<script setup>
+import { DecoupledEditor } from 'ckeditor5';
+import { Ckeditor } from '@ckeditor/ckeditor5-vue';
 
-	import 'ckeditor5/ckeditor5.css';
+import 'ckeditor5/ckeditor5.css';
 
-	export default {
-		name: 'app',
-		data() {
-			return {
-				editor: DecoupledEditor,
-				// ...
-			};
-		},
-		methods: {
-			onReady( editor )  {
-				// Insert the toolbar before the editable area.
-				editor.ui.getEditableElement().parentElement.insertBefore(
-					editor.ui.view.toolbar.element,
-					editor.ui.getEditableElement()
-				);
-			}
-		}
-	};
+function onReady( editor )  {
+	// Insert the toolbar before the editable area.
+	editor.ui.getEditableElement().parentElement.insertBefore(
+		editor.ui.view.toolbar.element,
+		editor.ui.getEditableElement()
+	);
+}
 </script>
 ```
 
@@ -379,35 +313,28 @@ It is not mandatory to build applications on top of the above sample, however, i
 
 CKEditor&nbsp;5 supports {@link getting-started/setup/ui-language multiple UI languages}, and so does the official Vue component. Follow the instructions below to translate CKEditor&nbsp;5 in your Vue application.
 
-Similarly to CSS style sheets, both packages have separate translations. Import them as shown in the example below. Then, pass them to the `translations` array inside the `editorConfig` prop in the component:
+Similarly to CSS style sheets, both packages have separate translations. Import them as shown in the example below. Then, pass them to the `translations` array inside the `config` prop in the component:
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor :editor="editor" v-model="editorData" :config="editorConfig" />
-	</div>
+	<ckeditor :editor="ClassicEditor" v-model="data" :config="config" />
 </template>
 
-<script>
-import { ClassicEditor, Bold, Essentials, Italic, Paragraph } from 'ckeditor5';
-// More imports...
+<script setup>
+import { ref, markRaw } from 'vue';
+import { ClassicEditor } from 'ckeditor5';
+import { Ckeditor } from '@ckeditor/ckeditor5-vue';
 
 import coreTranslations from 'ckeditor5/translations/es.js';
 import premiumFeaturesTranslations from 'ckeditor5-premium-features/translations/es.js';
 
-export default {
-	name: 'app',
-	data() {
-		return {
-			editor: ClassicEditor,
-			editorData: '<p>Hola desde CKEditor 5 en Vue!</p>',
-			editorConfig: {
-				// ... Other configuration options ...
-				translations: [ coreTranslations, premiumFeaturesTranslations ]
-			}
-		};
-	}
-};
+const data = ref( '<p>Hello world!</p>' );
+
+const config = markRaw( {
+	licenseKey: '<YOUR_LICENSE_KEY>', // Or "GPL"
+	translations: [ coreTranslations, premiumFeaturesTranslations ],
+	// Other configuration options
+} );
 </script>
 ```
 

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -16,15 +16,13 @@ order: 50
 	</a>
 </p>
 
-CKEditor&nbsp;5 has an official Vue integration that you can use to add rich text editor to your application. This guide will help you install it and configure to use the npm distribution of the CKEditor&nbsp;5.
+CKEditor&nbsp;5 has an official Vue integration that you can use to add a rich text editor to your application. This guide will help you install it and configure to use the CDN distribution of the CKEditor&nbsp;5.
 
 This guide assumes that you already have a Vue project. If you do not have one, see the [Vue documentation](https://vuejs.org/guide/quick-start) to learn how to create it.
 
 {@snippet getting-started/use-builder}
 
 ## Quick start
-
-### Installing from npm
 
 Start by installing the following packages:
 

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -16,19 +16,13 @@ order: 50
 	</a>
 </p>
 
-Vue.js is a versatile framework for building web user interfaces. CKEditor&nbsp;5 provides the official Vue component you can use in your application.
+CKEditor&nbsp;5 has an official Vue integration that you can use to add rich text editor to your application. This guide will help you install it and configure to use the npm distribution of the CKEditor&nbsp;5.
 
-<info-box hint>
-	Starting from version 5.0.0 of this package, you can use native type definitions provided by CKEditor&nbsp;5. Check the details about {@link getting-started/setup/typescript-support TypeScript support}.
-</info-box>
+This guide assumes that you already have a Vue project. If you do not have one, see the [Vue documentation](https://vuejs.org/guide/quick-start) to learn how to create it.
 
 ## Quick start
 
 {@snippet getting-started/use-builder}
-
-### Setting up the project
-
-This guide assumes that you already have a Vue project. If you do not have one, see the [Vue documentation](https://vuejs.org/guide/quick-start) to learn how to create it.
 
 ### Installing from npm
 
@@ -52,76 +46,15 @@ npm install ckeditor5-premium-features
 npm install @ckeditor/ckeditor5-vue
 ```
 
-With these packages installed, you now need to choose whether to install the `<ckeditor>` component globally or locally and follow the appropriate instructions below.
-
-#### Registering the `<ckeditor>` component globally
-
-To register the `<ckeditor>` component globally, you must install the CKEditor&nbsp;5 plugin for Vue.
-
-If you are using a plain Vue project, you should find the file where the `createApp` function is called and register the `CkeditorPlugin` plugin with the [`use()` method](https://vuejs.org/api/application.html#app-use).
-
-```js
-import { createApp } from 'vue';
-import { CkeditorPlugin } from '@ckeditor/ckeditor5-vue';
-import App from './App.vue';
-
-createApp( App )
-	.use( CkeditorPlugin )
-	.mount( '#app' );
-```
-
-If you are using Nuxt.js, you can follow the [Nuxt.js documentation](https://nuxt.com/docs/guide/directory-structure/plugins#vue-plugins) to get access to the `use()` method and register this plugin.
-
-Now you can use the `<ckeditor>` component in any of your Vue components. The following example shows a single file component with open source and premium plugins.
+With these packages installed, create a new Vue component called `Editor.vue`. It will use the `<ckeditor>` component to run the editor. The following example shows a single file component with open source and premium CKEditor&nbsp;5 plugins.
 
 ```html
 <template>
-	<div id="app">
-		<ckeditor
-			v-model="editorData"
-			:editor="editor"
-			:config="editorConfig"
-		/>
-	</div>
-</template>
-
-<script>
-import { ClassicEditor, Bold, Essentials, Italic, Mention, Paragraph, Undo } from 'ckeditor5';
-import { SlashCommand } from 'ckeditor5-premium-features';
-
-import 'ckeditor5/ckeditor5.css';
-import 'ckeditor5-premium-features/ckeditor5-premium-features.css';
-
-export default {
-	name: 'app',
-	data() {
-		return {
-			editor: ClassicEditor,
-			editorData: '<p>Hello from CKEditor 5 in Vue!</p>',
-			editorConfig: {
-				licenseKey: '<YOUR_LICENSE_KEY>', // Or 'GPL'.
-				plugins: [ Bold, Essentials, Italic, Mention, Paragraph, SlashCommand, Undo ],
-				toolbar: [ 'undo', 'redo', '|', 'bold', 'italic' ]
-			}
-		};
-	}
-};
-</script>
-```
-
-#### Using the `<ckeditor>` component locally
-
-If you do not want to enable the CKEditor&nbsp;5 component globally, you can import the `Ckeditor` component from the `@ckeditor/ckeditor5-vue` package directly into the Vue component where you want to use it, and add it to the `components` object.
-
-```html
-<template>
-	<div id="app">
-		<ckeditor
-			v-model="editorData"
-			:editor="editor"
-			:config="editorConfig"
-		/>
-	</div>
+	<ckeditor
+		v-model="data"
+		:editor="editor"
+		:config="config"
+	/>
 </template>
 
 <script>
@@ -133,15 +66,15 @@ import 'ckeditor5/ckeditor5.css';
 import 'ckeditor5-premium-features/ckeditor5-premium-features.css';
 
 export default {
-	name: 'app',
+	name: 'Editor',
 	components: {
 		Ckeditor
 	},
 	data() {
 		return {
 			editor: ClassicEditor,
-			editorData: '<p>Hello from CKEditor 5 in Vue!</p>',
-			editorConfig: {
+			data: '<p>Hello from CKEditor 5 in Vue!</p>',
+			config: {
 				licenseKey: '<YOUR_LICENSE_KEY>', // Or 'GPL'.
 				plugins: [ Bold, Essentials, Italic, Mention, Paragraph, SlashCommand, Undo ],
 				toolbar: [ 'undo', 'redo', '|', 'bold', 'italic' ]
@@ -150,6 +83,24 @@ export default {
 	}
 };
 </script>
+```
+
+Now you can import and use the `Editor.vue` component anywhere in your application.
+
+```html
+<template>
+	<Editor />
+</template>
+```
+
+If you use Nuxt.js with server-side rendering enabled, remember to wrap the `<Editor>` component in the `<ClientOnly>` component to avoid issues with the editor calling browser-specific APIs on the server.
+
+```html
+<template>
+	<ClientOnly>
+		<Editor />
+	</ClientOnly>
+</template>
 ```
 
 ## Component directives

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -46,7 +46,7 @@ npm install ckeditor5-premium-features
 npm install @ckeditor/ckeditor5-vue
 ```
 
-With these packages installed, create a new Vue component called `Editor.vue`. It will use the `<ckeditor>` component to run the editor. The following example shows a single file component with open source and premium CKEditor&nbsp;5 plugins.
+With these packages installed, create a new Vue component called `Editor.vue`. It will use the `<ckeditor>` component to run the editor. The following example shows a single file component with open-source and premium CKEditor&nbsp;5 plugins.
 
 ```html
 <template>
@@ -85,7 +85,7 @@ export default {
 </script>
 ```
 
-Now you can import and use the `Editor.vue` component anywhere in your application.
+Now, you can import and use the `Editor.vue` component anywhere in your application.
 
 ```html
 <template>

--- a/docs/getting-started/setup/loading-cdn-resources.md
+++ b/docs/getting-started/setup/loading-cdn-resources.md
@@ -1,0 +1,120 @@
+---
+category: setup
+meta-title: Loading CDN resources | CKEditor 5 documentation
+meta-description: Learn how to load CKEditor 5 resources from CDN.
+order: 130
+modified_at: 2024-09-10
+---
+
+# Loading CDN resources
+
+Loading CKEditor&nbsp;5 and its plugins from a CDN requires adding the necessary script and stylesheet tags to the `<head>` of your page. In some environments, this can be done manually without much hassle by following the {@link getting-started/integrations-cdn/quick-start CDN for Vanilla JavaScript} guide.
+
+However, in other environments this may require more work. This is especially true if you want to load some resources conditionally or dynamically, or need to wait for the resources to be loaded before using them.
+
+For these reason, we provide `useCKEditorCloud` and `loadCKEditorCloud` helper functions to make this process easier. These functions will handle adding the necessary script and stylesheet tags to your page, ensure that the resources are only loaded once, and provide access to the data exported by them. This way you can load CKEditor&nbsp;5 and its plugins from a CDN without worrying about the technical details.
+
+If you use our {@link getting-started/integrations-cdn/react-default-cdn React} and {@link getting-started/integrations-cdn/vuejs-v3 Vue.js 3+} integrations, see the {@link getting-started/setup/loading-cdn-resources#using-the-useckeditorcloud-function Using the `useCKEditorCloud` function} section. Otherwise, see the {@link getting-started/setup/loading-cdn-resources#using-the-loadckeditorcloud-function Using the `loadCKEditorCloud` function} section.
+
+## Using the `useCKEditorCloud` function
+
+Our {@link getting-started/integrations-cdn/react-default-cdn React} and {@link getting-started/integrations-cdn/vuejs-v3 Vue.js 3+} integrations export a helper functions named `useCKEditorCloud` to help you load CDN resources. These helpers are only small wrappers around the `loadCKEditorCloud` function, but are designed to better integrate with the specific framework, its lifecycle, and reactivity mechanisms.
+
+Here is an example of how you can use `useCKEditorCloud`:
+
+```js
+const cloud = useCKEditorCloud( {
+	version: '{@var ckeditor5-version}',
+	premium: true
+} );
+```
+
+This will add the necessary script and stylesheet tags to the page's `<head>` and update the internal state to reflect the loading status. Depending on the framework, the `useCKEditorCloud` function may return different values. Please refer to the documentation of the specific integration for more details.
+
+Regardless of the used framework, the `useCKEditorCloud` functions always accept the same options, which are described in the {@link getting-started/setup/loading-cdn-resources#the-loadckeditorcloud-function-options The `loadCKEditorCloud` function options} section.
+
+## Using the `loadCKEditorCloud` function
+
+To use `loadCKEditorCloud` helper, you need to first install the `@ckeditor/ckeditor5-integrations-common` package:
+
+```bash
+npm install @ckeditor/ckeditor5-integrations-common
+```
+
+Then you can use the `loadCKEditorCloud` function like this:
+
+```js
+import { loadCKEditorCloud } from '@ckeditor/ckeditor5-integrations-common';
+
+const { CKEditor, CKEditorPremiumFeatures } = await loadCKEditorCloud( {
+	version: '{@var ckeditor5-version}',
+	premium: true
+} );
+```
+
+The `loadCKEditorCloud` function returns a promise that resolves to an object in which each key contains data of the corresponding CDN resources. The exact object shape depends on the options passed to the function.
+
+The options accepted by the `loadCKEditorCloud` function are described in the {@link getting-started/setup/loading-cdn-resources#the-loadckeditorcloud-function-options The `loadCKEditorCloud` function options} section.
+
+## The `loadCKEditorCloud` function options
+
+The `loadCKEditorCloud` function (and `useCKEditorCloud` functions which are small wrappers around it) accepts an object with the following properties:
+
+* `version` (required) &ndash; The version of CKEditor&nbsp;5 and premium features (if `premium` option is set to `true`) to load.
+* `languages` (optional) &ndash; An array of language codes to load translations for.
+* `premium` (optional) &ndash; A boolean value that indicates whether to load premium plugins. <sup>[1]</sup>
+* `ckbox` (optional) &ndash; Configuration for loading CKBox integration. <sup>[1]</sup>
+* `plugins` (optional) &ndash; Configuration for loading additional plugins. The object should have the global plugin name as keys and the plugin configuration as values. <sup>[1]</sup>
+
+<info-box info>
+[1] Using this option will result in additional network requests for JavaScript and CSS assets. Make sure to only use these options when you need them.
+</info-box>
+
+<style>
+	sup {
+		top: -0.5em;
+		position: relative;
+		font-size: 75%;
+		line-height: 0;
+		vertical-align: baseline;
+	}
+</style>
+
+Here's an example showing all the available options:
+
+```javascript
+{
+	version: '{@var ckeditor5-version}',
+	languages: [ 'en', 'de' ],
+	premium: true,
+	ckbox: {
+		version: '2.5.1',
+		theme: 'lark' // Optional, default 'lark'.
+	},
+	plugins: {
+		ThirdPartyPlugin: [
+			'https://cdn.example.com/plugin.umd.js',
+			'https://cdn.example.com/plugin.css'
+		],
+		AnotherPlugin: () => import( './path/to/plugin.umd.js' ),
+		YetAnotherPlugin: {
+			scripts: [ 'https://cdn.example.com/plugin.umd.js' ],
+			stylesheets: [ 'https://cdn.example.com/plugin.css' ],
+			
+			// Optional, if it's not passed then the name of the plugin will be used.
+			checkPluginLoaded: () => window.PLUGIN_NAME
+		}
+	}
+}
+```
+
+Note that unless the `checkPluginLoaded` callback is used, the keys in the `plugins` object must match the names of the global object the plugins use. As shown in the example above, we used the `checkPluginLoaded` to be able to access the plugin using the `YetAnotherPlugin` key, while the plugin itself assigns to the `window.PLUGIN_NAME` property.
+
+With this configuration, the object returned by this function will have the following properties:
+
+* `CKEditor` &ndash; The base CKEditor&nbsp;5 library.
+* `CKEditorPremiumFeatures` &ndash; Premium features for CKEditor&nbsp;5. This option is only available when `premium` is set to `true`.
+* `CKBox` &ndash; The CKBox integration. This option is only available when the `ckbox` option is provided.
+* `ThirdPartyPlugin` &ndash; The custom plugin registered in the `plugins` option.
+* `AnotherPlugin` &ndash; The custom plugin registered in the `plugins` option.
+* `YetAnotherPlugin` &ndash; The custom plugin registered in the `plugins` option.

--- a/docs/getting-started/setup/loading-cdn-resources.md
+++ b/docs/getting-started/setup/loading-cdn-resources.md
@@ -8,17 +8,17 @@ modified_at: 2024-09-10
 
 # Loading CDN resources
 
-Loading CKEditor&nbsp;5 and its plugins from a CDN requires adding the necessary script and stylesheet tags to the `<head>` of your page. In some environments, this can be done manually without much hassle by following the {@link getting-started/integrations-cdn/quick-start CDN for Vanilla JavaScript} guide.
+Loading CKEditor&nbsp;5 and its plugins from a CDN requires adding the necessary script and style sheet tags to the `<head>` of your page. In some environments, this can be easily done manually by following the {@link getting-started/integrations-cdn/quick-start CDN for Vanilla JavaScript} guide.
 
-However, in other environments this may require more work. This is especially true if you want to load some resources conditionally or dynamically, or need to wait for the resources to be loaded before using them.
+However, other environments may require more work. This is especially true if you want to load some resources conditionally or dynamically, or need to wait for the resources to be loaded before using them.
 
-For these reason, we provide `useCKEditorCloud` and `loadCKEditorCloud` helper functions to make this process easier. These functions will handle adding the necessary script and stylesheet tags to your page, ensure that the resources are only loaded once, and provide access to the data exported by them. This way you can load CKEditor&nbsp;5 and its plugins from a CDN without worrying about the technical details.
+For this reason, we provide the `useCKEditorCloud` and `loadCKEditorCloud` helper functions to make this process easier. These functions will handle adding the necessary script and style sheet tags to your page, ensure that the resources are only loaded once, and provide access to the data exported by them. This way you can load CKEditor&nbsp;5 and its plugins from a CDN without worrying about the technical details.
 
-If you use our {@link getting-started/integrations-cdn/react-default-cdn React} and {@link getting-started/integrations-cdn/vuejs-v3 Vue.js 3+} integrations, see the {@link getting-started/setup/loading-cdn-resources#using-the-useckeditorcloud-function Using the `useCKEditorCloud` function} section. Otherwise, see the {@link getting-started/setup/loading-cdn-resources#using-the-loadckeditorcloud-function Using the `loadCKEditorCloud` function} section.
+If you use our {@link getting-started/integrations-cdn/react-default-cdn React} or {@link getting-started/integrations-cdn/vuejs-v3 Vue.js 3+} integrations, see the {@link getting-started/setup/loading-cdn-resources#using-the-useckeditorcloud-function Using the `useCKEditorCloud` function} section. Otherwise, see the {@link getting-started/setup/loading-cdn-resources#using-the-loadckeditorcloud-function Using the `loadCKEditorCloud` function} section.
 
 ## Using the `useCKEditorCloud` function
 
-Our {@link getting-started/integrations-cdn/react-default-cdn React} and {@link getting-started/integrations-cdn/vuejs-v3 Vue.js 3+} integrations export a helper functions named `useCKEditorCloud` to help you load CDN resources. These helpers are only small wrappers around the `loadCKEditorCloud` function, but are designed to better integrate with the specific framework, its lifecycle, and reactivity mechanisms.
+Our {@link getting-started/integrations-cdn/react-default-cdn React} and {@link getting-started/integrations-cdn/vuejs-v3 Vue.js 3+} integrations export a helper function named `useCKEditorCloud` to help you load CDN resources. These helpers are only small wrappers around the `loadCKEditorCloud` function, but are designed to better integrate with the specific framework, its lifecycle, and reactivity mechanisms.
 
 Here is an example of how you can use `useCKEditorCloud`:
 
@@ -29,13 +29,13 @@ const cloud = useCKEditorCloud( {
 } );
 ```
 
-This will add the necessary script and stylesheet tags to the page's `<head>` and update the internal state to reflect the loading status. Depending on the framework, the `useCKEditorCloud` function may return different values. Please refer to the documentation of the specific integration for more details.
+This will add the necessary script and style sheet tags to the page's `<head>` and update the internal state to reflect the loading status. Depending on the framework, the `useCKEditorCloud` function may return different values. Please refer to the documentation of the specific integration for more details.
 
-Regardless of the used framework, the `useCKEditorCloud` functions always accept the same options, which are described in the {@link getting-started/setup/loading-cdn-resources#the-loadckeditorcloud-function-options The `loadCKEditorCloud` function options} section.
+Regardless of the framework used, the `useCKEditorCloud` functions always accept the same options, which are described in {@link getting-started/setup/loading-cdn-resources#the-loadckeditorcloud-function-options The `loadCKEditorCloud` function options} section.
 
 ## Using the `loadCKEditorCloud` function
 
-To use `loadCKEditorCloud` helper, you need to first install the `@ckeditor/ckeditor5-integrations-common` package:
+To use the `loadCKEditorCloud` helper, you need to install the `@ckeditor/ckeditor5-integrations-common` package first:
 
 ```bash
 npm install @ckeditor/ckeditor5-integrations-common
@@ -54,7 +54,7 @@ const { CKEditor, CKEditorPremiumFeatures } = await loadCKEditorCloud( {
 
 The `loadCKEditorCloud` function returns a promise that resolves to an object in which each key contains data of the corresponding CDN resources. The exact object shape depends on the options passed to the function.
 
-The options accepted by the `loadCKEditorCloud` function are described in the {@link getting-started/setup/loading-cdn-resources#the-loadckeditorcloud-function-options The `loadCKEditorCloud` function options} section.
+The options accepted by the `loadCKEditorCloud` function are described in {@link getting-started/setup/loading-cdn-resources#the-loadckeditorcloud-function-options The `loadCKEditorCloud` function options} section.
 
 ## The `loadCKEditorCloud` function options
 
@@ -67,7 +67,7 @@ The `loadCKEditorCloud` function (and `useCKEditorCloud` functions which are sma
 * `plugins` (optional) &ndash; Configuration for loading additional plugins. The object should have the global plugin name as keys and the plugin configuration as values. <sup>[1]</sup>
 
 <info-box info>
-[1] Using this option will result in additional network requests for JavaScript and CSS assets. Make sure to only use these options when you need them.
+[1] Using this option will result in additional network requests for JavaScript and CSS assets. Make sure to only use this option when you need it.
 </info-box>
 
 <style>
@@ -80,7 +80,7 @@ The `loadCKEditorCloud` function (and `useCKEditorCloud` functions which are sma
 	}
 </style>
 
-Here's an example showing all the available options:
+Here is an example showing all the available options:
 
 ```javascript
 {
@@ -108,7 +108,7 @@ Here's an example showing all the available options:
 }
 ```
 
-Note that unless the `checkPluginLoaded` callback is used, the keys in the `plugins` object must match the names of the global object the plugins use. As shown in the example above, we used the `checkPluginLoaded` to be able to access the plugin using the `YetAnotherPlugin` key, while the plugin itself assigns to the `window.PLUGIN_NAME` property.
+Note that unless the `checkPluginLoaded` callback is used, the keys in the `plugins` object must match the names of the global object used by the plugins. As shown in the example above, we used the `checkPluginLoaded` to be able to access the plugin using the `YetAnotherPlugin` key, while the plugin itself assigns to the `window.PLUGIN_NAME` property.
 
 With this configuration, the object returned by this function will have the following properties:
 

--- a/docs/getting-started/setup/loading-cdn-resources.md
+++ b/docs/getting-started/setup/loading-cdn-resources.md
@@ -61,7 +61,7 @@ The options accepted by the `loadCKEditorCloud` function are described in {@link
 The `loadCKEditorCloud` function (and `useCKEditorCloud` functions which are small wrappers around it) accepts an object with the following properties:
 
 * `version` (required) &ndash; The version of CKEditor&nbsp;5 and premium features (if `premium` option is set to `true`) to load.
-* `languages` (optional) &ndash; An array of language codes to load translations for.
+* `translations` (optional) &ndash; An array of translations codes to load translations for.
 * `premium` (optional) &ndash; A boolean value that indicates whether to load premium plugins. <sup>[1]</sup>
 * `ckbox` (optional) &ndash; Configuration for loading CKBox integration. <sup>[1]</sup>
 * `plugins` (optional) &ndash; Configuration for loading additional plugins. The object should have the global plugin name as keys and the plugin configuration as values. <sup>[1]</sup>
@@ -85,7 +85,7 @@ Here is an example showing all the available options:
 ```javascript
 {
 	version: '{@var ckeditor5-version}',
-	languages: [ 'en', 'de' ],
+	translations: [ 'es', 'de' ],
 	premium: true,
 	ckbox: {
 		version: '2.5.1',
@@ -100,7 +100,7 @@ Here is an example showing all the available options:
 		YetAnotherPlugin: {
 			scripts: [ 'https://cdn.example.com/plugin.umd.js' ],
 			stylesheets: [ 'https://cdn.example.com/plugin.css' ],
-			
+
 			// Optional, if it's not passed then the name of the plugin will be used.
 			checkPluginLoaded: () => window.PLUGIN_NAME
 		}

--- a/docs/getting-started/setup/loading-cdn-resources.md
+++ b/docs/getting-started/setup/loading-cdn-resources.md
@@ -65,6 +65,7 @@ The `loadCKEditorCloud` function (and `useCKEditorCloud` functions which are sma
 * `premium` (optional) &ndash; A boolean value that indicates whether to load premium plugins. <sup>[1]</sup>
 * `ckbox` (optional) &ndash; Configuration for loading CKBox integration. <sup>[1]</sup>
 * `plugins` (optional) &ndash; Configuration for loading additional plugins. The object should have the global plugin name as keys and the plugin configuration as values. <sup>[1]</sup>
+* `injectedHtmlElementsAttributes` (optional) &ndash; An object with attributes that will be added to the `<script>` and `<link>` tags that are injected into the page. This can be used to add attributes like `integrity` or `crossorigin` to the tags. By default, it is set to `{ crossorigin: 'anonymous' }`.
 
 <info-box info>
 [1] Using this option will result in additional network requests for JavaScript and CSS assets. Make sure to only use this option when you need it.

--- a/docs/getting-started/setup/loading-cdn-resources.md
+++ b/docs/getting-started/setup/loading-cdn-resources.md
@@ -10,7 +10,7 @@ modified_at: 2024-09-10
 
 Loading CKEditor&nbsp;5 and its plugins from a CDN requires adding the necessary script and style sheet tags to the `<head>` of your page. In some environments, this can be easily done manually by following the {@link getting-started/integrations-cdn/quick-start CDN for Vanilla JavaScript} guide.
 
-However, other environments may require more work. This is especially true if you want to load some resources conditionally or dynamically, or need to wait for the resources to be loaded before using them.
+However, other environments may require more work. It is especially true if you want to load some resources conditionally or dynamically or need to wait for the resources to be loaded before using them.
 
 For this reason, we provide the `useCKEditorCloud` and `loadCKEditorCloud` helper functions to make this process easier. These functions will handle adding the necessary script and style sheet tags to your page, ensure that the resources are only loaded once, and provide access to the data exported by them. This way you can load CKEditor&nbsp;5 and its plugins from a CDN without worrying about the technical details.
 
@@ -18,7 +18,7 @@ If you use our {@link getting-started/integrations-cdn/react-default-cdn React} 
 
 ## Using the `useCKEditorCloud` function
 
-Our {@link getting-started/integrations-cdn/react-default-cdn React} and {@link getting-started/integrations-cdn/vuejs-v3 Vue.js 3+} integrations export a helper function named `useCKEditorCloud` to help you load CDN resources. These helpers are only small wrappers around the `loadCKEditorCloud` function, but are designed to better integrate with the specific framework, its lifecycle, and reactivity mechanisms.
+Our {@link getting-started/integrations-cdn/react-default-cdn React} and {@link getting-started/integrations-cdn/vuejs-v3 Vue.js 3+} integrations export a helper function named `useCKEditorCloud` to help you load CDN resources. These helpers are only small wrappers around the `loadCKEditorCloud` function but are designed to better integrate with the specific framework, its lifecycle, and reactivity mechanisms.
 
 Here is an example of how you can use `useCKEditorCloud`:
 

--- a/docs/getting-started/setup/loading-cdn-resources.md
+++ b/docs/getting-started/setup/loading-cdn-resources.md
@@ -61,7 +61,7 @@ The options accepted by the `loadCKEditorCloud` function are described in {@link
 The `loadCKEditorCloud` function (and `useCKEditorCloud` functions which are small wrappers around it) accepts an object with the following properties:
 
 * `version` (required) &ndash; The version of CKEditor&nbsp;5 and premium features (if `premium` option is set to `true`) to load.
-* `translations` (optional) &ndash; An array of translations codes to load translations for.
+* `translations` (optional) &ndash; An array of language codes to load translations for.
 * `premium` (optional) &ndash; A boolean value that indicates whether to load premium plugins. <sup>[1]</sup>
 * `ckbox` (optional) &ndash; Configuration for loading CKBox integration. <sup>[1]</sup>
 * `plugins` (optional) &ndash; Configuration for loading additional plugins. The object should have the global plugin name as keys and the plugin configuration as values. <sup>[1]</sup>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Update Vue docs for use with npm and CDN.
Docs: Add `Loading CDN resources` page.

---

### Additional information

Internally, we need to decide if we want to promote importing the `<Ckeditor>` component locally or registering it globally and if we should move examples to the Composition API.
