### PR TITLE
Jest testing not possible with CommentsRepository premium plugin 

### DIFF
--- a/docs/getting-started/integrations/angular.md
+++ b/docs/getting-started/integrations/angular.md
@@ -654,11 +654,14 @@ beforeAll( () => {
 		};
 	}
 
-	Range.prototype.getClientRects = () => ( {
-		item: () => null,
-		length: 0,
-		[ Symbol.iterator ]: function* () {}
-	} );
+	const getClientRects = () => ({
+	    item: () => null,
+	    length: 0,
+	    [Symbol.iterator]: function* () {} as any,
+	});
+	
+	Range.prototype.getClientRects = getClientRects;
+	Element.prototype.getClientRects = getClientRects;
 } );
 ```
 

--- a/docs/getting-started/integrations/react-default-npm.md
+++ b/docs/getting-started/integrations/react-default-npm.md
@@ -305,11 +305,14 @@ beforeAll( () => {
 		};
 	}
 
-	Range.prototype.getClientRects = () => ( {
-		item: () => null,
-		length: 0,
-		[ Symbol.iterator ]: function* () {}
-	} );
+	const getClientRects = () => ({
+	    item: () => null,
+	    length: 0,
+	    [Symbol.iterator]: function* () {} as any,
+	});
+	
+	Range.prototype.getClientRects = getClientRects;
+	Element.prototype.getClientRects = getClientRects;
 } );
 
 const SomeComponent = ( { value, onChange } ) => {

--- a/docs/getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/integrations/vuejs-v3.md
@@ -372,11 +372,14 @@ beforeAll( () => {
 		};
 	}
 
-	Range.prototype.getClientRects = () => ({
-		item: () => null,
-		length: 0,
-		[Symbol.iterator]: function* () {},
+	const getClientRects = () => ({
+	    item: () => null,
+	    length: 0,
+	    [Symbol.iterator]: function* () {} as any,
 	});
+	
+	Range.prototype.getClientRects = getClientRects;
+	Element.prototype.getClientRects = getClientRects;
 } );
 ```
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Enhance jest testing section to work with CommentsRepository. Closes #17421.

---

### Additional information

#### 📝 Provide a description of requested docs changes

The jest related docs for angular, react and vue are not working when the premium  plugin CommentsRepository is used

#### Error message
```
FrontEnd\node_modules\@ckeditor\ckeditor5-collaboration-core\dist\index.js:392
    const _0x27ffc6 = _0x20b54e['getClientRects']()['item'](0x0);
                                                           ^

TypeError: _0x20b54e.getClientRects(...).item is not a function
    at R (FrontEnd\node_modules\@ckeditor\ckeditor5-collaboration-core\dist\index.js:392:60)
    at r._getTargetForId (FrontEnd\node_modules\@ckeditor\ckeditor5-comments\dist\index.js:22:176593)     
    at d._target (FrontEnd\node_modules\@ckeditor\ckeditor5-comments\dist\index.js:22:178362)
    at d._getNormalizedTarget (FrontEnd\node_modules\@ckeditor\ckeditor5-comments\dist\index.js:22:54176) 
    at new d (FrontEnd\node_modules\@ckeditor\ckeditor5-comments\dist\index.js:22:52317)
    at o._attachCommentThread (FrontEnd\node_modules\@ckeditor\ckeditor5-comments\dist\index.js:22:137698)
    at ie.attachTo (FrontEnd\node_modules\@ckeditor\ckeditor5-comments\dist\index.js:22:154306)
    at FrontEnd\node_modules\@ckeditor\ckeditor5-comments\dist\index.js:22:178334
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

#### Fix
Additional mocking for Element.prototype.getClientRects is needed
