### PR TITLE
License cleanup - part 1/2

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5** – https://github.com/ckeditor/ckeditor5 <br>
+**CKEditor&nbsp;5** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -108,4 +108,9 @@ Report issues in [the `ckeditor5` repository](https://github.com/ckeditor/ckedit
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "node": ">=18.0.0"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-adapter-ckfinder/LICENSE.md
+++ b/packages/ckeditor5-adapter-ckfinder/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 CKFinder adapter** – https://github.com/ckeditor/ckeditor5-adapter-ckfinder <br>
+**CKEditor&nbsp;5 CKFinder adapter** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-adapter-ckfinder/LICENSE.md
+++ b/packages/ckeditor5-adapter-ckfinder/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 CKFinder adapter** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-adapter-ckfinder/README.md
+++ b/packages/ckeditor5-adapter-ckfinder/README.md
@@ -31,4 +31,9 @@ Check out the [comprehensive Image upload guide](https://ckeditor.com/docs/ckedi
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-adapter-ckfinder/package.json
+++ b/packages/ckeditor5-adapter-ckfinder/package.json
@@ -35,7 +35,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-alignment/LICENSE.md
+++ b/packages/ckeditor5-alignment/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Text alignment feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-alignment/LICENSE.md
+++ b/packages/ckeditor5-alignment/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 text alignment feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Text alignment feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-alignment/LICENSE.md
+++ b/packages/ckeditor5-alignment/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 text alignment feature** – https://github.com/ckeditor/ckeditor5-alignment <br>
+**CKEditor&nbsp;5 text alignment feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-alignment/README.md
+++ b/packages/ckeditor5-alignment/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-alignment` package](https://ckeditor.com/docs/cked
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-alignment/package.json
+++ b/packages/ckeditor5-alignment/package.json
@@ -35,7 +35,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-autoformat/LICENSE.md
+++ b/packages/ckeditor5-autoformat/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 autoformat feature** – https://github.com/ckeditor/ckeditor5-autoformat <br>
+**CKEditor&nbsp;5 autoformat feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-autoformat/LICENSE.md
+++ b/packages/ckeditor5-autoformat/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Autoformat feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-autoformat/LICENSE.md
+++ b/packages/ckeditor5-autoformat/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 autoformat feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Autoformat feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-autoformat/README.md
+++ b/packages/ckeditor5-autoformat/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-autoformat` package](https://ckeditor.com/docs/cke
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-autoformat/package.json
+++ b/packages/ckeditor5-autoformat/package.json
@@ -37,7 +37,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-autosave/LICENSE.md
+++ b/packages/ckeditor5-autosave/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Autosave feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-autosave/LICENSE.md
+++ b/packages/ckeditor5-autosave/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 autosave feature** – https://github.com/ckeditor/ckeditor5-autosave <br>
+**CKEditor&nbsp;5 autosave feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-autosave/LICENSE.md
+++ b/packages/ckeditor5-autosave/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 autosave feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Autosave feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-autosave/README.md
+++ b/packages/ckeditor5-autosave/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-autosave` package](https://ckeditor.com/docs/ckedi
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-autosave/package.json
+++ b/packages/ckeditor5-autosave/package.json
@@ -29,7 +29,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-basic-styles/LICENSE.md
+++ b/packages/ckeditor5-basic-styles/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 basic styles feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Basic styles feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-basic-styles/LICENSE.md
+++ b/packages/ckeditor5-basic-styles/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 basic styles feature** – https://github.com/ckeditor/ckeditor5-basic-styles <br>
+**CKEditor&nbsp;5 basic styles feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-basic-styles/LICENSE.md
+++ b/packages/ckeditor5-basic-styles/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Basic styles feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-basic-styles/README.md
+++ b/packages/ckeditor5-basic-styles/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-basic-styles` package](https://ckeditor.com/docs/c
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-basic-styles/package.json
+++ b/packages/ckeditor5-basic-styles/package.json
@@ -31,7 +31,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-block-quote/LICENSE.md
+++ b/packages/ckeditor5-block-quote/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Block quote feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-block-quote/LICENSE.md
+++ b/packages/ckeditor5-block-quote/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 block quote feature** – https://github.com/ckeditor/ckeditor5-block-quote <br>
+**CKEditor&nbsp;5 block quote feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-block-quote/LICENSE.md
+++ b/packages/ckeditor5-block-quote/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 block quote feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Block quote feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-block-quote/README.md
+++ b/packages/ckeditor5-block-quote/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-block-quote` package](https://ckeditor.com/docs/ck
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-block-quote/package.json
+++ b/packages/ckeditor5-block-quote/package.json
@@ -36,7 +36,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-bookmark/LICENSE.md
+++ b/packages/ckeditor5-bookmark/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 bookmark feature** – https://github.com/ckeditor/packages/ckeditor5-bookmarks <br>
+**CKEditor&nbsp;5 bookmark feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-bookmark/LICENSE.md
+++ b/packages/ckeditor5-bookmark/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 bookmark feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Bookmark feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-bookmark/LICENSE.md
+++ b/packages/ckeditor5-bookmark/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Bookmark feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-bookmark/README.md
+++ b/packages/ckeditor5-bookmark/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-bookmark` package](https://ckeditor.com/docs/ckedi
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-bookmark/package.json
+++ b/packages/ckeditor5-bookmark/package.json
@@ -44,7 +44,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-build-balloon-block/LICENSE.md
+++ b/packages/ckeditor5-build-balloon-block/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 balloon block editor build** – https://github.com/ckeditor/ckeditor5-build-balloon-block <br>
+**CKEditor&nbsp;5 balloon block editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-build-balloon-block/LICENSE.md
+++ b/packages/ckeditor5-build-balloon-block/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 balloon block editor build** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Balloon block editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-build-balloon-block/LICENSE.md
+++ b/packages/ckeditor5-build-balloon-block/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Balloon block editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-build-balloon-block/README.md
+++ b/packages/ckeditor5-build-balloon-block/README.md
@@ -69,4 +69,9 @@ BalloonEditor
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-build-balloon-block/package.json
+++ b/packages/ckeditor5-build-balloon-block/package.json
@@ -61,7 +61,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-build-balloon/LICENSE.md
+++ b/packages/ckeditor5-build-balloon/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 balloon editor build** – https://github.com/ckeditor/ckeditor5-build-balloon <br>
+**CKEditor&nbsp;5 balloon editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-build-balloon/LICENSE.md
+++ b/packages/ckeditor5-build-balloon/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 balloon editor build** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Balloon editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-build-balloon/LICENSE.md
+++ b/packages/ckeditor5-build-balloon/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Balloon editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-build-balloon/README.md
+++ b/packages/ckeditor5-build-balloon/README.md
@@ -67,4 +67,9 @@ BalloonEditor
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-build-balloon/package.json
+++ b/packages/ckeditor5-build-balloon/package.json
@@ -60,7 +60,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-build-classic/LICENSE.md
+++ b/packages/ckeditor5-build-classic/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 classic editor build** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Classic editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-build-classic/LICENSE.md
+++ b/packages/ckeditor5-build-classic/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 classic editor build** – https://github.com/ckeditor/ckeditor5-build-classic <br>
+**CKEditor&nbsp;5 classic editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-build-classic/LICENSE.md
+++ b/packages/ckeditor5-build-classic/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Classic editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-build-classic/README.md
+++ b/packages/ckeditor5-build-classic/README.md
@@ -67,4 +67,9 @@ ClassicEditor
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-build-classic/package.json
+++ b/packages/ckeditor5-build-classic/package.json
@@ -60,7 +60,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-build-decoupled-document/LICENSE.md
+++ b/packages/ckeditor5-build-decoupled-document/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Document editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-build-decoupled-document/LICENSE.md
+++ b/packages/ckeditor5-build-decoupled-document/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 document editor build** – https://github.com/ckeditor/ckeditor5-build-decoupled-document <br>
+**CKEditor&nbsp;5 document editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-build-decoupled-document/LICENSE.md
+++ b/packages/ckeditor5-build-decoupled-document/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 document editor build** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Document editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-build-decoupled-document/README.md
+++ b/packages/ckeditor5-build-decoupled-document/README.md
@@ -74,4 +74,9 @@ DecoupledEditor
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-build-decoupled-document/package.json
+++ b/packages/ckeditor5-build-decoupled-document/package.json
@@ -62,7 +62,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-build-inline/LICENSE.md
+++ b/packages/ckeditor5-build-inline/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 inline editor build** – https://github.com/ckeditor/ckeditor5-build-inline <br>
+**CKEditor&nbsp;5 inline editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-build-inline/LICENSE.md
+++ b/packages/ckeditor5-build-inline/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 inline editor build** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Inline editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-build-inline/LICENSE.md
+++ b/packages/ckeditor5-build-inline/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Inline editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-build-inline/README.md
+++ b/packages/ckeditor5-build-inline/README.md
@@ -67,4 +67,9 @@ InlineEditor
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-build-inline/package.json
+++ b/packages/ckeditor5-build-inline/package.json
@@ -60,7 +60,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-build-multi-root/LICENSE.md
+++ b/packages/ckeditor5-build-multi-root/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 multi-root editor build** – https://github.com/ckeditor/ckeditor5-build-multi-root <br>
+**CKEditor&nbsp;5 multi-root editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-build-multi-root/LICENSE.md
+++ b/packages/ckeditor5-build-multi-root/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 multi-root editor build** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Multi-root editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-build-multi-root/LICENSE.md
+++ b/packages/ckeditor5-build-multi-root/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Multi-root editor build** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-build-multi-root/README.md
+++ b/packages/ckeditor5-build-multi-root/README.md
@@ -100,4 +100,9 @@ MultiRootEditor
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-build-multi-root/package.json
+++ b/packages/ckeditor5-build-multi-root/package.json
@@ -60,7 +60,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-ckbox/LICENSE.md
+++ b/packages/ckeditor5-ckbox/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 CKBox feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](http://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-ckbox/LICENSE.md
+++ b/packages/ckeditor5-ckbox/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 CKBox feature** – https://github.com/ckeditor/ckeditor5-ckbox <br>
+**CKEditor&nbsp;5 CKBox feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](http://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-ckbox/README.md
+++ b/packages/ckeditor5-ckbox/README.md
@@ -31,4 +31,9 @@ Check out the [comprehensive Image upload guide](https://ckeditor.com/docs/ckedi
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-ckbox/package.json
+++ b/packages/ckeditor5-ckbox/package.json
@@ -40,7 +40,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-ckfinder/LICENSE.md
+++ b/packages/ckeditor5-ckfinder/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 CKFinder feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-ckfinder/LICENSE.md
+++ b/packages/ckeditor5-ckfinder/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 CKFinder feature** – https://github.com/ckeditor/ckeditor5-ckfinder <br>
+**CKEditor&nbsp;5 CKFinder feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-ckfinder/README.md
+++ b/packages/ckeditor5-ckfinder/README.md
@@ -31,4 +31,9 @@ Check out the [comprehensive Image upload guide](https://ckeditor.com/docs/ckedi
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-ckfinder/package.json
+++ b/packages/ckeditor5-ckfinder/package.json
@@ -33,7 +33,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-clipboard/LICENSE.md
+++ b/packages/ckeditor5-clipboard/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 clipboard feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Clipboard feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-clipboard/LICENSE.md
+++ b/packages/ckeditor5-clipboard/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 clipboard feature** – https://github.com/ckeditor/ckeditor5-clipboard <br>
+**CKEditor&nbsp;5 clipboard feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-clipboard/LICENSE.md
+++ b/packages/ckeditor5-clipboard/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Clipboard feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-clipboard/README.md
+++ b/packages/ckeditor5-clipboard/README.md
@@ -25,4 +25,9 @@ See the [`@ckeditor/ckeditor5-clipboard` package](https://ckeditor.com/docs/cked
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-clipboard/package.json
+++ b/packages/ckeditor5-clipboard/package.json
@@ -60,7 +60,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-cloud-services/LICENSE.md
+++ b/packages/ckeditor5-cloud-services/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 Cloud Services integration** – https://github.com/ckeditor/ckeditor5-cloud-services <br>
+**CKEditor&nbsp;5 Cloud Services integration** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-cloud-services/LICENSE.md
+++ b/packages/ckeditor5-cloud-services/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Cloud Services integration** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-cloud-services/README.md
+++ b/packages/ckeditor5-cloud-services/README.md
@@ -25,4 +25,9 @@ See the [`@ckeditor/ckeditor5-cloud-services` package](https://ckeditor.com/docs
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-cloud-services/package.json
+++ b/packages/ckeditor5-cloud-services/package.json
@@ -25,7 +25,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-code-block/LICENSE.md
+++ b/packages/ckeditor5-code-block/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 code block feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Code block feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-code-block/LICENSE.md
+++ b/packages/ckeditor5-code-block/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 code block feature** – https://github.com/ckeditor/ckeditor5-code-block <br>
+**CKEditor&nbsp;5 code block feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-code-block/LICENSE.md
+++ b/packages/ckeditor5-code-block/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Code block feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-code-block/README.md
+++ b/packages/ckeditor5-code-block/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-code-block` package](https://ckeditor.com/docs/cke
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-code-block/package.json
+++ b/packages/ckeditor5-code-block/package.json
@@ -41,7 +41,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-core/LICENSE.md
+++ b/packages/ckeditor5-core/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 core editor architecture** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Core editor architecture** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-core/LICENSE.md
+++ b/packages/ckeditor5-core/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Core editor architecture** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-core/LICENSE.md
+++ b/packages/ckeditor5-core/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 core editor architecture** – https://github.com/ckeditor/ckeditor5-core <br>
+**CKEditor&nbsp;5 core editor architecture** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-core/README.md
+++ b/packages/ckeditor5-core/README.md
@@ -27,4 +27,9 @@ Additionally, see the [`@ckeditor/ckeditor5-core` package](https://ckeditor.com/
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-core/package.json
+++ b/packages/ckeditor5-core/package.json
@@ -49,7 +49,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-easy-image/LICENSE.md
+++ b/packages/ckeditor5-easy-image/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Easy Image feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-easy-image/LICENSE.md
+++ b/packages/ckeditor5-easy-image/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 Easy Image feature** – https://github.com/ckeditor/ckeditor5-easy-image <br>
+**CKEditor&nbsp;5 Easy Image feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-easy-image/README.md
+++ b/packages/ckeditor5-easy-image/README.md
@@ -33,4 +33,9 @@ Check out the comprehensive [image upload](https://ckeditor.com/docs/ckeditor5/l
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-easy-image/package.json
+++ b/packages/ckeditor5-easy-image/package.json
@@ -31,7 +31,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-editor-balloon/LICENSE.md
+++ b/packages/ckeditor5-editor-balloon/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Balloon editor** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-editor-balloon/LICENSE.md
+++ b/packages/ckeditor5-editor-balloon/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**Balloon editor implementation** – https://github.com/ckeditor/ckeditor5-editor-balloon <br>
+**CKEditor&nbsp;5 Balloon editor** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-editor-balloon/README.md
+++ b/packages/ckeditor5-editor-balloon/README.md
@@ -23,4 +23,9 @@ npm install ckeditor5
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-editor-balloon/package.json
+++ b/packages/ckeditor5-editor-balloon/package.json
@@ -35,7 +35,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-editor-classic/LICENSE.md
+++ b/packages/ckeditor5-editor-classic/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**Classic editor implementation** – https://github.com/ckeditor/ckeditor5-editor-classic <br>
+**CKEditor&nbsp;5 Classic editor** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-editor-classic/LICENSE.md
+++ b/packages/ckeditor5-editor-classic/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Classic editor** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-editor-classic/README.md
+++ b/packages/ckeditor5-editor-classic/README.md
@@ -23,4 +23,9 @@ npm install ckeditor5
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-editor-classic/package.json
+++ b/packages/ckeditor5-editor-classic/package.json
@@ -35,7 +35,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-editor-decoupled/LICENSE.md
+++ b/packages/ckeditor5-editor-decoupled/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**Decoupled editor implementation** – https://github.com/ckeditor/ckeditor5-editor-decoupled <br>
+**CKEditor&nbsp;5 Decoupled editor** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-editor-decoupled/LICENSE.md
+++ b/packages/ckeditor5-editor-decoupled/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Decoupled editor** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-editor-decoupled/README.md
+++ b/packages/ckeditor5-editor-decoupled/README.md
@@ -23,4 +23,9 @@ npm install ckeditor5
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-editor-decoupled/package.json
+++ b/packages/ckeditor5-editor-decoupled/package.json
@@ -35,7 +35,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-editor-inline/LICENSE.md
+++ b/packages/ckeditor5-editor-inline/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Inline editor** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-editor-inline/LICENSE.md
+++ b/packages/ckeditor5-editor-inline/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**Inline editor implementation** – https://github.com/ckeditor/ckeditor5-editor-inline <br>
+**CKEditor&nbsp;5 Inline editor** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-editor-inline/README.md
+++ b/packages/ckeditor5-editor-inline/README.md
@@ -23,4 +23,9 @@ npm install ckeditor5
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-editor-inline/package.json
+++ b/packages/ckeditor5-editor-inline/package.json
@@ -35,7 +35,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-editor-multi-root/LICENSE.md
+++ b/packages/ckeditor5-editor-multi-root/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Multi-root editor** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-editor-multi-root/LICENSE.md
+++ b/packages/ckeditor5-editor-multi-root/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**Multi-root editor implementation** – https://github.com/ckeditor/ckeditor5-editor-multi-root <br>
+**CKEditor&nbsp;5 Multi-root editor** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-editor-multi-root/README.md
+++ b/packages/ckeditor5-editor-multi-root/README.md
@@ -23,4 +23,9 @@ npm install ckeditor5
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-editor-multi-root/package.json
+++ b/packages/ckeditor5-editor-multi-root/package.json
@@ -40,7 +40,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-engine/LICENSE.md
+++ b/packages/ckeditor5-engine/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Editing engine** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-engine/LICENSE.md
+++ b/packages/ckeditor5-engine/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 editing engine** – https://github.com/ckeditor/ckeditor5-engine <br>
+**CKEditor&nbsp;5 editing engine** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-engine/LICENSE.md
+++ b/packages/ckeditor5-engine/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 editing engine** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Editing engine** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-engine/README.md
+++ b/packages/ckeditor5-engine/README.md
@@ -39,4 +39,9 @@ Additionally, refer to the [`@ckeditor/ckeditor5-engine` package](https://ckedit
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-engine/package.json
+++ b/packages/ckeditor5-engine/package.json
@@ -53,7 +53,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-enter/LICENSE.md
+++ b/packages/ckeditor5-enter/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Enter feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-enter/LICENSE.md
+++ b/packages/ckeditor5-enter/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 enter feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Enter feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-enter/LICENSE.md
+++ b/packages/ckeditor5-enter/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 enter feature** – https://github.com/ckeditor/ckeditor5-enter <br>
+**CKEditor&nbsp;5 enter feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-enter/README.md
+++ b/packages/ckeditor5-enter/README.md
@@ -25,4 +25,9 @@ See the [`@ckeditor/ckeditor5-enter` package](https://ckeditor.com/docs/ckeditor
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-enter/package.json
+++ b/packages/ckeditor5-enter/package.json
@@ -30,7 +30,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-essentials/LICENSE.md
+++ b/packages/ckeditor5-essentials/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 essentials plugin** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-essentials/LICENSE.md
+++ b/packages/ckeditor5-essentials/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 essentials plugin** – https://github.com/ckeditor/ckeditor5-essentials <br>
+**CKEditor&nbsp;5 essentials plugin** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-essentials/README.md
+++ b/packages/ckeditor5-essentials/README.md
@@ -33,4 +33,9 @@ See the [`@ckeditor/ckeditor5-essentials` package](https://ckeditor.com/docs/cke
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-essentials/package.json
+++ b/packages/ckeditor5-essentials/package.json
@@ -32,7 +32,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-find-and-replace/LICENSE.md
+++ b/packages/ckeditor5-find-and-replace/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Find and replace feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-find-and-replace/LICENSE.md
+++ b/packages/ckeditor5-find-and-replace/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 find and replace feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Find and replace feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-find-and-replace/LICENSE.md
+++ b/packages/ckeditor5-find-and-replace/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 find and replace feature**  – https://github.com/ckeditor/ckeditor5-find-and-replace <br>
+**CKEditor&nbsp;5 find and replace feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-find-and-replace/README.md
+++ b/packages/ckeditor5-find-and-replace/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-find-and-replace` package](https://ckeditor.com/do
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-find-and-replace/package.json
+++ b/packages/ckeditor5-find-and-replace/package.json
@@ -41,7 +41,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-font/LICENSE.md
+++ b/packages/ckeditor5-font/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 font feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Font feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-font/LICENSE.md
+++ b/packages/ckeditor5-font/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 font feature** – https://github.com/ckeditor/ckeditor5-font <br>
+**CKEditor&nbsp;5 font feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-font/LICENSE.md
+++ b/packages/ckeditor5-font/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Font feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-font/README.md
+++ b/packages/ckeditor5-font/README.md
@@ -34,4 +34,9 @@ See the [`@ckeditor/ckeditor5-font` package](https://ckeditor.com/docs/ckeditor5
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-font/package.json
+++ b/packages/ckeditor5-font/package.json
@@ -32,7 +32,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-heading/LICENSE.md
+++ b/packages/ckeditor5-heading/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 headings feature** – https://github.com/ckeditor/ckeditor5-heading <br>
+**CKEditor&nbsp;5 headings feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-heading/LICENSE.md
+++ b/packages/ckeditor5-heading/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 headings feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Headings feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-heading/LICENSE.md
+++ b/packages/ckeditor5-heading/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Headings feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-heading/README.md
+++ b/packages/ckeditor5-heading/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-heading` package](https://ckeditor.com/docs/ckedit
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-heading/package.json
+++ b/packages/ckeditor5-heading/package.json
@@ -39,7 +39,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-highlight/LICENSE.md
+++ b/packages/ckeditor5-highlight/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 highlight feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Highlight feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-highlight/LICENSE.md
+++ b/packages/ckeditor5-highlight/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Highlight feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-highlight/LICENSE.md
+++ b/packages/ckeditor5-highlight/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 highlight feature** – https://github.com/ckeditor/ckeditor5-highlight <br>
+**CKEditor&nbsp;5 highlight feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-highlight/README.md
+++ b/packages/ckeditor5-highlight/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-highlight` package](https://ckeditor.com/docs/cked
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-highlight/package.json
+++ b/packages/ckeditor5-highlight/package.json
@@ -35,7 +35,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-horizontal-line/LICENSE.md
+++ b/packages/ckeditor5-horizontal-line/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 horizontal line feature**  – https://github.com/ckeditor/ckeditor5-horizontal-line <br>
+**CKEditor&nbsp;5 horizontal line feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-horizontal-line/LICENSE.md
+++ b/packages/ckeditor5-horizontal-line/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 horizontal line feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Horizontal line feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-horizontal-line/LICENSE.md
+++ b/packages/ckeditor5-horizontal-line/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Horizontal line feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-horizontal-line/README.md
+++ b/packages/ckeditor5-horizontal-line/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-horizontal-line` package](https://ckeditor.com/doc
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-horizontal-line/package.json
+++ b/packages/ckeditor5-horizontal-line/package.json
@@ -33,7 +33,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-html-embed/LICENSE.md
+++ b/packages/ckeditor5-html-embed/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 HTML embed feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-html-embed/LICENSE.md
+++ b/packages/ckeditor5-html-embed/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 HTML embed feature**  – https://github.com/ckeditor/ckeditor5-html-embed <br>
+**CKEditor&nbsp;5 HTML embed feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-html-embed/README.md
+++ b/packages/ckeditor5-html-embed/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-html-embed` package](https://ckeditor.com/docs/cke
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-html-embed/package.json
+++ b/packages/ckeditor5-html-embed/package.json
@@ -36,7 +36,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-html-support/LICENSE.md
+++ b/packages/ckeditor5-html-support/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 HTML support feature**  – https://github.com/ckeditor/ckeditor5-html-support <br>
+**CKEditor&nbsp;5 HTML support feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-html-support/LICENSE.md
+++ b/packages/ckeditor5-html-support/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 HTML support feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-html-support/README.md
+++ b/packages/ckeditor5-html-support/README.md
@@ -28,4 +28,9 @@ Check out the demo in the [General HTML Support feature guide](https://ckeditor.
 See the [`@ckeditor/ckeditor5-html-support` package](https://ckeditor.com/docs/ckeditor5/latest/api/html-support.html) page as well as the [General HTML Support feature](https://ckeditor.com/docs/ckeditor5/latest/features/html/general-html-support.html) guide in [CKEditor&nbsp;5 documentation](https://ckeditor.com/docs/ckeditor5/latest/).
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-html-support/package.json
+++ b/packages/ckeditor5-html-support/package.json
@@ -61,7 +61,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-image/LICENSE.md
+++ b/packages/ckeditor5-image/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 image feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Image feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-image/LICENSE.md
+++ b/packages/ckeditor5-image/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Image feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-image/LICENSE.md
+++ b/packages/ckeditor5-image/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 image feature** – https://github.com/ckeditor/ckeditor5-image <br>
+**CKEditor&nbsp;5 image feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-image/README.md
+++ b/packages/ckeditor5-image/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-image` package](https://ckeditor.com/docs/ckeditor
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-image/package.json
+++ b/packages/ckeditor5-image/package.json
@@ -55,7 +55,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-indent/LICENSE.md
+++ b/packages/ckeditor5-indent/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 block indentation feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Block indentation feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-indent/LICENSE.md
+++ b/packages/ckeditor5-indent/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Block indentation feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-indent/LICENSE.md
+++ b/packages/ckeditor5-indent/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 block indentation feature** – https://github.com/ckeditor/ckeditor5-indent <br>
+**CKEditor&nbsp;5 block indentation feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-indent/README.md
+++ b/packages/ckeditor5-indent/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-indent` package](https://ckeditor.com/docs/ckedito
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-indent/package.json
+++ b/packages/ckeditor5-indent/package.json
@@ -31,7 +31,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-language/LICENSE.md
+++ b/packages/ckeditor5-language/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 text part language feature** – https://github.com/ckeditor/ckeditor5-language <br>
+**CKEditor&nbsp;5 text part language feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-language/LICENSE.md
+++ b/packages/ckeditor5-language/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Text part language feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-language/LICENSE.md
+++ b/packages/ckeditor5-language/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 text part language feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Text part language feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-language/README.md
+++ b/packages/ckeditor5-language/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-language` package](https://ckeditor.com/docs/ckedi
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-language/package.json
+++ b/packages/ckeditor5-language/package.json
@@ -29,7 +29,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-link/LICENSE.md
+++ b/packages/ckeditor5-link/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Link feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-link/LICENSE.md
+++ b/packages/ckeditor5-link/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 link feature** – https://github.com/ckeditor/ckeditor5-link <br>
+**CKEditor&nbsp;5 link feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-link/LICENSE.md
+++ b/packages/ckeditor5-link/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 link feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Link feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-link/README.md
+++ b/packages/ckeditor5-link/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-link` package](https://ckeditor.com/docs/ckeditor5
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-link/package.json
+++ b/packages/ckeditor5-link/package.json
@@ -44,7 +44,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-list/LICENSE.md
+++ b/packages/ckeditor5-list/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 List feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-list/LICENSE.md
+++ b/packages/ckeditor5-list/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 list feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 List feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-list/LICENSE.md
+++ b/packages/ckeditor5-list/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 list feature** – https://github.com/ckeditor/ckeditor5-list <br>
+**CKEditor&nbsp;5 list feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-list/README.md
+++ b/packages/ckeditor5-list/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-list` package](https://ckeditor.com/docs/ckeditor5
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-list/package.json
+++ b/packages/ckeditor5-list/package.json
@@ -56,7 +56,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-markdown-gfm/LICENSE.md
+++ b/packages/ckeditor5-markdown-gfm/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 GitHub Flavored Markdown support** – https://github.com/ckeditor/ckeditor5-markdown-gfm <br>
+**CKEditor&nbsp;5 GitHub Flavored Markdown support** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-markdown-gfm/LICENSE.md
+++ b/packages/ckeditor5-markdown-gfm/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 GitHub Flavored Markdown support** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-markdown-gfm/README.md
+++ b/packages/ckeditor5-markdown-gfm/README.md
@@ -30,4 +30,9 @@ See the [`@ckeditor/ckeditor5-markdown-gfm` package](https://ckeditor.com/docs/c
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-markdown-gfm/package.json
+++ b/packages/ckeditor5-markdown-gfm/package.json
@@ -49,7 +49,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-media-embed/LICENSE.md
+++ b/packages/ckeditor5-media-embed/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Media embed feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-media-embed/LICENSE.md
+++ b/packages/ckeditor5-media-embed/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 media embed feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Media embed feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-media-embed/LICENSE.md
+++ b/packages/ckeditor5-media-embed/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 media embed feature**  – https://github.com/ckeditor/ckeditor5-media-embed <br>
+**CKEditor&nbsp;5 media embed feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-media-embed/README.md
+++ b/packages/ckeditor5-media-embed/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-media-embed` package](https://ckeditor.com/docs/ck
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-media-embed/package.json
+++ b/packages/ckeditor5-media-embed/package.json
@@ -39,7 +39,7 @@
     "lodash-es": "^4.17.15"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-mention/LICENSE.md
+++ b/packages/ckeditor5-mention/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 mention feature** – https://github.com/ckeditor/ckeditor5-mention <br>
+**CKEditor&nbsp;5 mention feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-mention/LICENSE.md
+++ b/packages/ckeditor5-mention/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Mention feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-mention/LICENSE.md
+++ b/packages/ckeditor5-mention/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 mention feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Mention feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-mention/README.md
+++ b/packages/ckeditor5-mention/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-mention` package](https://ckeditor.com/docs/ckedit
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-mention/package.json
+++ b/packages/ckeditor5-mention/package.json
@@ -40,7 +40,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-minimap/LICENSE.md
+++ b/packages/ckeditor5-minimap/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Minimap feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-minimap/LICENSE.md
+++ b/packages/ckeditor5-minimap/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 minimap feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Minimap feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-minimap/LICENSE.md
+++ b/packages/ckeditor5-minimap/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 minimap feature** – https://github.com/ckeditor/ckeditor5-minimap <br>
+**CKEditor&nbsp;5 minimap feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-minimap/README.md
+++ b/packages/ckeditor5-minimap/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-minimap` package](https://ckeditor.com/docs/ckedit
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-minimap/package.json
+++ b/packages/ckeditor5-minimap/package.json
@@ -38,7 +38,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-page-break/LICENSE.md
+++ b/packages/ckeditor5-page-break/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Page break feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-page-break/LICENSE.md
+++ b/packages/ckeditor5-page-break/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 page break feature**  – https://github.com/ckeditor/ckeditor5-page-break <br>
+**CKEditor&nbsp;5 page break feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-page-break/LICENSE.md
+++ b/packages/ckeditor5-page-break/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 page break feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Page break feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-page-break/README.md
+++ b/packages/ckeditor5-page-break/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-page-break` package](https://ckeditor.com/docs/cke
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-page-break/package.json
+++ b/packages/ckeditor5-page-break/package.json
@@ -33,7 +33,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-paragraph/LICENSE.md
+++ b/packages/ckeditor5-paragraph/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 paragraph feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Paragraph feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-paragraph/LICENSE.md
+++ b/packages/ckeditor5-paragraph/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Paragraph feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-paragraph/LICENSE.md
+++ b/packages/ckeditor5-paragraph/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 paragraph feature** – https://github.com/ckeditor/ckeditor5-paragraph <br>
+**CKEditor&nbsp;5 paragraph feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-paragraph/README.md
+++ b/packages/ckeditor5-paragraph/README.md
@@ -25,4 +25,9 @@ See the [`@ckeditor/ckeditor5-paragraph` package](https://ckeditor.com/docs/cked
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-paragraph/package.json
+++ b/packages/ckeditor5-paragraph/package.json
@@ -32,7 +32,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-paste-from-office/LICENSE.md
+++ b/packages/ckeditor5-paste-from-office/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 paste from Office feature** – https://github.com/ckeditor/ckeditor5-paste-from-office <br>
+**CKEditor&nbsp;5 paste from Office feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-paste-from-office/LICENSE.md
+++ b/packages/ckeditor5-paste-from-office/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Paste from Office feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-paste-from-office/LICENSE.md
+++ b/packages/ckeditor5-paste-from-office/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 paste from Office feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Paste from Office feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-paste-from-office/README.md
+++ b/packages/ckeditor5-paste-from-office/README.md
@@ -31,4 +31,9 @@ See the [`@ckeditor/ckeditor5-paste-from-office` package](https://docs.ckeditor.
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-paste-from-office/package.json
+++ b/packages/ckeditor5-paste-from-office/package.json
@@ -43,7 +43,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-remove-format/LICENSE.md
+++ b/packages/ckeditor5-remove-format/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Remove format feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-remove-format/LICENSE.md
+++ b/packages/ckeditor5-remove-format/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 remove format feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Remove format feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-remove-format/LICENSE.md
+++ b/packages/ckeditor5-remove-format/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 remove format feature** – https://github.com/ckeditor/ckeditor5-remove-format <br>
+**CKEditor&nbsp;5 remove format feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-remove-format/README.md
+++ b/packages/ckeditor5-remove-format/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-remove-format` package](https://ckeditor.com/docs/
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-remove-format/package.json
+++ b/packages/ckeditor5-remove-format/package.json
@@ -37,7 +37,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-restricted-editing/LICENSE.md
+++ b/packages/ckeditor5-restricted-editing/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 restricted editing feature** – https://github.com/ckeditor/ckeditor5-restricted-editing <br>
+**CKEditor&nbsp;5 restricted editing feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-restricted-editing/LICENSE.md
+++ b/packages/ckeditor5-restricted-editing/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Restricted editing feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-restricted-editing/LICENSE.md
+++ b/packages/ckeditor5-restricted-editing/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 restricted editing feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Restricted editing feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-restricted-editing/README.md
+++ b/packages/ckeditor5-restricted-editing/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-restricted-editing` package](https://ckeditor.com/
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-restricted-editing/package.json
+++ b/packages/ckeditor5-restricted-editing/package.json
@@ -38,7 +38,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-select-all/LICENSE.md
+++ b/packages/ckeditor5-select-all/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 select all feature** – https://github.com/ckeditor/ckeditor5-select-all <br>
+**CKEditor&nbsp;5 select all feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-select-all/LICENSE.md
+++ b/packages/ckeditor5-select-all/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Select all feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-select-all/LICENSE.md
+++ b/packages/ckeditor5-select-all/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 select all feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Select all feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-select-all/README.md
+++ b/packages/ckeditor5-select-all/README.md
@@ -29,5 +29,10 @@ See the [`@ckeditor/ckeditor5-select-all` package](https://ckeditor.com/docs/cke
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 

--- a/packages/ckeditor5-select-all/package.json
+++ b/packages/ckeditor5-select-all/package.json
@@ -31,7 +31,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-show-blocks/LICENSE.md
+++ b/packages/ckeditor5-show-blocks/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Show blocks feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-show-blocks/LICENSE.md
+++ b/packages/ckeditor5-show-blocks/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 show blocks feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Show blocks feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-show-blocks/LICENSE.md
+++ b/packages/ckeditor5-show-blocks/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 show blocks feature** – https://github.com/ckeditor/packages/ckeditor5-show-blocks <br>
+**CKEditor&nbsp;5 show blocks feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-show-blocks/README.md
+++ b/packages/ckeditor5-show-blocks/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-show-blocks` package](https://ckeditor.com/docs/ck
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-show-blocks/package.json
+++ b/packages/ckeditor5-show-blocks/package.json
@@ -60,7 +60,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-source-editing/LICENSE.md
+++ b/packages/ckeditor5-source-editing/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Source editing feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-source-editing/LICENSE.md
+++ b/packages/ckeditor5-source-editing/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 source editing feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Source editing feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-source-editing/LICENSE.md
+++ b/packages/ckeditor5-source-editing/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 source editing feature** – https://github.com/ckeditor/ckeditor5-source-editing <br>
+**CKEditor&nbsp;5 source editing feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-source-editing/README.md
+++ b/packages/ckeditor5-source-editing/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-source-editing` package](https://ckeditor.com/docs
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-source-editing/package.json
+++ b/packages/ckeditor5-source-editing/package.json
@@ -33,7 +33,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-special-characters/LICENSE.md
+++ b/packages/ckeditor5-special-characters/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 special characters feature** – https://github.com/ckeditor/ckeditor5-special-characters <br>
+**CKEditor&nbsp;5 special characters feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-special-characters/LICENSE.md
+++ b/packages/ckeditor5-special-characters/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 special characters feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Special characters feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-special-characters/LICENSE.md
+++ b/packages/ckeditor5-special-characters/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Special characters feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-special-characters/README.md
+++ b/packages/ckeditor5-special-characters/README.md
@@ -29,5 +29,10 @@ See the [`@ckeditor/ckeditor5-special-characters` package](https://ckeditor.com/
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 

--- a/packages/ckeditor5-special-characters/package.json
+++ b/packages/ckeditor5-special-characters/package.json
@@ -31,7 +31,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-style/LICENSE.md
+++ b/packages/ckeditor5-style/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Style feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-style/LICENSE.md
+++ b/packages/ckeditor5-style/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 style feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Style feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-style/LICENSE.md
+++ b/packages/ckeditor5-style/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 style feature** – https://github.com/ckeditor/ckeditor5-style <br>
+**CKEditor&nbsp;5 style feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-style/README.md
+++ b/packages/ckeditor5-style/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-style` package](https://ckeditor.com/docs/ckeditor
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-style/package.json
+++ b/packages/ckeditor5-style/package.json
@@ -58,7 +58,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-table/LICENSE.md
+++ b/packages/ckeditor5-table/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Table feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-table/LICENSE.md
+++ b/packages/ckeditor5-table/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 table feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Table feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-table/LICENSE.md
+++ b/packages/ckeditor5-table/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 table feature**  – https://github.com/ckeditor/ckeditor5-table <br>
+**CKEditor&nbsp;5 table feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-table/README.md
+++ b/packages/ckeditor5-table/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-table` package](https://ckeditor.com/docs/ckeditor
 
 ## License
 
-Licensed under the GPL, LGPL and MPL licenses, at your choice. For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-table/package.json
+++ b/packages/ckeditor5-table/package.json
@@ -48,7 +48,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-theme-lark/LICENSE.md
+++ b/packages/ckeditor5-theme-lark/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Lark theme** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-theme-lark/LICENSE.md
+++ b/packages/ckeditor5-theme-lark/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 lark theme** – https://github.com/ckeditor/ckeditor5-theme-lark <br>
+**CKEditor&nbsp;5 lark theme** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-theme-lark/LICENSE.md
+++ b/packages/ckeditor5-theme-lark/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 lark theme** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Lark theme** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-theme-lark/README.md
+++ b/packages/ckeditor5-theme-lark/README.md
@@ -25,4 +25,9 @@ See the [`@ckeditor/ckeditor5-theme-lark` package](https://ckeditor.com/docs/cke
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-theme-lark/package.json
+++ b/packages/ckeditor5-theme-lark/package.json
@@ -33,7 +33,7 @@
     "ckeditor5": "43.3.1"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-typing/LICENSE.md
+++ b/packages/ckeditor5-typing/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 typing feature** – https://github.com/ckeditor/ckeditor5-typing <br>
+**CKEditor&nbsp;5 typing feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-typing/LICENSE.md
+++ b/packages/ckeditor5-typing/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Typing feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-typing/LICENSE.md
+++ b/packages/ckeditor5-typing/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 typing feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Typing feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-typing/README.md
+++ b/packages/ckeditor5-typing/README.md
@@ -25,4 +25,9 @@ See the [`@ckeditor/ckeditor5-typing` package](https://ckeditor.com/docs/ckedito
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-typing/package.json
+++ b/packages/ckeditor5-typing/package.json
@@ -41,7 +41,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-ui/LICENSE.md
+++ b/packages/ckeditor5-ui/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 UI framework** – https://github.com/ckeditor/ckeditor5-ui <br>
+**CKEditor&nbsp;5 UI framework** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-ui/LICENSE.md
+++ b/packages/ckeditor5-ui/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 UI framework** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-ui/README.md
+++ b/packages/ckeditor5-ui/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-ui` package](https://ckeditor.com/docs/ckeditor5/l
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-ui/package.json
+++ b/packages/ckeditor5-ui/package.json
@@ -58,7 +58,7 @@
     "sinon"
   ],
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-undo/LICENSE.md
+++ b/packages/ckeditor5-undo/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 undo feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Undo feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-undo/LICENSE.md
+++ b/packages/ckeditor5-undo/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Undo feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-undo/LICENSE.md
+++ b/packages/ckeditor5-undo/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 undo feature** – https://github.com/ckeditor/ckeditor5-undo <br>
+**CKEditor&nbsp;5 undo feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-undo/README.md
+++ b/packages/ckeditor5-undo/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-undo` package](https://ckeditor.com/docs/ckeditor5
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-undo/package.json
+++ b/packages/ckeditor5-undo/package.json
@@ -32,7 +32,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-upload/LICENSE.md
+++ b/packages/ckeditor5-upload/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Upload feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-upload/LICENSE.md
+++ b/packages/ckeditor5-upload/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 upload feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Upload feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-upload/LICENSE.md
+++ b/packages/ckeditor5-upload/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 upload feature** – https://github.com/ckeditor/ckeditor5-upload <br>
+**CKEditor&nbsp;5 upload feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-upload/README.md
+++ b/packages/ckeditor5-upload/README.md
@@ -25,4 +25,9 @@ See the [`@ckeditor/ckeditor5-upload` package](https://ckeditor.com/docs/ckedito
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-upload/package.json
+++ b/packages/ckeditor5-upload/package.json
@@ -21,7 +21,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-utils/LICENSE.md
+++ b/packages/ckeditor5-utils/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 utilities** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Utilities** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-utils/LICENSE.md
+++ b/packages/ckeditor5-utils/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 utilities** – https://github.com/ckeditor/ckeditor5-utils <br>
+**CKEditor&nbsp;5 utilities** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-utils/LICENSE.md
+++ b/packages/ckeditor5-utils/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Utilities** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-utils/README.md
+++ b/packages/ckeditor5-utils/README.md
@@ -25,4 +25,9 @@ See the [`@ckeditor/ckeditor5-utils` package](https://ckeditor.com/docs/ckeditor
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-utils/package.json
+++ b/packages/ckeditor5-utils/package.json
@@ -27,7 +27,7 @@
     "typescript"
   ],
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-watchdog/LICENSE.md
+++ b/packages/ckeditor5-watchdog/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 watchdog feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Watchdog feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-watchdog/LICENSE.md
+++ b/packages/ckeditor5-watchdog/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 watchdog feature** – https://github.com/ckeditor/ckeditor5-watchdog <br>
+**CKEditor&nbsp;5 watchdog feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-watchdog/LICENSE.md
+++ b/packages/ckeditor5-watchdog/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Watchdog feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-watchdog/README.md
+++ b/packages/ckeditor5-watchdog/README.md
@@ -25,4 +25,9 @@ See the [`@ckeditor/ckeditor5-watchdog` package](https://ckeditor.com/docs/ckedi
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-watchdog/package.json
+++ b/packages/ckeditor5-watchdog/package.json
@@ -25,7 +25,7 @@
     "typescript": "5.0.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-widget/LICENSE.md
+++ b/packages/ckeditor5-widget/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Widget API** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-widget/LICENSE.md
+++ b/packages/ckeditor5-widget/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 widget API** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Widget API** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-widget/LICENSE.md
+++ b/packages/ckeditor5-widget/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 widget API** – https://github.com/ckeditor/ckeditor5-image <br>
+**CKEditor&nbsp;5 widget API** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-widget/README.md
+++ b/packages/ckeditor5-widget/README.md
@@ -25,4 +25,9 @@ See the [`@ckeditor/ckeditor5-widget` package](https://ckeditor.com/docs/ckedito
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-widget/package.json
+++ b/packages/ckeditor5-widget/package.json
@@ -40,7 +40,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com/ckeditor-5",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/packages/ckeditor5-word-count/LICENSE.md
+++ b/packages/ckeditor5-word-count/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5 Word and character count feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------

--- a/packages/ckeditor5-word-count/LICENSE.md
+++ b/packages/ckeditor5-word-count/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 word and character count feature** (https://github.com/ckeditor/ckeditor5)<br>
+**CKEditor&nbsp;5 Word and character count feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-word-count/LICENSE.md
+++ b/packages/ckeditor5-word-count/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5 word and character count feature**  – https://github.com/ckeditor/ckeditor5-word-count <br>
+**CKEditor&nbsp;5 word and character count feature** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/packages/ckeditor5-word-count/README.md
+++ b/packages/ckeditor5-word-count/README.md
@@ -29,4 +29,9 @@ See the [`@ckeditor/ckeditor5-word-count` package](https://ckeditor.com/docs/cke
 
 ## License
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html). For full details about the license, please check the `LICENSE.md` file or [https://ckeditor.com/legal/ckeditor-oss-license](https://ckeditor.com/legal/ckeditor-oss-license).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).

--- a/packages/ckeditor5-word-count/package.json
+++ b/packages/ckeditor5-word-count/package.json
@@ -38,7 +38,7 @@
     "webpack-cli": "^5.1.4"
   },
   "author": "CKSource (http://cksource.com/)",
-  "license": "GPL-2.0-or-later",
+  "license": "SEE LICENSE IN LICENSE.md",
   "homepage": "https://ckeditor.com",
   "bugs": "https://github.com/ckeditor/ckeditor5/issues",
   "repository": {

--- a/scripts/release/assets/zip/LICENSE.md
+++ b/scripts/release/assets/zip/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**CKEditor&nbsp;5** – https://github.com/ckeditor/ckeditor5 <br>
+**CKEditor&nbsp;5** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
 Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).

--- a/scripts/release/assets/zip/LICENSE.md
+++ b/scripts/release/assets/zip/LICENSE.md
@@ -4,7 +4,12 @@ Software License Agreement
 **CKEditor&nbsp;5** (https://github.com/ckeditor/ckeditor5)<br>
 Copyright (c) 2003–2024, [CKSource Holding sp. z o.o.](https://cksource.com) All rights reserved.
 
-Licensed under the terms of [GNU General Public License Version 2 or later](http://www.gnu.org/licenses/gpl.html).
+Licensed under a dual-license model, this software is available under:
+
+* the [GNU General Public License Version 2 or later](https://www.gnu.org/licenses/gpl.html),
+* or commercial license terms from CKSource Holding sp. z o.o.
+
+For more information, see: [https://ckeditor.com/legal/ckeditor-licensing-options](https://ckeditor.com/legal/ckeditor-licensing-options).
 
 Sources of Intellectual Property Included in CKEditor
 -----------------------------------------------------


### PR DESCRIPTION
> [!NOTE]
> We are **not** changing the license of CKEditor 5.
>
> In these PRs we are only cleaning up the situation with CKEditor 5 being dual-licensed. Meaning that it's available on GPL and also on a commercial license.

### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Licensing information cleanup - part 1/2.

---

### Additional information

See https://github.com/cksource/ckeditor5-commercial/issues/6820

Part 2/2 will be updates of the license headers and we'll do it after the release to avoid potential conflicts.