### PR TITLE
Letter descenders should not be clipped in the top-level menu bar categories

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenubutton.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/menubar/menubarmenubutton.css
@@ -47,6 +47,12 @@
 		& .ck-button__label {
 			width: unset;
 			line-height: unset;
+
+			/*
+			 * Top-level buttons don't use ellipsis and overflow: hidden clips descenders.
+			 *  See https://github.com/ckeditor/ckeditor5/issues/17422.
+			 */
+			overflow: visible;
 		}
 
 		&.ck-on {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (theme-lark): Letter descenders should not be clipped in the top-level menu bar categories. Closes #17422.

---

### Additional information


https://github.com/user-attachments/assets/56abd62e-65c1-4c9d-8d6f-82227ff13d25


