### PR TITLE
Fix font color picker not working properly on first change on Chrome

### DIFF
--- a/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
+++ b/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts
@@ -199,13 +199,15 @@ export default class ColorPickerView extends View {
 	public focus(): void {
 		// In some browsers we need to move the focus to the input first.
 		// Otherwise, the color picker doesn't behave as expected.
+		// In Chrome, after selecting the color via slider the first time,
+		// the editor collapses the selection and doesn't apply the color change.
 		// In FF, after selecting the color via slider, it instantly moves back to the previous color.
 		// In all iOS browsers and desktop Safari, once the saturation slider is moved for the first time,
 		// editor collapses the selection and doesn't apply the color change.
 		// See: https://github.com/cksource/ckeditor5-internal/issues/3245, https://github.com/ckeditor/ckeditor5/issues/14119,
 		// https://github.com/cksource/ckeditor5-internal/issues/3268.
 		/* istanbul ignore next -- @preserve */
-		if ( !this._config.hideInput && ( env.isGecko || env.isiOS || env.isSafari ) ) {
+		if ( !this._config.hideInput && ( env.isGecko || env.isiOS || env.isSafari || env.isBlink ) ) {
 			const input: LabeledFieldView<InputTextView> = this.hexInputRow!.children.get( 1 )! as LabeledFieldView<InputTextView>;
 
 			input.focus();

--- a/packages/ckeditor5-ui/tests/colorpicker/colorpickerview.js
+++ b/packages/ckeditor5-ui/tests/colorpicker/colorpickerview.js
@@ -370,6 +370,36 @@ describe( 'ColorPickerView', () => {
 			view.destroy();
 			view.element.remove();
 		} );
+
+		// See: https://github.com/ckeditor/ckeditor5/issues/17069
+		it( 'should focus input before color slider to avoid selection issues', () => {
+			const buggyBrowsers = [ 'isGecko', 'isiOS', 'isSafari', 'isBlink' ];
+
+			const inputField = view.hexInputRow.children.get( 1 );
+			const slider = view.slidersView.first;
+
+			const inputSpy = sinon.spy( inputField, 'focus' );
+			const sliderSpy = sinon.spy( slider.element, 'focus' );
+
+			buggyBrowsers.forEach( browser => {
+				inputSpy.resetHistory();
+				sliderSpy.resetHistory();
+
+				mockBrowser( browser );
+
+				view.focus();
+
+				sinon.assert.callOrder( inputSpy, sliderSpy );
+				sinon.assert.calledOnce( inputSpy );
+				sinon.assert.calledOnce( sliderSpy );
+			} );
+
+			function mockBrowser( mockFlag ) {
+				for ( const flag of buggyBrowsers ) {
+					testUtils.sinon.stub( env, flag ).get( () => flag === mockFlag );
+				}
+			}
+		} );
 	} );
 
 	describe( 'isValid()', () => {

--- a/packages/ckeditor5-ui/tests/colorselector/colorselectorview.js
+++ b/packages/ckeditor5-ui/tests/colorselector/colorselectorview.js
@@ -24,6 +24,7 @@ import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils.js';
 import removeButtonIcon from '@ckeditor/ckeditor5-core/theme/icons/eraser.svg';
 import checkButtonIcon from '@ckeditor/ckeditor5-core/theme/icons/check.svg';
 import cancelButtonIcon from '@ckeditor/ckeditor5-core/theme/icons/cancel.svg';
+import { env } from '@ckeditor/ckeditor5-utils';
 
 const colorDefinitions = [
 	{
@@ -432,6 +433,11 @@ describe( 'ColorSelectorView', () => {
 		} );
 
 		it( 'should execute when color picker is focused and enter pressed', () => {
+			// Focusing input and then color picker seems to fail focus handling in test suite
+			// that uses headless chrome browser. This is a workaround for that, as this deactivates
+			// focusing input before the color picker.
+			env.isBlink = false;
+
 			const keyEvtData = {
 				keyCode: keyCodes.enter,
 				preventDefault: sinon.spy(),
@@ -452,9 +458,7 @@ describe( 'ColorSelectorView', () => {
 			colorSelectorView.selectedColor = '#660055';
 			colorSelectorView.on( 'execute', spy );
 
-			colorSelectorView.focus();
 			colorSelectorView.keystrokes.press( keyEvtData );
-
 			sinon.assert.calledOnce( keyEvtData.preventDefault );
 			sinon.assert.calledOnce( keyEvtData.stopPropagation );
 			sinon.assert.calledOnce( spy );

--- a/packages/ckeditor5-ui/tests/colorselector/colorselectorview.js
+++ b/packages/ckeditor5-ui/tests/colorselector/colorselectorview.js
@@ -433,9 +433,9 @@ describe( 'ColorSelectorView', () => {
 		} );
 
 		it( 'should execute when color picker is focused and enter pressed', () => {
-			// Focusing input and then color picker seems to fail focus handling in test suite
-			// that uses headless chrome browser. This is a workaround for that, as this deactivates
-			// focusing input before the color picker.
+			// Focusing input and then the color picker breaks focus handling in the test 
+			// suite that uses a headless Chrome browser. It is a workaround for that, as 
+			// this deactivates focusing input before the color picker.
 			env.isBlink = false;
 
 			const keyEvtData = {

--- a/packages/ckeditor5-ui/tests/colorselector/colorselectorview.js
+++ b/packages/ckeditor5-ui/tests/colorselector/colorselectorview.js
@@ -433,8 +433,8 @@ describe( 'ColorSelectorView', () => {
 		} );
 
 		it( 'should execute when color picker is focused and enter pressed', () => {
-			// Focusing input and then the color picker breaks focus handling in the test 
-			// suite that uses a headless Chrome browser. It is a workaround for that, as 
+			// Focusing input and then the color picker breaks focus handling in the test
+			// suite that uses a headless Chrome browser. It is a workaround for that, as
 			// this deactivates focusing input before the color picker.
 			env.isBlink = false;
 

--- a/packages/ckeditor5-ui/tests/colorselector/colorselectorview.js
+++ b/packages/ckeditor5-ui/tests/colorselector/colorselectorview.js
@@ -452,7 +452,9 @@ describe( 'ColorSelectorView', () => {
 			colorSelectorView.selectedColor = '#660055';
 			colorSelectorView.on( 'execute', spy );
 
+			colorSelectorView.focus();
 			colorSelectorView.keystrokes.press( keyEvtData );
+
 			sinon.assert.calledOnce( keyEvtData.preventDefault );
 			sinon.assert.calledOnce( keyEvtData.stopPropagation );
 			sinon.assert.calledOnce( spy );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Fixed an issue where the first selected color was applied instead of the second selected color when using the font color picker for the first time after loading the page. Closes https://github.com/ckeditor/ckeditor5/issues/17069

---

### Additional information

#### Before

https://github.com/user-attachments/assets/7b69a7dc-b0cd-4f3e-ba10-1298bea343a0

#### After

https://github.com/user-attachments/assets/7071c6bb-af7b-45bf-82f4-28fe53208c43


