### PR TITLE
Allow youtube shorts links in media embed

### DIFF
--- a/packages/ckeditor5-media-embed/src/mediaembedediting.ts
+++ b/packages/ckeditor5-media-embed/src/mediaembedediting.ts
@@ -88,6 +88,7 @@ export default class MediaEmbedEditing extends Plugin {
 					name: 'youtube',
 					url: [
 						/^(?:m\.)?youtube\.com\/watch\?v=([\w-]+)(?:&t=(\d+))?/,
+						/^(?:m\.)?youtube\.com\/shorts\/([\w-]+)(?:\?t=(\d+))?/,
 						/^(?:m\.)?youtube\.com\/v\/([\w-]+)(?:\?t=(\d+))?/,
 						/^youtube\.com\/embed\/([\w-]+)(?:\?start=(\d+))?/,
 						/^youtu\.be\/([\w-]+)(?:\?t=(\d+))?/

--- a/packages/ckeditor5-media-embed/tests/mediaembedediting.js
+++ b/packages/ckeditor5-media-embed/tests/mediaembedediting.js
@@ -205,6 +205,10 @@ describe( 'MediaEmbedEditing', () => {
 
 						it( 'upcasts the URL (youtube)', () => {
 							testMediaUpcast( [
+								'https://www.youtube.com/shorts/foo',
+								'www.youtube.com/shorts/foo',
+								'youtube.com/shorts/foo',
+
 								'https://www.youtube.com/watch?v=foo',
 								'www.youtube.com/watch?v=foo',
 								'youtube.com/watch?v=foo',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (media-embed): It's now possible to embed YouTube shorts. Closes https://github.com/ckeditor/ckeditor5/issues/17090
