### PR TITLE
Show link form on second click in toolbar.

### DIFF
--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -884,12 +884,16 @@ export default class LinkUI extends Plugin {
 		}
 		// If there's a link under the selection...
 		else {
-			// Go to the editing UI if toolbar is already visible.
-			if ( this._isToolbarVisible ) {
+			if ( forceVisible && this._getSelectedLinkElement() ) {
+				// Show the toolbar below of the form view if user selected link and triggered
+				// the balloon from the toolbar or the menu bar.
+				this._addToolbarView();
 				this._addFormView();
-			}
-			// Otherwise display just the toolbar.
-			else {
+			} else if ( this._isToolbarVisible ) {
+				// Go to the editing UI if toolbar is already visible.
+				this._addFormView();
+			} else {
+				// Otherwise display just the toolbar.
 				this._addToolbarView();
 			}
 

--- a/packages/ckeditor5-link/src/linkui.ts
+++ b/packages/ckeditor5-link/src/linkui.ts
@@ -625,7 +625,15 @@ export default class LinkUI extends Plugin {
 		view.bind( 'isOn' ).to( command, 'value', value => !!value );
 
 		// Show the panel on button click.
-		this.listenTo<ButtonExecuteEvent>( view, 'execute', () => this._showUI( true ) );
+		this.listenTo<ButtonExecuteEvent>( view, 'execute', () => {
+			this._showUI( true );
+
+			// Open the form view on-top of the toolbar view if it's already visible.
+			// It should be visible every time the link is selected.
+			if ( this._getSelectedLinkElement() ) {
+				this._addFormView();
+			}
+		} );
 
 		return view;
 	}
@@ -884,16 +892,12 @@ export default class LinkUI extends Plugin {
 		}
 		// If there's a link under the selection...
 		else {
-			if ( forceVisible && this._getSelectedLinkElement() ) {
-				// Show the toolbar below of the form view if user selected link and triggered
-				// the balloon from the toolbar or the menu bar.
-				this._addToolbarView();
+			// Go to the editing UI if toolbar is already visible.
+			if ( this._isToolbarVisible ) {
 				this._addFormView();
-			} else if ( this._isToolbarVisible ) {
-				// Go to the editing UI if toolbar is already visible.
-				this._addFormView();
-			} else {
-				// Otherwise display just the toolbar.
+			}
+			// Otherwise display just the toolbar.
+			else {
 				this._addToolbarView();
 			}
 

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -172,6 +172,14 @@ describe( 'LinkUI', () => {
 
 				expect( linkUIFeature.formView.backButtonView.isVisible ).to.be.false;
 			} );
+
+			it( 'should open on-top of the toolbar if the link is selected', () => {
+				setModelData( editor.model, '<paragraph><$text linkHref="url">f[]oo</$text></paragraph>' );
+
+				linkButton.fire( 'execute' );
+
+				expect( balloon.visibleView ).to.equal( linkUIFeature.formView );
+			} );
 		}
 
 		describe( 'the "linkPreview" toolbar button', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (link): Open link form on top of the link toolbar if user clicked toolbar button on selected link. Focus no longer stays in link toolbar.

---

### Additional information

Part of #17230 

#### Before

https://github.com/user-attachments/assets/d0e86583-9115-4b9a-a9eb-b4d6654a4121

#### After

https://github.com/user-attachments/assets/5e0eec5a-dac4-4faa-8eb0-96989401ff03
