### PR TITLE
Fix incorrect upcast scan table heuristics responsible for creating heading rows.

### DIFF
--- a/packages/ckeditor5-table/src/converters/upcasttable.ts
+++ b/packages/ckeditor5-table/src/converters/upcasttable.ts
@@ -277,8 +277,8 @@ function scanTable( viewTable: ViewElement ) {
 			}
 
 			// We use the maximum number of columns to avoid false positives when detecting
-			// multiple `rowspans` with single column. Without it the lat row of `rowspan=3` would be detected as a heading row
-			// because it has only one column and the previous row has also only one column.
+			// multiple rows with single column within `rowspan`. Without it the last row of `rowspan=3`
+			// would be detected as a heading row because it has only one column (identical to the previous row).
 			maxPrevColumns = Math.max( maxPrevColumns || -Infinity, trColumns.length );
 		}
 	}

--- a/packages/ckeditor5-table/src/converters/upcasttable.ts
+++ b/packages/ckeditor5-table/src/converters/upcasttable.ts
@@ -279,7 +279,7 @@ function scanTable( viewTable: ViewElement ) {
 			// We use the maximum number of columns to avoid false positives when detecting
 			// multiple rows with single column within `rowspan`. Without it the last row of `rowspan=3`
 			// would be detected as a heading row because it has only one column (identical to the previous row).
-			maxPrevColumns = Math.max( maxPrevColumns || -Infinity, trColumns.length );
+			maxPrevColumns = Math.max( maxPrevColumns || 0, trColumns.length );
 		}
 	}
 

--- a/packages/ckeditor5-table/tests/converters/upcasttable.js
+++ b/packages/ckeditor5-table/tests/converters/upcasttable.js
@@ -701,7 +701,7 @@ describe( 'upcastTable()', () => {
 			);
 		} );
 
