### PR TITLE
Feature (ckeditor5-link): Add ensureSafeUrl to exports.

### DIFF
--- a/packages/ckeditor5-link/src/index.ts
+++ b/packages/ckeditor5-link/src/index.ts
@@ -19,7 +19,11 @@ export { default as LinkFormView } from './ui/linkformview.js';
 export { default as LinkCommand } from './linkcommand.js';
 export { default as UnlinkCommand } from './unlinkcommand.js';
 
-export { addLinkProtocolIfApplicable, isLinkableElement } from './utils.js';
+export {
+	addLinkProtocolIfApplicable,
+	ensureSafeUrl,
+	isLinkableElement,
+} from './utils.js';
 
 export type { LinkConfig, LinkDecoratorDefinition } from './linkconfig.js';
 

--- a/packages/ckeditor5-link/src/index.ts
+++ b/packages/ckeditor5-link/src/index.ts
@@ -22,7 +22,7 @@ export { default as UnlinkCommand } from './unlinkcommand.js';
 export {
 	addLinkProtocolIfApplicable,
 	ensureSafeUrl,
-	isLinkableElement,
+	isLinkableElement
 } from './utils.js';
 
 export type { LinkConfig, LinkDecoratorDefinition } from './linkconfig.js';


### PR DESCRIPTION
This adds the `ensureSafeUrl` export to the `ckeditor5-link` package in the same vein as a couple of the other link utilities (i.e. `addLinkProtocolIfApplicable`, `isLinkableElement`). The `ensureSafeUrl` is useful sanitization logic when building a custom UI around CKEditor5.

Commit message:

Other (link): Exported `ensureSafeUrl` icons from ckeditor5-link package.