### PR TITLE
Allow to specify which files choosen from CKBox are downloadable.

### DIFF
--- a/packages/ckeditor5-ckbox/src/ckboxcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxcommand.ts
@@ -432,7 +432,7 @@ export function prepareImageAssetAttributes( asset: CKBoxRawAssetDefinition ): C
  * @param asset The asset to prepare the attributes for.
  */
 function prepareLinkAssetAttributes(
-	config: CKBoxConfig['downloadableFiles'],
+	config: CKBoxConfig[ 'downloadableFiles' ],
 	asset: CKBoxRawAssetDefinition
 ): CKBoxAssetLinkAttributesDefinition {
 	return {
@@ -460,7 +460,7 @@ function isImage( asset: CKBoxRawAssetDefinition ) {
  * @param config The CKBox download asset configuration.
  * @param asset The asset to create the URL for.
  */
-function getAssetUrl( config: CKBoxConfig['downloadableFiles'], asset: CKBoxRawAssetDefinition ) {
+function getAssetUrl( config: CKBoxConfig[ 'downloadableFiles' ], asset: CKBoxRawAssetDefinition ) {
 	const url = new URL( asset.data.url );
 
 	if ( isDownloadableAsset( config, asset ) ) {
@@ -477,7 +477,7 @@ function getAssetUrl( config: CKBoxConfig['downloadableFiles'], asset: CKBoxRawA
  * @param asset The asset to check.
  */
 function isDownloadableAsset(
-	config: CKBoxConfig['downloadableFiles'],
+	config: CKBoxConfig[ 'downloadableFiles' ],
 	asset: CKBoxRawAssetDefinition
 ): boolean {
 	if ( typeof config === 'function' ) {

--- a/packages/ckeditor5-ckbox/src/ckboxcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxcommand.ts
@@ -399,7 +399,7 @@ function prepareAssets(
 			{
 				id: asset.data.id,
 				type: 'link',
-				attributes: prepareLinkAssetAttributes( downloadableFilesConfig, asset )
+				attributes: prepareLinkAssetAttributes( asset, downloadableFilesConfig )
 			} as const
 		)
 		.filter( asset => asset.type === 'image' ? isImageAllowed : isLinkAllowed );
@@ -428,16 +428,16 @@ export function prepareImageAssetAttributes( asset: CKBoxRawAssetDefinition ): C
 /**
  * Parses the assets attributes into the internal data format.
  *
- * @param config The CKBox download asset configuration.
  * @param asset The asset to prepare the attributes for.
+ * @param config The CKBox download asset configuration.
  */
 function prepareLinkAssetAttributes(
-	config: CKBoxConfig[ 'downloadableFiles' ],
-	asset: CKBoxRawAssetDefinition
+	asset: CKBoxRawAssetDefinition,
+	config: CKBoxConfig[ 'downloadableFiles' ]
 ): CKBoxAssetLinkAttributesDefinition {
 	return {
 		linkName: asset.data.name,
-		linkHref: getAssetUrl( config, asset )
+		linkHref: getAssetUrl( asset, config )
 	};
 }
 
@@ -457,13 +457,13 @@ function isImage( asset: CKBoxRawAssetDefinition ) {
 /**
  * Creates the URL for the asset.
  *
- * @param config The CKBox download asset configuration.
  * @param asset The asset to create the URL for.
+ * @param config The CKBox download asset configuration.
  */
-function getAssetUrl( config: CKBoxConfig[ 'downloadableFiles' ], asset: CKBoxRawAssetDefinition ) {
+function getAssetUrl( asset: CKBoxRawAssetDefinition, config: CKBoxConfig[ 'downloadableFiles' ] ) {
 	const url = new URL( asset.data.url );
 
-	if ( isDownloadableAsset( config, asset ) ) {
+	if ( isDownloadableAsset( asset, config ) ) {
 		url.searchParams.set( 'download', 'true' );
 	}
 
@@ -473,12 +473,12 @@ function getAssetUrl( config: CKBoxConfig[ 'downloadableFiles' ], asset: CKBoxRa
 /**
  * Determines if download should be enabled for given asset based on configuration.
  *
- * @param config The CKBox download asset configuration.
  * @param asset The asset to check.
+ * @param config The CKBox download asset configuration.
  */
 function isDownloadableAsset(
-	config: CKBoxConfig[ 'downloadableFiles' ],
-	asset: CKBoxRawAssetDefinition
+	asset: CKBoxRawAssetDefinition,
+	config: CKBoxConfig[ 'downloadableFiles' ]
 ): boolean {
 	if ( typeof config === 'function' ) {
 		return config( asset );

--- a/packages/ckeditor5-ckbox/src/ckboxcommand.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxcommand.ts
@@ -383,7 +383,7 @@ export default class CKBoxCommand extends Command {
  */
 function prepareAssets(
 	{ downloadableFilesConfig, assets, isImageAllowed, isLinkAllowed }: {
-		downloadableFilesConfig: CKBoxConfig['downloadableFiles'];
+		downloadableFilesConfig: CKBoxConfig[ 'downloadableFiles' ];
 		assets: Array<CKBoxRawAssetDefinition>;
 		isImageAllowed: boolean;
 		isLinkAllowed: boolean;

--- a/packages/ckeditor5-ckbox/src/ckboxconfig.ts
+++ b/packages/ckeditor5-ckbox/src/ckboxconfig.ts
@@ -173,6 +173,19 @@ export interface CKBoxConfig {
 	 * ```
 	 */
 	choosableFileExtensions?: Array<string>;
+
+	/**
+	 * Controls when to enable the download attribute for inserted links.
+	 *
+	 * By default, files are downloadable.
+	 *
+	 * ```ts
+	 * const ckboxConfig = {
+	 *   downloadableFiles: asset => asset.data.extension !== 'pdf'
+	 * };
+	 * ```
+	 */
+	downloadableFiles?: ( asset: CKBoxRawAssetDefinition ) => boolean;
 }
 
 export interface CKBoxDialogConfig {
@@ -461,6 +474,11 @@ export interface CKBoxRawAssetDataDefinition {
 	 * The asset location.
 	 */
 	url: string;
+
+	/**
+	 * The asset type.
+	 */
+	extension?: string;
 }
 
 /**

--- a/packages/ckeditor5-ckbox/tests/ckboxcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxcommand.js
@@ -1290,7 +1290,7 @@ describe( 'CKBoxCommand', () => {
 					const command = editor.commands.get( 'ckbox' );
 					const onChoose = command._prepareOptions().assets.onChoose;
 
-					// file1 should have download parameter
+					// `file1` should not have download parameter.
 					onChoose( [ assets.links[ 0 ] ] );
 
 					expect( getModelData( editor.model ) ).to.equal(
@@ -1303,7 +1303,7 @@ describe( 'CKBoxCommand', () => {
 						'</paragraph>'
 					);
 
-					// file2 should not have download parameter
+					// `file2` should not have download parameter.
 					editor.setData( '' );
 					onChoose( [ assets.links[ 1 ] ] );
 
@@ -1323,8 +1323,7 @@ describe( 'CKBoxCommand', () => {
 				it( 'should not affect image assets', async () => {
 					const editor = await createTestEditor( {
 						ckbox: {
-							tokenUrl: 'foo',
-							downloadableFiles: false
+							tokenUrl: 'foo'
 						}
 					} );
 

--- a/packages/ckeditor5-ckbox/tests/ckboxcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxcommand.js
@@ -1290,7 +1290,7 @@ describe( 'CKBoxCommand', () => {
 					const command = editor.commands.get( 'ckbox' );
 					const onChoose = command._prepareOptions().assets.onChoose;
 
-					// `file1` should not have download parameter.
+					// `file1` should have download parameter.
 					onChoose( [ assets.links[ 0 ] ] );
 
 					expect( getModelData( editor.model ) ).to.equal(

--- a/packages/ckeditor5-ckbox/tests/ckboxcommand.js
+++ b/packages/ckeditor5-ckbox/tests/ckboxcommand.js
@@ -1209,6 +1209,144 @@ describe( 'CKBoxCommand', () => {
 
 				sinon.assert.calledOnce( focusSpy );
 			} );
+
+			describe( 'downloadable files configuration', () => {
+				let command;
+
+				beforeEach( async () => {
+					assets = {
+						images: [
+							{
+								data: {
+									id: 'image-id1',
+									extension: 'png',
+									metadata: {
+										width: 100,
+										height: 100
+									},
+									name: 'image1',
+									imageUrls: {
+										100: 'https://example.com/workspace1/assets/image-id1/images/100.webp',
+										default: 'https://example.com/workspace1/assets/image-id1/images/100.png'
+									},
+									url: 'https://example.com/workspace1/assets/image-id1/file'
+								}
+							}
+						],
+						links: [
+							{
+								data: {
+									id: 'link-id1',
+									extension: 'pdf',
+									name: 'file1',
+									url: 'https://example.com/workspace1/assets/link-id1/file'
+								}
+							},
+							{
+								data: {
+									id: 'link-id2',
+									extension: 'zip',
+									name: 'file2',
+									url: 'https://example.com/workspace1/assets/link-id2/file'
+								}
+							}
+						]
+					};
+				} );
+
+				it( 'should add download parameter to URLs by default', async () => {
+					const editor = await createTestEditor( {
+						ckbox: {
+							tokenUrl: 'foo'
+						}
+					} );
+
+					command = editor.commands.get( 'ckbox' );
+					onChoose = command._prepareOptions().assets.onChoose;
+
+					onChoose( [ assets.links[ 1 ] ] );
+
+					expect( getModelData( editor.model ) ).to.equal(
+						'<paragraph>' +
+							'[<$text ' +
+								'ckboxLinkId="link-id2" ' +
+								'linkHref="https://example.com/workspace1/assets/link-id2/file?download=true">' +
+								'file2' +
+							'</$text>]' +
+						'</paragraph>'
+					);
+
+					await editor.destroy();
+				} );
+
+				it( 'should allow custom function for determining downloadable files', async () => {
+					const editor = await createTestEditor( {
+						ckbox: {
+							tokenUrl: 'foo',
+							downloadableFiles: asset => asset.data.name === 'file1'
+						}
+					} );
+
+					const command = editor.commands.get( 'ckbox' );
+					const onChoose = command._prepareOptions().assets.onChoose;
+
+					// file1 should have download parameter
+					onChoose( [ assets.links[ 0 ] ] );
+
+					expect( getModelData( editor.model ) ).to.equal(
+						'<paragraph>' +
+							'[<$text ' +
+								'ckboxLinkId="link-id1" ' +
+								'linkHref="https://example.com/workspace1/assets/link-id1/file?download=true">' +
+								'file1' +
+							'</$text>]' +
+						'</paragraph>'
+					);
+
+					// file2 should not have download parameter
+					editor.setData( '' );
+					onChoose( [ assets.links[ 1 ] ] );
+
+					expect( getModelData( editor.model ) ).to.equal(
+						'<paragraph>' +
+							'[<$text ' +
+								'ckboxLinkId="link-id2" ' +
+								'linkHref="https://example.com/workspace1/assets/link-id2/file">' +
+								'file2' +
+							'</$text>]' +
+						'</paragraph>'
+					);
+
+					await editor.destroy();
+				} );
+
+				it( 'should not affect image assets', async () => {
+					const editor = await createTestEditor( {
+						ckbox: {
+							tokenUrl: 'foo',
+							downloadableFiles: false
+						}
+					} );
+
+					const command = editor.commands.get( 'ckbox' );
+					const onChoose = command._prepareOptions().assets.onChoose;
+
+					onChoose( [ assets.images[ 0 ] ] );
+
+					expect( getModelData( editor.model ) ).to.equal(
+						'[<imageBlock ' +
+							'alt="" ' +
+							'ckboxImageId="image-id1" ' +
+							'height="100" ' +
+							'sources="[object Object]" ' +
+							'src="https://example.com/workspace1/assets/image-id1/images/100.png" ' +
+							'width="100">' +
+						'</imageBlock>]'
+					);
+
+					await editor.destroy();
+				} );
+			} );
 		} );
 	} );
 } );

--- a/packages/ckeditor5-ckbox/tests/manual/ckbox.js
+++ b/packages/ckeditor5-ckbox/tests/manual/ckbox.js
@@ -55,7 +55,8 @@ ClassicEditor
 		ckbox: {
 			tokenUrl: TOKEN_URL,
 			forceDemoLabel: true,
-			allowExternalImagesEditing: [ /^data:/, /^i.imgur.com\//, 'origin' ]
+			allowExternalImagesEditing: [ /^data:/, /^i.imgur.com\//, 'origin' ],
+			downloadableFiles: asset => asset.data.extension !== 'pdf'
 		}
 	} )
 	.then( editor => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/git-commit-message-convention.html))

Feature (ckbox): Allow to specify which files chosen from CKBox are downloadable. Closes #15928 

#### Additional Information

```ts
export interface CKBoxConfig {
  // ...

  /**
  * Controls when to enable the download attribute for inserted links.
  *
  * By default, files are downloadable.
  *
  * ```ts
  * const ckboxConfig = {
  *   downloadableFiles: asset => asset.data.extension !== 'pdf'
  * };
  * ```
  */
  downloadableFiles?: ( asset: CKBoxRawAssetDefinition ) => boolean;
};
```
