### PR TITLE
Pass information to the downcast converter when clipboard pipeline is used

### DIFF
--- a/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
@@ -318,7 +318,7 @@ export default class ClipboardPipeline extends Plugin {
 		}, { priority: 'low' } );
 
 		this.listenTo<ClipboardOutputTransformationEvent>( this, 'outputTransformation', ( evt, data ) => {
-			const content = editor.data.toView( data.content );
+			const content = editor.data.toView( data.content, { usingClipboardPipeline: true } );
 
 			viewDocument.fire<ViewDocumentClipboardOutputEvent>( 'clipboardOutput', {
 				dataTransfer: data.dataTransfer,

--- a/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
@@ -330,7 +330,7 @@ export default class ClipboardPipeline extends Plugin {
 		this.listenTo<ViewDocumentClipboardOutputEvent>( viewDocument, 'clipboardOutput', ( evt, data ) => {
 			if ( !data.content.isEmpty ) {
 				data.dataTransfer.setData( 'text/html', this.editor.data.htmlProcessor.toData( data.content ) );
-				data.dataTransfer.setData( 'text/plain', viewToPlainText( data.content ) );
+				data.dataTransfer.setData( 'text/plain', viewToPlainText( editor.data.htmlProcessor.domConverter, data.content ) );
 			}
 
 			if ( data.method == 'cut' ) {

--- a/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
+++ b/packages/ckeditor5-clipboard/src/utils/viewtoplaintext.ts
@@ -7,7 +7,7 @@
  * @module clipboard/utils/viewtoplaintext
  */
 
-import type { ViewDocumentFragment, ViewElement, ViewItem } from '@ckeditor/ckeditor5-engine';
+import type { DomConverter, ViewDocumentFragment, ViewElement, ViewItem } from '@ckeditor/ckeditor5-engine';
 
 // Elements which should not have empty-line padding.
 // Most `view.ContainerElement` want to be separate by new-line, but some are creating one structure
@@ -19,10 +19,14 @@ const listElements = [ 'ol', 'ul' ];
 /**
  * Converts {@link module:engine/view/item~Item view item} and all of its children to plain text.
  *
+ * @param converter The converter instance.
  * @param viewItem View item to convert.
  * @returns Plain text representation of `viewItem`.
  */
-export default function viewToPlainText( viewItem: ViewItem | ViewDocumentFragment ): string {
+export default function viewToPlainText(
+	converter: DomConverter,
+	viewItem: ViewItem | ViewDocumentFragment
+): string {
 	if ( viewItem.is( '$text' ) || viewItem.is( '$textProxy' ) ) {
 		return viewItem.data;
 	}
@@ -44,8 +48,36 @@ export default function viewToPlainText( viewItem: ViewItem | ViewDocumentFragme
 	let prev: ViewElement | null = null;
 
 	for ( const child of ( viewItem as ViewElement | ViewDocumentFragment ).getChildren() ) {
-		text += newLinePadding( child as ViewElement, prev ) + viewToPlainText( child );
+		text += newLinePadding( child as ViewElement, prev ) + viewToPlainText( converter, child );
 		prev = child as ViewElement;
+	}
+
+	// If item is a raw element, the only way to get its content is to render it and read the text directly from DOM.
+	if ( viewItem.is( 'rawElement' ) ) {
+		const tempElement = document.createElement( 'div' );
+
+		viewItem.render( tempElement, converter );
+
+		text += domElementToPlainText( tempElement );
+	}
+
+	return text;
+}
+
+/**
+ * Recursively converts DOM element and all of its children to plain text.
+ */
+function domElementToPlainText( element: HTMLElement ): string {
+	let text = '';
+
+	if ( element.nodeType === Node.TEXT_NODE ) {
+		return element.textContent!;
+	} else if ( element.tagName === 'BR' ) {
+		return '\n';
+	}
+
+	for ( const child of element.childNodes ) {
+		text += domElementToPlainText( child as HTMLElement );
 	}
 
 	return text;

--- a/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
@@ -485,9 +485,27 @@ describe( 'ClipboardPipeline feature', () => {
 				expect( data.dataTransfer ).to.equal( dataTransferMock );
 				expect( data.content ).is.instanceOf( ModelDocumentFragment );
 				expect( stringifyModel( data.content ) ).to.equal( '<paragraph>bc</paragraph><paragraph>de</paragraph>' );
-
 				done();
 			} );
+
+			viewDocument.fire( 'copy', {
+				dataTransfer: dataTransferMock,
+				preventDefault: preventDefaultSpy
+			} );
+		} );
+
+		it( 'triggers the conversion with the `useClipboardPipeline` flag', done => {
+			const dataTransferMock = createDataTransfer();
+			const preventDefaultSpy = sinon.spy();
+			const toViewSpy = sinon.spy( editor.data, 'toView' );
+
+			setModelData( editor.model, '<paragraph>a[bc</paragraph><paragraph>de]f</paragraph>' );
+
+			clipboardPlugin.on( 'outputTransformation', ( evt, data ) => {
+				expect( toViewSpy ).calledWithExactly( data.content, { usingClipboardPipeline: true } );
+
+				done();
+			}, { priority: 'lowest' } );
 
 			viewDocument.fire( 'copy', {
 				dataTransfer: dataTransferMock,

--- a/packages/ckeditor5-clipboard/tests/utils/viewtoplaintext.js
+++ b/packages/ckeditor5-clipboard/tests/utils/viewtoplaintext.js
@@ -3,14 +3,26 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
+import { DomConverter, StylesProcessor, ViewDocument, DowncastWriter } from '@ckeditor/ckeditor5-engine';
 import viewToPlainText from '../../src/utils/viewtoplaintext.js';
 
 import { parse as parseView } from '@ckeditor/ckeditor5-engine/src/dev-utils/view.js';
 
 describe( 'viewToPlainText()', () => {
+	let converter, viewDocument;
+
+	beforeEach( () => {
+		viewDocument = new ViewDocument( new StylesProcessor() );
+		converter = new DomConverter( viewDocument );
+	} );
+
+	afterEach( () => {
+		viewDocument.destroy();
+	} );
+
 	function testViewToPlainText( viewString, expectedText ) {
 		const view = parseView( viewString );
-		const text = viewToPlainText( view );
+		const text = viewToPlainText( converter, view );
 
 		expect( text ).to.equal( expectedText );
 	}
@@ -41,7 +53,7 @@ describe( 'viewToPlainText()', () => {
 		const view = parseView( viewString );
 		view.getChild( 1 )._setCustomProperty( 'dataPipeline:transparentRendering', true );
 
-		const text = viewToPlainText( view );
+		const text = viewToPlainText( converter, view );
 
 		expect( text ).to.equal( expectedText );
 	} );
@@ -125,5 +137,15 @@ describe( 'viewToPlainText()', () => {
 
 			'Foo\n\nA\n\nB\n\nBar'
 		);
+	} );
+
+	it( 'should convert a view RawElement', () => {
+		const writer = new DowncastWriter( viewDocument );
+		const rawElement = writer.createRawElement( 'div', { 'data-foo': 'bar' }, function( domElement ) {
+			domElement.innerHTML = '<p>Foo</p><br><p>Bar</p>';
+		} );
+		const text = viewToPlainText( converter, rawElement );
+
+		expect( text ).to.equal( 'Foo\nBar' );
 	} );
 } );

--- a/packages/ckeditor5-image/src/image/imageblockediting.ts
+++ b/packages/ckeditor5-image/src/image/imageblockediting.ts
@@ -115,10 +115,12 @@ export default class ImageBlockEditing extends Plugin {
 		conversion.for( 'upcast' )
 			.elementToElement( {
 				view: getImgViewElementMatcher( editor, 'imageBlock' ),
-				model: ( viewImage, { writer } ) => writer.createElement(
-					'imageBlock',
-					viewImage.hasAttribute( 'src' ) ? { src: viewImage.getAttribute( 'src' ) } : undefined
-				)
+				model: ( viewImage, { writer } ) => {
+					return writer.createElement(
+						'imageBlock',
+						viewImage.hasAttribute( 'src' ) ? { src: viewImage.getAttribute( 'src' ) } : undefined
+					);
+				}
 			} )
 			.add( upcastImageFigure( imageUtils ) );
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (clipboard): Pass information to the downcast converter when clipboard pipeline is used to allow for customization.

Feature (clipboard): `viewToPlainText()` helper will now parse the view `RawElement` instances.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
