### PR TITLE
Not initializing emoji plugin when merge fields use `:` as first char in prefix.

### DIFF
--- a/packages/ckeditor5-emoji/src/emojimention.ts
+++ b/packages/ckeditor5-emoji/src/emojimention.ts
@@ -69,11 +69,13 @@ export default class EmojiMention extends Plugin {
 		this._emojiDatabase = new Database();
 
 		const mentionFeedsConfigs = this.editor.config.get( 'mention.feeds' )! as Array<MentionFeed>;
+		const mergeFieldsPrefix = this.editor.config.get( 'mergeFields.prefix' )! as string;
 		const markerAlreadyUsed = mentionFeedsConfigs.some( config => config.marker === EMOJI_MENTION_MARKER );
+		const isMarkerUsedByMergeFields = mergeFieldsPrefix ? mergeFieldsPrefix[ 0 ] === EMOJI_MENTION_MARKER : false;
 
-		if ( markerAlreadyUsed ) {
+		if ( markerAlreadyUsed || isMarkerUsedByMergeFields ) {
 			/**
-			 * The `marker` in the `emoji` config is already used by other mention plugin configuration.
+			 * The `marker` in the `emoji` config is already used by other plugin configuration.
 			 *
 			 * @error emoji-config-marker-already-used
 			 * @param {string} marker Used marker.

--- a/packages/ckeditor5-emoji/tests/emojimention.js
+++ b/packages/ckeditor5-emoji/tests/emojimention.js
@@ -140,6 +140,26 @@ describe( 'EmojiMention', () => {
 		expect( config.itemRenderer ).to.equal( undefined );
 	} );
 
+	it( 'should not pass config for mention plugin when there is another conflicting merge fields config', async () => {
+		await editor.destroy();
+
+		editor = await ClassicEditor.create( editorElement, {
+			plugins: [
+				Emoji,
+				Paragraph,
+				Essentials,
+				Mention
+			],
+			mergeFields: {
+				prefix: ':'
+			}
+		} );
+
+		const configs = editor.config.get( 'mention.feeds' );
+
+		expect( configs.length ).to.equal( 0 );
+	} );
+
 	describe( '_customItemRenderer()', () => {
 		let itemRenderer;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Not initializing emoji plugin when merge fields use `:` as first char in prefix. Closes #17591

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
