### PR TITLE
Fixed `executeInParallel()` function throwing error when the number o…

### DIFF
--- a/scripts/release/utils/parsearguments.js
+++ b/scripts/release/utils/parsearguments.js
@@ -38,7 +38,7 @@ module.exports = function parseArguments( cliArguments ) {
 		default: {
 			nightly: false,
 			'nightly-alpha': false,
-			concurrency: require( 'os' ).cpus().length / 2,
+			concurrency: Math.floor( require( 'os' ).cpus().length / 2 ) || 1,
 			'compile-only': false,
 			packages: null,
 			branch: 'release',


### PR DESCRIPTION
…f cores is odd.

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Fixed `executeInParallel()` function throwing error when the number of cores is odd. See ckeditor/ckeditor5#17025.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
