### PR TITLE
Allow to disable new line padding on paste for specific elements

### DIFF
--- a/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
+++ b/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
@@ -87,13 +87,24 @@ function newLinePadding(
 	}
 
 	// Do not add padding around the elements that won't be rendered.
-	if (
-		element.is( 'element' ) && element.getCustomProperty( 'dataPipeline:transparentRendering' ) ||
-		previous.is( 'element' ) && previous.getCustomProperty( 'dataPipeline:transparentRendering' )
-	) {
+	if ( isNewLinePaddingDisabled( element ) || isNewLinePaddingDisabled( previous ) ) {
 		return '';
 	}
 
 	// Add empty lines between container elements.
 	return '\n\n';
+}
+
+/**
+ * Returns `true` if the new line padding should be disabled for the given element.
+ */
+function isNewLinePaddingDisabled( element: ViewElement ): boolean {
+	if ( !element.is( 'element' ) ) {
+		return false;
+	}
+
+	return !!(
+		element.getCustomProperty( 'dataPipeline:transparentRendering' ) ||
+		element.getCustomProperty( 'dataPipeline:noNewLinePaddingOnPaste' )
+	);
 }

--- a/packages/ckeditor5-clipboard/tests/utils/viewtoplaintext.js
+++ b/packages/ckeditor5-clipboard/tests/utils/viewtoplaintext.js
@@ -34,17 +34,19 @@ describe( 'viewToPlainText()', () => {
 		);
 	} );
 
-	it( 'should not put empty line before or after the element with `dataPipeline:transparentRendering` property', () => {
-		const viewString = 'Abc <container:h1>Header</container:h1> xyz';
-		const expectedText = 'Abc Header xyz';
+	for ( const property of [ 'transparentRendering', 'noNewLinePaddingOnPaste' ] ) {
+		it( `should not put empty line before or after the element with \`dataPipeline:${ property }\` property`, () => {
+			const viewString = 'Abc <container:h1>Header</container:h1> xyz';
+			const expectedText = 'Abc Header xyz';
 
-		const view = parseView( viewString );
-		view.getChild( 1 )._setCustomProperty( 'dataPipeline:transparentRendering', true );
+			const view = parseView( viewString );
+			view.getChild( 1 )._setCustomProperty( `dataPipeline:${ property }`, true );
 
-		const text = viewToPlainText( view );
+			const text = viewToPlainText( view );
 
-		expect( text ).to.equal( expectedText );
-	} );
+			expect( text ).to.equal( expectedText );
+		} );
+	}
 
 	it( 'should turn a soft break into a single empty line', () => {
 		testViewToPlainText(

--- a/packages/ckeditor5-widget/tests/manual/inline-widget.js
+++ b/packages/ckeditor5-widget/tests/manual/inline-widget.js
@@ -78,6 +78,8 @@ class InlineWidget extends Plugin {
 			const widgetElement = writer.createContainerElement( 'placeholder' );
 			const viewText = writer.createText( '{' + modelItem.getAttribute( 'type' ) + '}' );
 
+			// It prevents adding new line padding after the widget element during data downcast in the clipboard pipeline.
+			writer.setCustomProperty( 'dataPipeline:noNewLinePaddingOnPaste', true, widgetElement );
 			writer.insert( writer.createPositionAt( widgetElement, 0 ), viewText );
 
 			return widgetElement;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (clipboard): Add `dataPipeline:noNewLinePaddingOnPaste` attribute that allows disabling prepending new lines around inline widget during clipboard paste pipeline. Closes https://github.com/ckeditor/ckeditor5/issues/17052

---

### Additional information


