### PR TITLE
Fixed reset button not resetting the emoji picker state.

### DIFF
--- a/packages/ckeditor5-emoji/src/ui/emojisearchview.ts
+++ b/packages/ckeditor5-emoji/src/ui/emojisearchview.ts
@@ -64,6 +64,10 @@ export default class EmojiSearchView extends View {
 			this.fire<EmojiSearchViewInputEvent>( 'input', { value } );
 		} );
 
+		labeledInput.resetButtonView!.on( 'execute', () => {
+			this.fire<EmojiSearchViewInputEvent>( 'input', { value: '' } );
+		} );
+
 		return labeledInput;
 	}
 }

--- a/packages/ckeditor5-emoji/tests/ui/emojisearchview.js
+++ b/packages/ckeditor5-emoji/tests/ui/emojisearchview.js
@@ -91,5 +91,19 @@ describe( 'EmojiSearchView', () => {
 			sinon.assert.calledOnce( spy );
 			sinon.assert.calledWithExactly( spy, sinon.match.any, { value: 'smile' } );
 		} );
+
+		it( 'delegates the #input event up when reset button is being clicked', () => {
+			emojiSearchView.setSearchQuery( 'smile' );
+
+			const spy = sinon.spy();
+
+			emojiSearchView.on( 'input', spy );
+
+			const resetInputButton = emojiSearchView.element.querySelector( '.ck-search__reset' );
+			resetInputButton.click();
+
+			sinon.assert.calledOnce( spy );
+			sinon.assert.calledWithExactly( spy, sinon.match.any, { value: '' } );
+		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Internal: Fixed reset button not resetting the emoji picker state. See #17659.

---

### Additional information

_For example – encountered issues, assumptions you had to make, other affected tickets, etc._
