### PR TITLE
Search for package dependencies in snippet adapter only in known directories where package can exist

### DIFF
--- a/scripts/docs/snippetadapter.mjs
+++ b/scripts/docs/snippetadapter.mjs
@@ -558,7 +558,7 @@ function getPackageDependenciesPaths() {
 		absolute: true
 	};
 
-	return globSync( [ 'packages/*/node_modules', 'external/*/packages/*/node_modules' ], globOptions )
+	return globSync( [ 'packages/*/node_modules', 'external/ckeditor5-commercial/packages/*/node_modules' ], globOptions )
 		.map( p => upath.normalize( p ) );
 }
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Search for package dependencies in snippet adapter only in known directories where package can exist.

---

### Additional information

Closes cksource/ckeditor5-internal#3881.
