### PR TITLE
No longer jump to the first item after replacing phrase

### DIFF
--- a/packages/ckeditor5-find-and-replace/src/findandreplaceediting.ts
+++ b/packages/ckeditor5-find-and-replace/src/findandreplaceediting.ts
@@ -292,7 +292,7 @@ export default class FindAndReplaceEditing extends Plugin {
 			this.state!.highlightedResult = changedSearchResults[ 0 ];
 		} else {
 			// If there is already highlight item then refresh highlight offset after appending new items.
-			this.state!.refreshHighlightOffset();
+			this.state!.refreshHighlightOffset( model );
 		}
 	};
 }

--- a/packages/ckeditor5-find-and-replace/src/replacecommand.ts
+++ b/packages/ckeditor5-find-and-replace/src/replacecommand.ts
@@ -8,6 +8,7 @@
 */
 
 import type { ResultType } from './findandreplace.js';
+import { sortSearchResultsByMarkerPositions } from './findandreplacestate.js';
 import { ReplaceCommandBase } from './replacecommandbase.js';
 
 /**
@@ -22,6 +23,31 @@ export default class ReplaceCommand extends ReplaceCommandBase {
 	 * @fires execute
 	 */
 	public override execute( replacementText: string, result: ResultType ): void {
+		// We save highlight offset here, as the information about the highlighted result will be lost after the changes.
+		//
+		// It happens because result list is partially regenerated if the result is removed from the paragraph.
+		// Partially means that all sibling result items that are placed in the same paragraph are removed and added again,
+		// which causes the highlighted result to be malformed (usually it's set to first but it's not guaranteed).
+		//
+		// While this saving can be done in editing state, it's better to keep it here, as it's a part of the command logic
+		// and might be super tricky to implement in multi-root documents.
+		//
+		// Keep in mind that the highlighted offset is indexed from 1, as it's displayed to the user. It's why we subtract 1 here.
+		//
+		// More info: https://github.com/ckeditor/ckeditor5/issues/16648
+		const oldHighlightOffset = Math.max( this._state!.highlightedOffset - 1, 0 );
+
 		this._replace( replacementText, result );
+
+		// Let's revert the highlight offset to the previous value.
+		if ( this._state!.results.length ) {
+			// Highlight offset operates on sorted array, so we need to sort the results first.
+			// It's not guaranteed that items in state results are sorted, usually they are, but it's not guaranteed when
+			// the result is removed from the paragraph with other highlighted results.
+			const sortedResults = sortSearchResultsByMarkerPositions( this.editor.model, [ ...this._state!.results ] );
+
+			// Just make sure that we don't overflow the results array, so use modulo.
+			this._state!.highlightedResult = sortedResults[ oldHighlightOffset % sortedResults.length ];
+		}
 	}
 }

--- a/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
+++ b/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
@@ -1286,7 +1286,7 @@ describe( 'FindAndReplaceFormView', () => {
 				expect( matchCounterElement.textContent ).to.equal( '2 of 3' );
 
 				replaceButton.fire( 'execute' );
-				expect( matchCounterElement.textContent ).to.equal( '1 of 2' );
+				expect( matchCounterElement.textContent ).to.equal( '2 of 2' );
 
 				replaceButton.fire( 'execute' );
 				expect( matchCounterElement.textContent ).to.equal( '1 of 1' );

--- a/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
+++ b/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
@@ -1383,7 +1383,6 @@ describe( 'FindAndReplaceFormView', () => {
 				findNextButton.fire( 'execute' );
 
 				// Replace second and third one.
-				// findInput.fieldView.value = '###';
 				view._replaceInputView.fieldView.value = '###';
 
 				replaceButton.fire( 'execute' );

--- a/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
+++ b/packages/ckeditor5-find-and-replace/tests/ui/findandreplaceformview.js
@@ -1357,6 +1357,48 @@ describe( 'FindAndReplaceFormView', () => {
 				editor.execute( 'undo' );
 				expect( matchCounterElement.textContent ).to.equal( '4 of 4' );
 			} );
+
+			it( 'should keep highlighted offset after replacement', () => {
+				editor.setData(
+					`<p>
+						Chocolate <span style="color:#fff700;">cake</span> bar ice cream topping marzipan.
+						Powder gingerbread bear claw tootsie roll lollipop marzipan icing bonbon.
+					</p>
+					<p>
+						Chupa chups jelly beans halvah ice cream gingerbread bears candy halvah gummi bears.
+						cAke dragée dessert chocolate.
+					</p>
+					<p>
+						Sime text with text highlight: <mark class="marker-green">Chocolate</mark> bonbon
+						<mark class="marker-yellow">Chocolate</mark> ice cream <mark class="marker-blue">Chocolate</mark>
+						gummies <mark class="pen-green">Chocolate</mark> tootsie roll
+					</p>`
+				);
+
+				toggleDialog();
+
+				// Let's skip the first found item.
+				findInput.fieldView.value = 'Choco';
+				findButton.fire( 'execute' );
+				findNextButton.fire( 'execute' );
+
+				// Replace second and third one.
+				// findInput.fieldView.value = '###';
+				view._replaceInputView.fieldView.value = '###';
+
+				replaceButton.fire( 'execute' );
+				replaceButton.fire( 'execute' );
+
+				// And there check if the highlight is still in the right place.
+				replaceButton.fire( 'execute' );
+
+				expect( editor.getData() ).to.be.equal(
+					'<p>Chocolate cake bar ice cream topping marzipan. Powder gingerbread bear claw tootsie roll' +
+					' lollipop marzipan icing bonbon.</p><p>Chupa chups jelly beans halvah ice cream gingerbread ' +
+					'bears candy halvah gummi bears. cAke dragée dessert ###late.</p><p>Sime text with text highlight: ' +
+					'###late bonbon ###late ice cream Chocolate gummies Chocolate tootsie roll</p>'
+				);
+			} );
 		} );
 
 		describe( 'dirty state of the form', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (find-and-replace): Find and replace no longer randomly jumps to the first found item after the replace operation. Closes https://github.com/ckeditor/ckeditor5/issues/16648

---

### Additional information

After removal of marker, we used to reset search to the first changed item.  It's buggy because changed items refer to search results affected by the update algorithm, which used to change found elements, even if they were not replaced. It caused "random" jumps between items after replace. 

The example might be this list of results:

![obraz](https://github.com/user-attachments/assets/281d5e8a-53a1-4ae5-81ff-86f938702f9c)

I replaced one word in a paragraph containing few search results with `2`, `3` and `4` indices. It updated item with `3` index, but it turns out that algorithm updated also items with `2` i `4` IDs. It's counterintuitive, and leaded to the incorrect assumption in the editing flow that we can reset to the first changed node when at least one yellow marker above the search result is removed. In this case, highlight item was pointed to `2` item instead of `4` item. 

I enforced restoring old highlight offset after operations, so it should be fine now.  

#### Before

https://github.com/user-attachments/assets/67bfde88-190d-4940-b5e3-08a76e954f7a

#### After

https://github.com/user-attachments/assets/d1c5cf12-0dfd-4b62-b8d2-9abb65e054ba

