### PR TITLE
Stop blurry in the UI icons while zooming in the browser.

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/icon/icon.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-ui/components/icon/icon.css
@@ -18,9 +18,6 @@
 	/* Inherit cursor style (#5). */
 	cursor: inherit;
 
-	/* This will prevent blurry icons on Firefox. See #340. */
-	will-change: transform;
-
 	& * {
 		/* Inherit cursor style (#5). */
 		cursor: inherit;


### PR DESCRIPTION


### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix(theme-lark):Should prevent of blurry the UI icons while zooming in the page. Closes #17510.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
