### PR TITLE
Fix (image): Add form tag and submit button to insert via url dialog window to allow closing it by enter key

### DIFF
--- a/packages/ckeditor5-image/src/imageinsert/imageinsertviaurlui.ts
+++ b/packages/ckeditor5-image/src/imageinsert/imageinsertviaurlui.ts
@@ -196,6 +196,7 @@ export default class ImageInsertViaUrlUI extends Plugin {
 				{
 					label: t( 'Accept' ),
 					class: 'ck-button-action',
+					type: 'submit',
 					withText: true,
 					onExecute: () => this._handleSave()
 				}

--- a/packages/ckeditor5-image/tests/imageinsert/imageinsertviaurlui.js
+++ b/packages/ckeditor5-image/tests/imageinsert/imageinsertviaurlui.js
@@ -120,6 +120,11 @@ describe( 'ImageInsertViaUrlUI', () => {
 			expect( dialog.view.actionsView.children.get( 1 ).label ).to.equal( 'Accept' );
 		} );
 
+		it( 'has submittable form', () => {
+			expect( dialog.view.element.querySelector( 'form.ck-dialog' ) ).to.exist;
+			expect( acceptButton.type ).to.equal( 'submit' );
+		} );
+
 		it( 'should bind #isImageSelected', () => {
 			expect( urlView.isImageSelected ).to.be.false;
 
@@ -186,6 +191,7 @@ describe( 'ImageInsertViaUrlUI', () => {
 
 		testSubmit( 'accept button', () => acceptButton.fire( 'execute' ) );
 
+		// Can not be checked by simulating enter click because of unit test limitations
 		testSubmit( 'form submit (enter key)', () => {
 			const form = dialog.view.contentView.children.get( 0 );
 

--- a/packages/ckeditor5-ui/src/dialog/dialogactionsview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogactionsview.ts
@@ -149,7 +149,7 @@ export default class DialogActionsView extends View {
  */
 export type DialogActionButtonDefinition =
 	Pick<Button, 'label'> &
-	Partial<Pick<Button, 'withText' | 'class' | 'icon'>> &
+	Partial<Pick<Button, 'withText' | 'class' | 'icon' | 'type'>> &
 	{
 		onExecute: Function;
 		onCreate?: ( button: ButtonView ) => void;

--- a/packages/ckeditor5-ui/src/dialog/dialogview.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialogview.ts
@@ -260,7 +260,7 @@ export default class DialogView extends /* #__PURE__ */ DraggableViewMixin( View
 			},
 			children: [
 				{
-					tag: 'div',
+					tag: 'form',
 					attributes: {
 						tabindex: '-1',
 						class: [

--- a/packages/ckeditor5-ui/src/inputtext/inputtextview.ts
+++ b/packages/ckeditor5-ui/src/inputtext/inputtextview.ts
@@ -26,8 +26,7 @@ export default class InputTextView extends InputView {
 				type: 'text',
 				class: [
 					'ck-input-text'
-				],
-				required: true
+				]
 			}
 		} );
 	}

--- a/packages/ckeditor5-ui/src/inputtext/inputtextview.ts
+++ b/packages/ckeditor5-ui/src/inputtext/inputtextview.ts
@@ -26,7 +26,8 @@ export default class InputTextView extends InputView {
 				type: 'text',
 				class: [
 					'ck-input-text'
-				]
+				],
+				required: true
 			}
 		} );
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (image): Insert image via url dialog can be closed by "enter" button when input is focused. Closes #16902.

---

I tried to add better unit tests for this case but submitting form by "enter" button works different in browser than in unit test environment. I left comment to prevent confusion why unit test has no "enter" click.