### PR TITLE
Fixed the `EmojiFeed` plugin showing feeds when the first character is empty space.

### DIFF
--- a/packages/ckeditor5-emoji/src/emojimention.ts
+++ b/packages/ckeditor5-emoji/src/emojimention.ts
@@ -180,6 +180,11 @@ export default class EmojiMention extends Plugin {
 				return [];
 			}
 
+			// If the first character is space, do not display any feeds.
+			if ( searchQuery[ 0 ] === ' ' ) {
+				return [];
+			}
+
 			const emojis = await this._emojiDatabase.getEmojiBySearchQuery( searchQuery )
 				.then( queryResult => {
 					return ( queryResult as Array<NativeEmoji> ).map( emoji => {

--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -311,5 +311,33 @@ describe( 'EmojiMention', () => {
 				expect( queryResult.some( item => item.id === 'emoji:__SHOW_ALL_EMOJI__:' ) ).to.equal( false );
 			} );
 		} );
+
+		it( 'should not return any feeds when the first character of the search query is empty space', async () => {
+			await editor.destroy();
+
+			editor = await ClassicEditor.create( editorElement, {
+				plugins: [ EmojiMention, Mention ]
+			} );
+
+			queryEmoji = editor.config.get( 'mention.feeds' )[ 0 ].feed;
+
+			return queryEmoji( ' face' ).then( queryResult => {
+				expect( queryResult.length ).to.equal( 0 );
+			} );
+		} );
+
+		it( 'should not return any feeds when the two first characters of the search query are empty space', async () => {
+			await editor.destroy();
+
+			editor = await ClassicEditor.create( editorElement, {
+				plugins: [ EmojiMention, Mention ]
+			} );
+
+			queryEmoji = editor.config.get( 'mention.feeds' )[ 0 ].feed;
+
+			return queryEmoji( '  face' ).then( queryResult => {
+				expect( queryResult.length ).to.equal( 0 );
+			} );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Fixed the `EmojiFeed` plugin showing feeds when the first character is empty space. Closes #17577.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
