### PR TITLE
Use iterator instead of generator in ListWalker for better performance.

### DIFF
--- a/packages/ckeditor5-list/src/list/converters.ts
+++ b/packages/ckeditor5-list/src/list/converters.ts
@@ -47,7 +47,7 @@ import {
 	isListItemView
 } from './utils/view.js';
 
-import ListWalker, { iterateSiblingListBlocks } from './utils/listwalker.js';
+import ListWalker, { SiblingListBlocksIterator } from './utils/listwalker.js';
 import { findAndAddListHeadToMap } from './utils/postfixers.js';
 
 import type {
@@ -196,7 +196,7 @@ export function reconvertItemsOnDataChange(
 		const visited = new Set();
 		const stack: Array<ListItemAttributesMap> = [];
 
-		for ( const { node, previous } of iterateSiblingListBlocks( listHead, 'forward' ) ) {
+		for ( const { node, previous } of new SiblingListBlocksIterator( listHead ) ) {
 			if ( visited.has( node ) ) {
 				continue;
 			}

--- a/packages/ckeditor5-list/src/list/utils/listwalker.ts
+++ b/packages/ckeditor5-list/src/list/utils/listwalker.ts
@@ -224,15 +224,21 @@ export class SiblingListBlocksIterator implements IterableIterator<ListIteratorV
 		let previousNodeInList: ListElement | null = null;
 
 		if ( this.previous ) {
-			nodeIndent = this.node.getAttribute( 'listIndent' ) as number;
+			nodeIndent = this.node.getAttribute( 'listIndent' );
 			const previousNodeIndent = this.previousNodeIndent!;
 
+			// Let's find previous node for the same indent.
+			// We're going to need that when we get back to previous indent.
 			if ( nodeIndent > previousNodeIndent ) {
 				this.previousNodesByIndent[ previousNodeIndent ] = this.previous;
-			} else if ( nodeIndent < previousNodeIndent ) {
+			}
+			// Restore the one for given indent.
+			else if ( nodeIndent < previousNodeIndent ) {
 				previousNodeInList = this.previousNodesByIndent[ nodeIndent ];
 				this.previousNodesByIndent.length = nodeIndent;
-			} else {
+			}
+			// Same indent.
+			else {
 				previousNodeInList = this.previous;
 			}
 		}

--- a/packages/ckeditor5-list/src/list/utils/listwalker.ts
+++ b/packages/ckeditor5-list/src/list/utils/listwalker.ts
@@ -193,11 +193,11 @@ export default class ListWalker {
  * Iterates sibling list blocks starting from the given node.
  */
 export class SiblingListBlocksIterator implements IterableIterator<ListIteratorValue> {
-	private node: Node | null;
-	private isForward: boolean;
-	private previousNodesByIndent: Array<ListElement> = [];
-	private previous: ListElement | null = null;
-	private previousNodeIndent: number | null = null;
+	private _node: Node | null;
+	private _isForward: boolean;
+	private _previousNodesByIndent: Array<ListElement> = [];
+	private _previous: ListElement | null = null;
+	private _previousNodeIndent: number | null = null;
 
 	/**
 	 * @param node The model node.
@@ -207,8 +207,8 @@ export class SiblingListBlocksIterator implements IterableIterator<ListIteratorV
 		node: Node | null,
 		direction: 'forward' | 'backward' = 'forward'
 	) {
-		this.node = node;
-		this.isForward = direction === 'forward';
+		this._node = node;
+		this._isForward = direction === 'forward';
 	}
 
 	public [ Symbol.iterator ](): IterableIterator<ListIteratorValue> {
@@ -216,42 +216,42 @@ export class SiblingListBlocksIterator implements IterableIterator<ListIteratorV
 	}
 
 	public next(): IteratorResult<ListIteratorValue> {
-		if ( !isListItemBlock( this.node ) ) {
+		if ( !isListItemBlock( this._node ) ) {
 			return { done: true, value: undefined };
 		}
 
 		let nodeIndent = null;
 		let previousNodeInList: ListElement | null = null;
 
-		if ( this.previous ) {
-			nodeIndent = this.node.getAttribute( 'listIndent' );
-			const previousNodeIndent = this.previousNodeIndent!;
+		if ( this._previous ) {
+			nodeIndent = this._node.getAttribute( 'listIndent' );
+			const previousNodeIndent = this._previousNodeIndent!;
 
 			// Let's find previous node for the same indent.
 			// We're going to need that when we get back to previous indent.
 			if ( nodeIndent > previousNodeIndent ) {
-				this.previousNodesByIndent[ previousNodeIndent ] = this.previous;
+				this._previousNodesByIndent[ previousNodeIndent ] = this._previous;
 			}
 			// Restore the one for given indent.
 			else if ( nodeIndent < previousNodeIndent ) {
-				previousNodeInList = this.previousNodesByIndent[ nodeIndent ];
-				this.previousNodesByIndent.length = nodeIndent;
+				previousNodeInList = this._previousNodesByIndent[ nodeIndent ];
+				this._previousNodesByIndent.length = nodeIndent;
 			}
 			// Same indent.
 			else {
-				previousNodeInList = this.previous;
+				previousNodeInList = this._previous;
 			}
 		}
 
 		const value = {
-			node: this.node,
-			previous: this.previous,
+			node: this._node,
+			previous: this._previous,
 			previousNodeInList
 		};
 
-		this.previous = this.node as ListElement;
-		this.previousNodeIndent = nodeIndent;
-		this.node = this.isForward ? this.node.nextSibling : this.node.previousSibling;
+		this._previous = this._node as ListElement;
+		this._previousNodeIndent = nodeIndent;
+		this._node = this._isForward ? this._node.nextSibling : this._node.previousSibling;
 
 		return { value, done: false };
 	}

--- a/packages/ckeditor5-list/src/list/utils/listwalker.ts
+++ b/packages/ckeditor5-list/src/list/utils/listwalker.ts
@@ -220,11 +220,10 @@ export class SiblingListBlocksIterator implements IterableIterator<ListIteratorV
 			return { done: true, value: undefined };
 		}
 
-		let nodeIndent = null;
+		const nodeIndent = this._node.getAttribute( 'listIndent' );
 		let previousNodeInList: ListElement | null = null;
 
 		if ( this._previous ) {
-			nodeIndent = this._node.getAttribute( 'listIndent' );
 			const previousNodeIndent = this._previousNodeIndent!;
 
 			// Let's find previous node for the same indent.
@@ -234,7 +233,7 @@ export class SiblingListBlocksIterator implements IterableIterator<ListIteratorV
 			}
 			// Restore the one for given indent.
 			else if ( nodeIndent < previousNodeIndent ) {
-				previousNodeInList = this._previousNodesByIndent[ nodeIndent ];
+				previousNodeInList = this._previousNodesByIndent[ nodeIndent ] || null;
 				this._previousNodesByIndent.length = nodeIndent;
 			}
 			// Same indent.

--- a/packages/ckeditor5-list/src/list/utils/model.ts
+++ b/packages/ckeditor5-list/src/list/utils/model.ts
@@ -19,7 +19,7 @@ import type {
 
 import { uid, toArray, type ArrayOrItem } from 'ckeditor5/src/utils.js';
 
-import ListWalker, { type ListWalkerOptions, iterateSiblingListBlocks } from './listwalker.js';
+import ListWalker, { type ListWalkerOptions, SiblingListBlocksIterator } from './listwalker.js';
 import { type ListType } from '../listediting.js';
 
 /**
@@ -499,7 +499,7 @@ export function outdentFollowingItems( lastBlock: Element, writer: Writer ): Arr
 	// that this is the same effect that we would be get by multiple use of outdent command. However doing
 	// it like this is much more efficient because it's less operation (less memory usage, easier OT) and
 	// less conversion (faster).
-	for ( const { node } of iterateSiblingListBlocks( lastBlock.nextSibling, 'forward' ) ) {
+	for ( const { node } of new SiblingListBlocksIterator( lastBlock.nextSibling ) ) {
 		// Check each next list item, as long as its indent is higher than 0.
 		const indent = node.getAttribute( 'listIndent' );
 

--- a/packages/ckeditor5-list/src/list/utils/postfixers.ts
+++ b/packages/ckeditor5-list/src/list/utils/postfixers.ts
@@ -8,7 +8,7 @@
  */
 
 import type { Position, Writer } from 'ckeditor5/src/engine.js';
-import { iterateSiblingListBlocks, type ListIteratorValue } from './listwalker.js';
+import { SiblingListBlocksIterator, type ListIteratorValue } from './listwalker.js';
 import { getListItemBlocks, isListItemBlock, ListItemUid, type ListElement } from './model.js';
 
 /**
@@ -35,11 +35,11 @@ export function findAndAddListHeadToMap(
 
 		// Previously, the loop below was defined like this:
 		//
-		// 		for ( { node: listHead } of iterateSiblingListBlocks( listHead, 'backward' ) )
+		// 		for ( { node: listHead } of new SiblingListBlocksIterator( listHead, 'backward' ) )
 		//
 		// Unfortunately, such a destructuring is incorrectly transpiled by Babel and the loop never ends.
 		// See: https://github.com/ckeditor/ckeditor5-react/issues/345.
-		for ( const { node } of iterateSiblingListBlocks( listHead, 'backward' ) ) {
+		for ( const { node } of new SiblingListBlocksIterator( listHead, 'backward' ) ) {
 			listHead = node;
 
 			if ( itemToListHead.has( listHead ) ) {

--- a/packages/ckeditor5-list/tests/list/utils/postfixers.js
+++ b/packages/ckeditor5-list/tests/list/utils/postfixers.js
@@ -9,7 +9,7 @@ import {
 	fixListItemIds
 } from '../../../src/list/utils/postfixers.js';
 import {
-	iterateSiblingListBlocks
+	SiblingListBlocksIterator
 } from '../../../src/list/utils/listwalker.js';
 import stubUid from '../_utils/uid.js';
 import { modelList } from '../_utils/utils.js';
@@ -207,7 +207,7 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 
 			model.change( writer => {
-				fixListIndents( iterateSiblingListBlocks( fragment.getChild( 1 ) ), writer );
+				fixListIndents( new SiblingListBlocksIterator( fragment.getChild( 1 ) ), writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equal( modelList( [
@@ -226,7 +226,7 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 
 			model.change( writer => {
-				fixListIndents( iterateSiblingListBlocks( fragment.getChild( 0 ) ), writer );
+				fixListIndents( new SiblingListBlocksIterator( fragment.getChild( 0 ) ), writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equal( modelList( [
@@ -246,7 +246,7 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 
 			model.change( writer => {
-				fixListIndents( iterateSiblingListBlocks( fragment.getChild( 0 ) ), writer );
+				fixListIndents( new SiblingListBlocksIterator( fragment.getChild( 0 ) ), writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equal( modelList( [
@@ -266,7 +266,7 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 
 			model.change( writer => {
-				fixListIndents( iterateSiblingListBlocks( fragment.getChild( 0 ) ), writer );
+				fixListIndents( new SiblingListBlocksIterator( fragment.getChild( 0 ) ), writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equal( modelList( [
@@ -287,7 +287,7 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 
 			model.change( writer => {
-				fixListIndents( iterateSiblingListBlocks( fragment.getChild( 0 ) ), writer );
+				fixListIndents( new SiblingListBlocksIterator( fragment.getChild( 0 ) ), writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equal( modelList( [
@@ -312,7 +312,7 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 
 			model.change( writer => {
-				fixListIndents( iterateSiblingListBlocks( fragment.getChild( 0 ) ), writer );
+				fixListIndents( new SiblingListBlocksIterator( fragment.getChild( 0 ) ), writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equal( modelList( [
@@ -339,7 +339,7 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 
 			model.change( writer => {
-				fixListIndents( iterateSiblingListBlocks( fragment.getChild( 0 ) ), writer );
+				fixListIndents( new SiblingListBlocksIterator( fragment.getChild( 0 ) ), writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equal( modelList( [
@@ -365,7 +365,7 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 
 			model.change( writer => {
-				fixListIndents( iterateSiblingListBlocks( fragment.getChild( 1 ).getChild( 0 ) ), writer );
+				fixListIndents( new SiblingListBlocksIterator( fragment.getChild( 1 ).getChild( 0 ) ), writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equal(
@@ -393,7 +393,7 @@ describe( 'List - utils - postfixers', () => {
 			stubUid();
 
 			model.change( writer => {
-				fixListItemIds( iterateSiblingListBlocks( fragment.getChild( 0 ) ), seenIds, writer );
+				fixListItemIds( new SiblingListBlocksIterator( fragment.getChild( 0 ) ), seenIds, writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equal( modelList( [
@@ -415,7 +415,7 @@ describe( 'List - utils - postfixers', () => {
 			stubUid();
 
 			model.change( writer => {
-				fixListItemIds( iterateSiblingListBlocks( fragment.getChild( 0 ) ), seenIds, writer );
+				fixListItemIds( new SiblingListBlocksIterator( fragment.getChild( 0 ) ), seenIds, writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equal( modelList( [
@@ -438,7 +438,7 @@ describe( 'List - utils - postfixers', () => {
 			stubUid();
 
 			model.change( writer => {
-				fixListItemIds( iterateSiblingListBlocks( fragment.getChild( 0 ) ), seenIds, writer );
+				fixListItemIds( new SiblingListBlocksIterator( fragment.getChild( 0 ) ), seenIds, writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equal( modelList( [
@@ -461,7 +461,7 @@ describe( 'List - utils - postfixers', () => {
 			stubUid();
 
 			model.change( writer => {
-				fixListItemIds( iterateSiblingListBlocks( fragment.getChild( 0 ) ), seenIds, writer );
+				fixListItemIds( new SiblingListBlocksIterator( fragment.getChild( 0 ) ), seenIds, writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equalMarkup( modelList( [
@@ -484,7 +484,7 @@ describe( 'List - utils - postfixers', () => {
 			stubUid();
 
 			model.change( writer => {
-				fixListItemIds( iterateSiblingListBlocks( fragment.getChild( 0 ) ), seenIds, writer );
+				fixListItemIds( new SiblingListBlocksIterator( fragment.getChild( 0 ) ), seenIds, writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equalMarkup( modelList( [
@@ -508,7 +508,7 @@ describe( 'List - utils - postfixers', () => {
 			stubUid();
 
 			model.change( writer => {
-				fixListItemIds( iterateSiblingListBlocks( fragment.getChild( 0 ) ), seenIds, writer );
+				fixListItemIds( new SiblingListBlocksIterator( fragment.getChild( 0 ) ), seenIds, writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equalMarkup( modelList( [
@@ -537,7 +537,7 @@ describe( 'List - utils - postfixers', () => {
 			stubUid();
 
 			model.change( writer => {
-				fixListItemIds( iterateSiblingListBlocks( fragment.getChild( 0 ) ), seenIds, writer );
+				fixListItemIds( new SiblingListBlocksIterator( fragment.getChild( 0 ) ), seenIds, writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equalMarkup( modelList( [
@@ -567,7 +567,7 @@ describe( 'List - utils - postfixers', () => {
 			seenIds.add( 'b' );
 
 			model.change( writer => {
-				fixListItemIds( iterateSiblingListBlocks( fragment.getChild( 0 ) ), seenIds, writer );
+				fixListItemIds( new SiblingListBlocksIterator( fragment.getChild( 0 ) ), seenIds, writer );
 			} );
 
 			expect( stringifyModel( fragment ) ).to.equalMarkup( modelList( [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (list): Use iterator instead of generator in ListWalker for better performance.

---

The generator introduces some unnecessary overhead. This PR makes the `lists` performance demo 9% faster.
