### PR TITLE
Add retrying CI test support

### DIFF
--- a/scripts/ci/generate-circleci-configuration.mjs
+++ b/scripts/ci/generate-circleci-configuration.mjs
@@ -236,6 +236,7 @@ function generateTestSteps( packages, { checkCoverage, coverageFile = null } ) {
 			'node',
 			'scripts/ci/check-unit-tests-for-package.mjs',
 			'--package-name',
+			'--retries 3',
 			packageName,
 			checkCoverage ? '--check-coverage' : null,
 			allowNonFullCoverage ? '--allow-non-full-coverage' : null,

--- a/scripts/ci/generate-circleci-configuration.mjs
+++ b/scripts/ci/generate-circleci-configuration.mjs
@@ -235,7 +235,7 @@ function generateTestSteps( packages, { checkCoverage, coverageFile = null } ) {
 		const testCommand = [
 			'node',
 			'scripts/ci/check-unit-tests-for-package.mjs',
-			'--retries 3',
+			'--attempts 3',
 			'--package-name',
 			packageName,
 			checkCoverage ? '--check-coverage' : null,

--- a/scripts/ci/generate-circleci-configuration.mjs
+++ b/scripts/ci/generate-circleci-configuration.mjs
@@ -235,8 +235,8 @@ function generateTestSteps( packages, { checkCoverage, coverageFile = null } ) {
 		const testCommand = [
 			'node',
 			'scripts/ci/check-unit-tests-for-package.mjs',
-			'--package-name',
 			'--retries 3',
+			'--package-name',
 			packageName,
 			checkCoverage ? '--check-coverage' : null,
 			allowNonFullCoverage ? '--allow-non-full-coverage' : null,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Added the retrying test execution mechanism on CI. Closes #17169

---

### Additional information

Added `--retries` process `argv` argument to specify how many times tests should be retries. It's 3 by default.