### PR TITLE
Prefer to pick `width` style from `figure` element instead of img if possible.

### DIFF
--- a/packages/ckeditor5-image/src/imageresize/imageresizeediting.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizeediting.ts
@@ -186,6 +186,22 @@ export default class ImageResizeEditing extends Plugin {
 							return null;
 						}
 
+						// If this is an image inside a figure with width style, skip setting the width.
+						// See: https://github.com/ckeditor/ckeditor5/issues/17441
+						if ( viewElement.name !== 'figure' ) {
+							const imageUtils: ImageUtils = editor.plugins.get( 'ImageUtils' );
+							let parent = viewElement.parent;
+
+							// Traverse up through parents until we find a figure or run out of ancestors
+							while ( parent ) {
+								if ( parent.is( 'element' ) && imageUtils.isBlockImageView( parent ) && parent.getStyle( 'width' ) ) {
+									return null;
+								}
+
+								parent = parent.parent;
+							}
+						}
+
 						return viewElement.getStyle( 'width' );
 					}
 				}

--- a/packages/ckeditor5-image/tests/imageresize/imageresizeediting.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizeediting.js
@@ -105,6 +105,16 @@ describe( 'ImageResizeEditing', () => {
 				expect( editor.model.document.getRoot().getChild( 0 ).getAttribute( 'resizedWidth' ) ).to.equal( '100px' );
 			} );
 
+			it( 'it should prefer the width from the figure element over the width from the image element', () => {
+				editor.setData(
+					'<figure class="image" style="width:100px;">' +
+						`<img src="${ IMAGE_SRC_FIXTURE }" style="width:200px;">` +
+					'</figure>'
+				);
+
+				expect( editor.model.document.getRoot().getChild( 0 ).getAttribute( 'resizedWidth' ) ).to.equal( '100px' );
+			} );
+
 			it( 'upcasts 50% width correctly', () => {
 				editor.setData( `<figure class="image" style="width:50%;"><img src="${ IMAGE_SRC_FIXTURE }"></figure>` );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (image): Prefer to pick `width` style from `figure` element instead of `img` if possible. Closes https://github.com/ckeditor/ckeditor5/issues/17441

---

### Additional information

Consider this HTML:

```html
<figure style="clear: both;margin: 0.9em auto;min-width: 50px;text-align: center;box-sizing: border-box;display: block;max-width: 100%;width: 5.15%;"class="image image_resized">
 <img height="233" width="258" src="https://www.shutterstock.com/image-vector/sample-red-square-grunge-stamp-260nw-338250266.jpg" style="display: block;height: auto;margin: 0px auto;max-width: 100%;min-width: 100%;width: 100%;aspect-ratio: 258/233;" />
</figure>
```

#### Before

![image](https://github.com/user-attachments/assets/ebb46ea0-07b9-4d3b-b90d-2528b5d461f4)

#### After

![image](https://github.com/user-attachments/assets/e65f4bbf-fe79-45bd-a403-3b61ee9b9300)

#### Another possible fix :thinking: 

```tsx
editor.conversion.for( 'upcast' ).add( dispatcher => {
	dispatcher.on( 'element:figure', ( evt, data, conversionApi ) => {
		const viewFigure = data.viewItem;
		const viewImg = imageUtils.findViewImgElement( viewFigure );

		if ( !viewImg || !viewImg.getStyle( 'width' ) || !imageUtils.isBlockImageView( viewFigure ) ) {
			return;
		}

		const figureWidth = viewFigure.getStyle( 'width' );

		if ( figureWidth ) {
			conversionApi.writer.setAttribute( 'resizedWidth', figureWidth, data.modelRange.start.nodeAfter );
		}
	}, { priority: 'low' } );
} );
```

