### PR TITLE
Fixed dragging inline object with content.

### DIFF
--- a/packages/ckeditor5-clipboard/src/dragdroptarget.ts
+++ b/packages/ckeditor5-clipboard/src/dragdroptarget.ts
@@ -391,7 +391,7 @@ function findDropTargetRange(
 					const targetViewPosition = targetViewRanges[ 0 ].start;
 					const targetModelPosition = mapper.toModelPosition( targetViewPosition );
 					const canDropOnPosition = !draggedRange || Array
-						.from( draggedRange.getItems() )
+						.from( draggedRange.getItems( { shallow: true } ) )
 						.every( item => model.schema.checkChild( targetModelPosition, item as Node ) );
 
 					if ( canDropOnPosition ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (clipboard): An in-text drop of an inline object with elements inside should be possible. Closes #16101.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
