### PR TITLE
Make link toolbar button enabled when text above and link are selected.

### DIFF
--- a/packages/ckeditor5-engine/tests/model/documentselection.js
+++ b/packages/ckeditor5-engine/tests/model/documentselection.js
@@ -1130,12 +1130,15 @@ describe( 'DocumentSelection', () => {
 			it( 'if selection is a range, should find first character in it and copy it\'s attributes', () => {
 				selection._setTo( [ new Range( new Position( root, [ 2 ] ), new Position( root, [ 5 ] ) ) ] );
 
-				expect( Array.from( selection.getAttributes() ) ).to.deep.equal( [ [ 'b', true ] ] );
+				expect( Array.from( selection.getAttributes() ) ).to.deep.equal( [
+					[ 'b', true ],
+					[ 'c', true ]
+				] );
 
 				// Step into elements when looking for first character:
 				selection._setTo( [ new Range( new Position( root, [ 5 ] ), new Position( root, [ 7 ] ) ) ] );
 
-				expect( Array.from( selection.getAttributes() ) ).to.deep.equal( [ [ 'd', true ] ] );
+				expect( Array.from( selection.getAttributes() ) ).to.deep.equal( [] );
 			} );
 
 			it( 'if selection is collapsed it should seek a character to copy that character\'s attributes', () => {
@@ -1247,10 +1250,10 @@ describe( 'DocumentSelection', () => {
 				expect( selection.getAttribute( 'bold' ) ).to.equal( true );
 			} );
 
-			it( 'stops reading attributes if selection starts with an object', () => {
+			it( 'should not stop reading attributes if selection starts with an object', () => {
 				setData( model, '<p>[<imageBlock></imageBlock><$text bold="true">bar]</$text></p>' );
 
-				expect( selection.hasAttribute( 'bold' ) ).to.equal( false );
+				expect( selection.hasAttribute( 'bold' ) ).to.equal( true );
 			} );
 		} );
 

--- a/packages/ckeditor5-engine/tests/model/documentselection.js
+++ b/packages/ckeditor5-engine/tests/model/documentselection.js
@@ -1135,7 +1135,7 @@ describe( 'DocumentSelection', () => {
 				// Step into elements when looking for first character:
 				selection._setTo( [ new Range( new Position( root, [ 5 ] ), new Position( root, [ 7 ] ) ) ] );
 
-				expect( Array.from( selection.getAttributes() ) ).to.deep.equal( [ [ 'd', true ] ] );
+				expect( Array.from( selection.getAttributes() ) ).to.deep.equal( [] );
 			} );
 
 			it( 'if selection is collapsed it should seek a character to copy that character\'s attributes', () => {

--- a/packages/ckeditor5-engine/tests/model/documentselection.js
+++ b/packages/ckeditor5-engine/tests/model/documentselection.js
@@ -1130,15 +1130,12 @@ describe( 'DocumentSelection', () => {
 			it( 'if selection is a range, should find first character in it and copy it\'s attributes', () => {
 				selection._setTo( [ new Range( new Position( root, [ 2 ] ), new Position( root, [ 5 ] ) ) ] );
 
-				expect( Array.from( selection.getAttributes() ) ).to.deep.equal( [
-					[ 'b', true ],
-					[ 'c', true ]
-				] );
+				expect( Array.from( selection.getAttributes() ) ).to.deep.equal( [ [ 'b', true ] ] );
 
 				// Step into elements when looking for first character:
 				selection._setTo( [ new Range( new Position( root, [ 5 ] ), new Position( root, [ 7 ] ) ) ] );
 
-				expect( Array.from( selection.getAttributes() ) ).to.deep.equal( [] );
+				expect( Array.from( selection.getAttributes() ) ).to.deep.equal( [ [ 'd', true ] ] );
 			} );
 
 			it( 'if selection is collapsed it should seek a character to copy that character\'s attributes', () => {

--- a/packages/ckeditor5-link/src/linkcommand.ts
+++ b/packages/ckeditor5-link/src/linkcommand.ts
@@ -10,7 +10,7 @@
 import { Command } from 'ckeditor5/src/core.js';
 import { findAttributeRange } from 'ckeditor5/src/typing.js';
 import { Collection, diff, first, toMap } from 'ckeditor5/src/utils.js';
-import { LivePosition, type Range, type Item, type Model, type DocumentSelection } from 'ckeditor5/src/engine.js';
+import { LivePosition, type Range, type Item } from 'ckeditor5/src/engine.js';
 
 import AutomaticDecorators from './utils/automaticdecorators.js';
 import { extractTextFromLinkRange, isLinkableElement } from './utils.js';
@@ -65,9 +65,7 @@ export default class LinkCommand extends Command {
 			this.value = selectedElement.getAttribute( 'linkHref' ) as string | undefined;
 			this.isEnabled = model.schema.checkAttribute( selectedElement, 'linkHref' );
 		} else {
-			const selectionHref = selection.getAttribute( 'linkHref' ) || getLinkHrefFromSelectionItems( model, selection );
-
-			this.value = selectionHref as string | undefined;
+			this.value = selection.getAttribute( 'linkHref' ) as string | undefined;
 			this.isEnabled = model.schema.checkAttributeInSelection( selection, 'linkHref' );
 		}
 
@@ -387,29 +385,6 @@ export default class LinkCommand extends Command {
 
 		return true;
 	}
-}
-
-/**
-* Retrieves the 'linkHref' attribute from the first item in the selection that has this attribute.
-*
-* @param model - The data model in which the selection exists.
-* @param selection - The document selection from which to retrieve the 'linkHref' attribute.
-* @returns The 'linkHref' attribute value if found, otherwise `undefined`.
-*/
-function getLinkHrefFromSelectionItems( model: Model, selection: DocumentSelection ): string | undefined {
-	const validRanges = model.schema.getValidRanges( selection.getRanges(), 'linkHref' );
-
-	for ( const range of validRanges ) {
-		const walker = range.getWalker( { shallow: true } );
-
-		for ( const { item } of walker ) {
-			if ( item.hasAttribute( 'linkHref' ) ) {
-				return item.getAttribute( 'linkHref' ) as string | undefined;
-			}
-		}
-	}
-
-	return undefined;
 }
 
 /**

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -331,7 +331,7 @@ describe( 'LinkCommand', () => {
 			it( 'should overwrite existing `linkHref` attribute when selected text wraps text with `linkHref` attribute', () => {
 				setData( model, 'f[o<$text linkHref="other url">o</$text>ba]r' );
 
-				expect( command.value ).to.be.equal( 'other url' );
+				expect( command.value ).to.be.undefined;
 
 				command.execute( 'url' );
 

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -207,10 +207,10 @@ describe( 'LinkCommand', () => {
 				expect( command.value ).to.equal( 'url' );
 			} );
 
-			it( 'should be undefined when selection contains not only elements with `linkHref` attribute', () => {
+			it( 'should not be undefined when selection contains not only elements with `linkHref` attribute', () => {
 				setData( model, 'f[o<$text linkHref="url">ob</$text>]ar' );
 
-				expect( command.value ).to.be.undefined;
+				expect( command.value ).to.equal( 'url' );
 			} );
 		} );
 
@@ -331,7 +331,7 @@ describe( 'LinkCommand', () => {
 			it( 'should overwrite existing `linkHref` attribute when selected text wraps text with `linkHref` attribute', () => {
 				setData( model, 'f[o<$text linkHref="other url">o</$text>ba]r' );
 
-				expect( command.value ).to.be.undefined;
+				expect( command.value ).to.be.equal( 'other url' );
 
 				command.execute( 'url' );
 
@@ -373,7 +373,7 @@ describe( 'LinkCommand', () => {
 				'attribute', () => {
 				setData( model, 'f[o<$text linkHref="other url">ob]a</$text>r' );
 
-				expect( command.value ).to.be.undefined;
+				expect( command.value ).to.be.equal( 'other url' );
 
 				command.execute( 'url' );
 

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -207,7 +207,7 @@ describe( 'LinkCommand', () => {
 				expect( command.value ).to.equal( 'url' );
 			} );
 
-			it( 'should not be undefined when selection contains not only elements with `linkHref` attribute', () => {
+			it( 'should be undefined when selection contains not only elements with `linkHref` attribute', () => {
 				setData( model, 'f[o<$text linkHref="url">ob</$text>]ar' );
 
 				expect( command.value ).to.equal( 'url' );

--- a/packages/ckeditor5-link/tests/linkcommand.js
+++ b/packages/ckeditor5-link/tests/linkcommand.js
@@ -331,7 +331,7 @@ describe( 'LinkCommand', () => {
 			it( 'should overwrite existing `linkHref` attribute when selected text wraps text with `linkHref` attribute', () => {
 				setData( model, 'f[o<$text linkHref="other url">o</$text>ba]r' );
 
-				expect( command.value ).to.be.undefined;
+				expect( command.value ).to.be.equal( 'other url' );
 
 				command.execute( 'url' );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Fix (link):  The `Link` toolbar button should now be enabled when the selection starts at a non-link element and ends at the end of a link. Closes #16965

---

### Additional information

#### Before

https://github.com/user-attachments/assets/e85d4e2c-dfc1-4a00-9050-c8e429d964b7

#### After

https://github.com/user-attachments/assets/e7363195-5b4b-4b85-b0f4-e4612cb18aa1


