### PR TITLE
Improve mapper performance

### DIFF
--- a/packages/ckeditor5-engine/src/conversion/mapper.ts
+++ b/packages/ckeditor5-engine/src/conversion/mapper.ts
@@ -56,7 +56,7 @@ export default class Mapper extends /* #__PURE__ */ EmitterMixin() {
 	 * A map containing callbacks between view element names and functions evaluating length of view elements
 	 * in model.
 	 */
-	private _viewToModelLengthCallbacks: Record<string, ( element: ViewElement ) => number> = {};
+	private _viewToModelLengthCallbacks = new Map<string, ( element: ViewElement ) => number>();
 
 	/**
 	 * Model marker name to view elements mapping.
@@ -461,7 +461,7 @@ export default class Mapper extends /* #__PURE__ */ EmitterMixin() {
 		viewElementName: string,
 		lengthCallback: ( element: ViewElement ) => number
 	): void {
-		this._viewToModelLengthCallbacks[ viewElementName ] = lengthCallback;
+		this._viewToModelLengthCallbacks.set( viewElementName, lengthCallback );
 	}
 
 	/**
@@ -562,7 +562,9 @@ export default class Mapper extends /* #__PURE__ */ EmitterMixin() {
 		while ( stack.length > 0 ) {
 			const node = stack.pop()!;
 
-			const callback = ( node as any ).name && this._viewToModelLengthCallbacks[ ( node as any ).name ];
+			const callback = ( node as any ).name &&
+				this._viewToModelLengthCallbacks.size > 0 &&
+				this._viewToModelLengthCallbacks.get( ( node as any ).name );
 
 			if ( callback ) {
 				len += callback( node as ViewElement );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (engine): Improve performance of the `getModelLength` method.

---

While this looks like a simple change, it introduces significant performance improvements by avoiding recursion and calling `this._viewToModelLengthCallbacks.get()` on nodes without name or when the map is empty (most cases).

| Test name                    	| Improvement in % 	| Improvement in ms 	|
|------------------------------	|-----------------:	|------------------:	|
| `lists`                      	|            -4.9% 	|            -100ms 	|
| `formatting-long-paragraphs` 	|           -15.0% 	|            -730ms 	|
| `inline-styles`              	|           -22.2% 	|           -2310ms 	|
| `wiki`                       	|            -4.0% 	|            -140ms 	|

We could gain even more performance by removing the public `registerViewToModelLength` method and the `this._viewToModelLengthCallbacks` map, since it's only used in legacy lists, which we are deprecating. However, it's likely that it's used by the integrators and may not be possible. This would improve the performance (on top of proposed changes) of `formatting-long-paragraphs` by another 180ms (-4.4%)  and `inline-styles` by 300ms (-3.8%).