### PR TITLE
Made the page unscrollable while the modal is visible

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dialog/dialog.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dialog/dialog.css
@@ -32,10 +32,15 @@
 	max-height: var(--ck-dialog-max-height);
 	max-width: var(--ck-dialog-max-width);
 	border: 1px solid var(--ck-color-base-border);
+	overscroll-behavior: contain;
 
 	& .ck.ck-form__header {
 		border-bottom: 1px solid var(--ck-color-dialog-form-header-border);
 	}
+}
+
+.ck-dialog-body-scroll-locked {
+	overflow: hidden;
 }
 
 @keyframes ck-dialog-fade-in {

--- a/packages/ckeditor5-ui/src/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialog.ts
@@ -88,6 +88,15 @@ export default class Dialog extends Plugin {
 	}
 
 	/**
+	 * @inheritDoc
+	 */
+	public override destroy(): void {
+		super.destroy();
+
+		this._unlockBodyScroll();
+	}
+
+	/**
 	 * Initiates listeners for the `show` and `hide` events emitted by this plugin.
 	 *
 	 * We could not simply decorate the {@link #show} and {@link #hide} methods to fire events,
@@ -295,6 +304,10 @@ export default class Dialog extends Plugin {
 			position = isModal ? DialogViewPosition.SCREEN_CENTER : DialogViewPosition.EDITOR_CENTER;
 		}
 
+		if ( isModal ) {
+			this._lockBodyScroll();
+		}
+
 		view.set( {
 			position,
 			_isVisible: true,
@@ -342,6 +355,10 @@ export default class Dialog extends Plugin {
 		const editor = this.editor;
 		const view = this.view;
 
+		if ( view.isModal ) {
+			this._unlockBodyScroll();
+		}
+
 		// Reset the content view to prevent its children from being destroyed in the standard
 		// View#destroy() (and collections) chain. If the content children were left in there,
 		// they would have to be re-created by the feature using the dialog every time the dialog
@@ -360,6 +377,20 @@ export default class Dialog extends Plugin {
 		this.id = null;
 		this.isOpen = false;
 		Dialog._visibleDialogPlugin = null;
+	}
+
+	/**
+	 * Makes the <body> unscrollable (e.g. when the modal shows up).
+	 */
+	private _lockBodyScroll(): void {
+		document.body.classList.add( 'ck-dialog-body-scroll-locked' );
+	}
+
+	/**
+	 * Makes the <body> scrollable again (e.g. once the modal hides).
+	 */
+	private _unlockBodyScroll(): void {
+		document.body.classList.remove( 'ck-dialog-body-scroll-locked' );
 	}
 }
 

--- a/packages/ckeditor5-ui/tests/manual/dialog/dialog-body-scroll-lock.html
+++ b/packages/ckeditor5-ui/tests/manual/dialog/dialog-body-scroll-lock.html
@@ -1,0 +1,53 @@
+<form>
+	<fieldset>
+		<legend>Is document scrollable?</legend>
+		<div>
+			<input type="radio" id="yes" name="isScrollable" value="yes" />
+			<label for="yes">yes</label>
+		</div>
+		<div>
+			<input type="radio" id="no" name="isScrollable" value="no" checked />
+			<label for="no">no</label>
+		</div>
+	</fieldset>
+	<fieldset>
+		<legend>Has &lt;body&gt; position?</legend>
+		<div>
+			<input type="radio" id="yes" name="hasPosition" value="yes" />
+			<label for="yes">yes</label>
+		</div>
+		<div>
+			<input type="radio" id="no" name="hasPosition" value="no" checked />
+			<label for="no">no</label>
+		</div>
+	</fieldset>
+</form>
+
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
+
+<div id="editor">Editor content.</div>
+
+<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>
+
+<style>
+	.ck.ck-editor {
+		margin-top: 300px;
+	}
+
+	body {
+		outline: 2px dashed blue;
+		outline-offset: -2px;
+	}
+
+	body::before {
+		content: "<BODY>";
+		position: absolute;
+		display: block;
+		top: 10px;
+		right: 10px;
+		background: blue;
+		color: white;
+		padding: 2px 4px;
+		font-size: 8px;
+	}
+</style>

--- a/packages/ckeditor5-ui/tests/manual/dialog/dialog-body-scroll-lock.md
+++ b/packages/ckeditor5-ui/tests/manual/dialog/dialog-body-scroll-lock.md
@@ -1,0 +1,8 @@
+# Locking page scroll when the modal is open
+
+1. Click the ">>> Open modal <<<" button.
+2. Ensure that the entire page underneath does not scroll in different browsers.
+3. Ensure the same applies when various options are turned on.
+
+Known issues:
+* In Safari iOS, the page is still scrollable when the modal is visible.

--- a/packages/ckeditor5-ui/tests/manual/dialog/dialog-body-scroll-lock.md
+++ b/packages/ckeditor5-ui/tests/manual/dialog/dialog-body-scroll-lock.md
@@ -2,7 +2,8 @@
 
 1. Click the ">>> Open modal <<<" button.
 2. Ensure that the entire page underneath does not scroll in different browsers.
