### PR TITLE
Fix incorrect `inheritDoc` comment above editor name.

### DIFF
--- a/packages/ckeditor5-editor-balloon/src/ballooneditor.ts
+++ b/packages/ckeditor5-editor-balloon/src/ballooneditor.ts
@@ -34,7 +34,7 @@ import { isElement as _isElement } from 'lodash-es';
  */
 export default class BalloonEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 	/**
-	 * @inheritdoc
+	 * @inheritDoc
 	 */
 	public static override get editorName(): 'BalloonEditor' {
 		return 'BalloonEditor';

--- a/packages/ckeditor5-editor-classic/src/classiceditor.ts
+++ b/packages/ckeditor5-editor-classic/src/classiceditor.ts
@@ -30,7 +30,7 @@ import { isElement as _isElement } from 'lodash-es';
  */
 export default class ClassicEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 	/**
-	 * @inheritdoc
+	 * @inheritDoc
 	 */
 	public static override get editorName(): 'ClassicEditor' {
 		return 'ClassicEditor';

--- a/packages/ckeditor5-editor-decoupled/src/decouplededitor.ts
+++ b/packages/ckeditor5-editor-decoupled/src/decouplededitor.ts
@@ -42,7 +42,7 @@ import { isElement as _isElement } from 'lodash-es';
  */
 export default class DecoupledEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 	/**
-	 * @inheritdoc
+	 * @inheritDoc
 	 */
 	public static override get editorName(): 'DecoupledEditor' {
 		return 'DecoupledEditor';

--- a/packages/ckeditor5-editor-inline/src/inlineeditor.ts
+++ b/packages/ckeditor5-editor-inline/src/inlineeditor.ts
@@ -31,7 +31,7 @@ import { isElement as _isElement } from 'lodash-es';
  */
 export default class InlineEditor extends /* #__PURE__ */ ElementApiMixin( Editor ) {
 	/**
-	 * @inheritdoc
+	 * @inheritDoc
 	 */
 	public static override get editorName(): 'InlineEditor' {
 		return 'InlineEditor';

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditor.ts
@@ -50,7 +50,7 @@ import {
  */
 export default class MultiRootEditor extends Editor {
 	/**
-	 * @inheritdoc
+	 * @inheritDoc
 	 */
 	public static override get editorName(): 'MultiRootEditor' {
 		return 'MultiRootEditor';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Fix incorrect `inheritDoc` comment above editor name.