### PR TITLE
Storing selected emoji category in state so that it is restored when emoji picker is reopened.

### DIFF
--- a/packages/ckeditor5-emoji/src/emojipicker.ts
+++ b/packages/ckeditor5-emoji/src/emojipicker.ts
@@ -8,7 +8,7 @@
  */
 
 import '../theme/emojipicker.css';
-import type { Locale } from 'ckeditor5/src/utils.js';
+import type { Locale, ObservableChangeEvent } from 'ckeditor5/src/utils.js';
 import { Database } from 'emoji-picker-element';
 import { icons, Plugin, type Editor } from 'ckeditor5/src/core.js';
 import { Typing } from 'ckeditor5/src/typing.js';
@@ -56,6 +56,8 @@ export default class EmojiPicker extends Plugin {
 
 	private _emojiDatabase: Database;
 
+	private _currentCategoryName: string;
+
 	/**
 	 * @inheritDoc
 	 */
@@ -89,6 +91,7 @@ export default class EmojiPicker extends Plugin {
 		this._selectedSkinTone = 0;
 		this._searchQuery = null;
 		this._emojiDatabase = new Database();
+		this._currentCategoryName = '';
 	}
 
 	/**
@@ -124,6 +127,8 @@ export default class EmojiPicker extends Plugin {
 			this._getEmojiGroup( { databaseId: 8, title: 'Symbols', exampleEmoji: '🟢' } ),
 			this._getEmojiGroup( { databaseId: 9, title: 'Flags', exampleEmoji: '🏁' } )
 		] );
+
+		this._currentCategoryName = this._emojiGroups[ 0 ].title;
 
 		// Renders a fake visual selection marker on an expanded selection.
 		editor.conversion.for( 'editingDowncast' ).markerToHighlight( {
@@ -186,7 +191,7 @@ export default class EmojiPicker extends Plugin {
 	private _createDropdownPanelContent( locale: Locale ): DropdownPanelContent {
 		const searchView = new EmojiSearchView( locale );
 		const toneView = new EmojiToneView( locale, this._selectedSkinTone );
-		const categoriesView = new EmojiCategoriesView( locale, this._emojiGroups );
+		const categoriesView = new EmojiCategoriesView( locale, this._emojiGroups, this._currentCategoryName );
 		const gridView = new EmojiGridView( locale );
 		const infoView = new EmojiInfoView( locale );
 
@@ -213,7 +218,8 @@ export default class EmojiPicker extends Plugin {
 		} );
 
 		// Update the grid of emojis when selected category changes.
-		categoriesView.on( 'change:currentCategoryName', () => {
+		categoriesView.on<ObservableChangeEvent<string>>( 'change:currentCategoryName', ( ev, args, categoryName ) => {
+			this._currentCategoryName = categoryName;
 			this._updateGrid( dropdownPanelContent );
 		} );
 
@@ -245,7 +251,7 @@ export default class EmojiPicker extends Plugin {
 		gridView.tiles.clear();
 
 		if ( !this._searchQuery || this._searchQuery.length < 2 ) {
-			const emojisForCategory = this._getEmojisForCategory( categoriesView.currentCategoryName );
+			const emojisForCategory = this._getEmojisForCategory( this._currentCategoryName );
 
 			this._addTilesToGrid( gridView, emojisForCategory );
 			categoriesView.enableCategories();

--- a/packages/ckeditor5-emoji/src/ui/emojicategoriesview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojicategoriesview.ts
@@ -35,17 +35,15 @@ export default class EmojiCategoriesView extends View {
 	 */
 	private readonly _keystrokeHandler: KeystrokeHandler;
 
-	private _categoryNames: Array<string>;
 	private _buttonViews: ViewCollection<ButtonView>;
 
 	/**
 	 * @inheritDoc
 	 */
-	constructor( locale: Locale, emojiGroups: Array<EmojiGroup> ) {
+	constructor( locale: Locale, emojiGroups: Array<EmojiGroup>, categoryName: string ) {
 		super( locale );
 
-		this._categoryNames = emojiGroups.map( emojiGroup => emojiGroup.title );
-		this.set( 'currentCategoryName', this._categoryNames[ 0 ] );
+		this.set( 'currentCategoryName', categoryName );
 
 		this._buttonViews = new ViewCollection( emojiGroups.map( emojiGroup => {
 			const buttonView = new ButtonView();

--- a/packages/ckeditor5-emoji/tests/emojipicker.js
+++ b/packages/ckeditor5-emoji/tests/emojipicker.js
@@ -150,7 +150,7 @@ describe( 'EmojiPicker', () => {
 		expect( originalFirstEmojiInGridTitle ).to.not.equal( newFirstEmojiInGridTitle );
 	} );
 
-	it( 'should store the category when the picker is closed', async () => {
+	it( 'should load previous category after reopening the emoji picker', async () => {
 		clickEmojiToolbarButton();
 
 		const secondCategoryButton = document.querySelectorAll( '.ck-emoji-categories > button' )[ 1 ];

--- a/packages/ckeditor5-emoji/tests/emojipicker.js
+++ b/packages/ckeditor5-emoji/tests/emojipicker.js
@@ -150,6 +150,25 @@ describe( 'EmojiPicker', () => {
 		expect( originalFirstEmojiInGridTitle ).to.not.equal( newFirstEmojiInGridTitle );
 	} );
 
+	it( 'should store the category when the picker is closed', async () => {
+		clickEmojiToolbarButton();
+
+		const secondCategoryButton = document.querySelectorAll( '.ck-emoji-categories > button' )[ 1 ];
+		secondCategoryButton.click();
+
+		// Wait for the emojis to load.
+		await new Promise( resolve => setTimeout( resolve, 250 ) );
+
+		// Close the emoji picker.
+		document.body.dispatchEvent( new Event( 'mousedown', { bubbles: true } ) );
+
+		clickEmojiToolbarButton();
+
+		const secondCategoryButtonAfterReopen = document.querySelectorAll( '.ck-emoji-categories > button' )[ 1 ];
+
+		expect( [ ...secondCategoryButtonAfterReopen.classList ] ).to.include( 'ck-active-category' );
+	} );
+
 	it( 'should update the grid when skin tone changes', async () => {
 		clickEmojiToolbarButton();
 

--- a/packages/ckeditor5-emoji/tests/ui/emojicategoriesview.js
+++ b/packages/ckeditor5-emoji/tests/ui/emojicategoriesview.js
@@ -28,7 +28,7 @@ describe( 'EmojiCategoriesView', () => {
 			exampleEmoji: '📕'
 		} ];
 
-		emojiCategoriesView = new EmojiCategoriesView( locale, emojiGroups );
+		emojiCategoriesView = new EmojiCategoriesView( locale, emojiGroups, 'faces' );
 		emojiCategoriesView.render();
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Storing selected emoji category in state so that it is restored when emoji picker is reopened. Closes #17657.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
