### PR TITLE
Bookmark insert paragraph fix

### DIFF
--- a/packages/ckeditor5-list/src/list/listediting.ts
+++ b/packages/ckeditor5-list/src/list/listediting.ts
@@ -869,7 +869,7 @@ function createModelIndentPasteFixer( model: Model ): GetCallback<ModelInsertCon
 
 		if ( isListItemBlock( position.parent ) ) {
 			refItem = position.parent;
-		} else if ( isListItemBlock( position.nodeBefore ) ) {
+		} else if ( isListItemBlock( position.nodeBefore ) && isListItemBlock( position.nodeAfter ) ) {
 			refItem = position.nodeBefore;
 		} else {
 			return; // Content is not copied into a list.

--- a/packages/ckeditor5-list/tests/list/integrations/clipboard-single-block.js
+++ b/packages/ckeditor5-list/tests/list/integrations/clipboard-single-block.js
@@ -400,7 +400,68 @@ describe( 'ListEditing (multiBlock=false) integrations: clipboard copy & paste',
 			} ).not.to.throw();
 		} );
 
-		it( 'should correctly handle item that is pasted without its parent', () => {
+		it( 'should correctly handle item that is pasted between list items without its parent', () => {
+			// Wrap all changes in one block to avoid post-fixing the selection
+			// (which may be incorret) in the meantime.
+			model.change( () => {
+				setModelData( model,
+					'<paragraph>Foo</paragraph>' +
+					'<listItem listType="numbered" listItemId="a" listIndent="0">A</listItem>' +
+					'<listItem listType="numbered" listItemId="b" listIndent="1">B</listItem>' +
+					'[]' +
+					'<listItem listType="numbered" listItemId="c" listIndent="1">C</listItem>' +
+					'<paragraph>Bar</paragraph>'
+				);
+
+				const clipboard = editor.plugins.get( 'ClipboardPipeline' );
+
+				clipboard.fire( 'inputTransformation', {
+					content: parseView( '<li>X</li>' )
+				} );
+			} );
+
+			expect( getModelData( model ) ).to.equalMarkup(
+				'<paragraph>Foo</paragraph>' +
+				'<listItem listIndent="0" listItemId="a" listType="numbered">A</listItem>' +
+				'<listItem listIndent="1" listItemId="b" listType="numbered">B</listItem>' +
+				'<listItem listIndent="1" listItemId="a00" listType="numbered">X[]</listItem>' +
+				'<listItem listIndent="1" listItemId="c" listType="numbered">C</listItem>' +
+				'<paragraph>Bar</paragraph>'
+			);
+		} );
+
+		it( 'should correctly handle item that is pasted between list items without its parent #2', () => {
+			// Wrap all changes in one block to avoid post-fixing the selection
+			// (which may be incorret) in the meantime.
+			model.change( () => {
+				setModelData( model,
+					'<paragraph>Foo</paragraph>' +
+					'<listItem listType="numbered" listItemId="a" listIndent="0">A</listItem>' +
+					'<listItem listType="numbered" listItemId="b" listIndent="1">B</listItem>' +
+					'[]' +
+					'<listItem listType="numbered" listItemId="c" listIndent="1">C</listItem>' +
+					'<paragraph>Bar</paragraph>'
+				);
+
+				const clipboard = editor.plugins.get( 'ClipboardPipeline' );
+
+				clipboard.fire( 'inputTransformation', {
+					content: parseView( '<li>X<ul><li>Y</li></ul></li>' )
+				} );
+			} );
+
+			expect( getModelData( model ) ).to.equalMarkup(
+				'<paragraph>Foo</paragraph>' +
+				'<listItem listIndent="0" listItemId="a" listType="numbered">A</listItem>' +
+				'<listItem listIndent="1" listItemId="b" listType="numbered">B</listItem>' +
+				'<listItem listIndent="1" listItemId="a01" listType="numbered">X</listItem>' +
+				'<listItem listIndent="2" listItemId="a00" listType="numbered">Y[]</listItem>' +
+				'<listItem listIndent="1" listItemId="c" listType="numbered">C</listItem>' +
+				'<paragraph>Bar</paragraph>'
+			);
+		} );
+
+		it( 'should correctly handle item that is pasted after last list item without its parent', () => {
 			// Wrap all changes in one block to avoid post-fixing the selection
 			// (which may be incorret) in the meantime.
 			model.change( () => {
@@ -423,12 +484,12 @@ describe( 'ListEditing (multiBlock=false) integrations: clipboard copy & paste',
 				'<paragraph>Foo</paragraph>' +
 				'<listItem listIndent="0" listItemId="a" listType="numbered">A</listItem>' +
 				'<listItem listIndent="1" listItemId="b" listType="numbered">B</listItem>' +
-				'<listItem listIndent="1" listItemId="a00" listType="numbered">X[]</listItem>' +
+				'<listItem listIndent="0" listItemId="a00" listType="bulleted">X[]</listItem>' +
 				'<paragraph>Bar</paragraph>'
 			);
 		} );
 
-		it( 'should correctly handle item that is pasted without its parent #2', () => {
+		it( 'should correctly handle item that is pasted after last list item without its parent #2', () => {
 			// Wrap all changes in one block to avoid post-fixing the selection
 			// (which may be incorret) in the meantime.
 			model.change( () => {
@@ -451,8 +512,8 @@ describe( 'ListEditing (multiBlock=false) integrations: clipboard copy & paste',
 				'<paragraph>Foo</paragraph>' +
 				'<listItem listIndent="0" listItemId="a" listType="numbered">A</listItem>' +
 				'<listItem listIndent="1" listItemId="b" listType="numbered">B</listItem>' +
-				'<listItem listIndent="1" listItemId="a01" listType="numbered">X</listItem>' +
-				'<listItem listIndent="2" listItemId="a00" listType="numbered">Y[]</listItem>' +
+				'<listItem listIndent="0" listItemId="a01" listType="bulleted">X</listItem>' +
+				'<listItem listIndent="1" listItemId="a00" listType="bulleted">Y[]</listItem>' +
 				'<paragraph>Bar</paragraph>'
 			);
 		} );

--- a/packages/ckeditor5-list/tests/list/integrations/clipboard.js
+++ b/packages/ckeditor5-list/tests/list/integrations/clipboard.js
@@ -564,7 +564,64 @@ describe( 'ListEditing integrations: clipboard copy & paste', () => {
 			} ).not.to.throw();
 		} );
 
-		it( 'should correctly handle item that is pasted without its parent', () => {
+		it( 'should correctly handle item that is pasted between list items without its parent', () => {
+			// Wrap all changes in one block to avoid post-fixing the selection
+			// (which may be incorret) in the meantime.
+			model.change( () => {
+				setModelData( model,
+					'<paragraph>Foo</paragraph>' +
+					'<paragraph listType="numbered" listItemId="a" listIndent="0">A</paragraph>' +
+					'<paragraph listType="numbered" listItemId="b" listIndent="1">B</paragraph>' +
+					'[]' +
+					'<paragraph listType="numbered" listItemId="c" listIndent="1">C</paragraph>' +
+					'<paragraph>Bar</paragraph>'
+				);
+
+				clipboard.fire( 'inputTransformation', {
+					content: parseView( '<li>X</li>' )
+				} );
+			} );
+
+			expect( getModelData( model ) ).to.equalMarkup(
+				'<paragraph>Foo</paragraph>' +
+				'<paragraph listIndent="0" listItemId="a" listType="numbered">A</paragraph>' +
+				'<paragraph listIndent="1" listItemId="b" listType="numbered">B</paragraph>' +
+				'<paragraph listIndent="1" listItemId="a00" listType="numbered">X[]</paragraph>' +
+				'<paragraph listIndent="1" listItemId="c" listType="numbered">C</paragraph>' +
+				'<paragraph>Bar</paragraph>'
+			);
+		} );
+
+		it( 'should correctly handle item that is pasted between list items without its parent #2', () => {
+			// Wrap all changes in one block to avoid post-fixing the selection
+			// (which may be incorret) in the meantime.
+			model.change( () => {
+				setModelData( model,
+					'<paragraph>Foo</paragraph>' +
+					'<paragraph listType="numbered" listItemId="a" listIndent="0">A</paragraph>' +
+					'<paragraph listType="numbered" listItemId="b" listIndent="1">B</paragraph>' +
+					'[]' +
+					'<paragraph listType="numbered" listItemId="c" listIndent="1">C</paragraph>' +
+					'<paragraph>Bar</paragraph>'
+				);
+
+				clipboard.fire( 'inputTransformation', {
+					content: parseView( '<li>X<ul><li>Y</li></ul></li>' )
+				} );
+			} );
+
+			expect( getModelData( model ) ).to.equalMarkup(
+				'<paragraph>Foo</paragraph>' +
+				'<paragraph listIndent="0" listItemId="a" listType="numbered">A</paragraph>' +
+				'<paragraph listIndent="1" listItemId="b" listType="numbered">B</paragraph>' +
+				'<paragraph listIndent="1" listItemId="a01" listType="numbered">X</paragraph>' +
+				'<paragraph listIndent="2" listItemId="a00" listType="numbered">Y[]</paragraph>' +
+				'<paragraph listIndent="1" listItemId="c" listType="numbered">C</paragraph>' +
+				'<paragraph>Bar</paragraph>'
+			);
+		} );
+
+		it( 'should correctly handle item that is pasted after last list item without its parent', () => {
 			// Wrap all changes in one block to avoid post-fixing the selection
 			// (which may be incorret) in the meantime.
 			model.change( () => {
@@ -585,12 +642,12 @@ describe( 'ListEditing integrations: clipboard copy & paste', () => {
 				'<paragraph>Foo</paragraph>' +
 				'<paragraph listIndent="0" listItemId="a" listType="numbered">A</paragraph>' +
 				'<paragraph listIndent="1" listItemId="b" listType="numbered">B</paragraph>' +
-				'<paragraph listIndent="1" listItemId="a00" listType="numbered">X[]</paragraph>' +
+				'<paragraph listIndent="0" listItemId="a00" listType="bulleted">X[]</paragraph>' +
 				'<paragraph>Bar</paragraph>'
 			);
 		} );
 
-		it( 'should correctly handle item that is pasted without its parent #2', () => {
+		it( 'should correctly handle item that is pasted after last list item without its parent #2', () => {
 			// Wrap all changes in one block to avoid post-fixing the selection
 			// (which may be incorret) in the meantime.
 			model.change( () => {
@@ -611,8 +668,8 @@ describe( 'ListEditing integrations: clipboard copy & paste', () => {
 				'<paragraph>Foo</paragraph>' +
 				'<paragraph listIndent="0" listItemId="a" listType="numbered">A</paragraph>' +
 				'<paragraph listIndent="1" listItemId="b" listType="numbered">B</paragraph>' +
-				'<paragraph listIndent="1" listItemId="a01" listType="numbered">X</paragraph>' +
-				'<paragraph listIndent="2" listItemId="a00" listType="numbered">Y[]</paragraph>' +
+				'<paragraph listIndent="0" listItemId="a01" listType="bulleted">X</paragraph>' +
+				'<paragraph listIndent="1" listItemId="a00" listType="bulleted">Y[]</paragraph>' +
 				'<paragraph>Bar</paragraph>'
 			);
 		} );

--- a/tests/manual/all-features-dll.js
+++ b/tests/manual/all-features-dll.js
@@ -16,6 +16,7 @@ import '@ckeditor/ckeditor5-editor-balloon/build/editor-balloon.js';
 // Plugins.
 import '@ckeditor/ckeditor5-image/build/image.js';
 import '@ckeditor/ckeditor5-link/build/link.js';
+import '@ckeditor/ckeditor5-bookmark/build/bookmark.js';
 import '@ckeditor/ckeditor5-basic-styles/build/basic-styles.js';
 import '@ckeditor/ckeditor5-find-and-replace/build/find-and-replace.js';
 import '@ckeditor/ckeditor5-font/build/font.js';
@@ -53,6 +54,7 @@ const { BalloonEditor } = window.CKEditor5.editorBalloon;
 
 const { AutoImage, Image, ImageCaption, ImageResize, ImageStyle, ImageToolbar, ImageUpload } = window.CKEditor5.image;
 const { AutoLink, Link, LinkImage } = window.CKEditor5.link;
+const { Bookmark } = window.CKEditor5.bookmark;
 const { Bold, Italic, Strikethrough, Subscript, Superscript, Underline, Code } = window.CKEditor5.basicStyles;
 const { FindAndReplace } = window.CKEditor5.findAndReplace;
 const { FontColor, FontFamily, FontSize, FontBackgroundColor } = window.CKEditor5.font;
@@ -113,7 +115,7 @@ const config = {
 		Alignment,
 		Autoformat,
 		AutoImage, Image, ImageCaption, ImageResize, ImageStyle, ImageToolbar, ImageUpload,
-		AutoLink, Link, LinkImage,
+		AutoLink, Link, LinkImage, Bookmark,
 		BlockQuote,
 		Bold, Italic, Strikethrough, Subscript, Superscript, Underline, Code,
 		CloudServices,
@@ -145,7 +147,7 @@ const config = {
 		'|',
 		'ad-hoc-button',
 		'|',
-		'removeFormat', 'bold', 'italic', 'strikethrough', 'underline', 'code', 'subscript', 'superscript', 'link',
+		'removeFormat', 'bold', 'italic', 'strikethrough', 'underline', 'code', 'subscript', 'superscript', 'link', 'bookmark',
 		'|',
 		'highlight', 'fontSize', 'fontFamily', 'fontColor', 'fontBackgroundColor',
 		'|',

--- a/tests/manual/all-features.html
+++ b/tests/manual/all-features.html
@@ -60,10 +60,10 @@
 		</table>
 	</figure>
 
-	<h2>Basic features overview</h2>
+	<h2><a id="basic-features-overview"></a>Basic features overview</h2>
 	<p>Lorem <b>ipsum dolor sit </b>amet, consectetur <i>adipisicing elit</i>.<sub>1</sub></p>
 	<h3>Basic styles</h3>
-	<p>Ad alias, <s>architecto</s> culpa <b><i>cumque</i></b> dignissimos <code>dolor eos incidunt ipsa itaque</code> <u>laboriosam</u> magnam molestias nihil <i><u>numquam</u></i> odit quam, suscipit <i><s>veritatis</s></i> voluptate voluptatum.<sup>2</sup></p>
+	<p><a id="in-text-bookmark"></a>Ad alias, <s>architecto</s> culpa <b><i>cumque</i></b> dignissimos <code>dolor eos incidunt ipsa itaque</code> <u>laboriosam</u> magnam molestias nihil <i><u>numquam</u></i> odit quam, suscipit <i><s>veritatis</s></i> voluptate voluptatum.<sup>2</sup></p>
 	<h3>Image</h3>
 	<figure class="image">
 		<img alt="bar" src="sample.jpg">

--- a/tests/manual/all-features.js
+++ b/tests/manual/all-features.js
@@ -50,6 +50,7 @@ import WordCount from '@ckeditor/ckeditor5-word-count/src/wordcount.js';
 import CloudServices from '@ckeditor/ckeditor5-cloud-services/src/cloudservices.js';
 import Style from '@ckeditor/ckeditor5-style/src/style.js';
 import GeneralHtmlSupport from '@ckeditor/ckeditor5-html-support/src/generalhtmlsupport.js';
+import Bookmark from '@ckeditor/ckeditor5-bookmark/src/bookmark.js';
 
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config.js';
 
@@ -61,7 +62,7 @@ ClassicEditor
 			CodeBlock, TodoList, ListProperties, TableProperties, TableCellProperties, TableCaption, TableColumnResize,
 			EasyImage, ImageResize, ImageInsert, LinkImage, AutoImage, HtmlEmbed, HtmlComment,
 			AutoLink, Mention, TextTransformation,
-			Alignment, IndentBlock,
+			Alignment, IndentBlock, Bookmark,
 			PasteFromOffice, PageBreak, HorizontalLine, ShowBlocks,
 			SpecialCharacters, SpecialCharactersEssentials, WordCount,
 			CloudServices, TextPartLanguage, SourceEditing, Style, GeneralHtmlSupport
@@ -69,7 +70,7 @@ ClassicEditor
 		toolbar: [
 			'heading', 'style',
 			'|',
-			'removeFormat', 'bold', 'italic', 'strikethrough', 'underline', 'code', 'subscript', 'superscript', 'link',
+			'removeFormat', 'bold', 'italic', 'strikethrough', 'underline', 'code', 'subscript', 'superscript', 'link', 'bookmark',
 			'|',
 			'highlight', 'fontSize', 'fontFamily', 'fontColor', 'fontBackgroundColor',
 			'|',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (list): Inserting or dropping a paragraph after the end of a list should not convert the paragraph to a list item. Closes #17224.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
