### PR TITLE
Fix wrong panel position fallback calculation in menu and dropdown views

### DIFF
--- a/packages/ckeditor5-ui/src/dropdown/dropdownview.ts
+++ b/packages/ckeditor5-ui/src/dropdown/dropdownview.ts
@@ -286,7 +286,7 @@ export default class DropdownView extends View<HTMLDivElement> {
 				} );
 
 				this.panelView.position = (
-					optimalPanelPosition ? optimalPanelPosition.name : this._panelPositions[ 0 ].name
+					optimalPanelPosition ? optimalPanelPosition.name : this._defaultPanelPositionName
 				) as PanelPosition;
 			} else {
 				this.panelView.position = this.panelPosition;
@@ -356,6 +356,15 @@ export default class DropdownView extends View<HTMLDivElement> {
 				northWest, northEast, northMiddleWest, northMiddleEast, north
 			];
 		}
+	}
+
+	/**
+	 * Returns the default position of the dropdown panel based on the direction of the UI language.
+	 * It is used when the {@link #panelPosition} is set to `'auto'` and the panel has not found a
+	 * suitable position to fit into the viewport.
+	 */
+	private get _defaultPanelPositionName(): PanelPosition {
+		return this.locale!.uiLanguageDirection === 'rtl' ? 'sw' : 'se';
 	}
 
 	/**

--- a/packages/ckeditor5-ui/src/menubar/menubarmenupanelview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenupanelview.ts
@@ -105,4 +105,4 @@ export default class MenuBarMenuPanelView extends View implements FocusableView 
  *
  * They are reflected as CSS class suffixes on the panel view element.
  */
-export type MenuBarMenuPanelPosition = 'se' | 'sw' | 'ne' | 'nw' | 'w' | 'e';
+export type MenuBarMenuPanelPosition = 'se' | 'sw' | 'ne' | 'nw' | 'w' | 'ws' | 'e' | 'es';

--- a/packages/ckeditor5-ui/src/menubar/menubarmenuview.ts
+++ b/packages/ckeditor5-ui/src/menubar/menubarmenuview.ts
@@ -212,7 +212,7 @@ export default class MenuBarMenuView extends View implements FocusableView {
 			} );
 
 			this.panelView.position = (
-				optimalPanelPosition ? optimalPanelPosition.name : this._panelPositions[ 0 ].name
+				optimalPanelPosition ? optimalPanelPosition.name : this._defaultMenuPositionName
 			) as MenuBarMenuPanelPosition;
 		} );
 	}
@@ -245,6 +245,26 @@ export default class MenuBarMenuView extends View implements FocusableView {
 				return [ westSouth, westNorth, eastSouth, eastNorth ];
 			} else {
 				return [ southWest, southEast, northWest, northEast ];
+			}
+		}
+	}
+
+	/**
+	 * The default position of the panel when the menu is opened.
+	 * It is used when the optimal position cannot be calculated.
+	 */
+	private get _defaultMenuPositionName(): MenuBarMenuPanelPosition {
+		if ( this.locale!.uiLanguageDirection === 'ltr' ) {
+			if ( this.parentMenuView ) {
+				return 'es';
+			} else {
+				return 'se';
+			}
+		} else {
+			if ( this.parentMenuView ) {
+				return 'ws';
+			} else {
+				return 'sw';
 			}
 		}
 	}

--- a/packages/ckeditor5-ui/tests/dropdown/dropdownview.js
+++ b/packages/ckeditor5-ui/tests/dropdown/dropdownview.js
@@ -215,7 +215,38 @@ describe( 'DropdownView', () => {
 
 						view.isOpen = true;
 
-						expect( view.panelView.position ).is.equal( 'southEast' ); // first position from position list.
+						expect( view.panelView.position ).is.equal( 'se' ); // first position from position list.
+
+						view.element.remove();
+						parentWithOverflow.remove();
+					} );
+
+					it( 'fallback when _getOptimalPosition() will return null (RTL)', () => {
+						const locale = {
+							t() {}
+						};
+
+						const buttonView = new ButtonView( locale );
+						const panelView = new DropdownPanelView( locale );
+
+						const view = new DropdownView( locale, buttonView, panelView );
+
+						view.locale.uiLanguageDirection = 'rtl';
+						view.render();
+
+						const parentWithOverflow = global.document.createElement( 'div' );
+						parentWithOverflow.style.width = '1px';
+						parentWithOverflow.style.height = '1px';
+						parentWithOverflow.style.marginTop = '-1000px';
+						parentWithOverflow.style.overflow = 'scroll';
+
+						parentWithOverflow.appendChild( view.element );
+
+						global.document.body.appendChild( parentWithOverflow );
+
+						view.isOpen = true;
+
+						expect( view.panelView.position ).is.equal( 'sw' ); // first position from position list.
 
 						view.element.remove();
 						parentWithOverflow.remove();

--- a/packages/ckeditor5-ui/tests/menubar/menubarmenuview.js
+++ b/packages/ckeditor5-ui/tests/menubar/menubarmenuview.js
@@ -248,7 +248,51 @@ describe( 'MenuBarMenuView', () => {
 
 				menuView.isOpen = true;
 
-				expect( menuView.panelView.position ).to.equal( menuView._panelPositions[ 0 ].name );
+				expect( menuView.panelView.position ).to.equal( 'se' );
+			} );
+
+			it( 'should use the default position if none were considered optimal (has parent menu)', () => {
+				createTopLevelMenuWithLocale( locale );
+
+				sinon.stub( MenuBarMenuView, '_getOptimalPosition' ).returns( null );
+
+				menuView.parentMenuView = new MenuBarMenuView( locale );
+
+				menuView.panelView.position = null;
+
+				menuView.isOpen = true;
+
+				expect( menuView.panelView.position ).to.equal( 'es' );
+			} );
+
+			it( 'should use the default position if none were considered optimal (RTL)', () => {
+				createTopLevelMenuWithLocale( locale );
+
+				sinon.stub( MenuBarMenuView, '_getOptimalPosition' ).returns( null );
+
+				menuView.locale.uiLanguageDirection = 'rtl';
+
+				menuView.panelView.position = null;
+
+				menuView.isOpen = true;
+
+				expect( menuView.panelView.position ).to.equal( 'sw' );
+			} );
+
+			it( 'should use the default position if none were considered optimal (RTL, has parent menu)', () => {
+				createTopLevelMenuWithLocale( locale );
+
+				sinon.stub( MenuBarMenuView, '_getOptimalPosition' ).returns( null );
+
+				menuView.locale.uiLanguageDirection = 'rtl';
+
+				menuView.parentMenuView = new MenuBarMenuView( locale );
+
+				menuView.panelView.position = null;
+
+				menuView.isOpen = true;
+
+				expect( menuView.panelView.position ).to.equal( 'ws' );
 			} );
 
 			afterEach( () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): The menu or dropdown panels will no longer be placed in an incorrect position when a optimal position can't be found. Closes https://github.com/ckeditor/ckeditor5/issues/17220

---

### Additional information

According to comment here: https://github.com/ckeditor/ckeditor5/issues/17220#issue-2565799770

This condition is incorrect: 
`optimalPanelPosition ? optimalPanelPosition.name : this._panelPositions[ 0 ].name` 

The function returns the wrong value when `optimalPanelPosition` is not found. Instead of `se`, it returns `southEast`. This happens because it uses the `name` property from the `Function` type instead of the name returned by the positioning function.
