### PR TITLE
Add missing `editor.destroy` calls to tests

### DIFF
--- a/packages/ckeditor5-alignment/tests/alignmentcommand.js
+++ b/packages/ckeditor5-alignment/tests/alignmentcommand.js
@@ -28,8 +28,8 @@ describe( 'AlignmentCommand', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'is a command', () => {

--- a/packages/ckeditor5-alignment/tests/alignmentediting.js
+++ b/packages/ckeditor5-alignment/tests/alignmentediting.js
@@ -25,8 +25,8 @@ describe( 'AlignmentEditing', () => {
 		model = editor.model;
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'should have pluginName', () => {
@@ -55,6 +55,10 @@ describe( 'AlignmentEditing', () => {
 				} );
 
 			model = editor.model;
+		} );
+
+		afterEach( async () => {
+			await editor.destroy();
 		} );
 
 		it( 'is allowed on paragraph', () => {

--- a/packages/ckeditor5-autoformat/tests/autoformat.js
+++ b/packages/ckeditor5-autoformat/tests/autoformat.js
@@ -1182,6 +1182,10 @@ describe( 'Autoformat', () => {
 					} );
 			} );
 
+			afterEach( async () => {
+				await editor.destroy();
+			} );
+
 			it( 'should not replace asterisk with bulleted list item', () => {
 				setData( model, '<paragraph>*[]</paragraph>' );
 				insertSpace();
@@ -1308,6 +1312,8 @@ describe( 'Autoformat', () => {
 						insertSpace();
 
 						expect( getData( model ) ).to.equal( '<paragraph>## []</paragraph>' );
+
+						return editor.destroy();
 					} );
 			} );
 		} );
@@ -2401,6 +2407,10 @@ describe( 'Autoformat', () => {
 					} );
 			} );
 
+			afterEach( async () => {
+				await editor.destroy();
+			} );
+
 			it( 'should not replace asterisk with bulleted list item', () => {
 				setData( model, '<paragraph>*[]</paragraph>' );
 				insertSpace();
@@ -2528,6 +2538,8 @@ describe( 'Autoformat', () => {
 						insertSpace();
 
 						expect( getData( model ) ).to.equal( '<paragraph>## []</paragraph>' );
+
+						return editor.destroy();
 					} );
 			} );
 		} );

--- a/packages/ckeditor5-autoformat/tests/blockautoformatediting.js
+++ b/packages/ckeditor5-autoformat/tests/blockautoformatediting.js
@@ -30,6 +30,10 @@ describe( 'blockAutoformatEditing', () => {
 			} );
 	} );
 
