### PR TITLE
BodyCollection#attachToDom() should create another wrapper if the previous one got disconnected from DOM

### DIFF
--- a/packages/ckeditor5-ui/src/editorui/bodycollection.ts
+++ b/packages/ckeditor5-ui/src/editorui/bodycollection.ts
@@ -118,7 +118,8 @@ export default class BodyCollection extends ViewCollection {
 			children: this
 		} ).render() as HTMLElement;
 
-		if ( !BodyCollection._bodyWrapper ) {
+		// Create a shared wrapper if there were none or the previous one got disconnected from DOM.
+		if ( !BodyCollection._bodyWrapper || !BodyCollection._bodyWrapper.isConnected ) {
 			BodyCollection._bodyWrapper = createElement( document, 'div', { class: 'ck-body-wrapper' } );
 			document.body.appendChild( BodyCollection._bodyWrapper );
 		}

--- a/packages/ckeditor5-ui/tests/editorui/bodycollection.js
+++ b/packages/ckeditor5-ui/tests/editorui/bodycollection.js
@@ -116,6 +116,51 @@ describe( 'BodyCollection', () => {
 			expect( BodyCollection._bodyWrapper ).to.equal( bodyElements[ 0 ].parentNode );
 		} );
 
+		it( 'should create another wrapper if the previous one got disconnected from DOM', () => {
+			const body1 = new BodyCollection( locale );
+			body1.attachToDom();
+
+			let wrappers, bodyContainers;
+
+			wrappers = document.querySelectorAll( '.ck-body-wrapper' );
+			bodyContainers = document.querySelectorAll( '.ck-body' );
+
+			expect( wrappers.length ).to.equal( 1 );
+			expect( bodyContainers.length ).to.equal( 1 );
+
+			// Some external code breaks the wrapper.
+			wrappers[ 0 ].remove();
+
+			const body2 = new BodyCollection( locale );
+			body2.attachToDom();
+
+			wrappers = document.querySelectorAll( '.ck-body-wrapper' );
+			bodyContainers = document.querySelectorAll( '.ck-body' );
+
+			expect( wrappers.length ).to.equal( 1 );
+			expect( bodyContainers.length ).to.equal( 1 );
+			expect( bodyContainers[ 0 ] ).to.equal( body2.bodyCollectionContainer );
+			expect( body2.bodyCollectionContainer.parentElement ).to.equal( wrappers[ 0 ] );
+
+			body1.detachFromDom();
+
+			wrappers = document.querySelectorAll( '.ck-body-wrapper' );
+			bodyContainers = document.querySelectorAll( '.ck-body' );
+
+			expect( wrappers.length ).to.equal( 1 );
+			expect( bodyContainers.length ).to.equal( 1 );
+			expect( bodyContainers[ 0 ] ).to.equal( body2.bodyCollectionContainer );
+			expect( body2.bodyCollectionContainer.parentElement ).to.equal( wrappers[ 0 ] );
+
+			body2.detachFromDom();
+
+			wrappers = document.querySelectorAll( '.ck-body-wrapper' );
+			bodyContainers = document.querySelectorAll( '.ck-body' );
+
+			expect( wrappers.length ).to.equal( 0 );
+			expect( bodyContainers.length ).to.equal( 0 );
+		} );
+
 		it( 'should render views in proper body collections', () => {
 			const body1 = new BodyCollection( locale );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (ui): `BodyCollection#attachToDom()` should create another wrapper if the previous one got disconnected from DOM.

---

### Additional information

* This is related to https://github.com/ckeditor/ckeditor5/pull/17321.
* This PR addresses the failing tests after ☝️ when running the CI in the whole-project-production mode `yarn run test --repositories=ckeditor5 --production --reporter=dots --browsers=ChromeHeadless`.
* The previous PR removed [the code that blindly re-created the `.ck-body-wrapper` whenever it was not found in DOM](https://github.com/ckeditor/ckeditor5/pull/17321/files#diff-8d63c3c62f81def6671131d89c046acd07efae17491403c4cbc009e8957ecde0L85-L87).
  * That blind logic turned out to be relevant in our CI environment which I didn't realize. 
  * [There's a test helper that cleans all remaining `.ck-body-wrapper` after tests failed](https://github.com/ckeditor/ckeditor5/blob/28a9f1e7cb93c1a80cdb753bd24bf5f8304dd1c8/packages/ckeditor5-core/tests/_utils/cleanup.js#L8-L20). When all tests are run together and `.ck-body-wrapper` is not re-created, this cleanup code ends breaking tests because features keep adding things to the body wrapper that is no longer in DOM. 
* This PR brings the same blind `.ck-body-wrapper` re-creation logic back but in the new singleton style.
