### PR TITLE
Use binary search in `insertToPriorityArray`

### DIFF
--- a/packages/ckeditor5-utils/src/inserttopriorityarray.ts
+++ b/packages/ckeditor5-utils/src/inserttopriorityarray.ts
@@ -35,6 +35,7 @@ export interface ObjectWithPriority {
 export default function insertToPriorityArray<T extends ObjectWithPriority>( objects: Array<T>, objectToInsert: T ): void {
 	const priority = priorities.get( objectToInsert.priority );
 
+	// Binary search for better performance in large tables.
 	let left = 0;
 	let right = objects.length;
 

--- a/packages/ckeditor5-utils/src/inserttopriorityarray.ts
+++ b/packages/ckeditor5-utils/src/inserttopriorityarray.ts
@@ -40,7 +40,7 @@ export default function insertToPriorityArray<T extends ObjectWithPriority>( obj
 	let right = objects.length;
 
 	while ( left < right ) {
-		const mid = ( left + right ) >> 1; // Use bitwise operator for faster floor division by 2
+		const mid = ( left + right ) >> 1; // Use bitwise operator for faster floor division by 2.
 		const midPriority = priorities.get( objects[ mid ].priority );
 
 		if ( midPriority < priority ) {

--- a/packages/ckeditor5-utils/src/inserttopriorityarray.ts
+++ b/packages/ckeditor5-utils/src/inserttopriorityarray.ts
@@ -35,13 +35,19 @@ export interface ObjectWithPriority {
 export default function insertToPriorityArray<T extends ObjectWithPriority>( objects: Array<T>, objectToInsert: T ): void {
 	const priority = priorities.get( objectToInsert.priority );
 
-	for ( let i = 0; i < objects.length; i++ ) {
-		if ( priorities.get( objects[ i ].priority ) < priority ) {
-			objects.splice( i, 0, objectToInsert );
+	let left = 0;
+	let right = objects.length;
 
-			return;
+	while ( left < right ) {
+		const mid = ( left + right ) >> 1; // Use bitwise operator for faster floor division by 2
+		const midPriority = priorities.get( objects[ mid ].priority );
+
+		if ( midPriority < priority ) {
+			right = mid;
+		} else {
+			left = mid + 1;
 		}
 	}
 
-	objects.push( objectToInsert );
+	objects.splice( left, 0, objectToInsert );
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (utils): Use binary search in `insertToPriorityArray()` for better performance when handling big tables.

---

Reduces the time needed to render a table in the `tableHuge` test by ~67%.