### PR TITLE
[Bookmark] Tests for upcast blockquote with bookmark inside.

### DIFF
--- a/packages/ckeditor5-bookmark/tests/bookmarkediting.js
+++ b/packages/ckeditor5-bookmark/tests/bookmarkediting.js
@@ -18,6 +18,7 @@ import { Bold, Italic } from '@ckeditor/ckeditor5-basic-styles';
 import { Table } from '@ckeditor/ckeditor5-table';
 import { GeneralHtmlSupport } from '@ckeditor/ckeditor5-html-support';
 import { CodeBlock } from '@ckeditor/ckeditor5-code-block';
+import { BlockQuote } from '@ckeditor/ckeditor5-block-quote';
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
 
@@ -38,7 +39,10 @@ describe( 'BookmarkEditing', () => {
 
 		const config = {
 			language: 'en',
-			plugins: [ BookmarkEditing, Essentials, Bold, Italic, ImageInline, ImageBlock, Heading, Paragraph, Link, Table, CodeBlock ]
+			plugins: [
+				BookmarkEditing, Essentials, Bold, Italic, ImageInline, ImageBlock,
+				Heading, Paragraph, Link, Table, CodeBlock, BlockQuote
+			]
 		};
 
 		editor = await createEditor( element, config );
@@ -518,15 +522,67 @@ describe( 'BookmarkEditing', () => {
 				);
 			} );
 
-			it( 'should not convert an `a` with `id` attribute inside code block', () => {
+			it( 'should not convert an `a` with `id` attribute inside code block (only anchor)', () => {
 				editor.setData(
 					'<pre data-language="HTML" spellcheck="false">' +
-						'<code class="language-html"><a id="foo"></a></code>' +
+						'<code class="language-html">' +
+							'<a id="foo"></a>' +
+						'</code>' +
 					'</pre>'
 				);
 
 				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
 					'<codeBlock language="html"></codeBlock>'
+				);
+			} );
+
+			it( 'should not convert an `a` with `id` attribute inside code block (more content)', () => {
+				editor.setData(
+					'<pre data-language="HTML" spellcheck="false">' +
+						'<code class="language-html">' +
+							'<p>Some text before</p>' +
+							'<a id="foo"></a>' +
+							'<p>Some text after</p>' +
+						'</code>' +
+					'</pre>'
+				);
+
+				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+					'<codeBlock language="html">' +
+						'Some text beforeSome text after' +
+					'</codeBlock>'
+				);
+			} );
+
+			it( 'should not split blockquote containing an `a` with `id` attribute inside block quote (only anchor)', () => {
+				editor.setData(
+					'<blockquote>' +
+						'<a id="foo"></a>' +
+					'</blockquote>'
+				);
+
+				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+					'<blockQuote>' +
+						'<paragraph><bookmark bookmarkId="foo"></bookmark></paragraph>' +
+					'</blockQuote>'
+				);
+			} );
+
+			it( 'should not split blockquote containing an `a` with `id` attribute inside block quote (more content)', () => {
+				editor.setData(
+					'<blockquote>' +
+						'<p>Some text before</p>' +
+						'<a id="foo"></a>' +
+						'<p>Some text after</p>' +
+					'</blockquote>'
+				);
+
+				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+					'<blockQuote>' +
+						'<paragraph>Some text before</paragraph>' +
+						'<paragraph><bookmark bookmarkId="foo"></bookmark></paragraph>' +
+						'<paragraph>Some text after</paragraph>' +
+					'</blockQuote>'
 				);
 			} );
 		} );

--- a/packages/ckeditor5-bookmark/tests/manual/bookmark.html
+++ b/packages/ckeditor5-bookmark/tests/manual/bookmark.html
@@ -20,6 +20,12 @@
 		space before <a id="another_bookmark_name"></a> space after
 	</p>
 
+	<blockquote>
+		<p>
+			<a id="blockquote_with_pointed_bookmark"></a>Blockquote with a bookmark inside
+		</p>
+	</blockquote>
+
 	<h3>Wrapped bookmarks</h3>
 	<p>
 		<a name="wrapped_bookmark_name">
@@ -41,6 +47,11 @@
 			wrapped only with the id
 		</a>
 	</p>
+	<blockquote>
+		<p>
+			<a id="blockquote_with_wrapped_bookmark">Blockquote with a wrapped bookmark inside</a>
+		</p>
+	</blockquote>
 
 	<h3>Pointed bookmarks (contains not only the id attribute)</h3>
 	<p>

--- a/packages/ckeditor5-bookmark/tests/manual/bookmark.js
+++ b/packages/ckeditor5-bookmark/tests/manual/bookmark.js
@@ -17,6 +17,7 @@ import { EasyImage } from '@ckeditor/ckeditor5-easy-image';
 import { CloudServices } from '@ckeditor/ckeditor5-cloud-services';
 import { GeneralHtmlSupport } from '@ckeditor/ckeditor5-html-support';
 import { CodeBlock } from '@ckeditor/ckeditor5-code-block';
+import { BlockQuote } from '@ckeditor/ckeditor5-block-quote';
 
 import Bookmark from '../../src/bookmark.js';
 
@@ -24,14 +25,14 @@ import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud
 
 const config = {
 	plugins: [
-		Essentials, Link, LinkImage, Paragraph, Table, Image, ImageUpload, CodeBlock,
+		Essentials, Link, LinkImage, Paragraph, Table, Image, ImageUpload, CodeBlock, BlockQuote,
 		EasyImage, CloudServices, ImageInsert, Heading, Bold, Italic, Bookmark
 	],
 	toolbar: [
 		'bookmark', '|',
 		'undo', 'redo', '|',
 		'bold', 'italic', '|',
-		'insertImage', 'insertTable', 'codeBlock', '|',
+		'insertImage', 'insertTable', 'codeBlock', 'blockQuote', '|',
 		'heading', 'link'
 	],
 	cloudServices: CS_CONFIG,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Tests for upcast the `blockquote` with `bookmark` inside.

---

### Additional information

_All works as expected, the blockquote is not splitted. The code block tests were dane earlier (added on more test with extended content)._
