### PR TITLE
Export `GFMDataProcessor` and `MarkdownToHtml` from `ckeditor5-markdown-gfm`

### DIFF
--- a/packages/ckeditor5-markdown-gfm/src/index.ts
+++ b/packages/ckeditor5-markdown-gfm/src/index.ts
@@ -9,5 +9,7 @@
 
 export { default as Markdown } from './markdown.js';
 export { default as PasteFromMarkdownExperimental } from './pastefrommarkdownexperimental.js';
+export { default as GFMDataProcessor } from './gfmdataprocessor.js';
+export { MarkdownToHtml } from './markdown2html/markdown2html.js';
 
 import './augmentation.js';


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (markdown-gfm): Export `GFMDataProcessor` and `MarkdownToHtml` from package. Closes https://github.com/ckeditor/ckeditor5/issues/17395