### PR TITLE
Improve performance of `getSelectedBlocks`

### DIFF
--- a/packages/ckeditor5-engine/src/model/selection.ts
+++ b/packages/ckeditor5-engine/src/model/selection.ts
@@ -17,7 +17,7 @@ import type DocumentSelection from './documentselection.js';
 import type Element from './element.js';
 import type Item from './item.js';
 
-import { CKEditorError, EmitterMixin, first, isIterable } from '@ckeditor/ckeditor5-utils';
+import { CKEditorError, EmitterMixin, isIterable } from '@ckeditor/ckeditor5-utils';
 
 /**
  * Selection is a set of {@link module:engine/model/range~Range ranges}. It has a direction specified by its
@@ -667,17 +667,11 @@ export default class Selection extends /* #__PURE__ */ EmitterMixin( TypeCheckab
 				yield startBlock as any;
 			}
 
-			const firstElement = first( range.getWalker() );
-			const lastElement = first( range.getWalker( { direction: 'backward' } ) );
+			const containedElement = range.getContainedElement();
 
-			if (
-				firstElement &&
-				lastElement &&
-				firstElement.item === lastElement.item &&
-				lastElement.type == 'elementEnd' &&
-				lastElement.item.root.document!.model.schema.isBlock( lastElement.item )
-			) {
-				yield lastElement.item as any;
+			if ( containedElement ) {
+				// Fast path for selection that contains only one element (e.g. big table)
+				yield containedElement;
 			} else {
 				for ( const value of range.getWalker() ) {
 					const block = value.item;

--- a/packages/ckeditor5-engine/src/model/selection.ts
+++ b/packages/ckeditor5-engine/src/model/selection.ts
@@ -674,18 +674,14 @@ export default class Selection extends /* #__PURE__ */ EmitterMixin( TypeCheckab
 
 				if ( value.type == 'elementEnd' && isUnvisitedTopBlock( block as any, visited, range ) ) {
 					yield block as Element;
-				} else if ( block.is( 'model:element' ) && block.root.document!.model.schema.isBlock( block ) ) {
-					if ( value.type == 'elementEnd' ) {
-						treewalker.jumpTo( value.nextPosition );
-					} else {
-						const position = treewalker.position.clone();
-
-						position.offset = block.maxOffset;
-
-						if ( range.containsPosition( position ) ) {
-							treewalker.jumpTo( position );
-						}
-					}
+				}
+				// If element is block, we can skip its children and jump to the end of it.
+				else if (
+					value.type == 'elementStart' &&
+					block.is( 'model:element' ) &&
+					block.root.document!.model.schema.isBlock( block )
+				) {
+					treewalker.jumpTo( Position._createAt( block, 'end' ) );
 				}
 			}
 

--- a/packages/ckeditor5-engine/src/model/selection.ts
+++ b/packages/ckeditor5-engine/src/model/selection.ts
@@ -681,7 +681,9 @@ export default class Selection extends /* #__PURE__ */ EmitterMixin( TypeCheckab
 					block.is( 'model:element' ) &&
 					block.root.document!.model.schema.isBlock( block )
 				) {
-					treewalker.jumpTo( Position._createAt( block, 'end' ) );
+					treewalker.position.offset = block.maxOffset;
+
+					treewalker.jumpTo( treewalker.position );
 				}
 			}
 

--- a/packages/ckeditor5-engine/src/model/selection.ts
+++ b/packages/ckeditor5-engine/src/model/selection.ts
@@ -17,7 +17,7 @@ import type DocumentSelection from './documentselection.js';
 import type Element from './element.js';
 import type Item from './item.js';
 
-import { CKEditorError, EmitterMixin, isIterable } from '@ckeditor/ckeditor5-utils';
+import { CKEditorError, EmitterMixin, first, isIterable } from '@ckeditor/ckeditor5-utils';
 
 /**
  * Selection is a set of {@link module:engine/model/range~Range ranges}. It has a direction specified by its
@@ -667,11 +667,21 @@ export default class Selection extends /* #__PURE__ */ EmitterMixin( TypeCheckab
 				yield startBlock as any;
 			}
 
-			for ( const value of range.getWalker() ) {
-				const block = value.item;
+			const lastElement = first( range.getWalker( { direction: 'backward' } ) );
 
-				if ( value.type == 'elementEnd' && isUnvisitedTopBlock( block as any, visited, range ) ) {
-					yield block as Element;
+			if (
+				lastElement &&
+				lastElement.type == 'elementEnd' &&
+				lastElement.item.root.document!.model.schema.isBlock( lastElement.item )
+			) {
+				yield lastElement.item as any;
+			} else {
+				for ( const value of range.getWalker() ) {
+					const block = value.item;
+
+					if ( value.type == 'elementEnd' && isUnvisitedTopBlock( block as any, visited, range ) ) {
+						yield block as Element;
+					}
 				}
 			}
 

--- a/packages/ckeditor5-engine/src/model/selection.ts
+++ b/packages/ckeditor5-engine/src/model/selection.ts
@@ -670,7 +670,7 @@ export default class Selection extends /* #__PURE__ */ EmitterMixin( TypeCheckab
 			const containedElement = range.getContainedElement();
 
 			if ( containedElement ) {
-				// Fast path for selection that contains only one element (e.g. big table)
+				// Fast path for selection that contains only one element (e.g. big table).
 				yield containedElement;
 			} else {
 				for ( const value of range.getWalker() ) {

--- a/packages/ckeditor5-engine/src/model/selection.ts
+++ b/packages/ckeditor5-engine/src/model/selection.ts
@@ -667,10 +667,13 @@ export default class Selection extends /* #__PURE__ */ EmitterMixin( TypeCheckab
 				yield startBlock as any;
 			}
 
+			const firstElement = first( range.getWalker() );
 			const lastElement = first( range.getWalker( { direction: 'backward' } ) );
 
 			if (
+				firstElement &&
 				lastElement &&
+				firstElement.item === lastElement.item &&
 				lastElement.type == 'elementEnd' &&
 				lastElement.item.root.document!.model.schema.isBlock( lastElement.item )
 			) {

--- a/packages/ckeditor5-engine/src/model/selection.ts
+++ b/packages/ckeditor5-engine/src/model/selection.ts
@@ -669,8 +669,11 @@ export default class Selection extends /* #__PURE__ */ EmitterMixin( TypeCheckab
 
 			const containedElement = range.getContainedElement();
 
-			if ( containedElement ) {
-				// Fast path for selection that contains only one element (e.g. big table).
+			if (
+				containedElement &&
+				containedElement.root.document!.model.schema.isBlock( containedElement )
+			) {
+				// Fast path for selection that contains only one **block** element (e.g. big table).
 				yield containedElement;
 			} else {
 				for ( const value of range.getWalker() ) {

--- a/packages/ckeditor5-engine/src/model/selection.ts
+++ b/packages/ckeditor5-engine/src/model/selection.ts
@@ -681,9 +681,7 @@ export default class Selection extends /* #__PURE__ */ EmitterMixin( TypeCheckab
 					block.is( 'model:element' ) &&
 					block.root.document!.model.schema.isBlock( block )
 				) {
-					treewalker.position.offset = block.maxOffset;
-
-					treewalker.jumpTo( treewalker.position );
+					treewalker.jumpTo( Position._createAt( block, 'end' ) );
 				}
 			}
 

--- a/packages/ckeditor5-engine/src/model/treewalker.ts
+++ b/packages/ckeditor5-engine/src/model/treewalker.ts
@@ -183,6 +183,11 @@ export default class TreeWalker implements Iterable<TreeWalkerValue> {
 		}
 	}
 
+	public jumpTo( position: Position ): void {
+		this._position = position;
+		this._visitedParent = position.parent;
+	}
+
 	/**
 	 * Gets the next tree walker's value.
 	 */

--- a/packages/ckeditor5-engine/src/model/treewalker.ts
+++ b/packages/ckeditor5-engine/src/model/treewalker.ts
@@ -184,8 +184,12 @@ export default class TreeWalker implements Iterable<TreeWalkerValue> {
 	}
 
 	/**
-	 * Moves treewalker {@link #position} to provided `position`. Treewalker will
+	 * Moves tree walker {@link #position} to provided `position`. Tree walker will
 	 * continue traversing from that position.
+	 *
+	 * Note: in contrary to {@link ~TreeWalker#skip}, this method does not iterate over the nodes along the way.
+	 * It simply sets the current tree walker position to a new one.
+	 * From the performance standpoint, it is better to use {@link ~TreeWalker#jumpTo} rather than {@link ~TreeWalker#skip}.
 	 *
 	 * If the provided position is before the start boundary, the position will be
 	 * set to the start boundary. If the provided position is after the end boundary,

--- a/packages/ckeditor5-engine/src/model/treewalker.ts
+++ b/packages/ckeditor5-engine/src/model/treewalker.ts
@@ -184,11 +184,23 @@ export default class TreeWalker implements Iterable<TreeWalkerValue> {
 	}
 
 	/**
-	 * Moves {@link #position} to provided position.
+	 * Moves treewalker {@link #position} to provided `position`. Treewalker will
+	 * continue traversing from that position.
 	 *
-	 * @param position Position to jump to
+	 * If the provided position is before the start boundary, the position will be
+	 * set to the start boundary. If the provided position is after the end boundary,
+	 * the position will be set to the end boundary.
+	 * This is done to prevent the treewalker from traversing outside the boundaries.
+	 *
+	 * @param position Position to jump to.
 	 */
 	public jumpTo( position: Position ): void {
+		if ( this._boundaryStartParent && position.isBefore( this.boundaries!.start ) ) {
+			position = this.boundaries!.start;
+		} else if ( this._boundaryEndParent && position.isAfter( this.boundaries!.end ) ) {
+			position = this.boundaries!.end;
+		}
+
 		this._position = position;
 		this._visitedParent = position.parent;
 	}

--- a/packages/ckeditor5-engine/src/model/treewalker.ts
+++ b/packages/ckeditor5-engine/src/model/treewalker.ts
@@ -205,7 +205,7 @@ export default class TreeWalker implements Iterable<TreeWalkerValue> {
 			position = this.boundaries!.end;
 		}
 
-		this._position = position;
+		this._position = position.clone();
 		this._visitedParent = position.parent;
 	}
 

--- a/packages/ckeditor5-engine/src/model/treewalker.ts
+++ b/packages/ckeditor5-engine/src/model/treewalker.ts
@@ -183,6 +183,11 @@ export default class TreeWalker implements Iterable<TreeWalkerValue> {
 		}
 	}
 
+	/**
+	 * Moves {@link #position} to provided position.
+	 *
+	 * @param position Position to jump to
+	 */
 	public jumpTo( position: Position ): void {
 		this._position = position;
 		this._visitedParent = position.parent;

--- a/packages/ckeditor5-engine/src/view/treewalker.ts
+++ b/packages/ckeditor5-engine/src/view/treewalker.ts
@@ -160,6 +160,27 @@ export default class TreeWalker implements IterableIterator<TreeWalkerValue> {
 	}
 
 	/**
+	 * Moves treewalker {@link #position} to provided `position`. Treewalker will
+	 * continue traversing from that position.
+	 *
+	 * If the provided position is before the start boundary, the position will be
+	 * set to the start boundary. If the provided position is after the end boundary,
+	 * the position will be set to the end boundary.
+	 * This is done to prevent the treewalker from traversing outside the boundaries.
+	 *
+	 * @param position Position to jump to.
+	 */
+	public jumpTo( position: Position ): void {
+		if ( this._boundaryStartParent && position.isBefore( this.boundaries!.start ) ) {
+			position = this.boundaries!.start;
+		} else if ( this._boundaryEndParent && position.isAfter( this.boundaries!.end ) ) {
+			position = this.boundaries!.end;
+		}
+
+		this._position = position;
+	}
+
+	/**
 	 * Gets the next tree walker's value.
 	 *
 	 * @returns Object implementing iterator interface, returning

--- a/packages/ckeditor5-engine/src/view/treewalker.ts
+++ b/packages/ckeditor5-engine/src/view/treewalker.ts
@@ -160,8 +160,12 @@ export default class TreeWalker implements IterableIterator<TreeWalkerValue> {
 	}
 
 	/**
-	 * Moves treewalker {@link #position} to provided `position`. Treewalker will
+	 * Moves tree walker {@link #position} to provided `position`. Tree walker will
 	 * continue traversing from that position.
+	 *
+	 * Note: in contrary to {@link ~TreeWalker#skip}, this method does not iterate over the nodes along the way.
+	 * It simply sets the current tree walker position to a new one.
+	 * From the performance standpoint, it is better to use {@link ~TreeWalker#jumpTo} rather than {@link ~TreeWalker#skip}.
 	 *
 	 * If the provided position is before the start boundary, the position will be
 	 * set to the start boundary. If the provided position is after the end boundary,
@@ -177,7 +181,7 @@ export default class TreeWalker implements IterableIterator<TreeWalkerValue> {
 			position = this.boundaries!.end;
 		}
 
-		this._position = position;
+		this._position = position.clone();
 	}
 
 	/**

--- a/packages/ckeditor5-engine/tests/model/treewalker.js
+++ b/packages/ckeditor5-engine/tests/model/treewalker.js
@@ -737,6 +737,52 @@ describe( 'TreeWalker', () => {
 			expect( walker.position.parent ).to.equal( paragraph );
 			expect( walker.position.offset ).to.equal( 3 );
 		} );
+
+		it( 'cannot move position before the #_boundaryStartParent', () => {
+			const range = new Range(
+				new Position( paragraph, [ 2 ] ),
+				new Position( paragraph, [ 4 ] )
+			);
+			const walker = new TreeWalker( {
+				boundaries: range
+			} );
+
+			const positionBeforeAllowedRange = new Position( paragraph, [ 0 ] );
+
+			walker.jumpTo( positionBeforeAllowedRange );
+
+			// `jumpTo()` autocorrected the position to the first allowed position.
+			expect( walker.position.parent ).to.equal( paragraph );
+			expect( walker.position.offset ).to.equal( 2 );
+
+			walker.next();
+
+			expect( walker.position.parent ).to.equal( paragraph );
+			expect( walker.position.offset ).to.equal( 3 );
+		} );
+
+		it( 'cannot move position after the #_boundaryStartParent', () => {
+			const range = new Range(
+				new Position( paragraph, [ 0 ] ),
+				new Position( paragraph, [ 2 ] )
+			);
+			const walker = new TreeWalker( {
+				boundaries: range
+			} );
+
+			const positionAfterAllowedRange = new Position( paragraph, [ 4 ] );
+
+			// `jumpTo()` autocorrected the position to the last allowed position.
+			walker.jumpTo( positionAfterAllowedRange );
+
+			expect( walker.position.parent ).to.equal( paragraph );
+			expect( walker.position.offset ).to.equal( 2 );
+
+			walker.next();
+
+			expect( walker.position.parent ).to.equal( paragraph );
+			expect( walker.position.offset ).to.equal( 2 );
+		} );
 	} );
 } );
 

--- a/packages/ckeditor5-engine/tests/model/treewalker.js
+++ b/packages/ckeditor5-engine/tests/model/treewalker.js
@@ -720,6 +720,24 @@ describe( 'TreeWalker', () => {
 			} );
 		} );
 	} );
+
+	describe( 'jumpTo', () => {
+		it( 'should jump to the given position', () => {
+			const walker = new TreeWalker( {
+				startPosition: Position._createAt( paragraph, 0 )
+			} );
+
+			walker.jumpTo( new Position( paragraph, [ 2 ] ) );
+
+			expect( walker.position.parent ).to.equal( paragraph );
+			expect( walker.position.offset ).to.equal( 2 );
+
+			walker.next();
+
+			expect( walker.position.parent ).to.equal( paragraph );
+			expect( walker.position.offset ).to.equal( 3 );
+		} );
+	} );
 } );
 
 function expectValue( value, expected, options ) {

--- a/packages/ckeditor5-engine/tests/model/treewalker.js
+++ b/packages/ckeditor5-engine/tests/model/treewalker.js
@@ -761,7 +761,7 @@ describe( 'TreeWalker', () => {
 			expect( walker.position.offset ).to.equal( 3 );
 		} );
 
-		it( 'cannot move position after the #_boundaryStartParent', () => {
+		it( 'cannot move position after the #_boundaryEndParent', () => {
 			const range = new Range(
 				new Position( paragraph, [ 0 ] ),
 				new Position( paragraph, [ 2 ] )

--- a/packages/ckeditor5-engine/tests/view/treewalker.js
+++ b/packages/ckeditor5-engine/tests/view/treewalker.js
@@ -1216,6 +1216,70 @@ describe( 'TreeWalker', () => {
 			} );
 		} );
 	} );
+
+	describe( 'jumpTo', () => {
+		it( 'should jump to the given position', () => {
+			const walker = new TreeWalker( {
+				startPosition: Position._createAt( paragraph, 0 )
+			} );
+
+			walker.jumpTo( new Position( paragraph, 2 ) );
+
+			expect( walker.position.parent ).to.equal( paragraph );
+			expect( walker.position.offset ).to.equal( 2 );
+
+			walker.next();
+
+			expect( walker.position.parent ).to.equal( img2 );
+			expect( walker.position.offset ).to.equal( 0 );
+		} );
+
+		it( 'cannot move position before the #_boundaryStartParent', () => {
+			const range = new Range(
+				new Position( paragraph, 2 ),
+				new Position( paragraph, 4 )
+			);
+			const walker = new TreeWalker( {
+				boundaries: range
+			} );
+
+			const positionBeforeAllowedRange = new Position( paragraph, 0 );
+
+			walker.jumpTo( positionBeforeAllowedRange );
+
+			// `jumpTo()` autocorrected the position to the first allowed position.
+			expect( walker.position.parent ).to.equal( paragraph );
+			expect( walker.position.offset ).to.equal( 2 );
+
+			walker.next();
+
+			expect( walker.position.parent ).to.equal( img2 );
+			expect( walker.position.offset ).to.equal( 0 );
+		} );
+
+		it( 'cannot move position after the #_boundaryStartParent', () => {
+			const range = new Range(
+				new Position( paragraph, 0 ),
+				new Position( paragraph, 2 )
+			);
+			const walker = new TreeWalker( {
+				boundaries: range
+			} );
+
+			const positionAfterAllowedRange = new Position( paragraph, 4 );
+
+			// `jumpTo()` autocorrected the position to the last allowed position.
+			walker.jumpTo( positionAfterAllowedRange );
+
+			expect( walker.position.parent ).to.equal( paragraph );
+			expect( walker.position.offset ).to.equal( 2 );
+
+			walker.next();
+
+			expect( walker.position.parent ).to.equal( paragraph );
+			expect( walker.position.offset ).to.equal( 2 );
+		} );
+	} );
 } );
 
 function expectValue( value, expected, options = {} ) {

--- a/packages/ckeditor5-engine/tests/view/treewalker.js
+++ b/packages/ckeditor5-engine/tests/view/treewalker.js
@@ -1257,7 +1257,7 @@ describe( 'TreeWalker', () => {
 			expect( walker.position.offset ).to.equal( 0 );
 		} );
 
-		it( 'cannot move position after the #_boundaryStartParent', () => {
+		it( 'cannot move position after the #_boundaryEndParent', () => {
 			const range = new Range(
 				new Position( paragraph, 0 ),
 				new Position( paragraph, 2 )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Other (engine): Improve performance of `getSelectedBlocks` when selection contains only one block element. Closes #17629.

---

This greatly improves how long it takes to make a selection over a big table.

---

Use `Squash and merge`, as it's a fairly simply change with too many commits.