### PR TITLE
Improvements in `insertImage` command, tooltip manager and mention

### DIFF
--- a/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
@@ -318,7 +318,7 @@ export default class ClipboardPipeline extends Plugin {
 		}, { priority: 'low' } );
 
 		this.listenTo<ClipboardOutputTransformationEvent>( this, 'outputTransformation', ( evt, data ) => {
-			const content = editor.data.toView( data.content );
+			const content = editor.data.toView( data.content, { isClipboardPipeline: true } );
 
 			viewDocument.fire<ViewDocumentClipboardOutputEvent>( 'clipboardOutput', {
 				dataTransfer: data.dataTransfer,
@@ -330,7 +330,7 @@ export default class ClipboardPipeline extends Plugin {
 		this.listenTo<ViewDocumentClipboardOutputEvent>( viewDocument, 'clipboardOutput', ( evt, data ) => {
 			if ( !data.content.isEmpty ) {
 				data.dataTransfer.setData( 'text/html', this.editor.data.htmlProcessor.toData( data.content ) );
-				data.dataTransfer.setData( 'text/plain', viewToPlainText( data.content ) );
+				data.dataTransfer.setData( 'text/plain', viewToPlainText( editor.data.htmlProcessor.domConverter, data.content ) );
 			}
 
 			if ( data.method == 'cut' ) {

--- a/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
+++ b/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
@@ -7,7 +7,7 @@
  * @module clipboard/utils/viewtoplaintext
  */
 
-import type { ViewDocumentFragment, ViewElement, ViewItem } from '@ckeditor/ckeditor5-engine';
+import type { DomConverter, ViewDocumentFragment, ViewElement, ViewItem } from '@ckeditor/ckeditor5-engine';
 
 // Elements which should not have empty-line padding.
 // Most `view.ContainerElement` want to be separate by new-line, but some are creating one structure
@@ -19,10 +19,14 @@ const listElements = [ 'ol', 'ul' ];
 /**
  * Converts {@link module:engine/view/item~Item view item} and all of its children to plain text.
  *
+ * @param converter The converter instance.
  * @param viewItem View item to convert.
  * @returns Plain text representation of `viewItem`.
  */
-export default function viewToPlainText( viewItem: ViewItem | ViewDocumentFragment ): string {
+export default function viewToPlainText(
+	converter: DomConverter,
+	viewItem: ViewItem | ViewDocumentFragment
+): string {
 	if ( viewItem.is( '$text' ) || viewItem.is( '$textProxy' ) ) {
 		return viewItem.data;
 	}
@@ -44,8 +48,36 @@ export default function viewToPlainText( viewItem: ViewItem | ViewDocumentFragme
 	let prev: ViewElement | null = null;
 
 	for ( const child of ( viewItem as ViewElement | ViewDocumentFragment ).getChildren() ) {
-		text += newLinePadding( child as ViewElement, prev ) + viewToPlainText( child );
+		text += newLinePadding( child as ViewElement, prev ) + viewToPlainText( converter, child );
 		prev = child as ViewElement;
+	}
+
+	// If item is a raw element, the only way to get its content is to render it and read the text directly from DOM.
+	if ( viewItem.is( 'rawElement' ) ) {
+		const tempElement = document.createElement( 'div' );
+
+		viewItem.render( tempElement, converter );
+
+		text += domElementToPlainText( tempElement );
+	}
+
+	return text;
+}
+
+/**
+ * Recursively converts DOM element and all of its children to plain text.
+ */
+function domElementToPlainText( element: HTMLElement ): string {
+	let text = '';
+
+	if ( element.nodeType === Node.TEXT_NODE ) {
+		return element.textContent!;
+	} else if ( element.tagName === 'BR' ) {
+		return '\n';
+	}
+
+	for ( const child of element.childNodes ) {
+		text += domElementToPlainText( child as HTMLElement );
 	}
 
 	return text;

--- a/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
@@ -485,9 +485,27 @@ describe( 'ClipboardPipeline feature', () => {
 				expect( data.dataTransfer ).to.equal( dataTransferMock );
 				expect( data.content ).is.instanceOf( ModelDocumentFragment );
 				expect( stringifyModel( data.content ) ).to.equal( '<paragraph>bc</paragraph><paragraph>de</paragraph>' );
-
 				done();
 			} );
+
+			viewDocument.fire( 'copy', {
+				dataTransfer: dataTransferMock,
+				preventDefault: preventDefaultSpy
+			} );
+		} );
+
+		it( 'triggers the conversion with the `isClipboardPipeline` flag', done => {
+			const dataTransferMock = createDataTransfer();
+			const preventDefaultSpy = sinon.spy();
+			const toViewSpy = sinon.spy( editor.data, 'toView' );
+
+			setModelData( editor.model, '<paragraph>a[bc</paragraph><paragraph>de]f</paragraph>' );
+
+			clipboardPlugin.on( 'outputTransformation', ( evt, data ) => {
+				expect( toViewSpy ).calledWithExactly( data.content, { isClipboardPipeline: true } );
+
+				done();
+			}, { priority: 'lowest' } );
 
 			viewDocument.fire( 'copy', {
 				dataTransfer: dataTransferMock,

--- a/packages/ckeditor5-clipboard/tests/utils/viewtoplaintext.js
+++ b/packages/ckeditor5-clipboard/tests/utils/viewtoplaintext.js
@@ -3,14 +3,26 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
+import { DomConverter, StylesProcessor, ViewDocument, DowncastWriter } from '@ckeditor/ckeditor5-engine';
 import viewToPlainText from '../../src/utils/viewtoplaintext.js';
 
 import { parse as parseView } from '@ckeditor/ckeditor5-engine/src/dev-utils/view.js';
 
 describe( 'viewToPlainText()', () => {
+	let converter, viewDocument;
+
+	beforeEach( () => {
+		viewDocument = new ViewDocument( new StylesProcessor() );
+		converter = new DomConverter( viewDocument );
+	} );
+
+	afterEach( () => {
+		viewDocument.destroy();
+	} );
+
 	function testViewToPlainText( viewString, expectedText ) {
 		const view = parseView( viewString );
-		const text = viewToPlainText( view );
+		const text = viewToPlainText( converter, view );
 
 		expect( text ).to.equal( expectedText );
 	}
@@ -41,7 +53,7 @@ describe( 'viewToPlainText()', () => {
 		const view = parseView( viewString );
 		view.getChild( 1 )._setCustomProperty( 'dataPipeline:transparentRendering', true );
 
-		const text = viewToPlainText( view );
+		const text = viewToPlainText( converter, view );
 
 		expect( text ).to.equal( expectedText );
 	} );
@@ -125,5 +137,15 @@ describe( 'viewToPlainText()', () => {
 
 			'Foo\n\nA\n\nB\n\nBar'
 		);
+	} );
+
+	it( 'should convert a view RawElement', () => {
+		const writer = new DowncastWriter( viewDocument );
+		const rawElement = writer.createRawElement( 'div', { 'data-foo': 'bar' }, function( domElement ) {
+			domElement.innerHTML = '<p>Foo</p><br><p>Bar</p>';
+		} );
+		const text = viewToPlainText( converter, rawElement );
+
+		expect( text ).to.equal( 'Foo\nBar' );
 	} );
 } );

--- a/packages/ckeditor5-image/src/image/insertimagecommand.ts
+++ b/packages/ckeditor5-image/src/image/insertimagecommand.ts
@@ -97,12 +97,14 @@ export default class InsertImageCommand extends Command {
 	 * @param options Options for the executed command.
 	 * @param options.imageType The type of the image to insert. If not specified, the type will be determined automatically.
 	 * @param options.source The image source or an array of image sources to insert.
+	 * @param options.breakBlock If set to `true`, the block at the selection start will be broken before inserting the image.
 	 * See the documentation of the command to learn more about accepted formats.
 	 */
 	public override execute(
 		options: {
 			source: ArrayOrItem<string | Record<string, unknown>>;
 			imageType?: 'imageBlock' | 'imageInline' | null;
+			breakBlock?: boolean;
 		}
 	): void {
 		const sourceDefinitions = toArray<string | Record<string, unknown>>( options.source );
@@ -132,6 +134,8 @@ export default class InsertImageCommand extends Command {
 				const position = this.editor.model.createPositionAfter( selectedElement );
 
 				imageUtils.insertImage( { ...sourceDefinition, ...selectionAttributes }, position, options.imageType );
+			} else if ( options.breakBlock ) {
+				imageUtils.insertImage( { ...sourceDefinition, ...selectionAttributes }, selection.getFirstPosition(), options.imageType );
 			} else {
 				imageUtils.insertImage( { ...sourceDefinition, ...selectionAttributes }, null, options.imageType );
 			}

--- a/packages/ckeditor5-image/src/index.ts
+++ b/packages/ckeditor5-image/src/index.ts
@@ -43,6 +43,7 @@ export { default as ImageCaptionUI } from './imagecaption/imagecaptionui.js';
 export { createImageTypeRegExp } from './imageupload/utils.js';
 
 export type { ImageConfig } from './imageconfig.js';
+export type { ImageLoadedEvent } from './image/imageloadobserver.js';
 export type { default as ImageTypeCommand } from './image/imagetypecommand.js';
 export type { default as InsertImageCommand } from './image/insertimagecommand.js';
 export type { default as ReplaceImageSourceCommand } from './image/replaceimagesourcecommand.js';

--- a/packages/ckeditor5-image/tests/image/insertimagecommand.js
+++ b/packages/ckeditor5-image/tests/image/insertimagecommand.js
@@ -165,6 +165,22 @@ describe( 'InsertImageCommand', () => {
 				);
 		} );
 
+		it( 'should be possible to break the block with an inserted image', () => {
+			const imgSrc = 'foo/bar.jpg';
+
+			setModelData( model, '<paragraph>f[]oo</paragraph>' );
+
+			command.execute( {
+				imageType: 'imageBlock',
+				source: imgSrc,
+				breakBlock: true
+			} );
+
+			expect( getModelData( model ) ).to.equal(
+				`<paragraph>f</paragraph>[<imageBlock src="${ imgSrc }"></imageBlock>]<paragraph>oo</paragraph>`
+			);
+		} );
+
 		it( 'should insert multiple images at selection position as other widgets for inline type images', () => {
 			const imgSrc1 = 'foo/bar.jpg';
 			const imgSrc2 = 'foo/baz.jpg';

--- a/packages/ckeditor5-mention/src/mentioncommand.ts
+++ b/packages/ckeditor5-mention/src/mentioncommand.ts
@@ -113,27 +113,9 @@ export default class MentionCommand extends Command {
 
 		const mention = _addMentionAttributes( { _text: mentionText, id: mentionID }, mentionData );
 
-		if ( options.marker.length != 1 ) {
+		if ( !mentionID.startsWith( options.marker ) ) {
 			/**
-			 * The marker must be a single character.
-			 *
-			 * Correct markers: `'@'`, `'#'`.
-			 *
-			 * Incorrect markers: `'@@'`, `'[@'`.
-			 *
-			 * See {@link module:mention/mentionconfig~MentionConfig}.
-			 *
-			 * @error mentioncommand-incorrect-marker
-			 */
-			throw new CKEditorError(
-				'mentioncommand-incorrect-marker',
-				this
-			);
-		}
-
-		if ( mentionID.charAt( 0 ) != options.marker ) {
-			/**
-			 * The feed item ID must start with the marker character.
+			 * The feed item ID must start with the marker character(s).
 			 *
 			 * Correct mention feed setting:
 			 *

--- a/packages/ckeditor5-mention/src/mentionui.ts
+++ b/packages/ckeditor5-mention/src/mentionui.ts
@@ -722,12 +722,12 @@ export function createRegExp( marker: string, minimumCharacters: number ): RegEx
 	// The pattern consists of 3 groups:
 	//
 	// - 0 (non-capturing): Opening sequence - start of the line, space or an opening punctuation character like "(" or "\"",
-	// - 1: The marker character,
+	// - 1: The marker character(s),
 	// - 2: Mention input (taking the minimal length into consideration to trigger the UI),
 	//
 	// The pattern matches up to the caret (end of string switch - $).
-	//               (0:      opening sequence       )(1:   marker  )(2:                typed mention              )$
-	const pattern = `(?:^|[ ${ openAfterCharacters }])([${ marker }])(${ mentionCharacters }${ numberOfCharacters })$`;
+	//               (0:      opening sequence       )(1: marker  )(2:                typed mention              )$
+	const pattern = `(?:^|[ ${ openAfterCharacters }])(${ marker })(${ mentionCharacters }${ numberOfCharacters })$`;
 
 	return new RegExp( pattern, 'u' );
 }
@@ -822,8 +822,8 @@ function isMarkerInExistingMention( markerPosition: Position ): boolean | null {
 /**
  * Checks if string is a valid mention marker.
  */
-function isValidMentionMarker( marker: string ): boolean | string {
-	return marker && marker.length == 1;
+function isValidMentionMarker( marker: string ): boolean {
+	return !!marker;
 }
 
 /**

--- a/packages/ckeditor5-mention/tests/mentioncommand.js
+++ b/packages/ckeditor5-mention/tests/mentioncommand.js
@@ -151,19 +151,6 @@ describe( 'MentionCommand', () => {
 			expect( textNode.hasAttribute( 'bold' ) ).to.be.true;
 		} );
 
-		it( 'should throw if marker is not one character', () => {
-			setData( model, '<paragraph>foo @Jo[]bar</paragraph>' );
-
-			const testCases = [
-				{ marker: '##', mention: '##foo' },
-				{ marker: '', mention: '@foo' }
-			];
-
-			for ( const options of testCases ) {
-				expectToThrowCKEditorError( () => command.execute( options ), /mentioncommand-incorrect-marker/, editor );
-			}
-		} );
-
 		it( 'should throw if marker does not match mention id', () => {
 			setData( model, '<paragraph>foo @Jo[]bar</paragraph>' );
 

--- a/packages/ckeditor5-mention/tests/mentionui.js
+++ b/packages/ckeditor5-mention/tests/mentionui.js
@@ -86,10 +86,17 @@ describe( 'MentionUI', () => {
 			} );
 		} );
 
-		it( 'should throw if marker is longer then 1 character', () => {
-			return createClassicTestEditor( { feeds: [ { marker: '$$', feed: [ 'a' ] } ] } ).catch( error => {
-				assertCKEditorError( error, /mentionconfig-incorrect-marker/, null, { marker: '$$' } );
-			} );
+		it( 'should not throw if marker is longer then 1 character', done => {
+			expect( () => ClassicTestEditor
+				.create( editorElement, {
+					plugins: [ Paragraph, MentionEditing, MentionUI ],
+					mention: { feeds: [ { marker: '$$', feed: [ 'a' ] } ] }
+				} ).then( tempEditor => {
+					tempEditor.destroy();
+
+					done();
+				} )
+			).to.not.throw();
 		} );
 	} );
 
@@ -401,28 +408,35 @@ describe( 'MentionUI', () => {
 			env.features.isRegExpUnicodePropertySupported = false;
 			createRegExp( '@', 2 );
 			sinon.assert.calledOnce( regExpStub );
-			sinon.assert.calledWithExactly( regExpStub, '(?:^|[ \\(\\[{"\'])([@])(.{2,})$', 'u' );
+			sinon.assert.calledWithExactly( regExpStub, '(?:^|[ \\(\\[{"\'])(@)(.{2,})$', 'u' );
 		} );
 
 		it( 'returns a ES2018 RegExp for browsers supporting Unicode punctuation groups', () => {
 			env.features.isRegExpUnicodePropertySupported = true;
 			createRegExp( '@', 2 );
 			sinon.assert.calledOnce( regExpStub );
-			sinon.assert.calledWithExactly( regExpStub, '(?:^|[ \\p{Ps}\\p{Pi}"\'])([@])(.{2,})$', 'u' );
+			sinon.assert.calledWithExactly( regExpStub, '(?:^|[ \\p{Ps}\\p{Pi}"\'])(@)(.{2,})$', 'u' );
+		} );
+
+		it( 'returns a proper regexp for markers longer than 1 character', () => {
+			env.features.isRegExpUnicodePropertySupported = true;
+			createRegExp( '@@', 2 );
+			sinon.assert.calledOnce( regExpStub );
+			sinon.assert.calledWithExactly( regExpStub, '(?:^|[ \\p{Ps}\\p{Pi}"\'])(@@)(.{2,})$', 'u' );
 		} );
 
 		it( 'correctly escapes passed marker #1', () => {
 			env.features.isRegExpUnicodePropertySupported = true;
 			createRegExp( ']', 2 );
 			sinon.assert.calledOnce( regExpStub );
-			sinon.assert.calledWithExactly( regExpStub, '(?:^|[ \\p{Ps}\\p{Pi}"\'])([\\]])(.{2,})$', 'u' );
+			sinon.assert.calledWithExactly( regExpStub, '(?:^|[ \\p{Ps}\\p{Pi}"\'])(\\])(.{2,})$', 'u' );
 		} );
 
 		it( 'correctly escapes passed marker #2', () => {
 			env.features.isRegExpUnicodePropertySupported = true;
 			createRegExp( '\\', 2 );
 			sinon.assert.calledOnce( regExpStub );
-			sinon.assert.calledWithExactly( regExpStub, '(?:^|[ \\p{Ps}\\p{Pi}"\'])([\\\\])(.{2,})$', 'u' );
+			sinon.assert.calledWithExactly( regExpStub, '(?:^|[ \\p{Ps}\\p{Pi}"\'])(\\\\)(.{2,})$', 'u' );
 		} );
 	} );
 
@@ -460,6 +474,45 @@ describe( 'MentionUI', () => {
 
 					model.change( writer => {
 						writer.insertText( 'r', doc.selection.getFirstPosition() );
+					} );
+				} )
+				.then( waitForDebounce )
+				.then( () => {
+					expect( panelView.isVisible ).to.be.true;
+					expect( editor.model.markers.has( 'mention' ) ).to.be.true;
+					expect( mentionsView.items ).to.have.length( 1 );
+				} );
+		} );
+
+		it( 'should show panel after the whole marker is matched', () => {
+			return createClassicTestEditor( {
+				feeds: [ { marker: '@@', feed: [ '@Barney', '@Lily', '@Marshall', '@Robin', '@Ted' ] } ]
+			} )
+				.then( () => {
+					setData( editor.model, '<paragraph>foo []</paragraph>' );
+
+					model.change( writer => {
+						writer.insertText( '@', doc.selection.getFirstPosition() );
+					} );
+				} )
+				.then( waitForDebounce )
+				.then( () => {
+					expect( panelView.isVisible ).to.be.false;
+					expect( editor.model.markers.has( 'mention' ) ).to.be.false;
+				} )
+				.then( () => {
+					model.change( writer => {
+						writer.insertText( '@', doc.selection.getFirstPosition() );
+					} );
+				} )
+				.then( waitForDebounce )
+				.then( () => {
+					expect( panelView.isVisible ).to.be.true;
+					expect( editor.model.markers.has( 'mention' ) ).to.be.true;
+					expect( mentionsView.items ).to.have.length( 5 );
+
+					model.change( writer => {
+						writer.insertText( 't', doc.selection.getFirstPosition() );
 					} );
 				} )
 				.then( waitForDebounce )

--- a/packages/ckeditor5-ui/src/tooltipmanager.ts
+++ b/packages/ckeditor5-ui/src/tooltipmanager.ts
@@ -56,11 +56,19 @@ const BALLOON_CLASS = 'ck-tooltip';
  *
  * # Disabling tooltips
  *
- * In order to disable the tooltip  temporarily, use the `data-cke-tooltip-disabled` attribute:
+ * In order to disable the tooltip temporarily, use the `data-cke-tooltip-disabled` attribute:
  *
  * ```ts
  * domElement.dataset.ckeTooltipText = 'Disabled. For now.';
  * domElement.dataset.ckeTooltipDisabled = 'true';
+ * ```
+ *
+ * # Instant tooltips
+ *
+ * To remove the delay before showing or hiding the tooltip, use the `data-cke-tooltip-instant` attribute:
+ *
+ * ```ts
+ * domElement.dataset.ckeTooltipInstant = 'true';
  * ```
  *
  * # Styling tooltips
@@ -294,6 +302,8 @@ export default class TooltipManager extends /* #__PURE__ */ DomEmitterMixin() {
 		// * a tooltip is displayed for a focused element, then the same element gets mouseentered,
 		// * a tooltip is displayed for an element via mouseenter, then the focus moves to the same element.
 		if ( elementWithTooltipAttribute === this._currentElementWithTooltip ) {
+			this._unpinTooltipDebounced.cancel();
+
 			return;
 		}
 
@@ -302,7 +312,13 @@ export default class TooltipManager extends /* #__PURE__ */ DomEmitterMixin() {
 		// The tooltip should be pinned immediately when the element gets focused using keyboard.
 		// If it is focused using the mouse, the tooltip should be pinned after a delay to prevent flashing.
 		// See https://github.com/ckeditor/ckeditor5/issues/16383
-		if ( evt.name === 'focus' && !elementWithTooltipAttribute.matches( ':hover' ) ) {
+		// Also, if the element has an attribute `data-cke-tooltip-instant`, the tooltip should be pinned immediately.
+		// This is useful for elements that have their content partially hidden (e.g. a long text in a small container)
+		// and should show a tooltip on hover, like merge field.
+		if (
+			evt.name === 'focus' && !elementWithTooltipAttribute.matches( ':hover' ) ||
+			elementWithTooltipAttribute.matches( '[data-cke-tooltip-instant]' )
+		) {
 			this._pinTooltip( elementWithTooltipAttribute, getTooltipData( elementWithTooltipAttribute ) );
 		} else {
 			this._pinTooltipDebounced( elementWithTooltipAttribute, getTooltipData( elementWithTooltipAttribute ) );
@@ -329,6 +345,7 @@ export default class TooltipManager extends /* #__PURE__ */ DomEmitterMixin() {
 			// Do not hide the tooltip when the user moves the cursor over it.
 			if ( isEnteringBalloon ) {
 				this._unpinTooltipDebounced.cancel();
+
 				return;
 			}
 
@@ -347,7 +364,17 @@ export default class TooltipManager extends /* #__PURE__ */ DomEmitterMixin() {
 			// Note that this should happen whether the tooltip is already visible or not, for instance,
 			// it could be invisible but queued (debounced): it should get canceled.
 			if ( isLeavingBalloon || ( descendantWithTooltip && descendantWithTooltip !== relatedDescendantWithTooltip ) ) {
-				this._unpinTooltipDebounced();
+				this._pinTooltipDebounced.cancel();
+
+				// If the currently visible tooltip is instant, unpin it immediately.
+				if (
+					this._currentElementWithTooltip && this._currentElementWithTooltip.matches( '[data-cke-tooltip-instant]' ) ||
+					descendantWithTooltip && descendantWithTooltip.matches( '[data-cke-tooltip-instant]' )
+				) {
+					this._unpinTooltip();
+				} else {
+					this._unpinTooltipDebounced();
+				}
 			}
 		} else {
 			// If a tooltip is currently visible, don't act for a targets other than the one it is attached to.
@@ -358,6 +385,7 @@ export default class TooltipManager extends /* #__PURE__ */ DomEmitterMixin() {
 
 			// Note that unpinning should happen whether the tooltip is already visible or not, for instance, it could be invisible but
 			// queued (debounced): it should get canceled (e.g. quick focus then quick blur using the keyboard).
+			this._pinTooltipDebounced.cancel();
 			this._unpinTooltipDebounced();
 		}
 	}

--- a/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
+++ b/packages/ckeditor5-ui/tests/tooltip/tooltipmanager.js
@@ -306,6 +306,18 @@ describe( 'TooltipManager', () => {
 					} );
 				} );
 
+				it( 'should pin a tooltip instantly if element has a `data-cke-tooltip-instant` attribute', () => {
+					elements.a.dataset.ckeTooltipInstant = true;
+
+					utils.dispatchMouseEnter( elements.a );
+
+					sinon.assert.calledOnce( pinSpy );
+					sinon.assert.calledWith( pinSpy, {
+						target: elements.a,
+						positions: sinon.match.array
+					} );
+				} );
+
 				it( 'should pin just a single tooltip (singleton)', async () => {
 					const secondEditor = await ClassicTestEditor.create( element, {
 						plugins: [ Paragraph, Bold, Italic ],
@@ -697,6 +709,19 @@ describe( 'TooltipManager', () => {
 				utils.dispatchMouseLeave( tooltipManager.balloonPanelView.element, elements.b );
 
 				utils.waitForTheTooltipToHide( clock );
+				sinon.assert.calledOnce( unpinSpy );
+			} );
+
+			it( 'should remove the tooltip immediately if the element has `data-cke-tooltip-instant` attribute', () => {
+				elements.a.dataset.ckeTooltipInstant = true;
+
+				utils.dispatchMouseEnter( elements.a );
+
+				sinon.assert.calledOnce( pinSpy );
+
+				unpinSpy = sinon.spy( tooltipManager.balloonPanelView, 'unpin' );
+				utils.dispatchMouseLeave( tooltipManager.balloonPanelView.element, elements.b );
+
 				sinon.assert.calledOnce( unpinSpy );
 			} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (image): Added a possibility to break the current block by `InsertImageCommand` with `breakBlock` flag. Closes https://github.com/ckeditor/ckeditor5/issues/17742.

Feature (ui): The `.ck-with-instant-tooltip` class can now be used to display the tooltip without the delay. Closes https://github.com/ckeditor/ckeditor5/issues/17743.

Feature (mention): Allow the [mention marker](https://ckeditor.com/docs/ckeditor5/latest/api/module_mention_mentionconfig-MentionFeed.html#member-marker) to be longer than 1 character. Closes https://github.com/ckeditor/ckeditor5/issues/17744.

Fix (ui): Tooltip will no longer show after quickly hovering and moving the mouse away before the tooltip shows. Closes 
https://github.com/ckeditor/ckeditor5/issues/16949.

Fix (ui): Tooltip will no longer disappear if cursor is moved back over the element with visible tooltip. Closes https://github.com/ckeditor/ckeditor5/issues/17256.

Feature (clipboard): Pass information to the downcast converter when clipboard pipeline is used to allow for customization. Closes https://github.com/ckeditor/ckeditor5/issues/17745.

Feature (clipboard): `viewToPlainText()` helper will now parse the view `RawElement` instances. Closes https://github.com/ckeditor/ckeditor5/issues/17746.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
