### PR TITLE
Extend API docs for 'Essentials' for missing plugin.

### DIFF
--- a/packages/ckeditor5-essentials/src/essentials.ts
+++ b/packages/ckeditor5-essentials/src/essentials.ts
@@ -22,6 +22,7 @@ import { AccessibilityHelp } from 'ckeditor5/src/ui.js';
  *
  * It includes:
  *
+ * * {@link module:core/accessibility~Accessibility},
  * * {@link module:clipboard/clipboard~Clipboard},
  * * {@link module:enter/enter~Enter},
  * * {@link module:select-all/selectall~SelectAll},


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Extend API docs of `Essentials` plugin that it includes also the `AccessibilityHelp` plugin. Closes https://github.com/ckeditor/ckeditor5/issues/17499.

---

### Additional information

⚠️ `release` branch is the target. ⚠️ 
