### PR TITLE
Dev tools guide updates

### DIFF
--- a/docs/framework/contributing/git-commit-message-convention.md
+++ b/docs/framework/contributing/git-commit-message-convention.md
@@ -101,7 +101,7 @@ All entries must be separated with a blank line, otherwise the lines will not be
 
 The changelog generator understands squash commits created by GitHub when merging a pull request.
 
-When using the _"Squash and merge"_ option, ensure the default commit title is not modified. It should contain the pull request title and its number, e.g., `Example pull request (#000)`. The changelog entries should be added as a commit description. They must follow the same rules as merge commits.
+When using the _"Squash and merge"_ option, ensure the default commit title is not modified. It should contain the pull request title and its number, for example: `Sample pull request (#000)`. The changelog entries should be added as a commit description. They must follow the same rules as merge commits.
 
 ### Examples of correct and incorrect message formatting
 

--- a/docs/framework/contributing/git-commit-message-convention.md
+++ b/docs/framework/contributing/git-commit-message-convention.md
@@ -97,6 +97,12 @@ The proper order of sections for a commit message is as follows:
 
 All entries must be separated with a blank line, otherwise the lines will not be treated as separate entries.
 
+### Squash commits
+
+The changelog generator understands squash commits created by GitHub when merging a pull request.
+
+When using the _"Squash and merge"_ option, ensure the default commit title is not modified. It should contain the pull request title and its number, e.g., `Example pull request (#000)`. The changelog entries should be added as a commit description. They must follow the same rules as merge commits.
+
 ### Examples of correct and incorrect message formatting
 
 An example of a proper commit message:

--- a/docs/framework/contributing/testing-environment.md
+++ b/docs/framework/contributing/testing-environment.md
@@ -31,7 +31,6 @@ It accepts the following arguments that must be passed after the `--` option:
 * `--verbose` (alias `-v`) &ndash; Allows switching on webpack logs.
 * `--files` &ndash; Specifies test files to run. See the [Rules for using the `--files` option](#rules-for-using-the-files-option) section.
 * `--browsers` &ndash; Browsers that will be used to run the tests. Defaults to `Chrome`.
-* `--debug` (alias `-d`) &ndash; Allows specifying custom debug flags. For example, the `--debug engine` option uncomments the `// @if CK_DEBUG_ENGINE //` lines in the code. By default `--debug` is set to `true` even if you did not specify it. This enables the base set of debug logs (`// @if CK_DEBUG //`) which should always be enabled in the testing environment. You can completely turn off the debug mode by setting the `--debug false` option.
 * `--port` &ndash; Specifies the port for the server to use. Defaults to `9876`.
 * `--identity-file="/path/to/file.js"` (alias `-i`) &ndash; Path to the file containing the license key(s) for closed–source features.
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Added a "Squash commits" section to the "Git commit message convention" guide.

Internal: Removed the `--debug` modifier from the "Running automated tests" section in the "Testing environment" guide as it is not supported after switching sources to TypeScript.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
