### PR TITLE
Fix wrong integrations key name in license checks.

### DIFF
--- a/packages/ckeditor5-core/src/editor/utils/editorusagedata.ts
+++ b/packages/ckeditor5-core/src/editor/utils/editorusagedata.ts
@@ -30,7 +30,7 @@ export function getEditorUsageData( editor: Editor ): EditorUsageData {
 		plugins: getPluginsUsageData( editor.plugins ),
 		distribution: getDistributionUsageData(),
 		env: getEnvUsageData(),
-		integrations: Object.create( null ),
+		integration: Object.create( null ),
 		menuBar: {
 			isVisible: !!editor.config.get( 'menuBar.isVisible' )
 		},
@@ -185,7 +185,7 @@ export type EditorUsageData = {
 		channel: string;
 	};
 	env: EnvUsageData;
-	integrations: {
+	integration: {
 		[integrationName: string]: IntegrationUsageData;
 	};
 };

--- a/packages/ckeditor5-core/tests/editor/licensecheck.js
+++ b/packages/ckeditor5-core/tests/editor/licensecheck.js
@@ -806,7 +806,7 @@ describe( 'Editor - license check', () => {
 
 		it( 'should be possible to set integrations usage data using helper passed in the event without raising error', () => {
 			editor.on( 'collectUsageData', ( _, { setUsageData } ) => {
-				setUsageData( 'integrations.foo', 123 );
+				setUsageData( 'integration.foo', 123 );
 			} );
 
 			editor.fire( 'ready' );
@@ -815,7 +815,7 @@ describe( 'Editor - license check', () => {
 				sinon.match.string,
 				sinon.match( {
 					editor: {
-						integrations: {
+						integration: {
 							foo: 123
 						}
 					}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Rename `integrations` to `integration` usage data format. 
