### PR TITLE
Prevent blurry of the inline bookmark icon while zooming in.

### DIFF
--- a/packages/ckeditor5-bookmark/theme/bookmark.css
+++ b/packages/ckeditor5-bookmark/theme/bookmark.css
@@ -41,9 +41,11 @@
 			top: -0.1em;
 
 			& .ck-icon {
-				height: 1.2em;
+				height: 1.25em;
 				width: auto;
 				vertical-align: middle;
+				/* Overwrite the `.ck-icon` property to prevent the icon from being blurry while using zooming in. */
+				will-change: unset;
 			}
 		}
 	}

--- a/packages/ckeditor5-bookmark/theme/bookmark.css
+++ b/packages/ckeditor5-bookmark/theme/bookmark.css
@@ -41,7 +41,7 @@
 			top: -0.1em;
 
 			& .ck-icon {
-				height: 1.25em;
+				height: 1.2em;
 				width: auto;
 				vertical-align: middle;
 				/* Overwrite the `.ck-icon` `will-change` property to prevent the icon from being blurry while using zooming in. */

--- a/packages/ckeditor5-bookmark/theme/bookmark.css
+++ b/packages/ckeditor5-bookmark/theme/bookmark.css
@@ -44,7 +44,7 @@
 				height: 1.25em;
 				width: auto;
 				vertical-align: middle;
-				/* Overwrite the `.ck-icon` property to prevent the icon from being blurry while using zooming in. */
+				/* Overwrite the `.ck-icon` `will-change` property to prevent the icon from being blurry while using zooming in. */
 				will-change: unset;
 			}
 		}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Prevent blurry of the inline bookmark icon while zooming in the browser.

---

Rendered with zoom set to 100% and then zoom in to 300%.

Before:
![Screenshot 2024-11-21 at 10 18 10](https://github.com/user-attachments/assets/04c9fd64-1739-4c07-8a97-cf1f4e832884)

After:
![Screenshot 2024-11-21 at 10 17 39](https://github.com/user-attachments/assets/495a00ed-8cad-456c-8a68-a24dbf8912d1)


### Additional information

⚠️ `release` branch set as the target ⚠️ 
