### PR TITLE
Introduced `translations:synchronize` script to synchronize translations with language context files

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,7 @@
     "translations:collect": "node ./scripts/translations/collect.mjs",
     "translations:download": "node ./scripts/translations/download.mjs",
     "translations:upload": "node ./scripts/translations/upload.mjs",
+    "translations:synchronize": "node ./scripts/translations/synchronize.mjs",
     "build": "tsc -p ./tsconfig.release-ckeditor5.json",
     "build:dist": "node scripts/nim/build-ckeditor5.mjs",
     "predll:build": "npm run build",

--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "translations:download": "node ./scripts/translations/download.mjs",
     "translations:upload": "node ./scripts/translations/upload.mjs",
     "translations:synchronize": "node ./scripts/translations/synchronize.mjs",
+    "translations:validate": "node ./scripts/translations/synchronize.mjs --validate-only",
     "build": "tsc -p ./tsconfig.release-ckeditor5.json",
     "build:dist": "node scripts/nim/build-ckeditor5.mjs",
     "predll:build": "npm run build",

--- a/scripts/translations/synchronize.mjs
+++ b/scripts/translations/synchronize.mjs
@@ -1,0 +1,39 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* eslint-env node */
+
+import upath from 'upath';
+import { synchronizeTranslations } from '@ckeditor/ckeditor5-dev-translations';
+import { CKEDITOR5_ROOT_PATH } from '../constants.mjs';
+import {
+	parseArguments,
+	getCKEditor5SourceFiles,
+	getCKEditor5PackagePaths
+} from './utils.mjs';
+
+main();
+
+function main() {
+	const options = parseArguments( process.argv.slice( 2 ) );
+
+	return synchronizeTranslations( {
+		// An array containing absolute paths to CKEditor 5 source files.
+		sourceFiles: getCKEditor5SourceFiles( options ),
+
+		// Packages to process.
+		packagePaths: getCKEditor5PackagePaths( options ),
+
+		// A relative path to the `@ckeditor/ckeditor5-core` package where common translations are located.
+		corePackagePath: upath.relative(
+			options.cwd,
+			upath.join( CKEDITOR5_ROOT_PATH, 'packages', 'ckeditor5-core' )
+		),
+
+		// Whether to hide unused context errors from the `@ckeditor/ckeditor5-core` package.
+		// Required when only some of the common translations are used.
+		ignoreUnusedCorePackageContexts: options.ignoreUnusedCorePackageContexts
+	} );
+}

--- a/scripts/translations/synchronize.mjs
+++ b/scripts/translations/synchronize.mjs
@@ -37,6 +37,9 @@ function main() {
 		ignoreUnusedCorePackageContexts: options.ignoreUnusedCorePackageContexts,
 
 		// Whether to validate the translations contexts against the source messages only. No files will be updated.
-		validateOnly: options.validateOnly
+		validateOnly: options.validateOnly,
+
+		// Whether to skip adding the license header to newly created translation files.
+		skipLicenseHeader: options.skipLicenseHeader
 	} );
 }

--- a/scripts/translations/synchronize.mjs
+++ b/scripts/translations/synchronize.mjs
@@ -34,6 +34,9 @@ function main() {
 
 		// Whether to hide unused context errors from the `@ckeditor/ckeditor5-core` package.
 		// Required when only some of the common translations are used.
-		ignoreUnusedCorePackageContexts: options.ignoreUnusedCorePackageContexts
+		ignoreUnusedCorePackageContexts: options.ignoreUnusedCorePackageContexts,
+
+		// Whether to validate the translations contexts against the source messages only. No files will be updated.
+		validateOnly: options.validateOnly
 	} );
 }

--- a/scripts/translations/utils.mjs
+++ b/scripts/translations/utils.mjs
@@ -29,7 +29,8 @@ export function parseArguments( args ) {
 		boolean: [
 			'include-external-directory',
 			'ignore-unused-core-package-contexts',
-			'validate-only'
+			'validate-only',
+			'skip-license-header'
 		],
 
 		default: {
@@ -38,7 +39,8 @@ export function parseArguments( args ) {
 			ignore: [],
 			'include-external-directory': false,
 			'ignore-unused-core-package-contexts': false,
-			'validate-only': false
+			'validate-only': false,
+			'skip-license-header': false
 		}
 	};
 
@@ -48,7 +50,8 @@ export function parseArguments( args ) {
 	replaceKebabCaseWithCamelCase( options, [
 		'include-external-directory',
 		'ignore-unused-core-package-contexts',
-		'validate-only'
+		'validate-only',
+		'skip-license-header'
 	] );
 
 	// Normalize the current work directory path.

--- a/scripts/translations/utils.mjs
+++ b/scripts/translations/utils.mjs
@@ -28,7 +28,8 @@ export function parseArguments( args ) {
 
 		boolean: [
 			'include-external-directory',
-			'ignore-unused-core-package-contexts'
+			'ignore-unused-core-package-contexts',
+			'validate-only'
 		],
 
 		default: {
@@ -36,17 +37,19 @@ export function parseArguments( args ) {
 			packages: [],
 			ignore: [],
 			'include-external-directory': false,
-			'ignore-unused-core-package-contexts': false
+			'ignore-unused-core-package-contexts': false,
+			'validate-only': false
 		}
 	};
 
 	const options = minimist( args, config );
 
 	// Convert to camelCase.
-	options.includeExternalDirectory = options[ 'include-external-directory' ];
-	delete options[ 'include-external-directory' ];
-	options.ignoreUnusedCorePackageContexts = options[ 'ignore-unused-core-package-contexts' ];
-	delete options[ 'ignore-unused-core-package-contexts' ];
+	replaceKebabCaseWithCamelCase( options, [
+		'include-external-directory',
+		'ignore-unused-core-package-contexts',
+		'validate-only'
+	] );
 
 	// Normalize the current work directory path.
 	options.cwd = upath.resolve( options.cwd );
@@ -171,6 +174,40 @@ export function getCKEditor5PackageNames( transifexProcess, { cwd, packages, ign
  */
 export function normalizePath( ...values ) {
 	return values.join( '/' ).split( /[\\/]/g ).join( '/' );
+}
+
+/**
+ * Replaces all kebab-case keys in the `options` object with camelCase entries.
+ * Kebab-case keys will be removed.
+ *
+ * @param {object} options
+ * @param {Array.<string>} keys Kebab-case keys in `options` object.
+ */
+function replaceKebabCaseWithCamelCase( options, keys ) {
+	for ( const key of keys ) {
+		const camelCaseKey = toCamelCase( key );
+
+		options[ camelCaseKey ] = options[ key ];
+		delete options[ key ];
+	}
+}
+
+/**
+ * Returns a camelCase value for specified kebab-case `value`.
+ *
+ * @param {string} value Kebab-case string.
+ * @returns {string}
+ */
+function toCamelCase( value ) {
+	return value.split( '-' )
+		.map( ( item, index ) => {
+			if ( index == 0 ) {
+				return item.toLowerCase();
+			}
+
+			return item.charAt( 0 ).toUpperCase() + item.slice( 1 ).toLowerCase();
+		} )
+		.join( '' );
 }
 
 /**


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Introduced `translations:synchronize` script to synchronize translations with language context files. Missing translations will be added, unused translations will be deleted, and missing translation files will be created.

Internal: Introduced `translations:validate` script to check the language context files against the translations. No files will be modified.

---

### Additional information

This PR requires https://github.com/ckeditor/ckeditor5-dev/pull/1020.
