### PR TITLE
Don't restart editor by watchdog after license-related errors.

### DIFF
--- a/packages/ckeditor5-core/src/editor/editor.ts
+++ b/packages/ckeditor5-core/src/editor/editor.ts
@@ -919,7 +919,7 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 				 *
 				 * @error invalid-license-key
 				 */
-				throw new CKEditorError( 'invalid-license-key', this );
+				throw new CKEditorError( 'invalid-license-key' );
 			}
 
 			if ( reason == 'expired' ) {
@@ -929,7 +929,7 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 				 *
 				 * @error license-key-expired
 				 */
-				throw new CKEditorError( 'license-key-expired', this );
+				throw new CKEditorError( 'license-key-expired' );
 			}
 
 			if ( reason == 'domainLimit' ) {
@@ -941,7 +941,7 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 				 *
 				 * @error license-key-domain-limit
 				 */
-				throw new CKEditorError( 'license-key-domain-limit', this );
+				throw new CKEditorError( 'license-key-domain-limit' );
 			}
 
 			if ( reason == 'featureNotAllowed' ) {
@@ -954,7 +954,7 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 				 * @error license-key-plugin-not-allowed
 				 * @param {String} pluginName The plugin you tried to load.
 				 */
-				throw new CKEditorError( 'license-key-plugin-not-allowed', this, { pluginName } );
+				throw new CKEditorError( 'license-key-plugin-not-allowed', null, { pluginName } );
 			}
 
 			if ( reason == 'evaluationLimit' ) {
@@ -964,7 +964,7 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 				 *
 				 * @error license-key-evaluation-limit
 				 */
-				throw new CKEditorError( 'license-key-evaluation-limit', this );
+				throw new CKEditorError( 'license-key-evaluation-limit' );
 			}
 
 			if ( reason == 'trialLimit' ) {
@@ -975,7 +975,7 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 				 *
 				 * @error license-key-trial-limit
 				 */
-				throw new CKEditorError( 'license-key-trial-limit', this );
+				throw new CKEditorError( 'license-key-trial-limit' );
 			}
 
 			if ( reason == 'developmentLimit' ) {
@@ -986,7 +986,7 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 				 *
 				 * @error license-key-development-limit
 				 */
-				throw new CKEditorError( 'license-key-development-limit', this );
+				throw new CKEditorError( 'license-key-development-limit' );
 			}
 
 			if ( reason == 'usageLimit' ) {
@@ -1002,7 +1002,7 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 				 *
 				 * @error license-key-usage-limit
 				 */
-				throw new CKEditorError( 'license-key-usage-limit', this );
+				throw new CKEditorError( 'license-key-usage-limit' );
 			}
 
 			if ( reason == 'distributionChannel' ) {
@@ -1019,7 +1019,7 @@ export default abstract class Editor extends /* #__PURE__ */ ObservableMixin() {
 				 *
 				 * @error license-key-invalid-distribution-channel
 				 */
-				throw new CKEditorError( 'license-key-invalid-distribution-channel', this );
+				throw new CKEditorError( 'license-key-invalid-distribution-channel' );
 			}
 
 			/* istanbul ignore next -- @preserve */

--- a/packages/ckeditor5-core/tests/editor/licensecheck.js
+++ b/packages/ckeditor5-core/tests/editor/licensecheck.js
@@ -702,7 +702,7 @@ describe( 'Editor - license check', () => {
 
 				editor._showLicenseError( reason, pluginName );
 
-				expectToThrowCKEditorError( () => clock.tick( 1 ), error, editor, expectedData );
+				expectToThrowCKEditorError( () => clock.tick( 1 ), error, undefined, expectedData );
 			} );
 		}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Watchdog should not restart the editor when there are license-related errors.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
