### PR TITLE
Remove twitter from media embed docs

### DIFF
--- a/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed-preview.html
+++ b/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed-preview.html
@@ -1,8 +1,4 @@
 <div class="ck ck-content" id="snippet-media-embed-preview">
-	<h3>Follow us on Twitter for the latest news:</h3>
-	<figure class="media">
-		<oembed url="https://twitter.com/ckeditor/status/1441013225554948096"></oembed>
-	</figure>
 	<h3>And check our latest posts on Facebook:</h3>
 	<figure class="media">
 		<oembed

--- a/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed.html
+++ b/packages/ckeditor5-media-embed/docs/_snippets/features/media-embed.html
@@ -11,12 +11,6 @@
 		<oembed url="https://vimeo.com/1084537"></oembed>
 	</figure>
 
-	<h3>Twitter</h3>
-
-	<figure>
-		<oembed url="https://twitter.com/ckeditor/status/1430561610494627841"></oembed>
-	</figure>
-
 	<h3>Google Maps</h3>
 
 	<figure class="media">


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Remove twitter from media embed docs.

---

### Additional information

Twitter https CORS issue. Let's revert later.

```:x: Access to XMLHttpRequest at 'https://cdn.syndication.twimg.com/tweet-result?features=tfw_timeline_list%3A%3Btfw_follower_count_sunset%3Atrue%3Btfw_tweet_edit_backend%3Aon%3Btfw_refsrc_session%3Aon%3Btfw_fosnr_soft_interventions_enabled%3Aon%3Btfw_mixed_media_15897%3Atreatment%3Btfw_experiments_cookie_expiration%3A1209600%3Btfw_show_birdwatch_pivots_enabled%3Aon%3Btfw_duplicate_scribes_to_settings%3Aon%3Btfw_use_profile_image_shape_enabled%3Aon%3Btfw_video_hls_dynamic_manifests_15082%3Atrue_bitrate%3Btfw_legacy_timeline_sunset%3Atrue%3Btfw_tweet_edit_frontend%3Aon&id=1441013225554948096&lang=en&token=3hr2r84nn4z&4t3d0a=67um8dg6hec6&fhs95v=1g44e8hf095a&5tdnzw=a3i8b8zrlcet&ku3qc9=2p8e0mjvohno&omg0rz=6mu8jenx0oc6&58795q=3ibgar81ccj4&rr977e=uy5o88nbqvb&qhikm4=h9kd1r8euys' from origin 'https://platform.twitter.com/' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.```