### PR TITLE
little mistake ukrainian lang

### DIFF
--- a/packages/ckeditor5-table/lang/translations/uk.po
+++ b/packages/ckeditor5-table/lang/translations/uk.po
@@ -45,11 +45,11 @@ msgstr "Заголовок рядка"
 
 msgctxt "Label for the insert row below button."
 msgid "Insert row below"
-msgstr "Вставити рядок зверху"
+msgstr "Вставити рядок знизу"
 
 msgctxt "Label for the insert row above button."
 msgid "Insert row above"
-msgstr "Вставити рядок знизу"
+msgstr "Вставити рядок зверху"
 
 msgctxt "Label for the delete table row button."
 msgid "Delete row"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal (table): Improved the `uk` translations. Closes #17614.

Thanks, @iskatel-ua.

---

### Additional information

the translations were mixed up which misleads the user