### PR TITLE
Excluded modal windows from the Classic editor's integration with dialogs

### DIFF
--- a/packages/ckeditor5-editor-classic/src/classiceditorui.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditorui.ts
@@ -309,7 +309,9 @@ export default class ClassicEditorUI extends EditorUI {
 
 			dialogView.on<DialogViewMoveToEvent>( 'moveTo', ( evt, data ) => {
 				// Engage only when the panel is sticky, and the dialog is using one of default positions.
-				if ( !stickyPanel.isSticky || dialogView.wasMoved ) {
+				// Ignore modals because they are displayed on top of the page (and overlay) and they do not collide with anything
+				// See (https://github.com/ckeditor/ckeditor5/issues/17339).
+				if ( !stickyPanel.isSticky || dialogView.wasMoved || dialogView.isModal ) {
 					return;
 				}
 

--- a/packages/ckeditor5-editor-classic/tests/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditorui.js
@@ -614,6 +614,32 @@ describe( 'ClassicEditorUI', () => {
 				expect( dialogPlugin.view.element.firstChild.style.left ).to.equal( '185px' );
 				expect( dialogPlugin.view.element.firstChild.style.top ).to.equal( '5px' );
 			} );
+
+			it( 'should not move the dialog if it is a modal', async () => {
+				editorWithUi.ui.view.stickyPanel.isSticky = true;
+
+				dialogPlugin.show( {
+					label: 'Foo',
+					isModal: true,
+					content: dialogContentView,
+					position: DialogViewPosition.EDITOR_TOP_SIDE
+				} );
+
+				sinon.stub( dialogPlugin.view.element.firstChild, 'getBoundingClientRect' ).returns( {
+					top: 0,
+					right: 100,
+					bottom: 50,
+					left: 0,
+					width: 100,
+					height: 50
+				} );
+
+				// Automatic positioning of the dialog on first show takes a while.
+				await wait( 20 );
+
+				expect( dialogPlugin.view.element.firstChild.style.left ).to.equal( '185px' );
+				expect( dialogPlugin.view.element.firstChild.style.top ).to.equal( '15px' );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (editor-classic): Excluded modal windows from the Classic editor's integration between dialogs and the sticky toolbar. Closes #17339.
