### PR TITLE
Prevent bookmark popup flickering when clicking paragraphs with trailing bookmarks.

### DIFF
--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-bookmark/bookmark.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-bookmark/bookmark.css
@@ -12,6 +12,7 @@
 
 .ck-bookmark {
 	&.ck-widget {
+		display: inline-block;
 		outline: none;
 
 		& .ck-bookmark__icon .ck-icon__fill {

--- a/packages/ckeditor5-theme-lark/theme/ckeditor5-bookmark/bookmark.css
+++ b/packages/ckeditor5-theme-lark/theme/ckeditor5-bookmark/bookmark.css
@@ -38,6 +38,7 @@
 
 		& .ck-bookmark__icon {
 			position: relative;
+			display: block;
 			/* To make it align with text baseline. */
 			top: -0.1em;
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (bookmark): Prevent bookmark popup flickering when clicking paragraphs with trailing bookmarks.

---

### Additional information

When a widget (e.g., a bookmark anchor) is clicked, two consecutive `update` events may fire:

1. First, when the widget gets focused (this is fine)
3. Second, when the selection changes shortly after (beware, dragons live here)

While the widget usually stays selected, sometimes the selection may move to a different element (e.g., to the start of the parent paragraph). This can cause the toolbar to flicker as it's quickly shown and hidden.

This issue particularly affects widgets like anchors that contain a single SVG element. 

Making the element `inline-block` seems to reduce flickering. 

#### Before

https://github.com/user-attachments/assets/c931542c-fe3a-439a-9cf8-2070355d72a9

#### After

https://github.com/user-attachments/assets/7200e9b3-e3c6-4222-be14-fed75f83254e




