### PR TITLE
Bump eslint-config-ckeditor5 version and remove unused variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "coveralls": "^3.1.0",
     "date-fns": "^2.30.0",
     "eslint": "^7.19.0",
-    "eslint-config-ckeditor5": "^6.0.0",
+    "eslint-config-ckeditor5": "^7.0.0",
     "estree-walker": "^3.0.3",
     "fs-extra": "^11.1.1",
     "glob": "^10.2.5",

--- a/packages/ckeditor5-ckbox/src/ckboxui.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxui.ts
@@ -64,7 +64,6 @@ export default class CKBoxUI extends Plugin {
 		const locale = editor.locale;
 		const view = new ButtonClass( locale ) as InstanceType<T>;
 		const command = editor.commands.get( 'ckbox' )!;
-		const t = locale.t;
 
 		view.bind( 'isOn', 'isEnabled' ).to( command, 'value', 'isEnabled' );
 

--- a/packages/ckeditor5-ckfinder/src/ckfinderui.ts
+++ b/packages/ckeditor5-ckfinder/src/ckfinderui.ts
@@ -8,12 +8,7 @@
  */
 
 import { icons, Plugin } from 'ckeditor5/src/core.js';
-import {
-	ButtonView,
-	FileDialogButtonView,
-	MenuBarMenuListItemButtonView,
-	MenuBarMenuListItemFileDialogButtonView
-} from 'ckeditor5/src/ui.js';
+import { ButtonView, MenuBarMenuListItemButtonView } from 'ckeditor5/src/ui.js';
 import type { ImageInsertUI } from '@ckeditor/ckeditor5-image';
 
 import type CKFinderCommand from './ckfindercommand.js';

--- a/packages/ckeditor5-code-block/src/codeblockediting.ts
+++ b/packages/ckeditor5-code-block/src/codeblockediting.ts
@@ -24,8 +24,6 @@ import {
 } from 'ckeditor5/src/engine.js';
 import { ClipboardPipeline, type ClipboardContentInsertionEvent } from 'ckeditor5/src/clipboard.js';
 
-import type { ListEditing } from '@ckeditor/ckeditor5-list';
-
 import CodeBlockCommand from './codeblockcommand.js';
 import IndentCodeBlockCommand from './indentcodeblockcommand.js';
 import OutdentCodeBlockCommand from './outdentcodeblockcommand.js';

--- a/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/selectionobserver.ts
@@ -156,7 +156,7 @@ export default class SelectionObserver extends Observer {
 		// handler would like to check it and update (for example table multi cell selection).
 		this.listenTo( domDocument, 'mouseup', endDocumentIsSelecting, { priority: 'highest', useCapture: true } );
 
-		this.listenTo( domDocument, 'selectionchange', ( evt, domEvent ) => {
+		this.listenTo( domDocument, 'selectionchange', () => {
 			// @if CK_DEBUG_TYPING // if ( ( window as any ).logCKETyping ) {
 			// @if CK_DEBUG_TYPING // 	_debouncedLine();
 			// @if CK_DEBUG_TYPING // 	const domSelection = domDocument.defaultView!.getSelection();

--- a/packages/ckeditor5-link/src/utils/manualdecorator.ts
+++ b/packages/ckeditor5-link/src/utils/manualdecorator.ts
@@ -8,7 +8,7 @@
  */
 
 import { ObservableMixin, type ArrayOrItem } from 'ckeditor5/src/utils.js';
-import type { MatcherPattern, MatcherObjectPattern } from 'ckeditor5/src/engine.js';
+import type { MatcherObjectPattern } from 'ckeditor5/src/engine.js';
 import type { NormalizedLinkDecoratorManualDefinition } from '../utils.js';
 
 /**

--- a/packages/ckeditor5-list/src/list/converters.ts
+++ b/packages/ckeditor5-list/src/list/converters.ts
@@ -8,7 +8,6 @@
  */
 
 import {
-	UpcastWriter,
 	type DowncastAttributeEvent,
 	type DowncastWriter,
 	type EditingController,

--- a/packages/ckeditor5-ui/src/colorselector/colorgridsfragmentview.ts
+++ b/packages/ckeditor5-ui/src/colorselector/colorgridsfragmentview.ts
@@ -11,7 +11,6 @@ import View from '../view.js';
 import ButtonView from '../button/buttonview.js';
 import ColorGridView, { type ColorDefinition } from '../colorgrid/colorgridview.js';
 import ColorTileView from '../colorgrid/colortileview.js';
-import LabelView from '../label/labelview.js';
 import Template from '../template.js';
 
 import DocumentColorCollection from './documentcolorcollection.js';

--- a/packages/ckeditor5-utils/src/count.ts
+++ b/packages/ckeditor5-utils/src/count.ts
@@ -20,7 +20,8 @@
 export default function count( iterable: Iterable<unknown> ): number {
 	let count = 0;
 
-	for ( const _ of iterable ) { // eslint-disable-line no-unused-vars
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	for ( const _ of iterable ) {
 		count++;
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Bumps `eslint-config-ckeditor5 version` to 7.0.0 and removes unused variables. Closes #17010.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
