### PR TITLE
Add basic Microsoft Narrator tables PoC (extra divs within `td`)

### DIFF
--- a/packages/ckeditor5-table/src/converters/downcast.ts
+++ b/packages/ckeditor5-table/src/converters/downcast.ts
@@ -111,9 +111,23 @@ export function downcastCell( options: { asWidget?: boolean } = {} ): ElementCre
 				const isHeading = tableSlot.row < headingRows || tableSlot.column < headingColumns;
 				const cellElementName = isHeading ? 'th' : 'td';
 
-				result = options.asWidget ?
-					toWidgetEditable( writer.createEditableElement( cellElementName ), writer ) :
-					writer.createContainerElement( cellElementName );
+				const cellElement = writer.createContainerElement( cellElementName );
+
+				if ( options.asWidget ) {
+					const divElement = toWidgetEditable(
+						writer.createEditableElement( 'div', { class: 'ck-table-cell-content' } ),
+						writer
+					);
+
+					writer.insert(
+						writer.createPositionAt( divElement, 0 ),
+						writer.createSlot()
+					);
+
+					writer.insert( writer.createPositionAt( cellElement, 0 ), divElement );
+				}
+
+				result = cellElement;
 				break;
 			}
 		}

--- a/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
+++ b/packages/ckeditor5-table/src/tablecolumnresize/tablecolumnresizeediting.ts
@@ -857,7 +857,7 @@ export default class TableColumnResizeEditing extends Plugin {
 				const viewWriter = conversionApi.writer;
 
 				viewWriter.insert(
-					viewWriter.createPositionAt( viewElement!, 'end' ),
+					viewWriter.createPositionAt( viewElement!.getChild( 0 )!, 'end' ),
 					viewWriter.createUIElement( 'div', { class: 'ck-table-column-resizer' } )
 				);
 			}, { priority: 'lowest' } );

--- a/packages/ckeditor5-table/src/tableediting.ts
+++ b/packages/ckeditor5-table/src/tableediting.ts
@@ -143,7 +143,7 @@ export default class TableEditing extends Plugin {
 		conversion.for( 'upcast' ).add( ensureParagraphInTableCell( 'td' ) );
 		conversion.for( 'upcast' ).add( ensureParagraphInTableCell( 'th' ) );
 
-		conversion.for( 'editingDowncast' ).elementToElement( {
+		conversion.for( 'editingDowncast' ).elementToStructure( {
 			model: 'tableCell',
 			view: downcastCell( { asWidget: true } )
 		} );

--- a/packages/ckeditor5-table/theme/table.css
+++ b/packages/ckeditor5-table/theme/table.css
@@ -27,7 +27,6 @@
 		& td,
 		& th {
 			min-width: 2em;
-			padding: .4em;
 
 			/* The border is inherited from .ck-editor__nested-editable styles, so theoretically it's not necessary here.
 			However, the border is a content style, so it should use .ck-content (so it works outside the editor).
@@ -81,4 +80,11 @@ when content is available outside the editor. See https://github.com/ckeditor/ck
 	 * See https://github.com/ckeditor/ckeditor5/issues/9117.
 	 */
 	width: 100%;
+}
+
+.ck-editor__editable .ck-table-cell-content {
+	box-sizing: border-box;
+	min-height: 100%;
+	padding: .4em;
+	margin: -1px;
 }

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableediting.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-table/tableediting.css
@@ -16,12 +16,21 @@
 		 * So do not use `@mixin ck-focus-ring;` here, or any other border styles.
 		 * See more: https://github.com/ckeditor/ckeditor5/issues/16979
 		 */
-		&.ck-editor__nested-editable.ck-editor__nested-editable_focused,
-		&.ck-editor__nested-editable:focus {
-			/* A very slight background to highlight the focused cell */
+		&:has(.ck-editor__nested-editable.ck-editor__nested-editable_focused),
+		&:has(.ck-editor__nested-editable:focus) {
 			background: var(--ck-color-selector-focused-cell-background);
 			outline: 1px solid var(--ck-color-focus-border);
 			outline-offset: -1px; /* progressive enhancement - no IE support */
+			box-shadow: none;
+
+			& .ck-editor__nested-editable.ck-editor__nested-editable_focused,
+			& .ck-editor__nested-editable:focus {
+				/* A very slight background to highlight the focused cell */
+				background: none;
+				border: 0;
+				box-shadow: none;
+			}
+
 		}
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Add basic PoC that fixes `0 by 0` Microsoft Narrator screen reader

---

### Additional information

This PR tests changing this cell HTML structure:

```html
<th colspan="2" rowspan="4" class="ck-table-cell-content ck-editor__editable ck-editor__nested-editable" role="textbox" tabindex="-1" contenteditable="true">
    <span class="ck-table-bogus-paragraph">Terrestrial planets</span>
</th>
```

to: 

```html
<th colspan="2" rowspan="4">
  <div class="ck-table-cell-content ck-editor__editable ck-editor__nested-editable" role="textbox" tabindex="-1" contenteditable="true">
    <span class="ck-table-bogus-paragraph">Terrestrial planets</span>
  </div>
</th>
```

Table behavior is buggy, but narrator works correctly. 

#### Observations

1. It's super laggy on Firefox with Grammarly plugin, focusing single table cell takes ~1s. It does not happen in incognito mode.
2. Most of the table cell editable CSS is broken. Making contenteditable cell content height to fill entire cell is problematic on Firefox as it's centered (on Chrome it works fine)
![obraz](https://github.com/user-attachments/assets/9a8e7c9a-1e64-4128-beb2-b8be08df5558)
3. It looks like selection of the table is buggy and sometimes, mostly during selection, it selects neighbor table cells text content. 
4. Some plugins depend on `td` content and do not expect that the first child is content wrapper (e.g. table column resize plugin). These plugins need to be adjusted and tested.  
5. Fast selection change causes infinity hang on Edge
![obraz](https://github.com/user-attachments/assets/a5f4cddd-71b9-4423-a31c-6313e960fb79)
