### PR TITLE
Update Vite webpack docs.

### DIFF
--- a/docs/getting-started/legacy-getting-started/integrations/vuejs-v2.md
+++ b/docs/getting-started/legacy-getting-started/integrations/vuejs-v2.md
@@ -371,8 +371,9 @@ module.exports = {
 		//
 		//		svgRule.uses.clear();
 		//
-		// * or exclude ckeditor directory from node_modules:
+		// * or exclude ckeditor directories from node_modules:
 		svgRule.exclude.add( path.join( __dirname, 'node_modules', '@ckeditor' ) );
+		svgRule.exclude.add( path.join( __dirname, 'node_modules', 'ckeditor5-collaboration' ) );
 
 		// Add an entry for *.svg files belonging to CKEditor. You can either:
 		//

--- a/docs/getting-started/legacy-getting-started/integrations/vuejs-v2.md
+++ b/docs/getting-started/legacy-getting-started/integrations/vuejs-v2.md
@@ -361,7 +361,7 @@ module.exports = {
 	// Vue CLI would normally use its own loader to load .svg and .css files, however:
 	//	1. The icons used by CKEditor&nbsp;5 must be loaded using raw-loader,
 	//	2. The CSS used by CKEditor&nbsp;5 must be transpiled using PostCSS to load properly.
-	chainWebpack: configuration => {
+	chainWebpack: config => {
 		// (1.) To handle editor icons, get the default rule for *.svg files first:
 		const svgRule = config.module.rule( 'svg' );
 

--- a/docs/getting-started/legacy-getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/legacy-getting-started/integrations/vuejs-v3.md
@@ -389,8 +389,9 @@ module.exports = {
 		//
 		//		svgRule.uses.clear();
 		//
-		// * or exclude ckeditor directory from node_modules:
+		// * or exclude ckeditor directories from node_modules:
 		svgRule.exclude.add( path.join( __dirname, 'node_modules', '@ckeditor' ) );
+		svgRule.exclude.add( path.join( __dirname, 'node_modules', 'ckeditor5-collaboration' ) );
 
 		// Add an entry for *.svg files belonging to CKEditor. You can either:
 		//

--- a/docs/getting-started/legacy-getting-started/integrations/vuejs-v3.md
+++ b/docs/getting-started/legacy-getting-started/integrations/vuejs-v3.md
@@ -379,7 +379,7 @@ module.exports = {
 	// Vue CLI would normally use its own loader to load .svg and .css files, however:
 	//	1. The icons used by CKEditor&nbsp;5 must be loaded using raw-loader,
 	//	2. The CSS used by CKEditor&nbsp;5 must be transpiled using PostCSS to load properly.
-	chainWebpack: configuration => {
+	chainWebpack: config => {
 		// (1.) To handle the editor icons, get the default rule for *.svg files first:
 		const svgRule = config.module.rule( 'svg' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Rename `configure` to `config` in Vite Webpack docs. Closes https://github.com/ckeditor/ckeditor5/issues/17402
Docs: Add missing SVG exclude to Webpack configuration in Vite docs.

---

### Additional information

Closes https://github.com/cksource/ckeditor5-commercial/issues/6769, https://github.com/cksource/ckeditor5-commercial/issues/6769
