### PR TITLE
It should now be possible to pass the callback to the `SimpleUploadConfig#headers` property.

### DIFF
--- a/packages/ckeditor5-upload/src/adapters/simpleuploadadapter.ts
+++ b/packages/ckeditor5-upload/src/adapters/simpleuploadadapter.ts
@@ -205,7 +205,11 @@ class Adapter implements UploadAdapter {
 	 */
 	private _sendRequest( file: File ): void {
 		// Set headers if specified.
-		const headers = this.options.headers || {};
+		let headers = this.options.headers || {};
+
+		if ( typeof headers === 'function' ) {
+			headers = headers( file );
+		}
 
 		// Use the withCredentials flag if specified.
 		const withCredentials = this.options.withCredentials || false;

--- a/packages/ckeditor5-upload/src/uploadconfig.ts
+++ b/packages/ckeditor5-upload/src/uploadconfig.ts
@@ -44,29 +44,37 @@ export interface SimpleUploadConfig {
 	uploadUrl: string;
 
 	/**
-	 * An object that defines additional [headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers) sent with
-	 * the request to the server during the upload. This is the right place to implement security mechanisms like
+	 * Headers sent with the request to the server during the upload. This is the right place to implement security mechanisms like
 	 * authentication and [CSRF](https://developer.mozilla.org/en-US/docs/Glossary/CSRF) protection.
+	 *
+	 * The value can be specified either as an object of key-value pairs or a callback function that returns such an object:
 	 *
 	 * ```ts
 	 * ClassicEditor
 	 * 	.create( editorElement, {
 	 * 		simpleUpload: {
+	 * 			// Set headers statically:
 	 * 			headers: {
 	 * 				'X-CSRF-TOKEN': 'CSRF-Token',
 	 * 				Authorization: 'Bearer <JSON Web Token>'
 	 * 			}
+	 *
+	 * 			// Or dynamically, based on the file:
+	 * 			headers: ( file ) => {
+	 * 				return {
+	 * 					'X-File-Name': file.name,
+	 * 					'X-File-Size': file.size
+	 * 				};
+	 * 			}
 	 * 		}
 	 * 	} );
-	 * 	.then( ... )
-	 * 	.catch( ... );
 	 * ```
 	 *
 	 * Learn more about the server application requirements in the
 	 * {@glink features/images/image-upload/simple-upload-adapter#server-side-configuration "Server-side configuration"} section
 	 * of the feature guide.
 	 */
-	headers?: Record<string, string>;
+	headers?: Record<string, string> | ( ( file: File ) => Record<string, string> );
 
 	/**
 	 * This flag enables the

--- a/packages/ckeditor5-upload/src/uploadconfig.ts
+++ b/packages/ckeditor5-upload/src/uploadconfig.ts
@@ -44,8 +44,9 @@ export interface SimpleUploadConfig {
 	uploadUrl: string;
 
 	/**
-	 * Headers sent with the request to the server during the upload. This is the right place to implement security mechanisms like
-	 * authentication and [CSRF](https://developer.mozilla.org/en-US/docs/Glossary/CSRF) protection.
+	 * [Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers) sent with the request to the server during the upload.
+	 * This is the right place to implement security mechanisms like authentication and
+	 * [CSRF](https://developer.mozilla.org/en-US/docs/Glossary/CSRF) protection.
 	 *
 	 * The value can be specified either as an object of key-value pairs or a callback function that returns such an object:
 	 *


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (upload): It should now be possible to pass the callback to the `SimpleUploadConfig#headers` property. Closes https://github.com/ckeditor/ckeditor5/issues/15693