### PR TITLE
Partial update of link text with attributes preservation.

### DIFF
--- a/packages/ckeditor5-link/src/linkcommand.ts
+++ b/packages/ckeditor5-link/src/linkcommand.ts
@@ -382,7 +382,7 @@ export default class LinkCommand extends Command {
  *
  * @internal
  * @param oldText The original text to compare.
- * @param newText The new text to compare against.
+ * @param newText  The new text to compare against.
  * @returns Array of change objects containing offset and actual/expected content.
  *
  * @example

--- a/packages/ckeditor5-link/src/linkcommand.ts
+++ b/packages/ckeditor5-link/src/linkcommand.ts
@@ -380,9 +380,10 @@ export default class LinkCommand extends Command {
  * Uses the diff utility to find the differences and groups them into chunks containing information
  * about the offset and actual/expected content.
  *
- * @param oldText The original text to compare
- * @param newText The new text to compare against
- * @returns Array of change objects containing offset and actual/expected content
+ * @internal
+ * @param oldText The original text to compare.
+ * @param newText The new text to compare against.
+ * @returns Array of change objects containing offset and actual/expected content.
  *
  * @example
  * findChanges( 'hello world', 'hi there' );
@@ -407,30 +408,30 @@ export default class LinkCommand extends Command {
  * ]
  */
 export function findChanges( oldText: string, newText: string ): Array<{ offset: number; actual: string; expected: string }> {
-	// Get array of operations (insert/delete/equal) needed to transform oldText into newText
+	// Get array of operations (insert/delete/equal) needed to transform oldText into newText.
 	// Example: diff('abc', 'abxc') returns ['equal', 'equal', 'insert', 'equal']
 	const changes = diff( oldText, newText );
 
-	// Track position in both strings based on operation type
+	// Track position in both strings based on operation type.
 	const counter = { equal: 0, insert: 0, delete: 0 };
 	const result = [];
 
-	// Accumulate consecutive changes into slices before creating change objects
+	// Accumulate consecutive changes into slices before creating change objects.
 	let actualSlice = '';
 	let expectedSlice = '';
 
-	// Adding null as sentinel value to handle final accumulated changes
+	// Adding null as sentinel value to handle final accumulated changes.
 	for ( const action of [ ...changes, null ] ) {
 		if ( action == 'insert' ) {
-			// Example: for 'abxc', at insert position, adds 'x' to expectedSlice
+			// Example: for 'abc' -> 'abxc', at insert position, adds 'x' to expectedSlice.
 			expectedSlice += newText[ counter.equal + counter.insert ];
 		}
 		else if ( action == 'delete' ) {
-			// Example: for 'abc' -> 'ac', at delete position, adds 'b' to actualSlice
+			// Example: for 'abc' -> 'ac', at delete position, adds 'b' to actualSlice.
 			actualSlice += oldText[ counter.equal + counter.delete ];
 		}
 		else if ( actualSlice.length || expectedSlice.length ) {
-			// On 'equal' or end: bundle accumulated changes into a single change object
+			// On 'equal' or end: bundle accumulated changes into a single change object.
 			// Example: { offset: 2, actual: "", expected: "x" }
 			result.push( {
 				offset: counter.equal,
@@ -442,7 +443,7 @@ export function findChanges( oldText: string, newText: string ): Array<{ offset:
 			expectedSlice = '';
 		}
 
-		// Increment appropriate counter for the current operation
+		// Increment appropriate counter for the current operation.
 		if ( action ) {
 			counter[ action ]++;
 		}
@@ -454,9 +455,10 @@ export function findChanges( oldText: string, newText: string ): Array<{ offset:
 /**
  * Returns text node withing the link range that should be updated.
  *
- * @param range Selection range
- * @param linkRange Range of the entire link element
- * @returns Text node for content updates
+ * @internal
+ * @param range Partial link range.
+ * @param linkRange Range of the entire link.
+ * @returns Text node.
  */
 export function getLinkPartTextNode( range: Range, linkRange: Range ): Item | null {
 	if ( !range.isCollapsed ) {

--- a/packages/ckeditor5-link/src/linkcommand.ts
+++ b/packages/ckeditor5-link/src/linkcommand.ts
@@ -235,11 +235,18 @@ export default class LinkCommand extends Command {
 			};
 
 			const collapseSelectionAtLinkEnd = ( linkRange: Range ): void => {
+				const { plugins } = this.editor;
+
 				writer.setSelection( linkRange.end );
 
-				// TODO make it nicer
-				if ( this.editor.plugins.has( 'TwoStepCaretMovement' ) ) {
-					this.editor.plugins.get( 'TwoStepCaretMovement' )._handleForwardMovement();
+				if ( plugins.has( 'TwoStepCaretMovement' ) ) {
+					// After replacing the text of the link, we need to move the caret to the end of the link,
+					// override it's gravity to forward to prevent keeping e.g. bold attribute on the caret
+					// which was previously inside the link.
+					//
+					// If the plugin is not available, the caret will be placed at the end of the link and the
+					// bold attribute will be kept even if command moved caret outside the link.
+					plugins.get( 'TwoStepCaretMovement' )._handleForwardMovement();
 				} else {
 					// Remove the `linkHref` attribute and all link decorators from the selection.
 					// It stops adding a new content into the link element.

--- a/packages/ckeditor5-link/src/linkcommand.ts
+++ b/packages/ckeditor5-link/src/linkcommand.ts
@@ -237,10 +237,15 @@ export default class LinkCommand extends Command {
 			const collapseSelectionAtLinkEnd = ( linkRange: Range ): void => {
 				writer.setSelection( linkRange.end );
 
-				// Remove the `linkHref` attribute and all link decorators from the selection.
-				// It stops adding a new content into the link element.
-				for ( const key of [ 'linkHref', ...truthyManualDecorators, ...falsyManualDecorators ] ) {
-					writer.removeSelectionAttribute( key );
+				// TODO make it nicer
+				if ( this.editor.plugins.has( 'TwoStepCaretMovement' ) ) {
+					this.editor.plugins.get( 'TwoStepCaretMovement' )._handleForwardMovement();
+				} else {
+					// Remove the `linkHref` attribute and all link decorators from the selection.
+					// It stops adding a new content into the link element.
+					for ( const key of [ 'linkHref', ...truthyManualDecorators, ...falsyManualDecorators ] ) {
+						writer.removeSelectionAttribute( key );
+					}
 				}
 			};
 

--- a/packages/ckeditor5-link/src/linkcommand.ts
+++ b/packages/ckeditor5-link/src/linkcommand.ts
@@ -406,7 +406,7 @@ export default class LinkCommand extends Command {
  * 	}
  * ]
  */
-function findChanges( oldText: string, newText: string ) {
+export function findChanges( oldText: string, newText: string ): Array<{ offset: number; actual: string; expected: string }> {
 	// Get array of operations (insert/delete/equal) needed to transform oldText into newText
 	// Example: diff('abc', 'abxc') returns ['equal', 'equal', 'insert', 'equal']
 	const changes = diff( oldText, newText );
@@ -458,7 +458,7 @@ function findChanges( oldText: string, newText: string ) {
  * @param linkRange Range of the entire link element
  * @returns Text node for content updates
  */
-function getLinkPartTextNode( range: Range, linkRange: Range ) {
+export function getLinkPartTextNode( range: Range, linkRange: Range ): Item | null {
 	if ( !range.isCollapsed ) {
 		return first( range.getItems() );
 	}
@@ -470,9 +470,9 @@ function getLinkPartTextNode( range: Range, linkRange: Range ) {
 	}
 
 	// If the range is at the start of a link range then prefer node inside a link range.
-	if ( position.isEqual( linkRange.start ) ) {
-		return position.nodeAfter || position.nodeBefore;
+	if ( !position.nodeBefore || position.isEqual( linkRange.start ) ) {
+		return position.nodeAfter;
 	} else {
-		return position.nodeBefore || position.nodeAfter;
+		return position.nodeBefore;
 	}
 }

--- a/packages/ckeditor5-link/src/linkcommand.ts
+++ b/packages/ckeditor5-link/src/linkcommand.ts
@@ -380,9 +380,8 @@ export default class LinkCommand extends Command {
  * Uses the diff utility to find the differences and groups them into chunks containing information
  * about the offset and actual/expected content.
  *
- * @internal
  * @param oldText The original text to compare.
- * @param newText  The new text to compare against.
+ * @param newText The new text to compare against.
  * @returns Array of change objects containing offset and actual/expected content.
  *
  * @example
@@ -407,7 +406,7 @@ export default class LinkCommand extends Command {
  * 	}
  * ]
  */
-export function findChanges( oldText: string, newText: string ): Array<{ offset: number; actual: string; expected: string }> {
+function findChanges( oldText: string, newText: string ): Array<{ offset: number; actual: string; expected: string }> {
 	// Get array of operations (insert/delete/equal) needed to transform oldText into newText.
 	// Example: diff('abc', 'abxc') returns ['equal', 'equal', 'insert', 'equal']
 	const changes = diff( oldText, newText );
@@ -455,12 +454,11 @@ export function findChanges( oldText: string, newText: string ): Array<{ offset:
 /**
  * Returns text node withing the link range that should be updated.
  *
- * @internal
  * @param range Partial link range.
  * @param linkRange Range of the entire link.
  * @returns Text node.
  */
-export function getLinkPartTextNode( range: Range, linkRange: Range ): Item | null {
+function getLinkPartTextNode( range: Range, linkRange: Range ): Item | null {
 	if ( !range.isCollapsed ) {
 		return first( range.getItems() );
 	}

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -3,8 +3,9 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
+import { first } from '@ckeditor/ckeditor5-utils';
 import ModelTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/modeltesteditor.js';
-import LinkCommand from '../src/linkcommand.js';
+import LinkCommand, { findChanges, getLinkPartTextNode } from '../src/linkcommand.js';
 import ManualDecorator from '../src/utils/manualdecorator.js';
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 import AutomaticDecorators from '../src/utils/automaticdecorators.js';
@@ -1040,6 +1041,156 @@ describe( 'LinkCommand', () => {
 	describe( '#automaticDecorators', () => {
 		it( 'is defined', () => {
 			expect( command.automaticDecorators ).to.be.an.instanceOf( AutomaticDecorators );
+		} );
+	} );
+
+	describe( 'findChanges()', () => {
+		it( 'should detect single insertion', () => {
+			const changes = findChanges( 'abc', 'abxc' );
+			expect( changes ).to.deep.equal( [
+				{
+					offset: 2,
+					actual: '',
+					expected: 'x'
+				}
+			] );
+		} );
+
+		it( 'should detect single deletion', () => {
+			const changes = findChanges( 'abxc', 'abc' );
+			expect( changes ).to.deep.equal( [
+				{
+					offset: 2,
+					actual: 'x',
+					expected: ''
+				}
+			] );
+		} );
+
+		it( 'should detect multiple changes', () => {
+			const changes = findChanges( 'hello world', 'hi there' );
+			expect( changes ).to.deep.equal( [
+				{
+					offset: 1,
+					actual: 'ello',
+					expected: 'i'
+				},
+				{
+					offset: 2,
+					actual: 'wo',
+					expected: 'the'
+				},
+				{
+					offset: 3,
+					actual: 'ld',
+					expected: 'e'
+				}
+			] );
+		} );
+
+		it( 'should handle empty strings', () => {
+			const changes = findChanges( '', 'abc' );
+			expect( changes ).to.deep.equal( [
+				{
+					offset: 0,
+					actual: '',
+					expected: 'abc'
+				}
+			] );
+		} );
+	} );
+
+	describe( 'getLinkPartTextNode()', () => {
+		let root;
+
+		beforeEach( () => {
+			root = model.document.getRoot();
+		} );
+
+		it( 'should return first item from non-collapsed range', () => {
+			setData( model, '<$text linkHref="url">abcd</$text>' );
+
+			const range = model.createRange(
+				model.createPositionFromPath( root, [ 0 ] ),
+				model.createPositionFromPath( root, [ 3 ] )
+			);
+
+			const linkRange = model.createRange(
+				model.createPositionFromPath( root, [ 0 ] ),
+				model.createPositionFromPath( root, [ 4 ] )
+			);
+
+			const node = first( range.getItems() );
+
+			expect( getLinkPartTextNode( range, linkRange ).textNode ).to.equal( node.textNode );
+		} );
+
+		it( 'should return text node for collapsed selection', () => {
+			setData( model, '<$text linkHref="url">abcd</$text>' );
+
+			const range = model.createRange(
+				model.createPositionFromPath( root, [ 2 ] )
+			);
+
+			const linkRange = model.createRange(
+				model.createPositionFromPath( root, [ 0 ] ),
+				model.createPositionFromPath( root, [ 4 ] )
+			);
+
+			expect( getLinkPartTextNode( range, linkRange ).data ).to.equal( 'abcd' );
+		} );
+
+		it( 'should prefer node after when at link range start', () => {
+			setData( model, '<$text linkHref="url">abcd</$text>' );
+
+			const range = model.createRange(
+				model.createPositionFromPath( root, [ 0 ] )
+			);
+
+			const linkRange = model.createRange(
+				model.createPositionFromPath( root, [ 0 ] ),
+				model.createPositionFromPath( root, [ 4 ] )
+			);
+
+			expect( getLinkPartTextNode( range, linkRange ) ).to.equal( range.start.nodeAfter );
+		} );
+
+		it( 'should prefer node after if node before is blank', () => {
+			setData( model, '<paragraph>aa</paragraph><$text linkHref="url">abcd</$text>' );
+
+			const range = model.createRange(
+				model.createPositionFromPath( root, [ 0, 0 ] )
+			);
+
+			const linkRange = model.createRange(
+				model.createPositionFromPath( root, [ 1, 0 ] ),
+				model.createPositionFromPath( root, [ 1, 4 ] )
+			);
+
+			expect( range.start.nodeBefore ).to.be.null;
+			expect( getLinkPartTextNode( range, linkRange ) ).to.equal( range.start.nodeAfter );
+		} );
+
+		it( 'should prefer node before if node after is blank', () => {
+			setData( model, '<$text linkHref="url">abcd</$text>' );
+
+			const range = model.createRange(
+				model.createPositionFromPath( root, [ 4 ] )
+			);
+
+			const linkRange = model.createRange(
+				model.createPositionFromPath( root, [ 0 ] ),
+				model.createPositionFromPath( root, [ 4 ] )
+			);
+
+			const nodeBefore = range.start.nodeBefore;
+			const nodeAfter = range.start.nodeAfter;
+
+			expect( nodeAfter, 'nodeAfter should be null' ).to.be.null;
+			expect( nodeBefore, 'nodeBefore should exist' ).to.not.be.null;
+			expect( nodeBefore.data, 'nodeBefore should contain link text' ).to.equal( 'abcd' );
+
+			expect( getLinkPartTextNode( range, linkRange ) ).to.equal( nodeBefore );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -683,7 +683,9 @@ describe( 'LinkCommand', () => {
 
 						command.execute( 'url2', {}, 'Replacement Text' );
 
-						expect( getData( model ) ).to.equal( '[<$text linkHref="url2">Replacement text</$text>]' );
+						expect( getData( model ) ).to.equal(
+							'[<$text linkHref="url2">Replacement </$text><$text bold="true" linkHref="url2">Text</$text>]'
+						);
 					} );
 				} );
 			} );
@@ -769,8 +771,8 @@ describe( 'LinkCommand', () => {
 			return ModelTestEditor.create()
 				.then( newEditor => {
 					editor = newEditor;
-					model = editor.model;
-					command = new LinkCommand( editor );
+					model = newEditor.model;
+					command = new LinkCommand( newEditor );
 
 					command.manualDecorators.add( new ManualDecorator( {
 						id: 'linkIsFoo',

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -833,7 +833,7 @@ describe( 'LinkCommand', () => {
 			} );
 
 			it( 'should add additional attributes to link when link is modified', () => {
-				setData( model, 'f<$text linkHref="url">o[]oba</</$text>r' );
+				setData( model, 'f<$text linkHref="url">o[]oba</$text>r' );
 
 				command.execute( 'url', { linkIsFoo: true, linkIsBar: true, linkIsSth: true } );
 

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -639,7 +639,7 @@ describe( 'LinkCommand', () => {
 				} );
 
 				describe( 'keep formatting attributes', () => {
-					it( 'should correctly replace selected text with keepping the text attributes', () => {
+					it( 'should correctly replace selected text with keeping the text attributes', () => {
 						setData( model, 'foo[<$text bold="true" linkHref="url">textBar</$text>]baz' );
 
 						command.execute( 'url2', {}, 'abc' );
@@ -838,6 +838,42 @@ describe( 'LinkCommand', () => {
 						'<$text italic="true" linkHref="url2">nt</$text>' +
 						'[]bar'
 					);
+				} );
+
+				it( 'should be possible to prepend single character to the display text of the link' +
+					'if the selection is in the middle', () => {
+					setData( model, '<$text linkHref="url" bold="true">Lin[]k text</$text>' );
+
+					command.execute( 'url', {}, 'LLink text' );
+
+					expect( getData( model ) ).to.equal( '<$text bold="true" linkHref="url">LLink text</$text>[]' );
+				} );
+
+				it( 'should be possible to prepend single character to the display text of the link' +
+					'if the selection is in the end', () => {
+					setData( model, '<$text linkHref="url" bold="true">Link text[]</$text>' );
+
+					command.execute( 'url', {}, 'LLink text' );
+
+					expect( getData( model ) ).to.equal( '<$text bold="true" linkHref="url">LLink text</$text>[]' );
+				} );
+
+				it( 'should be possible to append single character to the display text of the link' +
+					'if the selection is in the middle', () => {
+					setData( model, '<$text linkHref="url" bold="true">Lin[]k text</$text>' );
+
+					command.execute( 'url', {}, 'Link textL' );
+
+					expect( getData( model ) ).to.equal( '<$text bold="true" linkHref="url">Link textL</$text>[]' );
+				} );
+
+				it( 'should be possible to append single character to the display text of the link' +
+					'if the selection is in the start', () => {
+					setData( model, '<$text linkHref="url" bold="true">[]Link text</$text>' );
+
+					command.execute( 'url', {}, 'LLink text' );
+
+					expect( getData( model ) ).to.equal( '<$text bold="true" linkHref="url">LLink text</$text>[]' );
 				} );
 			} );
 

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -8,12 +8,13 @@ import LinkCommand from '../src/linkcommand.js';
 import ManualDecorator from '../src/utils/manualdecorator.js';
 import { setData, getData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model.js';
 import AutomaticDecorators from '../src/utils/automaticdecorators.js';
+import LinkEditing from '../src/linkediting.js';
 
 describe( 'LinkCommand', () => {
 	let editor, model, command;
 
 	beforeEach( () => {
-		return ModelTestEditor.create()
+		return ModelTestEditor.create( { plugins: [ LinkEditing ] } )
 			.then( newEditor => {
 				editor = newEditor;
 				model = editor.model;
@@ -846,7 +847,7 @@ describe( 'LinkCommand', () => {
 	describe( 'manual decorators', () => {
 		beforeEach( async () => {
 			await editor.destroy();
-			return ModelTestEditor.create()
+			return ModelTestEditor.create( { plugins: [ LinkEditing ] } )
 				.then( newEditor => {
 					editor = newEditor;
 					model = newEditor.model;

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -2439,7 +2439,7 @@ describe( 'LinkUI', () => {
 					'<paragraph>fo' +
 						'<$text linkHref="http://ckeditor.com">http://</$text>' +
 						'<$text bold="true" linkHref="http://ckeditor.com">ckeditor.com</$text>' +
-						'<$text bold="true">[]</$text>ar' +
+						'[]ar' +
 					'</paragraph>'
 				);
 			} );
@@ -2483,7 +2483,7 @@ describe( 'LinkUI', () => {
 					'<paragraph>' +
 						'fo<$text linkHref="http://cksource.com">CKS</$text>' +
 						'<$text bold="true" linkHref="http://cksource.com">ource</$text>' +
-						'<$text bold="true">[]</$text>ar' +
+						'[]ar' +
 					'</paragraph>'
 				);
 			} );

--- a/packages/ckeditor5-link/tests/linkui.js
+++ b/packages/ckeditor5-link/tests/linkui.js
@@ -2436,11 +2436,15 @@ describe( 'LinkUI', () => {
 				) ).to.be.true;
 
 				expect( getModelData( editor.model ) ).to.equal(
-					'<paragraph>fo<$text linkHref="http://ckeditor.com">http://ckeditor.com</$text>[]ar</paragraph>'
+					'<paragraph>fo' +
+						'<$text linkHref="http://ckeditor.com">http://</$text>' +
+						'<$text bold="true" linkHref="http://ckeditor.com">ckeditor.com</$text>' +
+						'<$text bold="true">[]</$text>ar' +
+					'</paragraph>'
 				);
 			} );
 
-			it( 'should populate form on open on collapsed selection in link with text matching href but styled' +
+			it( 'should populate form on open on collapsed selection in link with text matching href but styled ' +
 				'and update text', () => {
 				setModelData( editor.model,
 					'<paragraph>' +
@@ -2476,7 +2480,11 @@ describe( 'LinkUI', () => {
 				) ).to.be.true;
 
 				expect( getModelData( editor.model ) ).to.equal(
-					'<paragraph>fo<$text linkHref="http://cksource.com">CKSource</$text>[]ar</paragraph>'
+					'<paragraph>' +
+						'fo<$text linkHref="http://cksource.com">CKS</$text>' +
+						'<$text bold="true" linkHref="http://cksource.com">ource</$text>' +
+						'<$text bold="true">[]</$text>ar' +
+					'</paragraph>'
 				);
 			} );
 

--- a/packages/ckeditor5-link/tests/manual/link.html
+++ b/packages/ckeditor5-link/tests/manual/link.html
@@ -1,3 +1,3 @@
 <div id="editor">
-	<p>This is <a href="http://ckeditor.com">CKEditor5</a> from <a href="http://cksource.com">CKSource</a>.</p>
+	foo<a href="http://ckeditor.com"><strong>textBar</strong></a>baz
 </div>

--- a/packages/ckeditor5-link/tests/manual/link.html
+++ b/packages/ckeditor5-link/tests/manual/link.html
@@ -1,3 +1,3 @@
 <div id="editor">
-	foo<a href="http://ckeditor.com"><strong>textBar</strong></a>baz
+	<p>This is <a href="http://ckeditor.com"><strong>CKEditor5</strong></a> from <a href="http://cksource.com">CKSource</a>.</p>
 </div>

--- a/packages/ckeditor5-link/tests/manual/link.js
+++ b/packages/ckeditor5-link/tests/manual/link.js
@@ -11,11 +11,12 @@ import Typing from '@ckeditor/ckeditor5-typing/src/typing.js';
 import Link from '../../src/link.js';
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph.js';
 import Undo from '@ckeditor/ckeditor5-undo/src/undo.js';
+import { Bold, Italic } from '@ckeditor/ckeditor5-basic-styles';
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
-		plugins: [ Link, Typing, Paragraph, Undo, Enter ],
-		toolbar: [ 'link', 'undo', 'redo' ]
+		plugins: [ Link, Bold, Italic, Typing, Paragraph, Undo, Enter ],
+		toolbar: [ 'link', 'bold', 'italic', '|', 'undo', 'redo' ]
 	} )
 	.then( editor => {
 		window.editor = editor;

--- a/packages/ckeditor5-typing/src/twostepcaretmovement.ts
+++ b/packages/ckeditor5-typing/src/twostepcaretmovement.ts
@@ -292,10 +292,11 @@ export default class TwoStepCaretMovement extends Plugin {
 	 * Updates the document selection and the view according to the two–step caret movement state
 	 * when moving **forwards**. Executed upon `keypress` in the {@link module:engine/view/view~View}.
 	 *
-	 * @param data Data of the key press.
+	 * @internal
+	 * @param eventData Data of the key press.
 	 * @returns `true` when the handler prevented caret movement.
 	 */
-	private _handleForwardMovement( data: DomEventData ): boolean {
+	public _handleForwardMovement( eventData?: DomEventData ): boolean {
 		const attributes = this.attributes;
 		const model = this.editor.model;
 		const selection = model.document.selection;
@@ -333,7 +334,9 @@ export default class TwoStepCaretMovement extends Plugin {
 		//		<paragraph>foo{}<$text attribute>bar</$text>baz</paragraph>
 		//
 		if ( isBetweenDifferentAttributes( position, attributes ) ) {
-			preventCaretMovement( data );
+			if ( eventData ) {
+				preventCaretMovement( eventData );
+			}
 
 			// CLEAR 2-SCM attributes if we are at the end of one 2-SCM and before
 			// the next one with a different value of the same attribute.
@@ -359,10 +362,11 @@ export default class TwoStepCaretMovement extends Plugin {
 	 * Updates the document selection and the view according to the two–step caret movement state
 	 * when moving **backwards**. Executed upon `keypress` in the {@link module:engine/view/view~View}.
 	 *
-	 * @param data Data of the key press.
+	 * @internal
+	 * @param eventData Data of the key press.
 	 * @returns `true` when the handler prevented caret movement
 	 */
-	private _handleBackwardMovement( data: DomEventData ): boolean {
+	public _handleBackwardMovement( eventData?: DomEventData ): boolean {
 		const attributes = this.attributes;
 		const model = this.editor.model;
 		const selection = model.document.selection;
@@ -377,7 +381,10 @@ export default class TwoStepCaretMovement extends Plugin {
 		//		<paragraph>foo<$text attribute>bar</$text>{}baz</paragraph>
 		//
 		if ( this._isGravityOverridden ) {
-			preventCaretMovement( data );
+			if ( eventData ) {
+				preventCaretMovement( eventData );
+			}
+
 			this._restoreGravity();
 
 			// CLEAR 2-SCM attributes if we are at the end of one 2-SCM and before
@@ -400,7 +407,10 @@ export default class TwoStepCaretMovement extends Plugin {
 			//
 			if ( position.isAtStart ) {
 				if ( hasAnyAttribute( selection, attributes ) ) {
-					preventCaretMovement( data );
+					if ( eventData ) {
+						preventCaretMovement( eventData );
+					}
+
 					setSelectionAttributesFromTheNodeBefore( model, attributes, position );
 
 					return true;
@@ -417,7 +427,10 @@ export default class TwoStepCaretMovement extends Plugin {
 				!hasAnyAttribute( selection, attributes ) &&
 				isBetweenDifferentAttributes( position, attributes, true )
 			) {
-				preventCaretMovement( data );
+				if ( eventData ) {
+					preventCaretMovement( eventData );
+				}
+
 				setSelectionAttributesFromTheNodeBefore( model, attributes, position );
 
 				return true;
@@ -443,7 +456,10 @@ export default class TwoStepCaretMovement extends Plugin {
 					!hasAnyAttribute( selection, attributes ) &&
 					isBetweenDifferentAttributes( position, attributes )
 				) {
-					preventCaretMovement( data );
+					if ( eventData ) {
+						preventCaretMovement( eventData );
+					}
+
 					setSelectionAttributesFromTheNodeBefore( model, attributes, position );
 
 					return true;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (link): Formatting is no longer lost after changing a URL or a displayed-text of the selected link. 
