### PR TITLE
Internal: Use `import.meta.resolve` instead of `require.resolve`.

### DIFF
--- a/scripts/docs/utils.mjs
+++ b/scripts/docs/utils.mjs
@@ -5,14 +5,11 @@
 
 /* eslint-env node */
 
-import module from 'module';
 import path from 'path';
 import fs from 'fs/promises';
 import { glob } from 'glob';
 import { loaders } from '@ckeditor/ckeditor5-dev-utils';
 import { CKEDITOR5_ROOT_PATH } from '../constants.mjs';
-
-const require = module.createRequire( import.meta.url );
 
 /**
  * Returns array with plugin paths.
@@ -67,7 +64,7 @@ export function normalizePath( modulePath ) {
  */
 export function addTypeScriptLoader( webpackConfig, configFile ) {
 	const tsconfigPath = path.join( CKEDITOR5_ROOT_PATH, configFile );
-	const coreIndexFile = require.resolve( '@ckeditor/ckeditor5-core' );
+	const coreIndexFile = import.meta.resolve( '@ckeditor/ckeditor5-core' );
 
 	// Do not include it when processing CKEditor 5 installed as the JavaScript code.
 	if ( coreIndexFile.endsWith( '.ts' ) ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Use `import.meta.resolve` instead of `require.resolve`. Fixes #17671.

---

We've added the `exports` field to the `package.json` files with `types` and `import` fields, but no `require` because our packages are ESM-only. This is the reason for the `require.resolve` call fails.