### PR TITLE
Moved the document scroll lock for modal windows from <body> to <html>

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dialog/dialog.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/dialog/dialog.css
@@ -39,7 +39,7 @@
 	}
 }
 
-.ck-dialog-body-scroll-locked {
+.ck-dialog-scroll-locked {
 	overflow: hidden;
 }
 

--- a/packages/ckeditor5-ui/src/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialog.ts
@@ -390,14 +390,14 @@ export default class Dialog extends Plugin {
 	 * Makes the <body> unscrollable (e.g. when the modal shows up).
 	 */
 	private _lockBodyScroll(): void {
-		document.body.classList.add( 'ck-dialog-body-scroll-locked' );
+		document.documentElement.classList.add( 'ck-dialog-scroll-locked' );
 	}
 
 	/**
 	 * Makes the <body> scrollable again (e.g. once the modal hides).
 	 */
 	private _unlockBodyScroll(): void {
-		document.body.classList.remove( 'ck-dialog-body-scroll-locked' );
+		document.documentElement.classList.remove( 'ck-dialog-scroll-locked' );
 	}
 }
 

--- a/packages/ckeditor5-ui/tests/dialog/dialog.js
+++ b/packages/ckeditor5-ui/tests/dialog/dialog.js
@@ -266,11 +266,11 @@ describe( 'Dialog', () => {
 				className: 'foo'
 			} );
 
-			expect( document.body.classList.contains( 'ck-dialog-body-scroll-locked' ) ).to.be.true;
+			expect( document.documentElement.classList.contains( 'ck-dialog-scroll-locked' ) ).to.be.true;
 
 			dialogPlugin.destroy();
 
-			expect( document.body.classList.contains( 'ck-dialog-body-scroll-locked' ) ).to.be.false;
+			expect( document.documentElement.classList.contains( 'ck-dialog-scroll-locked' ) ).to.be.false;
 		} );
 	} );
 
@@ -448,7 +448,7 @@ describe( 'Dialog', () => {
 		} );
 
 		it( 'should lock document scroll if the dialog is a modal', () => {
-			expect( document.body.classList.contains( 'ck-dialog-body-scroll-locked' ) ).to.be.false;
+			expect( document.documentElement.classList.contains( 'ck-dialog-scroll-locked' ) ).to.be.false;
 
 			dialogPlugin._show( {
 				position: DialogViewPosition.EDITOR_CENTER,
@@ -456,18 +456,18 @@ describe( 'Dialog', () => {
 				className: 'foo'
 			} );
 
-			expect( document.body.classList.contains( 'ck-dialog-body-scroll-locked' ) ).to.be.true;
+			expect( document.documentElement.classList.contains( 'ck-dialog-scroll-locked' ) ).to.be.true;
 		} );
 
 		it( 'should not lock document scroll if the dialog is not a modal', () => {
-			expect( document.body.classList.contains( 'ck-dialog-body-scroll-locked' ) ).to.be.false;
+			expect( document.documentElement.classList.contains( 'ck-dialog-scroll-locked' ) ).to.be.false;
 
 			dialogPlugin._show( {
 				position: DialogViewPosition.EDITOR_CENTER,
 				className: 'foo'
 			} );
 
-			expect( document.body.classList.contains( 'ck-dialog-body-scroll-locked' ) ).to.be.false;
+			expect( document.documentElement.classList.contains( 'ck-dialog-scroll-locked' ) ).to.be.false;
 		} );
 	} );
 
@@ -541,7 +541,7 @@ describe( 'Dialog', () => {
 		} );
 
 		it( 'should unlock document scroll if the dialog is a modal', () => {
-			expect( document.body.classList.contains( 'ck-dialog-body-scroll-locked' ) ).to.be.false;
+			expect( document.documentElement.classList.contains( 'ck-dialog-scroll-locked' ) ).to.be.false;
 
 			dialogPlugin._show( {
 				position: DialogViewPosition.EDITOR_CENTER,
@@ -549,11 +549,11 @@ describe( 'Dialog', () => {
 				className: 'foo'
 			} );
 
-			expect( document.body.classList.contains( 'ck-dialog-body-scroll-locked' ) ).to.be.true;
+			expect( document.documentElement.classList.contains( 'ck-dialog-scroll-locked' ) ).to.be.true;
 
 			dialogPlugin._hide();
 
-			expect( document.body.classList.contains( 'ck-dialog-body-scroll-locked' ) ).to.be.false;
+			expect( document.documentElement.classList.contains( 'ck-dialog-scroll-locked' ) ).to.be.false;
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): Moved the document scroll lock for modal windows from `<body>` to `<html>` to make it bulletproof. Closes #17298.
