### PR TITLE
Fix: Add `default` to `exports` entries in `package.json` files.

### DIFF
--- a/scripts/release/utils/updatepackageentrypoint.mjs
+++ b/scripts/release/utils/updatepackageentrypoint.mjs
@@ -43,7 +43,11 @@ export default async function updatePackageEntryPoint( packagePath ) {
 			import: './dist/*',
 			default: './dist/*'
 		},
-		'./src/*': './src/*'
+		'./src/*': {
+			types: './src/*.d.ts',
+			import: './src/*',
+			default: './src/*'
+		}
 	};
 
 	if ( files.includes( 'build' ) ) {

--- a/scripts/release/utils/updatepackageentrypoint.mjs
+++ b/scripts/release/utils/updatepackageentrypoint.mjs
@@ -29,7 +29,8 @@ export default async function updatePackageEntryPoint( packagePath ) {
 	pkgJson.exports = {
 		'.': {
 			types: './' + types,
-			import: './' + main
+			import: './' + main,
+			default: './' + main
 		},
 		'./dist/*': {
 			/**
@@ -39,12 +40,10 @@ export default async function updatePackageEntryPoint( packagePath ) {
 			 * files will be moved to the `dist` directory.
 			 */
 			types: './' + types,
-			import: './dist/*'
+			import: './dist/*',
+			default: './dist/*'
 		},
-		'./src/*': {
-			types: './' + types,
-			import: './src/*'
-		}
+		'./src/*': './src/*'
 	};
 
 	if ( files.includes( 'build' ) ) {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Add `default` to `exports` entries in `package.json` files. Fixes #17671.

---

In a few places in our tools, we use `require` instead of `import` to get data from packages. Instead of fixing all of them and potentially introducing breaking changes, it's easier to add a fallback `default` entry to the `exports` field.
