### PR TITLE
Fixed properly closing brackets in styling table snippet.

### DIFF
--- a/packages/ckeditor5-table/docs/features/tables-styling.md
+++ b/packages/ckeditor5-table/docs/features/tables-styling.md
@@ -190,14 +190,14 @@ const tableConfig = {
 				width: '550px',
 				height: '450px'
 			},
-			// The default styles for table cells in the editor.
-			// They should be synchronized with the content styles.
+		},
+		// The default styles for table cells in the editor.
+		// They should be synchronized with the content styles.
 		tableCellProperties: {
 			defaultProperties: {
 				horizontalAlignment: 'center',
 				verticalAlignment: 'bottom',
 				padding: '10px'
-			}
 			}
 		}
 	}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Docs: Config snippet with setting the default table and table cell styles should work as expected.

---

### Additional information

:warning: _target: `stable` branch_