+	afterEach( async () => {
+		await editor.destroy();
+	} );
+
 	describe( 'command name', () => {
 		it( 'should run a command when the pattern is matched', () => {
 			const spy = testUtils.sinon.spy();

--- a/packages/ckeditor5-autoformat/tests/inlineautoformatediting.js
+++ b/packages/ckeditor5-autoformat/tests/inlineautoformatediting.js
@@ -33,6 +33,10 @@ describe( 'inlineAutoformatEditing', () => {
 			} );
 	} );
 
+	afterEach( async () => {
+		await editor.destroy();
+	} );
+
 	describe( 'regExp', () => {
 		it( 'should not call the formatCallback if there are less than 3 capture groups', () => {
 			inlineAutoformatEditing( editor, plugin, /(\*)(.+?)\*/g, formatSpy );

--- a/packages/ckeditor5-block-quote/tests/blockquotecommand.js
+++ b/packages/ckeditor5-block-quote/tests/blockquotecommand.js
@@ -44,8 +44,8 @@ describe( 'BlockQuoteCommand', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'is a command', () => {

--- a/packages/ckeditor5-block-quote/tests/blockquoteediting.js
+++ b/packages/ckeditor5-block-quote/tests/blockquoteediting.js
@@ -88,6 +88,8 @@ describe( 'BlockQuoteEditing', () => {
 				editor.setData( '<blockquote><ul><li>xx</li></ul></blockquote>' );
 
 				expect( editor.getData() ).to.equal( '<blockquote><ul><li>xx</li></ul></blockquote>' );
+
+				return editor.destroy();
 			} );
 	} );
 

--- a/packages/ckeditor5-ckbox/tests/ckboxediting.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxediting.js
@@ -1870,6 +1870,8 @@ describe( 'CKBoxEditing', () => {
 
 			expect( uploadImageCommand.isEnabled ).to.be.true;
 			expect( uploadImageCommand.isAccessAllowed ).to.be.true;
+
+			await editor.destroy();
 		} );
 
 		it( 'should disable image upload command if access not allowed', async () => {
@@ -1894,6 +1896,8 @@ describe( 'CKBoxEditing', () => {
 
 			expect( uploadImageCommand.isEnabled ).to.be.false;
 			expect( uploadImageCommand.isAccessAllowed ).to.be.false;
+
+			await editor.destroy();
 		} );
 
 		it( 'should not disable image upload command if access allowed ( CKBox loaded first )', async () => {
@@ -1918,6 +1922,8 @@ describe( 'CKBoxEditing', () => {
 
 			expect( uploadImageCommand.isEnabled ).to.be.true;
 			expect( uploadImageCommand.isAccessAllowed ).to.be.true;
+
+			await editor.destroy();
 		} );
 
 		it( 'should disable image upload command if access not allowed ( CKBox loaded first )', async () => {
@@ -1942,6 +1948,8 @@ describe( 'CKBoxEditing', () => {
 
 			expect( uploadImageCommand.isEnabled ).to.be.false;
 			expect( uploadImageCommand.isAccessAllowed ).to.be.false;
+
+			await editor.destroy();
 		} );
 	} );
 } );

--- a/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
@@ -45,6 +45,10 @@ describe( 'ClipboardPipeline feature', () => {
 			} );
 	} );
 
+	afterEach( async () => {
+		await editor.destroy();
+	} );
+
 	describe( 'constructor()', () => {
 		it( 'registers ClipboardObserver', () => {
 			expect( view.getObserver( ClipboardObserver ) ).to.be.instanceOf( ClipboardObserver );

--- a/packages/ckeditor5-clipboard/tests/pasteplaintext.js
+++ b/packages/ckeditor5-clipboard/tests/pasteplaintext.js
@@ -50,6 +50,10 @@ describe( 'PastePlainText', () => {
 			} );
 	} );
 
+	afterEach( async () => {
+		await editor.destroy();
+	} );
+
 	it( 'should inherit selection attributes (collapsed selection)', () => {
 		let insertedNode;
 

--- a/packages/ckeditor5-core/tests/_utils-tests/classictesteditor.js
+++ b/packages/ckeditor5-core/tests/_utils-tests/classictesteditor.js
@@ -38,7 +38,7 @@ describe( 'ClassicTestEditor', () => {
 	} );
 
 	describe( 'constructor()', () => {
-		it( 'creates an instance of editor', () => {
+		it( 'creates an instance of editor', async () => {
 			const editor = new ClassicTestEditor( editorElement, { foo: 1 } );
 
 			expect( editor ).to.be.instanceof( Editor );
@@ -47,28 +47,40 @@ describe( 'ClassicTestEditor', () => {
 			expect( editor.ui ).to.be.instanceOf( EditorUI );
 			expect( editor.ui.view ).to.be.instanceOf( BoxedEditorUIView );
 			expect( editor.data.processor ).to.be.instanceof( HtmlDataProcessor );
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
-		it( 'creates the instance of the editable (without rendering)', () => {
+		it( 'creates the instance of the editable (without rendering)', async () => {
 			const editor = new ClassicTestEditor( editorElement );
 
 			expect( editor.ui.view.editable ).to.be.instanceOf( InlineEditableUIView );
 			expect( editor.ui.view.editable.isRendered ).to.be.false;
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
-		it( 'creates the #ui and ui#view (without rendering)', () => {
+		it( 'creates the #ui and ui#view (without rendering)', async () => {
 			const editor = new ClassicTestEditor( editorElement );
 
 			expect( editor.ui ).to.be.instanceOf( EditorUI );
 			expect( editor.ui.view ).to.be.instanceOf( BoxedEditorUIView );
 			expect( editor.ui.view.isRendered ).to.be.false;
 			expect( editor.ui.getEditableElement() ).to.be.undefined;
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
-		it( 'creates main root element', () => {
+		it( 'creates main root element', async () => {
 			const editor = new ClassicTestEditor( editorElement );
 
 			expect( editor.model.document.getRoot( 'main' ) ).to.instanceof( RootElement );
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
 		it( 'mixes ElementApiMixin', () => {
@@ -152,15 +164,18 @@ describe( 'ClassicTestEditor', () => {
 		} );
 
 		it( 'sets proper states', () => {
-			const editor = new ClassicTestEditor();
+			const baseEditor = new ClassicTestEditor();
 
-			expect( editor.state ).to.equal( 'initializing' );
+			expect( baseEditor.state ).to.equal( 'initializing' );
 
 			return ClassicTestEditor.create( editorElement ).then( editor => {
 				expect( editor.state ).to.equal( 'ready' );
 
 				return editor.destroy().then( () => {
 					expect( editor.state ).to.equal( 'destroyed' );
+
+					baseEditor.fire( 'ready' );
+					return baseEditor.destroy();
 				} );
 			} );
 		} );

--- a/packages/ckeditor5-core/tests/_utils-tests/modeltesteditor.js
+++ b/packages/ckeditor5-core/tests/_utils-tests/modeltesteditor.js
@@ -18,12 +18,15 @@ describe( 'ModelTestEditor', () => {
 	testUtils.createSinonSandbox();
 
 	describe( 'constructor()', () => {
-		it( 'creates an instance of editor', () => {
+		it( 'creates an instance of editor', async () => {
 			const editor = new ModelTestEditor( { foo: 1 } );
 
 			expect( editor ).to.be.instanceof( Editor );
 			expect( editor.config.get( 'foo' ) ).to.equal( 1 );
 			expect( editor.data.processor ).to.be.instanceof( HtmlDataProcessor );
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
 		it( 'should disable editing pipeline', () => {
@@ -38,10 +41,13 @@ describe( 'ModelTestEditor', () => {
 			} );
 		} );
 
-		it( 'creates main root element', () => {
+		it( 'creates main root element', async () => {
 			const editor = new ModelTestEditor();
 
 			expect( editor.model.document.getRoot( 'main' ) ).to.instanceof( RootElement );
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 	} );
 
@@ -55,6 +61,10 @@ describe( 'ModelTestEditor', () => {
 
 					editor.model.schema.extend( '$text', { allowIn: '$root' } );
 				} );
+		} );
+
+		afterEach( async () => {
+			await editor.destroy();
 		} );
 
 		it( 'should set data of the first root', () => {
@@ -76,6 +86,10 @@ describe( 'ModelTestEditor', () => {
 
 					editor.model.schema.extend( '$text', { allowIn: '$root' } );
 				} );
+		} );
+
+		afterEach( async () => {
+			await editor.destroy();
 		} );
 
 		it( 'should set data of the first root', () => {

--- a/packages/ckeditor5-core/tests/_utils-tests/virtualtesteditor.js
+++ b/packages/ckeditor5-core/tests/_utils-tests/virtualtesteditor.js
@@ -16,18 +16,24 @@ describe( 'VirtualTestEditor', () => {
 	testUtils.createSinonSandbox();
 
 	describe( 'constructor()', () => {
-		it( 'creates an instance of editor', () => {
+		it( 'creates an instance of editor', async () => {
 			const editor = new VirtualTestEditor( { foo: 1 } );
 
 			expect( editor ).to.be.instanceof( Editor );
 			expect( editor.data.processor ).to.be.instanceof( HtmlDataProcessor );
 			expect( editor.config.get( 'foo' ) ).to.equal( 1 );
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
-		it( 'creates main root element', () => {
+		it( 'creates main root element', async () => {
 			const editor = new VirtualTestEditor();
 
 			expect( editor.model.document.getRoot( 'main' ) ).to.instanceof( RootElement );
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 	} );
 

--- a/packages/ckeditor5-core/tests/_utils/memory.js
+++ b/packages/ckeditor5-core/tests/_utils/memory.js
@@ -6,8 +6,8 @@
 /* global window, document, setTimeout */
 
 const TEST_RETRIES = 2;
-const TEST_TIMEOUT = 5000;
-const GARBAGE_COLLECTOR_TIMEOUT = 500;
+const TEST_TIMEOUT = 6500;
+const GARBAGE_COLLECTOR_TIMEOUT = 800;
 
 /**
  * Memory tests suite definition that:
@@ -83,10 +83,15 @@ function runTest( createEditor ) {
 		} )
 		// Run create&destroy multiple times. Helps scaling up the issue.
 		.then( createAndDestroy ) // #1
+		.then( () => timeout( 300 ) )
 		.then( createAndDestroy ) // #2
+		.then( () => timeout( 300 ) )
 		.then( createAndDestroy ) // #3
+		.then( () => timeout( 300 ) )
 		.then( createAndDestroy ) // #4
+		.then( () => timeout( 300 ) )
 		.then( createAndDestroy ) // #5
+		.then( () => timeout( 300 ) )
 		.then( collectMemoryStats )
 		.then( memory => {
 			const memoryDifference = memory.usedJSHeapSize - memoryAfterFirstStart.usedJSHeapSize;
@@ -163,4 +168,8 @@ function isWindows() {
 	const userAgent = window.navigator.userAgent.toLowerCase();
 
 	return userAgent.indexOf( 'windows' ) > -1;
+}
+
+function timeout( ms ) {
+	return new Promise( resolve => setTimeout( resolve, ms ) );
 }

--- a/packages/ckeditor5-core/tests/accessibility.js
+++ b/packages/ckeditor5-core/tests/accessibility.js
@@ -16,6 +16,10 @@ describe( 'Accessibility', () => {
 	} );
 
 	afterEach( async () => {
+		if ( editor.state === 'initializing' ) {
+			editor.fire( 'ready' );
+		}
+
 		await editor.destroy();
 	} );
 

--- a/packages/ckeditor5-core/tests/accessibility.js
+++ b/packages/ckeditor5-core/tests/accessibility.js
@@ -16,7 +16,7 @@ describe( 'Accessibility', () => {
 	} );
 
 	afterEach( async () => {
-		editor.destroy();
+		await editor.destroy();
 	} );
 
 	it( 'should provide default categories, groups, and keystrokes', () => {
@@ -95,7 +95,7 @@ describe( 'Accessibility', () => {
 		] );
 	} );
 
-	it( 'should add info specific to the menu bar when available', () => {
+	it( 'should add info specific to the menu bar when available', async () => {
 		const editor = new Editor( {
 			menuBar: {
 				isVisible: true
@@ -111,7 +111,8 @@ describe( 'Accessibility', () => {
 			mayRequireFn: true
 		} );
 
-		editor.destroy();
+		editor.fire( 'ready' );
+		await editor.destroy();
 	} );
 
 	describe( 'addKeystrokeInfoCategory()', () => {

--- a/packages/ckeditor5-core/tests/editor/editor.js
+++ b/packages/ckeditor5-core/tests/editor/editor.js
@@ -473,7 +473,7 @@ describe( 'Editor', () => {
 			}, /editor-isreadonly-has-no-setter/ );
 		} );
 
-		it( 'should be set to true when at least one lock is set', () => {
+		it( 'should be set to true when at least one lock is set', async () => {
 			const editor = new TestEditor();
 
 			editor.enableReadOnlyMode( 'lock-1' );
@@ -486,9 +486,12 @@ describe( 'Editor', () => {
 			editor.disableReadOnlyMode( 'lock-2' );
 
 			expect( editor.isReadOnly ).to.be.false;
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
-		it( 'should allow using symbols as lock IDs', () => {
+		it( 'should allow using symbols as lock IDs', async () => {
 			const editor = new TestEditor();
 
 			const s1 = Symbol( 'lock' );
@@ -504,11 +507,14 @@ describe( 'Editor', () => {
 			editor.disableReadOnlyMode( s2 );
 
 			expect( editor.isReadOnly ).to.be.false;
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
 		// The `change:isReadOnly` event is fired manually and this test ensures
 		// the behavior is the same as when the `isReadOnly` would be a normal observable prop.
-		it( 'should be observable', () => {
+		it( 'should be observable', async () => {
 			const editor = new TestEditor();
 			const spy = sinon.spy();
 
@@ -533,6 +539,9 @@ describe( 'Editor', () => {
 				false,
 				true
 			] );
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
 		// The `change:isReadOnly` event is fired manually and this test ensures
@@ -555,9 +564,12 @@ describe( 'Editor', () => {
 			editor.disableReadOnlyMode( 'unit-test' );
 
 			expect( customPlugin.isEditorReadOnly ).to.equal( false );
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
-		it( 'setting read-only lock twice should not throw an error for the same lock ID', () => {
+		it( 'setting read-only lock twice should not throw an error for the same lock ID', async () => {
 			const editor = new TestEditor();
 
 			editor.enableReadOnlyMode( 'lock' );
@@ -568,9 +580,12 @@ describe( 'Editor', () => {
 			editor.disableReadOnlyMode( 'lock' );
 
 			expect( editor.isReadOnly ).to.be.false;
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
-		it( 'clearing read-only lock should not throw an error if the lock ID is not present', () => {
+		it( 'clearing read-only lock should not throw an error if the lock ID is not present', async () => {
 			const editor = new TestEditor();
 
 			editor.disableReadOnlyMode( 'lock' );
@@ -585,9 +600,12 @@ describe( 'Editor', () => {
 			editor.disableReadOnlyMode( 'lock' );
 
 			expect( editor.isReadOnly ).to.be.false;
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
-		it( 'setting read-only lock should throw an error when the lock ID is not a string', () => {
+		it( 'setting read-only lock should throw an error when the lock ID is not a string', async () => {
 			const editor = new TestEditor();
 
 			expectToThrowCKEditorError( () => {
@@ -597,9 +615,12 @@ describe( 'Editor', () => {
 			expectToThrowCKEditorError( () => {
 				editor.enableReadOnlyMode( 123 );
 			}, /editor-read-only-lock-id-invalid/, null, { lockId: 123 } );
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
-		it( 'clearing read-only lock should throw an error when the lock ID is not a string', () => {
+		it( 'clearing read-only lock should throw an error when the lock ID is not a string', async () => {
 			const editor = new TestEditor();
 
 			expectToThrowCKEditorError( () => {
@@ -609,17 +630,23 @@ describe( 'Editor', () => {
 			expectToThrowCKEditorError( () => {
 				editor.disableReadOnlyMode( 123 );
 			}, /editor-read-only-lock-id-invalid/, null, { lockId: 123 } );
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 	} );
 
 	describe( 'conversion', () => {
-		it( 'should have conversion property', () => {
+		it( 'should have conversion property', async () => {
 			const editor = new TestEditor();
 
 			expect( editor ).to.have.property( 'conversion' );
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
-		it( 'should have defined default conversion groups', () => {
+		it( 'should have defined default conversion groups', async () => {
 			const editor = new TestEditor();
 
 			expect( () => {
@@ -629,6 +656,9 @@ describe( 'Editor', () => {
 				editor.conversion.for( 'dataDowncast' );
 				editor.conversion.for( 'upcast' );
 			} ).not.to.throw();
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 	} );
 
@@ -686,7 +716,7 @@ describe( 'Editor', () => {
 	} );
 
 	describe( 'execute()', () => {
-		it( 'should execute specified command', () => {
+		it( 'should execute specified command', async () => {
 			class SomeCommand extends Command {
 				execute() {}
 			}
@@ -700,9 +730,12 @@ describe( 'Editor', () => {
 			editor.execute( 'someCommand' );
 
 			expect( command.execute.calledOnce ).to.be.true;
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
-		it( 'should return the result of command\'s execute()', () => {
+		it( 'should return the result of command\'s execute()', async () => {
 			class SomeCommand extends Command {
 				execute() {}
 			}
@@ -719,14 +752,20 @@ describe( 'Editor', () => {
 
 			expect( editorResult, 'editor.execute()' ).to.equal( commandResult );
 			expect( editorResult, 'editor.execute()' ).to.deep.equal( { foo: 'bar' } );
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
-		it( 'should throw an error if specified command has not been added', () => {
+		it( 'should throw an error if specified command has not been added', async () => {
 			const editor = new TestEditor();
 
 			expectToThrowCKEditorError( () => {
 				editor.execute( 'command' );
 			}, /^commandcollection-command-not-found/, editor );
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 
 		it.skip( 'should rethrow native errors as they are in the debug=true mode', () => {
@@ -750,7 +789,7 @@ describe( 'Editor', () => {
 			} ).to.throw( TypeError, /foo/ );
 		} );
 
-		it( 'should rethrow custom CKEditorError errors', () => {
+		it( 'should rethrow custom CKEditorError errors', async () => {
 			const editor = new TestEditor();
 
 			class SomeCommand extends Command {
@@ -770,11 +809,14 @@ describe( 'Editor', () => {
 			expectToThrowCKEditorError( () => {
 				editor.execute( 'someCommand' );
 			}, /foo/, editor );
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 	} );
 
 	describe( 'focus()', () => {
-		it( 'should call view\'s focus() method', () => {
+		it( 'should call view\'s focus() method', async () => {
 			const editor = new TestEditor();
 			const focusSpy = sinon.spy( editor.editing.view, 'focus' );
 
@@ -782,16 +824,19 @@ describe( 'Editor', () => {
 			editor.focus();
 
 			expect( focusSpy.calledOnce ).to.be.true;
+
+			editor.fire( 'ready' );
+			await editor.destroy();
 		} );
 	} );
 
 	describe( 'create()', () => {
-		it( 'should return a promise that resolves properly', () => {
+		it( 'should return a promise that resolves properly', async () => {
 			const promise = TestEditor.create();
 
 			expect( promise ).to.be.an.instanceof( Promise );
 
-			return promise;
+			await promise.then( editor => editor.destroy() );
 		} );
 
 		it( 'loads plugins', () => {
@@ -800,6 +845,8 @@ describe( 'Editor', () => {
 					expect( getPlugins( editor ).length ).to.equal( 1 );
 
 					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+
+					return editor.destroy();
 				} );
 		} );
 
@@ -817,8 +864,10 @@ describe( 'Editor', () => {
 			}
 
 			return TestEditor.create( { plugins: [ EventWatcher ] } )
-				.then( () => {
+				.then( editor => {
 					expect( fired ).to.deep.equal( [ 'ready' ] );
+
+					return editor.destroy();
 				} );
 		} );
 	} );
@@ -836,6 +885,9 @@ describe( 'Editor', () => {
 
 				expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
 				expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
+
+				editor.fire( 'ready' );
+				return editor.destroy();
 			} );
 		} );
 
@@ -856,6 +908,9 @@ describe( 'Editor', () => {
 						editor.plugins.get( PluginC ).afterInit,
 						editor.plugins.get( PluginD ).afterInit
 					);
+
+					editor.fire( 'ready' );
+					return editor.destroy();
 				} );
 		} );
 
@@ -902,6 +957,9 @@ describe( 'Editor', () => {
 						asyncSpy,
 						editor.plugins.get( PluginSync ).init
 					);
+
+					editor.fire( 'ready' );
+					return editor.destroy();
 				} );
 		} );
 
@@ -949,6 +1007,9 @@ describe( 'Editor', () => {
 						asyncSpy,
 						editor.plugins.get( PluginSync ).afterInit
 					);
+
+					editor.fire( 'ready' );
+					return editor.destroy();
 				} );
 		} );
 
@@ -964,6 +1025,9 @@ describe( 'Editor', () => {
 					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
 					expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
 					expect( editor.plugins.get( PluginC ) ).to.be.an.instanceof( Plugin );
+
+					editor.fire( 'ready' );
+					return editor.destroy();
 				} );
 		} );
 
@@ -981,6 +1045,9 @@ describe( 'Editor', () => {
 					expect( getPlugins( editor ).length ).to.equal( 1 );
 
 					expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+
+					editor.fire( 'ready' );
+					return editor.destroy();
 				} );
 		} );
 
@@ -1006,6 +1073,9 @@ describe( 'Editor', () => {
 					expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
 					expect( editor.plugins.get( PluginC ) ).to.be.an.instanceof( Plugin );
 					expect( editor.plugins.get( PrivatePlugin ) ).to.be.an.instanceof( PrivatePlugin );
+
+					editor.fire( 'ready' );
+					return editor.destroy();
 				} );
 		} );
 
@@ -1027,6 +1097,9 @@ describe( 'Editor', () => {
 					expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
 					expect( editor.plugins.get( PluginC ) ).to.be.an.instanceof( Plugin );
 					expect( editor.plugins.get( PluginD ) ).to.be.an.instanceof( Plugin );
+
+					editor.fire( 'ready' );
+					return editor.destroy();
 				} );
 		} );
 
@@ -1048,6 +1121,9 @@ describe( 'Editor', () => {
 					expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
 					expect( editor.plugins.get( PluginC ) ).to.be.an.instanceof( Plugin );
 					expect( editor.plugins.get( PluginD ) ).to.be.an.instanceof( Plugin );
+
+					editor.fire( 'ready' );
+					return editor.destroy();
 				} );
 		} );
 
@@ -1062,6 +1138,9 @@ describe( 'Editor', () => {
 					.then( () => {
 						expect( getPlugins( editor ).length ).to.equal( 1 );
 						expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+
+						editor.fire( 'ready' );
+						return editor.destroy();
 					} );
 			} );
 
@@ -1076,6 +1155,9 @@ describe( 'Editor', () => {
 					.then( () => {
 						expect( getPlugins( editor ).length ).to.equal( 1 );
 						expect( editor.plugins.get( PluginA ) ).to.be.an.instanceof( Plugin );
+
+						editor.fire( 'ready' );
+						return editor.destroy();
 					} );
 			} );
 
@@ -1092,6 +1174,9 @@ describe( 'Editor', () => {
 					.then( () => {
 						expect( getPlugins( editor ).length ).to.equal( 1 );
 						expect( editor.plugins.get( PluginA ) ).to.not.be.undefined;
+
+						editor.fire( 'ready' );
+						return editor.destroy();
 					} );
 			} );
 		} );
@@ -1107,6 +1192,9 @@ describe( 'Editor', () => {
 					.then( () => {
 						expect( getPlugins( editor ).length ).to.equal( 3 );
 						expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
+
+						editor.fire( 'ready' );
+						return editor.destroy();
 					} );
 			} );
 
@@ -1120,6 +1208,9 @@ describe( 'Editor', () => {
 					.then( () => {
 						expect( getPlugins( editor ).length ).to.equal( 2 );
 						expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
+
+						editor.fire( 'ready' );
+						return editor.destroy();
 					} );
 			} );
 
@@ -1134,6 +1225,9 @@ describe( 'Editor', () => {
 					.then( () => {
 						expect( getPlugins( editor ).length ).to.equal( 2 );
 						expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
+
+						editor.fire( 'ready' );
+						return editor.destroy();
 					} );
 			} );
 
@@ -1150,6 +1244,9 @@ describe( 'Editor', () => {
 					.then( () => {
 						expect( getPlugins( editor ).length ).to.equal( 2 );
 						expect( editor.plugins.get( PluginB ) ).to.be.an.instanceof( Plugin );
+
+						editor.fire( 'ready' );
+						return editor.destroy();
 					} );
 			} );
 		} );
@@ -1186,6 +1283,9 @@ describe( 'Editor', () => {
 						expect( getPlugins( editor ).length ).to.equal( 1 );
 						expect( editor.plugins.get( 'FooPlugin' ) ).to.be.an.instanceof( Plugin );
 						expect( editor.plugins.get( 'FooPlugin' ) ).to.be.an.instanceof( NoErrorPlugin );
+
+						editor.fire( 'ready' );
+						return editor.destroy();
 					} );
 			} );
 
@@ -1220,6 +1320,9 @@ describe( 'Editor', () => {
 						expect( getPlugins( editor ).length ).to.equal( 1 );
 						expect( editor.plugins.get( 'FooPlugin' ) ).to.be.an.instanceof( Plugin );
 						expect( editor.plugins.get( 'FooPlugin' ) ).to.be.an.instanceof( NoErrorPlugin );
+
+						editor.fire( 'ready' );
+						return editor.destroy();
 					} );
 			} );
 
@@ -1259,6 +1362,9 @@ describe( 'Editor', () => {
 						expect( editor.plugins.get( 'FooPlugin' ) ).to.be.an.instanceof( NoErrorPlugin );
 
 						Editor.builtinPlugins = originalBuiltinPlugins;
+
+						editor.fire( 'ready' );
+						return editor.destroy();
 					} );
 			} );
 		} );
@@ -1275,6 +1381,9 @@ describe( 'Editor', () => {
 						editor.plugins.get( PluginE ).init,
 						editor.plugins.get( PluginA ).afterInit
 					);
+
+					editor.fire( 'ready' );
+					return editor.destroy();
 				} );
 		} );
 
@@ -1290,6 +1399,9 @@ describe( 'Editor', () => {
 						editor.plugins.get( PluginA ).afterInit,
 						editor.plugins.get( PluginF ).afterInit
 					);
+
+					editor.fire( 'ready' );
+					return editor.destroy();
 				} );
 		} );
 	} );

--- a/packages/ckeditor5-core/tests/editor/utils/attachtoform.js
+++ b/packages/ckeditor5-core/tests/editor/utils/attachtoform.js
@@ -45,12 +45,15 @@ describe( 'attachToForm()', () => {
 		}
 	} );
 
-	it( 'should throw an error when is used with editor without `ElementApiMixin`', () => {
+	it( 'should throw an error when is used with editor without `ElementApiMixin`', async () => {
 		const editor = new Editor();
 
 		expectToThrowCKEditorError( () => {
 			attachToForm( editor );
 		}, /^attachtoform-missing-elementapi-interface/, editor );
+
+		editor.fire( 'ready' );
+		await editor.destroy();
 	} );
 
 	it( 'should update editor#element after the "submit" event', () => {

--- a/packages/ckeditor5-core/tests/editor/utils/dataapimixin.js
+++ b/packages/ckeditor5-core/tests/editor/utils/dataapimixin.js
@@ -7,11 +7,14 @@ import DataApiMixin from '../../../src/editor/utils/dataapimixin.js';
 import Editor from '../../../src/editor/editor.js';
 
 describe( 'DataApiMixin', () => {
-	it( 'it returns the passed parameter for compatibility reasons', () => {
+	it( 'it returns the passed parameter for compatibility reasons', async () => {
 		class CustomEditor extends Editor {}
 
 		const editor = new CustomEditor();
 
 		expect( DataApiMixin( editor ) ).to.equal( editor );
+
+		editor.fire( 'ready' );
+		await editor.destroy();
 	} );
 } );

--- a/packages/ckeditor5-core/tests/plugincollection.js
+++ b/packages/ckeditor5-core/tests/plugincollection.js
@@ -69,7 +69,9 @@ describe( 'PluginCollection', () => {
 		PluginFoo.requires = [];
 	} );
 
-	afterEach( () => {
+	afterEach( async () => {
+		editor.state = 'ready';
+		await editor.destroy();
 		sinon.restore();
 	} );
 

--- a/packages/ckeditor5-editor-balloon/src/ballooneditorui.ts
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditorui.ts
@@ -99,7 +99,10 @@ export default class BalloonEditorUI extends EditorUI {
 		const view = this.view;
 		const editingView = this.editor.editing.view;
 
-		editingView.detachDomRoot( view.editable.name! );
+		if ( editingView.getDomRoot( view.editable.name! ) ) {
+			editingView.detachDomRoot( view.editable.name! );
+		}
+
 		view.destroy();
 	}
 

--- a/packages/ckeditor5-editor-balloon/tests/ballooneditor.js
+++ b/packages/ckeditor5-editor-balloon/tests/ballooneditor.js
@@ -54,6 +54,11 @@ describe( 'BalloonEditor', () => {
 			} );
 		} );
 
+		afterEach( async () => {
+			editor.fire( 'ready' );
+			await editor.destroy();
+		} );
+
 		it( 'pushes BalloonToolbar to the list of plugins', () => {
 			expect( editor.config.get( 'plugins' ) ).to.include( BalloonToolbar );
 		} );
@@ -102,28 +107,37 @@ describe( 'BalloonEditor', () => {
 		} );
 
 		describe( 'config.initialData', () => {
-			it( 'if not set, is set using DOM element data', () => {
+			it( 'if not set, is set using DOM element data', async () => {
 				const editorElement = document.createElement( 'div' );
 				editorElement.innerHTML = '<p>Foo</p>';
 
 				const editor = new BalloonEditor( editorElement );
 
 				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Foo</p>' );
+
+				editor.fire( 'ready' );
+				await editor.destroy();
 			} );
 
-			it( 'if not set, is set using data passed in constructor', () => {
+			it( 'if not set, is set using data passed in constructor', async () => {
 				const editor = new BalloonEditor( '<p>Foo</p>' );
 
 				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Foo</p>' );
+
+				editor.fire( 'ready' );
+				await editor.destroy();
 			} );
 
-			it( 'if set, is not overwritten with DOM element data', () => {
+			it( 'if set, is not overwritten with DOM element data', async () => {
 				const editorElement = document.createElement( 'div' );
 				editorElement.innerHTML = '<p>Foo</p>';
 
 				const editor = new BalloonEditor( editorElement, { initialData: '<p>Bar</p>' } );
 
 				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Bar</p>' );
+
+				editor.fire( 'ready' );
+				await editor.destroy();
 			} );
 
 			it( 'it should throw if config.initialData is set and initial data is passed in constructor', () => {

--- a/packages/ckeditor5-editor-balloon/tests/ballooneditorui.js
+++ b/packages/ckeditor5-editor-balloon/tests/ballooneditorui.js
@@ -39,8 +39,8 @@ describe( 'BalloonEditorUI', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	describe( 'constructor()', () => {

--- a/packages/ckeditor5-editor-classic/src/classiceditorui.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditorui.ts
@@ -137,7 +137,11 @@ export default class ClassicEditorUI extends EditorUI {
 		const editingView = this.editor.editing.view;
 
 		this._elementReplacer.restore();
-		editingView.detachDomRoot( view.editable.name! );
+
+		if ( editingView.getDomRoot( view.editable.name! ) ) {
+			editingView.detachDomRoot( view.editable.name! );
+		}
+
 		view.destroy();
 	}
 

--- a/packages/ckeditor5-editor-classic/tests/classiceditor.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditor.js
@@ -246,7 +246,7 @@ describe( 'ClassicEditor', () => {
 			} ).then( editor => {
 				expect( editor.getData() ).to.equal( '<p>Hello world!</p>' );
 
-				editor.destroy();
+				return editor.destroy();
 			} );
 		} );
 
@@ -257,7 +257,7 @@ describe( 'ClassicEditor', () => {
 			} ).then( editor => {
 				expect( editor.getData() ).to.equal( '<p>Hello world!</p>' );
 
-				editor.destroy();
+				return editor.destroy();
 			} );
 		} );
 
@@ -269,7 +269,7 @@ describe( 'ClassicEditor', () => {
 			} ).then( editor => {
 				expect( editor.getData() ).to.equal( '' );
 
-				editor.destroy();
+				return editor.destroy();
 			} );
 		} );
 

--- a/packages/ckeditor5-editor-classic/tests/classiceditor.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditor.js
@@ -48,6 +48,13 @@ describe( 'ClassicEditor', () => {
 			editor = new ClassicEditor( editorElement );
 		} );
 
+		afterEach( async () => {
+			if ( editor.state !== 'destroyed' ) {
+				editor.fire( 'ready' );
+				await editor.destroy();
+			}
+		} );
+
 		it( 'uses HTMLDataProcessor', () => {
 			expect( editor.data.processor ).to.be.instanceof( HtmlDataProcessor );
 		} );
@@ -102,16 +109,19 @@ describe( 'ClassicEditor', () => {
 			} );
 
 			describe( 'automatic toolbar items groupping', () => {
-				it( 'should be on by default', () => {
+				it( 'should be on by default', async () => {
 					const editorElement = document.createElement( 'div' );
 					const editor = new ClassicEditor( editorElement );
 
 					expect( editor.ui.view.toolbar.options.shouldGroupWhenFull ).to.be.true;
 
+					editor.fire( 'ready' );
+					await editor.destroy();
+
 					editorElement.remove();
 				} );
 
-				it( 'can be disabled using config.toolbar.shouldNotGroupWhenFull', () => {
+				it( 'can be disabled using config.toolbar.shouldNotGroupWhenFull', async () => {
 					const editorElement = document.createElement( 'div' );
 					const editor = new ClassicEditor( editorElement, {
 						toolbar: {
@@ -121,34 +131,48 @@ describe( 'ClassicEditor', () => {
 
 					expect( editor.ui.view.toolbar.options.shouldGroupWhenFull ).to.be.false;
 
+					editor.fire( 'ready' );
+					await editor.destroy();
+
 					editorElement.remove();
 				} );
 			} );
 		} );
 
 		describe( 'config.initialData', () => {
-			it( 'if not set, is set using DOM element data', () => {
+			it( 'if not set, is set using DOM element data', async () => {
 				const editorElement = document.createElement( 'div' );
 				editorElement.innerHTML = '<p>Foo</p>';
 
 				const editor = new ClassicEditor( editorElement );
 
 				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Foo</p>' );
+
+				editor.fire( 'ready' );
+				await editor.destroy();
+
+				editorElement.remove();
 			} );
 
-			it( 'if not set, is set using data passed in constructor', () => {
+			it( 'if not set, is set using data passed in constructor', async () => {
 				const editor = new ClassicEditor( '<p>Foo</p>' );
 
 				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Foo</p>' );
+
+				editor.fire( 'ready' );
+				await editor.destroy();
 			} );
 
-			it( 'if set, is not overwritten with DOM element data', () => {
+			it( 'if set, is not overwritten with DOM element data', async () => {
 				const editorElement = document.createElement( 'div' );
 				editorElement.innerHTML = '<p>Foo</p>';
 
 				const editor = new ClassicEditor( editorElement, { initialData: '<p>Bar</p>' } );
 
 				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Bar</p>' );
+
+				editor.fire( 'ready' );
+				await editor.destroy();
 			} );
 
 			it( 'it should throw if config.initialData is set and initial data is passed in constructor', () => {

--- a/packages/ckeditor5-editor-classic/tests/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditorui.js
@@ -41,8 +41,8 @@ describe( 'ClassicEditorUI', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	describe( 'constructor()', () => {

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitorui.ts
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitorui.ts
@@ -93,7 +93,10 @@ export default class DecoupledEditorUI extends EditorUI {
 		const view = this.view;
 		const editingView = this.editor.editing.view;
 
-		editingView.detachDomRoot( view.editable.name! );
+		if ( editingView.getDomRoot( view.editable.name! ) ) {
+			editingView.detachDomRoot( view.editable.name! );
+		}
+
 		view.destroy();
 	}
 

--- a/packages/ckeditor5-editor-decoupled/tests/decouplededitor.js
+++ b/packages/ckeditor5-editor-decoupled/tests/decouplededitor.js
@@ -312,7 +312,7 @@ describe( 'DecoupledEditor', () => {
 			} ).then( editor => {
 				expect( editor.getData() ).to.equal( '<p>Hello world!</p>' );
 
-				editor.destroy();
+				return editor.destroy();
 			} );
 		} );
 
@@ -324,7 +324,7 @@ describe( 'DecoupledEditor', () => {
 			} ).then( editor => {
 				expect( editor.getData() ).to.equal( '' );
 
-				editor.destroy();
+				return editor.destroy();
 			} );
 		} );
 

--- a/packages/ckeditor5-editor-decoupled/tests/decouplededitor.js
+++ b/packages/ckeditor5-editor-decoupled/tests/decouplededitor.js
@@ -42,6 +42,11 @@ describe( 'DecoupledEditor', () => {
 			editor = new DecoupledEditor();
 		} );
 
+		afterEach( async () => {
+			editor.fire( 'ready' );
+			await editor.destroy();
+		} );
+
 		it( 'uses HTMLDataProcessor', () => {
 			expect( editor.data.processor ).to.be.instanceof( HtmlDataProcessor );
 		} );
@@ -66,16 +71,19 @@ describe( 'DecoupledEditor', () => {
 			} );
 
 			describe( 'automatic toolbar items groupping', () => {
-				it( 'should be on by default', () => {
+				it( 'should be on by default', async () => {
 					const editorElement = document.createElement( 'div' );
 					const editor = new DecoupledEditor( editorElement );
 
 					expect( editor.ui.view.toolbar.options.shouldGroupWhenFull ).to.be.true;
 
 					editorElement.remove();
+
+					editor.fire( 'ready' );
+					await editor.destroy();
 				} );
 
-				it( 'can be disabled using config.toolbar.shouldNotGroupWhenFull', () => {
+				it( 'can be disabled using config.toolbar.shouldNotGroupWhenFull', async () => {
 					const editorElement = document.createElement( 'div' );
 					const editor = new DecoupledEditor( editorElement, {
 						toolbar: {
@@ -86,6 +94,9 @@ describe( 'DecoupledEditor', () => {
 					expect( editor.ui.view.toolbar.options.shouldGroupWhenFull ).to.be.false;
 
 					editorElement.remove();
+
+					editor.fire( 'ready' );
+					await editor.destroy();
 				} );
 			} );
 
@@ -201,28 +212,37 @@ describe( 'DecoupledEditor', () => {
 		} );
 
 		describe( 'config.initialData', () => {
-			it( 'if not set, is set using DOM element data', () => {
+			it( 'if not set, is set using DOM element data', async () => {
 				const editorElement = document.createElement( 'div' );
 				editorElement.innerHTML = '<p>Foo</p>';
 
 				const editor = new DecoupledEditor( editorElement );
 
 				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Foo</p>' );
+
+				editor.fire( 'ready' );
+				await editor.destroy();
 			} );
 
-			it( 'if not set, is set using data passed in constructor', () => {
+			it( 'if not set, is set using data passed in constructor', async () => {
 				const editor = new DecoupledEditor( '<p>Foo</p>' );
 
 				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Foo</p>' );
+
+				editor.fire( 'ready' );
+				await editor.destroy();
 			} );
 
-			it( 'if set, is not overwritten with DOM element data', () => {
+			it( 'if set, is not overwritten with DOM element data', async () => {
 				const editorElement = document.createElement( 'div' );
 				editorElement.innerHTML = '<p>Foo</p>';
 
 				const editor = new DecoupledEditor( editorElement, { initialData: '<p>Bar</p>' } );
 
 				expect( editor.config.get( 'initialData' ) ).to.equal( '<p>Bar</p>' );
+
+				editor.fire( 'ready' );
+				await editor.destroy();
 			} );
 
 			it( 'it should throw if config.initialData is set and initial data is passed in constructor', () => {

--- a/packages/ckeditor5-editor-decoupled/tests/decouplededitorui.js
+++ b/packages/ckeditor5-editor-decoupled/tests/decouplededitorui.js
@@ -40,8 +40,8 @@ describe( 'DecoupledEditorUI', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	describe( 'constructor()', () => {

--- a/packages/ckeditor5-editor-inline/tests/inlineeditor.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditor.js
@@ -193,7 +193,7 @@ describe( 'InlineEditor', () => {
 			} ).then( editor => {
 				expect( editor.getData() ).to.equal( '<p>Hello world!</p>' );
 
-				editor.destroy();
+				return editor.destroy();
 			} );
 		} );
 

--- a/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
@@ -40,8 +40,8 @@ describe( 'InlineEditorUI', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	describe( 'constructor()', () => {

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditor.js
@@ -174,7 +174,7 @@ describe( 'MultiRootEditor', () => {
 				expect( editor.getData( { rootName: 'foo' } ) ).to.equal( editorData.foo );
 				expect( editor.getData( { rootName: 'bar' } ) ).to.equal( editorData.bar );
 
-				editor.destroy();
+				return editor.destroy();
 			} );
 		} );
 
@@ -189,15 +189,12 @@ describe( 'MultiRootEditor', () => {
 				expect( editor.getData( { rootName: 'foo' } ) ).to.equal( '' );
 				expect( editor.getData( { rootName: 'bar' } ) ).to.equal( '' );
 
-				editor.destroy();
+				return editor.destroy();
 			} );
 		} );
 
 		it( 'initializes the editor if no roots are specified', done => {
-			MultiRootEditor.create( {} ).then( editor => {
-				editor.destroy();
-				done();
-			} );
+			MultiRootEditor.create( {} ).then( editor => editor.destroy() ).then( done );
 		} );
 
 		it( 'should throw when trying to create the editor using the same source element more than once', done => {

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditorui.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditorui.js
@@ -31,8 +31,8 @@ describe( 'MultiRootEditorUI', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	describe( 'constructor()', () => {

--- a/packages/ckeditor5-essentials/tests/essentials.js
+++ b/packages/ckeditor5-essentials/tests/essentials.js
@@ -29,8 +29,8 @@ describe( 'Essentials preset', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 
 		editorElement.remove();
 	} );

--- a/packages/ckeditor5-font/tests/fontbackgroundcolor/fontbackgroundcolorcommand.js
+++ b/packages/ckeditor5-font/tests/fontbackgroundcolor/fontbackgroundcolorcommand.js
@@ -19,8 +19,8 @@ describe( 'FontBackgroundColorCommand', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'is a FontCommand', () => {

--- a/packages/ckeditor5-font/tests/fontbackgroundcolor/fontbackgroundcoloreditng.js
+++ b/packages/ckeditor5-font/tests/fontbackgroundcolor/fontbackgroundcoloreditng.js
@@ -25,8 +25,8 @@ describe( 'FontBackgroundColorEditing', () => {
 		} )
 	);
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'should have pluginName', () => {

--- a/packages/ckeditor5-font/tests/fontcolor/fontcolorcommand.js
+++ b/packages/ckeditor5-font/tests/fontcolor/fontcolorcommand.js
@@ -19,8 +19,8 @@ describe( 'FontColorCommand', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'is a FontCommand', () => {

--- a/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
+++ b/packages/ckeditor5-font/tests/fontcolor/fontcolorediting.js
@@ -25,8 +25,8 @@ describe( 'FontColorEditing', () => {
 		} )
 	);
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'should have pluginName', () => {

--- a/packages/ckeditor5-font/tests/fontcommand.js
+++ b/packages/ckeditor5-font/tests/fontcommand.js
@@ -33,8 +33,8 @@ describe( 'FontCommand', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'is a command', () => {

--- a/packages/ckeditor5-font/tests/fontfamily/fontfamilycommand.js
+++ b/packages/ckeditor5-font/tests/fontfamily/fontfamilycommand.js
@@ -20,8 +20,8 @@ describe( 'FontFamilyCommand', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'is a FontCommand', () => {

--- a/packages/ckeditor5-font/tests/fontfamily/fontfamilyediting.js
+++ b/packages/ckeditor5-font/tests/fontfamily/fontfamilyediting.js
@@ -25,8 +25,8 @@ describe( 'FontFamilyEditing', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'should have pluginName', () => {

--- a/packages/ckeditor5-font/tests/fontsize/fontsizecommand.js
+++ b/packages/ckeditor5-font/tests/fontsize/fontsizecommand.js
@@ -20,8 +20,8 @@ describe( 'FontSizeCommand', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'is a FontCommand', () => {

--- a/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
+++ b/packages/ckeditor5-font/tests/fontsize/fontsizeediting.js
@@ -26,8 +26,8 @@ describe( 'FontSizeEditing', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'should have pluginName', () => {

--- a/packages/ckeditor5-heading/tests/integration.js
+++ b/packages/ckeditor5-heading/tests/integration.js
@@ -149,8 +149,8 @@ describe( 'Heading integration', () => {
 					expect( editor.getData() )
 						.to.equal( '<h2>Heading 2</h2><h2 class="fancy">Fancy Heading 2</h2>' );
 
-					editor.destroy();
 					element.remove();
+					return editor.destroy();
 				} );
 		} );
 	} );

--- a/packages/ckeditor5-highlight/tests/highlightcommand.js
+++ b/packages/ckeditor5-highlight/tests/highlightcommand.js
@@ -33,8 +33,8 @@ describe( 'HighlightCommand', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'is a command', () => {

--- a/packages/ckeditor5-highlight/tests/highlightediting.js
+++ b/packages/ckeditor5-highlight/tests/highlightediting.js
@@ -26,8 +26,8 @@ describe( 'HighlightEditing', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'should have pluginName', () => {

--- a/packages/ckeditor5-image/tests/imageresize/imageresizebuttons.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizebuttons.js
@@ -252,7 +252,7 @@ describe( 'ImageResizeButtons', () => {
 				editorElement.remove();
 			}
 
-			if ( editor ) {
+			if ( editor && editor.state !== 'destroyed' ) {
 				await editor.destroy();
 			}
 		} );
@@ -296,7 +296,7 @@ describe( 'ImageResizeButtons', () => {
 			expect( buttonView.label ).to.equal( 'Resize image: 30%' );
 			expect( buttonView.labelView ).to.be.instanceOf( View );
 
-			editor.destroy();
+			await editor.destroy();
 		} );
 
 		it( 'should be created with invisible "Resize image to 50%" label when is not provided', async () => {
@@ -307,7 +307,7 @@ describe( 'ImageResizeButtons', () => {
 			expect( buttonView.label ).to.equal( 'Resize image to 50%' );
 			expect( buttonView.labelView ).to.be.instanceOf( View );
 
-			editor.destroy();
+			await editor.destroy();
 		} );
 
 		it( 'should be created with a proper tooltip in custom option', () => {
@@ -386,7 +386,7 @@ describe( 'ImageResizeButtons', () => {
 				editor.ui.componentFactory.create( 'resizeImage:noicon' );
 			}, 'imageresizebuttons-missing-icon', editor );
 
-			editor.destroy();
+			await editor.destroy();
 		} );
 	} );
 } );

--- a/packages/ckeditor5-image/tests/imagestyle/imagestyleediting.js
+++ b/packages/ckeditor5-image/tests/imagestyle/imagestyleediting.js
@@ -41,8 +41,8 @@ describe( 'ImageStyleEditing', () => {
 			expect( ImageStyleEditing.requires ).to.deep.equal( [ ImageUtils ] );
 		} );
 
-		afterEach( () => {
-			editor.destroy();
+		afterEach( async () => {
+			await editor.destroy();
 		} );
 	} );
 
@@ -87,7 +87,7 @@ describe( 'ImageStyleEditing', () => {
 						]
 					} );
 
-					editor.destroy();
+					await editor.destroy();
 				} );
 
 				it( 'should not set a default config if neither image editing plugins are loaded', async () => {
@@ -201,7 +201,7 @@ describe( 'ImageStyleEditing', () => {
 
 			expect( editor.commands.get( 'imageStyle' ) ).to.be.instanceOf( ImageStyleCommand );
 
-			editor.destroy();
+			await editor.destroy();
 		} );
 	} );
 
@@ -225,8 +225,8 @@ describe( 'ImageStyleEditing', () => {
 			document = model.document;
 		} );
 
-		afterEach( () => {
-			editor.destroy();
+		afterEach( async () => {
+			await editor.destroy();
 		} );
 
 		it( 'should remove imageStyle attribute with invalid value', () => {

--- a/packages/ckeditor5-language/tests/textpartlanguageediting.js
+++ b/packages/ckeditor5-language/tests/textpartlanguageediting.js
@@ -159,7 +159,7 @@ describe( 'TextPartLanguageEditing', () => {
 
 			expect( customEditor.config.get( 'language' ) ).to.deep.equal( languageConfig );
 
-			customEditor.destroy();
+			await customEditor.destroy();
 		} );
 	} );
 } );

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -616,8 +616,8 @@ describe( 'LinkCommand', () => {
 	} );
 
 	describe( 'manual decorators', () => {
-		beforeEach( () => {
-			editor.destroy();
+		beforeEach( async () => {
+			await editor.destroy();
 			return ModelTestEditor.create()
 				.then( newEditor => {
 					editor = newEditor;

--- a/packages/ckeditor5-link/tests/unlinkcommand.js
+++ b/packages/ckeditor5-link/tests/unlinkcommand.js
@@ -429,8 +429,8 @@ describe( 'UnlinkCommand', () => {
 	} );
 
 	describe( 'manual decorators', () => {
-		beforeEach( () => {
-			editor.destroy();
+		beforeEach( async () => {
+			await editor.destroy();
 			return ModelTestEditor.create( {
 				extraPlugins: [ LinkEditing ],
 				link: {

--- a/packages/ckeditor5-list/tests/legacytodolist/legacytodolistediting.js
+++ b/packages/ckeditor5-list/tests/legacytodolist/legacytodolistediting.js
@@ -1146,8 +1146,8 @@ describe( 'LegacyTodoListEditing', () => {
 					} );
 			} );
 
-			afterEach( () => {
-				editor.destroy();
+			afterEach( async () => {
+				await editor.destroy();
 			} );
 
 			testArrowKey();
@@ -1189,8 +1189,8 @@ describe( 'LegacyTodoListEditing', () => {
 					} );
 			} );
 
-			afterEach( () => {
-				editor.destroy();
+			afterEach( async () => {
+				await editor.destroy();
 			} );
 
 			testArrowKey();

--- a/packages/ckeditor5-markdown-gfm/tests/markdown.js
+++ b/packages/ckeditor5-markdown-gfm/tests/markdown.js
@@ -20,7 +20,7 @@ describe( 'Markdown', () => {
 			.then( editor => {
 				expect( editor.data.processor ).to.be.an.instanceof( GFMDataProcessor );
 
-				editor.destroy(); // Tests cleanup.
+				return editor.destroy(); // Tests cleanup.
 			} );
 	} );
 } );

--- a/packages/ckeditor5-paste-from-office/tests/_utils/utils.js
+++ b/packages/ckeditor5-paste-from-office/tests/_utils/utils.js
@@ -160,8 +160,8 @@ function generateNormalizationTests( title, fixtures, editorConfig, skip, only )
 				} );
 		} );
 
-		afterEach( () => {
-			editor.destroy();
+		afterEach( async () => {
+			await editor.destroy();
 		} );
 
 		for ( const name of Object.keys( fixtures.input ) ) {

--- a/packages/ckeditor5-paste-from-office/tests/filters/image.js
+++ b/packages/ckeditor5-paste-from-office/tests/filters/image.js
@@ -26,8 +26,8 @@ describe( 'PasteFromOffice - filters', () => {
 						} );
 				} );
 
-				afterEach( () => {
-					editor.destroy();
+				afterEach( async () => {
+					await editor.destroy();
 				} );
 
 				it( 'should handle correctly empty RTF data', () => {

--- a/packages/ckeditor5-remove-format/tests/removeformatcommand.js
+++ b/packages/ckeditor5-remove-format/tests/removeformatcommand.js
@@ -53,8 +53,8 @@ describe( 'RemoveFormatCommand', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'is a command', () => {

--- a/packages/ckeditor5-source-editing/tests/sourceediting.js
+++ b/packages/ckeditor5-source-editing/tests/sourceediting.js
@@ -828,7 +828,7 @@ describe( 'SourceEditing', () => {
 
 		editorElement.remove();
 
-		editor.destroy();
+		await editor.destroy();
 	} );
 } );
 

--- a/packages/ckeditor5-table/tests/_utils-tests/table-ascii-art.js
+++ b/packages/ckeditor5-table/tests/_utils-tests/table-ascii-art.js
@@ -26,8 +26,8 @@ describe( 'table ascii-art and model helpers', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	describe( 'for the table with only one cell', () => {
@@ -138,7 +138,7 @@ describe( 'table ascii-art and model helpers', () => {
 
 			assertSameCodeString( modelDataString,
 				`[
-					[ '00' ], 
+					[ '00' ],
 					[ '10' ]
 				]`
 			);

--- a/packages/ckeditor5-table/tests/converters/table-caption-post-fixer.js
+++ b/packages/ckeditor5-table/tests/converters/table-caption-post-fixer.js
@@ -26,8 +26,8 @@ describe( 'Table caption post-fixer', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	describe( 'on insert table', () => {

--- a/packages/ckeditor5-table/tests/converters/table-cell-paragraph-post-fixer.js
+++ b/packages/ckeditor5-table/tests/converters/table-cell-paragraph-post-fixer.js
@@ -25,8 +25,8 @@ describe( 'Table cell paragraph post-fixer', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'should omit elements that are not table rows (on table insert)', () => {

--- a/packages/ckeditor5-table/tests/converters/table-layout-post-fixer.js
+++ b/packages/ckeditor5-table/tests/converters/table-layout-post-fixer.js
@@ -26,8 +26,8 @@ describe( 'Table layout post-fixer', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	describe( 'on insert table', () => {

--- a/packages/ckeditor5-table/tests/converters/upcasttable.js
+++ b/packages/ckeditor5-table/tests/converters/upcasttable.js
@@ -30,8 +30,8 @@ describe( 'upcastTable()', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	function expectModel( data ) {

--- a/packages/ckeditor5-table/tests/plaintableoutput.js
+++ b/packages/ckeditor5-table/tests/plaintableoutput.js
@@ -176,7 +176,7 @@ describe( 'PlainTableOutput', () => {
 					'</table>'
 				);
 
-				testEditor.destroy();
+				await testEditor.destroy();
 			} );
 
 			it( 'should be overridable', () => {
@@ -450,7 +450,7 @@ describe( 'PlainTableOutput', () => {
 					'</figure>'
 				);
 
-				testEditor.destroy();
+				await testEditor.destroy();
 			} );
 
 			// See: https://github.com/ckeditor/ckeditor5/issues/11394
@@ -482,7 +482,7 @@ describe( 'PlainTableOutput', () => {
 					'</figure>'
 				);
 
-				testEditor.destroy();
+				await testEditor.destroy();
 			} );
 
 			function createEmptyTable() {

--- a/packages/ckeditor5-table/tests/table-integration.js
+++ b/packages/ckeditor5-table/tests/table-integration.js
@@ -34,8 +34,8 @@ describe( 'Table feature – integration', () => {
 				} );
 		} );
 
-		afterEach( () => {
-			editor.destroy();
+		afterEach( async () => {
+			await editor.destroy();
 		} );
 
 		it( 'pastes td as p when pasting into the table', () => {
@@ -98,8 +98,8 @@ describe( 'Table feature – integration', () => {
 				} );
 		} );
 
-		afterEach( () => {
-			editor.destroy();
+		afterEach( async () => {
+			await editor.destroy();
 		} );
 
 		it( 'fixing empty roots should be transparent to undo', () => {
@@ -169,8 +169,8 @@ describe( 'Table feature – integration', () => {
 				} );
 		} );
 
-		afterEach( () => {
-			editor.destroy();
+		afterEach( async () => {
+			await editor.destroy();
 		} );
 
 		it( 'merges elements without throwing errors', () => {
@@ -202,8 +202,8 @@ describe( 'Table feature – integration', () => {
 describe( 'Table feature – integration with markers', () => {
 	let editor;
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	// https://github.com/ckeditor/ckeditor5/pull/9780

--- a/packages/ckeditor5-table/tests/tablecaption/tablecaptionediting.js
+++ b/packages/ckeditor5-table/tests/tablecaption/tablecaptionediting.js
@@ -62,8 +62,8 @@ describe( 'TableCaptionEditing', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'should have pluginName', () => {

--- a/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tablecellproperties/tablecellpropertiesediting.js
@@ -1263,8 +1263,8 @@ describe( 'table cell properties', () => {
 					} );
 			} );
 
-			afterEach( () => {
-				editor.destroy();
+			afterEach( async () => {
+				await editor.destroy();
 			} );
 
 			describe( 'border', () => {

--- a/packages/ckeditor5-table/tests/tablecellwidth/tablecellwidthediting.js
+++ b/packages/ckeditor5-table/tests/tablecellwidth/tablecellwidthediting.js
@@ -161,8 +161,8 @@ describe( 'TableCellWidthEditing', () => {
 				} );
 		} );
 
-		afterEach( () => {
-			editor.destroy();
+		afterEach( async () => {
+			await editor.destroy();
 		} );
 
 		it( 'should not upcast the default `width` value from <td>', () => {

--- a/packages/ckeditor5-table/tests/tableediting.js
+++ b/packages/ckeditor5-table/tests/tableediting.js
@@ -38,8 +38,8 @@ describe( 'TableEditing', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 	} );
 
 	it( 'should have pluginName', () => {

--- a/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
+++ b/packages/ckeditor5-table/tests/tableproperties/tablepropertiesediting.js
@@ -36,8 +36,8 @@ describe( 'table properties', () => {
 				} );
 		} );
 
-		afterEach( () => {
-			editor.destroy();
+		afterEach( async () => {
+			await editor.destroy();
 		} );
 
 		it( 'should have pluginName', () => {
@@ -1316,8 +1316,8 @@ describe( 'table properties', () => {
 					} );
 			} );
 
-			afterEach( () => {
-				editor.destroy();
+			afterEach( async () => {
+				await editor.destroy();
 			} );
 
 			describe( 'border', () => {

--- a/packages/ckeditor5-ui/tests/componentfactory.js
+++ b/packages/ckeditor5-ui/tests/componentfactory.js
@@ -14,10 +14,10 @@ describe( 'ComponentFactory', () => {
 	beforeEach( () => {
 		editor = new Editor();
 		factory = new ComponentFactory( editor );
+		editor.state = 'ready';
 	} );
 
 	afterEach( async () => {
-		editor.state = 'ready';
 		await editor.destroy();
 	} );
 

--- a/packages/ckeditor5-ui/tests/componentfactory.js
+++ b/packages/ckeditor5-ui/tests/componentfactory.js
@@ -16,6 +16,11 @@ describe( 'ComponentFactory', () => {
 		factory = new ComponentFactory( editor );
 	} );
 
+	afterEach( async () => {
+		editor.state = 'ready';
+		await editor.destroy();
+	} );
+
 	describe( 'constructor()', () => {
 		it( 'sets all the properties', () => {
 			expect( factory ).to.have.property( 'editor', editor );

--- a/packages/ckeditor5-ui/tests/dialog/dialog.js
+++ b/packages/ckeditor5-ui/tests/dialog/dialog.js
@@ -31,8 +31,8 @@ describe( 'Dialog', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 		editorElement.remove();
 		Dialog._visibleDialogPlugin = undefined;
 	} );

--- a/packages/ckeditor5-ui/tests/editorui/editorui.js
+++ b/packages/ckeditor5-ui/tests/editorui/editorui.js
@@ -681,7 +681,7 @@ describe( 'EditorUI', () => {
 					editingArea.remove();
 
 					editor.fire( 'ready' );
-					editor.destroy().then( done );
+					editor.destroy().then( () => done() );
 					ui.destroy();
 				} );
 

--- a/packages/ckeditor5-ui/tests/editorui/editorui.js
+++ b/packages/ckeditor5-ui/tests/editorui/editorui.js
@@ -46,7 +46,11 @@ describe( 'EditorUI', () => {
 
 	afterEach( async () => {
 		ui.destroy();
-		await editor.destroy();
+
+		if ( editor.state === 'initializing' ) {
+			editor.fire( 'ready' );
+			await editor.destroy();
+		}
 	} );
 
 	describe( 'constructor()', () => {
@@ -675,6 +679,8 @@ describe( 'EditorUI', () => {
 					} ).to.not.throw();
 
 					editingArea.remove();
+
+					editor.fire( 'ready' );
 					editor.destroy().then( done );
 					ui.destroy();
 				} );

--- a/packages/ckeditor5-ui/tests/editorui/editorui.js
+++ b/packages/ckeditor5-ui/tests/editorui/editorui.js
@@ -661,7 +661,7 @@ describe( 'EditorUI', () => {
 					sinon.assert.notCalled( invisibleSpy );
 				} );
 
-				it( 'should do nothing if no toolbars were registered', () => {
+				it( 'should do nothing if no toolbars were registered', done => {
 					const editor = new Editor();
 					const ui = editor.ui = new MyEditorUI( editor );
 					const editingArea = document.createElement( 'div' );
@@ -675,7 +675,7 @@ describe( 'EditorUI', () => {
 					} ).to.not.throw();
 
 					editingArea.remove();
-					editor.destroy();
+					editor.destroy().then( done );
 					ui.destroy();
 				} );
 

--- a/packages/ckeditor5-ui/tests/editorui/editorui.js
+++ b/packages/ckeditor5-ui/tests/editorui/editorui.js
@@ -47,7 +47,7 @@ describe( 'EditorUI', () => {
 	afterEach( async () => {
 		ui.destroy();
 
-		if ( editor.state === 'initializing' ) {
+		if ( editor.state !== 'destroyed' ) {
 			editor.fire( 'ready' );
 			await editor.destroy();
 		}

--- a/packages/ckeditor5-ui/tests/editorui/editorui.js
+++ b/packages/ckeditor5-ui/tests/editorui/editorui.js
@@ -41,10 +41,12 @@ describe( 'EditorUI', () => {
 	beforeEach( () => {
 		editor = new Editor();
 		editor.ui = ui = new MyEditorUI( editor );
+		editor.state = 'ready';
 	} );
 
-	afterEach( () => {
+	afterEach( async () => {
 		ui.destroy();
+		await editor.destroy();
 	} );
 
 	describe( 'constructor()', () => {

--- a/packages/ckeditor5-ui/tests/editorui/poweredby.js
+++ b/packages/ckeditor5-ui/tests/editorui/poweredby.js
@@ -70,6 +70,7 @@ describe( 'PoweredBy', () => {
 					editor.ui.focusTracker.add( element );
 					element.focus();
 
+					editor.fire( 'ready' );
 					editor.ui.destroy();
 					editor.destroy().then( done );
 				} ).to.not.throw();

--- a/packages/ckeditor5-ui/tests/editorui/poweredby.js
+++ b/packages/ckeditor5-ui/tests/editorui/poweredby.js
@@ -72,7 +72,7 @@ describe( 'PoweredBy', () => {
 
 					editor.fire( 'ready' );
 					editor.ui.destroy();
-					editor.destroy().then( done );
+					editor.destroy().then( () => done() );
 				} ).to.not.throw();
 			} );
 
@@ -460,7 +460,7 @@ describe( 'PoweredBy', () => {
 		describe( 'if there was no balloon', () => {
 			it( 'should not throw', done => {
 				expect( () => {
-					editor.destroy().then( done );
+					editor.destroy().then( () => done() );
 				} ).to.not.throw();
 			} );
 		} );
@@ -468,7 +468,7 @@ describe( 'PoweredBy', () => {
 		it( 'should destroy the emitter listeners', done => {
 			const spy = testUtils.sinon.spy( editor.ui.poweredBy, 'stopListening' );
 
-			editor.destroy().then( done );
+			editor.destroy().then( () => done() );
 
 			sinon.assert.calledOnce( spy );
 		} );

--- a/packages/ckeditor5-ui/tests/editorui/poweredby.js
+++ b/packages/ckeditor5-ui/tests/editorui/poweredby.js
@@ -57,7 +57,7 @@ describe( 'PoweredBy', () => {
 
 	describe( 'constructor()', () => {
 		describe( 'balloon creation', () => {
-			it( 'should not throw if there is no view in EditorUI', () => {
+			it( 'should not throw if there is no view in EditorUI', done => {
 				expect( () => {
 					const editor = new Editor();
 
@@ -70,8 +70,8 @@ describe( 'PoweredBy', () => {
 					editor.ui.focusTracker.add( element );
 					element.focus();
 
-					editor.destroy();
 					editor.ui.destroy();
+					editor.destroy().then( done );
 				} ).to.not.throw();
 			} );
 
@@ -429,45 +429,45 @@ describe( 'PoweredBy', () => {
 				focusEditor( editor );
 			} );
 
-			it( 'should unpin the balloon', () => {
+			it( 'should unpin the balloon', async () => {
 				const unpinSpy = testUtils.sinon.spy( editor.ui.poweredBy._balloonView, 'unpin' );
 
-				editor.destroy();
+				await editor.destroy();
 
 				sinon.assert.calledOnce( unpinSpy );
 			} );
 
-			it( 'should destroy the balloon', () => {
+			it( 'should destroy the balloon', async () => {
 				const destroySpy = testUtils.sinon.spy( editor.ui.poweredBy._balloonView, 'destroy' );
 
-				editor.destroy();
+				await editor.destroy();
 
 				sinon.assert.called( destroySpy );
 
 				expect( editor.ui.poweredBy._balloonView ).to.be.null;
 			} );
 
-			it( 'should cancel any throttled show to avoid post-destroy timed errors', () => {
+			it( 'should cancel any throttled show to avoid post-destroy timed errors', async () => {
 				const spy = testUtils.sinon.spy( editor.ui.poweredBy._showBalloonThrottled, 'cancel' );
 
-				editor.destroy();
+				await editor.destroy();
 
 				sinon.assert.calledOnce( spy );
 			} );
 		} );
 
 		describe( 'if there was no balloon', () => {
-			it( 'should not throw', () => {
+			it( 'should not throw', done => {
 				expect( () => {
-					editor.destroy();
+					editor.destroy().then( done );
 				} ).to.not.throw();
 			} );
 		} );
 
-		it( 'should destroy the emitter listeners', () => {
+		it( 'should destroy the emitter listeners', done => {
 			const spy = testUtils.sinon.spy( editor.ui.poweredBy, 'stopListening' );
 
-			editor.destroy();
+			editor.destroy().then( done );
 
 			sinon.assert.calledOnce( spy );
 		} );

--- a/packages/ckeditor5-ui/tests/notification/notification.js
+++ b/packages/ckeditor5-ui/tests/notification/notification.js
@@ -26,6 +26,10 @@ describe( 'Notification', () => {
 			} );
 	} );
 
+	afterEach( async () => {
+		await editor.destroy();
+	} );
+
 	describe( 'init()', () => {
 		it( 'should create notification plugin', () => {
 			expect( notification ).to.instanceof( Notification );

--- a/packages/ckeditor5-ui/tests/panel/balloon/contextualballoon.js
+++ b/packages/ckeditor5-ui/tests/panel/balloon/contextualballoon.js
@@ -61,8 +61,8 @@ describe( 'ContextualBalloon', () => {
 			} );
 	} );
 
-	afterEach( () => {
-		editor.destroy();
+	afterEach( async () => {
+		await editor.destroy();
 		editorElement.remove();
 	} );
 
@@ -850,8 +850,8 @@ describe( 'ContextualBalloon', () => {
 					expect( balloon.view.pin.calledTwice );
 					expect( balloon.view.pin.secondCall.args[ 0 ].viewportOffsetConfig.top ).to.equal( 200 );
 
-					newEditor.destroy();
 					editorElement.remove();
+					return newEditor.destroy();
 				} );
 		} );
 

--- a/packages/ckeditor5-word-count/tests/utils.js
+++ b/packages/ckeditor5-word-count/tests/utils.js
@@ -49,8 +49,8 @@ describe( 'utils', () => {
 					} );
 			} );
 
-			afterEach( () => {
-				editor.destroy();
+			afterEach( async () => {
+				await editor.destroy();
 			} );
 
 			it( 'extracts plain text from blockqoutes', () => {

--- a/packages/ckeditor5-word-count/tests/wordcount.js
+++ b/packages/ckeditor5-word-count/tests/wordcount.js
@@ -598,8 +598,8 @@ describe( 'WordCount', () => {
 				} );
 		} );
 
-		afterEach( () => {
-			editor.destroy();
+		afterEach( async () => {
+			await editor.destroy();
 		} );
 
 		it( 'should sum characters of each root', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Tests: Add missing `editor.destroy` calls to tests.
Tests: Add `await` to some `editor.destroy` calls.

---

### Additional information

Make sure that new tests are not executed before destroying the previous instance of editor. It may improve stability of the tests. 

I adjusted a few destroy methods to prevent crashes while unmounting an editor without attached editable. It should not affect production code logic. 

https://github.com/ckeditor/ckeditor5/pull/17136/files#diff-08c4a50a4e3011f22016b07e32ee0247c3f16921b60f4f97325370ea52a83301R141-R144
https://github.com/ckeditor/ckeditor5/pull/17136/files#diff-3137b53b3f401a6509b1d23b4181c0a926b246478b0705f955beb96ad836bad3R102-R104
 https://github.com/ckeditor/ckeditor5/pull/17136/files#diff-6b59c13c57494bcace212545dcf111d9228cdc75359ff47007819627bb4449bbR96-R98