### PR TITLE
Fix: Avoid global state to improve icons tree-shaking.

### DIFF
--- a/packages/ckeditor5-bookmark/src/bookmarkediting.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkediting.ts
@@ -28,8 +28,6 @@ import UpdateBookmarkCommand from './updatebookmarkcommand.js';
 
 import '../theme/bookmark.css';
 
-const bookmarkIcon = icons.bookmarkInline;
-
 /**
  * The bookmark editing plugin.
  */
@@ -162,7 +160,7 @@ export default class BookmarkEditing extends Plugin {
 			const icon = new IconView();
 
 			icon.set( {
-				content: bookmarkIcon,
+				content: icons.bookmarkInline,
 				isColorInherited: false
 			} );
 

--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -34,8 +34,6 @@ import type InsertBookmarkCommand from './insertbookmarkcommand.js';
 
 import BookmarkEditing from './bookmarkediting.js';
 
-const bookmarkIcon = icons.bookmark;
-
 const VISUAL_SELECTION_MARKER_NAME = 'bookmark-ui';
 
 /**
@@ -275,7 +273,7 @@ export default class BookmarkUI extends Plugin {
 
 		view.set( {
 			label: t( 'Bookmark' ),
-			icon: bookmarkIcon
+			icon: icons.bookmark
 		} );
 
 		// Execute the command.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (bookmarks): Avoid global state to improve icons tree-shaking.

---

Two global variables in the new bookmarks plugin prevented the `icons` object from the `core` package from being properly tree-shaken.