### PR TITLE
No longer abort already destroyed `FileLoader` in `FileRepository`.

### DIFF
--- a/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
+++ b/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts
@@ -385,7 +385,13 @@ export default class ImageUploadEditing extends Plugin {
 
 				// Permanently remove image from insertion batch.
 				model.enqueueChange( { isUndoable: false }, writer => {
-					writer.remove( imageUploadElements.get( loader.id )! );
+					const node = imageUploadElements.get( loader.id );
+
+					// Handle situation when the image has been removed and then `abort` exception was thrown.
+					// See: https://github.com/cksource/ckeditor5-commercial/issues/6817
+					if ( node && node.root.rootName !== '$graveyard' ) {
+						writer.remove( node );
+					}
 				} );
 
 				clean();

--- a/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
+++ b/packages/ckeditor5-image/tests/imageupload/imageuploadediting.js
@@ -1567,14 +1567,7 @@ describe( 'ImageUploadEditing', () => {
 
 			editor.execute( 'undo' );
 
-			const removeMock = sinon.stub( Writer.prototype, 'remove' ).callThrough();
-
-			// Simulate change to trigger image upload error handling
-			const imagePlugin = editor.plugins.get( 'ImageUploadEditing' );
-			imagePlugin._uploadImageElements.set( loader.id, image );
-
-			// Throw aborted exception to simulate loader error
-			loader.status = 'aborted';
+			const removeMock = sinon.spy( Writer.prototype, 'remove' );
 
 			model.document.once( 'change', () => {
 				tryExpect( done, () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (upload): Editor should no longer crash when executing undo while an image is still being uploaded.

---

### Additional information

Closes https://github.com/cksource/ckeditor5-commercial/issues/6817

It looks like `undo` moves uploaded node to graveyard, which causes abort image uploading here:
https://github.com/ckeditor/ckeditor5/blob/ck/6817/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts#L227

```
						if ( isInsertedInGraveyard ) {
							// If the image was inserted to the graveyard for good (**not** replaced by another image),
							// only then abort the loading process.
							if ( !insertedImagesIds.has( uploadId ) ) {
								loader.abort();
							}
						} else {
```

which causes `aborted` exception, that is caught here:
https://github.com/ckeditor/ckeditor5/blob/ck/6817/packages/ckeditor5-image/src/imageupload/imageuploadediting.ts#L387-L389

```
			.catch( error => {
				if ( editor.ui ) {
					editor.ui.ariaLiveAnnouncer.announce( t( 'Error during image upload' ) );
				}

				// If status is not 'error' nor 'aborted' - throw error because it means that something else went wrong,
				// it might be generic error and it would be real pain to find what is going on.
				if ( loader.status !== 'error' && loader.status !== 'aborted' ) {
					throw error;
				}

				// Might be 'aborted'.
				if ( loader.status == 'error' && error ) {
					notification.showWarning( error, {
						title: t( 'Upload failed' ),
						namespace: 'upload'
					} );
				}

				// Permanently remove image from insertion batch.
				model.enqueueChange( { isUndoable: false }, writer => {
					writer.remove( imageUploadElements.get( loader.id )! );
				} );

				clean();
			} );
```

... and tries to abort again, which causes exception. I adjusted `FileLoader` method to handle similar scenarios, and asseration in image upload.
