### PR TITLE
Make sure that the focus is placed in action view after triggering link or bookmark from toolbar UI.

### DIFF
--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -475,9 +475,10 @@ export default class BookmarkUI extends Plugin {
 				this._addActionsView();
 			}
 
-			// Be sure panel with bookmark is visible.
+			// Be sure panel with bookmark is visible and focused.
 			if ( forceVisible ) {
 				this._balloon.showStack( 'main' );
+				this.actionsView!.focus();
 			}
 		}
 

--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -478,7 +478,15 @@ export default class BookmarkUI extends Plugin {
 			// Be sure panel with bookmark is visible and focused.
 			if ( forceVisible ) {
 				this._balloon.showStack( 'main' );
-				this.actionsView!.focus();
+
+				// While it'd be better to focus it using FocusCycler in the view element, it's not possible
+				// because focusing it like that would cause the tooltip and focus border to show on the
+				// button, which is not desired. So we focus it here, to explicit tell browser to move focus to the
+				// balloon, but we don't want to show the focus border.
+				//
+				// It should be called only if ballon is shown using toolbar button, as focusing the balloon while
+				// triggering the bookmark from the editable would cause the focus to be lost from such editable.
+				this.actionsView!.element!.focus();
 			}
 		}
 

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -518,9 +518,10 @@ export default class LinkUI extends Plugin {
 				this._addActionsView();
 			}
 
-			// Be sure panel with link is visible.
+			// Be sure panel with link is visible and focused.
 			if ( forceVisible ) {
 				this._balloon.showStack( 'main' );
+				this.actionsView!.focus();
 			}
 		}
 

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -521,7 +521,15 @@ export default class LinkUI extends Plugin {
 			// Be sure panel with link is visible and focused.
 			if ( forceVisible ) {
 				this._balloon.showStack( 'main' );
-				this.actionsView!.focus();
+
+				// While it'd be better to focus it using FocusCycler in the view element, it's not possible
+				// because focusing it like that would cause the tooltip and focus border to show on the
+				// button, which is not desired. So we focus it here, to explicit tell browser to move focus to the
+				// balloon, but we don't want to show the focus border.
+				//
+				// It should be called only if ballon is shown using toolbar button, as focusing the balloon while
+				// triggering the bookmark from the editable would cause the focus to be lost from such editable.
+				this.actionsView!.element!.focus();
 			}
 		}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (bookmark, link): Make sure that balloon's action view element is being focused after triggering it using toolbar.  

---

### Additional information

#### Before

https://github.com/user-attachments/assets/3683d1fe-b35d-4aec-8dc6-a45bb4667b44

#### After

https://github.com/user-attachments/assets/e3b0ff20-7e84-45fa-8387-bbb54f822d1a






