### PR TITLE
Remove tooltip from `insert` / `update` link form save button. 

### DIFF
--- a/packages/ckeditor5-link/src/ui/linkformview.ts
+++ b/packages/ckeditor5-link/src/ui/linkformview.ts
@@ -272,7 +272,7 @@ export default class LinkFormView extends View {
 
 		saveButton.set( {
 			label: t( 'Insert' ),
-			tooltip: true,
+			tooltip: false,
 			withText: true,
 			type: 'submit',
 			class: 'ck-button-action ck-button-bold'

--- a/packages/ckeditor5-link/tests/ui/linkformview.js
+++ b/packages/ckeditor5-link/tests/ui/linkformview.js
@@ -104,6 +104,10 @@ describe( 'LinkFormView', () => {
 				expect( secondFormRow.template.children[ 0 ].get( 1 ) ).to.equal( view.saveButtonView );
 			} );
 
+			it( 'should `saveButtonView` has no tooltip', () => {
+				expect( view.saveButtonView.tooltip ).to.be.false;
+			} );
+
 			it( 'should `backButtonView` has correct label', () => {
 				const headerChildren = view.template.children[ 0 ].get( 0 ).template.children[ 0 ];
 				const backButton = headerChildren.get( 0 );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (link): Remove tooltip from save button in link form view. 

---

### Additional information

Incorrect tooltip:

![obraz](https://github.com/user-attachments/assets/3e7e864d-d548-4ded-b88c-e67e18ad3bb5)