### PR TITLE
Fix (ui): Add aria-hidden to icons inside ButtonView to prevent accessing them individually.

### DIFF
--- a/packages/ckeditor5-ui/src/button/buttonview.ts
+++ b/packages/ckeditor5-ui/src/button/buttonview.ts
@@ -236,7 +236,8 @@ export default class ButtonView extends View<HTMLButtonElement> implements Butto
 		this.iconView = new IconView();
 		this.iconView.extendTemplate( {
 			attributes: {
-				class: 'ck-button__icon'
+				class: 'ck-button__icon',
+				'aria-hidden': true
 			}
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix: Disable accessing icons individually inside toolbar buttons. Closes #17554.


