### PR TITLE
Revert adding icons re-export

### DIFF
--- a/packages/ckeditor5-link/src/index.ts
+++ b/packages/ckeditor5-link/src/index.ts
@@ -23,7 +23,4 @@ export { addLinkProtocolIfApplicable, isLinkableElement } from './utils.js';
 
 export type { LinkConfig, LinkDecoratorDefinition } from './linkconfig.js';
 
-export { default as linkIcon } from '../theme/icons/link.svg';
-export { default as unlinkIcon } from '../theme/icons/unlink.svg';
-
 import './augmentation.js';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (link): Revert adding icons re-export. See #17358.

---

### Additional information

:warning: This PR targets the `release` branch :warning:
