### PR TITLE
Docs: Add `licenseKeys` to all editor code examples in crash course

### DIFF
--- a/docs/tutorials/crash-course/editor.md
+++ b/docs/tutorials/crash-course/editor.md
@@ -46,7 +46,9 @@ import 'ckeditor5/ckeditor5.css';
 const element = document.querySelector( '#app' );
 
 // Instantiate the editor using the `create` method.
-const editor = await ClassicEditor.create( element );
+const editor = await ClassicEditor.create( element, {
+	licenseKey: 'GPL' // Or '<YOUR_LICENSE_KEY>'.
+} );
 ```
 
 As you can see, the {@link module:core/editor/editor~Editor.create `create()`} method creates a new editor instance. It replaces the DOM element passed as the first argument with the editor UI, and sets the initial state of the editor to the content of that DOM element.
@@ -63,6 +65,7 @@ import { Essentials, Paragraph } from 'ckeditor5';
 
 // Update the call to the `create()` method.
 const editor = await ClassicEditor.create( element, {
+	licenseKey: 'GPL', // Or '<YOUR_LICENSE_KEY>'.
 	plugins: [
 		Essentials,
 		Paragraph

--- a/docs/tutorials/crash-course/plugin-configuration.md
+++ b/docs/tutorials/crash-course/plugin-configuration.md
@@ -16,6 +16,7 @@ In this tutorial, we will add a single option to the `highlight` plugin to confi
 
 ```js
 const editor = await ClassicEditor.create( element, {
+	licenseKey: 'GPL', // Or '<YOUR_LICENSE_KEY>'.
 	// Other options are omitted for readability - do not remove them.
 	highlight: {
 
@@ -71,6 +72,7 @@ Then, open the `src/main.js` file and update the editor's configuration to chang
 
 ```js
 const editor = await ClassicEditor.create( element, {
+	licenseKey: 'GPL', // Or '<YOUR_LICENSE_KEY>'.
 	// Other options are omitted for readability - do not remove them.
 	highlight: {
 		keystroke: 'Ctrl+Alt+9'

--- a/docs/tutorials/crash-course/plugins.md
+++ b/docs/tutorials/crash-course/plugins.md
@@ -16,6 +16,7 @@ In the previous chapter of this tutorial, we learned that the editor is just an 
 import { Essentials, Paragraph } from 'ckeditor5';
 
 const editor = await ClassicEditor.create( element, {
+	licenseKey: 'GPL', // Or '<YOUR_LICENSE_KEY>'.
 	plugins: [
 		Essentials,
 		Paragraph
@@ -69,6 +70,7 @@ Then, in the `src/main.js` file, import and register this function as an editor 
 import { Highlight } from './plugin';
 
 const editor = await ClassicEditor.create( element, {
+	licenseKey: 'GPL', // Or '<YOUR_LICENSE_KEY>'.
 	plugins: [
 		// Other plugins are omitted for readability - do not remove them.
 		Highlight


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Add `licenseKeys` to all editor code examples in crash course. Fixes #17634.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
