### PR TITLE
Return focus to editable after executing a delete command.

### DIFF
--- a/packages/ckeditor5-bookmark/src/bookmarkui.ts
+++ b/packages/ckeditor5-bookmark/src/bookmarkui.ts
@@ -302,6 +302,7 @@ export default class BookmarkUI extends Plugin {
 
 			this.listenTo( button, 'execute', () => {
 				editor.execute( 'delete' );
+				editor.editing.view.focus();
 			} );
 
 			return button;

--- a/packages/ckeditor5-bookmark/tests/bookmarkui.js
+++ b/packages/ckeditor5-bookmark/tests/bookmarkui.js
@@ -262,6 +262,14 @@ describe( 'BookmarkUI', () => {
 
 				sinon.assert.calledOnce( spy );
 			} );
+
+			it( 'should return focus to editable after executing a command', () => {
+				const spy = sinon.spy( editor.editing.view, 'focus' );
+
+				button.fire( 'execute' );
+
+				sinon.assert.calledOnce( spy );
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix(bookmark): Should return focus to editor after deleting the bookmark.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
