### PR TITLE
Delay selections in `should not enter infinite loop` test due to changes in latest Chrome

### DIFF
--- a/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
@@ -316,12 +316,14 @@ describe( 'SelectionObserver', () => {
 		let counter = 70;
 
 		const simulateSelectionChanges = () => {
+			if ( !counter ) {
+				return;
+			}
+
 			changeDomSelection();
 			counter--;
 
-			if ( counter > 0 ) {
-				setTimeout( simulateSelectionChanges, 10 );
-			}
+			setTimeout( simulateSelectionChanges, 10 );
 		};
 
 		return new Promise( resolve => {
@@ -329,6 +331,7 @@ describe( 'SelectionObserver', () => {
 				expect( wasInfiniteLoopDetected ).to.be.true;
 				expect( selectionChangeSpy.callCount ).to.equal( 60 );
 
+				counter = 0;
 				resolve();
 			} );
 

--- a/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
@@ -298,9 +298,7 @@ describe( 'SelectionObserver', () => {
 		domSelection.collapse( editable, 0 );
 	} );
 
-	it( 'should not enter infinite loop', () => {
-		let counter = 70;
-
+	it( 'should not enter infinite loop', async () => {
 		const viewFoo = viewDocument.getRoot().getChild( 0 ).getChild( 0 );
 		view.change( writer => {
 			writer.setSelection( viewFoo, 0 );
@@ -315,6 +313,17 @@ describe( 'SelectionObserver', () => {
 		selectionObserver._clearInfiniteLoop();
 		viewDocument.on( 'selectionChange', selectionChangeSpy );
 
+		let counter = 70;
+
+		const simulateSelectionChanges = () => {
+			changeDomSelection();
+			counter--;
+
+			if ( counter > 0 ) {
+				setTimeout( simulateSelectionChanges, 10 );
+			}
+		};
+
 		return new Promise( resolve => {
 			viewDocument.on( 'selectionChangeDone', () => {
 				expect( wasInfiniteLoopDetected ).to.be.true;
@@ -323,10 +332,7 @@ describe( 'SelectionObserver', () => {
 				resolve();
 			} );
 
-			while ( counter > 0 ) {
-				changeDomSelection();
-				counter--;
-			}
+			simulateSelectionChanges();
 		} );
 	} );
 
@@ -774,5 +780,9 @@ describe( 'SelectionObserver', () => {
 		const offset = domSelection.anchorOffset;
 
 		domSelection.collapse( domFoo, offset == 2 ? 3 : 2 );
+	}
+
+	function timeout( ms ) {
+		return new Promise( resolve => setTimeout( resolve, ms ) );
 	}
 } );

--- a/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
+++ b/packages/ckeditor5-engine/tests/view/observer/selectionobserver.js
@@ -298,7 +298,7 @@ describe( 'SelectionObserver', () => {
 		domSelection.collapse( editable, 0 );
 	} );
 
-	it( 'should not enter infinite loop', async () => {
+	it( 'should not enter infinite loop', () => {
 		const viewFoo = viewDocument.getRoot().getChild( 0 ).getChild( 0 );
 		view.change( writer => {
 			writer.setSelection( viewFoo, 0 );
@@ -780,9 +780,5 @@ describe( 'SelectionObserver', () => {
 		const offset = domSelection.anchorOffset;
 
 		domSelection.collapse( domFoo, offset == 2 ? 3 : 2 );
-	}
-
-	function timeout( ms ) {
-		return new Promise( resolve => setTimeout( resolve, ms ) );
 	}
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Tests (engine): Delay selections in `should not enter infinite loop` test due to changes in Chrome 129.

---

### Additional information

It looks like the newest Chrome version debounces `selectionchange` events, and I made a small delay to prevent this. In other words - firing multiple selection updates in small period of the time results in one `selectionchange` event instead of few. 

Fixes:
![obraz](https://github.com/user-attachments/assets/b7d4ee6c-b497-435f-b327-4339ca55313f)

After bumping Chrome from `128` to `129` in test suite. 
edit: More likely Karma <--> Chrome driver issue, works fine in real browser. 
