### PR TITLE
Rename the `cancel` event to `back` in `LinkAdvancedView`

### DIFF
--- a/packages/ckeditor5-link/lang/contexts.json
+++ b/packages/ckeditor5-link/lang/contexts.json
@@ -15,5 +15,6 @@
 	"Bookmarks": "Title for a feature displaying a list of bookmarks.",
 	"No bookmarks available.": "A message displayed instead of a list of bookmarks if it is empty.",
 	"Advanced": "Title for a feature displaying advanced link settings.",
-	"Displayed text": "The label of the input field for the displayed text of the link."
+	"Displayed text": "The label of the input field for the displayed text of the link.",
+	"Back": "The label of the button that returns to the previous view."
 }

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -376,8 +376,8 @@ export default class LinkUI extends Plugin {
 		const linkCommand: LinkCommand = this.editor.commands.get( 'link' )!;
 		const view = new LinkAdvancedView( this.editor.locale );
 
-		// Hide the panel after clicking the "Cancel" button.
-		this.listenTo( view, 'cancel', () => {
+		// Hide the panel after clicking the back button.
+		this.listenTo( view, 'back', () => {
 			// Make sure the focus always gets back to the editable _before_ removing the focused form view.
 			// Doing otherwise causes issues in some browsers. See https://github.com/ckeditor/ckeditor5-link/issues/193.
 			editor.editing.view.focus();

--- a/packages/ckeditor5-link/src/ui/linkadvancedview.ts
+++ b/packages/ckeditor5-link/src/ui/linkadvancedview.ts
@@ -119,7 +119,7 @@ export default class LinkAdvancedView extends View {
 
 		// Close the panel on esc key press when the **form has focus**.
 		this.keystrokes.set( 'Esc', ( data, cancel ) => {
-			this.fire<CancelEvent>( 'cancel' );
+			this.fire<BackEvent>( 'back' );
 			cancel();
 		} );
 	}
@@ -165,7 +165,7 @@ export default class LinkAdvancedView extends View {
 	}
 
 	/**
-	 * Creates a back button view that cancels the form.
+	 * Creates a back button view.
 	 */
 	private _createBackButton(): ButtonView {
 		const t = this.locale!.t;
@@ -173,12 +173,12 @@ export default class LinkAdvancedView extends View {
 
 		// TODO: maybe we should have a dedicated BackButtonView in the UI library.
 		backButton.set( {
-			label: t( 'Cancel' ),
+			label: t( 'Back' ),
 			icon: icons.previousArrow,
 			tooltip: true
 		} );
 
-		backButton.delegate( 'execute' ).to( this, 'cancel' );
+		backButton.delegate( 'execute' ).to( this, 'back' );
 
 		return backButton;
 	}
@@ -225,11 +225,11 @@ export default class LinkAdvancedView extends View {
 }
 
 /**
- * Fired when the form view is canceled, for example with a click on {@link ~LinkAdvancedView#backButtonView}.
+ * Fired when the {@link ~LinkAdvancedView#backButtonView} is pressed.
  *
- * @eventName ~LinkAdvancedView#cancel
+ * @eventName ~LinkAdvancedView#back
  */
-export type CancelEvent = {
-	name: 'cancel';
+export type BackEvent = {
+	name: 'back';
 	args: [];
 };

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -2274,7 +2274,7 @@ describe( 'LinkUI', () => {
 			setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
 
 			linkUIFeature._showUI();
-			linkUIFeature.listenTo( linkUIFeature.advancedView, 'cancel', spy );
+			linkUIFeature.listenTo( linkUIFeature.advancedView, 'back', spy );
 			linkUIFeature.formView.settingsButtonView.fire( 'execute' );
 			linkUIFeature.advancedView.backButtonView.fire( 'execute' );
 

--- a/packages/ckeditor5-link/tests/ui/linkadvancedview.js
+++ b/packages/ckeditor5-link/tests/ui/linkadvancedview.js
@@ -122,10 +122,10 @@ describe( 'LinkAdvancedView', () => {
 			expect( view._focusables ).to.be.instanceOf( ViewCollection );
 		} );
 
-		it( 'should fire `cancel` event on backButtonView#execute', () => {
+		it( 'should fire `back` event on backButtonView#execute', () => {
 			const spy = sinon.spy();
 
-			view.on( 'cancel', spy );
+			view.on( 'back', spy );
 
 			view.backButtonView.fire( 'execute' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (link): Rename the `cancel` event to `back` in `LinkAdvancedView`. See  #17230.
