### PR TITLE
No longer scroll to the top of the document if pasted element is larger than scrollable editable.

### DIFF
--- a/packages/ckeditor5-utils/src/dom/scroll.ts
+++ b/packages/ckeditor5-utils/src/dom/scroll.ts
@@ -113,7 +113,21 @@ export function scrollViewportToShowTarget<T extends boolean, U extends IfTrue<T
 
 		// Obtain the rect of the target after it has been scrolled within its ancestors.
 		// It's time to scroll the viewport.
-		const targetRect = getRectRelativeToWindow( target, currentWindow );
+		let targetRect = getRectRelativeToWindow( target, currentWindow );
+
+		// Detect situation where the target is higher than the first scrollable ancestor.
+		// In such case scrolling the viewport to reveal the target might be malfunctioning because
+		// the target `.top` position is lower than the ancestor's `.top` position. If it's large enough it can be negative.
+		// It causes the `scrollWindowToShowRect` to scroll the viewport to the negative top position which is not possible
+		// and leads to the viewport being scrolled to the absolute top of the document. To prevent this, the target's rect
+		// must be shifted to the ancestor's top position. It should not affect the target's visibility because the ancestor
+		// is already scrolled to reveal the target.
+		// See more: https://github.com/ckeditor/ckeditor5/issues/17079
+		const ancestorWindowRelativeRect = getRectRelativeToWindow( firstAncestorToScroll, currentWindow );
+
+		if ( targetRect.height > ancestorWindowRelativeRect.height ) {
+			targetRect = ancestorWindowRelativeRect;
+		}
 
 		scrollWindowToShowRect( {
 			window: currentWindow,

--- a/packages/ckeditor5-utils/src/dom/scroll.ts
+++ b/packages/ckeditor5-utils/src/dom/scroll.ts
@@ -126,7 +126,11 @@ export function scrollViewportToShowTarget<T extends boolean, U extends IfTrue<T
 		const ancestorWindowRelativeRect = getRectRelativeToWindow( firstAncestorToScroll, currentWindow );
 
 		if ( targetRect.height > ancestorWindowRelativeRect.height ) {
-			targetRect = ancestorWindowRelativeRect;
+			const ancestorTargetIntersection = targetRect.getIntersection( ancestorWindowRelativeRect );
+
+			if ( ancestorTargetIntersection ) {
+				targetRect = ancestorTargetIntersection;
+			}
 		}
 
 		scrollWindowToShowRect( {

--- a/packages/ckeditor5-utils/tests/dom/scroll.js
+++ b/packages/ckeditor5-utils/tests/dom/scroll.js
@@ -449,8 +449,6 @@ describe( 'scrollViewportToShowTarget()', () => {
 			scrollViewportToShowTarget( { target } );
 			assertScrollPosition( targetAncestor, { scrollLeft: 200, scrollTop: -1100 } );
 			assertScrollPosition( iframeAncestor, { scrollTop: -200, scrollLeft: 100 } );
-			sinon.assert.notCalled( iframeWindow.scrollTo );
-			sinon.assert.notCalled( window.scrollTo );
 		} );
 
 		// https://github.com/ckeditor/ckeditor5/issues/930

--- a/packages/ckeditor5-utils/tests/dom/scroll.js
+++ b/packages/ckeditor5-utils/tests/dom/scroll.js
@@ -433,6 +433,26 @@ describe( 'scrollViewportToShowTarget()', () => {
 			sinon.assert.calledWithExactly( window.scrollTo, 1820, 1520 );
 		} );
 
+		it( 'scroll content to the ancestor viewport if target is larger than it', () => {
+			stubGeometry( testUtils, target,
+				{ top: -500, right: 200, bottom: 200, left: 100, width: 100, height: 900 } );
+			stubGeometry( testUtils, targetAncestor,
+				{ top: 500, right: 300, bottom: 400, left: 0, width: 300, height: 300 },
+				{ scrollLeft: 200, scrollTop: -100 } );
+
+			stubGeometry( testUtils, iframe,
+				{ top: 200, right: 400, bottom: 400, left: 200, width: 200, height: 200 } );
+			stubGeometry( testUtils, iframeAncestor,
+				{ top: 0, right: 400, bottom: 400, left: 0, width: 400, height: 400 },
+				{ scrollLeft: 100, scrollTop: 100 } );
+
+			scrollViewportToShowTarget( { target } );
+			assertScrollPosition( targetAncestor, { scrollLeft: 200, scrollTop: -1100 } );
+			assertScrollPosition( iframeAncestor, { scrollTop: -200, scrollLeft: 100 } );
+			sinon.assert.notCalled( iframeWindow.scrollTo );
+			sinon.assert.notCalled( window.scrollTo );
+		} );
+
 		// https://github.com/ckeditor/ckeditor5/issues/930
 		it( 'should not throw if the child frame has no access to the #frameElement of the parent', () => {
 			sinon.stub( iframeWindow, 'frameElement' ).get( () => null );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (utils): No longer scroll to the top of the document if pasted element is larger than scrollable editable. Closes https://github.com/ckeditor/ckeditor5/issues/17079

---

### Additional information

It looks like `scrollWindowToShowRect` assumes that passed target elements entirely fits in the first scrollable parent _viewport rect_, which is not true for large tables (or any other widgets) pasted into editable. These pasted elements often are large enough to have a huge negative `top` position value that is calculated from the top of the viewport. It was causing `window.scrollTo` to fallback scroll to `0` top offset.

This PR enforces scrollable target rect to be the size of the first scrollable ancestor if it overflows it. 

#### Before

https://github.com/user-attachments/assets/b188b75c-0c25-43ce-8f37-fdff2efcdefc

#### After

https://github.com/user-attachments/assets/9a1022b3-a579-46ff-b523-5628622c5682

