### PR TITLE
Remove all restricted editing markers before setting the new data.

### DIFF
--- a/packages/ckeditor5-restricted-editing/src/restrictededitingmodeediting.ts
+++ b/packages/ckeditor5-restricted-editing/src/restrictededitingmodeediting.ts
@@ -142,6 +142,17 @@ export default class RestrictedEditingModeEditing extends Plugin {
 				writer.addClass( 'ck-restricted-editing_mode_restricted', root );
 			}
 		} );
+
+		// Remove existing restricted editing markers when setting new data to prevent marker resurrection.
+		// Without this, markers from removed content would be incorrectly restored due to the resurrection mechanism.
+		// See more: https://github.com/ckeditor/ckeditor5/issues/9646#issuecomment-843064995
+		editor.data.on( 'set', () => {
+			editor.model.change( writer => {
+				for ( const marker of editor.model.markers.getMarkersGroup( 'restrictedEditingException' ) ) {
+					writer.removeMarker( marker.name );
+				}
+			} );
+		}, { priority: 'high' } );
 	}
 
 	/**

--- a/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting.js
+++ b/packages/ckeditor5-restricted-editing/tests/restrictededitingmodeediting.js
@@ -242,6 +242,26 @@ describe( 'RestrictedEditingModeEditing', () => {
 
 				expect( model.markers.has( 'restrictedEditingException:1' ) ).to.be.false;
 			} );
+
+			it( 'should remove previous `restrictedEditingException` markers before setting new ones', () => {
+				editor.setData(
+					'<figure class="table">' +
+						'<table><tbody><tr><td><span class="restricted-editing-exception">bar</span></td></tr></tbody></table>' +
+					'</figure>'
+				);
+
+				expect( model.markers.has( 'restrictedEditingException:1' ) ).to.be.true;
+				expect( model.markers.has( 'restrictedEditingException:2' ) ).to.be.false;
+
+				editor.setData(
+					'<figure class="table">' +
+						'<table><tbody><tr><td><span class="restricted-editing-exception">bar</span></td></tr></tbody></table>' +
+					'</figure>'
+				);
+
+				expect( model.markers.has( 'restrictedEditingException:1' ) ).to.be.false;
+				expect( model.markers.has( 'restrictedEditingException:2' ) ).to.be.true;
+			} );
 		} );
 
 		describe( 'downcast', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (restricted-editing): Remove existing restricted editing markers when setting new data to prevent marker resurrection. Closes https://github.com/ckeditor/ckeditor5/issues/9646, https://github.com/ckeditor/ckeditor5/issues/9646

---

### Additional information

Based on https://github.com/ckeditor/ckeditor5/issues/9646#issuecomment-843064995
Ensure that all markers from restricted editing document are removed before setting the new data using `editor.setData`. 

#### Before

// TODO

#### After

// TODO