-		it( 'should not treat the row containing only th as a heading row if it follows colspan', () => {
+		it( 'should not treat the row containing only th as a heading row if it follows rowspan=2', () => {
 			editor.setData(
 				'<table>' +
 					'<tbody>' +
@@ -744,6 +744,60 @@ describe( 'upcastTable()', () => {
 						'<tableCell><paragraph>30</paragraph></tableCell>' +
 						'<tableCell><paragraph>31</paragraph></tableCell>' +
 						'<tableCell><paragraph>32</paragraph></tableCell>' +
+					'</tableRow>' +
+				'</table>'
+			);
+		} );
+
+		it( 'should not treat the row containing only th as a heading row if it is last row of rowspan=3', () => {
+			editor.setData(
+				'<table>' +
+					'<tbody>' +
+						'<tr>' +
+							'<th>00</th>' +
+							'<td>01</td>' +
+							'<td>02</td>' +
+						'</tr>' +
+						'<tr>' +
+							'<th>10</th>' +
+							'<td colspan="2" rowspan="3">11</td>' +
+						'</tr>' +
+						'<tr>' +
+							'<th>20</th>' +
+						'</tr>' +
+						'<tr>' +
+							'<th>30</th>' +
+						'</tr>' +
+						'<tr>' +
+							'<th>40</th>' +
+							'<td>41</td>' +
+							'<td>42</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>'
+			);
+
+			expectModel(
+				'<table headingColumns="1">' +
+					'<tableRow>' +
+						'<tableCell><paragraph>00</paragraph></tableCell>' +
+						'<tableCell><paragraph>01</paragraph></tableCell>' +
+						'<tableCell><paragraph>02</paragraph></tableCell>' +
+					'</tableRow>' +
+					'<tableRow>' +
+						'<tableCell><paragraph>10</paragraph></tableCell>' +
+						'<tableCell colspan="2" rowspan="3"><paragraph>11</paragraph></tableCell>' +
+					'</tableRow>' +
+					'<tableRow>' +
+						'<tableCell><paragraph>20</paragraph></tableCell>' +
+					'</tableRow>' +
+					'<tableRow>' +
+						'<tableCell><paragraph>30</paragraph></tableCell>' +
+					'</tableRow>' +
+					'<tableRow>' +
+						'<tableCell><paragraph>40</paragraph></tableCell>' +
+						'<tableCell><paragraph>41</paragraph></tableCell>' +
+						'<tableCell><paragraph>42</paragraph></tableCell>' +
 					'</tableRow>' +
 				'</table>'
 			);

--- a/packages/ckeditor5-table/tests/converters/upcasttable.js
+++ b/packages/ckeditor5-table/tests/converters/upcasttable.js
@@ -562,7 +562,7 @@ describe( 'upcastTable()', () => {
 	} );
 
 	describe( 'headingRows', () => {
-		it( 'should be able to detect heding row in 2x2 table', () => {
+		it( 'should be able to detect heading row in 2x2 table', () => {
 			editor.setData(
 				'<table>' +
 					'<tr>' +
@@ -590,7 +590,7 @@ describe( 'upcastTable()', () => {
 			);
 		} );
 
-		it( 'should be able to detect heding row in table with caption', () => {
+		it( 'should be able to detect heading row in table with caption', () => {
 			editor.setData(
 				'<table>' +
 					'<caption>Concerts</caption>' +
@@ -645,7 +645,7 @@ describe( 'upcastTable()', () => {
 			);
 		} );
 
-		it( 'should be able to detect heding row in 2x1 table', () => {
+		it( 'should be able to detect heading row in 2x1 table', () => {
 			editor.setData(
 				'<table>' +
 					'<tbody>' +
@@ -671,7 +671,7 @@ describe( 'upcastTable()', () => {
 			);
 		} );
 
-		it( 'should be able to detect heding row that has colspan', () => {
+		it( 'should be able to detect heading row that has colspan', () => {
 			editor.setData(
 				'<table>' +
 					'<tbody>' +
@@ -696,6 +696,54 @@ describe( 'upcastTable()', () => {
 						'<tableCell><paragraph>Data</paragraph></tableCell>' +
 						'<tableCell><paragraph>Data</paragraph></tableCell>' +
 						'<tableCell><paragraph>Data</paragraph></tableCell>' +
+					'</tableRow>' +
+				'</table>'
+			);
+		} );
+
+		it( 'should not treat the row containing only th as a heading row if it follows colspan', () => {
+			editor.setData(
+				'<table>' +
+					'<tbody>' +
+						'<tr>' +
+							'<th>00</th>' +
+							'<td>01</td>' +
+							'<td>02</td>' +
+						'</tr>' +
+						'<tr>' +
+							'<th>10</th>' +
+							'<td colspan="2" rowspan="2">11</td>' +
+						'</tr>' +
+						'<tr>' +
+							'<th>20</th>' +
+						'</tr>' +
+						'<tr>' +
+							'<th>30</th>' +
+							'<td>31</td>' +
+							'<td>32</td>' +
+						'</tr>' +
+					'</tbody>' +
+				'</table>'
+			);
+
+			expectModel(
+				'<table headingColumns="1">' +
+					'<tableRow>' +
+						'<tableCell><paragraph>00</paragraph></tableCell>' +
+						'<tableCell><paragraph>01</paragraph></tableCell>' +
+						'<tableCell><paragraph>02</paragraph></tableCell>' +
+					'</tableRow>' +
+					'<tableRow>' +
+						'<tableCell><paragraph>10</paragraph></tableCell>' +
+						'<tableCell colspan="2" rowspan="2"><paragraph>11</paragraph></tableCell>' +
+					'</tableRow>' +
+					'<tableRow>' +
+						'<tableCell><paragraph>20</paragraph></tableCell>' +
+					'</tableRow>' +
+					'<tableRow>' +
+						'<tableCell><paragraph>30</paragraph></tableCell>' +
+						'<tableCell><paragraph>31</paragraph></tableCell>' +
+						'<tableCell><paragraph>32</paragraph></tableCell>' +
 					'</tableRow>' +
 				'</table>'
 			);


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (table): Prevent table corruption when setting editor data with `th` cells following `colspan` rows. Closes #17556, #17404

---

### Additional information

Our table upcasting does not recognize colspans correctly during calculation of the header rows. This PR ensures that rows that follow the rows with colspans are not longer used as table headings.

<details>
   <summary>Check this HTML</summary>
   
   ```html
   	<figure class="table">
		<table>
			<tbody>
				<tr>
					<th>&nbsp;</th>
					<td colspan="2" rowspan="2">&nbsp;</td>
				</tr>
				<tr>
					<th>&nbsp;</th>
				</tr>
				<tr>
					<th>&nbsp;</th>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
				</tr>
			</tbody>
		</table>
	</figure>
	<figure class="table">
		<table>
			<tbody>
				<tr>
					<th>&nbsp;</th>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
				</tr>
				<tr>
					<th>&nbsp;</th>
					<td colspan="2" rowspan="2">&nbsp;</td>
				</tr>
				<tr>
					<th>&nbsp;</th>
				</tr>
				<tr>
					<th>&nbsp;</th>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
				</tr>
			</tbody>
		</table>
	</figure>
	<figure class="table">
		<table>
			<tbody>
				<tr>
					<th>&nbsp;</th>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
				</tr>
				<tr>
					<th>&nbsp;</th>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
				</tr>
				<tr>
					<th>&nbsp;</th>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
				</tr>
				<tr>
					<th>&nbsp;</th>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
				</tr>
				<tr>
					<th>&nbsp;</th>
					<td colspan="2" rowspan="2">&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
				</tr>
				<tr>
					<th>&nbsp;</th>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
				</tr>
				<tr>
					<th>&nbsp;</th>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
				</tr>
				<tr>
					<th>&nbsp;</th>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
					<td>&nbsp;</td>
				</tr>
			</tbody>
		</table>
	</figure>
   ```
</details> 

#### Before

![obraz](https://github.com/user-attachments/assets/000a4107-d1bf-4d22-b4ad-0a026149131f)

#### After

![obraz](https://github.com/user-attachments/assets/6d522f5a-e253-4189-9cab-ffbbc2ad16d0)
