### PR TITLE
No longer crash during `destroy()` of `MultiRootEditor` or `InlineEditor` when the editable was detached manually before destroying.

### DIFF
--- a/packages/ckeditor5-editor-balloon/tests/ballooneditorui.js
+++ b/packages/ckeditor5-editor-balloon/tests/ballooneditorui.js
@@ -189,6 +189,13 @@ describe( 'BalloonEditorUI', () => {
 
 			sinon.assert.callOrder( parentDestroySpy, viewDestroySpy );
 		} );
+
+		it( 'should not crash if called twice', async () => {
+			const newEditor = await VirtualBalloonTestEditor.create( '' );
+
+			await newEditor.destroy();
+			await newEditor.destroy();
+		} );
 	} );
 
 	describe( 'element()', () => {

--- a/packages/ckeditor5-editor-classic/tests/classiceditorui.js
+++ b/packages/ckeditor5-editor-classic/tests/classiceditorui.js
@@ -694,6 +694,13 @@ describe( 'ClassicEditorUI', () => {
 
 			sinon.assert.callOrder( parentDestroySpy, viewDestroySpy );
 		} );
+
+		it( 'should not crash if called twice', async () => {
+			const newEditor = await VirtualClassicTestEditor.create( '' );
+
+			await newEditor.destroy();
+			await newEditor.destroy(); // Should not throw.
+		} );
 	} );
 
 	describe( 'view()', () => {

--- a/packages/ckeditor5-editor-decoupled/tests/decouplededitorui.js
+++ b/packages/ckeditor5-editor-decoupled/tests/decouplededitorui.js
@@ -243,6 +243,13 @@ describe( 'DecoupledEditorUI', () => {
 
 			sinon.assert.callOrder( parentDestroySpy, viewDestroySpy );
 		} );
+
+		it( 'should not crash if called twice', async () => {
+			const newEditor = await VirtualDecoupledTestEditor.create( '' );
+
+			await newEditor.destroy();
+			await newEditor.destroy();
+		} );
 	} );
 
 	describe( 'element()', () => {

--- a/packages/ckeditor5-editor-inline/src/inlineeditorui.ts
+++ b/packages/ckeditor5-editor-inline/src/inlineeditorui.ts
@@ -114,7 +114,10 @@ export default class InlineEditorUI extends EditorUI {
 		const view = this.view;
 		const editingView = this.editor.editing.view;
 
-		editingView.detachDomRoot( view.editable.name! );
+		if ( editingView.getDomRoot( view.editable.name! ) ) {
+			editingView.detachDomRoot( view.editable.name! );
+		}
+
 		view.destroy();
 	}
 

--- a/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
@@ -337,6 +337,13 @@ describe( 'InlineEditorUI', () => {
 			await editor.destroy();
 			editor = null;
 		} );
+
+		it( 'should not crash if called twice', async () => {
+			const editor = VirtualInlineTestEditor.create( '' );
+
+			await editor.destroy();
+			await editor.destroy();
+		} );
 	} );
 
 	describe( 'element()', () => {

--- a/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
@@ -339,7 +339,7 @@ describe( 'InlineEditorUI', () => {
 		} );
 
 		it( 'should not crash if called twice', async () => {
-			const editor = VirtualInlineTestEditor.create( '' );
+			const editor = await VirtualInlineTestEditor.create( '' );
 
 			await editor.destroy();
 			await editor.destroy();

--- a/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
+++ b/packages/ckeditor5-editor-inline/tests/inlineeditorui.js
@@ -41,7 +41,9 @@ describe( 'InlineEditorUI', () => {
 	} );
 
 	afterEach( async () => {
-		await editor.destroy();
+		if ( editor ) {
+			await editor.destroy();
+		}
 	} );
 
 	describe( 'constructor()', () => {
@@ -327,6 +329,13 @@ describe( 'InlineEditorUI', () => {
 			await newEditor.destroy();
 
 			sinon.assert.callOrder( parentDestroySpy, viewDestroySpy );
+		} );
+
+		it( 'should not crash if the editable element is not present', async () => {
+			editor.editing.view.detachDomRoot( editor.ui.view.editable.name );
+
+			await editor.destroy();
+			editor = null;
 		} );
 	} );
 

--- a/packages/ckeditor5-editor-multi-root/src/multirooteditorui.ts
+++ b/packages/ckeditor5-editor-multi-root/src/multirooteditorui.ts
@@ -157,7 +157,12 @@ export default class MultiRootEditorUI extends EditorUI {
 	 * @param editable Editable to remove from the editor UI.
 	 */
 	public removeEditable( editable: InlineEditableUIView ): void {
-		this.editor.editing.view.detachDomRoot( editable.name! );
+		const editingView = this.editor.editing.view;
+
+		if ( editingView.getDomRoot( editable.name! ) ) {
+			editingView.detachDomRoot( editable.name! );
+		}
+
 		editable.unbind( 'isFocused' );
 		this.removeEditableElement( editable.name! );
 	}

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditorui.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditorui.js
@@ -439,5 +439,13 @@ describe( 'MultiRootEditorUI', () => {
 			// This should not throw
 			await newEditor.destroy();
 		} );
+
+		// Issue: https://github.com/ckeditor/ckeditor5/issues/16561
+		it( 'should not throw error when it was called twice', async () => {
+			const newEditor = await MultiRootEditor.create( { foo: '', bar: '' } );
+
+			await newEditor.destroy();
+			await newEditor.destroy(); // This should not throw
+		} );
 	} );
 } );

--- a/packages/ckeditor5-editor-multi-root/tests/multirooteditorui.js
+++ b/packages/ckeditor5-editor-multi-root/tests/multirooteditorui.js
@@ -423,5 +423,21 @@ describe( 'MultiRootEditorUI', () => {
 
 			sinon.assert.callOrder( parentDestroySpy, viewDestroySpy );
 		} );
+
+		// Some of integrations might detach the DOM editing view *before* destroying the editor.
+		// It happens quite often in the strict mode of the React integration. In such case, the editor
+		// component is being unmounted after editable component is detached from the DOM. In such scenario,
+		// the root doesn't contain the DOM editable anymore. This test ensures that the editor does not throw.
+		// Issue: https://github.com/ckeditor/ckeditor5/issues/16561
+		it( 'should not throw when trying to detach a DOM root that was not attached to editing view', async () => {
+			const newEditor = await MultiRootEditor.create( { foo: '', bar: '' } );
+			const editingView = newEditor.editing.view;
+
+			// Simulate unmounting the editable child component before the editor component.
+			editingView.detachDomRoot( 'foo' );
+
+			// This should not throw
+			await newEditor.destroy();
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (editor-inline, editor-multi-root):  No longer crash the editor during `destroy()` when the editable was manually detached before destroying. Closes https://github.com/ckeditor/ckeditor5/issues/16561

---

### Additional information

Some editor types check if elements exist before destroying, while others don't. Here's what works correctly:

https://github.com/ckeditor/ckeditor5/blob/ck/16561/packages/ckeditor5-editor-classic/src/classiceditorui.ts#L141-L143
https://github.com/ckeditor/ckeditor5/blob/ck/16561/packages/ckeditor5-editor-balloon/src/ballooneditorui.ts#L102-L104
https://github.com/ckeditor/ckeditor5/blob/ck/16561/packages/ckeditor5-editor-decoupled/src/decouplededitorui.ts#L96-L98

These editors don't have the checks yet:

https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-editor-inline/src/inlineeditorui.ts#L117-L119
https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-editor-multi-root/src/multirooteditorui.ts#L162-L164

This PR adds missing checks to fix crashes in React integration shown here:

1. https://github.com/ckeditor/ckeditor5-react/blob/474c8aa9c222b61ed86dad329e05beb92ede29a8/src/useMultiRootEditor.tsx#L64-L88
2. https://github.com/ckeditor/ckeditor5/issues/16561

tl;dr React integration removes editables from DOM just before destroying the editor in Strict Mode. This was causing the multiroot editor to crash.
