### PR TITLE
Add support for `latin-alpha` / `upper-alpha` list type highlighting in list style properties buttons.

### DIFF
--- a/packages/ckeditor5-list/src/legacylistproperties/legacylistpropertiesediting.ts
+++ b/packages/ckeditor5-list/src/legacylistproperties/legacylistpropertiesediting.ts
@@ -29,6 +29,7 @@ import LegacyListReversedCommand from './legacylistreversedcommand.js';
 import LegacyListStartCommand from './legacyliststartcommand.js';
 import { getSiblingListItem, getSiblingNodes } from '../legacylist/legacyutils.js';
 import type { ListPropertiesConfig } from '../listconfig.js';
+import { normalizeListStyle } from '../listproperties/utils/style.js';
 
 const DEFAULT_LIST_TYPE = 'default';
 
@@ -307,7 +308,7 @@ function createAttributeStrategies( enabledProperties: ListPropertiesConfig ) {
 			},
 
 			getAttributeOnUpcast( listParent ) {
-				return listParent.getStyle( 'list-style-type' ) || DEFAULT_LIST_TYPE;
+				return normalizeListStyle( listParent.getStyle( 'list-style-type' )! ) || DEFAULT_LIST_TYPE;
 			}
 		} );
 	}

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesediting.ts
@@ -33,7 +33,8 @@ import {
 	getAllSupportedStyleTypes,
 	getListTypeFromListStyleType,
 	getListStyleTypeFromTypeAttribute,
-	getTypeAttributeFromListStyleType
+	getTypeAttributeFromListStyleType,
+	normalizeListStyle
 } from './utils/style.js';
 import ListPropertiesUtils from './listpropertiesutils.js';
 import {
@@ -331,7 +332,7 @@ function createAttributeStrategies( enabledProperties: ListPropertiesConfig ) {
 				const style = listParent.getStyle( 'list-style-type' );
 
 				if ( style ) {
-					return style;
+					return normalizeListStyle( style );
 				}
 
 				const attribute = listParent.getAttribute( 'type' );

--- a/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
+++ b/packages/ckeditor5-list/src/listproperties/listpropertiesui.ts
@@ -299,9 +299,7 @@ function getStyleButtonCreator( {
 
 		button.set( { label, icon, tooltip } );
 
-		listStyleCommand.on( 'change:value', () => {
-			button.isOn = listStyleCommand.value === type;
-		} );
+		button.bind( 'isOn' ).to( listStyleCommand, 'value', value => value === type );
 
 		button.on( 'execute', () => {
 			// If the content the selection is anchored to is a list, let's change its style.

--- a/packages/ckeditor5-list/src/listproperties/ui/listpropertiesview.ts
+++ b/packages/ckeditor5-list/src/listproperties/ui/listpropertiesview.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+	ButtonView,
 	View,
 	ViewCollection,
 	FocusCycler,
@@ -16,7 +17,6 @@ import {
 	createLabeledInputNumber,
 	addKeyboardHandlingForGrid,
 	CollapsibleView,
-	type ButtonView,
 	type InputNumberView,
 	type FocusableView
 } from 'ckeditor5/src/ui.js';
@@ -283,6 +283,16 @@ export default class ListPropertiesView extends View {
 		stylesView.children.delegate( 'execute' ).to( this );
 
 		stylesView.focus = function( this: any ) {
+			// If there is a button that is already on, focus it.
+			// It's counterintuitive to focus the first button when there is already a button on.
+			for ( const child of this.children ) {
+				if ( child instanceof ButtonView && child.isOn ) {
+					child.focus();
+					return;
+				}
+			}
+
+			// ... otherwise focus the first button.
 			this.children.first.focus();
 		};
 

--- a/packages/ckeditor5-list/src/listproperties/utils/style.ts
+++ b/packages/ckeditor5-list/src/listproperties/utils/style.ts
@@ -61,3 +61,25 @@ export function getListStyleTypeFromTypeAttribute( value: string ): string | nul
 export function getTypeAttributeFromListStyleType( value: string ): string | null {
 	return LIST_STYLE_TO_TYPE_ATTRIBUTE[ value ] || null;
 }
+
+/**
+ * Normalizes list style by converting aliases to their canonical form.
+ *
+ * @param listStyle The list style value to normalize.
+ * @returns The canonical form of the list style.
+ *
+ * @example
+ * normalizeListStyle( 'lower-alpha' ); // Returns 'lower-latin'
+ * normalizeListStyle( 'upper-alpha' ); // Returns 'upper-latin'
+ * normalizeListStyle( 'disc' ); // Returns 'disc'
+ */
+export function normalizeListStyle( listStyle: string ): string {
+	switch ( listStyle ) {
+		case 'lower-alpha':
+			return 'lower-latin';
+		case 'upper-alpha':
+			return 'upper-latin';
+		default:
+			return listStyle;
+	}
+}

--- a/packages/ckeditor5-list/tests/legacylistproperties/legacylistpropertiesediting.js
+++ b/packages/ckeditor5-list/tests/legacylistproperties/legacylistpropertiesediting.js
@@ -166,13 +166,13 @@ describe( 'LegacyListPropertiesEditing', () => {
 					expect( editor.getData() ).to.equal( '<ul style="list-style-type:circle;"><li>Foo</li><li>Bar</li></ul>' );
 				} );
 
-				it( 'should convert single list (type: numbered, style: upper-alpha)', () => {
+				it( 'should convert single list (type: numbered, style: upper-latin)', () => {
 					setModelData( model,
-						'<listItem listIndent="0" listType="numbered" listStyle="upper-alpha">Foo</listItem>' +
-						'<listItem listIndent="0" listType="numbered" listStyle="upper-alpha">Bar</listItem>'
+						'<listItem listIndent="0" listType="numbered" listStyle="upper-latin">Foo</listItem>' +
+						'<listItem listIndent="0" listType="numbered" listStyle="upper-latin">Bar</listItem>'
 					);
 
-					expect( editor.getData() ).to.equal( '<ol style="list-style-type:upper-alpha;"><li>Foo</li><li>Bar</li></ol>' );
+					expect( editor.getData() ).to.equal( '<ol style="list-style-type:upper-latin;"><li>Foo</li><li>Bar</li></ol>' );
 				} );
 
 				it( 'should convert nested bulleted lists (main: circle, nested: disc)', () => {
@@ -334,18 +334,18 @@ describe( 'LegacyListPropertiesEditing', () => {
 					);
 				} );
 
-				it( 'should convert single list (type: numbered, style: upper-alpha)', () => {
-					editor.setData( '<ol style="list-style-type:upper-alpha;"><li>Foo</li><li>Bar</li></ol>' );
+				it( 'should convert single list (type: numbered, style: upper-latin)', () => {
+					editor.setData( '<ol style="list-style-type:upper-latin;"><li>Foo</li><li>Bar</li></ol>' );
 
 					expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
-						'<listItem listIndent="0" listStyle="upper-alpha" listType="numbered">Foo</listItem>' +
-						'<listItem listIndent="0" listStyle="upper-alpha" listType="numbered">Bar</listItem>'
+						'<listItem listIndent="0" listStyle="upper-latin" listType="numbered">Foo</listItem>' +
+						'<listItem listIndent="0" listStyle="upper-latin" listType="numbered">Bar</listItem>'
 					);
 				} );
 
 				it( 'should convert nested and mixed lists', () => {
 					editor.setData(
-						'<ol style="list-style-type:upper-alpha;">' +
+						'<ol style="list-style-type:upper-latin;">' +
 							'<li>OL 1</li>' +
 							'<li>OL 2' +
 								'<ul style="list-style-type:circle;">' +
@@ -358,18 +358,18 @@ describe( 'LegacyListPropertiesEditing', () => {
 					);
 
 					expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
-						'<listItem listIndent="0" listStyle="upper-alpha" listType="numbered">OL 1</listItem>' +
-						'<listItem listIndent="0" listStyle="upper-alpha" listType="numbered">OL 2</listItem>' +
+						'<listItem listIndent="0" listStyle="upper-latin" listType="numbered">OL 1</listItem>' +
+						'<listItem listIndent="0" listStyle="upper-latin" listType="numbered">OL 2</listItem>' +
 						'<listItem listIndent="1" listStyle="circle" listType="bulleted">UL 1</listItem>' +
 						'<listItem listIndent="1" listStyle="circle" listType="bulleted">UL 2</listItem>' +
-						'<listItem listIndent="0" listStyle="upper-alpha" listType="numbered">OL 3</listItem>'
+						'<listItem listIndent="0" listStyle="upper-latin" listType="numbered">OL 3</listItem>'
 					);
 				} );
 
 				it( 'should convert when the list is in the middle of the content', () => {
 					editor.setData(
 						'<p>Paragraph.</p>' +
-						'<ol style="list-style-type:upper-alpha;">' +
+						'<ol style="list-style-type:upper-latin;">' +
 							'<li>Foo</li>' +
 							'<li>Bar</li>' +
 						'</ol>' +
@@ -378,8 +378,8 @@ describe( 'LegacyListPropertiesEditing', () => {
 
 					expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
 						'<paragraph>Paragraph.</paragraph>' +
-						'<listItem listIndent="0" listStyle="upper-alpha" listType="numbered">Foo</listItem>' +
-						'<listItem listIndent="0" listStyle="upper-alpha" listType="numbered">Bar</listItem>' +
+						'<listItem listIndent="0" listStyle="upper-latin" listType="numbered">Foo</listItem>' +
+						'<listItem listIndent="0" listStyle="upper-latin" listType="numbered">Bar</listItem>' +
 						'<paragraph>Paragraph.</paragraph>'
 					);
 				} );
@@ -5440,10 +5440,10 @@ describe( 'LegacyListPropertiesEditing', () => {
 				it( 'should inherit the attributes when merging the same kind of lists', () => {
 					setModelData( model,
 						'<paragraph>Foo Bar.[]</paragraph>' +
-						'<listItem listIndent="0" listReversed="true" listStart="3" listStyle="upper-alpha" listType="numbered">' +
+						'<listItem listIndent="0" listReversed="true" listStart="3" listStyle="upper-latin" listType="numbered">' +
 							'Foo' +
 						'</listItem>' +
-						'<listItem listIndent="0" listReversed="true" listStart="3" listStyle="upper-alpha" listType="numbered">' +
+						'<listItem listIndent="0" listReversed="true" listStart="3" listStyle="upper-latin" listType="numbered">' +
 							'Bar' +
 						'</listItem>'
 					);
@@ -5451,13 +5451,13 @@ describe( 'LegacyListPropertiesEditing', () => {
 					editor.execute( 'numberedList' );
 
 					expect( getModelData( model ) ).to.equal(
-						'<listItem listIndent="0" listReversed="true" listStart="3" listStyle="upper-alpha" listType="numbered">' +
+						'<listItem listIndent="0" listReversed="true" listStart="3" listStyle="upper-latin" listType="numbered">' +
 							'Foo Bar.[]' +
 						'</listItem>' +
-						'<listItem listIndent="0" listReversed="true" listStart="3" listStyle="upper-alpha" listType="numbered">' +
+						'<listItem listIndent="0" listReversed="true" listStart="3" listStyle="upper-latin" listType="numbered">' +
 							'Foo' +
 						'</listItem>' +
-						'<listItem listIndent="0" listReversed="true" listStart="3" listStyle="upper-alpha" listType="numbered">' +
+						'<listItem listIndent="0" listReversed="true" listStart="3" listStyle="upper-latin" listType="numbered">' +
 							'Bar' +
 						'</listItem>'
 					);
@@ -5491,7 +5491,7 @@ describe( 'LegacyListPropertiesEditing', () => {
 							'<listItem listIndent="0" listReversed="true" listStart="2" listStyle="lower-latin" listType="numbered">' +
 								'Bar' +
 							'</listItem>' +
-							'<listItem listIndent="0" listStyle="upper-alpha" listType="bulleted">Foo Bar.[]</listItem>'
+							'<listItem listIndent="0" listStyle="upper-latin" listType="bulleted">Foo Bar.[]</listItem>'
 						);
 
 						editor.execute( 'numberedList' );
@@ -5573,7 +5573,7 @@ describe( 'LegacyListPropertiesEditing', () => {
 							'<listItem listIndent="0" listReversed="false" listStart="3" listStyle="lower-lating" listType="numbered">' +
 								'1.' +
 							'</listItem>' +
-							'<listItem listIndent="1" listReversed="true" listStart="1" listStyle="upper-alpha" listType="numbered">' +
+							'<listItem listIndent="1" listReversed="true" listStart="1" listStyle="upper-latin" listType="numbered">' +
 								'2.' +
 							'</listItem>' +
 							'<listItem listIndent="0" listReversed="false" listStart="3" listStyle="lower-lating" listType="numbered">' +
@@ -5590,10 +5590,10 @@ describe( 'LegacyListPropertiesEditing', () => {
 							'<listItem listIndent="0" listReversed="false" listStart="3" listStyle="lower-lating" listType="numbered">' +
 								'1.' +
 							'</listItem>' +
-							'<listItem listIndent="1" listReversed="true" listStart="1" listStyle="upper-alpha" listType="numbered">' +
+							'<listItem listIndent="1" listReversed="true" listStart="1" listStyle="upper-latin" listType="numbered">' +
 								'2.' +
 							'</listItem>' +
-							'<listItem listIndent="1" listReversed="true" listStart="1" listStyle="upper-alpha" listType="numbered">' +
+							'<listItem listIndent="1" listReversed="true" listStart="1" listStyle="upper-latin" listType="numbered">' +
 								'3.[]' +
 							'</listItem>' +
 							'<listItem listIndent="0" listReversed="false" listStart="3" listStyle="lower-lating" listType="numbered">' +
@@ -5607,13 +5607,13 @@ describe( 'LegacyListPropertiesEditing', () => {
 			describe( 'outdenting lists', () => {
 				it( 'should inherit the attributes from parent list', () => {
 					setModelData( model,
-						'<listItem listIndent="0" listReversed="true" listStart="2" listStyle="lower-alpha" listType="numbered">' +
+						'<listItem listIndent="0" listReversed="true" listStart="2" listStyle="lower-latin" listType="numbered">' +
 							'1.' +
 						'</listItem>' +
-						'<listItem listIndent="1" listReversed="false" listStart="3" listStyle="upper-alpha" listType="numbered">' +
+						'<listItem listIndent="1" listReversed="false" listStart="3" listStyle="upper-latin" listType="numbered">' +
 							'2.[]' +
 						'</listItem>' +
-						'<listItem listIndent="0" listReversed="true" listStart="2" listStyle="lower-alpha" listType="numbered">' +
+						'<listItem listIndent="0" listReversed="true" listStart="2" listStyle="lower-latin" listType="numbered">' +
 							'3.' +
 						'</listItem>'
 					);
@@ -5621,13 +5621,13 @@ describe( 'LegacyListPropertiesEditing', () => {
 					editor.execute( 'outdentList' );
 
 					expect( getModelData( model ) ).to.equal(
-						'<listItem listIndent="0" listReversed="true" listStart="2" listStyle="lower-alpha" listType="numbered">' +
+						'<listItem listIndent="0" listReversed="true" listStart="2" listStyle="lower-latin" listType="numbered">' +
 							'1.' +
 						'</listItem>' +
-						'<listItem listIndent="0" listReversed="true" listStart="2" listStyle="lower-alpha" listType="numbered">' +
+						'<listItem listIndent="0" listReversed="true" listStart="2" listStyle="lower-latin" listType="numbered">' +
 							'2.[]' +
 						'</listItem>' +
-						'<listItem listIndent="0" listReversed="true" listStart="2" listStyle="lower-alpha" listType="numbered">' +
+						'<listItem listIndent="0" listReversed="true" listStart="2" listStyle="lower-latin" listType="numbered">' +
 							'3.' +
 						'</listItem>'
 					);

--- a/packages/ckeditor5-list/tests/listproperties/converters.js
+++ b/packages/ckeditor5-list/tests/listproperties/converters.js
@@ -90,13 +90,13 @@ describe( 'ListPropertiesEditing - converters', () => {
 
 			it( 'should convert single list (type: numbered, style: upper-alpha)', () => {
 				test.data(
-					'<ol style="list-style-type:upper-alpha;">' +
+					'<ol style="list-style-type:upper-latin;">' +
 						'<li>Foo</li>' +
 						'<li>Bar</li>' +
 					'</ol>',
 
 					modelList( `
-						# Foo {style:upper-alpha}
+						# Foo {style:upper-latin}
 						# Bar
 					` )
 				);
@@ -104,7 +104,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 
 			it( 'should convert mixed lists', () => {
 				test.data(
-					'<ol style="list-style-type:upper-alpha;">' +
+					'<ol style="list-style-type:upper-latin;">' +
 						'<li>OL 1</li>' +
 						'<li>OL 2</li>' +
 					'</ol>' +
@@ -114,7 +114,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 					'</ul>',
 
 					modelList( `
-						# OL 1 {style:upper-alpha}
+						# OL 1 {style:upper-latin}
 						# OL 2
 						* UL 1 {style:circle}
 						* UL 2
@@ -124,7 +124,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 
 			it( 'should convert nested and mixed lists', () => {
 				test.data(
-					'<ol style="list-style-type:upper-alpha;">' +
+					'<ol style="list-style-type:upper-latin;">' +
 						'<li>OL 1</li>' +
 						'<li>OL 2' +
 							'<ul style="list-style-type:circle;">' +
@@ -136,7 +136,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 					'</ol>',
 
 					modelList( `
-						# OL 1 {id:000} {style:upper-alpha}
+						# OL 1 {id:000} {style:upper-latin}
 						# OL 2 {id:003}
 						  * UL 1 {id:001} {style:circle}
 						  * UL 2 {id:002}
@@ -148,7 +148,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 			it( 'should convert when the list is in the middle of the content', () => {
 				test.data(
 					'<p>Paragraph.</p>' +
-					'<ol style="list-style-type:upper-alpha;">' +
+					'<ol style="list-style-type:upper-latin;">' +
 						'<li>Foo</li>' +
 						'<li>Bar</li>' +
 					'</ol>' +
@@ -156,7 +156,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 
 					modelList( `
 						Paragraph.
-						# Foo {id:000} {style:upper-alpha}
+						# Foo {id:000} {style:upper-latin}
 						# Bar {id:001}
 						Paragraph.
 					` )
@@ -168,7 +168,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 					'<ul>' +
 						'<li>' +
 							'cd' +
-							'<ol style="list-style-type:upper-alpha;">' +
+							'<ol style="list-style-type:upper-latin;">' +
 								'<li>efg</li>' +
 							'</ol>' +
 						'</li>' +
@@ -176,7 +176,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 
 					modelList( `
 						* cd {id:001} {style:default}
-						  # efg {id:000} {style:upper-alpha}
+						  # efg {id:000} {style:upper-latin}
 					` )
 				);
 			} );
@@ -187,7 +187,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 				}, { priority: 'highest' } );
 
 				test.data(
-					'<ol style="list-style-type:upper-alpha;">' +
+					'<ol style="list-style-type:upper-latin;">' +
 						'<li>Foo</li>' +
 						'<li>Bar</li>' +
 					'</ol>',
@@ -236,17 +236,17 @@ describe( 'ListPropertiesEditing - converters', () => {
 				}, { priority: 'highest' } );
 
 				test.data(
-					'<ol style="list-style-type:upper-alpha;">' +
+					'<ol style="list-style-type:upper-latin;">' +
 						'<li>Foo</li>' +
 						'<li>Bar</li>' +
 					'</ol>',
 
 					modelList( `
-						# Foo {style:upper-alpha}
+						# Foo {style:upper-latin}
 						# Bar
 					` ),
 
-					'<ol style="list-style-type:upper-alpha;">' +
+					'<ol style="list-style-type:upper-latin;">' +
 						'<li>Foo</li>' +
 						'<li>Bar</li>' +
 					'</ol>'
@@ -261,23 +261,23 @@ describe( 'ListPropertiesEditing - converters', () => {
 				editor.conversion.elementToElement( { view: 'div', model: 'block' } );
 
 				test.data(
-					'<ol style="list-style-type:upper-alpha;">' +
+					'<ol style="list-style-type:upper-latin;">' +
 						'<li>Foo</li>' +
 						'<li><div>x</div></li>' +
 						'<li>Bar</li>' +
 					'</ol>',
 
 					modelList( `
-						# Foo {style:upper-alpha}
+						# Foo {style:upper-latin}
 						<block>x</block>
-						# Bar {style:upper-alpha}
+						# Bar {style:upper-latin}
 					` ),
 
-					'<ol style="list-style-type:upper-alpha;">' +
+					'<ol style="list-style-type:upper-latin;">' +
 						'<li>Foo</li>' +
 					'</ol>' +
 					'<div>x</div>' +
-					'<ol style="list-style-type:upper-alpha;">' +
+					'<ol style="list-style-type:upper-latin;">' +
 						'<li>Bar</li>' +
 					'</ol>'
 				);
@@ -295,7 +295,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 				);
 
 				test.data(
-					'<ol style="list-style-type:upper-alpha;">' +
+					'<ol style="list-style-type:upper-latin;">' +
 						'<li>Foo</li>' +
 						'<li>Bar</li>' +
 					'</ol>',
@@ -2244,13 +2244,13 @@ describe( 'ListPropertiesEditing - converters', () => {
 
 			it( 'should convert single list (type: numbered, styled, reversed, start: 5)', () => {
 				test.data(
-					'<ol style="list-style-type:lower-alpha;" reversed="reversed" start="5">' +
+					'<ol style="list-style-type:lower-latin;" reversed="reversed" start="5">' +
 						'<li>Foo</li>' +
 						'<li>Bar</li>' +
 					'</ol>',
 
 					modelList( `
-						# Foo {style:lower-alpha} {start:5} {reversed:true}
+						# Foo {style:lower-latin} {start:5} {reversed:true}
 						# Bar
 					` )
 				);
@@ -2259,7 +2259,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 			it( 'should convert when the list is in the middle of the content', () => {
 				test.data(
 					'<p>Paragraph.</p>' +
-					'<ol style="list-style-type:lower-alpha;" reversed="reversed" start="5">' +
+					'<ol style="list-style-type:lower-latin;" reversed="reversed" start="5">' +
 						'<li>Foo</li>' +
 						'<li>Bar</li>' +
 					'</ol>' +
@@ -2267,7 +2267,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 
 					modelList( `
 						Paragraph.
-						# Foo {id:000} {style:lower-alpha} {start:5} {reversed:true}
+						# Foo {id:000} {style:lower-latin} {start:5} {reversed:true}
 						# Bar {id:001}
 						Paragraph.
 					` )
@@ -2279,7 +2279,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 					'<ul>' +
 						'<li>' +
 							'cd' +
-							'<ol style="list-style-type:lower-alpha;" reversed="reversed" start="5">' +
+							'<ol style="list-style-type:lower-latin;" reversed="reversed" start="5">' +
 								'<li>efg</li>' +
 							'</ol>' +
 						'</li>' +
@@ -2287,7 +2287,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 
 					modelList( `
 						* cd {id:001} {style:default}
-						  # efg {id:000} {style:lower-alpha} {start:5} {reversed:true}
+						  # efg {id:000} {style:lower-latin} {start:5} {reversed:true}
 					` )
 				);
 			} );
@@ -2297,7 +2297,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 					'<ol>' +
 						'<li>' +
 							'cd' +
-							'<ol style="list-style-type:lower-alpha;" reversed="reversed" start="5">' +
+							'<ol style="list-style-type:lower-latin;" reversed="reversed" start="5">' +
 								'<li>efg</li>' +
 							'</ol>' +
 						'</li>' +
@@ -2305,7 +2305,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 
 					modelList( `
 						# cd {id:001} {style:default} {start:1} {reversed:false}
-						  # efg {id:000} {style:lower-alpha} {start:5} {reversed:true}
+						  # efg {id:000} {style:lower-latin} {start:5} {reversed:true}
 					` )
 				);
 			} );
@@ -2335,12 +2335,12 @@ describe( 'ListPropertiesEditing - converters', () => {
 					test.insert(
 						modelList( `
 							x
-							# [<paragraph>Foo</paragraph> {start:5} {reversed:true} {style:lower-alpha}
+							# [<paragraph>Foo</paragraph> {start:5} {reversed:true} {style:lower-latin}
 							# <paragraph>Bar</paragraph>]
 						` ),
 
 						'<p>x</p>' +
-						'<ol reversed="reversed" start="5" style="list-style-type:lower-alpha">' +
+						'<ol reversed="reversed" start="5" style="list-style-type:lower-latin">' +
 							'<li><span class="ck-list-bogus-paragraph">Foo</span></li>' +
 							'<li><span class="ck-list-bogus-paragraph">Bar</span></li>' +
 						'</ol>'
@@ -2353,18 +2353,18 @@ describe( 'ListPropertiesEditing - converters', () => {
 					test.insert(
 						modelList( `
 							x
-							# [<paragraph>Foo 1</paragraph> {start:1} {reversed:true} {style:lower-alpha}
-							  # <paragraph>Bar 1</paragraph> {start:7} {reversed:false} {style:upper-alpha}
+							# [<paragraph>Foo 1</paragraph> {start:1} {reversed:true} {style:lower-latin}
+							  # <paragraph>Bar 1</paragraph> {start:7} {reversed:false} {style:upper-latin}
 							  # <paragraph>Bar 2</paragraph>
 						    # <paragraph>Foo 2</paragraph>
 						    # <paragraph>Foo 3</paragraph>]
 						` ),
 
 						'<p>x</p>' +
-						'<ol reversed="reversed" style="list-style-type:lower-alpha">' +
+						'<ol reversed="reversed" style="list-style-type:lower-latin">' +
 							'<li>' +
 								'<span class="ck-list-bogus-paragraph">Foo 1</span>' +
-								'<ol start="7" style="list-style-type:upper-alpha">' +
+								'<ol start="7" style="list-style-type:upper-latin">' +
 									'<li><span class="ck-list-bogus-paragraph">Bar 1</span></li>' +
 									'<li><span class="ck-list-bogus-paragraph">Bar 2</span></li>' +
 								'</ol>' +
@@ -2383,13 +2383,13 @@ describe( 'ListPropertiesEditing - converters', () => {
 					test.remove(
 						modelList( `
 							<paragraph>p</paragraph>
-							# [<paragraph>a</paragraph>] {start:6} {reversed:true} {style:lower-alpha}
+							# [<paragraph>a</paragraph>] {start:6} {reversed:true} {style:lower-latin}
 							# <paragraph>b</paragraph>
 							# <paragraph>c</paragraph>
 						` ),
 
 						'<p>p</p>' +
-						'<ol reversed="reversed" start="6" style="list-style-type:lower-alpha">' +
+						'<ol reversed="reversed" start="6" style="list-style-type:lower-latin">' +
 							'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 							'<li><span class="ck-list-bogus-paragraph">c</span></li>' +
 						'</ol>'
@@ -2402,12 +2402,12 @@ describe( 'ListPropertiesEditing - converters', () => {
 			describe( 'set list properties', () => {
 				it( 'list start on list with defined style', () => {
 					const input = modelList( `
-						# [<paragraph>a</paragraph> {style:lower-alpha}
+						# [<paragraph>a</paragraph> {style:lower-latin}
 						# <paragraph>b</paragraph>]
 					` );
 
 					const output =
-						'<ol start="2" style="list-style-type:lower-alpha">' +
+						'<ol start="2" style="list-style-type:lower-latin">' +
 							'<li><span class="ck-list-bogus-paragraph">a</span></li>' +
 							'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 						'</ol>';
@@ -2421,12 +2421,12 @@ describe( 'ListPropertiesEditing - converters', () => {
 
 				it( 'list start on list with defined style and reversed', () => {
 					const input = modelList( `
-						# [<paragraph>a</paragraph> {style:lower-alpha} {reversed:true}
+						# [<paragraph>a</paragraph> {style:lower-latin} {reversed:true}
 						# <paragraph>b</paragraph>]
 					` );
 
 					const output =
-						'<ol reversed="reversed" start="2" style="list-style-type:lower-alpha">' +
+						'<ol reversed="reversed" start="2" style="list-style-type:lower-latin">' +
 							'<li><span class="ck-list-bogus-paragraph">a</span></li>' +
 							'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 						'</ol>';
@@ -2440,12 +2440,12 @@ describe( 'ListPropertiesEditing - converters', () => {
 
 				it( 'list start and reversed on list with defined style', () => {
 					const input = modelList( `
-						# [<paragraph>a</paragraph> {style:lower-alpha}
+						# [<paragraph>a</paragraph> {style:lower-latin}
 						# <paragraph>b</paragraph>]
 					` );
 
 					const output =
-						'<ol reversed="reversed" start="2" style="list-style-type:lower-alpha">' +
+						'<ol reversed="reversed" start="2" style="list-style-type:lower-latin">' +
 							'<li><span class="ck-list-bogus-paragraph">a</span></li>' +
 							'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 						'</ol>';
@@ -2462,12 +2462,12 @@ describe( 'ListPropertiesEditing - converters', () => {
 			describe( 'change list property value', () => {
 				it( 'change of list start', () => {
 					const input = modelList( `
-						# [<paragraph>a</paragraph> {style:lower-alpha} {start:4}
+						# [<paragraph>a</paragraph> {style:lower-latin} {start:4}
 						# <paragraph>b</paragraph>]
 					` );
 
 					const output =
-						'<ol start="2" style="list-style-type:lower-alpha">' +
+						'<ol start="2" style="list-style-type:lower-latin">' +
 							'<li><span class="ck-list-bogus-paragraph">a</span></li>' +
 							'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 						'</ol>';
@@ -2481,12 +2481,12 @@ describe( 'ListPropertiesEditing - converters', () => {
 
 				it( 'list start and reversed', () => {
 					const input = modelList( `
-						# [<paragraph>a</paragraph> {style:lower-alpha} {reversed:false} {start:6}
+						# [<paragraph>a</paragraph> {style:lower-latin} {reversed:false} {start:6}
 						# <paragraph>b</paragraph>]
 					` );
 
 					const output =
-						'<ol reversed="reversed" start="2" style="list-style-type:lower-alpha">' +
+						'<ol reversed="reversed" start="2" style="list-style-type:lower-latin">' +
 							'<li><span class="ck-list-bogus-paragraph">a</span></li>' +
 							'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 						'</ol>';
@@ -2501,12 +2501,12 @@ describe( 'ListPropertiesEditing - converters', () => {
 
 				it( 'list start, reversed, and style', () => {
 					const input = modelList( `
-						# [<paragraph>a</paragraph> {style:lower-alpha} {reversed:false} {start:3}
+						# [<paragraph>a</paragraph> {style:lower-latin} {reversed:false} {start:3}
 						# <paragraph>b</paragraph>]
 					` );
 
 					const output =
-						'<ol reversed="reversed" start="2" style="list-style-type:upper-alpha">' +
+						'<ol reversed="reversed" start="2" style="list-style-type:upper-latin">' +
 							'<li><span class="ck-list-bogus-paragraph">a</span></li>' +
 							'<li><span class="ck-list-bogus-paragraph">b</span></li>' +
 						'</ol>';
@@ -2515,7 +2515,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 						model.change( writer => {
 							writer.setAttribute( 'listStart', 2, selection.getFirstRange() );
 							writer.setAttribute( 'listReversed', true, selection.getFirstRange() );
-							writer.setAttribute( 'listStyle', 'upper-alpha', selection.getFirstRange() );
+							writer.setAttribute( 'listStyle', 'upper-latin', selection.getFirstRange() );
 						} );
 					} );
 				} );
@@ -2543,7 +2543,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 
 				it( 'to bulleted', () => {
 					const input = modelList( `
-						# [<paragraph>a</paragraph> {start:2} {style:lower-alpha} {reversed:true}
+						# [<paragraph>a</paragraph> {start:2} {style:lower-latin} {reversed:true}
 						# <paragraph>b</paragraph>]
 					` );
 
@@ -2566,7 +2566,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 					const input = modelList( [
 						'* <paragraph>a</paragraph>',
 						'* [<paragraph>b</paragraph>',
-						'  # <paragraph>c</paragraph>] {start:4} {reversed:true} {style:lower-alpha}'
+						'  # <paragraph>c</paragraph>] {start:4} {reversed:true} {style:lower-latin}'
 					] );
 
 					const output =
@@ -2576,7 +2576,7 @@ describe( 'ListPropertiesEditing - converters', () => {
 								'<ul>' +
 									'<li>' +
 										'<span class="ck-list-bogus-paragraph">b</span>' +
-										'<ol reversed="reversed" start="4" style="list-style-type:lower-alpha">' +
+										'<ol reversed="reversed" start="4" style="list-style-type:lower-latin">' +
 											'<li><span class="ck-list-bogus-paragraph">c</span></li>' +
 										'</ol>' +
 									'</li>' +

--- a/packages/ckeditor5-list/tests/listproperties/listpropertiesediting.js
+++ b/packages/ckeditor5-list/tests/listproperties/listpropertiesediting.js
@@ -255,6 +255,38 @@ describe( 'ListPropertiesEditing', () => {
 						# Foo {id:a00} {style:decimal}
 					` ) );
 				} );
+
+				it( 'should upcast to `listStyle` property using CSS list style aliases (lower-latin -> lower-latin)', () => {
+					editor.setData( '<ol style="list-style-type:lower-latin;"><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:lower-latin}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property using CSS list style aliases (lower-alpha -> lower-latin)', () => {
+					editor.setData( '<ol style="list-style-type:lower-alpha;"><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:lower-latin}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property using CSS list style aliases (upper-latin -> upper-latin)', () => {
+					editor.setData( '<ol style="list-style-type:upper-latin;"><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:upper-latin}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property using CSS list style aliases (upper-alpha -> upper-latin)', () => {
+					editor.setData( '<ol style="list-style-type:upper-alpha;"><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:upper-latin}
+					` ) );
+				} );
 			} );
 
 			describe( 'downcast', () => {
@@ -468,6 +500,38 @@ describe( 'ListPropertiesEditing', () => {
 
 					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
 						# Foo {id:a00} {style:decimal}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property using CSS list style aliases (lower-latin -> lower-latin)', () => {
+					editor.setData( '<ol style="list-style-type:lower-latin;"><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:lower-latin}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property using CSS list style aliases (lower-alpha -> lower-latin)', () => {
+					editor.setData( '<ol style="list-style-type:lower-alpha;"><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:lower-latin}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property using CSS list style aliases (upper-latin -> upper-latin)', () => {
+					editor.setData( '<ol style="list-style-type:upper-latin;"><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:upper-latin}
+					` ) );
+				} );
+
+				it( 'should upcast to `listStyle` property using CSS list style aliases (upper-alpha -> upper-latin)', () => {
+					editor.setData( '<ol style="list-style-type:upper-alpha;"><li>Foo</li></ol>' );
+
+					expect( getData( model, { withoutSelection: true } ) ).to.equalMarkup( modelList( `
+						# Foo {id:a00} {style:upper-latin}
 					` ) );
 				} );
 			} );

--- a/packages/ckeditor5-list/tests/listproperties/ui/listpropertiesview.js
+++ b/packages/ckeditor5-list/tests/listproperties/ui/listpropertiesview.js
@@ -607,6 +607,35 @@ describe( 'ListPropertiesView', () => {
 			view.element.remove();
 			view.destroy();
 		} );
+
+		it( 'should focus first active button if present in the styles view', () => {
+			const view = new ListPropertiesView( locale, {
+				enabledProperties: {
+					styles: true,
+					startIndex: true,
+					reversed: true
+				},
+				styleButtonViews: [
+					new ButtonView( locale ),
+					new ButtonView( locale ),
+					new ButtonView( locale )
+				],
+				styleGridAriaLabel: 'Foo'
+			} );
+
+			view.render();
+			document.body.appendChild( view.element );
+
+			view.stylesView.children.get( 1 ).isOn = true;
+
+			const spy = sinon.spy( view.stylesView.children.get( 1 ), 'focus' );
+
+			view.focus();
+			sinon.assert.calledOnce( spy );
+
+			view.element.remove();
+			view.destroy();
+		} );
 	} );
 
 	describe( 'focusLast()', () => {

--- a/packages/ckeditor5-list/tests/listproperties/utils/style.js
+++ b/packages/ckeditor5-list/tests/listproperties/utils/style.js
@@ -6,7 +6,8 @@
 import {
 	getListTypeFromListStyleType,
 	getTypeAttributeFromListStyleType,
-	getListStyleTypeFromTypeAttribute
+	getListStyleTypeFromTypeAttribute,
+	normalizeListStyle
 } from '../../../src/listproperties/utils/style.js';
 
 describe( 'ListProperties - utils - style', () => {
@@ -70,5 +71,26 @@ describe( 'ListProperties - utils - style', () => {
 				expect( getListStyleTypeFromTypeAttribute( 'Q' ) ).to.be.null;
 			} );
 		} );
+	} );
+
+	describe( 'normalizeListStyle()', () => {
+		const testData = [
+			[ 'lower-alpha', 'lower-latin' ],
+			[ 'upper-alpha', 'upper-latin' ],
+			[ 'disc', 'disc' ],
+			[ 'circle', 'circle' ],
+			[ 'square', 'square' ],
+			[ 'decimal', 'decimal' ],
+			[ 'lower-roman', 'lower-roman' ],
+			[ 'upper-roman', 'upper-roman' ],
+			[ 'lower-latin', 'lower-latin' ],
+			[ 'upper-latin', 'upper-latin' ]
+		];
+
+		for ( const [ input, expected ] of testData ) {
+			it( `should convert "${ input }" to "${ expected }"`, () => {
+				expect( normalizeListStyle( input ) ).to.equal( expected );
+			} );
+		}
 	} );
 } );

--- a/packages/ckeditor5-paste-from-office/tests/_data/list/many-one-item/model.word2016.html
+++ b/packages/ckeditor5-paste-from-office/tests/_data/list/many-one-item/model.word2016.html
@@ -1,9 +1,9 @@
 <paragraph listIndent="0" listItemId="a00" listStyle="default" listType="numbered">A</paragraph>
 <paragraph listIndent="0" listItemId="a01" listStyle="default" listType="numbered">B</paragraph>
 <paragraph listIndent="0" listItemId="a02" listStyle="upper-roman" listType="numbered">C</paragraph>
-<paragraph listIndent="0" listItemId="a03" listStyle="upper-alpha" listType="numbered">D</paragraph>
-<paragraph listIndent="0" listItemId="a04" listStyle="lower-alpha" listType="numbered">E</paragraph>
-<paragraph listIndent="0" listItemId="a05" listStyle="lower-alpha" listType="numbered">F</paragraph>
+<paragraph listIndent="0" listItemId="a03" listStyle="upper-latin" listType="numbered">D</paragraph>
+<paragraph listIndent="0" listItemId="a04" listStyle="lower-latin" listType="numbered">E</paragraph>
+<paragraph listIndent="0" listItemId="a05" listStyle="lower-latin" listType="numbered">F</paragraph>
 <paragraph listIndent="0" listItemId="a06" listStyle="lower-roman" listType="numbered">G</paragraph>
 
 <paragraph></paragraph>

--- a/packages/ckeditor5-paste-from-office/tests/_data/list/multi-block-block-after/model.word.html
+++ b/packages/ckeditor5-paste-from-office/tests/_data/list/multi-block-block-after/model.word.html
@@ -1,8 +1,8 @@
 <paragraph listIndent="0" listItemId="a03" listStyle="default" listType="numbered">A1</paragraph>
-<paragraph listIndent="1" listItemId="a01" listStyle="lower-alpha" listType="numbered">B2</paragraph>
+<paragraph listIndent="1" listItemId="a01" listStyle="lower-latin" listType="numbered">B2</paragraph>
 <paragraph listIndent="2" listItemId="a00" listStyle="lower-roman" listType="numbered">C3</paragraph>
-<paragraph listIndent="1" listItemId="a02" listStyle="lower-alpha" listType="numbered">D2</paragraph>
+<paragraph listIndent="1" listItemId="a02" listStyle="lower-latin" listType="numbered">D2</paragraph>
 <paragraph>E3</paragraph>
 <paragraph listIndent="0" listItemId="a06" listStyle="default" listType="numbered">F1</paragraph>
-<paragraph listIndent="1" listItemId="a05" listStyle="lower-alpha" listType="numbered">G2</paragraph>
+<paragraph listIndent="1" listItemId="a05" listStyle="lower-latin" listType="numbered">G2</paragraph>
 <paragraph listIndent="2" listItemId="a04" listStyle="lower-roman" listType="numbered">H3</paragraph>

--- a/packages/ckeditor5-paste-from-office/tests/_data/list/multi-block/model.word.html
+++ b/packages/ckeditor5-paste-from-office/tests/_data/list/multi-block/model.word.html
@@ -2,10 +2,10 @@
 <paragraph listIndent="0" listItemId="a00" listStyle="default" listType="numbered">A1</paragraph>
 <paragraph>a1</paragraph>
 <paragraph listIndent="0" listItemId="a03" listStyle="default" listType="numbered">B1</paragraph>
-<paragraph listIndent="1" listItemId="a01" listStyle="lower-alpha" listType="numbered">C2</paragraph>
-<paragraph listIndent="1" listItemId="a01" listStyle="lower-alpha" listType="numbered">c2</paragraph>
-<paragraph listIndent="1" listItemId="a02" listStyle="lower-alpha" listType="numbered">D2</paragraph>
-<paragraph listIndent="1" listItemId="a02" listStyle="lower-alpha" listType="numbered">d2</paragraph>
+<paragraph listIndent="1" listItemId="a01" listStyle="lower-latin" listType="numbered">C2</paragraph>
+<paragraph listIndent="1" listItemId="a01" listStyle="lower-latin" listType="numbered">c2</paragraph>
+<paragraph listIndent="1" listItemId="a02" listStyle="lower-latin" listType="numbered">D2</paragraph>
+<paragraph listIndent="1" listItemId="a02" listStyle="lower-latin" listType="numbered">d2</paragraph>
 <paragraph>b1</paragraph>
 <paragraph listIndent="0" listItemId="a04" listStyle="default" listType="numbered">E1</paragraph>
 <paragraph>e1</paragraph>
@@ -13,10 +13,10 @@
 <paragraph listIndent="0" listItemId="a05" listStyle="default" listType="numbered">A1</paragraph>
 <paragraph listIndent="0" listItemId="a05" listStyle="default" listType="numbered">a1</paragraph>
 <paragraph listIndent="0" listItemId="a08" listStyle="default" listType="numbered">B1</paragraph>
-<paragraph listIndent="1" listItemId="a06" listStyle="lower-alpha" listType="numbered">C2</paragraph>
-<paragraph listIndent="1" listItemId="a06" listStyle="lower-alpha" listType="numbered">c2</paragraph>
-<paragraph listIndent="1" listItemId="a07" listStyle="lower-alpha" listType="numbered">D2</paragraph>
-<paragraph listIndent="1" listItemId="a07" listStyle="lower-alpha" listType="numbered">d2</paragraph>
+<paragraph listIndent="1" listItemId="a06" listStyle="lower-latin" listType="numbered">C2</paragraph>
+<paragraph listIndent="1" listItemId="a06" listStyle="lower-latin" listType="numbered">c2</paragraph>
+<paragraph listIndent="1" listItemId="a07" listStyle="lower-latin" listType="numbered">D2</paragraph>
+<paragraph listIndent="1" listItemId="a07" listStyle="lower-latin" listType="numbered">d2</paragraph>
 <paragraph listIndent="0" listItemId="a08" listStyle="default" listType="numbered">b1</paragraph>
 <paragraph listIndent="0" listItemId="a09" listStyle="default" listType="numbered">E1</paragraph>
 <paragraph listIndent="0" listItemId="a09" listStyle="default" listType="numbered">e1</paragraph>
@@ -24,10 +24,10 @@
 <paragraph listIndent="0" listItemId="a0a" listStyle="default" listType="numbered">A1</paragraph>
 <paragraph listIndent="0" listItemId="a0a" listStyle="default" listType="numbered">a1</paragraph>
 <paragraph listIndent="0" listItemId="a0d" listStyle="default" listType="numbered">B1</paragraph>
-<paragraph listIndent="1" listItemId="a0b" listStyle="lower-alpha" listType="numbered">C2</paragraph>
-<paragraph listIndent="1" listItemId="a0b" listStyle="lower-alpha" listType="numbered">c2</paragraph>
-<paragraph listIndent="1" listItemId="a0c" listStyle="lower-alpha" listType="numbered">D2</paragraph>
-<paragraph listIndent="1" listItemId="a0c" listStyle="lower-alpha" listType="numbered">d2</paragraph>
+<paragraph listIndent="1" listItemId="a0b" listStyle="lower-latin" listType="numbered">C2</paragraph>
+<paragraph listIndent="1" listItemId="a0b" listStyle="lower-latin" listType="numbered">c2</paragraph>
+<paragraph listIndent="1" listItemId="a0c" listStyle="lower-latin" listType="numbered">D2</paragraph>
+<paragraph listIndent="1" listItemId="a0c" listStyle="lower-latin" listType="numbered">d2</paragraph>
 <paragraph listIndent="0" listItemId="a0d" listStyle="default" listType="numbered">b1</paragraph>
 <paragraph listIndent="0" listItemId="a0e" listStyle="default" listType="numbered">E1</paragraph>
 <paragraph listIndent="0" listItemId="a0e" listStyle="default" listType="numbered">e1</paragraph>

--- a/packages/ckeditor5-paste-from-office/tests/_data/list/nested-multiple/model.word2016.html
+++ b/packages/ckeditor5-paste-from-office/tests/_data/list/nested-multiple/model.word2016.html
@@ -6,9 +6,9 @@
 <paragraph>Foo Bar...</paragraph>
 <paragraph></paragraph>
 
-<paragraph listIndent="0" listItemId="a03" listStyle="lower-alpha" listType="numbered">A2</paragraph>
-<paragraph listIndent="0" listItemId="a05" listStyle="lower-alpha" listType="numbered">B1</paragraph>
-<paragraph listIndent="1" listItemId="a04" listStyle="lower-alpha" listType="numbered">C2</paragraph>
+<paragraph listIndent="0" listItemId="a03" listStyle="lower-latin" listType="numbered">A2</paragraph>
+<paragraph listIndent="0" listItemId="a05" listStyle="lower-latin" listType="numbered">B1</paragraph>
+<paragraph listIndent="1" listItemId="a04" listStyle="lower-latin" listType="numbered">C2</paragraph>
 
 <paragraph></paragraph>
 

--- a/packages/ckeditor5-paste-from-office/tests/_data/list/nested/model.word2016.html
+++ b/packages/ckeditor5-paste-from-office/tests/_data/list/nested/model.word2016.html
@@ -1,7 +1,7 @@
 <paragraph listIndent="0" listItemId="a00" listStyle="default" listType="numbered">A1</paragraph>
 <paragraph listIndent="0" listItemId="a05" listStyle="default" listType="numbered">B1</paragraph>
-<paragraph listIndent="1" listItemId="a02" listStyle="lower-alpha" listType="numbered">C2</paragraph>
+<paragraph listIndent="1" listItemId="a02" listStyle="lower-latin" listType="numbered">C2</paragraph>
 <paragraph listIndent="2" listItemId="a01" listStyle="default" listType="numbered">D4</paragraph>
-<paragraph listIndent="1" listItemId="a04" listStyle="lower-alpha" listType="numbered">E2</paragraph>
+<paragraph listIndent="1" listItemId="a04" listStyle="lower-latin" listType="numbered">E2</paragraph>
 <paragraph listIndent="2" listItemId="a03" listStyle="lower-roman" listType="numbered">F3</paragraph>
 <paragraph listIndent="0" listItemId="a06" listStyle="default" listType="numbered">G1</paragraph>


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (list): Add support for `lower-alpha` / `upper-alpha` list type highlighting in list style properties buttons. Closes https://github.com/ckeditor/ckeditor5/issues/17424
Fix (list): The list style buttons should show proper list type after clicking list for the first time.

MINOR BREAKING CHANGE (list): `lower-alpha` and `upper-alpha` list styles are now upcasted to `lower-latin` and `upper-latin` styles.

---

### Additional information

#### Aliasing

According to https://www.w3.org/TR/1998/PR-CSS2-19980324/lists.html#list-props:

```
lower-latin or lower-alpha
    Lower case ascii letters (a, b, c, ... z). 
upper-latin or upper-alpha
    Upper case ascii letters (A, B, C, ... Z). 
```

So it's valid to highlight the same list style property button.

#### Focus tracking

##### Before

https://github.com/user-attachments/assets/387bf1c1-98f4-4a13-a424-46618dad1027

##### After


https://github.com/user-attachments/assets/d7ce6b8c-8974-49c2-a947-18d0fd6e69cb


