### PR TITLE
Add punctuation support in auto-links.

### DIFF
--- a/packages/ckeditor5-link/tests/autolink.js
+++ b/packages/ckeditor5-link/tests/autolink.js
@@ -454,6 +454,16 @@ describe( 'AutoLink', () => {
 			sinon.assert.notCalled( spy );
 		} );
 
+		for ( const punctuation of '!.:,;?' ) {
+			it( `does not include "${ punctuation }" at the end of the link after space`, () => {
+				simulateTyping( `https://www.cksource.com${ punctuation } ` );
+
+				expect( getData( model ) ).to.equal(
+					`<paragraph><$text linkHref="https://www.cksource.com">https://www.cksource.com</$text>${ punctuation } []</paragraph>`
+				);
+			} );
+		}
+
 		// Some examples came from https://mathiasbynens.be/demo/url-regex.
 		describe( 'supported URL', () => {
 			const supportedURLs = [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (link): Trailing punctuation is no longer included in auto-linked URL. Closes https://github.com/ckeditor/ckeditor5/issues/14497

---

### Additional information

#### Before

https://github.com/user-attachments/assets/c3a9f78d-5a4d-4974-b0c0-178074c80866

#### After

https://github.com/user-attachments/assets/17327e56-b67c-4d78-8e47-c7913a74fb76


