### PR TITLE
Hide the settings button if there are no manual decorators.

### DIFF
--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -252,7 +252,7 @@ export default class LinkUI extends Plugin {
 		// Disable the "save" button if the command is disabled.
 		formView.saveButtonView.bind( 'isEnabled' ).to( linkCommand, 'isEnabled' );
 
-		// Enable the "Advanced" button only when there are manual decorators.
+		// Show the "Advanced" button only when there are manual decorators.
 		formView.settingsButtonView.bind( 'isVisible' ).to( linkCommand, 'manualDecorators', decorators => decorators.length > 0 );
 
 		// Change the "Save" button label depending on the command state.

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -253,7 +253,7 @@ export default class LinkUI extends Plugin {
 		formView.saveButtonView.bind( 'isEnabled' ).to( linkCommand, 'isEnabled' );
 
 		// Enable the "Advanced" button only when there are manual decorators.
-		formView.settingsButtonView.bind( 'isEnabled' ).to( linkCommand, 'manualDecorators', decorators => decorators.length > 0 );
+		formView.settingsButtonView.bind( 'isVisible' ).to( linkCommand, 'manualDecorators', decorators => decorators.length > 0 );
 
 		// Change the "Save" button label depending on the command state.
 		formView.saveButtonView.bind( 'label' ).to( linkCommand, 'value', value => value ? t( 'Update' ) : t( 'Insert' ) );

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -2227,6 +2227,16 @@ describe( 'LinkUI', () => {
 	} );
 
 	describe( 'advanced view', () => {
+		it( 'is not visible if there are no decorators', () => {
+			setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
+
+			editor.commands.get( 'link' ).manualDecorators.clear();
+
+			linkUIFeature._showUI();
+
+			expect( linkUIFeature.formView.settingsButtonView.isVisible ).to.be.false;
+		} );
+
 		it( 'can be opened by clicking the settings button', () => {
 			const spy = sinon.spy();
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (link): Hide the settings button if there are no manual decorators. See #17230
