### PR TITLE
Add support for `usePassive` option to the `DomEventObserver`

### DIFF
--- a/packages/ckeditor5-engine/src/view/observer/domeventobserver.ts
+++ b/packages/ckeditor5-engine/src/view/observer/domeventobserver.ts
@@ -57,6 +57,12 @@ export default abstract class DomEventObserver<
 	public useCapture: boolean = false;
 
 	/**
+	 * If set to `true`, indicates that the function specified by listener will never call `preventDefault()`.
+	 * Default value is `false`.
+	 */
+	public usePassive: boolean = false;
+
+	/**
 	 * Callback which should be called when the DOM event occurred. Note that the callback will not be called if
 	 * observer {@link #isEnabled is not enabled}.
 	 *
@@ -75,7 +81,7 @@ export default abstract class DomEventObserver<
 				if ( this.isEnabled && !this.checkShouldIgnoreEventFromTarget( domEvent.target as any ) ) {
 					this.onDomEvent( domEvent );
 				}
-			}, { useCapture: this.useCapture } );
+			}, { useCapture: this.useCapture, usePassive: this.usePassive } );
 		} );
 	}
 

--- a/packages/ckeditor5-engine/tests/view/observer/domeventobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/domeventobserver.js
@@ -44,6 +44,14 @@ class ClickCapturingObserver extends ClickObserver {
 	}
 }
 
+class ClickPassiveObserver extends ClickObserver {
+	constructor( view ) {
+		super( view );
+
+		this.usePassive = true;
+	}
+}
+
 describe( 'DomEventObserver', () => {
 	let view, viewDocument;
 
@@ -182,6 +190,23 @@ describe( 'DomEventObserver', () => {
 		} );
 
 		childDomElement.dispatchEvent( domEvent );
+	} );
+
+	it( 'should allow to listen passive events', () => {
+		const domElement = document.createElement( 'div' );
+		createViewRoot( viewDocument );
+		view.attachDomRoot( domElement );
+
+		const eventHandlerSpy = sinon.spy( ClickPassiveObserver.prototype, 'listenTo' );
+
+		view.addObserver( ClickPassiveObserver );
+
+		expect( eventHandlerSpy ).to.be.calledWith( domElement, 'click', sinon.match.func, {
+			useCapture: false,
+			usePassive: true
+		} );
+
+		eventHandlerSpy.restore();
 	} );
 
 	describe( 'integration with UIElement', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (engine): Add `usePassive` option to the `DomEventObserver` that enables listening passive events. Closes https://github.com/ckeditor/ckeditor5/issues/16412

### Additional information

Based on this PR https://github.com/ckeditor/ckeditor5/pull/16466. I added test. 