### PR TITLE
Add `sourceEditorId` property to clipboard input events.

### DIFF
--- a/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
@@ -443,7 +443,7 @@ export interface ClipboardContentInsertionData {
 	method: 'paste' | 'drop';
 
 	/**
-	 * ID of the editor instance from which the content was copied.
+	 * The ID of the editor instance from which the content was copied.
 	 */
 	sourceEditorId: string | null;
 

--- a/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
+++ b/packages/ckeditor5-clipboard/src/clipboardpipeline.ts
@@ -236,10 +236,12 @@ export default class ClipboardPipeline extends Plugin {
 			}
 
 			const eventInfo = new EventInfo( this, 'inputTransformation' );
+			const sourceEditorId = dataTransfer.getData( 'application/ckeditor5-editor-id' ) || null;
 
 			this.fire<ClipboardInputTransformationEvent>( eventInfo, {
 				content,
 				dataTransfer,
+				sourceEditorId,
 				targetRanges: data.targetRanges,
 				method: data.method as 'paste' | 'drop'
 			} );
@@ -278,6 +280,7 @@ export default class ClipboardPipeline extends Plugin {
 				this.fire<ClipboardContentInsertionEvent>( 'contentInsertion', {
 					content: modelFragment,
 					method: data.method,
+					sourceEditorId: data.sourceEditorId,
 					dataTransfer: data.dataTransfer,
 					targetRanges: data.targetRanges
 				} );
@@ -331,6 +334,7 @@ export default class ClipboardPipeline extends Plugin {
 			if ( !data.content.isEmpty ) {
 				data.dataTransfer.setData( 'text/html', this.editor.data.htmlProcessor.toData( data.content ) );
 				data.dataTransfer.setData( 'text/plain', viewToPlainText( editor.data.htmlProcessor.domConverter, data.content ) );
+				data.dataTransfer.setData( 'application/ckeditor5-editor-id', this.editor.id );
 			}
 
 			if ( data.method == 'cut' ) {
@@ -389,6 +393,11 @@ export interface ClipboardInputTransformationData {
 	 * Whether the event was triggered by a paste or a drop operation.
 	 */
 	method: 'paste' | 'drop';
+
+	/**
+	 * ID of the editor instance from which the content was copied.
+	 */
+	sourceEditorId: string | null;
 }
 
 /**
@@ -432,6 +441,11 @@ export interface ClipboardContentInsertionData {
 	 * Whether the event was triggered by a paste or a drop operation.
 	 */
 	method: 'paste' | 'drop';
+
+	/**
+	 * ID of the editor instance from which the content was copied.
+	 */
+	sourceEditorId: string | null;
 
 	/**
 	 * The data transfer instance.

--- a/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
@@ -507,7 +507,7 @@ describe( 'ClipboardPipeline feature', () => {
 				sinon.assert.calledWith( spy, editor.id );
 			} );
 
-			it( 'should contain editor ID when pasting content copied from the same editor', () => {
+			it( 'should contain an editor ID when pasting content copied from the same editor', () => {
 				const spy = sinon.spy();
 
 				setModelData( editor.model, '<paragraph>f[oo]bar</paragraph>' );

--- a/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
@@ -480,7 +480,7 @@ describe( 'ClipboardPipeline feature', () => {
 				sinon.assert.calledWith( inputTransformationSpy, null );
 			} );
 
-			it( 'should contain editor ID when pasting content copied from the same editor (in dataTransfer)', () => {
+			it( 'should contain an editor ID when pasting content copied from the same editor (in dataTransfer)', () => {
 				const spy = sinon.spy();
 
 				setModelData( editor.model, '<paragraph>f[oo]bar</paragraph>' );

--- a/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
@@ -534,7 +534,7 @@ describe( 'ClipboardPipeline feature', () => {
 				sinon.assert.calledWith( spy, editor.id );
 			} );
 
-			it( 'should be propagated to contentInsertion event', () => {
+			it( 'should be propagated to contentInsertion event (when it\'s external content)', () => {
 				const dataTransferMock = createDataTransfer( { 'text/html': '<p>external content</p>' } );
 				const contentInsertionSpy = sinon.spy();
 
@@ -549,6 +549,27 @@ describe( 'ClipboardPipeline feature', () => {
 				} );
 
 				sinon.assert.calledWith( contentInsertionSpy, null );
+			} );
+
+			it( 'should be propagated to contentInsertion event (when it\'s internal content)', () => {
+				const dataTransferMock = createDataTransfer( {
+					'text/html': '<p>internal content</p>',
+					'application/ckeditor5-editor-id': editor.id
+				} );
+
+				const contentInsertionSpy = sinon.spy();
+
+				clipboardPlugin.on( 'contentInsertion', ( evt, data ) => {
+					contentInsertionSpy( data.sourceEditorId );
+				} );
+
+				viewDocument.fire( 'paste', {
+					dataTransfer: dataTransferMock,
+					preventDefault: () => {},
+					stopPropagation: () => {}
+				} );
+
+				sinon.assert.calledWith( contentInsertionSpy, editor.id );
 			} );
 		} );
 

--- a/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
+++ b/packages/ckeditor5-clipboard/tests/clipboardpipeline.js
@@ -462,10 +462,105 @@ describe( 'ClipboardPipeline feature', () => {
 			expect( spy.callCount ).to.equal( 1 );
 		} );
 
+		describe( 'source editor ID in events', () => {
+			it( 'should be null when pasting content from outside the editor', () => {
+				const dataTransferMock = createDataTransfer( { 'text/html': '<p>external content</p>' } );
+				const inputTransformationSpy = sinon.spy();
+
+				clipboardPlugin.on( 'inputTransformation', ( evt, data ) => {
+					inputTransformationSpy( data.sourceEditorId );
+				} );
+
+				viewDocument.fire( 'paste', {
+					dataTransfer: dataTransferMock,
+					preventDefault: () => {},
+					stopPropagation: () => {}
+				} );
+
+				sinon.assert.calledWith( inputTransformationSpy, null );
+			} );
+
+			it( 'should contain editor ID when pasting content copied from the same editor (in dataTransfer)', () => {
+				const spy = sinon.spy();
+
+				setModelData( editor.model, '<paragraph>f[oo]bar</paragraph>' );
+
+				// Copy selected content.
+				const dataTransferMock = createDataTransfer();
+
+				viewDocument.fire( 'copy', {
+					dataTransfer: dataTransferMock,
+					preventDefault: () => {}
+				} );
+
+				clipboardPlugin.on( 'inputTransformation', ( evt, data ) => {
+					spy( data.dataTransfer.getData( 'application/ckeditor5-editor-id' ) );
+				} );
+
+				// Paste the copied content.
+				viewDocument.fire( 'paste', {
+					dataTransfer: dataTransferMock,
+					preventDefault: () => {},
+					stopPropagation: () => {}
+				} );
+
+				sinon.assert.calledWith( spy, editor.id );
+			} );
+
+			it( 'should contain editor ID when pasting content copied from the same editor', () => {
+				const spy = sinon.spy();
+
+				setModelData( editor.model, '<paragraph>f[oo]bar</paragraph>' );
+
+				// Copy selected content.
+				const dataTransferMock = createDataTransfer();
+
+				viewDocument.fire( 'copy', {
+					dataTransfer: dataTransferMock,
+					preventDefault: () => {}
+				} );
+
+				clipboardPlugin.on( 'inputTransformation', ( evt, data ) => {
+					spy( data.sourceEditorId );
+				} );
+
+				// Paste the copied content.
+				viewDocument.fire( 'paste', {
+					dataTransfer: dataTransferMock,
+					preventDefault: () => {},
+					stopPropagation: () => {}
+				} );
+
+				sinon.assert.calledWith( spy, editor.id );
+			} );
+
+			it( 'should be propagated to contentInsertion event', () => {
+				const dataTransferMock = createDataTransfer( { 'text/html': '<p>external content</p>' } );
+				const contentInsertionSpy = sinon.spy();
+
+				clipboardPlugin.on( 'contentInsertion', ( evt, data ) => {
+					contentInsertionSpy( data.sourceEditorId );
+				} );
+
+				viewDocument.fire( 'paste', {
+					dataTransfer: dataTransferMock,
+					preventDefault: () => {},
+					stopPropagation: () => {}
+				} );
+
+				sinon.assert.calledWith( contentInsertionSpy, null );
+			} );
+		} );
+
 		function createDataTransfer( data ) {
+			const state = Object.create( data || {} );
+
 			return {
 				getData( type ) {
-					return data[ type ];
+					return state[ type ];
+				},
+				setData( type, newData ) {
+					state[ type ] = newData;
 				}
 			};
 		}

--- a/packages/ckeditor5-code-block/tests/codeblockediting.js
+++ b/packages/ckeditor5-code-block/tests/codeblockediting.js
@@ -1682,7 +1682,7 @@ describe( 'CodeBlockEditing', () => {
 					'[]o' +
 				'</codeBlock>' );
 
-			sinon.assert.calledOnce( dataTransferMock.getData );
+			sinon.assert.calledTwice( dataTransferMock.getData );
 
 			// Make sure that ClipboardPipeline was not interrupted.
 			sinon.assert.calledOnce( contentInsertionSpy );
@@ -1723,7 +1723,7 @@ describe( 'CodeBlockEditing', () => {
 				'<paragraph>bar</paragraph>'
 			);
 
-			sinon.assert.calledOnce( dataTransferMock.getData );
+			sinon.assert.calledTwice( dataTransferMock.getData );
 
 			// Make sure that ClipboardPipeline was not interrupted.
 			sinon.assert.calledOnce( contentInsertionSpy );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (clipboard): Add ability to detect paste events originating from editor. Closes #15935 

---

### Additional information

The main use case is we need to track if the user has pasted content from outside the editor so we can decide if the content needs to be modified before it’s added into CKEditor. See more https://github.com/ckeditor/ckeditor5/issues/15935#issuecomment-1968599167

