### PR TITLE
Add a condition for reenabling the page scroll when Dialog plugin is destroyed

### DIFF
--- a/packages/ckeditor5-ui/src/dialog/dialog.ts
+++ b/packages/ckeditor5-ui/src/dialog/dialog.ts
@@ -100,7 +100,9 @@ export default class Dialog extends Plugin {
 	public override destroy(): void {
 		super.destroy();
 
-		this._unlockBodyScroll();
+		if ( Dialog._visibleDialogPlugin === this ) {
+			this._unlockBodyScroll();
+		}
 	}
 
 	/**

--- a/packages/ckeditor5-ui/tests/dialog/dialog.js
+++ b/packages/ckeditor5-ui/tests/dialog/dialog.js
@@ -272,6 +272,24 @@ describe( 'Dialog', () => {
 
 			expect( document.documentElement.classList.contains( 'ck-dialog-scroll-locked' ) ).to.be.false;
 		} );
+
+		it( 'should not unlock scrolling on the document if modal was displayed by another plugin instance', () => {
+			const tempDialogPlugin = new Dialog( editor );
+
+			tempDialogPlugin._show( {
+				position: DialogViewPosition.EDITOR_CENTER,
+				isModal: true,
+				className: 'foo'
+			} );
+
+			expect( document.documentElement.classList.contains( 'ck-dialog-scroll-locked' ) ).to.be.true;
+
+			dialogPlugin.destroy();
+
+			expect( document.documentElement.classList.contains( 'ck-dialog-scroll-locked' ) ).to.be.true;
+
+			tempDialogPlugin.destroy();
+		} );
 	} );
 
 	describe( 'show()', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (ui): Destroying another editor instance while modal is open will no longer unlock page scroll. Closes #17585.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
