### PR TITLE
Remove dependence on randomUUID

### DIFF
--- a/packages/ckeditor5-core/src/editor/utils/editorusagedata.ts
+++ b/packages/ckeditor5-core/src/editor/utils/editorusagedata.ts
@@ -7,7 +7,7 @@
  * @module core/editor/utils/editorusagedata
  */
 
-import { env, global } from '@ckeditor/ckeditor5-utils';
+import { env, global, uid } from '@ckeditor/ckeditor5-utils';
 
 import type Editor from '../editor.js';
 import type { ToolbarConfig, ToolbarConfigItem } from '../editorconfig.js';
@@ -141,14 +141,14 @@ function getEnvUsageData(): EnvUsageData {
 
 function getSessionId(): string {
 	if ( !localStorage.getItem( '__ckeditor-session-id' ) ) {
-		localStorage.setItem( '__ckeditor-session-id', crypto.randomUUID() );
+		localStorage.setItem( '__ckeditor-session-id', uid() );
 	}
 
 	return localStorage.getItem( '__ckeditor-session-id' )!;
 }
 
 function getPageSessionID() {
-	global.window.CKEDITOR_PAGE_SESSION_ID = global.window.CKEDITOR_PAGE_SESSION_ID || crypto.randomUUID();
+	global.window.CKEDITOR_PAGE_SESSION_ID = global.window.CKEDITOR_PAGE_SESSION_ID || uid();
 
 	return global.window.CKEDITOR_PAGE_SESSION_ID;
 }

--- a/packages/ckeditor5-core/tests/editor/utils/editorusagedata.js
+++ b/packages/ckeditor5-core/tests/editor/utils/editorusagedata.js
@@ -125,13 +125,13 @@ describe( 'getEditorUsageData()', () => {
 			expect( global.window.CKEDITOR_PAGE_SESSION_ID ).to.be.equal( usageData.pageSessionId );
 		} );
 
-		it( 'should use crypto API to generate session id', async () => {
-			const cryptoStub = sinon.stub( global.window.crypto, 'randomUUID' ).returns( 'FooBar' );
+		it( 'should not use crypto API to generate session id', async () => {
+			const spy = sinon.spy( global.window.crypto, 'randomUUID' );
 
 			editor = await ClassicTestEditor.create( domElement, {} );
+			getEditorUsageData( editor );
 
-			expect( getEditorUsageData( editor ).pageSessionId ).to.be.equal( 'FooBar' );
-			expect( cryptoStub ).to.have.been.calledOnce;
+			expect( spy ).to.not.have.been.called;
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (core): Removes dependence on `crypto.randomUUID`.

---

### Additional information

`crypto.randomUUID` is not available outside secure context (localhost or https).
