### PR TITLE
Fix MarkerOperation x MoveOperation OT for undo cases

### DIFF
--- a/packages/ckeditor5-engine/src/model/operation/transform.ts
+++ b/packages/ckeditor5-engine/src/model/operation/transform.ts
@@ -1414,7 +1414,7 @@ setTransformation( MergeOperation, MoveOperation, ( a, b, context ) => {
 	//
 	const removedRange = Range._createFromPositionAndShift( b.sourcePosition, b.howMany );
 
-	if ( b.type == 'remove' && !context.bWasUndone && !context.forceWeakRemove ) {
+	if ( b.type == 'remove' && !context.bWasUndone ) {
 		if ( a.deletionPosition.hasSameParentAs( b.sourcePosition ) && removedRange.containsPosition( a.sourcePosition ) ) {
 			return [ new NoOperation( 0 ) ];
 		}

--- a/packages/ckeditor5-engine/src/model/operation/transform.ts
+++ b/packages/ckeditor5-engine/src/model/operation/transform.ts
@@ -755,6 +755,7 @@ function padWithNoOps( operations: Array<Operation>, howMany: number ) {
  * after the original marker operation.
  *
  * See also `MarkerOperation` x `MoveOperation` transformation.
+ * See also https://github.com/ckeditor/ckeditor5/pull/17071.
  *
  * @param operations
  */
@@ -1232,6 +1233,7 @@ setTransformation( MarkerOperation, MoveOperation, ( a, b ) => {
 		// We will call these additional marker operations "partial marker operations" and we will mark them with negative base version.
 		//
 		// See also `handlePartialMarkerOperations()`.
+		// See also https://github.com/ckeditor/ckeditor5/pull/17071.
 		//
 		for ( let i = 1; i < ranges.length; i++ ) {
 			const op = a.clone();

--- a/packages/ckeditor5-engine/src/model/operation/transform.ts
+++ b/packages/ckeditor5-engine/src/model/operation/transform.ts
@@ -1969,14 +1969,17 @@ setTransformation( MoveOperation, MergeOperation, ( a, b, context ) => {
 				let gyMoveSource = b.graveyardPosition.clone();
 				let splitNodesMoveSource = b.targetPosition._getTransformedByMergeOperation( b );
 
-				if ( a.howMany > 1 ) {
-					results.push( new MoveOperation( a.sourcePosition, a.howMany - 1, a.targetPosition, 0 ) );
+				// `a.targetPosition` points to graveyard, so it was probably affected by `b` (which moved merged element to the graveyard).
+				const aTarget = a.targetPosition.getTransformedByOperation( b );
 
-					gyMoveSource = gyMoveSource._getTransformedByMove( a.sourcePosition, a.targetPosition, a.howMany - 1 );
-					splitNodesMoveSource = splitNodesMoveSource._getTransformedByMove( a.sourcePosition, a.targetPosition, a.howMany - 1 );
+				if ( a.howMany > 1 ) {
+					results.push( new MoveOperation( a.sourcePosition, a.howMany - 1, aTarget, 0 ) );
+
+					gyMoveSource = gyMoveSource._getTransformedByMove( a.sourcePosition, aTarget, a.howMany - 1 );
+					splitNodesMoveSource = splitNodesMoveSource._getTransformedByMove( a.sourcePosition, aTarget, a.howMany - 1 );
 				}
 
-				const gyMoveTarget = b.deletionPosition._getCombined( a.sourcePosition, a.targetPosition );
+				const gyMoveTarget = b.deletionPosition._getCombined( a.sourcePosition, aTarget );
 				const gyMove = new MoveOperation( gyMoveSource, 1, gyMoveTarget, 0 );
 
 				const splitNodesMoveTargetPath = gyMove.getMovedRangeStart().path.slice();

--- a/packages/ckeditor5-engine/src/model/operation/transform.ts
+++ b/packages/ckeditor5-engine/src/model/operation/transform.ts
@@ -759,7 +759,7 @@ function padWithNoOps( operations: Array<Operation>, howMany: number ) {
  * @param operations
  */
 function handlePartialMarkerOperations( operations: Array<Operation> ) {
-	const markerOps: Map<string, { op: MarkerOperation, ranges: Array<Range> }> = new Map();
+	const markerOps: Map<string, { op: MarkerOperation; ranges: Array<Range> }> = new Map();
 
 	for ( let i = 0; i < operations.length; i++ ) {
 		const op = operations[ i ];

--- a/packages/ckeditor5-engine/src/model/operation/transform.ts
+++ b/packages/ckeditor5-engine/src/model/operation/transform.ts
@@ -756,8 +756,6 @@ function padWithNoOps( operations: Array<Operation>, howMany: number ) {
  *
  * See also `MarkerOperation` x `MoveOperation` transformation.
  * See also https://github.com/ckeditor/ckeditor5/pull/17071.
- *
- * @param operations
  */
 function handlePartialMarkerOperations( operations: Array<Operation> ) {
 	const markerOps: Map<string, { op: MarkerOperation; ranges: Array<Range> }> = new Map();

--- a/packages/ckeditor5-engine/src/model/range.ts
+++ b/packages/ckeditor5-engine/src/model/range.ts
@@ -966,7 +966,7 @@ export default class Range extends TypeCheckable implements Iterable<TreeWalkerV
 		// Other ranges will be stuck to that range, if possible.
 		const ref = ranges[ 0 ];
 
-		// 2. Sort all the ranges so it's easier to process them.
+		// 2. Sort all the ranges, so it's easier to process them.
 		ranges.sort( ( a, b ) => {
 			return a.start.isAfter( b.start ) ? 1 : -1;
 		} );
@@ -975,21 +975,18 @@ export default class Range extends TypeCheckable implements Iterable<TreeWalkerV
 		const refIndex = ranges.indexOf( ref );
 
 		// 4. At this moment we don't need the original range.
-		// We are going to modify the result and we need to return a new instance of Range.
+		// We are going to modify the result, and we need to return a new instance of Range.
 		// We have to create a copy of the reference range.
 		const result = new this( ref.start, ref.end );
 
 		// 5. Ranges should be checked and glued starting from the range that is closest to the reference range.
 		// Since ranges are sorted, start with the range with index that is closest to reference range index.
-		if ( refIndex > 0 ) {
-			// eslint-disable-next-line no-constant-condition
-			for ( let i = refIndex - 1; true; i++ ) {
-				if ( ranges[ i ].end.isEqual( result.start ) ) {
-					( result as any ).start = Position._createAt( ranges[ i ].start );
-				} else {
-					// If ranges are not starting/ending at the same position there is no point in looking further.
-					break;
-				}
+		for ( let i = refIndex - 1; i >= 0; i-- ) {
+			if ( ranges[ i ].end.isEqual( result.start ) ) {
+				( result as any ).start = Position._createAt( ranges[ i ].start );
+			} else {
+				// If ranges are not starting/ending at the same position there is no point in looking further.
+				break;
 			}
 		}
 

--- a/packages/ckeditor5-engine/tests/model/operation/transform/undo.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/undo.js
@@ -840,7 +840,8 @@ describe( 'transform', () => {
 			kate._processExecute( 'insertText', { text: 'X' } );
 
 			syncClients();
-			expectClients( '<paragraph>Abc</paragraph><paragraph>X</paragraph><paragraph>Xyz</paragraph><paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
+			expectClients( '<paragraph>Abc</paragraph><paragraph>X</paragraph><paragraph>Xyz</paragraph>' +
+				'<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
 
 			john.setSelection( [ 0, 0 ], [ 3, 3 ] );
 			john._processExecute( 'delete' );

--- a/packages/ckeditor5-engine/tests/model/operation/transform/undo.js
+++ b/packages/ckeditor5-engine/tests/model/operation/transform/undo.js
@@ -10,818 +10,862 @@ import Element from '../../../../src/model/element.js';
 import Text from '../../../../src/model/text.js';
 
 describe( 'transform', () => {
-	let john;
+	describe( 'undo', () => {
+		let john;
 
-	beforeEach( () => {
-		return Client.get( 'john' ).then( client => ( john = client ) );
-	} );
+		beforeEach( () => {
+			return Client.get( 'john' ).then( client => ( john = client ) );
+		} );
 
-	afterEach( () => {
-		clearBuffer();
+		afterEach( () => {
+			clearBuffer();
 
-		return john.destroy();
-	} );
+			return john.destroy();
+		} );
 
-	it( 'split, remove', () => {
-		john.setData( '<paragraph>Foo[]Bar</paragraph>' );
+		it( 'split, remove', () => {
+			john.setData( '<paragraph>Foo[]Bar</paragraph>' );
 
-		john.split();
-		john.setSelection( [ 1 ], [ 2 ] );
-		john.remove();
-		john.undo();
-		john.undo();
-
-		expectClients( '<paragraph>FooBar</paragraph>' );
-	} );
-
-	it( 'move, merge', () => {
-		john.setData( '[<paragraph>Foo</paragraph>]<paragraph>Bar</paragraph>' );
-
-		john.move( [ 2 ] );
-		john.setSelection( [ 1 ] );
-		john.merge();
-		john.undo();
-		john.undo();
-
-		expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
-	} );
-
-	it.skip( 'move multiple, merge', () => {
-		john.setData( '[<paragraph>Foo</paragraph><paragraph>Bar</paragraph>]<paragraph>Xyz</paragraph>' );
-
-		john.move( [ 3 ] );
-
-		expectClients( '<paragraph>Xyz</paragraph><paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
-
-		john.setSelection( [ 1 ] );
-		john.merge();
-
-		expectClients( '<paragraph>XyzFoo</paragraph><paragraph>Bar</paragraph>' );
-
-		john.undo();
-
-		expectClients( '<paragraph>Xyz</paragraph><paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
-
-		john.undo();
-
-		// Wrong move is done.
-		expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph><paragraph>Xyz</paragraph>' );
-	} );
-
-	it( 'move inside unwrapped content', () => {
-		john.setData( '<blockQuote>[<paragraph>Foo</paragraph>]<paragraph>Bar</paragraph></blockQuote>' );
-
-		john.move( [ 0, 2 ] );
-		john.setSelection( [ 0, 0 ] );
-		john.unwrap();
-		john.undo();
-		john.undo();
-
-		expectClients(
-			'<blockQuote>' +
-				'<paragraph>Foo</paragraph>' +
-				'<paragraph>Bar</paragraph>' +
-			'</blockQuote>'
-		);
-	} );
-
-	it( 'remove node, merge', () => {
-		john.setData( '<paragraph>Foo</paragraph><paragraph>[Bar]</paragraph>' );
-
-		john.remove();
-		john.setSelection( [ 1 ] );
-		john.merge();
-		john.undo();
-		john.undo();
-
-		expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
-	} );
-
-	it( 'merge, merge #1', () => {
-		john.setData(
-			'<blockQuote>' +
-				'<paragraph>Foo</paragraph>' +
-				'<paragraph>Bar</paragraph>' +
-			'</blockQuote>' +
-			'[]' +
-			'<blockQuote>' +
-				'<paragraph>Xyz</paragraph>' +
-			'</blockQuote>'
-		);
-
-		john.merge();
-		john.setSelection( [ 0, 2 ] );
-		john.merge();
-
-		expectClients(
-			'<blockQuote>' +
-				'<paragraph>Foo</paragraph>' +
-				'<paragraph>BarXyz</paragraph>' +
-			'</blockQuote>'
-		);
-
-		john.undo();
-		john.undo();
-
-		expectClients(
-			'<blockQuote>' +
-				'<paragraph>Foo</paragraph>' +
-				'<paragraph>Bar</paragraph>' +
-			'</blockQuote>' +
-			'<blockQuote>' +
-				'<paragraph>Xyz</paragraph>' +
-			'</blockQuote>'
-		);
-	} );
-
-	it( 'merge, merge #2', () => {
-		john.setData(
-			'<blockQuote>' +
-				'<paragraph>Foo</paragraph>' +
-			'</blockQuote>' +
-			'[]' +
-			'<blockQuote>' +
-				'<paragraph>Bar</paragraph>' +
-				'<paragraph>Xyz</paragraph>' +
-			'</blockQuote>'
-		);
-
-		john.merge();
-		john.setSelection( [ 0, 1 ] );
-		john.merge();
-
-		expectClients(
-			'<blockQuote>' +
-				'<paragraph>FooBar</paragraph>' +
-				'<paragraph>Xyz</paragraph>' +
-			'</blockQuote>'
-		);
-
-		john.undo();
-		john.undo();
-
-		expectClients(
-			'<blockQuote>' +
-				'<paragraph>Foo</paragraph>' +
-			'</blockQuote>' +
-			'<blockQuote>' +
-				'<paragraph>Bar</paragraph>' +
-				'<paragraph>Xyz</paragraph>' +
-			'</blockQuote>'
-		);
-	} );
-
-	it( 'merge, unwrap', () => {
-		john.setData( '<paragraph></paragraph>[]<paragraph>Foo</paragraph>' );
-
-		john.merge();
-		john.setSelection( [ 0, 0 ] );
-		john.unwrap();
-
-		john.undo();
-		john.undo();
-
-		expectClients( '<paragraph></paragraph><paragraph>Foo</paragraph>' );
-	} );
-
-	it( 'remove node at the split position #1', () => {
-		john.setData( '<paragraph>Ab</paragraph>[]<paragraph>Xy</paragraph>' );
-
-		john.merge();
-		john.setSelection( [ 0, 1 ], [ 0, 2 ] );
-		john.remove();
-
-		john.undo();
-		john.undo();
-
-		expectClients( '<paragraph>Ab</paragraph><paragraph>Xy</paragraph>' );
-	} );
-
-	it( 'remove node at the split position #2', () => {
-		john.setData( '<paragraph>Ab</paragraph>[]<paragraph>Xy</paragraph>' );
-
-		john.merge();
-		john.setSelection( [ 0, 2 ], [ 0, 3 ] );
-		john.remove();
-
-		john.undo();
-		john.undo();
-
-		expectClients( '<paragraph>Ab</paragraph><paragraph>Xy</paragraph>' );
-	} );
-
-	it( 'undoing split after the element created by split has been removed', () => {
-		// This example is ported here from ckeditor5-undo to keep 100% CC in ckeditor5-engine alone.
-		john.setData( '<paragraph>Foo[]bar</paragraph>' );
-
-		john.split();
-		john.setSelection( [ 0, 3 ], [ 1, 3 ] );
-		john.delete();
-
-		expectClients( '<paragraph>Foo</paragraph>' );
-
-		john.undo();
-
-		expectClients( '<paragraph>Foo</paragraph><paragraph>bar</paragraph>' );
-
-		john.undo();
-
-		expectClients( '<paragraph>Foobar</paragraph>' );
-	} );
-
-	it( 'remove text from paragraph and merge it', () => {
-		john.setData( '<paragraph>Foo</paragraph><paragraph>[Bar]</paragraph>' );
-
-		john.remove();
-		john.setSelection( [ 1 ] );
-		john.merge();
-
-		expectClients( '<paragraph>Foo</paragraph>' );
-
-		john.undo();
-
-		expectClients( '<paragraph>Foo</paragraph><paragraph></paragraph>' );
-
-		john.undo();
-
-		expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
-	} );
-
-	it( 'delete split paragraphs', () => {
-		john.setData( '<paragraph>Foo</paragraph><paragraph>B[]ar</paragraph>' );
-
-		john.split();
-		john.setSelection( [ 2, 1 ] );
-		john.split();
-		john.setSelection( [ 1, 0 ], [ 3, 1 ] );
-		john.delete();
-		john.setSelection( [ 1 ] );
-		john.merge();
-
-		expectClients( '<paragraph>Foo</paragraph>' );
-
-		john.undo();
-		expectClients( '<paragraph>Foo</paragraph><paragraph></paragraph>' );
-
-		john.undo();
-		expectClients( '<paragraph>Foo</paragraph><paragraph>B</paragraph><paragraph>a</paragraph><paragraph>r</paragraph>' );
-
-		john.undo();
-		expectClients( '<paragraph>Foo</paragraph><paragraph>B</paragraph><paragraph>ar</paragraph>' );
-
-		john.undo();
-		expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
-
-		john.redo();
-		expectClients( '<paragraph>Foo</paragraph><paragraph>B</paragraph><paragraph>ar</paragraph>' );
-
-		john.redo();
-		expectClients( '<paragraph>Foo</paragraph><paragraph>B</paragraph><paragraph>a</paragraph><paragraph>r</paragraph>' );
-
-		john.redo();
-		expectClients( '<paragraph>Foo</paragraph><paragraph></paragraph>' );
-
-		john.redo();
-		expectClients( '<paragraph>Foo</paragraph>' );
-	} );
-
-	it( 'pasting on collapsed selection undo and redo', () => {
-		john.setData( '<paragraph>Foo[]Bar</paragraph>' );
-
-		// Below simulates pasting.
-		john.editor.model.change( () => {
 			john.split();
-			john.setSelection( [ 1 ] );
+			john.setSelection( [ 1 ], [ 2 ] );
+			john.remove();
+			john.undo();
+			john.undo();
 
-			john.insert( '<paragraph>1</paragraph>' );
+			expectClients( '<paragraph>FooBar</paragraph>' );
+		} );
+
+		it( 'move, merge', () => {
+			john.setData( '[<paragraph>Foo</paragraph>]<paragraph>Bar</paragraph>' );
+
+			john.move( [ 2 ] );
+			john.setSelection( [ 1 ] );
+			john.merge();
+			john.undo();
+			john.undo();
+
+			expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
+		} );
+
+		it.skip( 'move multiple, merge', () => {
+			john.setData( '[<paragraph>Foo</paragraph><paragraph>Bar</paragraph>]<paragraph>Xyz</paragraph>' );
+
+			john.move( [ 3 ] );
+
+			expectClients( '<paragraph>Xyz</paragraph><paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
+
 			john.setSelection( [ 1 ] );
 			john.merge();
 
+			expectClients( '<paragraph>XyzFoo</paragraph><paragraph>Bar</paragraph>' );
+
+			john.undo();
+
+			expectClients( '<paragraph>Xyz</paragraph><paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
+
+			john.undo();
+
+			// Wrong move is done.
+			expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph><paragraph>Xyz</paragraph>' );
+		} );
+
+		it( 'move inside unwrapped content', () => {
+			john.setData( '<blockQuote>[<paragraph>Foo</paragraph>]<paragraph>Bar</paragraph></blockQuote>' );
+
+			john.move( [ 0, 2 ] );
+			john.setSelection( [ 0, 0 ] );
+			john.unwrap();
+			john.undo();
+			john.undo();
+
+			expectClients(
+				'<blockQuote>' +
+					'<paragraph>Foo</paragraph>' +
+					'<paragraph>Bar</paragraph>' +
+				'</blockQuote>'
+			);
+		} );
+
+		it( 'remove node, merge', () => {
+			john.setData( '<paragraph>Foo</paragraph><paragraph>[Bar]</paragraph>' );
+
+			john.remove();
 			john.setSelection( [ 1 ] );
-			john.insert( '<paragraph>2</paragraph>' );
-			john.setSelection( [ 2 ] );
 			john.merge();
+			john.undo();
+			john.undo();
+
+			expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
 		} );
 
-		expectClients( '<paragraph>Foo1</paragraph><paragraph>2Bar</paragraph>' );
+		it( 'merge, merge #1', () => {
+			john.setData(
+				'<blockQuote>' +
+					'<paragraph>Foo</paragraph>' +
+					'<paragraph>Bar</paragraph>' +
+				'</blockQuote>' +
+				'[]' +
+				'<blockQuote>' +
+					'<paragraph>Xyz</paragraph>' +
+				'</blockQuote>'
+			);
 
-		john.undo();
-		expectClients( '<paragraph>FooBar</paragraph>' );
-
-		john.redo();
-		expectClients( '<paragraph>Foo1</paragraph><paragraph>2Bar</paragraph>' );
-
-		john.undo();
-		expectClients( '<paragraph>FooBar</paragraph>' );
-
-		john.redo();
-		expectClients( '<paragraph>Foo1</paragraph><paragraph>2Bar</paragraph>' );
-	} );
-
-	// Following case was throwing before a fix was applied:
-	//
-	// [] is selection and a marker. It is copied and pasted between XY. And then undone:
-	//
-	// <p>A[A</p><p>B]B</p><p>XY</p>
-	// <p>A[A</p><p>B]B</p><p>X[A</p><p>B]Y</p>
-	// <p>A[A</p><p>B]B</p><p>XY</p>
-	//
-	it( 'paste with markers, undo, redo', () => {
-		john.setData( '<paragraph>AA</paragraph><paragraph>BB</paragraph><paragraph>X[]Y</paragraph>' );
-
-		john.editor.model.change( writer => {
-			// Simulate copy. Create a document fragment that includes expected copied fragment + marker.
-			// <paragraph><$marker />A</paragraph><paragraph>B<$marker /></paragraph>
-			const docFrag = writer.createDocumentFragment();
-			const pA = writer.createElement( 'paragraph' );
-			const pB = writer.createElement( 'paragraph' );
-
-			writer.insertText( 'A', pA, 0 );
-			writer.insertText( 'B', pB, 0 );
-			writer.insert( pA, docFrag, 0 );
-			writer.insert( pB, docFrag, 1 );
-
-			const marker = writer.createRange( writer.createPositionAt( pA, 0 ), writer.createPositionAt( pB, 1 ) );
-			docFrag.markers.set( 'm', marker );
-
-			// Insert the document fragment (simulates paste).
-			john.setSelection( [ 2, 1 ], [ 2, 1 ] );
-			john.insertContent( docFrag );
-		} );
-
-		expectClients(
-			'<paragraph>AA</paragraph>' +
-			'<paragraph>BB</paragraph>' +
-			'<paragraph>X<m:start></m:start>A</paragraph>' +
-			'<paragraph>B<m:end></m:end>Y</paragraph>'
-		);
-
-		john.undo();
-		expectClients( '<paragraph>AA</paragraph><paragraph>BB</paragraph><paragraph>XY</paragraph>' );
-
-		john.redo();
-		expectClients(
-			'<paragraph>AA</paragraph>' +
-			'<paragraph>BB</paragraph>' +
-			'<paragraph>X<m:start></m:start>A</paragraph>' +
-			'<paragraph>B<m:end></m:end>Y</paragraph>'
-		);
-
-		john.undo();
-		expectClients( '<paragraph>AA</paragraph><paragraph>BB</paragraph><paragraph>XY</paragraph>' );
-	} );
-
-	it( 'selection attribute setting: split, bold, merge, undo, undo, undo', () => {
-		// This test is ported from undo to keep 100% CC in engine.
-		john.setData( '<paragraph>Foo[]</paragraph><paragraph>Bar</paragraph>' );
-
-		john.split();
-		john.setSelection( [ 1, 0 ] );
-		john._processExecute( 'bold' );
-		john._processExecute( 'deleteForward' );
-
-		expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
-
-		john.undo();
-		expectClients( '<paragraph>Foo</paragraph><paragraph selection:bold="true"></paragraph><paragraph>Bar</paragraph>' );
-
-		john.undo();
-		expectClients( '<paragraph>Foo</paragraph><paragraph></paragraph><paragraph>Bar</paragraph>' );
-
-		john.undo();
-		expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
-	} );
-
-	// https://github.com/ckeditor/ckeditor5/issues/1288
-	it( 'remove two groups of blocks then undo, undo', () => {
-		john.setData(
-			'<paragraph>X</paragraph><paragraph>A</paragraph><paragraph>B[</paragraph><paragraph>C</paragraph><paragraph>D]</paragraph>'
-		);
-
-		john.delete();
-		john.setSelection( [ 0, 1 ], [ 2, 1 ] );
-		john.delete();
-
-		expectClients( '<paragraph>X</paragraph>' );
-
-		john.undo();
-
-		expectClients( '<paragraph>X</paragraph><paragraph>A</paragraph><paragraph>B</paragraph>' );
-
-		john.undo();
-
-		expectClients(
-			'<paragraph>X</paragraph><paragraph>A</paragraph><paragraph>B</paragraph><paragraph>C</paragraph><paragraph>D</paragraph>'
-		);
-	} );
-
-	// https://github.com/ckeditor/ckeditor5/issues/1287 TC1
-	it( 'pasting on non-collapsed selection undo and redo', () => {
-		john.setData( '<paragraph>Fo[o</paragraph><paragraph>B]ar</paragraph>' );
-
-		// Below simulates pasting.
-		john.editor.model.change( () => {
-			john.editor.model.deleteContent( john.document.selection );
-
+			john.merge();
 			john.setSelection( [ 0, 2 ] );
+			john.merge();
+
+			expectClients(
+				'<blockQuote>' +
+					'<paragraph>Foo</paragraph>' +
+					'<paragraph>BarXyz</paragraph>' +
+				'</blockQuote>'
+			);
+
+			john.undo();
+			john.undo();
+
+			expectClients(
+				'<blockQuote>' +
+					'<paragraph>Foo</paragraph>' +
+					'<paragraph>Bar</paragraph>' +
+				'</blockQuote>' +
+				'<blockQuote>' +
+					'<paragraph>Xyz</paragraph>' +
+				'</blockQuote>'
+			);
+		} );
+
+		it( 'merge, merge #2', () => {
+			john.setData(
+				'<blockQuote>' +
+					'<paragraph>Foo</paragraph>' +
+				'</blockQuote>' +
+				'[]' +
+				'<blockQuote>' +
+					'<paragraph>Bar</paragraph>' +
+					'<paragraph>Xyz</paragraph>' +
+				'</blockQuote>'
+			);
+
+			john.merge();
+			john.setSelection( [ 0, 1 ] );
+			john.merge();
+
+			expectClients(
+				'<blockQuote>' +
+					'<paragraph>FooBar</paragraph>' +
+					'<paragraph>Xyz</paragraph>' +
+				'</blockQuote>'
+			);
+
+			john.undo();
+			john.undo();
+
+			expectClients(
+				'<blockQuote>' +
+					'<paragraph>Foo</paragraph>' +
+				'</blockQuote>' +
+				'<blockQuote>' +
+					'<paragraph>Bar</paragraph>' +
+					'<paragraph>Xyz</paragraph>' +
+				'</blockQuote>'
+			);
+		} );
+
+		it( 'merge, unwrap', () => {
+			john.setData( '<paragraph></paragraph>[]<paragraph>Foo</paragraph>' );
+
+			john.merge();
+			john.setSelection( [ 0, 0 ] );
+			john.unwrap();
+
+			john.undo();
+			john.undo();
+
+			expectClients( '<paragraph></paragraph><paragraph>Foo</paragraph>' );
+		} );
+
+		it( 'remove node at the split position #1', () => {
+			john.setData( '<paragraph>Ab</paragraph>[]<paragraph>Xy</paragraph>' );
+
+			john.merge();
+			john.setSelection( [ 0, 1 ], [ 0, 2 ] );
+			john.remove();
+
+			john.undo();
+			john.undo();
+
+			expectClients( '<paragraph>Ab</paragraph><paragraph>Xy</paragraph>' );
+		} );
+
+		it( 'remove node at the split position #2', () => {
+			john.setData( '<paragraph>Ab</paragraph>[]<paragraph>Xy</paragraph>' );
+
+			john.merge();
+			john.setSelection( [ 0, 2 ], [ 0, 3 ] );
+			john.remove();
+
+			john.undo();
+			john.undo();
+
+			expectClients( '<paragraph>Ab</paragraph><paragraph>Xy</paragraph>' );
+		} );
+
+		it( 'undoing split after the element created by split has been removed', () => {
+			// This example is ported here from ckeditor5-undo to keep 100% CC in ckeditor5-engine alone.
+			john.setData( '<paragraph>Foo[]bar</paragraph>' );
+
 			john.split();
+			john.setSelection( [ 0, 3 ], [ 1, 3 ] );
+			john.delete();
 
-			john.setSelection( [ 1 ] );
-			john.insert( '<paragraph>1</paragraph>' );
+			expectClients( '<paragraph>Foo</paragraph>' );
 
-			john.setSelection( [ 1 ] );
-			john.merge();
+			john.undo();
 
-			john.setSelection( [ 1 ] );
-			john.insert( '<paragraph>2</paragraph>' );
+			expectClients( '<paragraph>Foo</paragraph><paragraph>bar</paragraph>' );
 
-			john.setSelection( [ 2 ] );
-			john.merge();
+			john.undo();
+
+			expectClients( '<paragraph>Foobar</paragraph>' );
 		} );
 
-		expectClients( '<paragraph>Fo1</paragraph><paragraph>2ar</paragraph>' );
+		it( 'remove text from paragraph and merge it', () => {
+			john.setData( '<paragraph>Foo</paragraph><paragraph>[Bar]</paragraph>' );
 
-		john.undo();
-		expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
+			john.remove();
+			john.setSelection( [ 1 ] );
+			john.merge();
 
-		john.redo();
-		expectClients( '<paragraph>Fo1</paragraph><paragraph>2ar</paragraph>' );
+			expectClients( '<paragraph>Foo</paragraph>' );
 
-		john.undo();
-		expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
-	} );
+			john.undo();
 
-	it( 'collapsed marker at the beginning of merged element then undo', () => {
-		john.setData( '<paragraph>Foo</paragraph><paragraph>[]Bar</paragraph>' );
+			expectClients( '<paragraph>Foo</paragraph><paragraph></paragraph>' );
 
-		john.setMarker( 'm1' );
-		john.setSelection( [ 1 ] );
-		john.merge();
+			john.undo();
 
-		expectClients( '<paragraph>Foo<m1:start></m1:start>Bar</paragraph>' );
+			expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
+		} );
 
-		john.undo();
+		it( 'delete split paragraphs, then merge, undo, redo', () => {
+			john.setData( '<paragraph>Foo</paragraph><paragraph>B[]ar</paragraph>' );
 
-		expectClients( '<paragraph>Foo</paragraph><paragraph><m1:start></m1:start>Bar</paragraph>' );
-	} );
+			john.split();
+			john.setSelection( [ 2, 1 ] );
+			john.split();
+			john.setSelection( [ 1, 0 ], [ 3, 1 ] );
+			john.delete();
+			john.setSelection( [ 1 ] );
+			john.merge();
 
-	it( 'collapsed marker at the end of merge-target element then undo', () => {
-		john.setData( '<paragraph>Foo[]</paragraph><paragraph>Bar</paragraph>' );
+			expectClients( '<paragraph>Foo</paragraph>' );
 
-		john.setMarker( 'm1' );
-		john.setSelection( [ 1 ] );
-		john.merge();
+			john.undo();
+			expectClients( '<paragraph>Foo</paragraph><paragraph></paragraph>' );
 
-		expectClients( '<paragraph>Foo<m1:start></m1:start>Bar</paragraph>' );
+			john.undo();
+			expectClients( '<paragraph>Foo</paragraph><paragraph>B</paragraph><paragraph>a</paragraph><paragraph>r</paragraph>' );
 
-		john.undo();
+			john.undo();
+			expectClients( '<paragraph>Foo</paragraph><paragraph>B</paragraph><paragraph>ar</paragraph>' );
 
-		expectClients( '<paragraph>Foo<m1:start></m1:start></paragraph><paragraph>Bar</paragraph>' );
-	} );
+			john.undo();
+			expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
 
-	it( 'empty marker between merged elements then undo', () => {
-		john.setData( '<paragraph>Foo[</paragraph><paragraph>]Bar</paragraph>' );
+			john.redo();
+			expectClients( '<paragraph>Foo</paragraph><paragraph>B</paragraph><paragraph>ar</paragraph>' );
 
-		john.setMarker( 'm1' );
-		john.setSelection( [ 1 ] );
-		john.merge();
+			john.redo();
+			expectClients( '<paragraph>Foo</paragraph><paragraph>B</paragraph><paragraph>a</paragraph><paragraph>r</paragraph>' );
 
-		expectClients( '<paragraph>Foo<m1:start></m1:start>Bar</paragraph>' );
+			john.redo();
+			expectClients( '<paragraph>Foo</paragraph><paragraph></paragraph>' );
 
-		john.undo();
+			john.redo();
+			expectClients( '<paragraph>Foo</paragraph>' );
+		} );
 
-		expectClients( '<paragraph>Foo<m1:start></m1:start></paragraph><paragraph><m1:end></m1:end>Bar</paragraph>' );
-	} );
+		it( 'pasting on collapsed selection undo and redo', () => {
+			john.setData( '<paragraph>Foo[]Bar</paragraph>' );
 
-	it( 'left side of marker moved then undo', () => {
-		john.setData( '<paragraph>Foo[bar]</paragraph><paragraph></paragraph>' );
+			// Below simulates pasting.
+			john.editor.model.change( () => {
+				john.split();
+				john.setSelection( [ 1 ] );
 
-		john.setMarker( 'm1' );
-		john.setSelection( [ 0, 2 ], [ 0, 4 ] );
-		john.move( [ 1, 0 ] );
+				john.insert( '<paragraph>1</paragraph>' );
+				john.setSelection( [ 1 ] );
+				john.merge();
 
-		expectClients( '<paragraph>Fo<m1:start></m1:start>ar<m1:end></m1:end></paragraph><paragraph>ob</paragraph>' );
+				john.setSelection( [ 1 ] );
+				john.insert( '<paragraph>2</paragraph>' );
+				john.setSelection( [ 2 ] );
+				john.merge();
+			} );
 
-		john.undo();
+			expectClients( '<paragraph>Foo1</paragraph><paragraph>2Bar</paragraph>' );
 
-		expectClients( '<paragraph>Foo<m1:start></m1:start>bar<m1:end></m1:end></paragraph><paragraph></paragraph>' );
-	} );
+			john.undo();
+			expectClients( '<paragraph>FooBar</paragraph>' );
 
-	it( 'right side of marker moved then undo', () => {
-		john.setData( '<paragraph>[Foo]bar</paragraph><paragraph></paragraph>' );
+			john.redo();
+			expectClients( '<paragraph>Foo1</paragraph><paragraph>2Bar</paragraph>' );
 
-		john.setMarker( 'm1' );
-		john.setSelection( [ 0, 2 ], [ 0, 4 ] );
-		john.move( [ 1, 0 ] );
+			john.undo();
+			expectClients( '<paragraph>FooBar</paragraph>' );
 
-		expectClients( '<paragraph><m1:start></m1:start>Fo<m1:end></m1:end>ar</paragraph><paragraph>ob</paragraph>' );
+			john.redo();
+			expectClients( '<paragraph>Foo1</paragraph><paragraph>2Bar</paragraph>' );
+		} );
 
-		john.undo();
+		// Following case was throwing before a fix was applied:
+		//
+		// [] is selection and a marker. It is copied and pasted between XY. And then undone:
+		//
+		// <p>A[A</p><p>B]B</p><p>XY</p>
+		// <p>A[A</p><p>B]B</p><p>X[A</p><p>B]Y</p>
+		// <p>A[A</p><p>B]B</p><p>XY</p>
+		//
+		it( 'paste with markers, undo, redo', () => {
+			john.setData( '<paragraph>AA</paragraph><paragraph>BB</paragraph><paragraph>X[]Y</paragraph>' );
 
-		expectClients( '<paragraph><m1:start></m1:start>Foo<m1:end></m1:end>bar</paragraph><paragraph></paragraph>' );
-	} );
+			john.editor.model.change( writer => {
+				// Simulate copy. Create a document fragment that includes expected copied fragment + marker.
+				// <paragraph><$marker />A</paragraph><paragraph>B<$marker /></paragraph>
+				const docFrag = writer.createDocumentFragment();
+				const pA = writer.createElement( 'paragraph' );
+				const pB = writer.createElement( 'paragraph' );
 
-	it( 'marker on closing and opening tag - remove multiple elements #1', () => {
-		john.setData(
-			'<paragraph>Abc</paragraph>' +
-			'<paragraph>Foo[</paragraph>' +
-			'<paragraph>]Bar</paragraph>'
-		);
+				writer.insertText( 'A', pA, 0 );
+				writer.insertText( 'B', pB, 0 );
+				writer.insert( pA, docFrag, 0 );
+				writer.insert( pB, docFrag, 1 );
 
-		john.setMarker( 'm1' );
-		john.setSelection( [ 0, 1 ], [ 2, 2 ] );
-		john._processExecute( 'delete' );
+				const marker = writer.createRange( writer.createPositionAt( pA, 0 ), writer.createPositionAt( pB, 1 ) );
+				docFrag.markers.set( 'm', marker );
 
-		expectClients( '<paragraph>A<m1:start></m1:start>r</paragraph>' );
+				// Insert the document fragment (simulates paste).
+				john.setSelection( [ 2, 1 ], [ 2, 1 ] );
+				john.insertContent( docFrag );
+			} );
 
-		john.undo();
+			expectClients(
+				'<paragraph>AA</paragraph>' +
+				'<paragraph>BB</paragraph>' +
+				'<paragraph>X<m:start></m:start>A</paragraph>' +
+				'<paragraph>B<m:end></m:end>Y</paragraph>'
+			);
 
-		expectClients(
-			'<paragraph>Abc</paragraph>' +
-			'<paragraph>Foo<m1:start></m1:start></paragraph>' +
-			'<paragraph><m1:end></m1:end>Bar</paragraph>'
-		);
-	} );
+			john.undo();
+			expectClients( '<paragraph>AA</paragraph><paragraph>BB</paragraph><paragraph>XY</paragraph>' );
 
-	it( 'marker on closing and opening tag - remove multiple elements #2', () => {
-		john.setData(
-			'<paragraph>Foo[</paragraph>' +
-			'<paragraph>]Bar</paragraph>' +
-			'<paragraph>Xyz</paragraph>'
-		);
+			john.redo();
+			expectClients(
+				'<paragraph>AA</paragraph>' +
+				'<paragraph>BB</paragraph>' +
+				'<paragraph>X<m:start></m:start>A</paragraph>' +
+				'<paragraph>B<m:end></m:end>Y</paragraph>'
+			);
 
-		john.setMarker( 'm1' );
-		john.setSelection( [ 0, 1 ], [ 2, 2 ] );
-		john._processExecute( 'delete' );
+			john.undo();
+			expectClients( '<paragraph>AA</paragraph><paragraph>BB</paragraph><paragraph>XY</paragraph>' );
+		} );
 
-		expectClients( '<paragraph>F<m1:start></m1:start>z</paragraph>' );
+		it( 'selection attribute setting: split, bold, merge, undo, undo, undo', () => {
+			// This test is ported from undo to keep 100% CC in engine.
+			john.setData( '<paragraph>Foo[]</paragraph><paragraph>Bar</paragraph>' );
 
-		john.undo();
+			john.split();
+			john.setSelection( [ 1, 0 ] );
+			john._processExecute( 'bold' );
+			john._processExecute( 'deleteForward' );
 
-		expectClients(
-			'<paragraph>Foo<m1:start></m1:start></paragraph>' +
-			'<paragraph><m1:end></m1:end>Bar</paragraph>' +
-			'<paragraph>Xyz</paragraph>'
-		);
-	} );
+			expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
 
-	it( 'marker on closing and opening tag + some text - merge elements + remove text', () => {
-		john.setData(
-			'<paragraph>Foo[</paragraph>' +
-			'<paragraph>B]ar</paragraph>'
-		);
+			john.undo();
+			expectClients( '<paragraph>Foo</paragraph><paragraph selection:bold="true"></paragraph><paragraph>Bar</paragraph>' );
 
-		john.setMarker( 'm1' );
-		john.setSelection( [ 0, 1 ], [ 1, 2 ] );
-		john._processExecute( 'delete' );
+			john.undo();
+			expectClients( '<paragraph>Foo</paragraph><paragraph></paragraph><paragraph>Bar</paragraph>' );
 
-		expectClients( '<paragraph>F<m1:start></m1:start>r</paragraph>' );
+			john.undo();
+			expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
+		} );
 
-		john.undo();
+		// https://github.com/ckeditor/ckeditor5/issues/1288
+		it( 'remove two groups of blocks then undo, undo', () => {
+			john.setData(
+				'<paragraph>X</paragraph><paragraph>A</paragraph><paragraph>B[</paragraph><paragraph>C</paragraph><paragraph>D]</paragraph>'
+			);
 
-		expectClients(
-			'<paragraph>Foo<m1:start></m1:start></paragraph>' +
-			'<paragraph>B<m1:end></m1:end>ar</paragraph>'
-		);
-	} );
+			john.delete();
+			john.setSelection( [ 0, 1 ], [ 2, 1 ] );
+			john.delete();
 
-	// https://github.com/ckeditor/ckeditor5-engine/issues/1668
-	it( 'marker and moves with undo-redo-undo', () => {
-		john.setData( '<paragraph>X[]Y</paragraph>' );
+			expectClients( '<paragraph>X</paragraph>' );
 
-		const inputBufferBatch = john.editor.commands.get( 'input' ).buffer.batch;
+			john.undo();
 
-		john.editor.model.enqueueChange( inputBufferBatch, () => {
-			john.type( 'a' );
-			john.type( 'b' );
-			john.type( 'c' );
+			expectClients( '<paragraph>X</paragraph><paragraph>A</paragraph><paragraph>B</paragraph>' );
 
-			john.setSelection( [ 0, 1 ], [ 0, 4 ] );
+			john.undo();
+
+			expectClients(
+				'<paragraph>X</paragraph><paragraph>A</paragraph><paragraph>B</paragraph><paragraph>C</paragraph><paragraph>D</paragraph>'
+			);
+		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/1287 TC1
+		it( 'pasting on non-collapsed selection undo and redo', () => {
+			john.setData( '<paragraph>Fo[o</paragraph><paragraph>B]ar</paragraph>' );
+
+			// Below simulates pasting.
+			john.editor.model.change( () => {
+				john.editor.model.deleteContent( john.document.selection );
+
+				john.setSelection( [ 0, 2 ] );
+				john.split();
+
+				john.setSelection( [ 1 ] );
+				john.insert( '<paragraph>1</paragraph>' );
+
+				john.setSelection( [ 1 ] );
+				john.merge();
+
+				john.setSelection( [ 1 ] );
+				john.insert( '<paragraph>2</paragraph>' );
+
+				john.setSelection( [ 2 ] );
+				john.merge();
+			} );
+
+			expectClients( '<paragraph>Fo1</paragraph><paragraph>2ar</paragraph>' );
+
+			john.undo();
+			expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
+
+			john.redo();
+			expectClients( '<paragraph>Fo1</paragraph><paragraph>2ar</paragraph>' );
+
+			john.undo();
+			expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
+
+			john.redo();
+			expectClients( '<paragraph>Fo1</paragraph><paragraph>2ar</paragraph>' );
+		} );
+
+		it( 'collapsed marker at the beginning of merged element then undo', () => {
+			john.setData( '<paragraph>Foo</paragraph><paragraph>[]Bar</paragraph>' );
+
 			john.setMarker( 'm1' );
+			john.setSelection( [ 1 ] );
+			john.merge();
+
+			expectClients( '<paragraph>Foo<m1:start></m1:start>Bar</paragraph>' );
+
+			john.undo();
+
+			expectClients( '<paragraph>Foo</paragraph><paragraph><m1:start></m1:start>Bar</paragraph>' );
 		} );
 
-		expectClients( '<paragraph>X<m1:start></m1:start>abc<m1:end></m1:end>Y</paragraph>' );
+		it( 'collapsed marker at the end of merge-target element then undo', () => {
+			john.setData( '<paragraph>Foo[]</paragraph><paragraph>Bar</paragraph>' );
 
-		john.setSelection( [ 0, 0 ], [ 0, 5 ] );
-		john._processExecute( 'delete' );
+			john.setMarker( 'm1' );
+			john.setSelection( [ 1 ] );
+			john.merge();
 
-		expectClients( '<paragraph></paragraph>' );
+			expectClients( '<paragraph>Foo<m1:start></m1:start>Bar</paragraph>' );
 
-		john.undo();
+			john.undo();
 
-		expectClients( '<paragraph>X<m1:start></m1:start>abc<m1:end></m1:end>Y</paragraph>' );
+			expectClients( '<paragraph>Foo<m1:start></m1:start></paragraph><paragraph>Bar</paragraph>' );
+		} );
 
-		john.undo();
+		it( 'empty marker between merged elements then undo', () => {
+			john.setData( '<paragraph>Foo[</paragraph><paragraph>]Bar</paragraph>' );
 
-		expectClients( '<paragraph>XY</paragraph>' );
+			john.setMarker( 'm1' );
+			john.setSelection( [ 1 ] );
+			john.merge();
 
-		john.redo();
+			expectClients( '<paragraph>Foo<m1:start></m1:start>Bar</paragraph>' );
 
-		expectClients( '<paragraph>X<m1:start></m1:start>abc<m1:end></m1:end>Y</paragraph>' );
+			john.undo();
 
-		john.redo();
+			expectClients( '<paragraph>Foo<m1:start></m1:start></paragraph><paragraph><m1:end></m1:end>Bar</paragraph>' );
+		} );
 
-		expectClients( '<paragraph></paragraph>' );
+		it( 'left side of marker moved then undo', () => {
+			john.setData( '<paragraph>Foo[bar]</paragraph><paragraph></paragraph>' );
 
-		john.undo();
+			john.setMarker( 'm1' );
+			john.setSelection( [ 0, 2 ], [ 0, 4 ] );
+			john.move( [ 1, 0 ] );
 
-		expectClients( '<paragraph>X<m1:start></m1:start>abc<m1:end></m1:end>Y</paragraph>' );
+			expectClients( '<paragraph>Fo<m1:start></m1:start>ar<m1:end></m1:end></paragraph><paragraph>ob</paragraph>' );
 
-		john.undo();
+			john.undo();
 
-		expectClients( '<paragraph>XY</paragraph>' );
-	} );
+			expectClients( '<paragraph>Foo<m1:start></m1:start>bar<m1:end></m1:end></paragraph><paragraph></paragraph>' );
+		} );
 
-	// https://github.com/ckeditor/ckeditor5/issues/1385
-	it( 'paste inside paste + undo, undo + redo, redo', () => {
-		const model = john.editor.model;
+		it( 'right side of marker moved then undo', () => {
+			john.setData( '<paragraph>[Foo]bar</paragraph><paragraph></paragraph>' );
 
-		john.setData( '<paragraph>[]</paragraph>' );
+			john.setMarker( 'm1' );
+			john.setSelection( [ 0, 2 ], [ 0, 4 ] );
+			john.move( [ 1, 0 ] );
 
-		model.insertContent( getPastedContent() );
+			expectClients( '<paragraph><m1:start></m1:start>Fo<m1:end></m1:end>ar</paragraph><paragraph>ob</paragraph>' );
 
-		john.setSelection( [ 0, 3 ] );
+			john.undo();
 
-		model.insertContent( getPastedContent() );
+			expectClients( '<paragraph><m1:start></m1:start>Foo<m1:end></m1:end>bar</paragraph><paragraph></paragraph>' );
+		} );
 
-		expectClients( '<heading1>FooFoobarbar</heading1>' );
+		it( 'marker on closing and opening tag - remove multiple elements #1', () => {
+			john.setData(
+				'<paragraph>Abc</paragraph>' +
+				'<paragraph>Foo[</paragraph>' +
+				'<paragraph>]Bar</paragraph>'
+			);
 
-		john.undo();
+			john.setMarker( 'm1' );
+			john.setSelection( [ 0, 1 ], [ 2, 2 ] );
+			john._processExecute( 'delete' );
 
-		expectClients( '<heading1>Foobar</heading1>' );
+			expectClients( '<paragraph>A<m1:start></m1:start>r</paragraph>' );
 
-		john.undo();
+			john.undo();
 
-		expectClients( '<paragraph></paragraph>' );
+			expectClients(
+				'<paragraph>Abc</paragraph>' +
+				'<paragraph>Foo<m1:start></m1:start></paragraph>' +
+				'<paragraph><m1:end></m1:end>Bar</paragraph>'
+			);
+		} );
 
-		john.redo();
+		it( 'marker on closing and opening tag - remove multiple elements #2', () => {
+			john.setData(
+				'<paragraph>Foo[</paragraph>' +
+				'<paragraph>]Bar</paragraph>' +
+				'<paragraph>Xyz</paragraph>'
+			);
 
-		expectClients( '<heading1>Foobar</heading1>' );
+			john.setMarker( 'm1' );
+			john.setSelection( [ 0, 1 ], [ 2, 2 ] );
+			john._processExecute( 'delete' );
 
-		john.redo();
+			expectClients( '<paragraph>F<m1:start></m1:start>z</paragraph>' );
 
-		expectClients( '<heading1>FooFoobarbar</heading1>' );
+			john.undo();
 
-		function getPastedContent() {
-			return new Element( 'heading1', null, new Text( 'Foobar' ) );
-		}
-	} );
+			expectClients(
+				'<paragraph>Foo<m1:start></m1:start></paragraph>' +
+				'<paragraph><m1:end></m1:end>Bar</paragraph>' +
+				'<paragraph>Xyz</paragraph>'
+			);
+		} );
 
-	// https://github.com/ckeditor/ckeditor5/issues/1540
-	it( 'paste, select all, paste, undo, undo, redo, redo, redo', () => {
-		john.setData( '<paragraph>[]</paragraph>' );
+		it( 'marker on closing and opening tag + some text - merge elements + remove text', () => {
+			john.setData(
+				'<paragraph>Foo[</paragraph>' +
+				'<paragraph>B]ar</paragraph>'
+			);
 
-		pasteContent();
+			john.setMarker( 'm1' );
+			john.setSelection( [ 0, 1 ], [ 1, 2 ] );
+			john._processExecute( 'delete' );
 
-		john.setSelection( [ 0, 0 ], [ 1, 3 ] );
+			expectClients( '<paragraph>F<m1:start></m1:start>r</paragraph>' );
 
-		pasteContent();
+			john.undo();
 
-		expectClients( '<heading1>Foo</heading1><paragraph>Bar</paragraph>' );
+			expectClients(
+				'<paragraph>Foo<m1:start></m1:start></paragraph>' +
+				'<paragraph>B<m1:end></m1:end>ar</paragraph>'
+			);
+		} );
 
-		john.undo();
+		// https://github.com/ckeditor/ckeditor5-engine/issues/1668
+		it( 'marker and moves with undo-redo-undo', () => {
+			john.setData( '<paragraph>X[]Y</paragraph>' );
 
-		expectClients( '<heading1>Foo</heading1><paragraph>Bar</paragraph>' );
+			const inputBufferBatch = john.editor.commands.get( 'input' ).buffer.batch;
 
-		john.undo();
+			john.editor.model.enqueueChange( inputBufferBatch, () => {
+				john.type( 'a' );
+				john.type( 'b' );
+				john.type( 'c' );
 
-		expectClients( '<paragraph></paragraph>' );
+				john.setSelection( [ 0, 1 ], [ 0, 4 ] );
+				john.setMarker( 'm1' );
+			} );
 
-		john.redo();
+			expectClients( '<paragraph>X<m1:start></m1:start>abc<m1:end></m1:end>Y</paragraph>' );
 
-		expectClients( '<heading1>Foo</heading1><paragraph>Bar</paragraph>' );
+			john.setSelection( [ 0, 0 ], [ 0, 5 ] );
+			john._processExecute( 'delete' );
 
-		john.redo();
+			expectClients( '<paragraph></paragraph>' );
 
-		expectClients( '<heading1>Foo</heading1><paragraph>Bar</paragraph>' );
+			john.undo();
 
-		function pasteContent() {
+			expectClients( '<paragraph>X<m1:start></m1:start>abc<m1:end></m1:end>Y</paragraph>' );
+
+			john.undo();
+
+			expectClients( '<paragraph>XY</paragraph>' );
+
+			john.redo();
+
+			expectClients( '<paragraph>X<m1:start></m1:start>abc<m1:end></m1:end>Y</paragraph>' );
+
+			john.redo();
+
+			expectClients( '<paragraph></paragraph>' );
+
+			john.undo();
+
+			expectClients( '<paragraph>X<m1:start></m1:start>abc<m1:end></m1:end>Y</paragraph>' );
+
+			john.undo();
+
+			expectClients( '<paragraph>XY</paragraph>' );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/1385
+		it( 'paste inside paste + undo, undo + redo, redo', () => {
+			const model = john.editor.model;
+
+			john.setData( '<paragraph>[]</paragraph>' );
+
+			model.insertContent( getPastedContent() );
+
+			john.setSelection( [ 0, 3 ] );
+
+			model.insertContent( getPastedContent() );
+
+			expectClients( '<heading1>FooFoobarbar</heading1>' );
+
+			john.undo();
+
+			expectClients( '<heading1>Foobar</heading1>' );
+
+			john.undo();
+
+			expectClients( '<paragraph></paragraph>' );
+
+			john.redo();
+
+			expectClients( '<heading1>Foobar</heading1>' );
+
+			john.redo();
+
+			expectClients( '<heading1>FooFoobarbar</heading1>' );
+
+			function getPastedContent() {
+				return new Element( 'heading1', null, new Text( 'Foobar' ) );
+			}
+		} );
+
+		// https://github.com/ckeditor/ckeditor5/issues/1540
+		it( 'paste, select all, paste, undo, undo, redo, redo, redo', () => {
+			john.setData( '<paragraph>[]</paragraph>' );
+
+			pasteContent();
+
+			john.setSelection( [ 0, 0 ], [ 1, 3 ] );
+
+			pasteContent();
+
+			expectClients( '<heading1>Foo</heading1><paragraph>Bar</paragraph>' );
+
+			john.undo();
+
+			expectClients( '<heading1>Foo</heading1><paragraph>Bar</paragraph>' );
+
+			john.undo();
+
+			expectClients( '<paragraph></paragraph>' );
+
+			john.redo();
+
+			expectClients( '<heading1>Foo</heading1><paragraph>Bar</paragraph>' );
+
+			john.redo();
+
+			expectClients( '<heading1>Foo</heading1><paragraph>Bar</paragraph>' );
+
+			function pasteContent() {
+				john.editor.model.insertContent(
+					new DocumentFragment( [
+						new Element( 'heading1', null, new Text( 'Foo' ) ),
+						new Element( 'paragraph', null, new Text( 'Bar' ) )
+					] )
+				);
+			}
+		} );
+
+		// Happens in track changes. Emulated here.
+		// https://github.com/ckeditor/ckeditor5-engine/issues/1701
+		it( 'paste, remove, undo, undo, redo, redo', () => {
+			john.setData( '<paragraph>Ab[]cd</paragraph><paragraph>Wxyz</paragraph>' );
+
 			john.editor.model.insertContent(
 				new DocumentFragment( [
-					new Element( 'heading1', null, new Text( 'Foo' ) ),
+					new Element( 'paragraph', null, new Text( 'Foo' ) ),
 					new Element( 'paragraph', null, new Text( 'Bar' ) )
 				] )
 			);
-		}
-	} );
 
-	// Happens in track changes. Emulated here.
-	// https://github.com/ckeditor/ckeditor5-engine/issues/1701
-	it( 'paste, remove, undo, undo, redo, redo', () => {
-		john.setData( '<paragraph>Ab[]cd</paragraph><paragraph>Wxyz</paragraph>' );
+			john.setSelection( [ 1, 3 ], [ 2, 2 ] );
 
-		john.editor.model.insertContent(
-			new DocumentFragment( [
-				new Element( 'paragraph', null, new Text( 'Foo' ) ),
-				new Element( 'paragraph', null, new Text( 'Bar' ) )
-			] )
-		);
+			john._processExecute( 'delete' );
 
-		john.setSelection( [ 1, 3 ], [ 2, 2 ] );
+			expectClients( '<paragraph>AbFoo</paragraph><paragraph>Baryz</paragraph>' );
 
-		john._processExecute( 'delete' );
+			john.undo();
 
-		expectClients( '<paragraph>AbFoo</paragraph><paragraph>Baryz</paragraph>' );
+			expectClients( '<paragraph>AbFoo</paragraph><paragraph>Barcd</paragraph><paragraph>Wxyz</paragraph>' );
 
-		john.undo();
+			john.undo();
 
-		expectClients( '<paragraph>AbFoo</paragraph><paragraph>Barcd</paragraph><paragraph>Wxyz</paragraph>' );
+			expectClients( '<paragraph>Abcd</paragraph><paragraph>Wxyz</paragraph>' );
 
-		john.undo();
+			john.redo();
 
-		expectClients( '<paragraph>Abcd</paragraph><paragraph>Wxyz</paragraph>' );
+			expectClients( '<paragraph>AbFoo</paragraph><paragraph>Barcd</paragraph><paragraph>Wxyz</paragraph>' );
 
-		john.redo();
+			john.redo();
 
-		expectClients( '<paragraph>AbFoo</paragraph><paragraph>Barcd</paragraph><paragraph>Wxyz</paragraph>' );
+			expectClients( '<paragraph>AbFoo</paragraph><paragraph>Baryz</paragraph>' );
+		} );
 
-		john.redo();
+		// https://github.com/ckeditor/ckeditor5/issues/8870
+		it( 'object, p, p, p, remove, undo', () => {
+			john.setData( '<imageBlock></imageBlock><paragraph>A</paragraph><paragraph>B[]</paragraph>' );
 
-		expectClients( '<paragraph>AbFoo</paragraph><paragraph>Baryz</paragraph>' );
-	} );
+			// I couldn't use delete command because simply executing this command several times does not
+			// work correctly when selection reaches <imageBlock></imageBlock><p>[]</p>.
+			// At this point we have custom control for firing delete event on view and I didn't want to
+			// simulate that.
+			//
+			john.remove( [ 2, 0 ], [ 2, 1 ] );
+			john.merge( [ 2 ] );
+			john.remove( [ 1, 0 ], [ 1, 1 ] );
+			john.remove( [ 1 ], [ 2 ] );
+			john.remove( [ 0 ], [ 1 ] );
 
-	// https://github.com/ckeditor/ckeditor5/issues/8870
-	it( 'object, p, p, p, remove, undo', () => {
-		john.setData( '<imageBlock></imageBlock><paragraph>A</paragraph><paragraph>B[]</paragraph>' );
+			john.undo();
+			john.undo();
+			john.undo();
+			john.undo();
+			john.undo();
 
-		// I couldn't use delete command because simply executing this command several times does not
-		// work correctly when selection reaches <imageBlock></imageBlock><p>[]</p>.
-		// At this point we have custom control for firing delete event on view and I didn't want to
-		// simulate that.
-		//
-		john.remove( [ 2, 0 ], [ 2, 1 ] );
-		john.merge( [ 2 ] );
-		john.remove( [ 1, 0 ], [ 1, 1 ] );
-		john.remove( [ 1 ], [ 2 ] );
-		john.remove( [ 0 ], [ 1 ] );
+			expectClients( '<imageBlock></imageBlock><paragraph>A</paragraph><paragraph>B</paragraph>' );
+		} );
 
-		john.undo();
-		john.undo();
-		john.undo();
-		john.undo();
-		john.undo();
+		it( 'remove merged element then undo', () => {
+			john.setData( '<paragraph>Foo</paragraph>[]<paragraph>Bar</paragraph>' );
 
-		expectClients( '<imageBlock></imageBlock><paragraph>A</paragraph><paragraph>B</paragraph>' );
-	} );
+			john.merge();
+			john.setSelection( [ 0, 0 ], [ 0, 6 ] );
+			john.remove();
 
-	it( 'remove merged element then undo', () => {
-		john.setData( '<paragraph>Foo</paragraph>[]<paragraph>Bar</paragraph>' );
+			expectClients( '<paragraph></paragraph>' );
 
-		john.merge();
-		john.setSelection( [ 0, 0 ], [ 0, 6 ] );
-		john.remove();
+			john.undo();
+			john.undo();
 
-		expectClients( '<paragraph></paragraph>' );
+			expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
+		} );
 
-		john.undo();
-		john.undo();
+		// https://github.com/cksource/ckeditor5-commercial/issues/4371.
+		it( 'add paragraphs and marker, remove marker, undo on both clients', async () => {
+			const kate = await Client.get( 'kate' );
 
-		expectClients( '<paragraph>Foo</paragraph><paragraph>Bar</paragraph>' );
-	} );
+			kate.setData( '<paragraph>[]</paragraph>' );
+			john.setData( '<paragraph>[]</paragraph>' );
 
-	// https://github.com/cksource/ckeditor5-commercial/issues/4371.
-	it( 'add paragraphs and marker, remove marker, undo on both clients', async () => {
-		const kate = await Client.get( 'kate' );
+			syncClients();
 
-		kate.setData( '<paragraph>[]</paragraph>' );
-		john.setData( '<paragraph>[]</paragraph>' );
+			kate._processExecute( 'insertText', { text: 'A' } );
+			kate._processExecute( 'insertText', { text: 'B' } );
+			kate._processExecute( 'insertText', { text: 'C' } );
+			kate._processExecute( 'enter' );
+			kate._processExecute( 'insertText', { text: 'X' } );
+			kate._processExecute( 'insertText', { text: 'Y' } );
+			kate._processExecute( 'insertText', { text: 'Z' } );
+			kate.setSelection( [ 0, 1 ], [ 1, 2 ] );
+			kate.setMarker( 'm1' );
 
-		syncClients();
+			syncClients();
+			expectClients( '<paragraph>A<m1:start></m1:start>BC</paragraph><paragraph>XY<m1:end></m1:end>Z</paragraph>' );
 
-		kate._processExecute( 'insertText', { text: 'A' } );
-		kate._processExecute( 'insertText', { text: 'B' } );
-		kate._processExecute( 'insertText', { text: 'C' } );
-		kate._processExecute( 'enter' );
-		kate._processExecute( 'insertText', { text: 'X' } );
-		kate._processExecute( 'insertText', { text: 'Y' } );
-		kate._processExecute( 'insertText', { text: 'Z' } );
-		kate.setSelection( [ 0, 1 ], [ 1, 2 ] );
-		kate.setMarker( 'm1' );
+			john.setSelection( [ 0, 1 ], [ 1, 2 ] );
+			john.delete();
 
-		syncClients();
-		expectClients( '<paragraph>A<m1:start></m1:start>BC</paragraph><paragraph>XY<m1:end></m1:end>Z</paragraph>' );
+			syncClients();
+			expectClients( '<paragraph>A<m1:start></m1:start>Z</paragraph>' );
 
-		john.setSelection( [ 0, 1 ], [ 1, 2 ] );
-		john.delete();
+			kate.undo();
 
-		syncClients();
-		expectClients( '<paragraph>A<m1:start></m1:start>Z</paragraph>' );
+			syncClients();
+			expectClients( '<paragraph>AZ</paragraph>' );
 
-		kate.undo();
+			kate.undo();
 
-		syncClients();
-		expectClients( '<paragraph>AZ</paragraph>' );
+			syncClients();
+			expectClients( '<paragraph>A</paragraph>' );
 
-		kate.undo();
+			john.undo();
 
-		syncClients();
-		expectClients( '<paragraph>A</paragraph>' );
+			syncClients();
+			expectClients( '<paragraph>A<m1:start></m1:start>BC</paragraph><paragraph>XY<m1:end></m1:end></paragraph>' );
 
-		john.undo();
+			return kate.destroy();
+		} );
 
-		syncClients();
-		expectClients( '<paragraph>A<m1:start></m1:start>BC</paragraph><paragraph>XY<m1:end></m1:end></paragraph>' );
+		// https://github.com/ckeditor/ckeditor5/issues/9296
+		it( 'multiple enters, then backspaces, then undo, redo', () => {
+			john.setData( '<paragraph>AB[]CD</paragraph>' );
 
-		return kate.destroy();
+			john.split();
+			john.setSelection( [ 1, 0 ] );
+
+			john.split();
+			john.setSelection( [ 2, 0 ] );
+
+			john.split();
+			john.setSelection( [ 3, 0 ] );
+
+			expectClients( '<paragraph>AB</paragraph><paragraph></paragraph><paragraph></paragraph><paragraph>CD</paragraph>' );
+
+			john.delete();
+			john.delete();
+			john.delete();
+
+			expectClients( '<paragraph>ABCD</paragraph>' );
+
+			john.undo();
+
+			expectClients( '<paragraph>AB</paragraph><paragraph></paragraph><paragraph></paragraph><paragraph>CD</paragraph>' );
+
+			john.undo();
+			john.undo();
+			john.undo();
+
+			expectClients( '<paragraph>ABCD</paragraph>' );
+
+			john.redo();
+			john.redo();
+			john.redo();
+			john.redo();
+
+			expectClients( '<paragraph>ABCD</paragraph>' );
+		} );
 	} );
 } );

--- a/packages/ckeditor5-engine/tests/model/range.js
+++ b/packages/ckeditor5-engine/tests/model/range.js
@@ -251,6 +251,13 @@ describe( 'Range', () => {
 				expect( range.start.offset ).to.equal( 2 );
 				expect( range.end.offset ).to.equal( 9 );
 			} );
+
+			it( 'should combine ranges with reference range #2 - multiple backwards', () => {
+				const range = Range._createFromRanges( makeRanges( root, 4, 6, 3, 4, 2, 3, 6, 7, 1, 2 ) );
+
+				expect( range.start.offset ).to.equal( 1 );
+				expect( range.end.offset ).to.equal( 7 );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (engine): Fixed incorrect marker handling in some scenarios involving undo and real-time collaboration, which earlier lead to `model-nodelist-offset-out-of-bounds` error.

Fix (engine): Fixed incorrect handling of merge changes during undo in some scenarios involving real-time collaboration, which earlier led to `model-nodelist-offset-out-of-bounds` error.

Fix (engine): Fixed conflict resolution error, which led to editor crash in some scenarios where two users removed bigger intersecting part of the content and used undo.

Fix (engine): Fixed incorrect undo behavior leading to an editor crash when a user pressed enter key multiple times, then pressed backspace that many times, then undone all the changes. Closes #9296.