### PR TITLE
Skip already visited list elements during reconversion and post fixing

### DIFF
--- a/packages/ckeditor5-list/src/list/converters.ts
+++ b/packages/ckeditor5-list/src/list/converters.ts
@@ -138,32 +138,33 @@ export function reconvertItemsOnDataChange(
 		const changes = model.document.differ.getChanges();
 		const itemsToRefresh = [];
 		const itemToListHead = new Map<ListElement, ListElement>();
+		const visited = new Set<Element>();
 		const changedItems = new Set<Node>();
 
 		for ( const entry of changes ) {
 			if ( entry.type == 'insert' && entry.name != '$text' ) {
-				findAndAddListHeadToMap( entry.position, itemToListHead );
+				findAndAddListHeadToMap( entry.position, itemToListHead, visited );
 
 				// Insert of a non-list item.
 				if ( !entry.attributes.has( 'listItemId' ) ) {
-					findAndAddListHeadToMap( entry.position.getShiftedBy( entry.length ), itemToListHead );
+					findAndAddListHeadToMap( entry.position.getShiftedBy( entry.length ), itemToListHead, visited );
 				} else {
 					changedItems.add( entry.position.nodeAfter! );
 				}
 			}
 			// Removed list item.
 			else if ( entry.type == 'remove' && entry.attributes.has( 'listItemId' ) ) {
-				findAndAddListHeadToMap( entry.position, itemToListHead );
+				findAndAddListHeadToMap( entry.position, itemToListHead, visited );
 			}
 			// Changed list attribute.
 			else if ( entry.type == 'attribute' ) {
 				const item = entry.range.start.nodeAfter!;
 
 				if ( attributeNames.includes( entry.attributeKey ) ) {
-					findAndAddListHeadToMap( entry.range.start, itemToListHead );
+					findAndAddListHeadToMap( entry.range.start, itemToListHead, visited );
 
 					if ( entry.attributeNewValue === null ) {
-						findAndAddListHeadToMap( entry.range.start.getShiftedBy( 1 ), itemToListHead );
+						findAndAddListHeadToMap( entry.range.start.getShiftedBy( 1 ), itemToListHead, visited );
 
 						// Check if paragraph should be converted from bogus to plain paragraph.
 						if ( doesItemBlockRequiresRefresh( item as Element ) ) {

--- a/packages/ckeditor5-list/src/list/converters.ts
+++ b/packages/ckeditor5-list/src/list/converters.ts
@@ -137,9 +137,9 @@ export function reconvertItemsOnDataChange(
 	return () => {
 		const changes = model.document.differ.getChanges();
 		const itemsToRefresh = [];
-		const itemToListHead = new Map<ListElement, ListElement>();
-		const visited = new Set<Element>();
+		const itemToListHead = new Set<ListElement>();
 		const changedItems = new Set<Node>();
+		const visited = new Set<Element>();
 
 		for ( const entry of changes ) {
 			if ( entry.type == 'insert' && entry.name != '$text' ) {

--- a/packages/ckeditor5-list/src/list/listediting.ts
+++ b/packages/ckeditor5-list/src/list/listediting.ts
@@ -755,6 +755,7 @@ function modelChangePostFixer(
 	listEditing: ListEditing
 ) {
 	const changes = model.document.differ.getChanges();
+	const visited = new Set<Element>();
 	const itemToListHead = new Map<ListElement, ListElement>();
 	const multiBlock = listEditing.editor.config.get( 'list.multiBlock' );
 
@@ -775,30 +776,30 @@ function modelChangePostFixer(
 				}
 			}
 
-			findAndAddListHeadToMap( entry.position, itemToListHead );
+			findAndAddListHeadToMap( entry.position, itemToListHead, visited );
 
 			// Insert of a non-list item - check if there is a list after it.
 			if ( !entry.attributes.has( 'listItemId' ) ) {
-				findAndAddListHeadToMap( entry.position.getShiftedBy( entry.length ), itemToListHead );
+				findAndAddListHeadToMap( entry.position.getShiftedBy( entry.length ), itemToListHead, visited );
 			}
 
 			// Check if there is no nested list.
 			for ( const { item: innerItem, previousPosition } of model.createRangeIn( item as Element ) ) {
 				if ( isListItemBlock( innerItem ) ) {
-					findAndAddListHeadToMap( previousPosition, itemToListHead );
+					findAndAddListHeadToMap( previousPosition, itemToListHead, visited );
 				}
 			}
 		}
 		// Removed list item or block adjacent to a list.
 		else if ( entry.type == 'remove' ) {
-			findAndAddListHeadToMap( entry.position, itemToListHead );
+			findAndAddListHeadToMap( entry.position, itemToListHead, visited );
 		}
 		// Changed list item indent or type.
 		else if ( entry.type == 'attribute' && attributeNames.includes( entry.attributeKey ) ) {
-			findAndAddListHeadToMap( entry.range.start, itemToListHead );
+			findAndAddListHeadToMap( entry.range.start, itemToListHead, visited );
 
 			if ( entry.attributeNewValue === null ) {
-				findAndAddListHeadToMap( entry.range.start.getShiftedBy( 1 ), itemToListHead );
+				findAndAddListHeadToMap( entry.range.start.getShiftedBy( 1 ), itemToListHead, visited );
 			}
 		}
 

--- a/packages/ckeditor5-list/src/list/listediting.ts
+++ b/packages/ckeditor5-list/src/list/listediting.ts
@@ -756,7 +756,7 @@ function modelChangePostFixer(
 ) {
 	const changes = model.document.differ.getChanges();
 	const visited = new Set<Element>();
-	const itemToListHead = new Map<ListElement, ListElement>();
+	const itemToListHead = new Set<ListElement>();
 	const multiBlock = listEditing.editor.config.get( 'list.multiBlock' );
 
 	let applied = false;

--- a/packages/ckeditor5-list/src/list/utils/postfixers.ts
+++ b/packages/ckeditor5-list/src/list/utils/postfixers.ts
@@ -7,7 +7,7 @@
  * @module list/list/utils/postfixers
  */
 
-import type { Position, Writer } from 'ckeditor5/src/engine.js';
+import type { Element, Position, Writer } from 'ckeditor5/src/engine.js';
 import { SiblingListBlocksIterator, type ListIteratorValue } from './listwalker.js';
 import { getListItemBlocks, isListItemBlock, ListItemUid, type ListElement } from './model.js';
 
@@ -17,10 +17,12 @@ import { getListItemBlocks, isListItemBlock, ListItemUid, type ListElement } fro
  * @internal
  * @param position The search starting position.
  * @param itemToListHead The map from list item element to the list head element.
+ * @param visited A set of elements that were already visited.
  */
 export function findAndAddListHeadToMap(
 	position: Position,
-	itemToListHead: Map<ListElement, ListElement>
+	itemToListHead: Map<ListElement, ListElement>,
+	visited: Set<Element>
 ): void {
 	const previousNode = position.nodeBefore;
 
@@ -41,6 +43,12 @@ export function findAndAddListHeadToMap(
 		// See: https://github.com/ckeditor/ckeditor5-react/issues/345.
 		for ( const { node } of new SiblingListBlocksIterator( listHead, 'backward' ) ) {
 			listHead = node;
+
+			if ( visited.has( listHead ) ) {
+				return;
+			}
+
+			visited.add( listHead );
 
 			if ( itemToListHead.has( listHead ) ) {
 				return;

--- a/packages/ckeditor5-list/src/list/utils/postfixers.ts
+++ b/packages/ckeditor5-list/src/list/utils/postfixers.ts
@@ -21,7 +21,7 @@ import { getListItemBlocks, isListItemBlock, ListItemUid, type ListElement } fro
  */
 export function findAndAddListHeadToMap(
 	position: Position,
-	itemToListHead: Map<ListElement, ListElement>,
+	itemToListHead: Set<ListElement>,
 	visited: Set<Element>
 ): void {
 	const previousNode = position.nodeBefore;
@@ -30,7 +30,7 @@ export function findAndAddListHeadToMap(
 		const item = position.nodeAfter;
 
 		if ( isListItemBlock( item ) ) {
-			itemToListHead.set( item, item );
+			itemToListHead.add( item );
 		}
 	} else {
 		let listHead = previousNode;
@@ -50,12 +50,12 @@ export function findAndAddListHeadToMap(
 
 			visited.add( listHead );
 
-			if ( itemToListHead.has( listHead ) ) {
+			if ( itemToListHead.has( previousNode ) ) {
 				return;
 			}
 		}
 
-		itemToListHead.set( previousNode, listHead );
+		itemToListHead.add( listHead );
 	}
 }
 

--- a/packages/ckeditor5-list/tests/list/utils/postfixers.js
+++ b/packages/ckeditor5-list/tests/list/utils/postfixers.js
@@ -43,8 +43,9 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 1 );
 			const itemToListHead = new Map();
+			const visited = new Set();
 
-			findAndAddListHeadToMap( position, itemToListHead );
+			findAndAddListHeadToMap( position, itemToListHead, visited );
 
 			const heads = Array.from( itemToListHead.values() );
 
@@ -62,8 +63,9 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 2 );
 			const itemToListHead = new Map();
+			const visited = new Set();
 
-			findAndAddListHeadToMap( position, itemToListHead );
+			findAndAddListHeadToMap( position, itemToListHead, visited );
 
 			const heads = Array.from( itemToListHead.values() );
 
@@ -81,8 +83,9 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 3 );
 			const itemToListHead = new Map();
+			const visited = new Set();
 
-			findAndAddListHeadToMap( position, itemToListHead );
+			findAndAddListHeadToMap( position, itemToListHead, visited );
 
 			const heads = Array.from( itemToListHead.values() );
 
@@ -101,10 +104,11 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 3 );
 			const itemToListHead = new Map();
+			const visited = new Set();
 
 			itemToListHead.set( fragment.getChild( 2 ), fragment.getChild( 1 ) );
 
-			findAndAddListHeadToMap( position, itemToListHead );
+			findAndAddListHeadToMap( position, itemToListHead, visited );
 
 			const heads = Array.from( itemToListHead.values() );
 
@@ -123,10 +127,11 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 4 );
 			const itemToListHead = new Map();
+			const visited = new Set();
 
 			itemToListHead.set( fragment.getChild( 2 ), fragment.getChild( 1 ) );
 
-			findAndAddListHeadToMap( position, itemToListHead );
+			findAndAddListHeadToMap( position, itemToListHead, visited );
 
 			const heads = Array.from( itemToListHead.values() );
 
@@ -145,8 +150,9 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 4 );
 			const itemToListHead = new Map();
+			const visited = new Set();
 
-			findAndAddListHeadToMap( position, itemToListHead );
+			findAndAddListHeadToMap( position, itemToListHead, visited );
 
 			const heads = Array.from( itemToListHead.values() );
 
@@ -166,8 +172,9 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 5 );
 			const itemToListHead = new Map();
+			const visited = new Set();
 
-			findAndAddListHeadToMap( position, itemToListHead );
+			findAndAddListHeadToMap( position, itemToListHead, visited );
 
 			const heads = Array.from( itemToListHead.values() );
 
@@ -188,8 +195,9 @@ describe( 'List - utils - postfixers', () => {
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 3 );
 			const itemToListHead = new Map();
+			const visited = new Set();
 
-			findAndAddListHeadToMap( position, itemToListHead );
+			findAndAddListHeadToMap( position, itemToListHead, visited );
 
 			const heads = Array.from( itemToListHead.values() );
 

--- a/packages/ckeditor5-list/tests/list/utils/postfixers.js
+++ b/packages/ckeditor5-list/tests/list/utils/postfixers.js
@@ -42,7 +42,7 @@ describe( 'List - utils - postfixers', () => {
 
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 1 );
-			const itemToListHead = new Map();
+			const itemToListHead = new Set();
 			const visited = new Set();
 
 			findAndAddListHeadToMap( position, itemToListHead, visited );
@@ -62,7 +62,7 @@ describe( 'List - utils - postfixers', () => {
 
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 2 );
-			const itemToListHead = new Map();
+			const itemToListHead = new Set();
 			const visited = new Set();
 
 			findAndAddListHeadToMap( position, itemToListHead, visited );
@@ -82,7 +82,7 @@ describe( 'List - utils - postfixers', () => {
 
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 3 );
-			const itemToListHead = new Map();
+			const itemToListHead = new Set();
 			const visited = new Set();
 
 			findAndAddListHeadToMap( position, itemToListHead, visited );
@@ -103,10 +103,10 @@ describe( 'List - utils - postfixers', () => {
 
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 3 );
-			const itemToListHead = new Map();
+			const itemToListHead = new Set();
 			const visited = new Set();
 
-			itemToListHead.set( fragment.getChild( 2 ), fragment.getChild( 1 ) );
+			itemToListHead.add( fragment.getChild( 1 ) );
 
 			findAndAddListHeadToMap( position, itemToListHead, visited );
 
@@ -126,10 +126,10 @@ describe( 'List - utils - postfixers', () => {
 
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 4 );
-			const itemToListHead = new Map();
+			const itemToListHead = new Set();
 			const visited = new Set();
 
-			itemToListHead.set( fragment.getChild( 2 ), fragment.getChild( 1 ) );
+			itemToListHead.add( fragment.getChild( 1 ) );
 
 			findAndAddListHeadToMap( position, itemToListHead, visited );
 
@@ -149,7 +149,7 @@ describe( 'List - utils - postfixers', () => {
 
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 4 );
-			const itemToListHead = new Map();
+			const itemToListHead = new Set();
 			const visited = new Set();
 
 			findAndAddListHeadToMap( position, itemToListHead, visited );
@@ -171,7 +171,7 @@ describe( 'List - utils - postfixers', () => {
 
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 5 );
-			const itemToListHead = new Map();
+			const itemToListHead = new Set();
 			const visited = new Set();
 
 			findAndAddListHeadToMap( position, itemToListHead, visited );
@@ -194,7 +194,7 @@ describe( 'List - utils - postfixers', () => {
 
 			const fragment = parseModel( input, schema );
 			const position = model.createPositionAt( fragment, 3 );
-			const itemToListHead = new Map();
+			const itemToListHead = new Set();
 			const visited = new Set();
 
 			findAndAddListHeadToMap( position, itemToListHead, visited );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (list): Skip already visited list elements during reconversion and post fixing for better performance. Fixes #17625.

---

This change makes the `lists` performance demo ~18% faster.
