### PR TITLE
Do not show back button if balloon was not opened using another balloon.

### DIFF
--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -281,9 +281,7 @@ export default class BookmarkUI extends Plugin {
 			button.bind( 'isEnabled' ).to( updateBookmarkCommand );
 
 			this.listenTo( button, 'execute', () => {
-				this._showFormView( {
-					showBackButton: true
-				} );
+				this._showFormView();
 			} );
 
 			return button;
@@ -328,9 +326,7 @@ export default class BookmarkUI extends Plugin {
 		} );
 
 		// Execute the command.
-		this.listenTo( view, 'execute', () => this._showFormView( {
-			showBackButton: updateCommand.isEnabled
-		} ) );
+		this.listenTo( view, 'execute', () => this._showFormView() );
 
 		view.bind( 'isEnabled' ).toMany(
 			[ insertCommand, updateCommand ],
@@ -368,19 +364,16 @@ export default class BookmarkUI extends Plugin {
 	/**
 	 * Adds the {@link #formView} to the {@link #_balloon}.
 	 */
-	private _addFormView( { showBackButton }: { showBackButton: boolean } ): void {
+	private _addFormView(): void {
 		if ( !this.formView ) {
 			this._createViews();
 		}
-
-		this.formView!.backButtonView.isVisible = showBackButton;
 
 		if ( this._isFormInPanel ) {
 			return;
 		}
 
-		const editor = this.editor;
-		const updateBookmarkCommand: UpdateBookmarkCommand = editor.commands.get( 'updateBookmark' )!;
+		const updateBookmarkCommand: UpdateBookmarkCommand = this.editor.commands.get( 'updateBookmark' )!;
 
 		this.formView!.disableCssTransitions();
 		this.formView!.resetFormStatus();
@@ -390,6 +383,7 @@ export default class BookmarkUI extends Plugin {
 			position: this._getBalloonPositionData()
 		} );
 
+		this.formView!.backButtonView.isVisible = updateBookmarkCommand.isEnabled;
 		this.formView!.idInputView.fieldView.value = updateBookmarkCommand.value || '';
 
 		// Select input when form view is currently visible.
@@ -423,7 +417,7 @@ export default class BookmarkUI extends Plugin {
 	/**
 	 * Shows the {@link #formView}.
 	 */
-	private _showFormView( { showBackButton = false }: { showBackButton?: boolean } = {} ): void {
+	private _showFormView(): void {
 		if ( !this.formView ) {
 			this._createViews();
 		}
@@ -432,9 +426,7 @@ export default class BookmarkUI extends Plugin {
 			this._showFakeVisualSelection();
 		}
 
-		this._addFormView( {
-			showBackButton
-		} );
+		this._addFormView();
 
 		// Be sure panel with bookmark is visible.
 		this._balloon.showStack( 'main' );

--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -326,7 +326,7 @@ export default class BookmarkUI extends Plugin {
 		} );
 
 		// Execute the command.
-		this.listenTo( view, 'execute', () => this._showFormView( false ) );
+		this.listenTo( view, 'execute', () => this._showFormView( updateCommand.isEnabled ) );
 
 		view.bind( 'isEnabled' ).toMany(
 			[ insertCommand, updateCommand ],

--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -281,7 +281,9 @@ export default class BookmarkUI extends Plugin {
 			button.bind( 'isEnabled' ).to( updateBookmarkCommand );
 
 			this.listenTo( button, 'execute', () => {
-				this._showFormView( true );
+				this._showFormView( {
+					showBackButton: true
+				} );
 			} );
 
 			return button;
@@ -326,7 +328,9 @@ export default class BookmarkUI extends Plugin {
 		} );
 
 		// Execute the command.
-		this.listenTo( view, 'execute', () => this._showFormView( updateCommand.isEnabled ) );
+		this.listenTo( view, 'execute', () => this._showFormView( {
+			showBackButton: updateCommand.isEnabled
+		} ) );
 
 		view.bind( 'isEnabled' ).toMany(
 			[ insertCommand, updateCommand ],
@@ -364,7 +368,7 @@ export default class BookmarkUI extends Plugin {
 	/**
 	 * Adds the {@link #formView} to the {@link #_balloon}.
 	 */
-	private _addFormView( showBackButton: boolean ): void {
+	private _addFormView( { showBackButton }: { showBackButton: boolean } ): void {
 		if ( !this.formView ) {
 			this._createViews();
 		}
@@ -419,7 +423,7 @@ export default class BookmarkUI extends Plugin {
 	/**
 	 * Shows the {@link #formView}.
 	 */
-	private _showFormView( showBackButton: boolean ): void {
+	private _showFormView( { showBackButton = false }: { showBackButton?: boolean } = {} ): void {
 		if ( !this.formView ) {
 			this._createViews();
 		}
@@ -428,7 +432,9 @@ export default class BookmarkUI extends Plugin {
 			this._showFakeVisualSelection();
 		}
 
-		this._addFormView( showBackButton );
+		this._addFormView( {
+			showBackButton
+		} );
 
 		// Be sure panel with bookmark is visible.
 		this._balloon.showStack( 'main' );

--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -281,7 +281,7 @@ export default class BookmarkUI extends Plugin {
 			button.bind( 'isEnabled' ).to( updateBookmarkCommand );
 
 			this.listenTo( button, 'execute', () => {
-				this._showFormView();
+				this._showFormView( true );
 			} );
 
 			return button;
@@ -326,7 +326,7 @@ export default class BookmarkUI extends Plugin {
 		} );
 
 		// Execute the command.
-		this.listenTo( view, 'execute', () => this._showFormView() );
+		this.listenTo( view, 'execute', () => this._showFormView( false ) );
 
 		view.bind( 'isEnabled' ).toMany(
 			[ insertCommand, updateCommand ],
@@ -364,10 +364,12 @@ export default class BookmarkUI extends Plugin {
 	/**
 	 * Adds the {@link #formView} to the {@link #_balloon}.
 	 */
-	private _addFormView(): void {
+	private _addFormView( showBackButton: boolean ): void {
 		if ( !this.formView ) {
 			this._createViews();
 		}
+
+		this.formView!.backButtonView.isVisible = showBackButton;
 
 		if ( this._isFormInPanel ) {
 			return;
@@ -417,7 +419,7 @@ export default class BookmarkUI extends Plugin {
 	/**
 	 * Shows the {@link #formView}.
 	 */
-	private _showFormView(): void {
+	private _showFormView( showBackButton: boolean ): void {
 		if ( !this.formView ) {
 			this._createViews();
 		}
@@ -426,7 +428,7 @@ export default class BookmarkUI extends Plugin {
 			this._showFakeVisualSelection();
 		}
 
-		this._addFormView();
+		this._addFormView( showBackButton );
 
 		// Be sure panel with bookmark is visible.
 		this._balloon.showStack( 'main' );

--- a/packages/ckeditor5-bookmark/src/ui/bookmarkformview.ts
+++ b/packages/ckeditor5-bookmark/src/ui/bookmarkformview.ts
@@ -277,6 +277,7 @@ export default class BookmarkFormView extends View {
 		const backButton = new ButtonView( this.locale );
 
 		backButton.set( {
+			class: 'ck-button-back',
 			label: t( 'Back' ),
 			icon: icons.previousArrow,
 			tooltip: true

--- a/packages/ckeditor5-bookmark/tests/bookmarkui.js
+++ b/packages/ckeditor5-bookmark/tests/bookmarkui.js
@@ -146,6 +146,12 @@ describe( 'BookmarkUI', () => {
 
 			sinon.assert.calledOnce( spy );
 		} );
+
+		it( 'should toggle the balloon UI with hidden back button', () => {
+			button.fire( 'execute' );
+
+			expect( bookmarkUIFeature.formView.backButtonView.isVisible ).to.be.false;
+		} );
 	}
 
 	describe( 'bookmark toolbar components', () => {
@@ -209,6 +215,12 @@ describe( 'BookmarkUI', () => {
 
 				updateBookmarkCommand.isEnabled = false;
 				expect( button.isEnabled ).to.equal( false );
+			} );
+
+			it( 'should toggle the balloon UI with visible back button', () => {
+				button.fire( 'execute' );
+
+				expect( bookmarkUIFeature.formView.backButtonView.isVisible ).to.be.true;
 			} );
 
 			it( 'should trigger #_showFormView() on execute', () => {

--- a/packages/ckeditor5-bookmark/tests/bookmarkui.js
+++ b/packages/ckeditor5-bookmark/tests/bookmarkui.js
@@ -1128,7 +1128,9 @@ describe( 'BookmarkUI', () => {
 		it( 'should create #formView', () => {
 			setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
 
-			bookmarkUIFeature._addFormView();
+			bookmarkUIFeature._addFormView( {
+				showBackButton: true
+			} );
 
 			expect( bookmarkUIFeature.formView ).to.be.instanceOf( BookmarkFormView );
 		} );
@@ -1136,7 +1138,9 @@ describe( 'BookmarkUI', () => {
 		it( 'should add #formView to the balloon and attach the balloon to the selection when text fragment is selected', () => {
 			setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
 
-			bookmarkUIFeature._addFormView();
+			bookmarkUIFeature._addFormView( {
+				showBackButton: true
+			} );
 			formView = bookmarkUIFeature.formView;
 
 			expect( balloon.visibleView ).to.equal( formView );
@@ -1145,14 +1149,18 @@ describe( 'BookmarkUI', () => {
 		it( 'should implement the CSS transition disabling feature', () => {
 			setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
 
-			bookmarkUIFeature._addFormView();
+			bookmarkUIFeature._addFormView( {
+				showBackButton: true
+			} );
 
 			expect( bookmarkUIFeature.formView.disableCssTransitions ).to.be.a( 'function' );
 		} );
 
 		describe( 'button label', () => {
 			it( 'should have "Insert" by default', () => {
-				bookmarkUIFeature._addFormView();
+				bookmarkUIFeature._addFormView( {
+					showBackButton: true
+				} );
 				formView = bookmarkUIFeature.formView;
 
 				expect( formView.saveButtonView.label ).to.equal( 'Insert' );
@@ -1161,7 +1169,9 @@ describe( 'BookmarkUI', () => {
 			it( 'should have "Insert" label when bookmark is not selected', () => {
 				setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
 
-				bookmarkUIFeature._addFormView();
+				bookmarkUIFeature._addFormView( {
+					showBackButton: true
+				} );
 				formView = bookmarkUIFeature.formView;
 
 				bookmarkUIFeature._showFormView();
@@ -1172,7 +1182,9 @@ describe( 'BookmarkUI', () => {
 			it( 'should have "Save" label when bookmark is selected', () => {
 				setModelData( editor.model, '<paragraph>[<bookmark bookmarkId="id"></bookmark>]</paragraph>' );
 
-				bookmarkUIFeature._addFormView();
+				bookmarkUIFeature._addFormView( {
+					showBackButton: true
+				} );
 				formView = bookmarkUIFeature.formView;
 
 				bookmarkUIFeature._showFormView();

--- a/packages/ckeditor5-bookmark/tests/bookmarkui.js
+++ b/packages/ckeditor5-bookmark/tests/bookmarkui.js
@@ -147,10 +147,20 @@ describe( 'BookmarkUI', () => {
 			sinon.assert.calledOnce( spy );
 		} );
 
-		it( 'should toggle the balloon UI with hidden back button', () => {
+		it( 'should toggle the balloon UI with hidden back button (if not updating)', () => {
+			editor.commands.get( 'updateBookmark' ).isEnabled = false;
+
 			button.fire( 'execute' );
 
 			expect( bookmarkUIFeature.formView.backButtonView.isVisible ).to.be.false;
+		} );
+
+		it( 'should toggle the balloon UI with visible back button (if updating)', () => {
+			editor.commands.get( 'updateBookmark' ).isEnabled = true;
+
+			button.fire( 'execute' );
+
+			expect( bookmarkUIFeature.formView.backButtonView.isVisible ).to.be.true;
 		} );
 	}
 

--- a/packages/ckeditor5-bookmark/tests/bookmarkui.js
+++ b/packages/ckeditor5-bookmark/tests/bookmarkui.js
@@ -148,16 +148,18 @@ describe( 'BookmarkUI', () => {
 		} );
 
 		it( 'should toggle the balloon UI with hidden back button (if not updating)', () => {
-			editor.commands.get( 'updateBookmark' ).isEnabled = false;
+			const updateBookmark = editor.commands.get( 'updateBookmark' );
 
+			sinon.stub( updateBookmark, 'isEnabled' ).get( () => false );
 			button.fire( 'execute' );
 
 			expect( bookmarkUIFeature.formView.backButtonView.isVisible ).to.be.false;
 		} );
 
 		it( 'should toggle the balloon UI with visible back button (if updating)', () => {
-			editor.commands.get( 'updateBookmark' ).isEnabled = true;
+			const updateBookmark = editor.commands.get( 'updateBookmark' );
 
+			sinon.stub( updateBookmark, 'isEnabled' ).get( () => true );
 			button.fire( 'execute' );
 
 			expect( bookmarkUIFeature.formView.backButtonView.isVisible ).to.be.true;
@@ -228,6 +230,9 @@ describe( 'BookmarkUI', () => {
 			} );
 
 			it( 'should toggle the balloon UI with visible back button', () => {
+				const updateBookmarkCommand = editor.commands.get( 'updateBookmark' );
+
+				sinon.stub( updateBookmarkCommand, 'isEnabled' ).get( () => true );
 				button.fire( 'execute' );
 
 				expect( bookmarkUIFeature.formView.backButtonView.isVisible ).to.be.true;
@@ -1128,9 +1133,7 @@ describe( 'BookmarkUI', () => {
 		it( 'should create #formView', () => {
 			setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
 
-			bookmarkUIFeature._addFormView( {
-				showBackButton: true
-			} );
+			bookmarkUIFeature._addFormView();
 
 			expect( bookmarkUIFeature.formView ).to.be.instanceOf( BookmarkFormView );
 		} );
@@ -1138,9 +1141,7 @@ describe( 'BookmarkUI', () => {
 		it( 'should add #formView to the balloon and attach the balloon to the selection when text fragment is selected', () => {
 			setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
 
-			bookmarkUIFeature._addFormView( {
-				showBackButton: true
-			} );
+			bookmarkUIFeature._addFormView();
 			formView = bookmarkUIFeature.formView;
 
 			expect( balloon.visibleView ).to.equal( formView );
@@ -1149,18 +1150,14 @@ describe( 'BookmarkUI', () => {
 		it( 'should implement the CSS transition disabling feature', () => {
 			setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
 
-			bookmarkUIFeature._addFormView( {
-				showBackButton: true
-			} );
+			bookmarkUIFeature._addFormView();
 
 			expect( bookmarkUIFeature.formView.disableCssTransitions ).to.be.a( 'function' );
 		} );
 
 		describe( 'button label', () => {
 			it( 'should have "Insert" by default', () => {
-				bookmarkUIFeature._addFormView( {
-					showBackButton: true
-				} );
+				bookmarkUIFeature._addFormView();
 				formView = bookmarkUIFeature.formView;
 
 				expect( formView.saveButtonView.label ).to.equal( 'Insert' );
@@ -1169,9 +1166,7 @@ describe( 'BookmarkUI', () => {
 			it( 'should have "Insert" label when bookmark is not selected', () => {
 				setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
 
-				bookmarkUIFeature._addFormView( {
-					showBackButton: true
-				} );
+				bookmarkUIFeature._addFormView();
 				formView = bookmarkUIFeature.formView;
 
 				bookmarkUIFeature._showFormView();
@@ -1182,9 +1177,7 @@ describe( 'BookmarkUI', () => {
 			it( 'should have "Save" label when bookmark is selected', () => {
 				setModelData( editor.model, '<paragraph>[<bookmark bookmarkId="id"></bookmark>]</paragraph>' );
 
-				bookmarkUIFeature._addFormView( {
-					showBackButton: true
-				} );
+				bookmarkUIFeature._addFormView();
 				formView = bookmarkUIFeature.formView;
 
 				bookmarkUIFeature._showFormView();

--- a/packages/ckeditor5-bookmark/tests/ui/bookmarkformview.js
+++ b/packages/ckeditor5-bookmark/tests/ui/bookmarkformview.js
@@ -65,6 +65,11 @@ describe( 'BookmarkFormView', () => {
 			expect( formHeaderView.children.get( 0 ) ).to.equal( view.backButtonView );
 		} );
 
+		it( 'should create back button view with proper classes', () => {
+			expect( view.backButtonView.element.classList.contains( 'ck-button' ) ).to.be.true;
+			expect( view.backButtonView.element.classList.contains( 'ck-button-back' ) ).to.be.true;
+		} );
+
 		it( 'should create #focusTracker instance', () => {
 			expect( view.focusTracker ).to.be.instanceOf( FocusTracker );
 		} );

--- a/packages/ckeditor5-image/src/imageresize/imageresizebuttons.ts
+++ b/packages/ckeditor5-image/src/imageresize/imageresizebuttons.ts
@@ -143,7 +143,11 @@ export default class ImageResizeButtons extends Plugin {
 			} else {
 				const optionValueWithUnit = value ? value + this._resizeUnit : null;
 
-				button.bind( 'isOn' ).to( command, 'value', getIsOnButtonCallback( optionValueWithUnit ) );
+				button.bind( 'isOn' ).to(
+					command, 'value',
+					command, 'isEnabled',
+					getIsOnButtonCallback( optionValueWithUnit )
+				);
 
 				this.listenTo( button, 'execute', () => {
 					editor.execute( 'resizeImage', { width: optionValueWithUnit } );
@@ -303,7 +307,11 @@ export default class ImageResizeButtons extends Plugin {
 
 				const allDropdownValues = map( optionsWithSerializedValues, 'valueWithUnits' );
 
-				definition.model.bind( 'isOn' ).to( command, 'value', getIsOnCustomButtonCallback( allDropdownValues ) );
+				definition.model.bind( 'isOn' ).to(
+					command, 'value',
+					command, 'isEnabled',
+					getIsOnCustomButtonCallback( allDropdownValues )
+				);
 			} else {
 				definition = {
 					type: 'button',
@@ -317,7 +325,11 @@ export default class ImageResizeButtons extends Plugin {
 					} )
 				};
 
-				definition.model.bind( 'isOn' ).to( command, 'value', getIsOnButtonCallback( option.valueWithUnits ) );
+				definition.model.bind( 'isOn' ).to(
+					command, 'value',
+					command, 'isEnabled',
+					getIsOnButtonCallback( option.valueWithUnits )
+				);
 			}
 
 			definition.model.bind( 'isEnabled' ).to( command, 'isEnabled' );
@@ -338,9 +350,14 @@ function isCustomImageResizeOption( option: ImageResizeOption ) {
 /**
  * A helper function for setting the `isOn` state of buttons in value bindings.
  */
-function getIsOnButtonCallback( value: string | null ): ( commandValue: unknown ) => boolean {
-	return ( commandValue: unknown ): boolean => {
-		const objectCommandValue = commandValue as null | { width: string | null };
+function getIsOnButtonCallback( value: string | null ) {
+	return ( commandValue: ResizeImageCommand['value'], isEnabled: boolean ): boolean => {
+		const objectCommandValue = commandValue as null | undefined | { width: string | null };
+
+		if ( objectCommandValue === undefined || !isEnabled ) {
+			return false;
+		}
+
 		if ( value === null && objectCommandValue === value ) {
 			return true;
 		}
@@ -352,8 +369,8 @@ function getIsOnButtonCallback( value: string | null ): ( commandValue: unknown 
 /**
  * A helper function for setting the `isOn` state of custom size button in value bindings.
  */
-function getIsOnCustomButtonCallback( allDropdownValues: Array<string | null> ): ( commandValue: unknown ) => boolean {
-	return ( commandValue: unknown ): boolean => !allDropdownValues.some(
-		dropdownValue => getIsOnButtonCallback( dropdownValue )( commandValue )
+function getIsOnCustomButtonCallback( allDropdownValues: Array<string | null> ) {
+	return ( commandValue: ResizeImageCommand['value'], isEnabled: boolean ): boolean => !allDropdownValues.some(
+		dropdownValue => getIsOnButtonCallback( dropdownValue )( commandValue, isEnabled )
 	);
 }

--- a/packages/ckeditor5-image/src/imageresize/resizeimagecommand.ts
+++ b/packages/ckeditor5-image/src/imageresize/resizeimagecommand.ts
@@ -17,7 +17,7 @@ export default class ResizeImageCommand extends Command {
 	/**
 	 * Desired image width and height.
 	 */
-	declare public value: null | {
+	declare public value: undefined | null | {
 		width: string | null;
 		height: string | null;
 	};

--- a/packages/ckeditor5-image/tests/imageresize/imageresizebuttons.js
+++ b/packages/ckeditor5-image/tests/imageresize/imageresizebuttons.js
@@ -5,6 +5,7 @@
 
 /* global document */
 
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor.js';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor.js';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
 import Image from '../../src/image.js';
@@ -108,6 +109,108 @@ describe( 'ImageResizeButtons', () => {
 			command.isEnabled = false;
 
 			expect( plugin.isEnabled ).to.be.false;
+		} );
+	} );
+
+	describe( 'resize options main toolbar buttons', () => {
+		let editor;
+
+		beforeEach( async () => {
+			editor = await ClassicEditor
+				.create( editorElement, {
+					plugins: [ Image, ImageStyle, Paragraph, Undo, Table, ImageResizeButtons, ImageCustomResizeUI ],
+					image: {
+						resizeUnit: '%',
+						resizeOptions: [ {
+							name: 'resizeImage:original',
+							value: null,
+							icon: 'original'
+						},
+						{
+							name: 'resizeImage:custom',
+							value: 'custom',
+							icon: 'custom'
+						},
+						{
+							name: 'resizeImage:25',
+							value: '25',
+							icon: 'small'
+						},
+						{
+							name: 'resizeImage:50',
+							value: '50',
+							icon: 'medium'
+						},
+						{
+							name: 'resizeImage:75',
+							value: '75',
+							icon: 'large'
+						} ]
+					},
+					toolbar: [ 'resizeImage:original', 'resizeImage:custom', 'resizeImage:25', 'resizeImage:50', 'resizeImage:75' ]
+				} );
+
+			plugin = editor.plugins.get( 'ImageResizeButtons' );
+		} );
+
+		afterEach( async () => {
+			if ( editorElement ) {
+				editorElement.remove();
+			}
+
+			if ( editor && editor.state !== 'destroyed' ) {
+				await editor.destroy();
+			}
+		} );
+
+		it( 'should register resize options as items in the main toolbar', () => {
+			const toolbar = editor.ui.view.toolbar;
+
+			expect( toolbar.items.map( item => item.label ) ).to.deep.equal( [
+				'Resize image to the original size',
+				'Custom image size',
+				'Resize image to 25%',
+				'Resize image to 50%',
+				'Resize image to 75%'
+			] );
+		} );
+
+		it( 'should synchronize button states with command\'s isEnabled property', () => {
+			const toolbar = editor.ui.view.toolbar;
+			const resizeCommand = editor.commands.get( 'resizeImage' );
+			const resizeComponents = toolbar.items.filter( item => item.label && item.label.includes( 'Resize image' ) );
+
+			resizeCommand.isEnabled = true;
+			expect( resizeComponents.every( item => item.isEnabled ) ).to.be.true;
+
+			resizeCommand.isEnabled = false;
+			expect( resizeComponents.every( item => item.isEnabled ) ).to.be.false;
+		} );
+
+		it( 'should properly sync isOn states of buttons', () => {
+			const toolbar = editor.ui.view.toolbar;
+			const resizeCommand = editor.commands.get( 'resizeImage' );
+			const resizeComponents = toolbar.items.filter( item => item.label && item.label.includes( 'Resize image' ) );
+
+			resizeCommand.isEnabled = false;
+			resizeCommand.value = undefined;
+
+			expect( resizeComponents.every( item => item.isOn ) ).to.be.false;
+
+			resizeCommand.isEnabled = false;
+			expect( resizeComponents.every( item => item.isOn ) ).to.be.false;
+
+			resizeCommand.value = undefined;
+			resizeCommand.isEnabled = true;
+			expect( resizeComponents.every( item => item.isOn ) ).to.be.false;
+
+			resizeCommand.value = { width: '50%' };
+			resizeCommand.isEnabled = true;
+
+			expect( resizeComponents[ 2 ].isOn ).to.be.true;
+
+			resizeCommand.isEnabled = false;
+			expect( resizeComponents[ 2 ].isOn ).to.be.false;
 		} );
 	} );
 

--- a/packages/ckeditor5-image/tests/manual/imageresizebuttons.js
+++ b/packages/ckeditor5-image/tests/manual/imageresizebuttons.js
@@ -116,7 +116,14 @@ const imageConfig2 = {
 
 const config2 = {
 	...commonConfig,
-	image: imageConfig2
+	image: imageConfig2,
+	toolbar: [
+		...commonConfig.toolbar, '|',
+		'resizeImage:50',
+		'resizeImage:75',
+		'resizeImage:original',
+		'resizeImage:custom'
+	]
 };
 
 ClassicEditor

--- a/packages/ckeditor5-image/tests/manual/textalternative.js
+++ b/packages/ckeditor5-image/tests/manual/textalternative.js
@@ -18,7 +18,7 @@ import ImageToolbar from '../../src/imagetoolbar.js';
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [ EnterPlugin, TypingPlugin, ParagraphPlugin, HeadingPlugin, ImagePlugin, UndoPlugin, ClipboardPlugin, ImageToolbar ],
-		toolbar: [ 'heading', '|', 'undo', 'redo' ],
+		toolbar: [ 'heading', '|', 'undo', 'redo', '|', 'imageTextAlternative' ],
 		image: {
 			toolbar: [ 'imageTextAlternative' ]
 		}

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -723,7 +723,7 @@ export default class LinkUI extends Plugin {
 	/**
 	 * Adds the {@link #formView} to the {@link #_balloon}.
 	 */
-	private _addFormView( { showBackButton }: { showBackButton: boolean } ): void {
+	private _addFormView( { showBackButton = false }: { showBackButton?: boolean } = {} ): void {
 		if ( !this.formView ) {
 			this._createViews();
 		}

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -718,10 +718,12 @@ export default class LinkUI extends Plugin {
 	/**
 	 * Adds the {@link #formView} to the {@link #_balloon}.
 	 */
-	private _addFormView(): void {
+	private _addFormView( showBackButton: boolean = true ): void {
 		if ( !this.formView ) {
 			this._createViews();
 		}
+
+		this.formView!.backButtonView.isVisible = showBackButton;
 
 		if ( this._isFormInPanel ) {
 			return;
@@ -879,13 +881,13 @@ export default class LinkUI extends Plugin {
 				this._balloon.showStack( 'main' );
 			}
 
-			this._addFormView();
+			this._addFormView( !forceVisible );
 		}
 		// If there's a link under the selection...
 		else {
 			// Go to the editing UI if toolbar is already visible.
 			if ( this._isToolbarVisible ) {
-				this._addFormView();
+				this._addFormView( !forceVisible );
 			}
 			// Otherwise display just the toolbar.
 			else {

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -254,9 +254,7 @@ export default class LinkUI extends Plugin {
 
 		// Open the form view on Ctrl+K when the **link toolbar have focus**..
 		toolbarView.keystrokes.set( LINK_KEYSTROKE, ( data, cancel ) => {
-			this._addFormView( {
-				showBackButton: true
-			} );
+			this._addFormView();
 
 			cancel();
 		} );
@@ -555,9 +553,7 @@ export default class LinkUI extends Plugin {
 			button.bind( 'isEnabled' ).to( linkCommand );
 
 			this.listenTo<ButtonExecuteEvent>( button, 'execute', () => {
-				this._addFormView( {
-					showBackButton: true
-				} );
+				this._addFormView();
 			} );
 
 			return button;
@@ -723,19 +719,18 @@ export default class LinkUI extends Plugin {
 	/**
 	 * Adds the {@link #formView} to the {@link #_balloon}.
 	 */
-	private _addFormView( { showBackButton = false }: { showBackButton?: boolean } = {} ): void {
+	private _addFormView(): void {
 		if ( !this.formView ) {
 			this._createViews();
 		}
 
-		this.formView!.backButtonView.isVisible = showBackButton;
+		const linkCommand: LinkCommand = this.editor.commands.get( 'link' )!;
+
+		this.formView!.backButtonView.isVisible = linkCommand.isEnabled && !!linkCommand.value;
 
 		if ( this._isFormInPanel ) {
 			return;
 		}
-
-		const editor = this.editor;
-		const linkCommand: LinkCommand = editor.commands.get( 'link' )!;
 
 		this.formView!.disableCssTransitions();
 		this.formView!.resetFormStatus();
@@ -886,17 +881,13 @@ export default class LinkUI extends Plugin {
 				this._balloon.showStack( 'main' );
 			}
 
-			this._addFormView( {
-				showBackButton: !forceVisible
-			} );
+			this._addFormView();
 		}
 		// If there's a link under the selection...
 		else {
 			// Go to the editing UI if toolbar is already visible.
 			if ( this._isToolbarVisible ) {
-				this._addFormView( {
-					showBackButton: !forceVisible
-				} );
+				this._addFormView();
 			}
 			// Otherwise display just the toolbar.
 			else {

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -724,16 +724,15 @@ export default class LinkUI extends Plugin {
 			this._createViews();
 		}
 
-		const linkCommand: LinkCommand = this.editor.commands.get( 'link' )!;
-
-		this.formView!.backButtonView.isVisible = linkCommand.isEnabled && !!linkCommand.value;
-
 		if ( this._isFormInPanel ) {
 			return;
 		}
 
+		const linkCommand: LinkCommand = this.editor.commands.get( 'link' )!;
+
 		this.formView!.disableCssTransitions();
 		this.formView!.resetFormStatus();
+		this.formView!.backButtonView.isVisible = linkCommand.isEnabled && !!linkCommand.value;
 
 		this._balloon.add( {
 			view: this.formView!,

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -254,7 +254,10 @@ export default class LinkUI extends Plugin {
 
 		// Open the form view on Ctrl+K when the **link toolbar have focus**..
 		toolbarView.keystrokes.set( LINK_KEYSTROKE, ( data, cancel ) => {
-			this._addFormView();
+			this._addFormView( {
+				showBackButton: true
+			} );
+
 			cancel();
 		} );
 
@@ -552,7 +555,9 @@ export default class LinkUI extends Plugin {
 			button.bind( 'isEnabled' ).to( linkCommand );
 
 			this.listenTo<ButtonExecuteEvent>( button, 'execute', () => {
-				this._addFormView();
+				this._addFormView( {
+					showBackButton: true
+				} );
 			} );
 
 			return button;
@@ -718,7 +723,7 @@ export default class LinkUI extends Plugin {
 	/**
 	 * Adds the {@link #formView} to the {@link #_balloon}.
 	 */
-	private _addFormView( showBackButton: boolean = true ): void {
+	private _addFormView( { showBackButton }: { showBackButton: boolean } ): void {
 		if ( !this.formView ) {
 			this._createViews();
 		}
@@ -881,13 +886,17 @@ export default class LinkUI extends Plugin {
 				this._balloon.showStack( 'main' );
 			}
 
-			this._addFormView( !forceVisible );
+			this._addFormView( {
+				showBackButton: !forceVisible
+			} );
 		}
 		// If there's a link under the selection...
 		else {
 			// Go to the editing UI if toolbar is already visible.
 			if ( this._isToolbarVisible ) {
-				this._addFormView( !forceVisible );
+				this._addFormView( {
+					showBackButton: !forceVisible
+				} );
 			}
 			// Otherwise display just the toolbar.
 			else {

--- a/packages/ckeditor5-link/src/ui/linkformview.ts
+++ b/packages/ckeditor5-link/src/ui/linkformview.ts
@@ -248,6 +248,7 @@ export default class LinkFormView extends View {
 		const backButton = new ButtonView( this.locale );
 
 		backButton.set( {
+			class: 'ck-button-back',
 			label: t( 'Back' ),
 			icon: icons.previousArrow,
 			tooltip: true

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -2933,7 +2933,9 @@ describe( 'LinkUI with Bookmark', () => {
 		it( 'should create #bookmarksView', () => {
 			setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
 
-			linkUIFeature._showUI();
+			linkUIFeature._showUI( {
+				showBackButton: true
+			} );
 
 			expect( linkUIFeature.bookmarksView ).to.be.instanceOf( LinkBookmarksView );
 		} );

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -166,6 +166,11 @@ describe( 'LinkUI', () => {
 				command.isEnabled = !initState;
 				expect( linkButton.isEnabled ).to.equal( !initState );
 			} );
+
+			it( 'should toggle the link UI with hidden back button', () => {
+				linkButton.fire( 'execute' );
+				expect( linkUIFeature.formView.backButtonView.isVisible ).to.be.false;
+			} );
 		}
 
 		describe( 'the "linkPreview" toolbar button', () => {
@@ -300,6 +305,12 @@ describe( 'LinkUI', () => {
 				button.fire( 'execute' );
 
 				sinon.assert.calledOnce( stubAddForm );
+			} );
+
+			it( 'should open link form view with back button', () => {
+				button.fire( 'execute' );
+
+				expect( linkUIFeature.formView.backButtonView.isVisible ).to.be.true;
 			} );
 		} );
 

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -169,6 +169,7 @@ describe( 'LinkUI', () => {
 
 			it( 'should toggle the link UI with hidden back button', () => {
 				linkButton.fire( 'execute' );
+
 				expect( linkUIFeature.formView.backButtonView.isVisible ).to.be.false;
 			} );
 		}
@@ -308,6 +309,12 @@ describe( 'LinkUI', () => {
 			} );
 
 			it( 'should open link form view with back button', () => {
+				const linkCommand = editor.commands.get( 'link' );
+
+				// Simulate link selection.
+				linkCommand.isEnabled = true;
+				linkCommand.value = 'http://ckeditor.com';
+
 				button.fire( 'execute' );
 
 				expect( linkUIFeature.formView.backButtonView.isVisible ).to.be.true;
@@ -2933,9 +2940,7 @@ describe( 'LinkUI with Bookmark', () => {
 		it( 'should create #bookmarksView', () => {
 			setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
 
-			linkUIFeature._showUI( {
-				showBackButton: true
-			} );
+			linkUIFeature._showUI();
 
 			expect( linkUIFeature.bookmarksView ).to.be.instanceOf( LinkBookmarksView );
 		} );

--- a/packages/ckeditor5-link/tests/ui/linkformview.js
+++ b/packages/ckeditor5-link/tests/ui/linkformview.js
@@ -107,6 +107,13 @@ describe( 'LinkFormView', () => {
 
 				expect( backButton.template.children[ 0 ].get( 1 ).text ).to.equal( 'Back' );
 			} );
+
+			it( 'should `backButtonView` has correct CSS class', () => {
+				const headerChildren = view.template.children[ 0 ].get( 0 ).template.children[ 0 ];
+				const backButton = headerChildren.get( 0 );
+
+				expect( backButton.class ).to.equal( 'ck-button-back' );
+			} );
 		} );
 	} );
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-bookmark/bookmarkform.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-bookmark/bookmarkform.css
@@ -26,8 +26,14 @@
 	& .ck-form__header {
 		padding: var(--ck-spacing-small) var(--ck-spacing-medium);
 
-		& > .ck:not(:first-child) {
-			margin-inline-start: var(--ck-spacing-small);
+		/* Back button is hidden */
+		&:has(.ck-button-back.ck-hidden) {
+			padding-inline-start: var(--ck-spacing-large);
+			padding-inline-end: var(--ck-spacing-large);
+		}
+
+		& > .ck-button-back {
+			margin-inline-end: var(--ck-spacing-small);
 		}
 	}
 

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkform.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-link/linkform.css
@@ -28,8 +28,14 @@
 	& .ck-form__header {
 		padding: var(--ck-spacing-small) var(--ck-spacing-medium);
 
-		& > .ck:not(:first-child) {
-			margin-inline-start: var(--ck-spacing-small);
+		/* Back button is hidden */
+		&:has(.ck-button-back.ck-hidden) {
+			padding-inline-start: var(--ck-spacing-large);
+			padding-inline-end: var(--ck-spacing-large);
+		}
+
+		& > .ck-button-back {
+			margin-inline-end: var(--ck-spacing-small);
 		}
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (bookmark, link, image): Do not show back button if balloon was not opened using another balloon.
Fix (image): No longer crash editor when using image resize buttons in toolbar. 

### Additional information

Take a look at back button arrows.

#### Before

https://github.com/user-attachments/assets/f5964832-3b2f-4fce-9078-3c61ee0355b8

#### After

https://github.com/user-attachments/assets/850dca9c-f012-4348-94d8-edd6b59caba8



