### PR TITLE
Do not attach refresh token interval if initialization of token failed in `init()` method of `CloudServices` plugin.

### DIFF
--- a/packages/ckeditor5-cloud-services/src/cloudservices.ts
+++ b/packages/ckeditor5-cloud-services/src/cloudservices.ts
@@ -101,11 +101,21 @@ export default class CloudServices extends ContextPlugin implements CloudService
 			return;
 		}
 
+		// Initialization of the token may fail. By default, the token is being refreshed on the failure.
+		// The problem is that if this happens here, then the token refresh interval will be executed even
+		// after destroying the editor (as the exception was thrown from `init` method). To prevent that
+		// behavior we need to catch the exception and destroy the uninitialized token instance.
+		// See: https://github.com/ckeditor/ckeditor5/issues/17531
 		const cloudServicesCore: CloudServicesCore = this.context.plugins.get( 'CloudServicesCore' );
+		const uninitializedToken = cloudServicesCore.createToken( this.tokenUrl );
 
-		this.token = await cloudServicesCore.createToken( this.tokenUrl ).init();
-
-		this._tokens.set( this.tokenUrl, this.token );
+		try {
+			this.token = await uninitializedToken.init();
+			this._tokens.set( this.tokenUrl, this.token );
+		} catch ( error ) {
+			uninitializedToken.destroy();
+			throw error;
+		}
 	}
 
 	/**

--- a/packages/ckeditor5-cloud-services/tests/cloudservices.js
+++ b/packages/ckeditor5-cloud-services/tests/cloudservices.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-licensing-options
  */
 
-/* global document */
+/* global document, console */
 
 import CloudServices from '../src/cloudservices.js';
 import CloudServicesCore from '../src/cloudservicescore.js';
@@ -169,6 +169,35 @@ describe( 'CloudServices', () => {
 
 					return context.destroy();
 				} );
+		} );
+
+		it( 'if token url crashes, then it should not create infinity loop of requests after destroy of the editor', async () => {
+			const clock = sinon.useFakeTimers();
+
+			sinon.stub( console, 'warn' );
+
+			const tokenUrlStub = sinon.stub().rejects( new Error( 'Token URL crashed' ) );
+
+			try {
+				await Context.create( {
+					plugins: [ CloudServices ],
+					cloudServices: {
+						tokenUrl: tokenUrlStub
+					}
+				} );
+
+				expect.fail( 'Context.create should reject' );
+			} catch ( error ) {
+				expect( error.message ).to.equal( 'Token URL crashed' );
+			}
+
+			expect( tokenUrlStub ).to.be.calledOnce;
+
+			clock.tick( 17000 );
+			clock.restore();
+
+			// Editor was destroyed at this moment, so no more requests should be made.
+			expect( tokenUrlStub ).to.be.calledOnce;
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (cloud-services): No longer keep refreshing token if `tokenUrl` method failed in the initialization of the plugin. Closes https://github.com/ckeditor/ckeditor5/issues/17531

---

### Additional information

Related to https://github.com/ckeditor/ckeditor5/issues/17462. 

The `init` method of the `Token` tries to initialize the token, but if the first initialization fails (that one in `init` of `cloud-services`) it keeps the refresh interval running after destroying of the editor. The editor was destroyed because `Token.init` throws exception directly in `cloud-services` init method (which leads to editor crash). 
