### PR TITLE
Export `AttributeCommand` class from basic styles package

### DIFF
--- a/packages/ckeditor5-basic-styles/src/index.ts
+++ b/packages/ckeditor5-basic-styles/src/index.ts
@@ -28,6 +28,6 @@ export { default as SuperscriptUI } from './superscript/superscriptui.js';
 export { default as Underline } from './underline.js';
 export { default as UnderlineEditing } from './underline/underlineediting.js';
 export { default as UnderlineUI } from './underline/underlineui.js';
-export type { default as AttributeCommand } from './attributecommand.js';
+export { default as AttributeCommand } from './attributecommand.js';
 
 import './augmentation.js';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (basic-styles): Export `AttributeCommand` class. Closes https://github.com/ckeditor/ckeditor5/issues/17105