-3. Ensure the same applies when various options are turned on.
+3. Ensure the same applies when various test options are turned on.
+4. Play with the global scroll of the webpage before opening the modal.
 
 Known issues:
 * In Safari iOS, the page is still scrollable when the modal is visible.

--- a/packages/ckeditor5-ui/tests/manual/dialog/dialog-body-scroll-lock.ts
+++ b/packages/ckeditor5-ui/tests/manual/dialog/dialog-body-scroll-lock.ts
@@ -1,0 +1,86 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+import { Plugin } from '@ckeditor/ckeditor5-core';
+import { ClassicEditor } from '@ckeditor/ckeditor5-editor-classic';
+import { ButtonView, Dialog, TextareaView } from '../../../src/index.js';
+import { Essentials } from '@ckeditor/ckeditor5-essentials';
+import { Heading } from '@ckeditor/ckeditor5-heading';
+import { Bold, Italic } from '@ckeditor/ckeditor5-basic-styles';
+
+declare global {
+	interface Window { editor: any }
+}
+
+interface FormElements extends HTMLFormControlsCollection {
+	isScrollable: RadioNodeList;
+	hasPosition: RadioNodeList;
+}
+
+class PluginWithModal extends Plugin {
+	public static get requires() {
+		return [ Dialog ] as const;
+	}
+
+	public init(): void {
+		this.editor.ui.componentFactory.add( 'modal', locale => {
+			const button = new ButtonView( locale );
+			const dialog = this.editor.plugins.get( 'Dialog' );
+			const textareaView = new TextareaView( locale );
+
+			textareaView.minRows = 5;
+			textareaView.maxRows = 10;
+			textareaView.value =
+				`Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor
+				quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean
+				ultricies mi vitae est. Mauris placerat eleifend leo.`.repeat( 10 );
+
+			button.label = '>>> Open modal <<<';
+			button.withText = true;
+			button.on( 'execute', () => {
+				dialog.show( {
+					id: 'modalWithText',
+					isModal: true,
+					title: 'A modal',
+					content: textareaView,
+					actionButtons: [
+						{
+							label: 'Close',
+							class: 'ck-button-action',
+							withText: true,
+							onExecute: () => dialog.hide()
+						}
+					],
+					onShow() {
+						textareaView.element!.style.margin = '10px';
+						textareaView.element!.style.width = '400px';
+					}
+				} );
+			} );
+
+			return button;
+		} );
+	}
+}
+
+ClassicEditor.create( document.querySelector( '#editor' ) as HTMLElement, {
+	extraPlugins: [ Essentials, Heading, Bold, Italic, PluginWithModal ],
+	toolbar: [ 'heading', '|', 'bold', 'italic', '|', 'modal' ]
+} ).then( editor => {
+	window.editor = editor;
+} );
+
+const form = document.querySelector( 'form' )!;
+
+form.addEventListener( 'change', () => {
+	const elements = form.elements as FormElements;
+
+	document.body.style.height = elements.isScrollable.value === 'yes' ? '3000px' : '';
+	document.body.style.width = elements.isScrollable.value === 'yes' ? '3000px' : '';
+
+	document.body.style.position = elements.hasPosition.value === 'yes' ? 'absolute' : '';
+	document.body.style.top = elements.hasPosition.value === 'yes' ? '100px' : '';
+	document.body.style.left = elements.hasPosition.value === 'yes' ? '100px' : '';
+} );

--- a/packages/ckeditor5-ui/tests/manual/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/tests/manual/dialog/dialog.ts
@@ -446,7 +446,7 @@ class MultiRootEditorIntegration extends Plugin {
 			this.listenTo( view, 'execute', () => {
 				const root = editor.model.document.selection.getFirstRange()!.root;
 
-				editor.detachRoot( root, true );
+				editor.detachRoot( root.rootName!, true );
 			} );
 
 			return view;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Made the page unscrollable while the modal is visible. Closes #17093.

---

## Some info

There are two main strategies for freezing the web page scroll available:
1. `overflow: hidden` on `<body>`: A very straightforward recipe. It fails in iOS, though. Still, I chose this one because I figured out we can sacrifice the mobile UX for the sake of a simple code and a quicker solution. Besides, Bootstrap.js uses this one and they don't seem to mind at all.
2. `position: fixed` on `<body>`: Initially, I went with this [one](https://css-tricks.com/prevent-page-scrolling-when-a-modal-is-open/) because it looked promising but soon I realized it has some drawbacks (also in non-mobile browsers). For instance, it causes page reflows when the body is narrower than the viewport or when the body was positioned with `absolute` in the first place. It requires some extra code (the article shows just basics, there's more to it once you look into it) and feels more complex. I decided it was not worth the hassle (for now).
3. A hybrid that uses `overflow: hidden` in most cases and `position: fixed` for iOS with additional hacks. It's a fairly popular [MIT-licensed npm module](https://www.npmjs.com/package/body-scroll-lock) but I found it overkill for what we need right now.